### PR TITLE
chore: `/r/boards` example updates

### DIFF
--- a/examples/gno.land/r/boards/README.md
+++ b/examples/gno.land/r/boards/README.md
@@ -66,13 +66,13 @@ Next, query for the permanent board ID by querying (you need this to create a ne
 
 ```bash
 ./build/gnokey query "vm/qeval" --data "gno.land/r/boards
-GetBoardIDFromName(\"BOARDNAME\")"
+GetBoardIDFromName(\"BOARDNAME\")" --remote gno.land:36657
 ```
 
 ### Create a post of a board with a smart contract call.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func CreatePost --args 1 --args "Hello World" --args#file "./examples/gno.land/r/boards/README.md" --gas-fee 1gnot --gas-wanted 2000000 > createpost.unsigned.txt
+./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreatePost" --args BOARD_ID --args "Hello World" --args\#file "./examples/gno.land/r/boards/README.md" --gas-fee 1gnot --gas-wanted 2000000 > createpost.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createpost.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createpost.signed.txt
 ./build/gnokey broadcast createpost.signed.txt --remote gno.land:36657
 ```
@@ -80,14 +80,14 @@ GetBoardIDFromName(\"BOARDNAME\")"
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func CreateReply --args 1 --args 1 --args "A comment" --gas-fee 1gnot --gas-wanted 2000000 > createcomment.unsigned.txt
+./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "A comment" --gas-fee 1gnot --gas-wanted 2100000 > createcomment.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createcomment.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createcomment.signed.txt
 ./build/gnokey broadcast createcomment.signed.txt --remote gno.land:36657
 ```
 
 ```bash
 ./build/gnokey query "vm/qrender" --data "gno.land/r/boards
-gnolang/1"
+gnolang/1" --remote gno.land:36657
 ```
 
 ### Render page with optional path expression.

--- a/examples/gno.land/r/boards/README.md
+++ b/examples/gno.land/r/boards/README.md
@@ -5,7 +5,7 @@ name ["gno.land/r/boards"](https://gno.land/r/boards/)
 
 
 
-## Build `gnokey`, create your account, and interract with Gno.
+## Build `gnokey`, create your account, and interact with Gno.
 
 NOTE: Where you see `--remote gno.land:36657` here, that flag can be replaced
 with `--remote localhost:26657` for local testnets.
@@ -40,7 +40,7 @@ NOTE: `KEYNAME` is your key identifier, and should be changed.
 ./build/gnokey list
 ```
 
-## Interract with the blockchain:
+## Interact with the blockchain:
 
 ### Get your current balance, account number, and sequence number.
 

--- a/examples/gno.land/r/boards/README.md
+++ b/examples/gno.land/r/boards/README.md
@@ -80,7 +80,7 @@ GetBoardIDFromName(\"BOARDNAME\")" --remote gno.land:36657
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "A comment" --gas-fee 1gnot --gas-wanted 2100000 > createcomment.unsigned.txt
+./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "A comment" --gas-fee 1gnot --gas-wanted 2000000 > createcomment.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createcomment.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createcomment.signed.txt
 ./build/gnokey broadcast createcomment.signed.txt --remote gno.land:36657
 ```

--- a/examples/gno.land/r/boards/README.md
+++ b/examples/gno.land/r/boards/README.md
@@ -56,6 +56,8 @@ Go to https://gno.land/faucet
 
 ### Create a board with a smart contract call.
 
+NOTE: `BOARDNAME` will be the slug of the board, and should be changed.
+
 ```bash
 ./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func CreateBoard --args "BOARDNAME" --gas-fee 1gnot --gas-wanted 2000000 > createboard.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createboard.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createboard.signed.txt
@@ -71,23 +73,27 @@ GetBoardIDFromName(\"BOARDNAME\")" --remote gno.land:36657
 
 ### Create a post of a board with a smart contract call.
 
+NOTE: If a board was created successfully, your SEQUENCE_NUMBER would have increased.
+
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreatePost" --args BOARD_ID --args "Hello World" --args\#file "./examples/gno.land/r/boards/README.md" --gas-fee 1gnot --gas-wanted 2000000 > createpost.unsigned.txt
+./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreatePost" --args BOARD_ID --args "Hello gno.land" --args\#file "./examples/gno.land/r/boards/example_post.md" --gas-fee 1gnot --gas-wanted 2000000 > createpost.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createpost.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createpost.signed.txt
 ./build/gnokey broadcast createpost.signed.txt --remote gno.land:36657
 ```
 
 ### Create a comment to a post.
 
+NOTE: If a post was created successfully, your SEQUENCE_NUMBER would have increased again.
+
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "A comment" --gas-fee 1gnot --gas-wanted 2000000 > createcomment.unsigned.txt
+./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "Nice to meet you too!" --gas-fee 1gnot --gas-wanted 2000000 > createcomment.unsigned.txt
 ./build/gnokey sign KEYNAME --txpath createcomment.unsigned.txt --chainid "testchain" --number ACCOUNT_NUMBER --sequence SEQUENCE_NUMBER > createcomment.signed.txt
 ./build/gnokey broadcast createcomment.signed.txt --remote gno.land:36657
 ```
 
 ```bash
 ./build/gnokey query "vm/qrender" --data "gno.land/r/boards
-gnolang/1" --remote gno.land:36657
+BOARDNAME/1" --remote gno.land:36657
 ```
 
 ### Render page with optional path expression.

--- a/examples/gno.land/r/boards/example_post.md
+++ b/examples/gno.land/r/boards/example_post.md
@@ -1,0 +1,3 @@
+Hey all! 👋
+
+This is my first post in this land!

--- a/examples/gno.land/r/nft/README.md
+++ b/examples/gno.land/r/nft/README.md
@@ -4,7 +4,7 @@ I read over EIP-721 which appears to be the de-facto NFT standard on Ethereum. T
 
  - [EIP-721](https://eips.ethereum.org/EIPS/eip-721)
  - [gno.land/r/nft/nft.go](https://gno.land/r/nft/nft.go)
- - [zrealm_nft3.go test](https://github.com/gnolang/gno/blob/master/tests/files2/zrealm_nft3.go)
+ - [zrealm_nft3.go test](https://github.com/gnolang/gno/blob/master/tests/files2/zrealm_nft3.gno)
 
 In short, this demonstrates how to implement Ethereum contract interfaces in Gno.land; by using only standard Go language features.
 


### PR DESCRIPTION
👋 GNOmes! This PR hopefully makes it easier for newcomers to interact with the board examples. Deets:

* `CreatePost` - Loading MD from file now works on `bash` and `zsh`.
* `CreateReply` - Updates command with more arguments.
* Adds missing `--remote` flags in a couple of spots.
* Clarifies that some IDs need to be replaced in the examples (eg: board
  ID).