### PR TITLE
Add internal mempool client interface check

### DIFF
--- a/pkgs/bft/rpc/client/httpclient.go
+++ b/pkgs/bft/rpc/client/httpclient.go
@@ -52,6 +52,7 @@ type rpcClient interface {
 	NetworkClient
 	SignClient
 	StatusClient
+	MempoolClient
 }
 
 // baseRPCClient implements the basic RPC method logic without the actual


### PR DESCRIPTION
Problem solved: 
missing internal interface check on mempool client ( gno/pkgs/bft/rpc/client/interface.go )