### PR TITLE
chore: --home default option: $HOME/.gno

### DIFF
--- a/pkgs/crypto/keys/client/options.go
+++ b/pkgs/crypto/keys/client/options.go
@@ -1,5 +1,10 @@
 package client
 
+import (
+	"fmt"
+	"os"
+)
+
 type BaseOptions struct {
 	Home   string `flag:"home" help:"home directory"`
 	Remote string `flag:"remote" help:"remote node URL (default 127.0.0.1:26657)"`
@@ -7,7 +12,15 @@ type BaseOptions struct {
 }
 
 var DefaultBaseOptions = BaseOptions{
-	Home:   "",
+	Home:   homeDir(),
 	Remote: "127.0.0.1:26657",
 	Quiet:  false,
+}
+
+func homeDir() string {
+	hd, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s/.gno", hd)
 }


### PR DESCRIPTION
IMHO, I think that `$HOME/.gno` is sufficient as the default for the Home directory(`--home`).  `:-)`

```
$ gnokey list --help
# BaseOptions options
- home (string) - home directory (default /Users/anarch/.gno)
- remote (string) - remote node URL (default 127.0.0.1:26657) (default 127.0.0.1:26657)
- quiet (bool) - for parsing output

# ListOptions options
```
