### PR TITLE
updated gno.land example README.md

### DIFF
--- a/examples/gno.land/r/boards/README.md
+++ b/examples/gno.land/r/boards/README.md
@@ -8,7 +8,7 @@ https://github.com/gnolang/gno/tree/master/examples/gno.land
 ## build and start gnoland.
 
 ```bash
-git clone github.com/gnolang/gno
+git clone https://github.com/gnolang/gno
 cd ./gno
 make 
 ```
@@ -33,7 +33,8 @@ Use this mnemonic:
 ## start gnoland web server (optional).
 
 ```bash
-go run ./gnoland/website/\*.go
+cd ./gnoland/website
+go run main.go
 ```
 
 ## sign an addpkg (add avl package) transaction.


### PR DESCRIPTION
This is a minor fix to the gno.land example README.md.  

- The gotuna startup sequence was executed from the wrong directory so had no access to the views.
- Clone sequence was off as it did not include git:// or https://.

If there is another way I should report these types of things please just let me know.