### PR TITLE
Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: logos
+name: build
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,16 +3,8 @@ on: [push, pull_request]
 
 jobs:
   goscan:
-    strategy:
-      fail-fast: false
-      matrix:
-        build-os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.build-os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '^1.15'
       - name: build
         run: make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,4 +1,3 @@
-# TODO: Add target OS
 name: logos
 on: [push, pull_request]
 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,7 +3,7 @@ name: logos
 on: [push, pull_request]
 
 jobs:
-  logos:
+  goscan:
     strategy:
       fail-fast: false
       matrix:
@@ -15,5 +15,5 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.15'
-      - name: make
-        run: make
+      - name: goscan
+        run: make goscan

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,19 @@
+# TODO: Add target OS
+name: logos
+on: [push, pull_request]
+
+jobs:
+  logos:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.build-os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: make
+        run: make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -6,5 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
       - name: build
         run: make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,7 +2,7 @@ name: logos
 on: [push, pull_request]
 
 jobs:
-  goscan:
+  gno:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,3 +12,7 @@ jobs:
           go-version: '^1.15'
       - name: build
         run: make
+      - uses: actions/upload-artifact@v2
+        with:
+          name: gno
+          path: github.com/gnolang

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -14,5 +14,5 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '^1.15'
-      - name: goscan
-        run: make goscan
+      - name: build
+        run: make

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,49 @@
+# gnoland is the main executable of gnolang
+gnoland:
+	echo "Building Gnoland for a wide range of systems"
+	mkdir build || true
+	GOOS=darwin GOARCH=amd64 go build -o build/gno-darwin-amd64 cmd/main.go
+	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/main.go
+	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/main.go
+	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/main.go
+	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/main.go
+	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/main.go
+
+# goscan scans go code
+goscan:
+	echo "Building goscan for a wide range of systems"
+	mkdir build || true
+	GOOS=darwin GOARCH=amd64 go build -o build/goscan-darwin-amd64 cmd/goscan/goscan.go
+	GOOS=darwin GOARCH=arm64 go build -o build/goscan-darwin-arm64 cmd/goscan/goscan.go
+	GOOS=linux GOARCH=amd64 go build -o build/goscan-linux-amd64 cmd/goscan/goscan.go
+	GOOS=linux GOARCH=arm64 go build -o build/goscan-linux-arm64 cmd/goscan/goscan.go
+	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-amd64 cmd/goscan/goscan.go
+	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-arm64 cmd/goscan/goscan.go
+
+
+# Is logos test code or will it be a part of the system?
+logos:
+	echo "Building logos for a wide range of systems"
+	mkdir build || true
+	GOOS=darwin GOARCH=amd64 go build -o build/logos-darwin-amd64 logos/cmd/logos.go
+	GOOS=darwin GOARCH=arm64 go build -o build/logos-darwin-arm64 logos/cmd/logos.go
+	GOOS=linux GOARCH=amd64 go build -o build/logos-linux-amd64 logos/cmd/logos.go
+	GOOS=linux GOARCH=arm64 go build -o build/logos-linux-arm64 logos/cmd/logos.go
+	GOOS=windows GOARCH=amd64 go build -o build/logos-win-amd64 logos/cmd/logos.go
+	GOOS=windows GOARCH=amd64 go build -o build/logos-win-arm64 logos/cmd/logos.go
+
+
+
+all:
+	gnoland goscan logos
+
+
+
+
+
 # TODO stringer -type=Op
+# Unsure what the above refers to. Created a basic Makefile.
+
+# TODO can probobaly make this more specific, but that may not be desirable.  Sometimes it's nice to check if it builds
+# everywhere.
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # gnoland is the main executable of gnolang
 # bring this back when ready
-# gnoland:
-#	echo "Building Gnoland for a wide range of systems"
-#	mkdir build || true
-#	go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
+gnoland:
+	echo "Building Gnoland for a wide range of systems"
+	mkdir build || true
+	go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
 #	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/gnoland/main.go
 #	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/gnoland/main.go
 #	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/gnoland/main.go
@@ -43,7 +43,7 @@ test:
 	go test tests/*.go -v -run="Test/realm.go"
 
 all:
-	deps test goscan logos
+	deps test gnoland goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,37 @@
 # gnoland is the main executable of gnolang
-gnoland:
-	echo "Building Gnoland for a wide range of systems"
-	mkdir build || true
-	GOOS=darwin GOARCH=amd64 go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
-	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/gnoland/main.go
-	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/gnoland/main.go
-	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/gnoland/main.go
-	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/gnoland/main.go
-	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/gnoland/main.go
+# bring this back when ready
+# gnoland:
+#	echo "Building Gnoland for a wide range of systems"
+#	mkdir build || true
+#	go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
+#	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/gnoland/main.go
+#	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/gnoland/main.go
+#	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/gnoland/main.go
+#	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/gnoland/main.go
+#	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/gnoland/main.go
 
 # goscan scans go code
 goscan:
 	echo "Building goscan for a wide range of systems"
 	mkdir build || true
-	GOOS=darwin GOARCH=amd64 go build -o build/goscan-darwin-amd64 cmd/goscan/goscan.go
-	GOOS=darwin GOARCH=arm64 go build -o build/goscan-darwin-arm64 cmd/goscan/goscan.go
-	GOOS=linux GOARCH=amd64 go build -o build/goscan-linux-amd64 cmd/goscan/goscan.go
-	GOOS=linux GOARCH=arm64 go build -o build/goscan-linux-arm64 cmd/goscan/goscan.go
-	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-amd64 cmd/goscan/goscan.go
-	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-arm64 cmd/goscan/goscan.go
+	go build -o build/goscan cmd/goscan/goscan.go
+#	GOOS=darwin GOARCH=arm64 go build -o build/goscan-darwin-arm64 cmd/goscan/goscan.go
+#	GOOS=linux GOARCH=amd64 go build -o build/goscan-linux-amd64 cmd/goscan/goscan.go
+#	GOOS=linux GOARCH=arm64 go build -o build/goscan-linux-arm64 cmd/goscan/goscan.go
+#	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-amd64 cmd/goscan/goscan.go
+#	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-arm64 cmd/goscan/goscan.go
 
 
 # Is logos test code or will it be a part of the system?
 logos:
 	echo "Building logos for a wide range of systems"
 	mkdir build || true
-	GOOS=darwin GOARCH=amd64 go build -o build/logos-darwin-amd64 logos/cmd/logos.go
-	GOOS=darwin GOARCH=arm64 go build -o build/logos-darwin-arm64 logos/cmd/logos.go
-	GOOS=linux GOARCH=amd64 go build -o build/logos-linux-amd64 logos/cmd/logos.go
-	GOOS=linux GOARCH=arm64 go build -o build/logos-linux-arm64 logos/cmd/logos.go
-	GOOS=windows GOARCH=amd64 go build -o build/logos-win-amd64 logos/cmd/logos.go
-	GOOS=windows GOARCH=amd64 go build -o build/logos-win-arm64 logos/cmd/logos.go
+	go build -o build/logos logos/cmd/logos.go
+#	GOOS=darwin GOARCH=arm64 go build -o build/logos-darwin-arm64 logos/cmd/logos.go
+#	GOOS=linux GOARCH=amd64 go build -o build/logos-linux-amd64 logos/cmd/logos.go
+#	GOOS=linux GOARCH=arm64 go build -o build/logos-linux-arm64 logos/cmd/logos.go
+#	GOOS=windows GOARCH=amd64 go build -o build/logos-win-amd64 logos/cmd/logos.go
+#	GOOS=windows GOARCH=amd64 go build -o build/logos-win-arm64 logos/cmd/logos.go
 
 
 deps:
@@ -38,7 +39,7 @@ deps:
 
 
 all:
-	deps gnoland goscan logos
+	deps goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 gnoland:
 	echo "Building Gnoland for a wide range of systems"
 	mkdir build || true
-	GOOS=darwin GOARCH=amd64 go build -o build/gno-darwin-amd64 cmd/main.go
-	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/main.go
-	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/main.go
-	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/main.go
-	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/main.go
-	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/main.go
+	GOOS=darwin GOARCH=amd64 go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
+	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/gnoland/main.go
+	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/gnoland/main.go
+	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/gnoland/main.go
+	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/gnoland/main.go
+	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/gnoland/main.go
 
 # goscan scans go code
 goscan:
@@ -33,9 +33,12 @@ logos:
 	GOOS=windows GOARCH=amd64 go build -o build/logos-win-arm64 logos/cmd/logos.go
 
 
+deps:
+	go mod download
+
 
 all:
-	gnoland goscan logos
+	deps gnoland goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,36 @@
 all: xgo test gnoland goscan logos
 
+build-dir:
+	mkdir build || echo "Build folder is already present."
+
 # gnoland is the main executable of gnolang
 # bring this back when ready
 gnoland:
-	echo "Building Gnoland for a wide range of systems"
-	mkdir build || true
+	echo "Building gnoland"
 	xgo ./cmd/gnoland
 
 # goscan scans go code to determine its AST
 goscan:
-	echo "Building goscan for a wide range of systems"
-	mkdir build || true
+	echo "Building goscan"
 	xgo ./cmd/goscan
 
 
 # Is logos test code or will it be a part of the system?
 logos:
-	echo "Building logos for a wide range of systems"
-	mkdir build || true
+	echo "building logos"
 	xgo ./logos/cmd
 
 
 test:
+	echo "Running tests"
 	go test tests/*.go -v -run="Test/realm.go"
 
 xgo:
+	echo "installing xgo"
 	go get src.techknowlogick.com/xgo
-
-
 
 
 
 # TODO stringer -type=Op
 # Unsure what the above refers to. Created a basic Makefile.
-
-# TODO can probobaly make this more specific, but that may not be desirable.  Sometimes it's nice to check if it builds
-# everywhere.
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,12 @@ deps:
 	go mod download
 
 
+
+test:
+	go test tests/*.go -v -run="Test/realm.go"
+
 all:
-	deps goscan logos
+	deps test goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+all:
+	xgo test gnoland goscan logos
+
 # gnoland is the main executable of gnolang
 # bring this back when ready
 gnoland:
@@ -24,10 +27,6 @@ test:
 
 xgo:
 	go get src.techknowlogick.com/xgo
-
-
-all:
-	xgo test gnoland goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-all:
-	xgo test gnoland goscan logos
+all: xgo test gnoland goscan logos
 
 # gnoland is the main executable of gnolang
 # bring this back when ready

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-all: xgo test gnoland goscan logos
-
-build-dir:
-	mkdir build || echo "Build folder is already present."
+all: xgo gnoland goscan logos
 
 # gnoland is the main executable of gnolang
 # bring this back when ready
@@ -15,7 +12,7 @@ goscan:
 	xgo ./cmd/goscan
 
 
-# Is logos test code or will it be a part of the system?
+# Logos is the interface to Gnoland
 logos:
 	echo "building logos"
 	xgo ./logos/cmd
@@ -29,7 +26,7 @@ xgo:
 	echo "installing xgo"
 	go get src.techknowlogick.com/xgo
 
-
+# NB: Binaries will output in the folder github.com/gnoland
 
 # TODO stringer -type=Op
 # Unsure what the above refers to. Created a basic Makefile.

--- a/Makefile
+++ b/Makefile
@@ -3,47 +3,31 @@
 gnoland:
 	echo "Building Gnoland for a wide range of systems"
 	mkdir build || true
-	go build -o build/gno-darwin-amd64 cmd/gnoland/main.go
-#	GOOS=darwin GOARCH=arm64 go build -o build/gno-darwin-arm64 cmd/gnoland/main.go
-#	GOOS=linux GOARCH=amd64 go build -o build/gno-linux-amd64 cmd/gnoland/main.go
-#	GOOS=linux GOARCH=arm64 go build -o build/gno-linux-arm64 cmd/gnoland/main.go
-#	GOOS=windows GOARCH=amd64 go build -o build/gno-win-amd64 cmd/gnoland/main.go
-#	GOOS=windows GOARCH=amd64 go build -o build/gno-win-arm64 cmd/gnoland/main.go
+	xgo ./cmd/gnoland
 
-# goscan scans go code
+# goscan scans go code to determine its AST
 goscan:
 	echo "Building goscan for a wide range of systems"
 	mkdir build || true
-	go build -o build/goscan cmd/goscan/goscan.go
-#	GOOS=darwin GOARCH=arm64 go build -o build/goscan-darwin-arm64 cmd/goscan/goscan.go
-#	GOOS=linux GOARCH=amd64 go build -o build/goscan-linux-amd64 cmd/goscan/goscan.go
-#	GOOS=linux GOARCH=arm64 go build -o build/goscan-linux-arm64 cmd/goscan/goscan.go
-#	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-amd64 cmd/goscan/goscan.go
-#	GOOS=windows GOARCH=amd64 go build -o build/goscan-win-arm64 cmd/goscan/goscan.go
+	xgo ./cmd/goscan
 
 
 # Is logos test code or will it be a part of the system?
 logos:
 	echo "Building logos for a wide range of systems"
 	mkdir build || true
-	go build -o build/logos logos/cmd/logos.go
-#	GOOS=darwin GOARCH=arm64 go build -o build/logos-darwin-arm64 logos/cmd/logos.go
-#	GOOS=linux GOARCH=amd64 go build -o build/logos-linux-amd64 logos/cmd/logos.go
-#	GOOS=linux GOARCH=arm64 go build -o build/logos-linux-arm64 logos/cmd/logos.go
-#	GOOS=windows GOARCH=amd64 go build -o build/logos-win-amd64 logos/cmd/logos.go
-#	GOOS=windows GOARCH=amd64 go build -o build/logos-win-arm64 logos/cmd/logos.go
-
-
-deps:
-	go mod download
-
+	xgo ./logos/cmd
 
 
 test:
 	go test tests/*.go -v -run="Test/realm.go"
 
+xgo:
+	go get src.techknowlogick.com/xgo
+
+
 all:
-	deps test gnoland goscan logos
+	xgo test gnoland goscan logos
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,23 @@
 all: xgo gnoland goscan logos
 
+targets = windows/amd64,windows/arm64,darwin-10.14/arm64,darwin-10.14/amd64,linux/*
+
 # gnoland is the main executable of gnolang
 # bring this back when ready
 gnoland:
 	echo "Building gnoland"
-	xgo ./cmd/gnoland
+	xgo -v -x --targets=$(targets) ./cmd/gnoland
 
 # goscan scans go code to determine its AST
 goscan:
 	echo "Building goscan"
-	xgo ./cmd/goscan
+	xgo -v -x --targets=$(targets) ./cmd/goscan
 
 
 # Logos is the interface to Gnoland
 logos:
 	echo "building logos"
-	xgo ./logos/cmd
+	xgo -v -x --targets=4(targets) ./logos/cmd
 
 
 test:

--- a/cmd/goscan/goscan.go
+++ b/cmd/goscan/goscan.go
@@ -10,10 +10,16 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+/*
+Goscan:
+
+
+ */
+
 func main() {
 	fset := token.NewFileSet() // positions are relative to fset
 
-	filename := os.Args[1]
+	filename := os.Args[1] // Take a filename as an argument.
 	bz, err := ioutil.ReadFile(filename)
 	if err != nil {
 		panic(err)
@@ -27,6 +33,7 @@ func main() {
 	}
 
 	// Print the imports from the file's AST.
+	// AST: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 	spew.Dump(f)
 
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jaekwon/testify v1.6.1
 	github.com/mattn/go-runewidth v0.0.10
 	github.com/stretchr/testify v1.6.1
+	src.techknowlogick.com/xgo v1.2.1-0.20210207204503-1ea8454a58df // indirect
 )
 
 replace github.com/gdamore/tcell => github.com/gnolang/tcell v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -27,3 +27,5 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+src.techknowlogick.com/xgo v1.2.1-0.20210207204503-1ea8454a58df h1:emObvP33uBegaUw3n4wBs5Jj/pahioIqMZnTdET9lFA=
+src.techknowlogick.com/xgo v1.2.1-0.20210207204503-1ea8454a58df/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=


### PR DESCRIPTION
- Made xgo the default build tool so that contributors don't need to worry about a C environment or cross-compile config
- Added a basic Makefile
- Set default build targets to be amd64/arm64 for mac, windows, and linux
- Made the default darwin version 10.14 for compatibility reasons