### PR TITLE
fix: `gnodev test --precompile`

### DIFF
--- a/cmd/gnodev/precompile.go
+++ b/cmd/gnodev/precompile.go
@@ -114,8 +114,13 @@ func precompileFile(srcPath string, opts precompileOptions) error {
 	}
 
 	// write .go file.
-	dir := filepath.Dir(srcPath)
-	targetPath := filepath.Join(dir, targetFilename)
+	var targetPath string
+	if opts.Output != defaultPrecompileOptions.Output {
+		targetPath = filepath.Join(opts.Output, targetFilename)
+	} else {
+		dir := filepath.Dir(srcPath)
+		targetPath = filepath.Join(dir, targetFilename)
+	}
 	err = os.WriteFile(targetPath, []byte(transformed), 0o644)
 	if err != nil {
 		return fmt.Errorf("write .go file: %w", err)


### PR DESCRIPTION
Currently, precompile doesn't respect the `precompileOptions.Output`. So it always precompiles the `*.gno` files in the current directory. But `gnodev test --precompile` looks for the precompiled files in the temporary directory. 

TODO:
precompiled files still fail the build cmd because of the imports. 