### PR TITLE
chore: add p/acl package

### DIFF
--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -3,9 +3,9 @@ package acl
 import "std"
 
 func HasPerm(addr std.Address, verb string, resource string) bool {
-
+	return false
 }
 
 func HasRole(addr std.Address, role string) bool {
-
+	return HasPerm(addr, "role", role)
 }

--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -6,11 +6,6 @@ import (
 	"gno.land/p/avl"
 )
 
-type Directory struct {
-	permBuckets *avl.MutTree // identifier -> perms
-	userGroups  *avl.MutTree // std.Address -> []string
-}
-
 func New() *Directory {
 	return &Directory{
 		userGroups:  avl.NewMutTree(),
@@ -18,14 +13,43 @@ func New() *Directory {
 	}
 }
 
+type Directory struct {
+	permBuckets *avl.MutTree // identifier -> perms
+	userGroups  *avl.MutTree // std.Address -> []string
+}
+
 func (d *Directory) HasPerm(addr std.Address, verb, resource string) bool {
-	userPerms, ok := d.permBuckets.Get("u:" + addr.String())
+	// FIXME: consider memoize.
+
+	// user perms
+	if d.getBucketPerms("u:"+addr.String()).hasPerm(verb, resource) {
+		return true
+	}
+
+	// everyone's perms.
+	if d.getBucketPerms("g:"+Everyone).hasPerm(verb, resource) {
+		return true
+	}
+
+	// user groups' perms.
+	groups, ok := d.userGroups.Get(addr.String())
 	if ok {
-		if userPerms.(perms).hasPerm(verb, resource) {
-			return true
+		for _, group := range groups.([]string) {
+			if d.getBucketPerms("g:"+group).hasPerm(verb, resource) {
+				return true
+			}
 		}
 	}
+
 	return false
+}
+
+func (d *Directory) getBucketPerms(bucket string) perms {
+	res, ok := d.permBuckets.Get(bucket)
+	if ok {
+		return res.(perms)
+	}
+	return perms{}
 }
 
 func (d *Directory) HasRole(addr std.Address, role string) bool {
@@ -69,5 +93,5 @@ func (d *Directory) AddUserToGroup(user std.Address, group string) {
 		groups = existing.([]string)
 	}
 	groups = append(groups, group)
-	d.userGroups.Set(user.String(), &groups)
+	d.userGroups.Set(user.String(), groups)
 }

--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -1,11 +1,32 @@
 package acl
 
-import "std"
+import (
+	"std"
 
-func HasPerm(addr std.Address, verb string, resource string) bool {
+	"gno.land/p/avl"
+)
+
+type Directory struct {
+	PermBuckets *avl.MutTree // identifier -> []perm
+	UserGroups  *avl.MutTree // std.Address -> []string
+}
+
+func New() *Directory {
+	return &Directory{
+		UserGroups:  avl.NewMutTree(),
+		PermBuckets: avl.NewMutTree(),
+	}
+}
+
+func (d *Directory) HasPerm(addr std.Address, verb string, resource string) bool {
 	return false
 }
 
-func HasRole(addr std.Address, role string) bool {
-	return HasPerm(addr, "role", role)
+func (d *Directory) HasRole(addr std.Address, role string) bool {
+	return d.HasPerm(addr, "role", role)
+}
+
+type perm struct {
+	verbs     []string
+	resources []string
 }

--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -1,0 +1,11 @@
+package acl
+
+import "std"
+
+func HasPerm(addr std.Address, verb string, resource string) bool {
+
+}
+
+func HasRole(addr std.Address, role string) bool {
+
+}

--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -7,18 +7,24 @@ import (
 )
 
 type Directory struct {
-	PermBuckets *avl.MutTree // identifier -> []perm
-	UserGroups  *avl.MutTree // std.Address -> []string
+	permBuckets *avl.MutTree // identifier -> perms
+	userGroups  *avl.MutTree // std.Address -> []string
 }
 
 func New() *Directory {
 	return &Directory{
-		UserGroups:  avl.NewMutTree(),
-		PermBuckets: avl.NewMutTree(),
+		userGroups:  avl.NewMutTree(),
+		permBuckets: avl.NewMutTree(),
 	}
 }
 
-func (d *Directory) HasPerm(addr std.Address, verb string, resource string) bool {
+func (d *Directory) HasPerm(addr std.Address, verb, resource string) bool {
+	userPerms, ok := d.permBuckets.Get("u:" + addr.String())
+	if ok {
+		if userPerms.(perms).hasPerm(verb, resource) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -26,7 +32,42 @@ func (d *Directory) HasRole(addr std.Address, role string) bool {
 	return d.HasPerm(addr, "role", role)
 }
 
-type perm struct {
-	verbs     []string
-	resources []string
+func (d *Directory) AddUserPerm(addr std.Address, verb, resource string) {
+	bucket := "u:" + addr.String()
+	p := perm{
+		verbs:     []string{verb},
+		resources: []string{resource},
+	}
+	d.addPermToBucket(bucket, p)
+}
+
+func (d *Directory) AddGroupPerm(name string, verb, resource string) {
+	bucket := "g:" + name
+	p := perm{
+		verbs:     []string{verb},
+		resources: []string{resource},
+	}
+	d.addPermToBucket(bucket, p)
+}
+
+func (d *Directory) addPermToBucket(bucket string, p perm) {
+	var ps perms
+
+	existing, ok := d.permBuckets.Get(bucket)
+	if ok {
+		ps = existing.(perms)
+	}
+	ps = append(ps, p)
+
+	d.permBuckets.Set(bucket, ps)
+}
+
+func (d *Directory) AddUserToGroup(user std.Address, group string) {
+	existing, ok := d.userGroups.Get(user.String())
+	var groups []string
+	if ok {
+		groups = existing.([]string)
+	}
+	groups = append(groups, group)
+	d.userGroups.Set(user.String(), &groups)
 }

--- a/examples/gno.land/p/acl/acl.gno
+++ b/examples/gno.land/p/acl/acl.gno
@@ -95,3 +95,8 @@ func (d *Directory) AddUserToGroup(user std.Address, group string) {
 	groups = append(groups, group)
 	d.userGroups.Set(user.String(), groups)
 }
+
+// TODO: helpers to remove permissions.
+// TODO: helpers to adds multiple permissions at once -> {verbs: []string{"read","write"}}.
+// TODO: helpers to delete users from gorups.
+// TODO: helpers to quickly reset states.

--- a/examples/gno.land/p/acl/acl_test.gno
+++ b/examples/gno.land/p/acl/acl_test.gno
@@ -8,15 +8,64 @@ import (
 )
 
 func Test(t *testing.T) {
-	test1 := testutils.TestAddress("test1")
-	test2 := testutils.TestAddress("test2")
+	adm := testutils.TestAddress("admin")
+	mod := testutils.TestAddress("mod")
+	usr := testutils.TestAddress("user")
+	cst := testutils.TestAddress("custom")
 
 	dir := New()
 
-	shouldNotHasRole(t, dir, test1, "foo")
-	shouldNotHasRole(t, dir, test2, "foo")
-	shouldNotHasPerm(t, dir, test1, "write", "r/boards:gnolang/1")
-	shouldNotHasPerm(t, dir, test2, "write", "r/boards:gnolang/1")
+	shouldNotHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldNotHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
+
+	dir.AddUserPerm(adm, "*", "*")
+
+	shouldHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
+
+	dir.AddUserPerm(cst, "write", "r/boards:gnolang/.*")
+
+	shouldHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
+
+	println("DONE")
+	/*
+		dir.AddGroupPerm("mods", "role", "moderator")
+			dir.AddGroupPerm("mods", "role", "moderator")
+			dir.AddGroupUser("mods", mod)
+			dir.AddGroupPerm(acl.Everyone, "read", "*")
+			dir.AddGroupUser("", "mod")
+	*/
 }
 
 func shouldHasRole(t *testing.T, dir *Directory, addr std.Address, role string) {
@@ -39,7 +88,7 @@ func shouldHasPerm(t *testing.T, dir *Directory, addr std.Address, verb string, 
 	t.Helper()
 	check := dir.HasPerm(addr, verb, resource)
 	if !check {
-		t.Errorf("%q should has perm for %q - %q", addr.String(), verb, resource string)
+		t.Errorf("%q should has perm for %q - %q", addr.String(), verb, resource)
 	}
 }
 

--- a/examples/gno.land/p/acl/acl_test.gno
+++ b/examples/gno.land/p/acl/acl_test.gno
@@ -11,22 +11,42 @@ func Test(t *testing.T) {
 	test1 := testutils.TestAddress("test1")
 	test2 := testutils.TestAddress("test2")
 
-	shouldNotHasRole(t, test1, "foo")
-	shouldNotHasRole(t, test2, "foo")
+	dir := New()
+
+	shouldNotHasRole(t, dir, test1, "foo")
+	shouldNotHasRole(t, dir, test2, "foo")
+	shouldNotHasPerm(t, dir, test1, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, test2, "write", "r/boards:gnolang/1")
 }
 
-func shouldHasRole(t *testing.T, addr std.Address, role string) {
+func shouldHasRole(t *testing.T, dir *Directory, addr std.Address, role string) {
 	t.Helper()
-	check := HasRole(addr, role)
+	check := dir.HasRole(addr, role)
 	if !check {
 		t.Errorf("%q should has role %q", addr.String(), role)
 	}
 }
 
-func shouldNotHasRole(t *testing.T, addr std.Address, role string) {
+func shouldNotHasRole(t *testing.T, dir *Directory, addr std.Address, role string) {
 	t.Helper()
-	check := HasRole(addr, role)
+	check := dir.HasRole(addr, role)
 	if check {
 		t.Errorf("%q should not has role %q", addr.String(), role)
+	}
+}
+
+func shouldHasPerm(t *testing.T, dir *Directory, addr std.Address, verb string, resource string) {
+	t.Helper()
+	check := dir.HasPerm(addr, verb, resource)
+	if !check {
+		t.Errorf("%q should has perm for %q - %q", addr.String(), verb, resource string)
+	}
+}
+
+func shouldNotHasPerm(t *testing.T, dir *Directory, addr std.Address, verb string, resource string) {
+	t.Helper()
+	check := dir.HasPerm(addr, verb, resource)
+	if check {
+		t.Errorf("%q should not has perm for %q - %q", addr.String(), verb, resource)
 	}
 }

--- a/examples/gno.land/p/acl/acl_test.gno
+++ b/examples/gno.land/p/acl/acl_test.gno
@@ -1,0 +1,7 @@
+package acl
+
+import "testing"
+
+func Test(t *testing.T) {
+
+}

--- a/examples/gno.land/p/acl/acl_test.gno
+++ b/examples/gno.land/p/acl/acl_test.gno
@@ -1,7 +1,32 @@
 package acl
 
-import "testing"
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/testutils"
+)
 
 func Test(t *testing.T) {
+	test1 := testutils.TestAddress("test1")
+	test2 := testutils.TestAddress("test2")
 
+	shouldNotHasRole(t, test1, "foo")
+	shouldNotHasRole(t, test2, "foo")
+}
+
+func shouldHasRole(t *testing.T, addr std.Address, role string) {
+	t.Helper()
+	check := HasRole(addr, role)
+	if !check {
+		t.Errorf("%q should has role %q", addr.String(), role)
+	}
+}
+
+func shouldNotHasRole(t *testing.T, addr std.Address, role string) {
+	t.Helper()
+	check := HasRole(addr, role)
+	if check {
+		t.Errorf("%q should not has role %q", addr.String(), role)
+	}
 }

--- a/examples/gno.land/p/acl/acl_test.gno
+++ b/examples/gno.land/p/acl/acl_test.gno
@@ -15,6 +15,7 @@ func Test(t *testing.T) {
 
 	dir := New()
 
+	// by default, no one has perm.
 	shouldNotHasRole(t, dir, adm, "foo")
 	shouldNotHasRole(t, dir, mod, "foo")
 	shouldNotHasRole(t, dir, usr, "foo")
@@ -28,8 +29,23 @@ func Test(t *testing.T) {
 	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
 
-	dir.AddUserPerm(adm, "*", "*")
+	// adding all the rights to admin.
+	dir.AddUserPerm(adm, ".*", ".*")
+	shouldHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1") // new
+	shouldNotHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1") // new
+	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
 
+	// adding custom regexp rule for user "cst".
+	dir.AddUserPerm(cst, "write", "r/boards:gnolang/.*")
 	shouldHasRole(t, dir, adm, "foo")
 	shouldNotHasRole(t, dir, mod, "foo")
 	shouldNotHasRole(t, dir, usr, "foo")
@@ -37,14 +53,16 @@ func Test(t *testing.T) {
 	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
-	shouldNotHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, cst, "write", "r/boards:gnolang/1") // new
 	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
 
-	dir.AddUserPerm(cst, "write", "r/boards:gnolang/.*")
-
+	// adding a group perm for a new group.
+	// no changes expected.
+	dir.AddGroupPerm("mods", "role", "moderator")
+	dir.AddGroupPerm("mods", "write", ".*")
 	shouldHasRole(t, dir, adm, "foo")
 	shouldNotHasRole(t, dir, mod, "foo")
 	shouldNotHasRole(t, dir, usr, "foo")
@@ -58,14 +76,35 @@ func Test(t *testing.T) {
 	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
 	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
 
-	println("DONE")
-	/*
-		dir.AddGroupPerm("mods", "role", "moderator")
-			dir.AddGroupPerm("mods", "role", "moderator")
-			dir.AddGroupUser("mods", mod)
-			dir.AddGroupPerm(acl.Everyone, "read", "*")
-			dir.AddGroupUser("", "mod")
-	*/
+	// assigning the user "mod" to the "mods" group.
+	dir.AddUserToGroup(mod, "mods")
+	shouldHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, mod, "write", "r/boards:gnolang/1") // new
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, mod, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "read", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, cst, "read", "r/boards:gnolang/1")
+
+	// adding "read" permission for everyone.
+	dir.AddGroupPerm(Everyone, "read", ".*")
+	shouldHasRole(t, dir, adm, "foo")
+	shouldNotHasRole(t, dir, mod, "foo")
+	shouldNotHasRole(t, dir, usr, "foo")
+	shouldNotHasRole(t, dir, cst, "foo")
+	shouldHasPerm(t, dir, adm, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, mod, "write", "r/boards:gnolang/1")
+	shouldNotHasPerm(t, dir, usr, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, cst, "write", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, adm, "read", "r/boards:gnolang/1")
+	shouldHasPerm(t, dir, mod, "read", "r/boards:gnolang/1") // new
+	shouldHasPerm(t, dir, usr, "read", "r/boards:gnolang/1") // new
+	shouldHasPerm(t, dir, cst, "read", "r/boards:gnolang/1") // new
 }
 
 func shouldHasRole(t *testing.T, dir *Directory, addr std.Address, role string) {

--- a/examples/gno.land/p/acl/const.gno
+++ b/examples/gno.land/p/acl/const.gno
@@ -1,0 +1,3 @@
+package acl
+
+const Everyone string = "everyone"

--- a/examples/gno.land/p/acl/perm.gno
+++ b/examples/gno.land/p/acl/perm.gno
@@ -30,7 +30,7 @@ func (perm perm) hasPerm(verb, resource string) bool {
 }
 
 func match(pattern, target string) bool {
-	if pattern == "*" {
+	if pattern == ".*" {
 		return true
 	}
 

--- a/examples/gno.land/p/acl/perm.gno
+++ b/examples/gno.land/p/acl/perm.gno
@@ -1,0 +1,44 @@
+package acl
+
+import "regexp"
+
+type perm struct {
+	verbs     []string
+	resources []string
+}
+
+func (perm perm) hasPerm(verb, resource string) bool {
+	// check verb
+	verbOK := false
+	for _, pattern := range perm.verbs {
+		if match(pattern, verb) {
+			verbOK = true
+			break
+		}
+	}
+	if !verbOK {
+		return false
+	}
+
+	// check resource
+	for _, pattern := range perm.resources {
+		if match(pattern, resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func match(pattern, target string) bool {
+	if pattern == "*" {
+		return true
+	}
+
+	if pattern == target {
+		return true
+	}
+
+	//regexp handling
+	match, _ := regexp.MatchString(pattern, target)
+	return match
+}

--- a/examples/gno.land/p/acl/perms.gno
+++ b/examples/gno.land/p/acl/perms.gno
@@ -1,0 +1,12 @@
+package acl
+
+type perms []perm
+
+func (perms perms) hasPerm(verb, resource string) bool {
+	for _, perm := range perms {
+		if perm.hasPerm(verb, resource) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR adds a `p/acl` package, allowing realms to manage permissions for users, groups, and “everyone”.

A permission is composed of a verb and a resource.
Each ones can be an exact match, or a regexp.