### PR TITLE
chore: Add dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.18.1 as build
+
+RUN mkdir /opt/src /opt/build
+ADD . /opt/src/
+ADD . /opt/build/
+WORKDIR /opt/build
+RUN make
+
+
+FROM debian:stable-slim
+
+COPY --from=build /opt/build/build/* /opt/gno/bin/
+COPY --from=build /opt/src /opt/gno/src
+ENV PATH="${PATH}:/opt/gno/bin"
+WORKDIR /opt/gno/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+services:
+  gnonode:
+    container_name: gnoland-node
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - LOG_LEVEL=4
+    command: [ "gnoland" ]
+    volumes:
+      - "gnonode:/opt/gno/src/testdir"
+    networks:
+      - gnonode
+    restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "100m"
+
+networks:
+  gnonode: {}
+volumes:
+  gnonode: {}


### PR DESCRIPTION
Add Dockerfile and docker-compose to run local node.
This could be useful if there are golang version conflicts on the host running the node.
To save state between runs we use "named volume"
Environment variables right now aren't used but were added for future necessities.