### PR TITLE
chore: add base PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/detailed_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/detailed_pr_template.md
@@ -1,0 +1,37 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+# Description
+
+Please provide a detailed description of what was done in this PR
+
+# Changes include
+
+- [ ] Bugfix (non-breaking change that solves an issue)
+- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
+
+# Breaking changes
+
+Please complete this section if any breaking changes have been made, otherwise delete it
+
+# Checklist (for contributors)
+
+- [ ] I have assigned this PR to myself
+- [ ] I have added at least 1 reviewer
+- [ ] I have added the relevant labels
+- [ ] I have updated the official documentation
+- [ ] I have added sufficient documentation in code
+
+# Testing
+
+- [ ] I have tested this code with the official test suite
+- [ ] I have tested this code manually
+
+## Manual tests
+
+Please complete this section if you ran manual tests for this functionality, otherwise delete it
+
+# Additional comments
+
+Please post additional comments in this section if you have them, otherwise delete it

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Description
+
+Please provide a detailed description of what was done in this PR
+
+# Changes include
+
+- [ ] Bugfix (non-breaking change that solves an issue)
+- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
+
+# Breaking changes
+
+Please complete this section if any breaking changes have been made, otherwise delete it
+
+# Checklist (for contributors)
+
+- [ ] I have assigned this PR to myself
+- [ ] I have added at least 1 reviewer
+- [ ] I have added the relevant labels
+- [ ] I have updated the official documentation
+- [ ] I have added sufficient documentation in code
+
+# Testing
+
+- [ ] I have tested this code with the official test suite
+- [ ] I have tested this code manually
+
+## Manual tests
+
+Please complete this section if you ran manual tests for this functionality, otherwise delete it
+
+# Additional comments
+
+Please post additional comments in this section if you have them, otherwise delete it

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,10 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->
+
 # Description
 
 Please provide a detailed description of what was done in this PR
 
-# Changes include
+# How has this been tested?
 
-- [ ] Bugfix (non-breaking change that solves an issue)
-- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
-
-# Breaking changes
-
-Please complete this section if any breaking changes have been made, otherwise delete it
-
-# Checklist (for contributors)
-
-- [ ] I have assigned this PR to myself
-- [ ] I have added at least 1 reviewer
-- [ ] I have added the relevant labels
-- [ ] I have updated the official documentation
-- [ ] I have added sufficient documentation in code
-
-# Testing
-
-- [ ] I have tested this code with the official test suite
-- [ ] I have tested this code manually
-
-## Manual tests
-
-Please complete this section if you ran manual tests for this functionality, otherwise delete it
-
-# Additional comments
-
-Please post additional comments in this section if you have them, otherwise delete it
+Please complete this section if you ran tests for this functionality, otherwise delete it


### PR DESCRIPTION
# Description

This PR adds a base PR template for future contributions, that should be discussed in detail by the team.
It streamlines the PR review process by providing relevant information in the PR at a glance.

The base template is relatively simple to fill out. For more detailed PR templates, users can utilize the `detailed_pr_template.md`, by appending the `template=detailed_pr_template.md` query parameter ([GitHub guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request)).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

~Tagging @moul and @harry-hov for visibility, as I can't add you as reviewers yet on the PR directly.~
