### PR TITLE
chore: get rid of deprecated package "io/ioutil"

### DIFF
--- a/cmd/gnodev/precompile.go
+++ b/cmd/gnodev/precompile.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -87,7 +86,7 @@ func precompileFile(srcPath string, opts precompileOptions) error {
 	}
 
 	// parse .gno.
-	source, err := ioutil.ReadFile(srcPath)
+	source, err := os.ReadFile(srcPath)
 	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
@@ -117,7 +116,7 @@ func precompileFile(srcPath string, opts precompileOptions) error {
 	// write .go file.
 	dir := filepath.Dir(srcPath)
 	targetPath := filepath.Join(dir, targetFilename)
-	err = ioutil.WriteFile(targetPath, []byte(transformed), 0o644)
+	err = os.WriteFile(targetPath, []byte(transformed), 0o644)
 	if err != nil {
 		return fmt.Errorf("write .go file: %w", err)
 	}

--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -51,7 +50,7 @@ func testApp(cmd *command.Command, args []string, iopts interface{}) error {
 
 	verbose := opts.Verbose
 
-	tempdirRoot, err := ioutil.TempDir("", "gno-precompile")
+	tempdirRoot, err := os.MkdirTemp("", "gno-precompile")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
SA1019: "io/ioutil" has been deprecated since Go 1.16. As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. So removed it.
