### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/*
 *.log.*
 *.log
 *.gno.gen.go
+.vscode
+.idea


### PR DESCRIPTION
This PR adds .vscode and .idea to .gitignore to ensure those don't get added to patches by git. 