### PR TITLE
chore: specify gno.land as default repo in realms' func web doc

### DIFF
--- a/gnoland/website/static/js/realm_funcs.js
+++ b/gnoland/website/static/js/realm_funcs.js
@@ -42,7 +42,7 @@ function updateCommand(x) {
 	shell.append(u("<span>").text(command)).append(u("<br>"));
 
 	// command 3: broadcast tx.
-	var args = ["gnokey", "broadcast", "signed.tx"];
+	var args = ["gnokey", "broadcast", "signed.tx", "--remote", "gno.land:36657"];
 	var command = args.join(" ");
 	command = command;
 	shell.append(u("<span>").text(command)).append(u("<br>"));


### PR DESCRIPTION
because I think that it's easier for devs to adapt their environment than for newcomers, and by doing this, I expect having less support to do :)