### PR TITLE
fix backslash issue with example `go test` and add install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ This is a still a work in a progress, though much of the structure of the interp
 and AST have taken place.  Work is ongoing now to demonstrate the Realm concept before
 continuing to make the tests/files/\*.go tests pass.
 
-Try this: 
+Make sure you have >=[go1.15](https://golang.org/doc/install) installed, and then try this: 
+
 ```bash
-> go test tests/\*.go -v -run="Test/realm.go"
+> git clone git@github.com:gnolang/gno.git
+> cd gno
+> go mod download github.com/davecgh/go-spew
+> go test tests/*.go -v -run="Test/realm.go"
 ```
 
 ## Ownership 


### PR DESCRIPTION
When I tried to run `go test tests/\*.go -v -run="Test/realm.go"`, I kept getting this error:

```
malformed import path "tests/*.go": invalid char '*'
```
Removing an extra backslash seems to have fixed it.

I've also added a couple more install commands to help new people try the AST more easily.