### PR TITLE
chore(vm): fix a crash when requesting a missing file

### DIFF
--- a/pkgs/sdk/vm/keeper.go
+++ b/pkgs/sdk/vm/keeper.go
@@ -407,7 +407,7 @@ func (vm *VMKeeper) QueryFile(ctx sdk.Context, filepath string) (res string, err
 	if filename != "" {
 		memFile := store.GetMemFile(dirpath, filename)
 		if memFile == nil {
-			return "", fmt.Errorf("file %s is not available", filepath)
+			return "", fmt.Errorf("file %q is not available", filepath) // TODO: XSS protection
 		}
 		return memFile.Body, nil
 	} else {

--- a/pkgs/sdk/vm/keeper.go
+++ b/pkgs/sdk/vm/keeper.go
@@ -406,6 +406,9 @@ func (vm *VMKeeper) QueryFile(ctx sdk.Context, filepath string) (res string, err
 	dirpath, filename := std.SplitFilepath(filepath)
 	if filename != "" {
 		memFile := store.GetMemFile(dirpath, filename)
+		if memFile == nil {
+			return "", fmt.Errorf("file %s is not available", filepath)
+		}
 		return memFile.Body, nil
 	} else {
 		memPkg := store.GetMemPackage(dirpath)


### PR DESCRIPTION
We could test it using the web-interface. Open a file: https://gno.land/r/boards/missing.txt (or http://127.0.0.1:8888/r/boards/missing.txt on a local node).

Before:

```
RPC error -32603 - Internal error: runtime error: invalid memory address or nil pointer dereference
```

After:

```
file gno.land/r/boards/missing.txt is not available
```

Closes #171