### PR TITLE
chore: tell GitHub that .gno files can be rendered as go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gno linguist-language=Go


### PR DESCRIPTION
I think that some editors will also follow this.

---

I plan to open a PR on github/linguist to improve GitHub support (stats, search engine, filters, etc); this will take longer than I expected because they have some unmatched requirements (https://github.com/github/linguist/blob/master/CONTRIBUTING.md#adding-an-extension-to-a-language=)
