### PR TITLE
limit out put comment new lines in file test. 

### DIFF
--- a/examples/gno.land/r/demo/releases-example/releases0_filetest.gno
+++ b/examples/gno.land/r/demo/releases-example/releases0_filetest.gno
@@ -7,24 +7,23 @@ import (
 func main() {
 	println("-----------")
 	changelog := releases.NewChangelog("example")
-	println(changelog.Render(""))
+	print(changelog.Render(""))
 
 	println("-----------")
 	changelog.NewRelease("v1", "r/blahblah", "* initial version")
-	println(changelog.Render(""))
+	print(changelog.Render(""))
 
 	println("-----------")
 	changelog.NewRelease("v2", "r/blahblah2", "* various improvements\n* new shiny logo")
-	println(changelog.Render(""))
+	print(changelog.Render(""))
 
 	println("-----------")
-	println(changelog.Latest().Render())
+	print(changelog.Latest().Render())
 }
 
 // Output:
 // -----------
 // # example
-//
 //
 // -----------
 // # example
@@ -32,7 +31,6 @@ func main() {
 // ## [example v1 (latest)](r/blahblah)
 //
 // * initial version
-//
 //
 // -----------
 // # example
@@ -45,7 +43,6 @@ func main() {
 // ## [example v1](r/blahblah)
 //
 // * initial version
-//
 //
 // -----------
 // ## [example v2 (latest)](r/blahblah2)

--- a/examples/gno.land/r/demo/releases-example/releases1_filetest.gno
+++ b/examples/gno.land/r/demo/releases-example/releases1_filetest.gno
@@ -6,13 +6,13 @@ import (
 
 func main() {
 	println("-----------")
-	println(releases_example.Render(""))
+	print(releases_example.Render(""))
 
 	println("-----------")
-	println(releases_example.Render("v1"))
+	print(releases_example.Render("v1"))
 
 	println("-----------")
-	println(releases_example.Render("v42"))
+	print(releases_example.Render("v42"))
 }
 
 // Output:
@@ -27,12 +27,10 @@ func main() {
 //
 // initial release
 //
-//
 // -----------
 // ## [example-app v1](r/demo/examples-example-v1)
 //
 // initial release
-//
 //
 // -----------
 // no such release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

#440  1 of 3

The actual is the same as and wanted results in the test file. However, in the run time, when go.parser parses the wanted comment, it recognizes up to two lines of // style comments. parser.ParseComments() already returns two newline max. Since prinln(renderedContent) returns three new lines, it always fails. Therefore, we can not use println in the file test if the rendered content already has two new lines.

replace println() with print() will fix it.


# How has this been tested?

1. set syncWanted=false in tests/file.go
2. make gnodev
3. make test.examples