### PR TITLE
chore: add DefaultBaseOptions for gnofaucet

### DIFF
--- a/cmd/gnofaucet/gnofaucet.go
+++ b/cmd/gnofaucet/gnofaucet.go
@@ -92,6 +92,7 @@ type serveOptions struct {
 }
 
 var DefaultServeOptions = serveOptions{
+	BaseOptions:   client.DefaultBaseOptions,
 	ChainID:       "", // must override
 	GasWanted:     50000,
 	GasFee:        "1000000ugnot",


### PR DESCRIPTION
to make it consistent with gnokey, also, you should set proper env variables to make it work.