### PR TITLE
feat: add labels config for the repostitory

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "bug",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "name": "bug fix",
+    "color": "8a1d1c",
+    "description": "Functionality that fixes a bug"
+  },
+  {
+    "name": "dependencies",
+    "color": "5319e7",
+    "description": "Update to the dependencies"
+  },
+  {
+    "name": "documentation",
+    "color": "0075ca",
+    "description": "Improvements or additions to documentation"
+  },
+  {
+    "name": "duplicate",
+    "color": "cfd3d7",
+    "description": "This issue or pull request already exists"
+  },
+  {
+    "name": "good first issue",
+    "color": "7057ff",
+    "description": "Good for newcomers"
+  },
+  {
+    "name": "help wanted",
+    "color": "008672",
+    "description": "Extra attention is needed"
+  },
+  {
+    "name": "breaking change",
+    "color": "a7327e",
+    "description": "Functionality that contains breaking changes"
+  },
+  {
+    "name": "don't merge",
+    "color": "b60205",
+    "description": "Please don't merge this functionality temporarily"
+  },
+  {
+    "name": "feature",
+    "color": "ffb703",
+    "description": "New update to Gno"
+  },
+  {
+    "name": "hotfix",
+    "color": "003049",
+    "description": "Major bug fix that should be merged ASAP"
+  },
+  {
+    "name": "info needed",
+    "color": "54eba0",
+    "description": "More information needed"
+  },
+  {
+    "name": "question",
+    "color": "fbca04",
+    "description": "Questions about Gno"
+  },
+  {
+    "name": "investigating",
+    "color": "8c008c",
+    "description": "This behavior is still being tested out"
+  }
+]


### PR DESCRIPTION
# Description

This PR introduces a list of base labels to the repository, that can be managed by the community.

:one:  **Propose to remove**
- dapp
- github_actions (dependencies can mean the same)
- gnoland
- integration
- invalid
- packaging
- enhancement (I believe it’s redundant given other labels)
- core
- chore
- experiments (see list below for alternative)
- tool
- wontfix
- tests* (Not sure about this one, I believe we should include tests with any new functionality we add upstream)

:two:  **Propose to add**
- bug fix - Functionality that fixes a bug
- breaking change - Functionality that contains breaking changes
- don't merge (replaces experiments) - Please don’t merge this functionality temporarily
- feature - New update to Gno
- hotfix - Major bug fix that should be merged ASAP
- info needed - More information needed
- investigating - This behavior is still being tested out

:three: **Final list**
- bug - Something isn’t working
- bug fix - Functionality that fixes a bug
- dependencies - Update to the dependencies
- documentation - Improvements or additions to documentation
- duplicate - This issue or pull request already exists
- good first issue - Good for newcomers
- help wanted - Extra attention is needed
- breaking change - Functionality that contains breaking changes
- don't merge - Please don’t merge this functionality temporarily
- feature - New update to Gno
- hotfix - Major bug fix that should be merged ASAP
- info needed - More information needed
- question - Questions about Gno
- investigating - This behavior is still being tested out

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually

# Additional comments

We can utilize a GitHub action job for each time this labels config is changed.
This would involve defining a specific job with [a path filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), and utilizing the [GITHUB_TOKEN](https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp)  for managing the repo labels (that's used to authenticate with the tool for managing these labels).
