### PR TITLE
fix: assign contract owner upon contract deployment

### DIFF
--- a/pkgs/sdk/vm/keeper.go
+++ b/pkgs/sdk/vm/keeper.go
@@ -152,12 +152,25 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
 		return err
 	}
 	// Parse and run the files, construct *PV.
+	msgCtx := stdlibs.ExecContext{
+		ChainID:       ctx.ChainID(),
+		Height:        ctx.BlockHeight(),
+		Timestamp:     ctx.BlockTime().Unix(),
+		Msg:           msg,
+		OrigCaller:    creator.Bech32(),
+		OrigSend:      deposit,
+		OrigSendSpent: new(std.Coins),
+		OrigPkgAddr:   pkgAddr.Bech32(),
+		Banker:        NewSDKBanker(vm, ctx),
+	}
+	// Parse and run the files, construct *PV.
 	m2 := gno.NewMachineWithOptions(
 		gno.MachineOptions{
 			PkgPath:   "",
 			Output:    os.Stdout, // XXX
 			Store:     store,
 			Alloc:     store.GetAllocator(),
+			Context:   msgCtx,
 			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
 		})
 	m2.RunMemPackage(memPkg, true)

--- a/pkgs/sdk/vm/keeper_test.go
+++ b/pkgs/sdk/vm/keeper_test.go
@@ -75,7 +75,11 @@ package test
 
 import "std"
 
+var admin std.Address
+
 func init() {
+
+     admin = 	std.GetOrigCaller()
 }
 
 func Echo(msg string) string {
@@ -85,7 +89,14 @@ func Echo(msg string) string {
 	banker := std.GetBanker(std.BankerTypeOrigSend)
 	banker.SendCoins(pkgAddr, addr, send) // send back
 	return "echo:"+msg
-}`},
+}
+
+func GetAdmin() string {
+
+	return admin.String()
+}
+
+`},
 	}
 	pkgPath := "gno.land/r/test"
 	msg1 := NewMsgAddPackage(addr, pkgPath, files)
@@ -100,6 +111,13 @@ func Echo(msg string) string {
 	assert.Equal(t, res, "")
 	fmt.Println(err.Error())
 	assert.True(t, strings.Contains(err.Error(), "insufficient coins error"))
+
+	// Run GetAdmin()
+	msg3 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
+	res, err = env.vmk.Call(ctx, msg3)
+	assert.NoError(t, err)
+	assert.Equal(t, res, addr)
+
 }
 
 // Sending more than tx send fails.

--- a/pkgs/sdk/vm/keeper_test.go
+++ b/pkgs/sdk/vm/keeper_test.go
@@ -111,13 +111,6 @@ func GetAdmin() string {
 	assert.Equal(t, res, "")
 	fmt.Println(err.Error())
 	assert.True(t, strings.Contains(err.Error(), "insufficient coins error"))
-
-	// Run GetAdmin()
-	msg3 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
-	res, err = env.vmk.Call(ctx, msg3)
-	assert.NoError(t, err)
-	assert.Equal(t, res, addr)
-
 }
 
 // Sending more than tx send fails.
@@ -250,4 +243,58 @@ func Echo(msg string) string {
 	// XXX change this into an error and make sure error message is descriptive.
 	_, err = env.vmk.Call(ctx, msg2)
 	assert.Error(t, err)
+}
+
+// Assign admin as OrigCaller on deploying the package.
+func TestVMKeeperOrigCallerInit(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{"init.gno", `
+package test
+
+import "std"
+
+var admin std.Address
+
+func init() {
+     admin = 	std.GetOrigCaller()
+}
+
+func Echo(msg string) string {
+	addr := std.GetOrigCaller()
+	pkgAddr := std.GetOrigPkgAddr()
+	send := std.GetOrigSend()
+	banker := std.GetBanker(std.BankerTypeOrigSend)
+	banker.SendCoins(pkgAddr, addr, send) // send back
+	return "echo:"+msg
+}
+
+func GetAdmin() string {
+	return admin.String()
+}
+
+`},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Run GetAdmin()
+	coins := std.MustParseCoins("")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "GetAdmin", []string{})
+	res, err := env.vmk.Call(ctx, msg2)
+	addrString := fmt.Sprintf("(\"%s\" string)", addr.String())
+	assert.NoError(t, err)
+	assert.Equal(t, res, addrString)
 }


### PR DESCRIPTION
The issue to fix:

There is a bug that prevents us from assigning the contract deployer as the contract owner.  VM panics on a non-pointer interface error when we try to deploy a contract where we put the caller as contract owner in the init() function. The contract admin address is hardcoded in many contract examples as a workaround

Cause:
It turns out AddPackage does not set VM ExecContext in Keeper. 

Two People Review Needed: Yes
Since the fix modifies vm/keeper.go, an extensive review is needed. 
