### PR TITLE
feat(gnotxport): support stdout + add --follow

### DIFF
--- a/cmd/gnokey/gnokeys.go
+++ b/cmd/gnokey/gnokeys.go
@@ -80,6 +80,14 @@ type SignBroadcastOptions struct {
 	ChainID   string `flag:"chainid" help:"chainid to sign for (only useful if --broadcast)"`
 }
 
+var defaultSignBroadcastOptions = SignBroadcastOptions{
+	GasWanted: 0,
+	GasFee:    "",
+	Memo:      "",
+	Broadcast: false,
+	ChainID:   "dev",
+}
+
 //----------------------------------------
 // makeAddPackageTx
 
@@ -92,10 +100,11 @@ type makeAddPackageTxOptions struct {
 }
 
 var defaultMakeAddPackageTxOptions = makeAddPackageTxOptions{
-	BaseOptions: client.DefaultBaseOptions,
-	PkgPath:     "", // must override
-	PkgDir:      "", // must override
-	Deposit:     "",
+	BaseOptions:          client.DefaultBaseOptions,
+	SignBroadcastOptions: defaultSignBroadcastOptions,
+	PkgPath:              "", // must override
+	PkgDir:               "", // must override
+	Deposit:              "",
 }
 
 func makeAddPackageTxApp(cmd *command.Command, args []string, iopts interface{}) error {
@@ -182,11 +191,12 @@ type makeCallTxOptions struct {
 }
 
 var defaultMakeCallTxOptions = makeCallTxOptions{
-	BaseOptions: client.DefaultBaseOptions,
-	PkgPath:     "", // must override
-	Func:        "", // must override
-	Args:        nil,
-	Send:        "",
+	BaseOptions:          client.DefaultBaseOptions,
+	SignBroadcastOptions: defaultSignBroadcastOptions,
+	PkgPath:              "", // must override
+	Func:                 "", // must override
+	Args:                 nil,
+	Send:                 "",
 }
 
 func makeCallTxApp(cmd *command.Command, args []string, iopts interface{}) error {
@@ -349,9 +359,10 @@ type makeSendTxOptions struct {
 }
 
 var defaultMakeSendTxOptions = makeSendTxOptions{
-	BaseOptions: client.DefaultBaseOptions,
-	Send:        "", // must override
-	To:          "", // must override
+	BaseOptions:          client.DefaultBaseOptions,
+	SignBroadcastOptions: defaultSignBroadcastOptions,
+	Send:                 "", // must override
+	To:                   "", // must override
 }
 
 func makeSendTxApp(cmd *command.Command, args []string, iopts interface{}) error {

--- a/cmd/gnotxport/export.go
+++ b/cmd/gnotxport/export.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"io"
 
 	"github.com/gnolang/gno/pkgs/amino"
 	"github.com/gnolang/gno/pkgs/bft/rpc/client"
@@ -45,9 +46,15 @@ func txExportApp(cmd *command.Command, args []string, iopts interface{}) error {
 	} else {
 		last = opts.EndHeight
 	}
-	out, err := os.OpenFile(opts.OutFile, os.O_RDWR|os.O_CREATE, 0o755)
-	if err != nil {
-		return err
+	var out  io.Writer
+	switch opts.OutFile{
+		case "-", "STDOUT":
+		out = os.Stdout
+		default:
+		out, err = os.OpenFile(opts.OutFile, os.O_RDWR|os.O_CREATE, 0o755)
+		if err != nil {
+			return err
+		}
 	}
 
 	for height := opts.StartHeight; height <= last; height++ {

--- a/cmd/gnotxport/export.go
+++ b/cmd/gnotxport/export.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
-	"io"
 
 	"github.com/gnolang/gno/pkgs/amino"
 	"github.com/gnolang/gno/pkgs/bft/rpc/client"
@@ -46,11 +46,11 @@ func txExportApp(cmd *command.Command, args []string, iopts interface{}) error {
 	} else {
 		last = opts.EndHeight
 	}
-	var out  io.Writer
-	switch opts.OutFile{
-		case "-", "STDOUT":
+	var out io.Writer
+	switch opts.OutFile {
+	case "-", "STDOUT":
 		out = os.Stdout
-		default:
+	default:
 		out, err = os.OpenFile(opts.OutFile, os.O_RDWR|os.O_CREATE, 0o755)
 		if err != nil {
 			return err

--- a/pkgs/crypto/keys/client/add.go
+++ b/pkgs/crypto/keys/client/add.go
@@ -36,12 +36,13 @@ const DryRunKeyPass = "12345678"
 
 /*
 input
-	- bip39 mnemonic
-	- bip39 passphrase
-	- bip44 path
-	- local encryption password
+  - bip39 mnemonic
+  - bip39 passphrase
+  - bip44 path
+  - local encryption password
+
 output
-	- armor encrypted private key (saved to file)
+  - armor encrypted private key (saved to file)
 */
 func addApp(cmd *command.Command, args []string, iopts interface{}) error {
 	var kb keys.Keybase

--- a/pkgs/crypto/keys/client/sign.go
+++ b/pkgs/crypto/keys/client/sign.go
@@ -28,6 +28,7 @@ type SignOptions struct {
 var DefaultSignOptions = SignOptions{
 	BaseOptions: DefaultBaseOptions,
 	TxPath:      "-", // read from stdin.
+	ChainID:     "dev",
 }
 
 func signApp(cmd *command.Command, args []string, iopts interface{}) error {

--- a/pkgs/crypto/keys/keybase_test.go
+++ b/pkgs/crypto/keys/keybase_test.go
@@ -260,7 +260,6 @@ func TestExportImport(t *testing.T) {
 	require.Equal(t, john, john2)
 }
 
-//
 func TestExportImportPubKey(t *testing.T) {
 	// make the storage with reasonable defaults
 	cstore := NewInMemory()


### PR DESCRIPTION
* gnotxport: `--out -|STDOUT` to write to stdout.
* gnotxport: now have a `--follow` flag to keep connected and print new events.
* global: setup default value for `--chainid` to `--dev` to make it optional.