### PR TITLE
Trim whitespace from address

### DIFF
--- a/cmd/gnofaucet/gnofaucet.go
+++ b/cmd/gnofaucet/gnofaucet.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gnolang/gno/gnoland"
 	"github.com/gnolang/gno/pkgs/amino"
@@ -193,7 +194,7 @@ func serveApp(cmd *command.Command, args []string, iopts interface{}) error {
 			return
 		}
 		r.ParseForm()
-		toAddrStr := r.Form["toaddr"][0]
+		toAddrStr := strings.TrimSpace(r.Form["toaddr"][0])
 		if toAddrStr == "" {
 			fmt.Println("no toAddr")
 			return


### PR DESCRIPTION
Imported "strings" package and made strings.TrimSpace trim the toaddr value entered on the faucet form, because the faucet was only succeeding for users when they manually trimmed whitespace from the beginning or end of the address themselves.