### PR TITLE
Sdk amino fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ fmt:
 test: test.gno test.go test.flappy
 	@echo "Full test suite finished."
 
-test.gno: test.files1 test.files2 test.realm test.packages test.examples
+test.gno: test.files1 test.files2 test.packages test.examples
 	go test tests/*.go -v -run "TestFileStr"
 	go test tests/*.go -v -run "TestSelectors"
 

--- a/cmd/genproto/genproto.go
+++ b/cmd/genproto/genproto.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gnolang/gno/pkgs/crypto/hd"
 	"github.com/gnolang/gno/pkgs/crypto/merkle"
 	"github.com/gnolang/gno/pkgs/crypto/multisig"
+	"github.com/gnolang/gno/pkgs/sdk"
 	"github.com/gnolang/gno/pkgs/sdk/bank"
 	"github.com/gnolang/gno/pkgs/sdk/vm"
 	"github.com/gnolang/gno/pkgs/std"
@@ -36,6 +37,7 @@ func main() {
 		hd.Package,
 		multisig.Package,
 		std.Package,
+		sdk.Package,
 		bank.Package,
 		vm.Package,
 		gno.Package,

--- a/pkgs/amino/amino.go
+++ b/pkgs/amino/amino.go
@@ -683,11 +683,23 @@ func (cdc *Codec) unmarshalPBBindings(bz []byte, pbm PBMessager) error {
 	pbo := pbm.EmptyPBMessage(cdc)
 	err := proto.Unmarshal(bz, pbo)
 	if err != nil {
-		return err
+		rt := reflect.TypeOf(pbm)
+		info, err2 := cdc.getTypeInfoWLock(rt)
+		if err2 != nil {
+			return err2
+		}
+		return errors.New("unmarshal to %v failed: %v",
+			info.Type, err)
 	}
 	err = pbm.FromPBMessage(cdc, pbo)
 	if err != nil {
-		return err
+		rt := reflect.TypeOf(pbm)
+		info, err2 := cdc.getTypeInfoWLock(rt)
+		if err2 != nil {
+			return err2
+		}
+		return errors.New("unmarshal to %v failed: %v",
+			info.Type, err)
 	}
 	return nil
 }

--- a/pkgs/amino/genproto/bindings.go
+++ b/pkgs/amino/genproto/bindings.go
@@ -700,6 +700,10 @@ func pb2goStmts(rootPkg *amino.Package, isRoot bool, imports *ast.GenDecl, scope
 				_return(),
 			),
 		)
+		// wrap b with if stmt.
+		b = []ast.Stmt{_if(_b(pbo, "!=", "nil"),
+			b...,
+		)}
 
 	case reflect.Int:
 		b = append(b,

--- a/pkgs/bft/store/store_test.go
+++ b/pkgs/bft/store/store_test.go
@@ -293,7 +293,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 		if subStr := tuple.wantPanic; subStr != "" {
 			if panicErr == nil {
 				t.Errorf("#%d: want a non-nil panic", i)
-			} else if got := fmt.Sprintf("%#v", panicErr); !strings.Contains(got, subStr) {
+			} else if got := fmt.Sprintf("%#v\n%v", panicErr, panicErr); !strings.Contains(got, subStr) {
 				t.Errorf("#%d:\n\tgotErr: %q\nwant substring: %q", i, got, subStr)
 			}
 			continue

--- a/pkgs/crypto/crypto.go
+++ b/pkgs/crypto/crypto.go
@@ -58,6 +58,9 @@ func (addr Address) MarshalAmino() (string, error) {
 }
 
 func (addr *Address) UnmarshalAmino(b32str string) (err error) {
+	if b32str == "" {
+		return nil // leave addr as zero.
+	}
 	addr2, err := AddressFromBech32(b32str)
 	if err != nil {
 		return err

--- a/pkgs/sdk/package.go
+++ b/pkgs/sdk/package.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"github.com/gnolang/gno/pkgs/amino"
+	abci "github.com/gnolang/gno/pkgs/bft/abci/types"
+)
+
+var Package = amino.RegisterPackage(amino.NewPackage(
+	"github.com/gnolang/gno/pkgs/sdk",
+	"tm",
+	amino.GetCallersDirname(),
+).
+	WithDependencies(
+		abci.Package,
+	).
+	WithTypes(
+		Result{},
+	))

--- a/pkgs/sdk/sdk.proto
+++ b/pkgs/sdk/sdk.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package tm;
+
+option go_package = "github.com/gnolang/gno/pkgs/sdk/pb";
+
+// imports
+import "github.com/gnolang/gno/pkgs/bft/abci/types/abci.proto";
+import "github.com/gnolang/gno/pkgs/crypto/merkle/merkle.proto";
+
+// messages
+message Result {
+	abci.ResponseBase ResponseBase = 1;
+	sint64 GasWanted = 2;
+	sint64 GasUsed = 3;
+}

--- a/pkgs/sdk/testutils/package.go
+++ b/pkgs/sdk/testutils/package.go
@@ -9,5 +9,11 @@ var Package = amino.RegisterPackage(amino.NewPackage(
 	"sdk.testutils",
 	amino.GetCallersDirname(),
 ).WithDependencies().WithTypes(
+	// ...
 	&TestMsg{}, "TestMsg",
+
+	// testmsgs.go
+	MsgCounter{},
+	MsgNoRoute{},
+	MsgCounter2{},
 ))

--- a/pkgs/sdk/testutils/testmsgs.go
+++ b/pkgs/sdk/testutils/testmsgs.go
@@ -1,0 +1,54 @@
+package testutils
+
+import (
+	"github.com/gnolang/gno/pkgs/crypto"
+	"github.com/gnolang/gno/pkgs/std"
+)
+
+const (
+	RouteMsgCounter  = "MsgCounter"
+	RouteMsgCounter2 = "MsgCounter2"
+)
+
+// ValidateBasic() fails on negative counters.
+// Otherwise it's up to the handlers
+type MsgCounter struct {
+	Counter       int64
+	FailOnHandler bool
+}
+
+// Implements Msg
+func (msg MsgCounter) Route() string                { return RouteMsgCounter }
+func (msg MsgCounter) Type() string                 { return "counter1" }
+func (msg MsgCounter) GetSignBytes() []byte         { return nil }
+func (msg MsgCounter) GetSigners() []crypto.Address { return nil }
+func (msg MsgCounter) ValidateBasic() error {
+	if msg.Counter >= 0 {
+		return nil
+	}
+	return std.ErrInvalidSequence("counter should be a non-negative integer.")
+}
+
+// a msg we dont know how to route
+type MsgNoRoute struct {
+	MsgCounter
+}
+
+func (tx MsgNoRoute) Route() string { return "noroute" }
+
+// Another counter msg. Duplicate of MsgCounter
+type MsgCounter2 struct {
+	Counter int64
+}
+
+// Implements Msg
+func (msg MsgCounter2) Route() string                { return RouteMsgCounter2 }
+func (msg MsgCounter2) Type() string                 { return "counter2" }
+func (msg MsgCounter2) GetSignBytes() []byte         { return nil }
+func (msg MsgCounter2) GetSigners() []crypto.Address { return nil }
+func (msg MsgCounter2) ValidateBasic() error {
+	if msg.Counter >= 0 {
+		return nil
+	}
+	return std.ErrInvalidSequence("counter should be a non-negative integer.")
+}

--- a/tests/files2/zrealm_tests0.gno
+++ b/tests/files2/zrealm_tests0.gno
@@ -637,7 +637,7 @@ func main() {
 //                     "BlockNode": null,
 //                     "Location": {
 //                         "File": "tests.gno",
-//                         "Line": "36",
+//                         "Line": "38",
 //                         "Nonce": "0",
 //                         "PkgPath": "gno.land/r/tests"
 //                     }
@@ -671,7 +671,7 @@ func main() {
 //                     "BlockNode": null,
 //                     "Location": {
 //                         "File": "tests.gno",
-//                         "Line": "41",
+//                         "Line": "43",
 //                         "Nonce": "0",
 //                         "PkgPath": "gno.land/r/tests"
 //                     }
@@ -705,7 +705,7 @@ func main() {
 //                     "BlockNode": null,
 //                     "Location": {
 //                         "File": "tests.gno",
-//                         "Line": "49",
+//                         "Line": "51",
 //                         "Nonce": "0",
 //                         "PkgPath": "gno.land/r/tests"
 //                     }


### PR DESCRIPTION
After running "make genproto", amino uses a different codepath that uses protobuf underneath.
This fixes remaining testing errors that result from running tests w/ "make genproto".