### PR TITLE
ci: add a build CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  go-build:
+    name: Go Build
+    strategy:
+      fail-fast: false
+      matrix:
+        goversion: ["1.17.x"]
+        goarch: ["amd64"]
+        goos: ["linux"]
+        program: ["genproto", "gnofaucet", "gnokey", "gnoland", "gnotxport", "goscan", "gnodev"]
+        # fixme: add "gnoview"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v3
+      - name: install
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go install ./cmd/${{ matrix.program }}

--- a/cmd/gnofaucet/gnofaucet.go
+++ b/cmd/gnofaucet/gnofaucet.go
@@ -111,7 +111,7 @@ func serveApp(cmd *command.Command, args []string, iopts interface{}) error {
 	if err != nil {
 		return err
 	}
-	info, err := kb.Get(name)
+	info, err := kb.GetByName(name)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func sendAmountTo(cmd *command.Command, cli rpcclient.Client, name, pass string,
 	if err != nil {
 		return err
 	}
-	info, err := kb.Get(name)
+	info, err := kb.GetByName(name)
 	if err != nil {
 		return err
 	}

--- a/cmd/gnoview/main.go
+++ b/cmd/gnoview/main.go
@@ -26,7 +26,6 @@ func bootGnoland() (*gno.PackageValue, *bytes.Buffer) {
 	pn := gno.NewPackageNode("main", "gno.land/r/main", &gno.FileSet{})
 	pv := pn.NewPackage(rr)
 	rlm := pv.GetRealm()
-	rlm.SetLogRealmOps(true)
 	out := new(bytes.Buffer)
 	m := gno.NewMachineWithOptions(gno.MachineOptions{
 		Package:  pv,


### PR DESCRIPTION
This is a simple job that just ensures that everything is still building.

I’ll add more CI jobs after with various unit tests etc; but I prefer to discuss eventual details on the smallest one.

I also fixed the `gnofaucet` binary (h/t Jack Gu for finding the issue).

I started debugging the `gnoview` binary, but there are too many incompatibility issues, I prefer to disable it from the CI for now and let @jaekwon decide how this binary should be managed (fixes, full rewrite, etc).