### PR TITLE
chore: improve Windows OS support

### DIFF
--- a/pkgs/amino/amino.go
+++ b/pkgs/amino/amino.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"time"
@@ -890,7 +890,7 @@ func GetCallersDirname() string {
 	if !ok {
 		panic("could not get caller to derive caller's package directory")
 	}
-	dirname = path.Dir(filename)
+	dirname = filepath.Dir(filename)
 	if filename == "" || dirname == "" {
 		panic("could not derive caller's package directory")
 	}

--- a/pkgs/command/prompt.go
+++ b/pkgs/command/prompt.go
@@ -104,7 +104,7 @@ func (cmd *Command) readPasswordFromInBuf() (string, error) {
 	var fd int
 	var pass string
 	if cmd.In == os.Stdin {
-		fd = syscall.Stdin
+		fd = int(syscall.Stdin)
 		inputPass, err := term.ReadPassword(fd)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Errors fixed
- gnoland
Uses filepath as `amino/pkg/pgk.go GetCallersDirname` 
https://github.com/gnolang/gno/blob/3fe1433917ac6a0d0305b2cc8d5ad9344894fb59/pkgs/amino/pkg/pkg.go#L311
```
panic: dirName not canonical. got C:/.../gno/core/pkgs/crypto/multisig, expected C:\...\gno\core\pkgs\crypto\multisig
```
- gnokey
```
pkgs\command\prompt.go:107:8: cannot use syscall.Stdin (variable of type syscall.Handle) as type int in assignmentent
```