### PR TITLE
docs: improve vim config with usage of gofmt

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -5,7 +5,16 @@
 Add to your .vimrc file:
 
 ```vim
-au BufRead,BufNewFile *.gno set filetype=go
+function! GnoFmt()
+	cexpr system('gofmt -e -w ' . expand('%')) "or replace with gofumpt
+	edit!
+endfunction
+command! GnoFmt call GnoFmt()
+augroup gno_autocmd
+	autocmd!
+	autocmd BufNewFile,BufRead *.gno set filetype=go
+	autocmd BufWritePost *.gno GnoFmt
+augroup END
 ```
 
 TODO: other vim tweaks to make work with vim-go etc.


### PR DESCRIPTION
The change allows to run gofmt when the buffer is saved. The buffer is then updated with the formatted code.

If errors occur, they feed the quickfix list, thanks to the `cexpr` command.

`gofmt` can be replaced with `gofumpt` without other changes. Using `goimports` is also possible but I'm not sure the added imports will be correct for a gno file.

Thanks @moul for the gofmt tip ;)