### PR TITLE
fix: potential nil dereferences

### DIFF
--- a/pkgs/bft/mempool/clist_mempool.go
+++ b/pkgs/bft/mempool/clist_mempool.go
@@ -684,9 +684,9 @@ func (cache *mapTxCache) Push(tx types.Tx) bool {
 
 	if cache.list.Len() >= cache.size {
 		popped := cache.list.Front()
-		poppedTxHash := popped.Value.([sha256.Size]byte)
-		delete(cache.map_, poppedTxHash)
 		if popped != nil {
+			poppedTxHash := popped.Value.([sha256.Size]byte)
+			delete(cache.map_, poppedTxHash)
 			cache.list.Remove(popped)
 		}
 	}

--- a/pkgs/iavl/proof_range.go
+++ b/pkgs/iavl/proof_range.go
@@ -91,10 +91,10 @@ func (proof *RangeProof) LeftIndex() int64 {
 // Verify that a key has some value.
 // Does not assume that the proof itself is valid, call Verify() first.
 func (proof *RangeProof) VerifyItem(key, value []byte) error {
-	leaves := proof.Leaves
 	if proof == nil {
 		return errors.Wrap(ErrInvalidProof, "proof is nil")
 	}
+	leaves := proof.Leaves
 	if !proof.rootVerified {
 		return errors.New("must call Verify(root) first")
 	}


### PR DESCRIPTION
I have reordered some operations to prevent potential nil dereference cases.
