### PR TITLE
chore: allow passing password as stdin

### DIFF
--- a/cmd/gnofaucet/gnofaucet.go
+++ b/cmd/gnofaucet/gnofaucet.go
@@ -80,27 +80,29 @@ func main() {
 // serveApp
 
 type serveOptions struct {
-	client.BaseOptions        // home, ...
-	ChainID            string `flag:"chain-id" help:"chain id"`
-	GasWanted          int64  `flag:"gas-wanted" help:"gas requested for tx"`
-	GasFee             string `flag:"gas-fee" help:"gas payment fee"`
-	Memo               string `flag:"memo" help:"any descriptive text"`
-	TestTo             string `flag:"test-to" help:"test addr (optional)"`
-	Send               string `flag:"send" help:"send coins"`
-	CaptchaSecret      string `flag:"captcha-secret" help:"recaptcha secret key (if empty, captcha are disabled)"`
-	IsBehindProxy      bool   `flag:"is-behind-proxy" help:"use X-Forwarded-For IP for throttling."`
+	client.BaseOptions           // home, ...
+	ChainID               string `flag:"chain-id" help:"chain id"`
+	GasWanted             int64  `flag:"gas-wanted" help:"gas requested for tx"`
+	GasFee                string `flag:"gas-fee" help:"gas payment fee"`
+	Memo                  string `flag:"memo" help:"any descriptive text"`
+	TestTo                string `flag:"test-to" help:"test addr (optional)"`
+	Send                  string `flag:"send" help:"send coins"`
+	CaptchaSecret         string `flag:"captcha-secret" help:"recaptcha secret key (if empty, captcha are disabled)"`
+	IsBehindProxy         bool   `flag:"is-behind-proxy" help:"use X-Forwarded-For IP for throttling"`
+	InsecurePasswordStdin bool   `flag:"insecure-password-stdin" help:"WARNING! take password from stdin"`
 }
 
 var DefaultServeOptions = serveOptions{
-	BaseOptions:   client.DefaultBaseOptions,
-	ChainID:       "", // must override
-	GasWanted:     50000,
-	GasFee:        "1000000ugnot",
-	Memo:          "",
-	TestTo:        "",
-	Send:          "1000000ugnot",
-	CaptchaSecret: "",
-	IsBehindProxy: false,
+	BaseOptions:           client.DefaultBaseOptions,
+	ChainID:               "", // must override
+	GasWanted:             50000,
+	GasFee:                "1000000ugnot",
+	Memo:                  "",
+	TestTo:                "",
+	Send:                  "1000000ugnot",
+	CaptchaSecret:         "",
+	IsBehindProxy:         false,
+	InsecurePasswordStdin: false,
 }
 
 func serveApp(cmd *command.Command, args []string, iopts interface{}) error {
@@ -167,9 +169,9 @@ func serveApp(cmd *command.Command, args []string, iopts interface{}) error {
 	const dummy = "test"
 	var pass string
 	if opts.Quiet {
-		pass, err = cmd.GetPassword("")
+		pass, err = cmd.GetPassword("", opts.InsecurePasswordStdin)
 	} else {
-		pass, err = cmd.GetPassword("Enter password.")
+		pass, err = cmd.GetPassword("Enter password.", opts.InsecurePasswordStdin)
 	}
 	if err != nil {
 		return err

--- a/cmd/gnokey/gnokeys.go
+++ b/cmd/gnokey/gnokeys.go
@@ -302,9 +302,9 @@ func signAndBroadcast(cmd *command.Command, args []string, tx std.Tx, baseopts c
 	}
 	sopts.Home = baseopts.Home
 	if baseopts.Quiet {
-		sopts.Pass, err = cmd.GetPassword("")
+		sopts.Pass, err = cmd.GetPassword("", baseopts.InsecurePasswordStdin)
 	} else {
-		sopts.Pass, err = cmd.GetPassword("Enter password.")
+		sopts.Pass, err = cmd.GetPassword("Enter password.", baseopts.InsecurePasswordStdin)
 	}
 	if err != nil {
 		return err

--- a/pkgs/command/prompt.go
+++ b/pkgs/command/prompt.go
@@ -12,13 +12,19 @@ import (
 
 // GetPassword will prompt for a password one-time (to sign a tx).
 // Passwords may be blank; user must validate.
-func (cmd *Command) GetPassword(prompt string) (pass string, err error) {
+func (cmd *Command) GetPassword(prompt string, insecureUseStdin bool) (pass string, err error) {
 	if prompt != "" {
 		// On stderr so it isn't part of bash output.
 		cmd.ErrPrintln(prompt)
 	}
-	pass, err = cmd.readPasswordFromInBuf()
 
+	// insecure stdin.
+	if insecureUseStdin {
+		return cmd.readLineFromInBuf()
+	}
+
+	// secure prompt.
+	pass, err = cmd.readPasswordFromInBuf()
 	if err != nil {
 		return "", err
 	}
@@ -30,11 +36,11 @@ func (cmd *Command) GetPassword(prompt string) (pass string, err error) {
 // It enforces the password length. Only parses password once if
 // input is piped in.
 func (cmd *Command) GetCheckPassword(prompt, prompt2 string) (string, error) {
-	pass, err := cmd.GetPassword(prompt)
+	pass, err := cmd.GetPassword(prompt, false)
 	if err != nil {
 		return "", err
 	}
-	pass2, err := cmd.GetPassword(prompt2)
+	pass2, err := cmd.GetPassword(prompt2, false)
 	if err != nil {
 		return "", err
 	}

--- a/pkgs/crypto/keys/client/delete.go
+++ b/pkgs/crypto/keys/client/delete.go
@@ -53,8 +53,8 @@ func deleteApp(cmd *command.Command, args []string, iopts interface{}) error {
 	skipPass := opts.Force
 	var oldpass string
 	if !skipPass {
-		if oldpass, err = cmd.GetPassword(
-			"DANGER - enter password to permanently delete key:"); err != nil {
+		msg := "DANGER - enter password to permanently delete key:"
+		if oldpass, err = cmd.GetPassword(msg, false); err != nil {
 			return err
 		}
 	}

--- a/pkgs/crypto/keys/client/options.go
+++ b/pkgs/crypto/keys/client/options.go
@@ -6,25 +6,26 @@ import (
 )
 
 type BaseOptions struct {
-	Home   string `flag:"home" help:"home directory"`
-	Remote string `flag:"remote" help:"remote node URL (default 127.0.0.1:26657)"`
-	Quiet  bool   `flag:"quiet" help:"for parsing output"`
+	Home                  string `flag:"home" help:"home directory"`
+	Remote                string `flag:"remote" help:"remote node URL (default 127.0.0.1:26657)"`
+	Quiet                 bool   `flag:"quiet" help:"for parsing output"`
+	InsecurePasswordStdin bool   `flag:"insecure-password-stdin" help:"WARNING! take password from stdin"`
 }
 
 var DefaultBaseOptions = BaseOptions{
-	Home:   homeDir(),
-	Remote: "127.0.0.1:26657",
-	Quiet:  false,
+	Home:                  homeDir(),
+	Remote:                "127.0.0.1:26657",
+	Quiet:                 false,
+	InsecurePasswordStdin: false,
 }
 
 func homeDir() string {
 	// if environment set, always use that.
 	hd := os.Getenv("GNO_HOME")
 	if hd != "" {
-		return fmt.Sprintf("%s/.gno", hd)
+		return hd
 	}
-	// look for dir in local directory.
-	// XXX
+
 	// look for dir in home directory.
 	hd, err := os.UserHomeDir()
 	if err != nil {

--- a/pkgs/crypto/keys/client/sign.go
+++ b/pkgs/crypto/keys/client/sign.go
@@ -56,9 +56,9 @@ func signApp(cmd *command.Command, args []string, iopts interface{}) error {
 	}
 
 	if opts.Quiet {
-		opts.Pass, err = cmd.GetPassword("")
+		opts.Pass, err = cmd.GetPassword("", opts.InsecurePasswordStdin)
 	} else {
-		opts.Pass, err = cmd.GetPassword("Enter password.")
+		opts.Pass, err = cmd.GetPassword("Enter password.", opts.InsecurePasswordStdin)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
* [x] allow passing password from `stdin`.
* [x] BREAKING: if `$GNO_HOME` is passed, don’t append anything, just take it raw.
* [ ] ~add foundations and first example for integration tests using passwords. (Depends on #327);~ will be done later.