### PR TITLE
chore: support setting --home with GNO_HOME env var

### DIFF
--- a/pkgs/crypto/keys/client/options.go
+++ b/pkgs/crypto/keys/client/options.go
@@ -1,5 +1,7 @@
 package client
 
+import "os"
+
 type BaseOptions struct {
 	Home   string `flag:"home" help:"home directory"`
 	Remote string `flag:"remote" help:"remote node URL (default 127.0.0.1:26657)"`
@@ -7,7 +9,7 @@ type BaseOptions struct {
 }
 
 var DefaultBaseOptions = BaseOptions{
-	Home:   "",
+	Home:   os.Getenv("GNO_HOME"),
 	Remote: "127.0.0.1:26657",
 	Quiet:  false,
 }


### PR DESCRIPTION
It's the only flag I systematically append to the commands generated by the
help page.

I'm not sure how relevant it could be to support more variables like this, and
potentially how unsafe it could be, so I limited this PR to this one for now.