### PR TITLE
chore: disable auto precompile on gnodev test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test.packages2:
 	go test tests/*.go -v -run "TestPackages/bytes" --timeout 30m
 
 test.examples:
-	go run ./cmd/gnodev test ./examples --no-precompile --verbose
+	go run ./cmd/gnodev test ./examples --verbose
 
 # Code gen
 stringer:

--- a/cmd/gnodev/main_test.go
+++ b/cmd/gnodev/main_test.go
@@ -42,22 +42,34 @@ func TestMain(t *testing.T) {
 		{args: []string{"test", "../../examples/gno.land/p/rand"}, stderrShouldContain: "ok      ./../../examples/gno.land/p/rand \t"},
 		{args: []string{"test", "../../tests/integ/no-such-dir"}, errShouldContain: "no such file or directory"},
 		{args: []string{"test", "../../tests/integ/empty-dir"}}, // FIXME: should have an output
-		{args: []string{"test", "../../tests/integ/empty-gno1", "--no-precompile"}, stderrShouldBe: "?       ./../../tests/integ/empty-gno1 \t[no test files]\n"},
-		{args: []string{"test", "../../tests/integ/empty-gno1"}, errShouldBe: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno1/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
-		{args: []string{"test", "../../tests/integ/empty-gno2", "--no-precompile"}, recoverShouldBe: "empty.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling + rename dontcare.gno with actual test file
-		{args: []string{"test", "../../tests/integ/empty-gno2"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno2/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
-		{args: []string{"test", "../../tests/integ/empty-gno3", "--no-precompile"}, recoverShouldBe: "../../tests/integ/empty-gno3/empty_filetest.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling
-		{args: []string{"test", "../../tests/integ/empty-gno3"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno3/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
 		{args: []string{"test", "../../tests/integ/minimalist-gno1"}, stderrShouldBe: "?       ./../../tests/integ/minimalist-gno1 \t[no test files]\n"},
 		{args: []string{"test", "../../tests/integ/minimalist-gno2"}, stderrShouldContain: "ok "},
 		{args: []string{"test", "../../tests/integ/minimalist-gno3"}, stderrShouldContain: "ok "},
 		{args: []string{"test", "../../tests/integ/valid1", "--verbose"}, stderrShouldContain: "ok "},
 		{args: []string{"test", "../../tests/integ/valid2"}, stderrShouldContain: "ok "},
 		{args: []string{"test", "../../tests/integ/valid2", "--verbose"}, stderrShouldContain: "ok "},
-		{args: []string{"test", "../../tests/integ/failing1", "--verbose", "--no-precompile"}, errShouldBe: "FAIL: 0 build errors, 1 test errors", stderrShouldContain: "FAIL: TestAlwaysFailing"},
+
+		// TODO: when 'gnodev test' will by default imply running precompile, we should use the following tests.
+		//{args: []string{"test", "../../tests/integ/empty-gno1", "--no-precompile"}, stderrShouldBe: "?       ./../../tests/integ/empty-gno1 \t[no test files]\n"},
+		//{args: []string{"test", "../../tests/integ/empty-gno1"}, errShouldBe: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno1/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
+		//{args: []string{"test", "../../tests/integ/empty-gno2", "--no-precompile"}, recoverShouldBe: "empty.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling + rename dontcare.gno with actual test file
+		//{args: []string{"test", "../../tests/integ/empty-gno2"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno2/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
+		//{args: []string{"test", "../../tests/integ/empty-gno3", "--no-precompile"}, recoverShouldBe: "../../tests/integ/empty-gno3/empty_filetest.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling
+		//{args: []string{"test", "../../tests/integ/empty-gno3"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno3/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
+		//{args: []string{"test", "../../tests/integ/failing1", "--verbose", "--no-precompile"}, errShouldBe: "FAIL: 0 build errors, 1 test errors", stderrShouldContain: "FAIL: TestAlwaysFailing"},
+		//{args: []string{"test", "../../tests/integ/failing1", "--verbose"}, errShouldBe: "FAIL: 0 build errors, 1 test errors", stderrShouldContain: "FAIL: TestAlwaysFailing"},
+		//{args: []string{"test", "../../tests/integ/failing2", "--verbose", "--no-precompile"}, recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop", stderrShouldContain: "== RUN   file/failing_filetest.gno"},
+		//{args: []string{"test", "../../tests/integ/failing2", "--verbose"}, stderrShouldBe: "=== PREC  ./../../tests/integ/failing2\n=== BUILD ./../../tests/integ/failing2\n=== RUN   file/failing_filetest.gno\n", recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop"},
+		{args: []string{"test", "../../tests/integ/empty-gno1"}, stderrShouldBe: "?       ./../../tests/integ/empty-gno1 \t[no test files]\n"},
+		{args: []string{"test", "../../tests/integ/empty-gno1", "--precompile"}, errShouldBe: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno1/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
+		{args: []string{"test", "../../tests/integ/empty-gno2"}, recoverShouldBe: "empty.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling + rename dontcare.gno with actual test file
+		{args: []string{"test", "../../tests/integ/empty-gno2", "--precompile"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno2/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
+		{args: []string{"test", "../../tests/integ/empty-gno3"}, recoverShouldBe: "../../tests/integ/empty-gno3/empty_filetest.gno:1:1: expected 'package', found 'EOF'"}, // FIXME: better error handling
+		{args: []string{"test", "../../tests/integ/empty-gno3", "--precompile"}, errShouldContain: "FAIL: 1 build errors, 0 test errors", stderrShouldContain: "../../tests/integ/empty-gno3/empty.gno: parse: tmp.gno:1:1: expected 'package', found 'EOF'"},
 		{args: []string{"test", "../../tests/integ/failing1", "--verbose"}, errShouldBe: "FAIL: 0 build errors, 1 test errors", stderrShouldContain: "FAIL: TestAlwaysFailing"},
-		{args: []string{"test", "../../tests/integ/failing2", "--verbose", "--no-precompile"}, recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop", stderrShouldContain: "== RUN   file/failing_filetest.gno"},
-		{args: []string{"test", "../../tests/integ/failing2", "--verbose"}, stderrShouldBe: "=== PREC  ./../../tests/integ/failing2\n=== BUILD ./../../tests/integ/failing2\n=== RUN   file/failing_filetest.gno\n", recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop"},
+		{args: []string{"test", "../../tests/integ/failing1", "--verbose", "--precompile"}, errShouldBe: "FAIL: 0 build errors, 1 test errors", stderrShouldContain: "FAIL: TestAlwaysFailing"},
+		{args: []string{"test", "../../tests/integ/failing2", "--verbose"}, recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop", stderrShouldContain: "== RUN   file/failing_filetest.gno"},
+		{args: []string{"test", "../../tests/integ/failing2", "--verbose", "--precompile"}, stderrShouldBe: "=== PREC  ./../../tests/integ/failing2\n=== BUILD ./../../tests/integ/failing2\n=== RUN   file/failing_filetest.gno\n", recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop"},
 
 		// test opts
 		{args: []string{"test", "../../examples/gno.land/p/ufmt"}, stderrShouldContain: "ok      ./../../examples/gno.land/p/ufmt"},

--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -24,22 +24,22 @@ import (
 )
 
 type testOptions struct {
-	Verbose      bool          `flag:"verbose" help:"verbose"`
-	RootDir      string        `flag:"root-dir" help:"clone location of github.com/gnolang/gno (gnodev tries to guess it)"`
-	Run          string        `flag:"run" help:"test name filtering pattern"`
-	Timeout      time.Duration `flag:"timeout" help:"max execution time (in ns)"` // FIXME: support ParseDuration: "1s"
-	NoPrecompile bool          `flag:"no-precompile" help:"skip precompiling gno to go"`
+	Verbose    bool          `flag:"verbose" help:"verbose"`
+	RootDir    string        `flag:"root-dir" help:"clone location of github.com/gnolang/gno (gnodev tries to guess it)"`
+	Run        string        `flag:"run" help:"test name filtering pattern"`
+	Timeout    time.Duration `flag:"timeout" help:"max execution time (in ns)"`               // FIXME: support ParseDuration: "1s"
+	Precompile bool          `flag:"precompile" help:"precompiling gno to go before testing"` // TODO: precompile should be the default, but it needs to automatically precompile dependencies in memory.
 	// VM Options
 	// A flag about if we should download the production realms
 	// UseNativeLibs bool // experimental, but could be useful for advanced developer needs
 }
 
 var defaultTestOptions = testOptions{
-	Verbose:      false,
-	Run:          "",
-	RootDir:      "",
-	Timeout:      0,
-	NoPrecompile: false,
+	Verbose:    false,
+	Run:        "",
+	RootDir:    "",
+	Timeout:    0,
+	Precompile: false,
 }
 
 func testApp(cmd *command.Command, args []string, iopts interface{}) error {
@@ -77,7 +77,7 @@ func testApp(cmd *command.Command, args []string, iopts interface{}) error {
 	buildErrCount := 0
 	testErrCount := 0
 	for _, pkgPath := range pkgPaths {
-		if !opts.NoPrecompile {
+		if opts.Precompile {
 			if verbose {
 				cmd.ErrPrintfln("=== PREC  %s", pkgPath)
 			}


### PR DESCRIPTION
we should find a reliable way to re-enable it because it brings more useful
warnings for contracts developers.

but the current implementation is not reliable because it won't automatically
precompile imported packages.

and if the imported package is withing ~/go/mod/pkg, it's read-only. So we
also need to make it working in memory.

Signed-off-by: Manfred Touron <94029+moul@users.noreply.github.com>

Fixes https://github.com/xplrz/gnoland-workshop/issues/6