### PR TITLE
There is a problem that gnoland cannot be run after a completely new clone

### DIFF
--- a/cmd/gnoland/main.go
+++ b/cmd/gnoland/main.go
@@ -162,8 +162,8 @@ func makeGenesisDoc(pvPub crypto.PubKey) *bft.GenesisDoc {
 		"p/grc/grc20/impl",
 		"p/grc/grc721",
 		"p/maths",
-		"r/foo20",
 		"r/users",
+		"r/foo20",
 		"r/boards",
 		"r/banktest",
 	} {


### PR DESCRIPTION
The order of package import of gnoland main.go may affect the genesis.json of testdir, which is created at the beginning, and a problem may occur, and it is corrected by changing the order