### PR TITLE
update deprecated functions ioutil.ReadFile and ioutil.WriteFile

### DIFF
--- a/cmd/gnotxport/import.go
+++ b/cmd/gnotxport/import.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -31,7 +31,7 @@ var defaultTxImportOptions = txImportOptions{
 func txImportApp(cmd *command.Command, args []string, iopts interface{}) error {
 	opts := iopts.(txImportOptions)
 	c := client.NewHTTP(opts.Remote, "/websocket")
-	filebz, err := ioutil.ReadFile(opts.InFile)
+	filebz, err := os.ReadFile(opts.InFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/goscan/goscan.go
+++ b/cmd/goscan/goscan.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 
 	"github.com/davecgh/go-spew/spew"
@@ -14,7 +13,7 @@ func main() {
 	fset := token.NewFileSet() // positions are relative to fset
 
 	filename := os.Args[1]
-	bz, err := ioutil.ReadFile(filename)
+	bz, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/misc/gnoview/main.go
+++ b/misc/gnoview/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"runtime/debug"
@@ -36,7 +35,7 @@ func bootGnoland() (*gno.PackageValue, *bytes.Buffer) {
 
 	// Run the file from machine.
 	path := "./data/gnoland/main.go"
-	bz, err := ioutil.ReadFile(path)
+	bz, err := os.ReadFile(path)
 	if err != nil {
 		panic("could not read file")
 	}

--- a/pkgs/amino/cmd/goscan/goscan.go
+++ b/pkgs/amino/cmd/goscan/goscan.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 
 	"github.com/davecgh/go-spew/spew"
@@ -14,7 +13,7 @@ func main() {
 	fset := token.NewFileSet() // positions are relative to fset
 
 	filename := os.Args[1]
-	bz, err := ioutil.ReadFile(filename)
+	bz, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/pkgs/amino/genproto/bindings.go
+++ b/pkgs/amino/genproto/bindings.go
@@ -6,7 +6,7 @@ import (
 	"go/ast"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"regexp"
@@ -82,7 +82,7 @@ func WriteProtoBindingsForTypes(filename string, pkg *amino.Package, rtz ...refl
 	if err != nil {
 		return
 	}
-	err = ioutil.WriteFile(filename, buf.Bytes(), 0o644)
+	err = os.WriteFile(filename, buf.Bytes(), 0o644)
 	if err != nil {
 		return
 	}

--- a/pkgs/amino/genproto/genproto.go
+++ b/pkgs/amino/genproto/genproto.go
@@ -293,7 +293,7 @@ func (p3c *P3Context) GenerateProto3SchemaForTypes(pkg *amino.Package, rtz ...re
 func (p3c *P3Context) WriteProto3SchemaForTypes(filename string, pkg *amino.Package, rtz ...reflect.Type) {
 	fmt.Printf("writing proto3 schema to %v for package %v\n", filename, pkg)
 	p3doc := p3c.GenerateProto3SchemaForTypes(pkg, rtz...)
-	err := ioutil.WriteFile(filename, []byte(p3doc.Print()), 0o644)
+	err := os.WriteFile(filename, []byte(p3doc.Print()), 0o644)
 	if err != nil {
 		panic(err)
 	}
@@ -522,12 +522,12 @@ func RunProtoc(pkg *amino.Package, protosDir string) {
 
 func copyFile(src string, dst string) {
 	// Read all content of src to data
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		panic(err)
 	}
 	// Write data to dst
-	err = ioutil.WriteFile(dst, data, 0o644)
+	err = os.WriteFile(dst, data, 0o644)
 	if err != nil {
 		panic(err)
 	}

--- a/pkgs/autofile/group_test.go
+++ b/pkgs/autofile/group_test.go
@@ -2,7 +2,6 @@ package autofile
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -100,14 +99,14 @@ func TestRotateFile(t *testing.T) {
 	g.FlushAndSync()
 
 	// Read g.Head.Path+"000"
-	body1, err := ioutil.ReadFile(g.Head.Path + ".000")
+	body1, err := os.ReadFile(g.Head.Path + ".000")
 	assert.NoError(t, err, "Failed to read first rolled file")
 	if string(body1) != "Line 1\nLine 2\nLine 3\n" {
 		t.Errorf("Got unexpected contents: [%v]", string(body1))
 	}
 
 	// Read g.Head.Path
-	body2, err := ioutil.ReadFile(g.Head.Path)
+	body2, err := os.ReadFile(g.Head.Path)
 	assert.NoError(t, err, "Failed to read first rolled file")
 	if string(body2) != "Line 4\nLine 5\nLine 6\n" {
 		t.Errorf("Got unexpected contents: [%v]", string(body2))

--- a/pkgs/bft/config/toml.go
+++ b/pkgs/bft/config/toml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"text/template"
 
@@ -24,7 +25,7 @@ func init() {
 }
 
 func LoadConfigFile(configFilePath string) *Config {
-	bz, err := ioutil.ReadFile(configFilePath)
+	bz, err := os.ReadFile(configFilePath)
 	if err != nil {
 		panic(err)
 	}

--- a/pkgs/bft/config/toml_test.go
+++ b/pkgs/bft/config/toml_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -32,7 +31,7 @@ func TestEnsureRoot(t *testing.T) {
 	WriteConfigFile(configPath, throwaway)
 
 	// make sure config is set properly
-	data, err := ioutil.ReadFile(join(tmpDir, defaultConfigFilePath))
+	data, err := os.ReadFile(join(tmpDir, defaultConfigFilePath))
 	require.Nil(err)
 
 	if !checkConfig(string(data)) {
@@ -53,7 +52,7 @@ func TestEnsureTestRoot(t *testing.T) {
 	rootDir := cfg.RootDir
 
 	// make sure config is set properly
-	data, err := ioutil.ReadFile(join(rootDir, defaultConfigFilePath))
+	data, err := os.ReadFile(join(rootDir, defaultConfigFilePath))
 	require.Nil(err)
 
 	if !checkConfig(string(data)) {

--- a/pkgs/bft/consensus/replay_test.go
+++ b/pkgs/bft/consensus/replay_test.go
@@ -74,7 +74,7 @@ func startNewConsensusStateAndWaitForBlock(t *testing.T, consensusReplayConfig *
 	cs := newConsensusStateWithConfigAndBlockStore(consensusReplayConfig, state, privValidator, kvstore.NewKVStoreApplication(), blockDB)
 	cs.SetLogger(logger)
 
-	bytes, _ := ioutil.ReadFile(cs.config.WalFile())
+	bytes, _ := os.ReadFile(cs.config.WalFile())
 	t.Logf("====== WAL: \n\r%X\n", bytes)
 
 	// This is just a signal that we haven't halted; its not something contained

--- a/pkgs/bft/mempool/clist_mempool_test.go
+++ b/pkgs/bft/mempool/clist_mempool_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -528,7 +527,7 @@ func checksumIt(data []byte) string {
 }
 
 func checksumFile(p string, t *testing.T) string {
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	require.Nil(t, err, "expecting successful read of %q", p)
 	return checksumIt(data)
 }

--- a/pkgs/bft/privval/file.go
+++ b/pkgs/bft/privval/file.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/gnolang/gno/pkgs/amino"
@@ -172,7 +172,7 @@ func LoadFilePVEmptyState(keyFilePath, stateFilePath string) *FilePV {
 
 // If loadState is true, we load from the stateFilePath. Otherwise, we use an empty LastSignState.
 func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
-	keyJSONBytes, err := ioutil.ReadFile(keyFilePath)
+	keyJSONBytes, err := os.ReadFile(keyFilePath)
 	if err != nil {
 		osm.Exit(err.Error())
 	}
@@ -189,7 +189,7 @@ func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
 
 	pvState := FilePVLastSignState{}
 	if loadState {
-		stateJSONBytes, err := ioutil.ReadFile(stateFilePath)
+		stateJSONBytes, err := os.ReadFile(stateFilePath)
 		if err != nil {
 			osm.Exit(err.Error())
 		}

--- a/pkgs/bft/state/state.go
+++ b/pkgs/bft/state/state.go
@@ -3,7 +3,7 @@ package state
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/gnolang/gno/pkgs/amino"
@@ -184,7 +184,7 @@ func MakeGenesisStateFromFile(genDocFile string) (State, error) {
 // MakeGenesisDocFromFile reads and unmarshals genesis doc from the given file.
 // XXX duplicated in bft/types/genesis.go, remove this.
 func MakeGenesisDocFromFile(genDocFile string) (*types.GenesisDoc, error) {
-	genDocJSON, err := ioutil.ReadFile(genDocFile)
+	genDocJSON, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't read GenesisDoc file: %v", err)
 	}

--- a/pkgs/bft/types/genesis.go
+++ b/pkgs/bft/types/genesis.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/gnolang/gno/pkgs/amino"
@@ -115,7 +115,7 @@ func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 
 // GenesisDocFromFile reads JSON data from a file and unmarshalls it into a GenesisDoc.
 func GenesisDocFromFile(genDocFile string) (*GenesisDoc, error) {
-	jsonBlob, err := ioutil.ReadFile(genDocFile)
+	jsonBlob, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "Couldn't read GenesisDoc file")
 	}

--- a/pkgs/command/flags.go
+++ b/pkgs/command/flags.go
@@ -3,7 +3,6 @@ package command
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -331,7 +330,7 @@ func parseFlags(fargs []string) map[string]interface{} {
 			// if a --flag#file <file_location> flag, read contents.
 			if strings.HasSuffix(fname, "#file") {
 				ffile := farg
-				fargbz, err := ioutil.ReadFile(ffile)
+				fargbz, err := os.ReadFile(ffile)
 				if err != nil {
 					panic(fmt.Sprintf(
 						"error reading file: %v", err))

--- a/pkgs/crypto/hd/fundraiser_test.go
+++ b/pkgs/crypto/hd/fundraiser_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,7 +28,7 @@ func initFundraiserTestVectors(t *testing.T) []addrData {
 	// var hdPath string = "m/44'/118'/0'/0/0"
 	var hdToAddrTable []addrData
 
-	b, err := ioutil.ReadFile("test.json")
+	b, err := os.ReadFile("test.json")
 	if err != nil {
 		t.Fatalf("could not read fundraiser test vector file (test.json): %s", err)
 	}

--- a/pkgs/crypto/keys/client/broadcast.go
+++ b/pkgs/crypto/keys/client/broadcast.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/gnolang/gno/pkgs/amino"
 	abci "github.com/gnolang/gno/pkgs/bft/abci/types"
@@ -33,7 +33,7 @@ func broadcastApp(cmd *command.Command, args []string, iopts interface{}) error 
 	}
 	filename := args[0]
 
-	jsonbz, err := ioutil.ReadFile(filename)
+	jsonbz, err := os.ReadFile(filename)
 	if err != nil {
 		return errors.Wrap(err, "reading tx document file "+filename)
 	}

--- a/pkgs/crypto/keys/client/import.go.bak
+++ b/pkgs/crypto/keys/client/import.go.bak
@@ -2,7 +2,7 @@ package keys
 
 import (
 	"bufio"
-	"io/ioutil"
+	"os"
 
 	"github.com/tendermint/classic/sdk/client/input"
 	"github.com/spf13/cobra"
@@ -25,7 +25,7 @@ func runImportCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	bz, err := ioutil.ReadFile(args[1])
+	bz, err := os.ReadFile(args[1])
 	if err != nil {
 		return err
 	}

--- a/pkgs/crypto/keys/client/import_test.go.bak
+++ b/pkgs/crypto/keys/client/import_test.go.bak
@@ -1,7 +1,7 @@
 package keys
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +31,7 @@ HbP+c6JmeJy9JXe2rbbF1QtCX1gLqGcDQPBXiCtFvP7/8wTZtVOPj8vREzhZ9ElO
 =f3l4
 -----END TENDERMINT PRIVATE KEY-----
 `
-	require.NoError(t, ioutil.WriteFile(keyfile, []byte(armoredKey), 0644))
+	require.NoError(t, os.WriteFile(keyfile, []byte(armoredKey), 0644))
 
 	// Now enter password
 	mockIn, _, _ := tests.ApplyMockIO(importKeyCommand)

--- a/pkgs/crypto/keys/client/sign.go
+++ b/pkgs/crypto/keys/client/sign.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/gnolang/gno/pkgs/amino"
 	"github.com/gnolang/gno/pkgs/command"
@@ -50,7 +50,7 @@ func signApp(cmd *command.Command, args []string, iopts interface{}) error {
 		}
 		opts.TxJson = []byte(txjsonstr)
 	} else { // from file
-		opts.TxJson, err = ioutil.ReadFile(txpath)
+		opts.TxJson, err = os.ReadFile(txpath)
 		if err != nil {
 			return err
 		}

--- a/pkgs/crypto/keys/client/verify.go
+++ b/pkgs/crypto/keys/client/verify.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 
 	"github.com/gnolang/gno/pkgs/command"
 	"github.com/gnolang/gno/pkgs/crypto/keys"
@@ -49,7 +49,7 @@ func verifyApp(cmd *command.Command, args []string, iopts interface{}) error {
 		}
 		msg = []byte(msgstr)
 	} else { // from file
-		msg, err = ioutil.ReadFile(docpath)
+		msg, err = os.ReadFile(docpath)
 		if err != nil {
 			return err
 		}

--- a/pkgs/gnolang/go2gno.go
+++ b/pkgs/gnolang/go2gno.go
@@ -35,7 +35,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -60,7 +60,7 @@ func MustParseFile(filename string, body string) *FileNode {
 }
 
 func ReadFile(path string) (*FileNode, error) {
-	bz, err := ioutil.ReadFile(path)
+	bz, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkgs/gnolang/nodes.go
+++ b/pkgs/gnolang/nodes.go
@@ -3,6 +3,7 @@ package gnolang
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -1109,7 +1110,7 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 			continue
 		}
 		fpath := filepath.Join(dir, file.Name())
-		bz, err := ioutil.ReadFile(fpath)
+		bz, err := os.ReadFile(fpath)
 		if err != nil {
 			panic(err)
 		}

--- a/pkgs/gnolang/precompile.go
+++ b/pkgs/gnolang/precompile.go
@@ -87,7 +87,7 @@ func PrecompileAndCheckMempkg(mempkg *std.MemPackage) error {
 			continue
 		}
 		tmpFile := filepath.Join(tmpDir, mfile.Name)
-		err = ioutil.WriteFile(tmpFile, []byte(translated), 0o644)
+		err = os.WriteFile(tmpFile, []byte(translated), 0o644)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue

--- a/pkgs/os/os.go
+++ b/pkgs/os/os.go
@@ -2,7 +2,6 @@ package os
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -60,11 +59,11 @@ func FileExists(filePath string) bool {
 }
 
 func ReadFile(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 func MustReadFile(filePath string) []byte {
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		Exit(fmt.Sprintf("MustReadFile failed: %v", err))
 		return nil
@@ -73,7 +72,7 @@ func MustReadFile(filePath string) []byte {
 }
 
 func WriteFile(filePath string, contents []byte, mode os.FileMode) error {
-	return ioutil.WriteFile(filePath, contents, mode)
+	return os.WriteFile(filePath, contents, mode)
 }
 
 func MustWriteFile(filePath string, contents []byte, mode os.FileMode) {

--- a/pkgs/os/tempfile_test.go
+++ b/pkgs/os/tempfile_test.go
@@ -27,7 +27,7 @@ func TestWriteFileAtomic(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 
-	if err = ioutil.WriteFile(f.Name(), old, 0o664); err != nil {
+	if err = os.WriteFile(f.Name(), old, 0o664); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func TestWriteFileAtomic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rData, err := ioutil.ReadFile(f.Name())
+	rData, err := os.ReadFile(f.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,11 +78,11 @@ func TestWriteFileAtomicDuplicateFile(t *testing.T) {
 	f.WriteString(testString)
 	WriteFileAtomic(fileToWrite, []byte(expectedString), 0o777)
 	// Check that the first atomic file was untouched
-	firstAtomicFileBytes, err := ioutil.ReadFile(fname)
+	firstAtomicFileBytes, err := os.ReadFile(fname)
 	require.Nil(t, err, "Error reading first atomic file")
 	require.Equal(t, []byte(testString), firstAtomicFileBytes, "First atomic file was overwritten")
 	// Check that the resultant file is correct
-	resultantFileBytes, err := ioutil.ReadFile(fileToWrite)
+	resultantFileBytes, err := os.ReadFile(fileToWrite)
 	require.Nil(t, err, "Error reading resultant file")
 	require.Equal(t, []byte(expectedString), resultantFileBytes, "Written file had incorrect bytes")
 
@@ -127,14 +127,14 @@ func TestWriteFileAtomicManyDuplicates(t *testing.T) {
 	for i := 0; i < atomicWriteFileMaxNumConflicts+2; i++ {
 		fileRand := randWriteFileSuffix()
 		fname := "/tmp/" + atomicWriteFilePrefix + fileRand
-		firstAtomicFileBytes, err := ioutil.ReadFile(fname)
+		firstAtomicFileBytes, err := os.ReadFile(fname)
 		require.Nil(t, err, "Error reading first atomic file")
 		require.Equal(t, []byte(fmt.Sprintf(testString, i)), firstAtomicFileBytes,
 			"atomic write file %d was overwritten", i)
 	}
 
 	// Check that the resultant file is correct
-	resultantFileBytes, err := ioutil.ReadFile(fileToWrite)
+	resultantFileBytes, err := os.ReadFile(fileToWrite)
 	require.Nil(t, err, "Error reading resultant file")
 	require.Equal(t, []byte(expectedString), resultantFileBytes, "Written file had incorrect bytes")
 }

--- a/pkgs/p2p/key.go
+++ b/pkgs/p2p/key.go
@@ -3,7 +3,7 @@ package p2p
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/gnolang/gno/pkgs/amino"
 	"github.com/gnolang/gno/pkgs/crypto"
@@ -39,7 +39,7 @@ func LoadOrGenNodeKey(filePath string) (*NodeKey, error) {
 }
 
 func LoadNodeKey(filePath string) (*NodeKey, error) {
-	jsonBytes, err := ioutil.ReadFile(filePath)
+	jsonBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func genNodeKey(filePath string) (*NodeKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = ioutil.WriteFile(filePath, jsonBytes, 0o600)
+	err = os.WriteFile(filePath, jsonBytes, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/backup/file_access.gno
+++ b/tests/backup/file_access.gno
@@ -23,7 +23,7 @@ func main() {
 		panic(err)
 	}
 
-	b, err := ioutil.ReadFile(file.Name())
+	b, err := os.ReadFile(file.Name())
 	if err != nil {
 		panic(err)
 	}

--- a/tests/backup/ioutil.gno
+++ b/tests/backup/ioutil.gno
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func main() {
-	_, err := ioutil.ReadFile("__NotExisting__")
+	_, err := os.ReadFile("__NotExisting__")
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/tests/file.go
+++ b/tests/file.go
@@ -6,7 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
+	"os"
 	"regexp"
 	rtdb "runtime/debug"
 	"strconv"
@@ -84,7 +84,7 @@ func RunFileTest(rootDir string, path string, nativeLibs bool, logger loggerFunc
 	// m.Use(interp.Symbols)
 	// m.Use(stdlib.Symbols)
 	// m.Use(unsafe.Symbols)
-	bz, err := ioutil.ReadFile(path)
+	bz, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Some functions like `ioutil.ReadFile` and `ioutil.WriteFile` are deprecated on Go 1.16, so they need to be updated to `os.ReadFile` and `os.WriteFile`

# How has this been tested?
Tested this code with the official test suite of the files changed

####  Doubts about files that ends with `.go.bak`
`.go.bak` Is possible change this kind of files like a any other go file? I made 2 update on two file that ends with `.go.bak` 