### PR TITLE
feat: add support for private key exports

### DIFF
--- a/pkgs/crypto/keys/client/add.go
+++ b/pkgs/crypto/keys/client/add.go
@@ -168,13 +168,7 @@ func addApp(cmd *command.Command, args []string, iopts interface{}) error {
 	}
 
 	if len(mnemonic) == 0 {
-		// read entropy seed straight from crypto.Rand and convert to mnemonic
-		entropySeed, err := bip39.NewEntropy(mnemonicEntropySize)
-		if err != nil {
-			return err
-		}
-
-		mnemonic, err = bip39.NewMnemonic(entropySeed[:])
+		mnemonic, err = generateMnemonic(mnemonicEntropySize)
 		if err != nil {
 			return err
 		}

--- a/pkgs/crypto/keys/client/export.go
+++ b/pkgs/crypto/keys/client/export.go
@@ -23,10 +23,12 @@ type ExportOptions struct {
 	OutputPath string `flag:"output-path"`
 }
 
-var DefaultExportOptions = ExportOptions{}
+var DefaultExportOptions = ExportOptions{
+	BaseOptions: DefaultBaseOptions,
+}
 
 // exportApp performs private key exports using the provided params
-func exportApp(cmd *command.Command, args []string, iopts interface{}) error {
+func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 	// Read the flag values
 	opts, ok := iopts.(ExportOptions)
 	if !ok {
@@ -43,20 +45,11 @@ func exportApp(cmd *command.Command, args []string, iopts interface{}) error {
 		)
 	}
 
-	// Get the key info using the name / bech32
-	// TODO consider if this step is even needed
-	info, err := kb.GetByNameOrAddress(opts.NameOrBech32)
-	if err != nil {
-		return fmt.Errorf(
-			"unable to read private key, %v",
-			err,
-		)
-	}
-
 	// Get the key-base decrypt password
-	decryptPassword, err := cmd.GetCheckPassword(
+	decryptPassword, err := cmd.GetPassword(
 		"Enter a passphrase to decrypt your private key from disk:",
-		"Repeat the passphrase:")
+		false,
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"unable to retrieve decrypt password from user, %v",
@@ -77,7 +70,7 @@ func exportApp(cmd *command.Command, args []string, iopts interface{}) error {
 
 	// Generate the encrypted armor
 	armor, err := kb.ExportPrivKey(
-		info.GetName(),
+		opts.NameOrBech32,
 		decryptPassword,
 		encryptPassword,
 	)

--- a/pkgs/crypto/keys/client/export.go
+++ b/pkgs/crypto/keys/client/export.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/pkgs/command"
+	"github.com/gnolang/gno/pkgs/crypto/keys"
+	"github.com/gnolang/gno/pkgs/errors"
+)
+
+var (
+	errInvalidExportArgs = errors.New("invalid export arguments provided")
+)
+
+type ExportOptions struct {
+	BaseOptions
+
+	// The name or address of the private key to be exported
+	NameOrBech32 string `flag:"key"`
+
+	// Output path for the encrypted private key armor
+	OutputPath string `flag:"output-path"`
+}
+
+var DefaultExportOptions = ExportOptions{}
+
+// exportApp performs private key exports using the provided params
+func exportApp(cmd *command.Command, args []string, iopts interface{}) error {
+	// Read the flag values
+	opts, ok := iopts.(ExportOptions)
+	if !ok {
+		return errInvalidExportArgs
+	}
+
+	// Create a new instance of the key-base
+	kb, err := keys.NewKeyBaseFromDir(opts.Home)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to create a key base from directory %s, %v",
+			err,
+			opts.Home,
+		)
+	}
+
+	// Get the key info using the name / bech32
+	// TODO consider if this step is even needed
+	info, err := kb.GetByNameOrAddress(opts.NameOrBech32)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to read private key, %v",
+			err,
+		)
+	}
+
+	// Get the key-base decrypt password
+	decryptPassword, err := cmd.GetCheckPassword(
+		"Enter a passphrase to decrypt your private key from disk:",
+		"Repeat the passphrase:")
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve decrypt password from user, %v",
+			decryptPassword,
+		)
+	}
+
+	// Get the armor encrypt password
+	encryptPassword, err := cmd.GetCheckPassword(
+		"Enter a passphrase to encrypt your private key armor:",
+		"Repeat the passphrase:")
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve armor encrypt password from user, %v",
+			decryptPassword,
+		)
+	}
+
+	// Generate the encrypted armor
+	armor, err := kb.ExportPrivKey(
+		info.GetName(),
+		decryptPassword,
+		encryptPassword,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to export the private key, %v",
+			err,
+		)
+	}
+
+	// Write the encrypted armor to disk
+	if err := os.WriteFile(
+		opts.OutputPath,
+		[]byte(armor),
+		0644,
+	); err != nil {
+		return fmt.Errorf(
+			"unable to write encrypted armor to file, %v",
+			err,
+		)
+	}
+
+	fmt.Printf("Encrypted private key armor successfully outputted to %s\n", opts.OutputPath)
+
+	return nil
+}

--- a/pkgs/crypto/keys/client/export.go
+++ b/pkgs/crypto/keys/client/export.go
@@ -17,10 +17,10 @@ type ExportOptions struct {
 	BaseOptions
 
 	// The name or address of the private key to be exported
-	NameOrBech32 string `flag:"key"`
+	NameOrBech32 string `flag:"key" help:"Name or Bech32 address of the private key"`
 
 	// Output path for the encrypted private key armor
-	OutputPath string `flag:"output-path"`
+	OutputPath string `flag:"output-path" help:"The desired output path for the encrypted armor file"`
 }
 
 var DefaultExportOptions = ExportOptions{

--- a/pkgs/crypto/keys/client/export.go
+++ b/pkgs/crypto/keys/client/export.go
@@ -39,9 +39,9 @@ func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 	kb, err := keys.NewKeyBaseFromDir(opts.Home)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to create a key base from directory %s, %v",
-			err,
+			"unable to create a key base from directory %s, %w",
 			opts.Home,
+			err,
 		)
 	}
 
@@ -52,8 +52,8 @@ func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to retrieve decrypt password from user, %v",
-			decryptPassword,
+			"unable to retrieve decrypt password from user, %w",
+			err,
 		)
 	}
 
@@ -63,8 +63,8 @@ func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 		"Repeat the passphrase:")
 	if err != nil {
 		return fmt.Errorf(
-			"unable to retrieve armor encrypt password from user, %v",
-			decryptPassword,
+			"unable to retrieve armor encrypt password from user, %w",
+			err,
 		)
 	}
 
@@ -76,7 +76,7 @@ func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to export the private key, %v",
+			"unable to export the private key, %w",
 			err,
 		)
 	}
@@ -88,12 +88,12 @@ func exportApp(cmd *command.Command, _ []string, iopts interface{}) error {
 		0644,
 	); err != nil {
 		return fmt.Errorf(
-			"unable to write encrypted armor to file, %v",
+			"unable to write encrypted armor to file, %w",
 			err,
 		)
 	}
 
-	fmt.Printf("Encrypted private key armor successfully outputted to %s\n", opts.OutputPath)
+	cmd.Printfln("Encrypted private key armor successfully outputted to %s", opts.OutputPath)
 
 	return nil
 }

--- a/pkgs/crypto/keys/client/export_test.go
+++ b/pkgs/crypto/keys/client/export_test.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/pkgs/command"
+	"github.com/gnolang/gno/pkgs/crypto/keys"
+	"github.com/gnolang/gno/pkgs/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExport_ExportKey makes sure the key can be exported correctly
+func TestExport_ExportKey(t *testing.T) {
+	t.Parallel()
+
+	// numLines returns the number of new lines
+	// in a string
+	numLines := func(s string) int {
+		n := strings.Count(s, "\n")
+		if len(s) > 0 && !strings.HasSuffix(s, "\n") {
+			n++
+		}
+
+		return n
+	}
+
+	var (
+		keyName         = "key name"
+		encryptPassword = "encrypt password"
+
+		cmd = command.NewMockCommand()
+	)
+
+	// Generate a temporary key-base directory
+	kbHome, kbCleanUp := testutils.NewTestCaseDir(t)
+	defer kbCleanUp()
+
+	kb, err := keys.NewKeyBaseFromDir(kbHome)
+	if err != nil {
+		t.Fatalf(
+			"unable to create a key base in directory %s, %v",
+			kbHome,
+			err,
+		)
+	}
+
+	// Generate a random mnemonic
+	mnemonic, err := generateMnemonic(mnemonicEntropySize)
+	if err != nil {
+		t.Fatalf(
+			"unable to generate a mnemonic phrase, %v",
+			err,
+		)
+	}
+
+	// Add an initial key to the key base
+	info, err := kb.CreateAccount(
+		keyName,
+		mnemonic,
+		"",
+		encryptPassword,
+		0,
+		0,
+	)
+	if err != nil {
+		t.Fatalf(
+			"unable to create a key base account, %v",
+			err,
+		)
+	}
+
+	outputFile, outputCleanupFn := testutils.NewTestFile(t)
+	defer outputCleanupFn()
+
+	opts := ExportOptions{
+		BaseOptions: BaseOptions{
+			Home: kbHome,
+		},
+		NameOrBech32: info.GetName(),
+		OutputPath:   outputFile.Name(),
+	}
+
+	// Prepend standard input
+	cmd.SetIn(
+		strings.NewReader(
+			fmt.Sprintf(
+				"%s\n%s\n%s\n",
+				encryptPassword,
+				encryptPassword,
+				encryptPassword,
+			),
+		),
+	)
+
+	// Make sure the command executes correctly
+	assert.NoError(
+		t,
+		exportApp(cmd, nil, opts),
+	)
+
+	// Make sure the encrypted armor has been written to disk
+	buff, err := os.ReadFile(outputFile.Name())
+	if err != nil {
+		t.Fatalf(
+			"unable to read temporary file from disk, %v",
+			err,
+		)
+	}
+
+	assert.Greater(t, numLines(string(buff)), 1)
+}

--- a/pkgs/crypto/keys/client/helper.go
+++ b/pkgs/crypto/keys/client/helper.go
@@ -1,0 +1,16 @@
+package client
+
+import "github.com/gnolang/gno/pkgs/crypto/bip39"
+
+// generateMnemonic generates a new BIP39 mnemonic using the
+// provided entropy size
+func generateMnemonic(entropySize int) (string, error) {
+	// Generate the entropy seed
+	entropySeed, err := bip39.NewEntropy(entropySize)
+	if err != nil {
+		return "", err
+	}
+
+	// Generate the actual mnemonic
+	return bip39.NewMnemonic(entropySeed[:])
+}

--- a/pkgs/crypto/keys/client/root.go
+++ b/pkgs/crypto/keys/client/root.go
@@ -14,6 +14,7 @@ var mainApps AppList = []AppItem{
 	{addApp, "add", "add key to keybase", DefaultAddOptions},
 	{deleteApp, "delete", "delete key from keybase", DefaultDeleteOptions},
 	{generateApp, "generate", "generate a new private key", DefaultGenerateOptions},
+	{exportApp, "export", "export encrypted private key armor", DefaultExportOptions},
 	{listApp, "list", "list all known keys", DefaultListOptions},
 	{signApp, "sign", "sign a document", DefaultSignOptions},
 	{verifyApp, "verify", "verify a document signature", DefaultVerifyOptions},

--- a/pkgs/crypto/keys/client/sign.go
+++ b/pkgs/crypto/keys/client/sign.go
@@ -19,7 +19,7 @@ type SignOptions struct {
 	Sequence      *uint64 `flag:"sequence" help:"sequence to sign with (required)"`
 	ShowSignBytes bool    `flag:"show-signbytes" help:"show sign bytes and quit"`
 
-	// internal flags, when called programatically
+	// internal flags, when called programmatically
 	NameOrBech32 string `flag:"-"`
 	TxJson       []byte `flag:"-"`
 	Pass         string `flag:"-"`

--- a/pkgs/testutils/os.go
+++ b/pkgs/testutils/os.go
@@ -1,18 +1,34 @@
 package testutils
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/jaekwon/testify/require"
 )
 
 // NewTestCaseDir creates a new temporary directory for a test case.
 // Returns the directory path and a cleanup function.
-// nolint: errcheck
 func NewTestCaseDir(t *testing.T) (string, func()) {
-	dir, err := ioutil.TempDir("", t.Name()+"_")
-	require.NoError(t, err)
-	return dir, func() { os.RemoveAll(dir) }
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", t.Name()+"_")
+	if err != nil {
+		t.Fatalf("unable to generate temporary directory, %v", err)
+	}
+
+	return dir, func() { _ = os.RemoveAll(dir) }
+}
+
+// NewTestFile creates a new temporary file for a test case
+func NewTestFile(t *testing.T) (*os.File, func()) {
+	t.Helper()
+
+	file, err := os.CreateTemp("", t.Name()+"-")
+	if err != nil {
+		t.Fatalf(
+			"unable to create a temporary output file, %v",
+			err,
+		)
+	}
+
+	return file, func() { _ = os.RemoveAll(file.Name()) }
 }


### PR DESCRIPTION
# Description

This PR adds support for exporting private keys from the key-base, using the `gnokey export` command.

The private key armor that is saved is encrypted using a passphrase that the user sets.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests

Tested manually by invoking the command:
```bash
gnokey export --key MyKey --output-path ./mykey.asc
```

Additionally, a new unit test has been added for covering this functionality.

# Additional comments
There should be an `import` command also available, that knows how to do the opposite of export.
I'll add this functionality in a separate PR.
