### PR TITLE
WIP: dissociate *FuncValue and *PackageValue for concurrent node execution…

### DIFF
--- a/gno_test.go
+++ b/gno_test.go
@@ -49,10 +49,8 @@ func next(i int) int {
 
 func assertOutput(t *testing.T, input string, output string) {
 	buf := new(bytes.Buffer)
-	pn := NewPackageNode("test", ".test", &FileSet{})
-	pkg := pn.NewPackage()
 	m := NewMachineWithOptions(MachineOptions{
-		Package: pkg,
+		PkgPath: "test",
 		Output:  buf,
 	})
 	n := MustParseFile("main.go", input)

--- a/gonative.go
+++ b/gonative.go
@@ -137,7 +137,6 @@ func go2GnoType2(rt reflect.Type) (t Type) {
 						PkgPath:    pkgPath,
 						body:       nil, // XXX
 						nativeBody: nil,
-						pkg:        nil, // XXX
 					}
 					mtvs[i] = TypedValue{T: ft, V: fv}
 				}

--- a/gonative_test.go
+++ b/gonative_test.go
@@ -23,7 +23,7 @@ func gonativeTestStore(args ...interface{}) Store {
 				return pn, pv
 			}
 		}
-		panic("should not happen")
+		return nil, nil
 	})
 	return store
 }

--- a/gonative_test.go
+++ b/gonative_test.go
@@ -52,7 +52,8 @@ func TestGoNativeDefine(t *testing.T) {
 
 	// Import above package and evaluate foo.Foo.
 	m := NewMachineWithOptions(MachineOptions{
-		Store: store,
+		PkgPath: "test",
+		Store:   store,
 	})
 	m.RunDeclaration(ImportD("foo", "test.foo"))
 	tvs := m.Eval(Sel(Nx("foo"), "Foo"))
@@ -71,8 +72,9 @@ func TestGoNativeDefine2(t *testing.T) {
 	// Import above package and run file.
 	out := new(bytes.Buffer)
 	m := NewMachineWithOptions(MachineOptions{
-		Output: out,
-		Store:  store,
+		PkgPath: "main",
+		Output:  out,
+		Store:   store,
 	})
 
 	c := `package main
@@ -110,8 +112,9 @@ func TestGoNativeDefine3(t *testing.T) {
 
 	// Import above package and run file.
 	m := NewMachineWithOptions(MachineOptions{
-		Output: out,
-		Store:  store,
+		PkgPath: "main",
+		Output:  out,
+		Store:   store,
 	})
 
 	c := `package main

--- a/machine.go
+++ b/machine.go
@@ -1308,10 +1308,8 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue) {
 	}
 	m.Frames = append(m.Frames, fr)
 	pv := fv.GetPackage(m.Store)
-	if debug {
-		if pv == nil {
-			panic("should not happen")
-		}
+	if pv == nil {
+		panic(fmt.Sprintf("package value missing in store: %s", fv.PkgPath))
 	}
 	m.Package = pv
 	rlm := pv.GetRealm()

--- a/machine.go
+++ b/machine.go
@@ -48,6 +48,8 @@ type Machine struct {
 // Creates a new MemRealmer for any new realms.
 // Looks in store for package of pkgPath; if not found,
 // creates new instances as necessary.
+// If pkgPath is zero, the machine has no active package
+// and one must be set prior to usage.
 func NewMachine(pkgPath string, store Store) *Machine {
 	return NewMachineWithOptions(
 		MachineOptions{
@@ -66,7 +68,6 @@ type MachineOptions struct {
 }
 
 func NewMachineWithOptions(opts MachineOptions) *Machine {
-	//rlm := pv.GetRealm()
 	checkTypes := opts.CheckTypes
 	readOnly := opts.ReadOnly
 	output := opts.Output

--- a/machine.go
+++ b/machine.go
@@ -232,8 +232,9 @@ func (m *Machine) TestMemPackage(t *testing.T, memPkg std.MemPackage) {
 		}
 	}
 	{ // run all (import) tests in test files.
-		pkg := NewPackageNode(Name(memPkg.Name+"_test"), memPkg.Path, itfiles)
+		pkg := NewPackageNode(Name(memPkg.Name+"_test"), memPkg.Path+"_test", itfiles)
 		pv := pkg.NewPackage()
+		m.Store.SetCachePackage(pv)
 		pvBlock := pv.GetBlock(m.Store)
 		m.SetActivePackage(pv)
 		m.RunFiles(itfiles.Files...)

--- a/machine.go
+++ b/machine.go
@@ -130,6 +130,7 @@ func (m *Machine) PreprocessAllFilesAndSaveBlockNodes() {
 	for memPkg := range ch {
 		fset := ParseMemPackage(memPkg)
 		pn := NewPackageNode(Name(memPkg.Name), memPkg.Path, fset)
+		m.Store.SetBlockNode(pn)
 		PredefineFileSet(m.Store, pn, fset)
 		for _, fn := range fset.Files {
 			// Save Types to m.Store (while preprocessing).

--- a/machine.go
+++ b/machine.go
@@ -233,13 +233,14 @@ func (m *Machine) TestMemPackage(t *testing.T, memPkg std.MemPackage) {
 		}
 	}
 	{ // run all (import) tests in test files.
-		pkg := NewPackageNode(Name(memPkg.Name+"_test"), memPkg.Path+"_test", itfiles)
-		pv := pkg.NewPackage()
+		pn := NewPackageNode(Name(memPkg.Name+"_test"), memPkg.Path+"_test", itfiles)
+		pv := pn.NewPackage()
+		m.Store.SetBlockNode(pn)
 		m.Store.SetCachePackage(pv)
 		pvBlock := pv.GetBlock(m.Store)
 		m.SetActivePackage(pv)
 		m.RunFiles(itfiles.Files...)
-		pkg.PrepareNewValues(pv)
+		pn.PrepareNewValues(pv)
 		EnableDebug()
 		fmt.Println("DEBUG ENABLED")
 		for i := 0; i < len(pvBlock.Values); i++ {

--- a/nodes.go
+++ b/nodes.go
@@ -1270,10 +1270,12 @@ func (pn *PackageNode) NewPackage() *PackageValue {
 	return pv
 }
 
-// Prepares new func values (e.g. by attaching the proper file block).
+// Prepares new func values (e.g. by attaching the proper file block closure).
 // Returns a slice of new PackageValue.Values.
 // After return, *PackageNode.Values and *PackageValue.Values have the same
 // length.
+// NOTE: declared methods do not get their closures set here. See
+// *DeclaredType.GetValueAt() which returns a filled copy.
 func (pn *PackageNode) PrepareNewValues(pv *PackageValue) []TypedValue {
 	if pv.PkgPath == "" {
 		// nothing to prepare for throwaway packages.

--- a/op_binary.go
+++ b/op_binary.go
@@ -446,7 +446,24 @@ func isEql(store Store, lv, rv *TypedValue) bool {
 				panic("function can only be compared with `nil`")
 			}
 		}
-		return lv.V == rv.V
+		if _, ok := lv.V.(*BoundMethodValue); ok {
+			// BoundMethodValues are objects so just compare.
+			return lv.V == rv.V
+		} else if lv.V == nil && rv.V == nil {
+			return true
+		} else {
+			lfv := lv.V.(*FuncValue)
+			rfv, ok := rv.V.(*FuncValue)
+			if !ok {
+				return false
+			}
+			if lfv.Source.GetLocation() !=
+				rfv.Source.GetLocation() {
+				return false
+			}
+			return lfv.GetClosure(store) ==
+				rfv.GetClosure(store)
+		}
 	case PointerKind:
 		// TODO: assumes runtime instance normalization.
 		return lv.V == rv.V

--- a/op_call.go
+++ b/op_call.go
@@ -187,10 +187,6 @@ func (m *Machine) doOpReturn() {
 			// We are changing realms or exiting a realm.
 			finalize = true
 		}
-		fmt.Println("DIFFER m.Realm", fmt.Sprintf("%p", crlm), crlm,
-			"cfr.LastRealm", fmt.Sprintf("%p", cfr.LastRealm), cfr.LastRealm,
-			"m.Package.PkgPath", m.Package.PkgPath,
-			"m.Package.Realm", fmt.Sprintf("%p", m.Package.Realm), m.Package.Realm, cfr.Source)
 		if finalize {
 			// Finalize realm updates!
 			// NOTE: This is a resource intensive undertaking.

--- a/op_call.go
+++ b/op_call.go
@@ -6,7 +6,6 @@ import (
 )
 
 func (m *Machine) doOpPrecall() {
-
 	cx := m.PopExpr().(*CallExpr)
 	v := m.PeekValue(1 + cx.NumArgs).V
 	if debug {
@@ -188,6 +187,10 @@ func (m *Machine) doOpReturn() {
 			// We are changing realms or exiting a realm.
 			finalize = true
 		}
+		fmt.Println("DIFFER m.Realm", fmt.Sprintf("%p", crlm), crlm,
+			"cfr.LastRealm", fmt.Sprintf("%p", cfr.LastRealm), cfr.LastRealm,
+			"m.Package.PkgPath", m.Package.PkgPath,
+			"m.Package.Realm", fmt.Sprintf("%p", m.Package.Realm), m.Package.Realm, cfr.Source)
 		if finalize {
 			// Finalize realm updates!
 			// NOTE: This is a resource intensive undertaking.

--- a/op_expressions.go
+++ b/op_expressions.go
@@ -668,7 +668,6 @@ func (m *Machine) doOpFuncLit() {
 			PkgPath:    m.Package.PkgPath,
 			body:       x.Body,
 			nativeBody: nil,
-			pkg:        m.Package,
 		},
 	})
 }

--- a/op_types.go
+++ b/op_types.go
@@ -332,11 +332,11 @@ func (m *Machine) doOpStaticTypeOf() {
 				switch cxt := xt.(type) {
 				case *PointerType:
 					dt := cxt.Elt.(*DeclaredType)
-					t2 := dt.GetValueRefAt(path).T
+					t2 := dt.GetStaticValueAt(path).T
 					m.PushValue(asValue(t2))
 					return
 				case *DeclaredType:
-					t2 := cxt.GetValueRefAt(path).T
+					t2 := cxt.GetStaticValueAt(path).T
 					m.PushValue(asValue(t2))
 					return
 				case *NativeType:
@@ -387,7 +387,7 @@ func (m *Machine) doOpStaticTypeOf() {
 					dxt.Kind().String()))
 			}
 		case VPValMethod, VPPtrMethod:
-			ftv := dxt.(*DeclaredType).GetValueRefAt(path)
+			ftv := dxt.(*DeclaredType).GetStaticValueAt(path)
 			ft := ftv.GetFunc().GetType(m.Store)
 			mt := ft.BoundType()
 			m.PushValue(asValue(mt))

--- a/pkgs/sdk/vm/builtins.go
+++ b/pkgs/sdk/vm/builtins.go
@@ -30,8 +30,7 @@ func (vmk *VMKeeper) initBuiltinPackages(store gno.Store) {
 			Output:  os.Stdout,
 			Store:   store,
 		})
-		save := true // save once before natives injected later.
-		return m2.RunMemPackage(memPkg, save)
+		return m2.RunMemPackage(memPkg, true)
 	}
 	store.SetPackageGetter(getPackage)
 	store.SetPackageInjector(vmk.packageInjector)

--- a/pkgs/sdk/vm/builtins.go
+++ b/pkgs/sdk/vm/builtins.go
@@ -26,7 +26,7 @@ func (vmk *VMKeeper) initBuiltinPackages(store gno.Store) {
 		}
 		memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
 		m2 := gno.NewMachineWithOptions(gno.MachineOptions{
-			Package: nil,
+			PkgPath: "",
 			Output:  os.Stdout,
 			Store:   store,
 		})

--- a/preprocess.go
+++ b/preprocess.go
@@ -2793,7 +2793,7 @@ func predefineNow2(store Store, last BlockNode, d Decl, m map[Name]struct{}) (De
 				IsMethod:   true,
 				Source:     cd,
 				Name:       cd.Name,
-				Closure:    nil, // set later, see PrepareNewValues().
+				Closure:    nil, // set lazily.
 				FileName:   fileNameOf(last),
 				PkgPath:    pkg.PkgPath,
 				body:       cd.Body,
@@ -2843,7 +2843,7 @@ func tryPredefine(store Store, last BlockNode, d Decl) (un Name) {
 	// so value paths cannot be used here.
 	switch d := d.(type) {
 	case *ImportDecl:
-		pv := store.GetPackage(d.PkgPath)
+		pv := store.GetPackage(d.PkgPath, true)
 		if pv == nil {
 			panic(fmt.Sprintf(
 				"unknown import path %s",
@@ -2924,7 +2924,7 @@ func tryPredefine(store Store, last BlockNode, d Decl) (un Name) {
 				} else if idx, ok := UverseNode().GetLocalIndex(tx.Name); ok {
 					// uverse name
 					path := NewValuePathUverse(idx, tx.Name)
-					tv := Uverse().GetValueRefAt(nil, path)
+					tv := Uverse().GetValueAt(nil, path)
 					t = tv.GetType()
 				} else {
 					// yet undefined
@@ -3008,7 +3008,7 @@ func tryPredefine(store Store, last BlockNode, d Decl) (un Name) {
 					IsMethod:   false,
 					Source:     d,
 					Name:       d.Name,
-					Closure:    nil, // set later, see PrepareNewValues().
+					Closure:    nil, // set lazily.
 					FileName:   fileNameOf(last),
 					PkgPath:    pkg.PkgPath,
 					body:       d.Body,

--- a/preprocess.go
+++ b/preprocess.go
@@ -1906,7 +1906,8 @@ func evalStaticType(store Store, last BlockNode, x Expr) Type {
 		return ctx.Type // no need to set attribute.
 	}
 	pn := packageOf(last)
-	if store != nil {
+	// See comment in evalStaticTypeOfRaw.
+	if store != nil && pn.PkgPath != ".uverse" {
 		pv := pn.NewPackage() // temporary
 		store = store.Fork()
 		store.SetCachePackage(pv)
@@ -1972,7 +1973,13 @@ func evalStaticTypeOfRaw(store Store, last BlockNode, x Expr) (t Type) {
 		return ctx.T
 	} else {
 		pn := packageOf(last)
-		if store != nil {
+		// NOTE: do not load the package value from store,
+		// because we may be preprocessing in the middle of
+		// PreprocessAllFilesAndSaveBlockNodes,
+		// and the preprocessor will panic when
+		// package values are already there that weren't
+		// yet predefined this time around.
+		if store != nil && pn.PkgPath != ".uverse" {
 			pv := pn.NewPackage() // temporary
 			store = store.Fork()
 			store.SetCachePackage(pv)

--- a/realm.go
+++ b/realm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	rdebug "runtime/debug"
 	"strings"
 )
 
@@ -363,6 +364,7 @@ func (rlm *Realm) processNewCreatedMarks(store Store) {
 	}
 	// Save new realm time.
 	if len(rlm.newCreated) > 0 {
+		fmt.Println("SETPACKAGEREALM")
 		store.SetPackageRealm(rlm)
 	}
 }
@@ -1371,6 +1373,10 @@ func (rlm *Realm) nextObjectID() ObjectID {
 	nxtid := ObjectID{
 		PkgID:   rlm.ID,
 		NewTime: rlm.Time, // starts at 1.
+	}
+	fmt.Println("NEXTID", nxtid, fmt.Sprintf("%p", rlm))
+	if false {
+		rdebug.PrintStack()
 	}
 	return nxtid
 }

--- a/realm.go
+++ b/realm.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	rdebug "runtime/debug"
 	"strings"
 )
 
@@ -364,7 +363,6 @@ func (rlm *Realm) processNewCreatedMarks(store Store) {
 	}
 	// Save new realm time.
 	if len(rlm.newCreated) > 0 {
-		fmt.Println("SETPACKAGEREALM")
 		store.SetPackageRealm(rlm)
 	}
 }
@@ -400,7 +398,7 @@ func (rlm *Realm) incRefCreatedDescendants(store Store, oo Object) {
 					panic("should not happen")
 				}
 			}
-			// package values are skipped.
+			// extern package values are skipped.
 			continue
 		}
 		child.IncRefCount()
@@ -1373,10 +1371,6 @@ func (rlm *Realm) nextObjectID() ObjectID {
 	nxtid := ObjectID{
 		PkgID:   rlm.ID,
 		NewTime: rlm.Time, // starts at 1.
-	}
-	fmt.Println("NEXTID", nxtid, fmt.Sprintf("%p", rlm))
-	if false {
-		rdebug.PrintStack()
 	}
 	return nxtid
 }

--- a/store.go
+++ b/store.go
@@ -544,12 +544,13 @@ func (ds *defaultStore) ClearObjectCache() {
 	if len(ds.current) > 0 {
 		ds.current = make(map[string]struct{})
 	}
+	ds.SetCachePackage(Uverse())
 }
 
 // Unstable.
 // This function is used to handle queries and checktx transactions.
 func (ds *defaultStore) Fork() Store {
-	return &defaultStore{
+	ds2 := &defaultStore{
 		pkgGetter:    ds.pkgGetter,
 		cacheObjects: make(map[ObjectID]Object), // new cache.
 		cacheTypes:   ds.cacheTypes,
@@ -560,6 +561,8 @@ func (ds *defaultStore) Fork() Store {
 		opslog:       nil, // new ops log.
 		current:      make(map[string]struct{}),
 	}
+	ds2.SetCachePackage(Uverse())
+	return ds2
 }
 
 // TODO: consider a better/faster/simpler way of achieving the overall same goal?

--- a/tests/imports_test.go
+++ b/tests/imports_test.go
@@ -48,7 +48,7 @@ import (
 )
 
 // NOTE: this isn't safe.
-func testStore(stdin io.Reader, stdout, stderr io.Writer, isRealm bool, nativeLibs bool) (store gno.Store) {
+func testStore(stdin io.Reader, stdout, stderr io.Writer, nativeLibs bool) (store gno.Store) {
 	filesPath := "./files"
 	if nativeLibs {
 		filesPath = "./files2"
@@ -63,14 +63,14 @@ func testStore(stdin io.Reader, stdout, stderr io.Writer, isRealm bool, nativeLi
 			baseDir := filepath.Join(filesPath, "extern", pkgPath[len(testPath):])
 			memPkg := gno.ReadMemPackage(baseDir, pkgPath)
 			m2 := gno.NewMachineWithOptions(gno.MachineOptions{
-				Package: nil,
+				PkgPath: "test",
 				Output:  stdout,
 				Store:   store,
 			})
 			// pkg := gno.NewPackageNode(gno.Name(memPkg.Name), memPkg.Path, nil)
 			// pv := pkg.NewPackage()
 			// m2.SetActivePackage(pv)
-			return m2.RunMemPackage(memPkg, isRealm) // XXX , false)?
+			return m2.RunMemPackage(memPkg, false)
 		}
 		// TODO: if isRealm, can we panic here?
 		// otherwise, built-in package value.
@@ -349,24 +349,24 @@ func testStore(stdin io.Reader, stdout, stderr io.Writer, isRealm bool, nativeLi
 		if osm.DirExists(stdlibPath) {
 			memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
 			m2 := gno.NewMachineWithOptions(gno.MachineOptions{
-				Package: nil,
+				PkgPath: "test",
 				Output:  stdout,
 				Store:   store,
 			})
-			return m2.RunMemPackage(memPkg, isRealm) // XXX , false)?
+			return m2.RunMemPackage(memPkg, true)
 		}
 		// if examples package...
 		examplePath := filepath.Join("../examples", pkgPath)
 		if osm.DirExists(examplePath) {
 			memPkg := gno.ReadMemPackage(examplePath, pkgPath)
 			m2 := gno.NewMachineWithOptions(gno.MachineOptions{
-				Package: nil,
+				PkgPath: "test",
 				Output:  stdout,
 				Store:   store,
 			})
-			return m2.RunMemPackage(memPkg, isRealm) // XXX , false)?
+			return m2.RunMemPackage(memPkg, true)
 		}
-		panic("unknown package path " + pkgPath)
+		return nil, nil
 	}
 	// NOTE: store is also used in closure above.
 	db := dbm.NewMemDB()

--- a/tests/package_test.go
+++ b/tests/package_test.go
@@ -60,15 +60,14 @@ func TestPackages(t *testing.T) {
 func runPackageTest(t *testing.T, dir string, path string) {
 	memPkg := gno.ReadMemPackage(dir, path)
 
-	isRealm := false // XXX try true too?
 	stdin := new(bytes.Buffer)
 	// stdout := new(bytes.Buffer)
 	stdout := os.Stdout
 	stderr := new(bytes.Buffer)
-	store := testStore(stdin, stdout, stderr, isRealm, false)
+	store := testStore(stdin, stdout, stderr, false)
 	store.SetLogStoreOps(true)
 	m := gno.NewMachineWithOptions(gno.MachineOptions{
-		Package: nil,
+		PkgPath: "test",
 		Output:  stdout,
 		Store:   store,
 		Context: nil,

--- a/types.go
+++ b/types.go
@@ -1277,9 +1277,8 @@ type DeclaredType struct {
 	Base    Type         // not a DeclaredType
 	Methods []TypedValue // {T:*FuncType,V:*FuncValue}...
 
-	typeid  TypeID
-	sealed  bool // for ensuring correctness with recursive types.
-	updated bool // for tracking new methods for preexisting types. // XXX remove
+	typeid TypeID
+	sealed bool // for ensuring correctness with recursive types.
 }
 
 // returns an unsealed *DeclaredType.
@@ -1290,7 +1289,6 @@ func declareWith(pkgPath string, name Name, b Type) *DeclaredType {
 		Name:    name,
 		Base:    baseOf(b),
 		sealed:  false,
-		updated: false,
 	}
 	return dt
 }
@@ -1353,7 +1351,6 @@ func (dt *DeclaredType) DefineMethod(fv *FuncValue) {
 		T: fv.Type,
 		V: fv,
 	})
-	dt.updated = true
 }
 
 func (dt *DeclaredType) GetPathForName(n Name) ValuePath {
@@ -1392,19 +1389,6 @@ func (dt *DeclaredType) GetUnboundPathForName(n Name) ValuePath {
 	panic(fmt.Sprintf(
 		"unknown *DeclaredType method named %s",
 		n))
-}
-
-// Returns the method declared onto dt.
-// Slow, for testing only.
-// XXX delete, since this doesn't fill closure etc?
-func (dt *DeclaredType) GetMethod(n Name) *FuncValue {
-	for i := 0; i < len(dt.Methods); i++ {
-		mv := &dt.Methods[i]
-		if fv := mv.GetFunc(); fv.Name == n {
-			return fv
-		}
-	}
-	return nil
 }
 
 // Searches embedded fields to find matching field or method.

--- a/types.go
+++ b/types.go
@@ -1291,7 +1291,7 @@ type DeclaredType struct {
 
 	typeid  TypeID
 	sealed  bool // for ensuring correctness with recursive types.
-	updated bool // for tracking new methods for preexisting types.
+	updated bool // for tracking new methods for preexisting types. // XXX remove
 }
 
 // returns an unsealed *DeclaredType.

--- a/types.go
+++ b/types.go
@@ -854,18 +854,6 @@ func (it *InterfaceType) Elem() Type {
 	panic("interface types have no elements")
 }
 
-// TODO: optimize
-// XXX DEPRECATED -- this is wrong, doesnot work with embedded types.
-func (it *InterfaceType) GetMethodType(n Name) *FuncType {
-	panic("DEPRECATED")
-	for _, im := range it.Methods {
-		if im.Name == n {
-			return im.Type.(*FuncType)
-		}
-	}
-	return nil
-}
-
 func (it *InterfaceType) FindEmbeddedFieldType(n Name, m map[Type]struct{}) (
 	trail []ValuePath, hasPtr bool, rcvr Type, ft Type) {
 
@@ -1407,7 +1395,8 @@ func (dt *DeclaredType) GetUnboundPathForName(n Name) ValuePath {
 }
 
 // Returns the method declared onto dt.
-// For embedded field methods, use FindEmbeddedFieldType().
+// Slow, for testing only.
+// XXX delete, since this doesn't fill closure etc?
 func (dt *DeclaredType) GetMethod(n Name) *FuncValue {
 	for i := 0; i < len(dt.Methods); i++ {
 		mv := &dt.Methods[i]
@@ -1472,47 +1461,52 @@ func (dt *DeclaredType) FindEmbeddedFieldType(n Name, m map[Type]struct{}) (
 	}
 }
 
-// The Preprocesses uses *DT.GetPathForName(name) to set the path, and also
-// *DT.GetMethod(name) to consult the type.  OpSelector uses
-// *TV.GetPointerTo(path), and for declared types, in turn uses
-// *DT.GetValueRefAt(path) to find any methods (see values.go).
-//
-// If the method is embedded (as a method of an embedded struct, or the
-// method of an embedded interface), then the current implementation in
-// preprocessor doesn't work, as it uses *DT.GetMethod(name), which uses
-// *DT.GetValueRef(name).
+// The Preprocesses uses *DT.FindEmbeddedFieldType() to set the path.
+// OpSelector uses *TV.GetPointerTo(path), and for declared types, in turn
+// uses *DT.GetValueAt(path) to find any methods (see values.go).
 //
 // i.e.,
-//  preprocessor: *DT.GetPathForName(name)
-//                *DT.GetMethod(name)
-//                 -> *DT.GetValueRef(name)
-//                *DT.GetValueRefAt(path) // from op_type/evalTypeOf()
+//  preprocessor: *DT.FindEmbeddedFieldType(name)
+//                *DT.GetValueAt(path) // from op_type/evalTypeOf()
 //
 //       runtime: *TV.GetPointerTo(path)
-//                 -> *DT.GetValueRefAt(path)
-//                     -> *DT.GetValueRef(name) // if interface
-//                     -> *DT.FindEmbeddedFieldType(name) // proposed
-// TODO: update above to visualize flow chart.
-//
-// NOTE: The preprocessor expands (elided) embedded field selectors.
-// NOTE: only works for local methods.
-func (dt *DeclaredType) GetValueRefAt(path ValuePath) *TypedValue {
+//                 -> *DT.GetValueAt(path)
+func (dt *DeclaredType) GetValueAt(store Store, path ValuePath) TypedValue {
 	switch path.Type {
 	case VPInterface:
 		panic("should not happen")
 		// should call *DT.FindEmbeddedFieldType(name) instead.
 		// tr, hp, rt, ft := dt.FindEmbeddedFieldType(n)
-	case VPValMethod, VPPtrMethod:
+	case VPValMethod, VPPtrMethod, VPField:
 		if path.Depth == 0 {
-			return &dt.Methods[path.Index]
+			mtv := dt.Methods[path.Index]
+			// Fill in *FV.Closure.
+			ft := mtv.T
+			fv := mtv.V.(*FuncValue).Copy()
+			fv.Closure = fv.GetClosure(store)
+			return TypedValue{T: ft, V: fv}
 		} else {
-			panic("DeclaredType.GetValueRefAt() expects depth == 0")
+			panic("DeclaredType.GetValueAt() expects depth == 0")
 		}
-	case VPField:
+	default:
+		panic(fmt.Sprintf(
+			"unexpected value path type %s",
+			path.String()))
+	}
+}
+
+// Like GetValueAt, but doesn't fill *FuncValue closures.
+func (dt *DeclaredType) GetStaticValueAt(path ValuePath) TypedValue {
+	switch path.Type {
+	case VPInterface:
+		panic("should not happen")
+		// should call *DT.FindEmbeddedFieldType(name) instead.
+		// tr, hp, rt, ft := dt.FindEmbeddedFieldType(n)
+	case VPValMethod, VPPtrMethod, VPField:
 		if path.Depth == 0 {
-			return &dt.Methods[path.Index]
+			return dt.Methods[path.Index]
 		} else {
-			panic("DeclaredType.GetValueRefAt() expects depth == 0")
+			panic("DeclaredType.GetStaticValueAt() expects depth == 0")
 		}
 	default:
 		panic(fmt.Sprintf(

--- a/uverse.go
+++ b/uverse.go
@@ -59,14 +59,17 @@ var gStringerType = &DeclaredType{
 // Uverse package
 
 var uverseNode *PackageNode
+var uverseValue *PackageValue
 
 const uversePkgPath = ".uverse"
 
 // Always returns a new copy from the latest state of source.
 func Uverse() *PackageValue {
-	pn := UverseNode()
-	pv := pn.NewPackage()
-	return pv
+	if uverseValue == nil {
+		pn := UverseNode()
+		uverseValue = pn.NewPackage()
+	}
+	return uverseValue
 }
 
 // Always returns the same instance with possibly differing completeness.

--- a/values.go
+++ b/values.go
@@ -523,16 +523,18 @@ func (fv *FuncValue) GetClosure(store Store) *Block {
 		if fv.FileName == "" {
 			return nil
 		} else {
-			// NOTE: *PackageNode.StaticBlock.Values static declared functions and
-			// in methods in *DeclaredType.Methods initially have zero closure,
+			// NOTE: *PackageNode.StaticBlock.Values static
+			// declared functions and in methods in
+			// *DeclaredType.Methods initially have zero closure,
 			// but get filled lazily here.
 			pv := fv.GetPackage(store)
 			fb := pv.fBlocksMap[fv.FileName]
 			if fb == nil {
 				panic(fmt.Sprintf("file block missing for file %q", fv.FileName))
 			}
-			// XXX cannot set closure without tripping up refcount counting,
-			// as we don't bump the ref count of closure block here.
+			// XXX cannot set closure without tripping up refcount
+			// counting, as we don't bump the ref count of closure
+			// block here.
 			// fv.Closure = fb
 			return fb
 		}

--- a/values.go
+++ b/values.go
@@ -455,7 +455,7 @@ type FuncValue struct {
 	IsMethod bool      // is an (unbound) method
 	Source   BlockNode // for block mem allocation
 	Name     Name      // name of function/method
-	Closure  Value     // *Block or RefValue to closure (a file's Block for unbound methods).
+	Closure  Value     // *Block or RefValue to closure (may be nil for file blocks; lazy)
 	FileName Name      // file name where declared
 	PkgPath  string
 
@@ -513,7 +513,7 @@ func (fv *FuncValue) GetSource(store Store) BlockNode {
 }
 
 func (fv *FuncValue) GetPackage(store Store) *PackageValue {
-	pv := store.GetPackage(fv.PkgPath)
+	pv := store.GetPackage(fv.PkgPath, false)
 	return pv
 }
 
@@ -531,7 +531,9 @@ func (fv *FuncValue) GetClosure(store Store) *Block {
 			if fb == nil {
 				panic(fmt.Sprintf("file block missing for file %q", fv.FileName))
 			}
-			fv.Closure = fb
+			// XXX cannot set closure without tripping up refcount counting,
+			// as we don't bump the ref count of closure block here.
+			// fv.Closure = fb
 			return fb
 		}
 	case RefValue:
@@ -755,11 +757,11 @@ func (pv *PackageValue) GetBlock(store Store) *Block {
 	}
 }
 
-func (pv *PackageValue) GetValueRefAt(store Store, path ValuePath) *TypedValue {
-	return pv.
+func (pv *PackageValue) GetValueAt(store Store, path ValuePath) TypedValue {
+	return *(pv.
 		GetBlock(store).
 		GetPointerTo(store, path).
-		TV
+		TV)
 }
 
 func (pv *PackageValue) AddFileBlock(fn Name, fb *Block) {
@@ -1565,13 +1567,15 @@ func (tv *TypedValue) GetPointerTo(store Store, path ValuePath) PointerValue {
 			switch t := dtv.V.(TypeValue).Type.(type) {
 			case *PointerType:
 				dt := t.Elt.(*DeclaredType)
+				tv := dt.GetValueAt(store, path)
 				return PointerValue{
-					TV:   dt.GetValueRefAt(path),
+					TV:   &tv, // heap alloc
 					Base: nil, // TODO: make TypeValue an object.
 				}
 			case *DeclaredType:
+				tv := t.GetValueAt(store, path)
 				return PointerValue{
-					TV:   t.GetValueRefAt(path),
+					TV:   &tv, // heap alloc
 					Base: nil, // TODO: make TypeValue an object.
 				}
 			case *NativeType:
@@ -1607,7 +1611,7 @@ func (tv *TypedValue) GetPointerTo(store Store, path ValuePath) PointerValue {
 		}
 	case VPValMethod:
 		dt := dtv.T.(*DeclaredType)
-		mtv := dt.GetValueRefAt(path)
+		mtv := dt.GetValueAt(store, path)
 		mv := mtv.GetFunc()
 		mt := mv.GetType(store)
 		if debug {
@@ -1631,7 +1635,7 @@ func (tv *TypedValue) GetPointerTo(store Store, path ValuePath) PointerValue {
 		dt := tv.T.(*PointerType).Elt.(*DeclaredType)
 		// ^ support nil receivers, vs:
 		// dt := dtv.T.(*DeclaredType)
-		mtv := dt.GetValueRefAt(path)
+		mtv := dt.GetValueAt(store, path)
 		mv := mtv.GetFunc()
 		mt := mv.GetType(store)
 		if debug {
@@ -2389,7 +2393,7 @@ func fillValueTV(store Store, tv *TypedValue) *TypedValue {
 	switch cv := tv.V.(type) {
 	case RefValue:
 		if cv.PkgPath != "" { // load package
-			tv.V = store.GetPackage(cv.PkgPath)
+			tv.V = store.GetPackage(cv.PkgPath, false)
 		} else { // load object
 			tv.V = store.GetObject(cv.ObjectID)
 		}

--- a/values.go
+++ b/values.go
@@ -517,25 +517,20 @@ func (fv *FuncValue) GetPackage(store Store) *PackageValue {
 	return pv
 }
 
+// NOTE: this function does not automatically memoize the closure for
+// file-level declared methods and functions. For those, caller
+// should set .Closure manually after *FuncValue.Copy().
 func (fv *FuncValue) GetClosure(store Store) *Block {
 	switch cv := fv.Closure.(type) {
 	case nil:
 		if fv.FileName == "" {
 			return nil
 		} else {
-			// NOTE: *PackageNode.StaticBlock.Values static
-			// declared functions and in methods in
-			// *DeclaredType.Methods initially have zero closure,
-			// but get filled lazily here.
 			pv := fv.GetPackage(store)
 			fb := pv.fBlocksMap[fv.FileName]
 			if fb == nil {
 				panic(fmt.Sprintf("file block missing for file %q", fv.FileName))
 			}
-			// XXX cannot set closure without tripping up refcount
-			// counting, as we don't bump the ref count of closure
-			// block here.
-			// fv.Closure = fb
 			return fb
 		}
 	case RefValue:


### PR DESCRIPTION
Discovered this issue while implementing store.Fork():

In short, the static *PackageNode includes references to *FuncValue for top-level functions and declared type methods, and these in turn hold references to *PackageValue which used to get set during PrepareNewValues(), but this creates a one-to-one pairing between static nodes and runtime package-values (and closure blocks).  This makes parallel usage of static nodes impossible, e.g. for concurrent checktx or query usage of nodes.

To solve this issue, this PR implements *FuncValue.GetPackage() and .GetClosure() to fetch the relevant package value from the store at runtime. This has a bit of ripple effect throughout the codebase, for example, now the store is more important than it used to be, so there are less cases where a nil store is allowed.

There are other ways to solve the pairing problem, but they are less elegant AFAIK.  For example, we could implement exec-local mapping of exec-context -> package value per *FuncValue (much like python's thread-local), but this is pretty ugly.  Another alternative approach is to implement PrepareNewValues() to copy the *FuncValue with pkg still associated, but this may have other unexpected issues -- function instance equality may fail (or at least, the same function may appear in multiple different *FuncValue instances, perhaps?), and it would also require duplicating each declared type and all of their method *FuncValues, which may be complicated especially by recursive usage of types (e.g. *MyType.Method(*MyType)), thus in the very least may require complex copying logic.

The only downside I see to the approach in this PR is that it isn't obvious how to make it optimal in speed, as it requires a store lookup, which probably in the very least requires a map lookup.  On the flip side, this approach appears to simplify things considerably.

TODO: finish making tests pass, and re-evaluate the result against above nodes.