### PR TITLE
chore: prevent running CI when unnecessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build
 
 on:
   pull_request:
+    paths:
+      - "**.go"
+      - "**.gno"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/build.yml"
   push:
     branches:
       - master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,13 @@ name: Tests
 
 on:
   pull_request:
+    paths:
+      - "**.go"
+      - "**.gno"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/unit-tests.yml"
+      - "Makefile"
   push:
     branches:
       - master
@@ -14,16 +21,10 @@ jobs:
       matrix:
         goversion: ["1.17.x", "1.18.x"]
         args:
-          - ./tests/*.go -test.short -run "TestFileStr|TestPackages|TestSelectors" --timeout 20m
-          - ./tests/*.go -test.short -run "TestFiles1" --timeout 20m
-          - ./tests/*.go -test.short -run "TestFiles2" --timeout 20m
-          - ./tests/*.go -run "TestFiles/^zrealm" --timeout 20m
-          - ./tests/*.go -run "TestFiles1/^zrealm" --timeout 20m
-          - ./tests/*.go -run "TestFiles2/^zrealm" --timeout 20m
-          - ./tests/*.go -run "TestPackages" --timeout 20m
-          # temporarily disable the pkgs/... tests because some tests are flappy and
-          # we need to choose a good strategy to manage them.
-          # - ./pkgs/... -p 1 -count 1 --timeout 20m
+          - test.go
+          - test.files1
+          - test.files2
+          - test.packages
     runs-on: ubuntu-latest
     timeout-minutes: 21
     steps:
@@ -32,4 +33,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
       - name: test
-        run: go test ${{ matrix.args }}
+        run: make ${{ matrix.args }}


### PR DESCRIPTION
* [x] avoid running CI when unnecessary (example -> https://github.com/gnolang/gno/pull/134)
* [x] refactor `unit-tests` actions to use the Makefile rules
