### PR TITLE
fix(bft/rpc): check http status code

### DIFF
--- a/pkgs/bft/rpc/lib/client/http_client.go
+++ b/pkgs/bft/rpc/lib/client/http_client.go
@@ -197,6 +197,10 @@ func (c *JSONRPCClient) Call(method string, params map[string]interface{}, resul
 	}
 	defer httpResponse.Body.Close() // nolint: errcheck
 
+	if !statusOK(httpResponse.StatusCode) {
+		return nil, errors.New("server at '%s' returned %s", c.address, httpResponse.Status)
+	}
+
 	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, err
@@ -229,6 +233,10 @@ func (c *JSONRPCClient) sendBatch(requests []*jsonRPCBufferedRequest) ([]interfa
 		return nil, err
 	}
 	defer httpResponse.Body.Close() // nolint: errcheck
+
+	if !statusOK(httpResponse.StatusCode) {
+		return nil, errors.New("server at '%s' returned %s", c.address, httpResponse.Status)
+	}
 
 	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
@@ -319,6 +327,10 @@ func (c *URIClient) Call(method string, params map[string]interface{}, result in
 		return nil, err
 	}
 	defer resp.Body.Close() // nolint: errcheck
+
+	if !statusOK(resp.StatusCode) {
+		return nil, errors.New("server at '%s' returned %s", c.address, resp.Status)
+	}
 
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -436,3 +448,5 @@ func argsToJSON(args map[string]interface{}) error {
 	}
 	return nil
 }
+
+func statusOK(code int) bool { return code >= 200 && code <= 299 }


### PR DESCRIPTION
This change improves the error handling of rpc clients.

Previously, the client tried to unmarshal the response body whatever the returned status code. This typically outputs errors like `invalid character '<' looking for beginning of value` because the body format is HTML and not JSON. This kind of error is difficult to interpret for the end user, this was mentioned for instance in this issue https://github.com/gnolang/gno/issues/329#issuecomment-1257190905.

Now, if the status code is not between 200 and 299, the client doesn't try to unmarshal the response body and directly returns an error `server at '<ADDRESS>' returned <ERROR_STATUS>`.
