### PR TITLE
chore: mark TestBroadcastTxForPeerStopsWhenPeerStops as flappy

### DIFF
--- a/pkgs/bft/mempool/reactor_test.go
+++ b/pkgs/bft/mempool/reactor_test.go
@@ -172,7 +172,9 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	ensureNoTxs(t, reactors[1], 100*time.Millisecond)
 }
 
-func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
+func TestFlappyBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
+	testutils.FilterStability(t, testutils.Flappy)
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}


### PR DESCRIPTION
Signed-off-by: Manfred Touron <94029+moul@users.noreply.github.com>