### PR TITLE
faucet update

### DIFF
--- a/examples/gno.land/r/faucet-admin/admin.gno
+++ b/examples/gno.land/r/faucet-admin/admin.gno
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"errors"
+	"std"
+)
+
+
+// getter
+func AdminAddress() std.Address {
+	return adminAddress
+}
+
+func ControllerAddress() std.Address {
+	return controlAddress
+}
+
+func InPause() bool {
+	return setPause
+}
+
+func GetMessage() string {
+	return faucetMsg
+}
+
+
+var reqAddr = make(map[std.Address]uint)
+
+// TODO
+// Rules need to be more clear / more detail / more reasonable
+func PerTransferSend(addr std.Address) std.Coins {
+	// if found exists > it's their (n)th faucet request > give 1 gnot
+	if _, found := reqAddr[addr]; found {
+		return std.Coins{std.Coin{"ugnot", 1000000}}
+	} 
+
+	// if not found > it's their 1st faucet request > give 10 gnot
+	reqAddr[addr] = 1
+	return std.Coins{std.Coin{"ugnot", 10000000}} 
+}
+
+
+// setter
+// only admin is allowed to execute this function
+func SetAdminInPause(inPause bool) error {
+	if err := assertIsAdmin(); err != nil {
+		return err
+	}
+	setPause = inPause
+	return nil
+}
+
+func SetAdminMessage(message string) error {
+	if err := assertIsAdmin(); err != nil {
+		return err
+	}
+	faucetMsg = message
+	return nil
+}
+
+func SetAdminPerTransferSend(send std.Coins) error {
+	if err := assertIsAdmin(); err != nil {
+		return err
+	}
+	faucetMount = send
+	return nil
+}
+
+func SetAdminAdminAddr(addr std.Address) error {
+	if err := assertIsAdmin(); err != nil {
+		return err
+	}
+	adminAddress = addr
+	return nil
+}
+
+func SetAdminControllerAddr(addr std.Address) error {
+	if err := assertIsAdmin(); err != nil {
+		return err
+	}
+	controlAddress = addr
+	return nil
+}
+
+func assertIsAdmin() error {
+	caller := std.GetOrigCaller()
+	if caller != adminAddress {
+		return errors.New("restricted for admin")
+	}
+	return nil
+}

--- a/examples/gno.land/r/faucet-admin/admin_test.gno
+++ b/examples/gno.land/r/faucet-admin/admin_test.gno
@@ -1,0 +1,104 @@
+package admin
+
+import (
+	"fmt"
+	"std"
+	"testing"
+
+	"gno.land/p/testutils"
+	FA "gno.land/r/faucet-admin"
+)
+
+func TestPackage(t *testing.T) {
+	var (
+		adminAddr = std.Address("g1qsme7hy3whlhwjf2lfq93szez7jveqzj5gwexj") 
+		controllerAddr = std.Address("g1tzgxd2e59hywmqtg0pd3nljff39j36sxu2flpg")
+		newAdminAddr = testutils.TestAddress("new admin addr")
+		newControllerAddr = testutils.TestAddress("new controller addr")
+		_tmp1 = testutils.TestAddress("tmp 1")
+		_tmp2 = testutils.TestAddress("tmp 2")
+	)
+
+	// test for getter in /r/faucet-admin
+	shouldEqual(t, AdminAddress(), "g1qsme7hy3whlhwjf2lfq93szez7jveqzj5gwexj")
+	shouldEqual(t, ControllerAddress(), "g1tzgxd2e59hywmqtg0pd3nljff39j36sxu2flpg")
+	shouldEqual(t, InPause(), false)
+	shouldEqual(t, Message(), "# Let's Go for Gno Faucet by Onbloc & b1t\n\n")
+
+	// TODO (struct compare fix)
+	// why is it failing ?_?
+	// shouldEqual(t, GetPerTransferSend(_tmp1), std.Coins{std.Coin{"ugnot", 1000000}})
+
+	
+	// normal address
+	assertErr(t, FA.SetAdminInPause(true))
+	assertErr(t, FA.SetAdminMessage("test"))
+	assertErr(t, FA.SetAdminPerTransferSend(std.Coins{std.Coin{"ugnot", 100000}})) 
+	assertErr(t, FA.SetAdminAdminAddr(newAdminAddr))
+	assertErr(t, FA.SetAdminControllerAddr(newControllerAddr))
+
+	// controller address
+	std.TestSetOrigCaller(controllerAddr)
+	assertErr(t, FA.SetAdminInPause(true))
+	assertErr(t, FA.SetAdminMessage("test"))
+	assertErr(t, FA.SetAdminPerTransferSend(std.Coins{std.Coin{"ugnot", 200000}})) 
+	assertErr(t, FA.SetAdminAdminAddr(newAdminAddr))
+	assertErr(t, FA.SetAdminControllerAddr(newControllerAddr))
+
+	// admin address
+	std.TestSetOrigCaller(adminAddr)
+	assertNoErr(t, FA.SetAdminInPause(true))
+	assertNoErr(t, FA.SetAdminMessage("test"))
+	assertNoErr(t, FA.SetAdminPerTransferSend(std.Coins{std.Coin{"ugnot", 300000}}))
+	
+	// set new admin address
+	assertNoErr(t, FA.SetAdminAdminAddr(newAdminAddr))
+	// test old admin address
+	assertErr(t, FA.SetAdminControllerAddr(newControllerAddr))
+
+	// new admin address
+	std.TestSetOrigCaller(newAdminAddr)
+	assertNoErr(t, FA.SetAdminInPause(true))
+	assertNoErr(t, FA.SetAdminMessage("test"))
+	assertNoErr(t, FA.SetAdminPerTransferSend(std.Coins{std.Coin{"ugnot", 400000}}))
+	assertNoErr(t, FA.SetAdminControllerAddr(newControllerAddr))
+}
+
+
+func assertErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		// t.Logf("expected an error, but got nil.")
+		t.Errorf("expected an error, but got nil.")
+	}
+}
+
+func assertNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		// t.Logf("expected no error, but got err: %v", err.Error())
+		t.Errorf("expected no error, but got err: %v", err.Error())
+	}
+}
+
+// TODO
+// struct compare failing
+func shouldEqual(t *testing.T, got interface{}, expected interface{}) {
+	t.Helper()
+
+	if got != expected {
+		t.Errorf("expected %v(type: %T), got %v(type: %T)", expected, expected, got, got)
+	}
+}
+
+func assertBalance(t *testing.T, addr std.Address, expectedBal int64) {
+	t.Helper()
+
+	banker := std.GetBanker(std.BankerTypeReadonly)
+	coins := banker.GetCoins(addr)
+	got := coins.AmountOf("ugnot")
+
+	if expectedBal != got {
+		t.Errorf("invalid balance: expected %d, got %d.", expectedBal, got)
+	}
+}

--- a/examples/gno.land/r/faucet-admin/params.gno
+++ b/examples/gno.land/r/faucet-admin/params.gno
@@ -1,0 +1,15 @@
+package admin
+
+import (
+	"std"
+)
+
+
+var (
+	adminAddress = std.Address("g1qsme7hy3whlhwjf2lfq93szez7jveqzj5gwexj")
+	controlAddress = std.Address("g1tzgxd2e59hywmqtg0pd3nljff39j36sxu2flpg")
+	setPause = false
+
+	faucetMount = std.Coins{std.Coin{"ugnot", 1000000}}
+	faucetMsg = "# Let's Go for Gno Faucet by Onbloc & b1t\n\n"	
+)

--- a/examples/gno.land/r/faucet-controller/faucet.gno
+++ b/examples/gno.land/r/faucet-controller/faucet.gno
@@ -1,0 +1,80 @@
+package faucet
+
+import (
+	"errors"
+	"std"
+
+	"gno.land/p/ufmt"
+	FA "gno.land/r/faucet-admin" // faucet admin
+)
+
+var (
+	// configurable by only admin
+	// use getter func from 'gno.land/r/faucet-admin'
+	gInPause = FA.GetInPause()
+
+	// internal vars, for stats
+	gTotalTransferred std.Coins
+	gTotalTransfers   = uint(0)
+)
+
+
+func Transfer(to std.Address) error {
+	if err := assertIsController(); err != nil {
+		return err
+	}
+
+	if gInPause {
+		return errors.New("faucet in pause")
+	}
+
+	send := FA.GetPerTransferSend(to)
+
+	gTotalTransferred = gTotalTransferred.Add(send)
+	gTotalTransfers++
+
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	pkgaddr := std.GetOrigPkgAddr()
+	banker.SendCoins(pkgaddr, to, send)
+	return nil
+}
+
+func Render(path string) string {
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	balance := banker.GetCoins(std.GetOrigPkgAddr())
+
+	output := FA.GetMessage()
+	if gInPause {
+		output += "Status: inactive.\n"
+	} else {
+		output += "Status: active.\n"
+	}
+	output += ufmt.Sprintf("Balance: %s.\n", balance.String())
+	output += ufmt.Sprintf("Faucet total transfered: %s (in %d times).\n\n", gTotalTransferred.String(), gTotalTransfers)
+
+	output += ufmt.Sprintf("Admin: %", FA.GetAdminAddress())
+	output += ufmt.Sprintf("Controller: \n\n")
+
+	for _, v := range FA.GetControllerAddress() {
+		output += ufmt.Sprintf("- %s \n\n", v)
+	}
+
+	output += ufmt.Sprintf("\n\n")
+
+	output += ufmt.Sprintf("Facuet Rules\n\n")
+	output += ufmt.Sprintf(" 1. you'll receive 10 GNOT for 1st faucet\n")
+	output += ufmt.Sprintf(" 2. you'll receive 1 GNOT for next faucet\n\n")
+
+	// if path == "?debug" {
+	// 	output += ufmt.Sprintf("Admin: %s, Controller: %s\n", gAdminAddr.String(), gControllerAddr.String())
+	// }
+	return output
+}
+
+func assertIsController() error {
+	caller := std.GetOrigCaller()
+	if caller != FA.GetControllerAddress() {
+		return errors.New("restricted for controller")
+	}
+	return nil
+}

--- a/examples/gno.land/r/faucet-controller/faucet_test.gno
+++ b/examples/gno.land/r/faucet-controller/faucet_test.gno
@@ -1,0 +1,110 @@
+package faucet
+
+import (
+	"fmt"
+	"std"
+	"testing"
+
+	"gno.land/p/testutils"
+	faucet "gno.land/r/faucet-controller" // Actual Transfer
+	FA "gno.land/r/faucet-admin"
+)
+
+func TestPackage(t *testing.T) {
+	var (
+		faucetAdminAddr = FA.GetAdminAddress()
+		faucetControllerAddr = FA.GetControllerAddress()
+		faucetPause	= FA.GetInPause()
+		faucetMsg = FA.GetMessage()
+		_tmpAdminAddr	= testutils.TestAddress("just tmp admin")
+		_tmpControllerAddr = testutils.TestAddress("just tmp controller")
+		_tmpUserAddr1 = testutils.TestAddress("just tmp user 01")
+		_tmpUserAddr2 = testutils.TestAddress("just tmp user 02")
+		_tmpUserAddr3 = testutils.TestAddress("just tmp user 03")
+
+		// faucetAddr = std.TestDerivePkgAddr("gno.land/r/faucet-controller")		
+	)
+
+	// deposit 20,000gnot to facuet 
+	std.TestSetOrigSend(std.Coins{{"ugnot", 20000000000}}, nil)
+	// std.TestSetOrigPkgAddr(faucetAddr)
+	// assertBalance(t, faucetAddr, 20000000000)
+	
+	// as a normal user
+	// balance should empty
+	// can't call transfer(controller command) or admin commands
+	std.TestSetOrigCaller(_tmpUserAddr1)
+	assertBalance(t, _tmpUserAddr1, 0)
+	assertErr(t, faucet.Transfer(_tmpUserAddr1))
+	assertErr(t, FA.SetAdminInPause(true))
+
+	// as a controll user
+	// transfer available, but not admin commands
+	std.TestSetOrigCaller(faucetControllerAddr)
+	assertBalance(t, _tmpUserAddr1, 0)
+	assertBalance(t, _tmpUserAddr2, 0)
+	
+	assertNoErr(t, faucet.Transfer(_tmpUserAddr1))
+	assertBalance(t, _tmpUserAddr1, 10000000)
+
+	assertNoErr(t, faucet.Transfer(_tmpUserAddr2))
+	assertBalance(t, _tmpUserAddr2, 10000000)
+
+	// as an admin user
+	// admin commads available, but not transfer
+	std.TestSetOrigCaller(faucetAdminAddr)
+	assertErr(t, faucet.Transfer(_tmpUserAddr1))
+
+	// change controller address
+	assertNoErr(t, FA.SetAdminControllerAddr(_tmpControllerAddr)) 
+	// test old controller 
+	std.TestSetOrigCaller(faucetControllerAddr)
+	assertErr(t, faucet.Transfer(_tmpUserAddr1))
+
+	// as an new controller, test faucet rules
+	std.TestSetOrigCaller(_tmpControllerAddr)
+
+	assertNoErr(t, faucet.Transfer(_tmpUserAddr3))  // 1st faucet gives you 10gnot
+	assertBalance(t, _tmpUserAddr3, 10000000) // + 10,000,000
+
+	assertNoErr(t, faucet.Transfer(_tmpUserAddr3)) // since 2nd faucet gives you 1gnot
+	assertBalance(t, _tmpUserAddr3, 11000000) // + 1,000,000
+}
+ 
+// check response
+func shouldEqual(t *testing.T, got interface{}, expected interface{}) {
+	t.Helper()
+
+	if got != expected {
+		t.Errorf("expected %v(%T), got %v(%T)", expected, expected, got, got)
+	}
+}
+
+func assertErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected an error, but got nil.")
+		// t.Logf("info: got err: %v", err)
+		// t.Errorf("expected an error, but got nil.")
+	}
+}
+
+func assertNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		println("expected no error, but got err:", err)
+		// t.Errorf("expected no error, but got err: ", err)
+	}
+}
+
+func assertBalance(t *testing.T, addr std.Address, expectedBal int64) {
+	t.Helper()
+
+	banker := std.GetBanker(std.BankerTypeReadonly)
+	coins := banker.GetCoins(addr)
+	got := coins.AmountOf("ugnot")
+
+	if expectedBal != got {
+		t.Errorf("invalid balance: expected %d, got %d.", expectedBal, got)
+	}
+}


### PR DESCRIPTION
#364 
#361 

- [x] divided faucet realm into two different realms to specific each realms's role (admin & controller)
- [ ] add more clear faucet rules

https://discord.com/channels/957002220384182312/957685423696646155/1028089477664624670
- [ ] support multiple controller address // b1t working on it
- [ ] discord bot // b1t working on it
