### PR TITLE
WIP check for exposed or package path match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-all: gnoland gnokey goscan logos
-
+########################################
+# Dist suite
 .PHONY: logos goscan gnoland gnokey gnofaucet logos reset
+all: gnoland gnokey goscan logos
 
 reset:
 	rm -rf testdir
@@ -24,6 +25,7 @@ install_gnokey:
 	go install ./cmd/gnokey
 
 install_gnodev:
+	echo "Installing gnodev"
 	go install ./cmd/gnodev
 
 # The faucet (daemon)
@@ -45,6 +47,7 @@ logos:
 clean:
 	rm -rf build
 
+########################################
 # Test suite
 .PHONY: test test.go test.gno test.files1 test.files2 test.realm test.packages
 test: test.gno test.go

--- a/cmd/gnoland/main.go
+++ b/cmd/gnoland/main.go
@@ -134,7 +134,8 @@ func makeGenesisDoc(pvPub crypto.PubKey) *bft.GenesisDoc {
 			// NOTE: these are commented out and sent as SendTxs instead to keep account numbers aligned.
 			//"g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq=100000gnot", // @moul
 			//"g14da4n9hcynyzz83q607uu8keuh9hwlv42ra6fa=100000gnot", // !p2
-			//"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj=10000gnot", // @difranco
+			//"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj=100000gnot", // @difranco
+			//"g15gdm49ktawvkrl88jadqpucng37yxutucuwaef=100000gnot", // @
 		},
 	}
 	return gen

--- a/examples/gno.land/p/testutils/access.gno
+++ b/examples/gno.land/p/testutils/access.gno
@@ -1,0 +1,41 @@
+package testutils
+
+// for testing access. see tests/files/access*.go
+
+// NOTE: non-package variables cannot be overridden, except during init().
+var TestVar1 int
+var testVar2 int
+
+func init() {
+	TestVar1 = 123
+	testVar2 = 456
+}
+
+type TestAccessStruct struct {
+	PublicField  string
+	privateField string
+}
+
+func (tas TestAccessStruct) PublicMethod() string {
+	return tas.PublicField + "/" + tas.privateField
+}
+
+func (tas TestAccessStruct) privateMethod() string {
+	return tas.PublicField + "/" + tas.privateField
+}
+
+func NewTestAccessStruct(pub, priv string) TestAccessStruct {
+	return TestAccessStruct{
+		PublicField:  pub,
+		privateField: priv,
+	}
+}
+
+// see access6.g0 etc.
+type PrivateInterface interface {
+	privateMethod() string
+}
+
+func PrintPrivateInterface(pi PrivateInterface) {
+	println("testutils.PrintPrivateInterface", pi.privateMethod())
+}

--- a/examples/gno.land/p/testutils/misc.gno
+++ b/examples/gno.land/p/testutils/misc.gno
@@ -4,3 +4,13 @@ package testutils
 func WrapCall(fn func()) {
 	fn()
 }
+
+// for testing access.
+// NOTE: non-package variables cannot be overridden.
+var TestVar1 int
+var testVar2 int
+
+func init() {
+	TestVar1 = 123
+	testVar2 = 456
+}

--- a/gonative_test.go
+++ b/gonative_test.go
@@ -102,7 +102,7 @@ func TestGoNativeDefine3(t *testing.T) {
 	out := new(bytes.Buffer)
 	pkg := NewPackageNode("foo", "test.foo", nil)
 	pkg.DefineGoNativeType(reflect.TypeOf(Foo{}))
-	pkg.DefineGoNativeValue("printFoo", func(f Foo) {
+	pkg.DefineGoNativeValue("PrintFoo", func(f Foo) {
 		out.Write([]byte(fmt.Sprintf("A: %v\n", f.A)))
 		out.Write([]byte(fmt.Sprintf("B: %v\n", f.B)))
 		out.Write([]byte(fmt.Sprintf("C: %v\n", f.C)))
@@ -122,7 +122,7 @@ func TestGoNativeDefine3(t *testing.T) {
 import foo "test.foo"
 func main() {
 	f := foo.Foo{A:1}
-	foo.printFoo(f)
+	foo.PrintFoo(f)
 }`
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)

--- a/op_types.go
+++ b/op_types.go
@@ -392,7 +392,7 @@ func (m *Machine) doOpStaticTypeOf() {
 			mt := ft.BoundType()
 			m.PushValue(asValue(mt))
 		case VPInterface:
-			_, _, _, ft := findEmbeddedFieldType(dxt, path.Name, nil)
+			_, _, _, ft, _ := findEmbeddedFieldType(dxt.GetPkgPath(), dxt, path.Name, nil)
 			m.PushValue(asValue(ft))
 		case VPNative:
 			// if dxt is *PointerType, convert to *NativeType.

--- a/tests/files/access0.gno
+++ b/tests/files/access0.gno
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	println(testutils.TestVar1)
+}
+
+// Output:
+// 123

--- a/tests/files/access1.gno
+++ b/tests/files/access1.gno
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	println(testutils.testVar2)
+}
+
+// Error:
+// cannot access gno.land/p/testutils.testVar2 from main

--- a/tests/files/access2.gno
+++ b/tests/files/access2.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/access_test
+package access_test
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	testutils.TestVar1 += 1
+	println(testutils.TestVar1)
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/tests/files/access3.gno
+++ b/tests/files/access3.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.PublicField)
+}
+
+// Output:
+// PUB

--- a/tests/files/access4.gno
+++ b/tests/files/access4.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.privateField)
+}
+
+// Error:
+// cannot access gno.land/p/testutils.TestAccessStruct.privateField from main

--- a/tests/files/access5.gno
+++ b/tests/files/access5.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.PublicMethod())
+}
+
+// Output:
+// PUB/PRIV

--- a/tests/files/access6.gno
+++ b/tests/files/access6.gno
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+type mystruct struct{}
+
+func (_ mystruct) privateMethod() string {
+	return "mystruct.privateMethod"
+}
+
+func main() {
+	x := mystruct{}
+	testutils.PrintPrivateInterface(x)
+}
+
+// Error:
+// main.mystruct does not implement gno.land/p/testutils.PrivateInterface

--- a/tests/files/access7.gno
+++ b/tests/files/access7.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+type mystruct struct{}
+
+func (_ mystruct) privateMethod() string {
+	return "mystruct.privateMethod"
+}
+
+type PrivateInterface2 interface {
+	privateMethod() string
+}
+
+func main() {
+	var x PrivateInterface2 = mystruct{}
+	testutils.PrintPrivateInterface(x)
+}
+
+// Error:
+// main.PrivateInterface2 does not implement gno.land/p/testutils.PrivateInterface

--- a/tests/files2/access0.gno
+++ b/tests/files2/access0.gno
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	println(testutils.TestVar1)
+}
+
+// Output:
+// 123

--- a/tests/files2/access1.gno
+++ b/tests/files2/access1.gno
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	println(testutils.testVar2)
+}
+
+// Error:
+// cannot access gno.land/p/testutils.testVar2 from main

--- a/tests/files2/access2.gno
+++ b/tests/files2/access2.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/access_test
+package access_test
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	testutils.TestVar1 += 1
+	println(testutils.TestVar1)
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/tests/files2/access3.gno
+++ b/tests/files2/access3.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.PublicField)
+}
+
+// Output:
+// PUB

--- a/tests/files2/access4.gno
+++ b/tests/files2/access4.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.privateField)
+}
+
+// Error:
+// cannot access gno.land/p/testutils.TestAccessStruct.privateField from main

--- a/tests/files2/access5.gno
+++ b/tests/files2/access5.gno
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+func main() {
+	x := testutils.NewTestAccessStruct("PUB", "PRIV")
+	println(x.PublicMethod())
+}
+
+// Output:
+// PUB/PRIV

--- a/tests/files2/access6.gno
+++ b/tests/files2/access6.gno
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+type mystruct struct{}
+
+func (_ mystruct) privateMethod() string {
+	return "mystruct.privateMethod"
+}
+
+func main() {
+	x := mystruct{}
+	testutils.PrintPrivateInterface(x)
+}
+
+// Error:
+// main.mystruct does not implement gno.land/p/testutils.PrivateInterface

--- a/tests/files2/access7.gno
+++ b/tests/files2/access7.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"gno.land/p/testutils"
+)
+
+type mystruct struct{}
+
+func (_ mystruct) privateMethod() string {
+	return "mystruct.privateMethod"
+}
+
+type PrivateInterface2 interface {
+	privateMethod() string
+}
+
+func main() {
+	var x PrivateInterface2 = mystruct{}
+	testutils.PrintPrivateInterface(x)
+}
+
+// Error:
+// main.PrivateInterface2 does not implement gno.land/p/testutils.PrivateInterface

--- a/values.go
+++ b/values.go
@@ -1629,7 +1629,8 @@ func (tv *TypedValue) GetPointerTo(alloc *Allocator, store Store, path ValuePath
 		if dtv.IsUndefined() {
 			panic("interface method call on undefined value")
 		}
-		tr, _, _, _ := findEmbeddedFieldType(dtv.T, path.Name, nil)
+		callerPath := dtv.T.GetPkgPath()
+		tr, _, _, _, _ := findEmbeddedFieldType(callerPath, dtv.T, path.Name, nil)
 		if len(tr) == 0 {
 			panic(fmt.Sprintf("method %s not found in type %s",
 				path.Name, dtv.T.String()))


### PR DESCRIPTION
this is something that the Go precompiler would catch, but it isn't expensive to check with logic, so it is done here.
this will also be relevant for what may become an implementation of package versions.