### PR TITLE
chore: move the grc721 interface in p/grc/

### DIFF
--- a/examples/gno.land/p/grc/grc721/grc721.gno
+++ b/examples/gno.land/p/grc/grc721/grc721.gno
@@ -1,0 +1,34 @@
+package grc721
+
+import "std"
+
+type GRC721 interface {
+	BalanceOf(owner std.Address) (count int64)
+	OwnerOf(tid TokenID) std.Address
+	SafeTransferFrom(from, to std.Address, tid TokenID)
+	TransferFrom(from, to std.Address, tid TokenID)
+	Approve(approved std.Address, tid TokenID)
+	SetApprovalForAll(operator std.Address, approved bool)
+	GetApproved(tid TokenID) std.Address
+	IsApprovedForAll(owner, operator std.Address) bool
+}
+
+type TokenID string
+
+type TransferEvent struct {
+	From    std.Address
+	To      std.Address
+	TokenID TokenID
+}
+
+type ApprovalEvent struct {
+	Owner    std.Address
+	Approved std.Address
+	TokenID  TokenID
+}
+
+type ApprovalForAllEvent struct {
+	Owner    std.Address
+	Operator std.Address
+	Approved bool
+}

--- a/examples/gno.land/r/nft/nft.gno
+++ b/examples/gno.land/r/nft/nft.gno
@@ -5,72 +5,35 @@ import (
 	"strconv"
 
 	"gno.land/p/avl"
+	igrc721 "gno.land/p/grc/grc721"
 )
 
-//----------------------------------------
-// types
+type grc721 struct {
+	igrc721.GRC721 // implements the GRC721 interface
 
-type TokenID string
-
-type GRC721 interface {
-	BalanceOf(owner std.Address) (count int64)
-	OwnerOf(tid TokenID) std.Address
-	SafeTransferFrom(from, to std.Address, tid TokenID)
-	TransferFrom(from, to std.Address, tid TokenID)
-	Approve(approved std.Address, tid TokenID)
-	SetApprovalForAll(operator std.Address, approved bool)
-	GetApproved(tid TokenID) std.Address
-	IsApprovedForAll(owner, operator std.Address) bool
-}
-
-// TODO use
-type TransferEvent struct {
-	From    std.Address
-	To      std.Address
-	TokenID TokenID
-}
-
-// TODO use
-type ApprovalEvent struct {
-	Owner    std.Address
-	Approved std.Address
-	TokenID  TokenID
-}
-
-// TODO use
-type ApprovalForAllEvent struct {
-	Owner    std.Address
-	Operator std.Address
-	Approved bool
+	tokenCounter int
+	tokens       *avl.Tree // igrc721.TokenID -> *NFToken{}
+	operators    *avl.Tree // owner std.Address -> operator std.Address
 }
 
 type NFToken struct {
 	owner    std.Address
 	approved std.Address
-	tokenID  TokenID
+	tokenID  igrc721.TokenID
 	data     string
-}
-
-//----------------------------------------
-// impl
-
-type grc721 struct {
-	tokenCounter int
-	tokens       *avl.Tree // TokenID -> *NFToken{}
-	operators    *avl.Tree // owner std.Address -> operator std.Address
 }
 
 var gGRC721 = &grc721{}
 
 func GetGRC721() *grc721 { return gGRC721 }
 
-func (grc *grc721) nextTokenID() TokenID {
+func (grc *grc721) nextTokenID() igrc721.TokenID {
 	grc.tokenCounter++
 	s := strconv.Itoa(grc.tokenCounter)
-	return TokenID(s)
+	return igrc721.TokenID(s)
 }
 
-func (grc *grc721) getToken(tid TokenID) (*NFToken, bool) {
+func (grc *grc721) getToken(tid igrc721.TokenID) (*NFToken, bool) {
 	_, token, ok := grc.tokens.Get(string(tid))
 	if !ok {
 		return nil, false
@@ -78,7 +41,7 @@ func (grc *grc721) getToken(tid TokenID) (*NFToken, bool) {
 	return token.(*NFToken), true
 }
 
-func (grc *grc721) Mint(to std.Address, data string) TokenID {
+func (grc *grc721) Mint(to std.Address, data string) igrc721.TokenID {
 	tid := grc.nextTokenID()
 	newTokens, _ := grc.tokens.Set(string(tid), &NFToken{
 		owner:   to,
@@ -93,7 +56,7 @@ func (grc *grc721) BalanceOf(owner std.Address) (count int64) {
 	panic("not yet implemented")
 }
 
-func (grc *grc721) OwnerOf(tid TokenID) std.Address {
+func (grc *grc721) OwnerOf(tid igrc721.TokenID) std.Address {
 	token, ok := grc.getToken(tid)
 	if !ok {
 		panic("token does not exist")
@@ -102,7 +65,7 @@ func (grc *grc721) OwnerOf(tid TokenID) std.Address {
 }
 
 // XXX not fully implemented yet.
-func (grc *grc721) SafeTransferFrom(from, to std.Address, tid TokenID) {
+func (grc *grc721) SafeTransferFrom(from, to std.Address, tid igrc721.TokenID) {
 	grc.TransferFrom(from, to, tid)
 	// When transfer is complete, this function checks if `_to` is a smart
 	// contract (code size > 0). If so, it calls `onERC721Received` on
@@ -111,7 +74,7 @@ func (grc *grc721) SafeTransferFrom(from, to std.Address, tid TokenID) {
 	// XXX ensure "to" is a realm with onERC721Received() signature.
 }
 
-func (grc *grc721) TransferFrom(from, to std.Address, tid TokenID) {
+func (grc *grc721) TransferFrom(from, to std.Address, tid igrc721.TokenID) {
 	caller := std.GetCallerAt(2)
 	token, ok := grc.getToken(tid)
 	// Throws if `_tokenId` is not a valid NFT.
@@ -138,7 +101,7 @@ func (grc *grc721) TransferFrom(from, to std.Address, tid TokenID) {
 	token.owner = to
 }
 
-func (grc *grc721) Approve(approved std.Address, tid TokenID) {
+func (grc *grc721) Approve(approved std.Address, tid igrc721.TokenID) {
 	caller := std.GetCallerAt(2)
 	token, ok := grc.getToken(tid)
 	// Throws if `_tokenId` is not a valid NFT.
@@ -164,7 +127,7 @@ func (grc *grc721) SetApprovalForAll(operator std.Address, approved bool) {
 	grc.operators = newOperators
 }
 
-func (grc *grc721) GetApproved(tid TokenID) std.Address {
+func (grc *grc721) GetApproved(tid igrc721.TokenID) std.Address {
 	token, ok := grc.getToken(tid)
 	// Throws if `_tokenId` is not a valid NFT.
 	if !ok {

--- a/tests/files2/zrealm_nft0.gno
+++ b/tests/files2/zrealm_nft0.gno
@@ -43,7 +43,7 @@ func main() {
 //         {
 //             "T": {
 //                 "@type": "/gno.tref",
-//                 "ID": "gno.land/r/nft.TokenID"
+//                 "ID": "gno.land/p/grc/grc721.TokenID"
 //             },
 //             "V": {
 //                 "@type": "/gno.vstr",
@@ -99,7 +99,7 @@ func main() {
 //                     },
 //                     "V": {
 //                         "@type": "/gno.vref",
-//                         "Hash": "d6f02aad674df014ea8e7057d28f345b8185fd91",
+//                         "Hash": "cfbadf6a2492396ea5e3703c57ad9503d423cf16",
 //                         "ObjectID": "6bde79a5f04d2658d17cbc323e45df5fad216511:6"
 //                     }
 //                 }
@@ -146,6 +146,7 @@ func main() {
 // }
 // u[6bde79a5f04d2658d17cbc323e45df5fad216511:4]={
 //     "Fields": [
+//         {},
 //         {
 //             "N": "AQAAAAAAAAA=",
 //             "T": {
@@ -172,7 +173,7 @@ func main() {
 //                     },
 //                     "V": {
 //                         "@type": "/gno.vref",
-//                         "Hash": "5bc850fde6b94814d4ab7aac069a70adb6d90ab2",
+//                         "Hash": "97fc33e7e42903156d9bbbf78a0ede94ac6efd24",
 //                         "ObjectID": "6bde79a5f04d2658d17cbc323e45df5fad216511:5"
 //                     }
 //                 }


### PR DESCRIPTION
this PR does not bring real value to the NFT package itself, but intend to introduce the concept of having interfaces for common standards available from the `gno.land/p/grc/*` packages.

the concept becomes more interesting as soon as we have more than one, which is the case with #136 that introduces the GRC20

is it okay to go this way or better reducing the amount of imports and not a problem to mix implementation and interfaces for such standards?