### PR TITLE
chore: remove confusing unicode chars

### DIFF
--- a/bak/classic/sdk/x/distribution/keeper/allocation_test.go
+++ b/bak/classic/sdk/x/distribution/keeper/allocation_test.go
@@ -138,7 +138,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 		Address: valConsPk2.Address(),
 		Power:   10,
 	}
-	abciValС := abci.Validator{
+	abciValC := abci.Validator{
 		Address: valConsPk3.Address(),
 		Power:   10,
 	}
@@ -174,7 +174,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 			SignedLastBlock: true,
 		},
 		{
-			Validator:       abciValС,
+			Validator:       abciValC,
 			SignedLastBlock: true,
 		},
 	}


### PR DESCRIPTION
Hello!
I have run [Snyk SAST](https://app.snyk.io/) on this repo and found some confusing unicode chars

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/7482065/174668239-1d569db5-fea2-4744-83ee-f4b8f0e405aa.png">
