### PR TITLE
WIP: fixing some nondeterministic tests

### DIFF
--- a/pkgs/p2p/switch_test.go
+++ b/pkgs/p2p/switch_test.go
@@ -417,7 +417,7 @@ func TestSwitchReconnectsToInboundPersistentPeer(t *testing.T) {
 
 	conn, err := rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	require.NotNil(t, sw.Peers().Get(rp.ID()))
 
 	conn.Close()
@@ -501,7 +501,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 			}
 		}(c)
 	}
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, cfg.MaxNumInboundPeers, sw.Peers().Size())
 
 	// 2. check we close new connections if we already have MaxNumInboundPeers peers
@@ -511,7 +511,7 @@ func TestSwitchAcceptRoutine(t *testing.T) {
 	require.NoError(t, err)
 	// check conn is closed
 	one := make([]byte, 1)
-	conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 	_, err = conn.Read(one)
 	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, cfg.MaxNumInboundPeers, sw.Peers().Size())
@@ -614,7 +614,7 @@ func TestSwitchInitPeerIsNotCalledBeforeRemovePeer(t *testing.T) {
 	_, err = rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
 	// wait till the switch adds rp to the peer set
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// stop peer asynchronously
 	go sw.StopPeerForError(sw.Peers().Get(rp.ID()), "test")
@@ -623,7 +623,7 @@ func TestSwitchInitPeerIsNotCalledBeforeRemovePeer(t *testing.T) {
 	_, err = rp.Dial(sw.NetAddress())
 	require.NoError(t, err)
 	// wait till the switch adds rp to the peer set
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// make sure reactor.RemovePeer is finished before InitPeer is called
 	assert.False(t, reactor.InitCalledBeforeRemoveFinished())

--- a/pkgs/p2p/transport_test.go
+++ b/pkgs/p2p/transport_test.go
@@ -97,7 +97,7 @@ func TestTransportMultiplexConnFilterTimeout(t *testing.T) {
 	MultiplexTransportFilterTimeout(5 * time.Millisecond)(mt)
 	MultiplexTransportConnFilters(
 		func(_ ConnSet, _ net.Conn, _ []net.IP) error {
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			return nil
 		},
 	)(mt)
@@ -236,18 +236,18 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 		select {
 		case <-fastc:
 			// Fast peer connected.
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			// We error if the fast peer didn't succeed.
 			errc <- fmt.Errorf("Fast peer timed out")
 		}
 
-		sc, err := upgradeSecretConn(c, 20*time.Millisecond, ed25519.GenPrivKey())
+		sc, err := upgradeSecretConn(c, 100*time.Millisecond, ed25519.GenPrivKey())
 		if err != nil {
 			errc <- err
 			return
 		}
 
-		_, err = handshake(sc, 20*time.Millisecond,
+		_, err = handshake(sc, 100*time.Millisecond,
 			testNodeInfo(
 				ed25519.GenPrivKey().PubKey().Address().ID(),
 				"slow_peer",
@@ -548,7 +548,7 @@ func TestTransportHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ni, err := handshake(c, 20*time.Millisecond, emptyNodeInfo())
+	ni, err := handshake(c, 100*time.Millisecond, emptyNodeInfo())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
From https://github.com/moul/gno/runs/6054431723?check_suite_focus=true

 - [x] fix TestTransportMultiplexAcceptNonBlocking
 - [ ] fix TestSignerVoteKeepAlive

The timeout based tests are definitely a problem.
The privval socket system maybe requires a redo, or merging fixes from mainline tendermint at some point.
The p2p/transport system is also pretty confusing. 

This PR can stay open while we find more issues.