### PR TITLE
Persistent peer

### DIFF
--- a/cmd/gnoland/main.go
+++ b/cmd/gnoland/main.go
@@ -22,6 +22,7 @@ func main() {
 	cfg := config.LoadOrMakeConfigWithOptions(rootDir, func(cfg *config.Config) {
 		cfg.Consensus.CreateEmptyBlocks = false
 		cfg.Consensus.CreateEmptyBlocksInterval = 60 * time.Second
+		cfg.P2P.PersistentPeers = "g1vxgs9pdk6ql6290vhjrg8cxryyze7r6pz2nn6a@74.207.253.37:26656"
 	})
 
 	// create priv validator first.


### PR DESCRIPTION
Without testing gno on an actual network, it will be easier to miss bugs.  This PR adds a peer to config, and paves the way for others to add their peers to config.  This pattern is used by both Osmosis and Bitcoin to ensure that people can join the network easily, and saves a lot of time in syncs and development flow.
