### PR TITLE
Adds support for pebbledb

### DIFF
--- a/pkgs/db/db.go
+++ b/pkgs/db/db.go
@@ -37,6 +37,16 @@ const (
 	//   - requires gcc
 	//   - use rocksdb build tag (go build -tags rocksdb)
 	RocksDBBackend BackendType = "rocksdb"
+	// RocksDBBackend represents rocksdb (uses github.com/linxGnu/gorocksdb)
+	//   - EXPERIMENTAL
+	//   - requires gcc
+	//   - use rocksdb build tag (go build -tags rocksdb)
+	GrocksDBBackend BackendType = "grocksdb"
+	// PebbleDBBackend represents pebbledb (github.com/cockroachdb/pebble)
+	//  - Because of performance and lack of cgo, should likely become default instead of goleveldb
+	//  - Faster than rocks or grocks
+	//  - Easier to implement and maintain because pure go
+	PebbleDBBackend BackendType = "pebbledb"
 )
 
 type dbCreator func(name string, dir string) (DB, error)

--- a/pkgs/db/pebble.go
+++ b/pkgs/db/pebble.go
@@ -1,0 +1,423 @@
+//go:build pebbledb
+
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cockroachdb/pebble"
+)
+
+func init() {
+	dbCreator := func(name string, dir string) (DB, error) {
+		return NewPebbleDB(name, dir)
+	}
+	registerDBCreator(PebbleDBBackend, dbCreator, false)
+}
+
+// PebbleDB is a PebbleDB backend.
+type PebbleDB struct {
+	db *pebble.DB
+}
+
+var _ DB = (*PebbleDB)(nil)
+
+func (db *PebbleDB) DB() *pebble.DB {
+	return db.db
+}
+
+// NB:  A lot of the code in this file is sourced from here: https://github.com/cockroachdb/pebble/blob/master/cmd/pebble/db.go
+// NB: This was my best working commit from today July 27 2022: https://github.com/notional-labs/tm-db/tree/6a41b774b9c362cac7d22156fa1021780d801f8a
+
+func NewPebbleDB(name string, dir string) (DB, error) {
+	dbPath := filepath.Join(dir, name+".db")
+	//	cache := pebble.NewCache(1024 * 1024 * 32)
+	//	defer cache.Unref()
+	opts := &pebble.Options{
+		//		Cache:                       cache,
+		//		FormatMajorVersion:          pebble.FormatNewest,
+		//		L0CompactionThreshold:       2,
+		//		L0StopWritesThreshold:       1000,
+		//		LBaseMaxBytes:               64 << 20, // 64 MB
+		//		Levels:                      make([]pebble.LevelOptions, 7),
+		//		MaxConcurrentCompactions:    3,
+		//		MaxOpenFiles:                1024,
+		//		MemTableSize:                64 << 20,
+		//		MemTableStopWritesThreshold: 4,
+	}
+	/*
+		for i := 0; i < len(opts.Levels); i++ {
+			l := &opts.Levels[i]
+			l.BlockSize = 32 << 10       // 32 KB
+			l.IndexBlockSize = 256 << 10 // 256 KB
+			l.FilterPolicy = bloom.FilterPolicy(10)
+			l.FilterType = pebble.TableFilter
+			if i > 0 {
+				l.TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
+			}
+			l.EnsureDefaults()
+		}
+	*/
+	//	opts.Levels[6].FilterPolicy = nil
+	//	opts.FlushSplitBytes = opts.Levels[0].TargetFileSize
+
+	opts.EnsureDefaults()
+
+	p, err := pebble.Open(dbPath, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &PebbleDB{
+		db: p,
+	}, err
+}
+
+// Get implements DB.
+func (db *PebbleDB) Get(key []byte) ([]byte, error) {
+	if len(key) == 0 {
+		return nil, errKeyEmpty
+	}
+	res, closer, err := db.db.Get(key)
+	if err != nil {
+		return res, nil
+	}
+	closer.Close()
+	return res, nil
+}
+
+// Has implements DB.
+func (db *PebbleDB) Has(key []byte) (bool, error) {
+	if len(key) == 0 {
+		return false, errKeyEmpty
+	}
+	bytes, err := db.Get(key)
+	if err != nil {
+		return false, err
+	}
+	return bytes != nil, nil
+}
+
+// Set implements DB.
+func (db *PebbleDB) Set(key []byte, value []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	if value == nil {
+		return errValueNil
+	}
+	err := db.db.Set(key, value, pebble.NoSync)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetSync implements DB.
+func (db *PebbleDB) SetSync(key []byte, value []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	if value == nil {
+		return errValueNil
+	}
+	err := db.db.Set(key, value, pebble.Sync)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete implements DB.
+func (db *PebbleDB) Delete(key []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	err := db.db.Delete(key, pebble.NoSync)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteSync implements DB.
+func (db PebbleDB) DeleteSync(key []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	err := db.db.Delete(key, pebble.Sync)
+	if err != nil {
+		return nil
+	}
+	return nil
+}
+
+// Close implements DB.
+func (db PebbleDB) Close() error {
+	db.db.Close()
+	return nil
+}
+
+// Print implements DB.
+func (db *PebbleDB) Print() error {
+	itr, err := db.Iterator(nil, nil)
+	if err != nil {
+		return err
+	}
+	defer itr.Close()
+	for ; itr.Valid(); itr.Next() {
+		key := itr.Key()
+		value := itr.Value()
+		fmt.Printf("[%X]:\t[%X]\n", key, value)
+	}
+	return nil
+}
+
+// The stats section was contributed by ValNodes.  Toss e'm some stake!
+// Stats implements DB.
+func (db *PebbleDB) Stats() map[string]string {
+	stats := make(map[string]string, 1)
+	stats["Metrics"] = fmt.Sprint(db.db.Metrics())
+	return stats
+}
+
+// NewBatch implements DB.
+func (db *PebbleDB) NewBatch() Batch {
+	return newPebbleDBBatch(db)
+}
+
+// NB For the reverse iterator and the iterator, this seems to make some sense: https://github.com/cockroachdb/pebble/blob/7b78c71e40558c8d6cc1c673b5075376609ff4ea/cmd/pebble/db.go#L120
+
+// Iterator implements DB.
+func (db *PebbleDB) Iterator(start, end []byte) (Iterator, error) {
+	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
+		return nil, errKeyEmpty
+	}
+	o := pebble.IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+	}
+	itr := db.db.NewIter(&o)
+	itr.First()
+
+	return newPebbleDBIterator(itr, start, end, false), nil
+}
+
+// ReverseIterator implements DB.
+func (db *PebbleDB) ReverseIterator(start, end []byte) (Iterator, error) {
+	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
+		return nil, errKeyEmpty
+	}
+	o := pebble.IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+	}
+	itr := db.db.NewIter(&o)
+	itr.Last()
+	return newPebbleDBIterator(itr, start, end, true), nil
+}
+
+type pebbleDBIterator struct {
+	source     *pebble.Iterator
+	start, end []byte
+	isReverse  bool
+	isInvalid  bool
+}
+
+var _ Iterator = (*pebbleDBIterator)(nil)
+
+func newPebbleDBIterator(source *pebble.Iterator, start, end []byte, isReverse bool) *pebbleDBIterator {
+	if isReverse {
+		if end == nil {
+			source.Last()
+		}
+	} else {
+		if start == nil {
+			source.First()
+		}
+	}
+	return &pebbleDBIterator{
+		source:    source,
+		start:     start,
+		end:       end,
+		isReverse: isReverse,
+		isInvalid: false,
+	}
+}
+
+// Domain implements Iterator.
+func (itr *pebbleDBIterator) Domain() ([]byte, []byte) {
+	return itr.start, itr.end
+}
+
+// Valid implements Iterator.
+func (itr *pebbleDBIterator) Valid() bool {
+	// Once invalid, forever invalid.
+	if itr.isInvalid {
+		return false
+	}
+
+	// If source has error, invalid.
+	if err := itr.source.Error(); err != nil {
+		itr.isInvalid = true
+
+		return false
+	}
+
+	// If source is invalid, invalid.
+	if !itr.source.Valid() {
+		itr.isInvalid = true
+
+		return false
+	}
+
+	// If key is end or past it, invalid.
+	start := itr.start
+	end := itr.end
+	key := itr.source.Key()
+	if itr.isReverse {
+		if start != nil && bytes.Compare(key, start) < 0 {
+			itr.isInvalid = true
+
+			return false
+		}
+	} else {
+		if end != nil && bytes.Compare(end, key) <= 0 {
+			itr.isInvalid = true
+
+			return false
+		}
+	}
+
+	// It's valid.
+	return true
+}
+
+// Key implements Iterator.
+func (itr *pebbleDBIterator) Key() []byte {
+	itr.assertIsValid()
+	return itr.source.Key()
+}
+
+// Value implements Iterator.
+func (itr *pebbleDBIterator) Value() []byte {
+	itr.assertIsValid()
+	return itr.source.Value()
+}
+
+// Next implements Iterator.
+func (itr pebbleDBIterator) Next() {
+	itr.assertIsValid()
+	if itr.isReverse {
+		itr.source.Prev()
+	} else {
+		itr.source.Next()
+	}
+}
+
+// Error implements Iterator.
+func (itr *pebbleDBIterator) Error() error {
+	return itr.source.Error()
+}
+
+// Close implements Iterator.
+func (itr *pebbleDBIterator) Close() error {
+	err := itr.source.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (itr *pebbleDBIterator) assertIsValid() {
+	if !itr.Valid() {
+		panic("iterator is invalid")
+	}
+}
+
+type pebbleDBBatch struct {
+	db    *PebbleDB
+	batch *pebble.Batch
+}
+
+var _ Batch = (*pebbleDBBatch)(nil)
+
+// new PebbleDBBatch returns a new PebbleDBBatch.
+func newPebbleDBBatch(db *PebbleDB) *pebbleDBBatch {
+	return &pebbleDBBatch{
+		batch: db.db.NewBatch(),
+	}
+}
+
+// Set implements Batch.
+// 1) we make sure that the key is not empty, and if it is we return errKeyEmpty.
+// 2) Then we check if the value is nil, If the value is nil, we return an error.
+// 3) Then we check if the batch is nil value, and return errBatchClosed if it is.
+// 4) We set a new value in the batch.
+// 5) We return nil.
+func (b *pebbleDBBatch) Set(key, value []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	if value == nil {
+		return errValueNil
+	}
+	if b.batch == nil {
+		return errBatchClosed
+	}
+	b.batch.Set(key, value, nil)
+	return nil
+}
+
+// Delete implements Batch.
+func (b *pebbleDBBatch) Delete(key []byte) error {
+	if len(key) == 0 {
+		return errKeyEmpty
+	}
+	if b.batch == nil {
+		return errBatchClosed
+	}
+	b.batch.Delete(key, nil)
+	return nil
+}
+
+// Write implements Batch.
+func (b *pebbleDBBatch) Write() error {
+	if b.batch == nil {
+		return errBatchClosed
+	}
+	err := b.batch.Commit(pebble.NoSync)
+	if err != nil {
+		return err
+	}
+	// Make sure batch cannot be used afterwards. Callers should still call Close(), for errors.
+
+	return b.Close()
+}
+
+// WriteSync implements Batch.
+func (b *pebbleDBBatch) WriteSync() error {
+	if b.batch == nil {
+		return errBatchClosed
+	}
+	err := b.batch.Commit(pebble.Sync)
+	if err != nil {
+		return err
+	}
+	// Make sure batch cannot be used afterwards. Callers should still call Close(), for errors.
+	return b.Close()
+}
+
+// Close implements Batch.
+func (b *pebbleDBBatch) Close() error {
+	if b.batch != nil {
+		err := b.batch.Close()
+		if err != nil {
+			return err
+		}
+		b.batch = nil
+	}
+
+	return nil
+}

--- a/pkgs/db/pebble_test.go
+++ b/pkgs/db/pebble_test.go
@@ -1,0 +1,60 @@
+//go:build pebbledb
+
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPebbleDBBackend(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	_, ok := db.(*PebbleDB)
+	assert.True(t, ok)
+}
+
+func TestWithPebbleDB(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pebbledb")
+
+	db, err := NewPebbleDB(path, "")
+	require.NoError(t, err)
+
+	t.Run("PebbleDB", func(t *testing.T) { Run(t, db) })
+}
+
+func TestPebbleDBStats(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	require.NoError(t, err)
+	defer cleanupDBDir(dir, name)
+
+	assert.NotEmpty(t, db.Stats())
+}
+
+func BenchmarkPebbleDBRandomReadsWrites(b *testing.B) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	dir := os.TempDir()
+	db, err := NewDB(name, PebbleDBBackend, dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		db.Close()
+		cleanupDBDir("", name)
+	}()
+
+	benchmarkRandomReadsWrites(b, db)
+}
+


### PR DESCRIPTION
Pebbledb is a rocks-like kv store written in pure go.

It has performance and resource consumption benefits when compared to rocksdb. 

Likely, its ease of use, configurability, and performance will make it the logical candidate for default when compared to rocksdb and goleveldb.

Errors need to be corrected before marking ready for review. 
