### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkgs/bft/abci/example/kvstore/kvstore_test.go
+++ b/pkgs/bft/abci/example/kvstore/kvstore_test.go
@@ -1,7 +1,6 @@
 package kvstore
 
 import (
-	"io/ioutil"
 	"sort"
 	"testing"
 
@@ -54,11 +53,7 @@ func TestKVStoreKV(t *testing.T) {
 }
 
 func TestPersistentKVStoreKV(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
-	if err != nil {
-		t.Fatal(err)
-	}
-	kvstore := NewPersistentKVStoreApplication(dir)
+	kvstore := NewPersistentKVStoreApplication(t.TempDir())
 	key := testKey
 	value := key
 	tx := []byte(key)
@@ -70,11 +65,7 @@ func TestPersistentKVStoreKV(t *testing.T) {
 }
 
 func TestPersistentKVStoreInfo(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
-	if err != nil {
-		t.Fatal(err)
-	}
-	kvstore := NewPersistentKVStoreApplication(dir)
+	kvstore := NewPersistentKVStoreApplication(t.TempDir())
 	InitKVStore(kvstore)
 	height := int64(0)
 
@@ -101,10 +92,7 @@ func TestPersistentKVStoreInfo(t *testing.T) {
 
 // add a validator, remove a validator, update a validator
 func TestValUpdates(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "abci-kvstore-test") // TODO
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	kvstore := NewPersistentKVStoreApplication(dir)
 
 	// init with some validators

--- a/pkgs/bft/config/toml_test.go
+++ b/pkgs/bft/config/toml_test.go
@@ -22,9 +22,7 @@ func TestEnsureRoot(t *testing.T) {
 	require := require.New(t)
 
 	// setup temp dir for test
-	tmpDir, err := ioutil.TempDir("", "config-test")
-	require.Nil(err)
-	defer os.RemoveAll(tmpDir) // nolint: errcheck
+	tmpDir := t.TempDir()
 
 	// create root dir
 	throwaway := DefaultConfig()

--- a/pkgs/bft/mempool/clist_mempool_test.go
+++ b/pkgs/bft/mempool/clist_mempool_test.go
@@ -368,8 +368,7 @@ func TestSerialReap(t *testing.T) {
 
 func TestMempoolCloseWAL(t *testing.T) {
 	// 1. Create the temporary directory for mempool and WAL testing.
-	rootDir, err := ioutil.TempDir("", "mempool-test")
-	require.Nil(t, err, "expecting successful tmpdir creation")
+	rootDir := t.TempDir()
 
 	// 2. Ensure that it doesn't contain any elements -- Sanity check
 	m1, err := filepath.Glob(filepath.Join(rootDir, "*"))

--- a/pkgs/db/boltdb_test.go
+++ b/pkgs/db/boltdb_test.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,24 +12,19 @@ import (
 
 func TestBoltDBNewBoltDB(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	defer cleanupDBDir(dir, name)
 
-	db, err := NewBoltDB(name, dir)
+	db, err := NewBoltDB(name, t.TempDir())
 	require.NoError(t, err)
 	db.Close()
 }
 
 func BenchmarkBoltDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	db, err := NewBoltDB(name, "")
+	db, err := NewBoltDB(name, b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() {
-		db.Close()
-		cleanupDBDir("", name)
-	}()
+	defer db.Close()
 
 	benchmarkRandomReadsWrites(b, db)
 }

--- a/pkgs/db/c_level_db_test.go
+++ b/pkgs/db/c_level_db_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,9 +91,7 @@ func TestCLevelDBBackend(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	// Can't use "" (current directory) or "./" here because levigo.Open returns:
 	// "Error initializing DB: IO error: test_XXX.db: Invalid argument"
-	dir := os.TempDir()
-	db := NewDB(name, CLevelDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, CLevelDBBackend, t.TempDir())
 
 	_, ok := db.(*CLevelDB)
 	assert.True(t, ok)
@@ -102,9 +99,7 @@ func TestCLevelDBBackend(t *testing.T) {
 
 func TestCLevelDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db := NewDB(name, CLevelDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, CLevelDBBackend, t.TempDir())
 
 	assert.NotEmpty(t, db.Stats())
 }

--- a/pkgs/db/common_test.go
+++ b/pkgs/db/common_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"sync"
 	"testing"
@@ -63,10 +62,8 @@ func checkValuePanics(t *testing.T, itr Iterator) {
 	assert.Panics(t, func() { itr.Value() }, "checkValuePanics expected panic but didn't")
 }
 
-func newTempDB(t *testing.T, backend BackendType) (db DB, dbDir string) {
-	dirname, err := ioutil.TempDir("", "db_common_test")
-	require.Nil(t, err)
-	return NewDB("testdb", backend, dirname), dirname
+func newTempDB(t *testing.T, backend BackendType) (db DB) {
+	return NewDB("testdb", backend, t.TempDir())
 }
 
 //----------------------------------------

--- a/pkgs/db/db_test.go
+++ b/pkgs/db/db_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +10,7 @@ import (
 func TestDBIteratorSingleKey(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			db.SetSync(bz("1"), bz("value_1"))
 			itr := db.Iterator(nil, nil)
@@ -31,8 +29,7 @@ func TestDBIteratorSingleKey(t *testing.T) {
 func TestDBIteratorTwoKeys(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			db.SetSync(bz("1"), bz("value_1"))
 			db.SetSync(bz("2"), bz("value_1"))
@@ -59,8 +56,7 @@ func TestDBIteratorTwoKeys(t *testing.T) {
 func TestDBIteratorMany(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			keys := make([][]byte, 100)
 			for i := 0; i < 100; i++ {
@@ -84,8 +80,7 @@ func TestDBIteratorMany(t *testing.T) {
 func TestDBIteratorEmpty(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			itr := db.Iterator(nil, nil)
 
@@ -97,8 +92,7 @@ func TestDBIteratorEmpty(t *testing.T) {
 func TestDBIteratorEmptyBeginAfter(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			itr := db.Iterator(bz("1"), nil)
 
@@ -110,8 +104,7 @@ func TestDBIteratorEmptyBeginAfter(t *testing.T) {
 func TestDBIteratorNonemptyBeginAfter(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			db.SetSync(bz("1"), bz("value_1"))
 			itr := db.Iterator(bz("2"), nil)

--- a/pkgs/db/go_level_db_test.go
+++ b/pkgs/db/go_level_db_test.go
@@ -9,35 +9,32 @@ import (
 )
 
 func TestGoLevelDBNewGoLevelDB(t *testing.T) {
+	dir := t.TempDir()
 	name := fmt.Sprintf("test_%x", randStr(12))
-	defer cleanupDBDir("", name)
 
 	// Test we can't open the db twice for writing
-	wr1, err := NewGoLevelDB(name, "")
+	wr1, err := NewGoLevelDB(name, dir)
 	require.Nil(t, err)
-	_, err = NewGoLevelDB(name, "")
+	_, err = NewGoLevelDB(name, dir)
 	require.NotNil(t, err)
 	wr1.Close() // Close the db to release the lock
 
 	// Test we can open the db twice for reading only
-	ro1, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
+	ro1, err := NewGoLevelDBWithOpts(name, dir, &opt.Options{ReadOnly: true})
 	require.Nil(t, err)
 	defer ro1.Close()
-	ro2, err := NewGoLevelDBWithOpts(name, "", &opt.Options{ReadOnly: true})
+	ro2, err := NewGoLevelDBWithOpts(name, dir, &opt.Options{ReadOnly: true})
 	require.Nil(t, err)
 	defer ro2.Close()
 }
 
 func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	db, err := NewGoLevelDB(name, "")
+	db, err := NewGoLevelDB(name, b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() {
-		db.Close()
-		cleanupDBDir("", name)
-	}()
+	defer db.Close()
 
 	benchmarkRandomReadsWrites(b, db)
 }

--- a/pkgs/db/gorocks_db_test.go
+++ b/pkgs/db/gorocks_db_test.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,9 +12,7 @@ import (
 
 func TestGoRocksDBBackend(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db := NewDB(name, GoRocksDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, GoRocksDBBackend, t.TempDir())
 
 	_, ok := db.(*RocksDB)
 	assert.True(t, ok)
@@ -23,9 +20,7 @@ func TestGoRocksDBBackend(t *testing.T) {
 
 func TestGoRocksDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db := NewDB(name, GoRocksDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, GoRocksDBBackend, t.TempDir())
 
 	assert.NotEmpty(t, db.Stats())
 }

--- a/pkgs/db/grocks_db_test.go
+++ b/pkgs/db/grocks_db_test.go
@@ -5,7 +5,6 @@ package db
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,9 +12,7 @@ import (
 
 func TestGRocksDBBackend(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db := NewDB(name, GRocksDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, GRocksDBBackend, t.TempDir())
 
 	_, ok := db.(*RocksDB)
 	assert.True(t, ok)
@@ -23,9 +20,7 @@ func TestGRocksDBBackend(t *testing.T) {
 
 func TestGRocksDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	dir := os.TempDir()
-	db := NewDB(name, GRocksDBBackend, dir)
-	defer cleanupDBDir(dir, name)
+	db := NewDB(name, GRocksDBBackend, t.TempDir())
 
 	assert.NotEmpty(t, db.Stats())
 }

--- a/pkgs/db/util_test.go
+++ b/pkgs/db/util_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"os"
 	"testing"
 )
 
@@ -10,8 +9,7 @@ import (
 func TestPrefixIteratorNoMatchNil(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 			itr := IteratePrefix(db, []byte("2"))
 
 			checkInvalid(t, itr)
@@ -28,8 +26,7 @@ func TestPrefixIteratorNoMatch1(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 			itr := IteratePrefix(db, []byte("2"))
 			db.SetSync(bz("1"), bz("value_1"))
 
@@ -42,8 +39,7 @@ func TestPrefixIteratorNoMatch1(t *testing.T) {
 func TestPrefixIteratorNoMatch2(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 			db.SetSync(bz("3"), bz("value_3"))
 			itr := IteratePrefix(db, []byte("4"))
 
@@ -56,8 +52,7 @@ func TestPrefixIteratorNoMatch2(t *testing.T) {
 func TestPrefixIteratorMatch1(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 			db.SetSync(bz("2"), bz("value_2"))
 			itr := IteratePrefix(db, bz("2"))
 
@@ -75,8 +70,7 @@ func TestPrefixIteratorMatch1(t *testing.T) {
 func TestPrefixIteratorMatches1N(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
-			db, dir := newTempDB(t, backend)
-			defer os.RemoveAll(dir)
+			db := newTempDB(t, backend)
 
 			// prefixed
 			db.SetSync(bz("a/1"), bz("value_1"))


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```