### PR TITLE
chore(tx/call): improve error format output

### DIFF
--- a/cmd/gnokey/gnokeys.go
+++ b/cmd/gnokey/gnokeys.go
@@ -335,10 +335,10 @@ func signAndBroadcast(cmd *command.Command, args []string, tx std.Tx, baseopts c
 		return errors.Wrap(err, "broadcast tx")
 	}
 	if bres.CheckTx.IsErr() {
-		return errors.New("transaction failed %#v\nlog %s", bres, bres.CheckTx.Log)
+		return errors.Wrap(bres.CheckTx.Error, "check transaction failed: log:%s", bres.CheckTx.Log)
 	}
 	if bres.DeliverTx.IsErr() {
-		return errors.New("transaction failed %#v\nlog %s", bres, bres.DeliverTx.Log)
+		return errors.Wrap(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
 	}
 	cmd.Println(string(bres.DeliverTx.Data))
 	cmd.Println("OK!")

--- a/pkgs/sdk/vm/keeper.go
+++ b/pkgs/sdk/vm/keeper.go
@@ -228,7 +228,7 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 	m.SetActivePackage(mpv)
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.New("VM call panic: %v\n%s\n",
+			err = errors.Wrap(fmt.Errorf("%v", r), "VM call panic: %v\n%s\n",
 				r, m.String())
 			return
 		}


### PR DESCRIPTION
Fix #329

As mentioned in the issue, errors from `maketx call`  are hard to read/interpret. This PR tries to improve that.

As an example, this is the output of `maketx call` for the `Register` function of `gno.land/r/users`, when the signer is not invited and didn't send any payment (`--send` flag).

<details><summary>Before</summary>

```
transaction failed &core_types.ResultBroadcastTxCommit{CheckTx:abci.ResponseCheckTx{ResponseBase:abci.ResponseBase{Error:abci.Error(nil), Data:[]uint8(nil), Events:[]abci.Event(nil), Log:"msg:0,success:true,log:,events:[]", Info:""}, GasWanted:2000000, GasUsed:28568}, DeliverTx:abci.ResponseDeliverTx{ResponseBase:abci.ResponseBase{Error:"VM call panic: (\"payment must not be less than 200000000\" string)\nMachine:\n    CheckTypes: false\n\tOp: [OpHalt OpExec OpBody OpPopBlock OpBody OpPopBlock OpBody]\n\tValues: (len: 1)\n          #0 (Register func(inviter std.Address,name string,profile string)())\n\tExprs:\n\n\tStmts:\n          #3 bodyStmt[0/0/1]=(end)\n          #2 bodyStmt[0/0/1]=(end)\n          #1 bodyStmt[0/0/6]=_<VPBlock(0,0)>, _<VPBlock(0,0)>, ok<VPBlock(1,6)> := name2User<VPBlock(3,13)>.Get(name<VPBlock(1,1)>)\n          #0 return\n\tBlocks:\n          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006956780,Source:if (const-type bool)((const (len...,Parent:0xc0069565a0)\n (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0011e3820,Source:if (const-type bool)((const (len...,Parent:0xc004dda2c8)\n (s typs) @(1) []\n          @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\n (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\n (s typs) @(2) []\n          @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\n            inviter: (\"\" std.Address)\n            name: (\"testtest1\" string)\n            profile: (\"\" string)\n            caller: (\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\" std.Address)\n            sentCoins: (slice[] std.Coins)\n            minCoin: (struct{(\"ugnot\" string),(200000000 int64)} std.Coin)\n            ok: (undefined)\n            invites: (undefined)\n            user: (undefined)\n (s vals) @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\n            inviter: ( std.Address)\n            name: ( string)\n            profile: ( string)\n            caller: ( std.Address)\n            sentCoins: (nil std.Coins)\n            minCoin: (nil std.Coin)\n            ok: (false bool)\n            invites: (0 int)\n            user: (nil *gno.land/r/users.User)\n (s typs) @(3) [std.Address string string std.Address std.Coins std.Coin bool int *gno.land/r/users.User]\n          @(4) Block(ID:4d94e14b6268677dcba069f6e90c230e383956d7:3,Addr:0xc0068963c0,Source:ref(gno.land/r/users/users.gno:1...,Parent:0xc006896000)\n            (RefNode names not shown)\n (s vals) @(4) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc003d13620,Source:file{ package users; import rege...,Parent:0xc003e29360)\n            regexp: (package(regexp regexp) package{})\n            std: (package(std std) package{})\n            strconv: (package(strconv strconv) package{})\n            strings: (package(strings strings) package{})\n            avl: (package(avl gno.land/p/avl) package{})\n (s typs) @(4) [package{} package{} package{} package{} package{}]\n          @(5) gno.land/r/users\n\tBlocks (other):\n          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\n (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\n          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\n            inviter: (\"\" std.Address)\n            name: (\"testtest1\" string)\n            profile: (\"\" string)\n            caller: (\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\" std.Address)\n            sentCoins: (slice[] std.Coins)\n            minCoin: (struct{(\"ugnot\" string),(200000000 int64)} std.Coin)\n            ok: (undefined)\n            invites: (undefined)\n            user: (undefined)\n (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\n            inviter: ( std.Address)\n            name: ( string)\n            profile: ( string)\n            caller: ( std.Address)\n            sentCoins: (nil std.Coins)\n            minCoin: (nil std.Coin)\n            ok: (false bool)\n            invites: (0 int)\n            user: (nil *gno.land/r/users.User)\n\tFrames:\n\n\tRealm:\n\t  gno.land/r/users\n\tException:\n\t  (\"payment must not be less than 200000000\" string)\n\t  payment must not be less than 200000000\n", Data:[]uint8(nil), Events:[]abci.Event(nil), Log:"msg:0,success:false,log:--= Error =--\nData: errors.FmtError{format:\"VM call panic: %v\\n%s\\n\", args:[]interface {}{(*gnolang.TypedValue)(0xc0068ecc90), \"Machine:\\n    CheckTypes: false\\n\\tOp: [OpHalt OpExec OpBody OpPopBlock OpBody OpPopBlock OpBody]\\n\\tValues: (len: 1)\\n          #0 (Register func(inviter std.Address,name string,profile string)())\\n\\tExprs:\\n\\n\\tStmts:\\n          #3 bodyStmt[0/0/1]=(end)\\n          #2 bodyStmt[0/0/1]=(end)\\n          #1 bodyStmt[0/0/6]=_<VPBlock(0,0)>, _<VPBlock(0,0)>, ok<VPBlock(1,6)> := name2User<VPBlock(3,13)>.Get(name<VPBlock(1,1)>)\\n          #0 return\\n\\tBlocks:\\n          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006956780,Source:if (const-type bool)((const (len...,Parent:0xc0069565a0)\\n (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0011e3820,Source:if (const-type bool)((const (len...,Parent:0xc004dda2c8)\\n (s typs) @(1) []\\n          @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\\n (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\\n (s typs) @(2) []\\n          @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\\n            inviter: (\\\"\\\" std.Address)\\n            name: (\\\"testtest1\\\" string)\\n            profile: (\\\"\\\" string)\\n            caller: (\\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\\" std.Address)\\n            sentCoins: (slice[] std.Coins)\\n            minCoin: (struct{(\\\"ugnot\\\" string),(200000000 int64)} std.Coin)\\n            ok: (undefined)\\n            invites: (undefined)\\n            user: (undefined)\\n (s vals) @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\\n            inviter: ( std.Address)\\n            name: ( string)\\n            profile: ( string)\\n            caller: ( std.Address)\\n            sentCoins: (nil std.Coins)\\n            minCoin: (nil std.Coin)\\n            ok: (false bool)\\n            invites: (0 int)\\n            user: (nil *gno.land/r/users.User)\\n (s typs) @(3) [std.Address string string std.Address std.Coins std.Coin bool int *gno.land/r/users.User]\\n          @(4) Block(ID:4d94e14b6268677dcba069f6e90c230e383956d7:3,Addr:0xc0068963c0,Source:ref(gno.land/r/users/users.gno:1...,Parent:0xc006896000)\\n            (RefNode names not shown)\\n (s vals) @(4) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc003d13620,Source:file{ package users; import rege...,Parent:0xc003e29360)\\n            regexp: (package(regexp regexp) package{})\\n            std: (package(std std) package{})\\n            strconv: (package(strconv strconv) package{})\\n            strings: (package(strings strings) package{})\\n            avl: (package(avl gno.land/p/avl) package{})\\n (s typs) @(4) [package{} package{} package{} package{} package{}]\\n          @(5) gno.land/r/users\\n\\tBlocks (other):\\n          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\\n (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\\n          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\\n            inviter: (\\\"\\\" std.Address)\\n            name: (\\\"testtest1\\\" string)\\n            profile: (\\\"\\\" string)\\n            caller: (\\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\\" std.Address)\\n            sentCoins: (slice[] std.Coins)\\n            minCoin: (struct{(\\\"ugnot\\\" string),(200000000 int64)} std.Coin)\\n            ok: (undefined)\\n            invites: (undefined)\\n            user: (undefined)\\n (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\\n            inviter: ( std.Address)\\n            name: ( string)\\n            profile: ( string)\\n            caller: ( std.Address)\\n            sentCoins: (nil std.Coins)\\n            minCoin: (nil std.Coin)\\n            ok: (false bool)\\n            invites: (0 int)\\n            user: (nil *gno.land/r/users.User)\\n\\tFrames:\\n\\n\\tRealm:\\n\\t  gno.land/r/users\\n\\tException:\\n\\t  (\\\"payment must not be less than 200000000\\\" string)\\n\\t  payment must not be less than 200000000\"}}\nMsg Traces:\n--= /Error =--\n,events:[]", Info:""}, GasWanted:2000000, GasUsed:146684}, Hash:[]uint8{0x5b, 0xe6, 0x2c, 0x6e, 0xd8, 0x7, 0x40, 0xce, 0xe8, 0x24, 0x1e, 0x4f, 0xca, 0x4d, 0x79, 0xdc, 0xc1, 0xf9, 0x69, 0x9f, 0x93, 0x48, 0x99, 0x34, 0x20, 0x92, 0x8c, 0x87, 0x2f, 0x5f, 0xc8, 0x16}, Height:158}
log msg:0,success:false,log:--= Error =--
Data: errors.FmtError{format:"VM call panic: %v\n%s\n", args:[]interface {}{(*gnolang.TypedValue)(0xc0068ecc90), "Machine:\n    CheckTypes: false\n\tOp: [OpHalt OpExec OpBody OpPopBlock OpBody OpPopBlock OpBody]\n\tValues: (len: 1)\n          #0 (Register func(inviter std.Address,name string,profile string)())\n\tExprs:\n\n\tStmts:\n          #3 bodyStmt[0/0/1]=(end)\n          #2 bodyStmt[0/0/1]=(end)\n          #1 bodyStmt[0/0/6]=_<VPBlock(0,0)>, _<VPBlock(0,0)>, ok<VPBlock(1,6)> := name2User<VPBlock(3,13)>.Get(name<VPBlock(1,1)>)\n          #0 return\n\tBlocks:\n          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006956780,Source:if (const-type bool)((const (len...,Parent:0xc0069565a0)\n (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0011e3820,Source:if (const-type bool)((const (len...,Parent:0xc004dda2c8)\n (s typs) @(1) []\n          @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\n (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\n (s typs) @(2) []\n          @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\n            inviter: (\"\" std.Address)\n            name: (\"testtest1\" string)\n            profile: (\"\" string)\n            caller: (\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\" std.Address)\n            sentCoins: (slice[] std.Coins)\n            minCoin: (struct{(\"ugnot\" string),(200000000 int64)} std.Coin)\n            ok: (undefined)\n            invites: (undefined)\n            user: (undefined)\n (s vals) @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\n            inviter: ( std.Address)\n            name: ( string)\n            profile: ( string)\n            caller: ( std.Address)\n            sentCoins: (nil std.Coins)\n            minCoin: (nil std.Coin)\n            ok: (false bool)\n            invites: (0 int)\n            user: (nil *gno.land/r/users.User)\n (s typs) @(3) [std.Address string string std.Address std.Coins std.Coin bool int *gno.land/r/users.User]\n          @(4) Block(ID:4d94e14b6268677dcba069f6e90c230e383956d7:3,Addr:0xc0068963c0,Source:ref(gno.land/r/users/users.gno:1...,Parent:0xc006896000)\n            (RefNode names not shown)\n (s vals) @(4) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc003d13620,Source:file{ package users; import rege...,Parent:0xc003e29360)\n            regexp: (package(regexp regexp) package{})\n            std: (package(std std) package{})\n            strconv: (package(strconv strconv) package{})\n            strings: (package(strings strings) package{})\n            avl: (package(avl gno.land/p/avl) package{})\n (s typs) @(4) [package{} package{} package{} package{} package{}]\n          @(5) gno.land/r/users\n\tBlocks (other):\n          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\n (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\n          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\n            inviter: (\"\" std.Address)\n            name: (\"testtest1\" string)\n            profile: (\"\" string)\n            caller: (\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\" std.Address)\n            sentCoins: (slice[] std.Coins)\n            minCoin: (struct{(\"ugnot\" string),(200000000 int64)} std.Coin)\n            ok: (undefined)\n            invites: (undefined)\n            user: (undefined)\n (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\n            inviter: ( std.Address)\n            name: ( string)\n            profile: ( string)\n            caller: ( std.Address)\n            sentCoins: (nil std.Coins)\n            minCoin: (nil std.Coin)\n            ok: (false bool)\n            invites: (0 int)\n            user: (nil *gno.land/r/users.User)\n\tFrames:\n\n\tRealm:\n\t  gno.land/r/users\n\tException:\n\t  (\"payment must not be less than 200000000\" string)\n\t  payment must not be less than 200000000"}}
Msg Traces:
--= /Error =--
,events:[]
--= Error =--
Data: errors.FmtError{format:"transaction failed %#v\nlog %s", args:[]interface {}{(*core_types.ResultBroadcastTxCommit)(0xc000132200), "msg:0,success:false,log:--= Error =--\nData: errors.FmtError{format:\"VM call panic: %v\\n%s\\n\", args:[]interface {}{(*gnolang.TypedValue)(0xc0068ecc90), \"Machine:\\n    CheckTypes: false\\n\\tOp: [OpHalt OpExec OpBody OpPopBlock OpBody OpPopBlock OpBody]\\n\\tValues: (len: 1)\\n          #0 (Register func(inviter std.Address,name string,profile string)())\\n\\tExprs:\\n\\n\\tStmts:\\n          #3 bodyStmt[0/0/1]=(end)\\n          #2 bodyStmt[0/0/1]=(end)\\n          #1 bodyStmt[0/0/6]=_<VPBlock(0,0)>, _<VPBlock(0,0)>, ok<VPBlock(1,6)> := name2User<VPBlock(3,13)>.Get(name<VPBlock(1,1)>)\\n          #0 return\\n\\tBlocks:\\n          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006956780,Source:if (const-type bool)((const (len...,Parent:0xc0069565a0)\\n (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0011e3820,Source:if (const-type bool)((const (len...,Parent:0xc004dda2c8)\\n (s typs) @(1) []\\n          @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\\n (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\\n (s typs) @(2) []\\n          @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\\n            inviter: (\\\"\\\" std.Address)\\n            name: (\\\"testtest1\\\" string)\\n            profile: (\\\"\\\" string)\\n            caller: (\\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\\" std.Address)\\n            sentCoins: (slice[] std.Coins)\\n            minCoin: (struct{(\\\"ugnot\\\" string),(200000000 int64)} std.Coin)\\n            ok: (undefined)\\n            invites: (undefined)\\n            user: (undefined)\\n (s vals) @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\\n            inviter: ( std.Address)\\n            name: ( string)\\n            profile: ( string)\\n            caller: ( std.Address)\\n            sentCoins: (nil std.Coins)\\n            minCoin: (nil std.Coin)\\n            ok: (false bool)\\n            invites: (0 int)\\n            user: (nil *gno.land/r/users.User)\\n (s typs) @(3) [std.Address string string std.Address std.Coins std.Coin bool int *gno.land/r/users.User]\\n          @(4) Block(ID:4d94e14b6268677dcba069f6e90c230e383956d7:3,Addr:0xc0068963c0,Source:ref(gno.land/r/users/users.gno:1...,Parent:0xc006896000)\\n            (RefNode names not shown)\\n (s vals) @(4) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc003d13620,Source:file{ package users; import rege...,Parent:0xc003e29360)\\n            regexp: (package(regexp regexp) package{})\\n            std: (package(std std) package{})\\n            strconv: (package(strconv strconv) package{})\\n            strings: (package(strings strings) package{})\\n            avl: (package(avl gno.land/p/avl) package{})\\n (s typs) @(4) [package{} package{} package{} package{} package{}]\\n          @(5) gno.land/r/users\\n\\tBlocks (other):\\n          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0069565a0,Source:if (const-type bool)(inviter<VPB...,Parent:0xc006896d20)\\n (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004dda020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004bb7820)\\n          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc006896d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0068963c0)\\n            inviter: (\\\"\\\" std.Address)\\n            name: (\\\"testtest1\\\" string)\\n            profile: (\\\"\\\" string)\\n            caller: (\\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\\" std.Address)\\n            sentCoins: (slice[] std.Coins)\\n            minCoin: (struct{(\\\"ugnot\\\" string),(200000000 int64)} std.Coin)\\n            ok: (undefined)\\n            invites: (undefined)\\n            user: (undefined)\\n (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bb7820,Source:func Register(inviter std<VPBloc...,Parent:0xc003d13620)\\n            inviter: ( std.Address)\\n            name: ( string)\\n            profile: ( string)\\n            caller: ( std.Address)\\n            sentCoins: (nil std.Coins)\\n            minCoin: (nil std.Coin)\\n            ok: (false bool)\\n            invites: (0 int)\\n            user: (nil *gno.land/r/users.User)\\n\\tFrames:\\n\\n\\tRealm:\\n\\t  gno.land/r/users\\n\\tException:\\n\\t  (\\\"payment must not be less than 200000000\\\" string)\\n\\t  payment must not be less than 200000000\"}}\nMsg Traces:\n--= /Error =--\n,events:[]"}}
Msg Traces:
--= /Error =--
```
</details>

<details><summary>After</summary>

```
("payment must not be less than 200000000" string)
--= Error =--
Data: "(\"payment must not be less than 200000000\" string)"
Msg Traces:
    0  /home/tom/src/gno/cmd/gnokey/gnokeys.go:341 - deliver transaction failed: log:msg:0,success:false,log:--= Error =--
Data: &errors.errorString{s:"(\"payment must not be less than 200000000\" string)"}
Msg Traces:
    0  /home/tom/src/gno/pkgs/sdk/vm/keeper.go:231 - VM call panic: ("payment must not be less than 200000000" string)
Machine:
    CheckTypes: false
	Op: [OpHalt OpExec OpBody OpPopBlock OpBody OpPopBlock OpBody]
	Values: (len: 1)
          #0 (Register func(inviter std.Address,name string,profile string)())
	Exprs:

	Stmts:
          #3 bodyStmt[0/0/1]=(end)
          #2 bodyStmt[0/0/1]=(end)
          #1 bodyStmt[0/0/6]=_<VPBlock(0,0)>, _<VPBlock(0,0)>, ok<VPBlock(1,6)> := name2User<VPBlock(3,13)>.Get(name<VPBlock(1,1)>)
          #0 return
	Blocks:
          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc003d241e0,Source:if (const-type bool)((const (len...,Parent:0xc002eba780)
 (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc001c85820,Source:if (const-type bool)((const (len...,Parent:0xc004bbc2c8)
 (s typs) @(1) []
          @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc002eba780,Source:if (const-type bool)(inviter<VPB...,Parent:0xc001900d20)
 (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bbc020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004c79c20)
 (s typs) @(2) []
          @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc001900d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0019003c0)
            inviter: ("" std.Address)
            name: ("testtest1" string)
            profile: ("" string)
            caller: ("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5" std.Address)
            sentCoins: (slice[] std.Coins)
            minCoin: (struct{("ugnot" string),(200000000 int64)} std.Coin)
            ok: (undefined)
            invites: (undefined)
            user: (undefined)
 (s vals) @(3) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c79c20,Source:func Register(inviter std<VPBloc...,Parent:0xc0032510a0)
            inviter: ( std.Address)
            name: ( string)
            profile: ( string)
            caller: ( std.Address)
            sentCoins: (nil std.Coins)
            minCoin: (nil std.Coin)
            ok: (false bool)
            invites: (0 int)
            user: (nil *gno.land/r/users.User)
 (s typs) @(3) [std.Address string string std.Address std.Coins std.Coin bool int *gno.land/r/users.User]
          @(4) Block(ID:4d94e14b6268677dcba069f6e90c230e383956d7:3,Addr:0xc0019003c0,Source:ref(gno.land/r/users/users.gno:1...,Parent:0xc001900000)
            (RefNode names not shown)
 (s vals) @(4) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0032510a0,Source:file{ package users; import rege...,Parent:0xc003b1eb20)
            regexp: (package(regexp regexp) package{})
            std: (package(std std) package{})
            strconv: (package(strconv strconv) package{})
            strings: (package(strings strings) package{})
            avl: (package(avl gno.land/p/avl) package{})
 (s typs) @(4) [package{} package{} package{} package{} package{}]
          @(5) gno.land/r/users
	Blocks (other):
          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc002eba780,Source:if (const-type bool)(inviter<VPB...,Parent:0xc001900d20)
 (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004bbc020,Source:if (const-type bool)(inviter<VPB...,Parent:0xc004c79c20)
          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc001900d20,Source:func Register(inviter std<VPBloc...,Parent:0xc0019003c0)
            inviter: ("" std.Address)
            name: ("testtest1" string)
            profile: ("" string)
            caller: ("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5" std.Address)
            sentCoins: (slice[] std.Coins)
            minCoin: (struct{("ugnot" string),(200000000 int64)} std.Coin)
            ok: (undefined)
            invites: (undefined)
            user: (undefined)
 (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c79c20,Source:func Register(inviter std<VPBloc...,Parent:0xc0032510a0)
            inviter: ( std.Address)
            name: ( string)
            profile: ( string)
            caller: ( std.Address)
            sentCoins: (nil std.Coins)
            minCoin: (nil std.Coin)
            ok: (false bool)
            invites: (0 int)
            user: (nil *gno.land/r/users.User)
	Frames:

	Realm:
	  gno.land/r/users
	Exception:
	  ("payment must not be less than 200000000" string)
	  payment must not be less than 200000000

Stack Trace:
    0  /home/tom/src/gno/pkgs/errors/errors.go:20
    1  /home/tom/src/gno/pkgs/sdk/vm/keeper.go:231
    2  /usr/lib/go/src/runtime/panic.go:884
    3  /home/tom/src/gno/pkgs/gnolang/op_call.go:405
    4  /home/tom/src/gno/pkgs/gnolang/machine.go:997
    5  /home/tom/src/gno/pkgs/gnolang/machine.go:572
    6  /home/tom/src/gno/pkgs/sdk/vm/keeper.go:238
    7  /home/tom/src/gno/pkgs/sdk/vm/handler.go:65
    8  /home/tom/src/gno/pkgs/sdk/vm/handler.go:29
    9  /home/tom/src/gno/pkgs/sdk/baseapp.go:644
   10  /home/tom/src/gno/pkgs/sdk/baseapp.go:823
   11  /home/tom/src/gno/pkgs/sdk/baseapp.go:580
   12  /home/tom/src/gno/pkgs/bft/abci/client/local_client.go:82
   13  /home/tom/src/gno/pkgs/bft/proxy/app_conn.go:73
   14  /home/tom/src/gno/pkgs/bft/state/execution.go:254
   15  /home/tom/src/gno/pkgs/bft/state/execution.go:103
   16  /home/tom/src/gno/pkgs/bft/consensus/state.go:1346
   17  /home/tom/src/gno/pkgs/bft/consensus/state.go:1275
   18  /home/tom/src/gno/pkgs/bft/consensus/state.go:1221
   19  /home/tom/src/gno/pkgs/bft/consensus/state.go:1251
   20  /home/tom/src/gno/pkgs/bft/consensus/state.go:1640
   21  /home/tom/src/gno/pkgs/bft/consensus/state.go:1483
   22  /home/tom/src/gno/pkgs/bft/consensus/state.go:691
   23  /home/tom/src/gno/pkgs/bft/consensus/state.go:635
   24  /usr/lib/go/src/runtime/asm_amd64.s:1595
--= /Error =--
,events:[]
Stack Trace:
    0  /home/tom/src/gno/pkgs/errors/errors.go:20
    1  /home/tom/src/gno/cmd/gnokey/gnokeys.go:341
    2  /home/tom/src/gno/cmd/gnokey/gnokeys.go:266
    3  /home/tom/src/gno/pkgs/command/command.go:64
    4  /home/tom/src/gno/cmd/gnokey/gnokeys.go:66
    5  /home/tom/src/gno/pkgs/command/command.go:45
    6  /home/tom/src/gno/pkgs/crypto/keys/client/root.go:48
    7  /home/tom/src/gno/cmd/gnokey/gnokeys.go:27
    8  /usr/lib/go/src/runtime/proc.go:259
    9  /usr/lib/go/src/runtime/asm_amd64.s:1595
--= /Error =--
```

</details>

First benefit, the root cause appears at the first line, second is the 2 stack traces (server and client) are clearly visibles.