### PR TITLE
chore: fix to import path of misc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ gnotxport:
 # Logos is the interface to Gnoland
 logos:
 	@echo "building logos"
-	go build -o build/logos ./logos/cmd/logos.go
+	go build -o build/logos ./misc/logos/cmd/logos.go
 
 clean:
 	rm -rf build

--- a/misc/logos/cmd/logos.go
+++ b/misc/logos/cmd/logos.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/gdamore/tcell/v2/encoding"
-	"github.com/gnolang/gno/logos"
+	"github.com/gnolang/gno/misc/logos"
 )
 
 var (


### PR DESCRIPTION
Fix to import path of `misc` :-)


```
$ make
Building gnoland
go build -o build/gnoland ./cmd/gnoland
Building gnokey
go build -o build/gnokey ./cmd/gnokey
Building goscan
go build -o build/goscan ./cmd/goscan
building logos
go build -o build/logos ./logos/cmd/logos.go
stat /Users/anarch/go/blockchain/src/gno/logos/cmd/logos.go: directory not found
make: *** [logos] Error 1
```
