### PR TITLE
chore: split biggest unit test suites in Makefile + CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,9 @@ jobs:
       matrix:
         goversion: ["1.17.x", "1.18.x"]
         args:
-          - test.go
+          - test.go1
+          - test.go2
+          - test.go3
           - test.files1
           - test.files2
           - test.packages

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ examples.build: install_gnodev examples.precompile
 
 ########################################
 # Test suite
-.PHONY: test test.go test.gno test.files1 test.files2 test.realm test.packages test.flappy
+.PHONY: test test.go test.go1 test.go2 test.go3 test.gno test.files1 test.files2 test.realm test.packages test.flappy
 test: test.gno test.go test.flappy
 	@echo "Full test suite finished."
 
@@ -73,23 +73,34 @@ test.flappy:
 	TEST_STABILITY=flappy go run -modfile ./misc/devdeps/go.mod moul.io/testman test -test.v -timeout=20m -retry=10 -run ^TestFlappy \
 		./pkgs/bft/consensus ./pkgs/bft/blockchain ./pkgs/bft/mempool ./pkgs/p2p
 
-test.go:
+test.go: test.go1 test.go2 test.go3
+
+test.go1:
+	# test most of pkgs/* except amino and bft.
 	go test . -v
 	# -p 1 shows test failures as they come
 	# maybe another way to do this?
-	go test ./pkgs/... -v -p 1 -timeout=20m
+	go test `go list ./pkgs/... | grep -v pkgs/amino/ | grep -v pkgs/bft/` -v -p 1 -timeout=30m
+
+test.go2:
+	# test amino.
+	go test ./pkgs/amino/... -v -p 1 -timeout=30m
+
+test.go3:
+	# test bft.
+	go test ./pkgs/bft/... -v -p 1 -timeout=30m
 
 test.files1:
-	go test tests/*.go -v -test.short -run "TestFiles1/" --timeout 20m
+	go test tests/*.go -v -test.short -run "TestFiles1/" --timeout 30m
 
 test.files2:
-	go test tests/*.go -v -test.short -run "TestFiles2/" --timeout 20m
+	go test tests/*.go -v -test.short -run "TestFiles2/" --timeout 30m
 
 test.realm:
-	go test tests/*.go -v -run "TestFiles/^zrealm" --timeout 20m
+	go test tests/*.go -v -run "TestFiles/^zrealm" --timeout 30m
 
 test.packages:
-	go test tests/*.go -v -run "TestPackages" --timeout 20m
+	go test tests/*.go -v -run "TestPackages" --timeout 30m
 
 test.examples:
 	go run ./cmd/gnodev test ./examples


### PR DESCRIPTION
the pros:
* it makes things faster to run on CI, and potentially faster locally when using
`make -j`.
* make logs more readable on failing CI jobs (GitHub is not very easy to use for
very long CI logs).
* allow retrying a specific job on CI instead of running everything.
* give a feeling on the impact of a recent change based on if everything is red VS
only one suite is red.

the bad:
* the Makefile starts being complex, I think we'll need a rewrite in a near future.

  $ go test -v ./pkgs/... | grep -E '^ok'| awk '{print $3 " " $2}' | sort -nr | head
  466.970s github.com/gnolang/gno/pkgs/amino
  129.709s github.com/gnolang/gno/pkgs/bft/consensus
  42.514s github.com/gnolang/gno/pkgs/bft/wal
  23.129s github.com/gnolang/gno/pkgs/iavl
  11.344s github.com/gnolang/gno/pkgs/crypto/keys
  9.834s github.com/gnolang/gno/pkgs/bft/rpc/lib/client
  8.694s github.com/gnolang/gno/pkgs/bft/mempool
  8.211s github.com/gnolang/gno/pkgs/bft/privval
  8.034s github.com/gnolang/gno/pkgs/bft/rpc/lib