### PR TITLE
Use relative link paths for the GNO website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: logos goscan gnoland gnokey gnofaucet logos reset gnoweb gnotxport
 all: build
 
-build: gnoland gnokey goscan logos gnoweb gnotxport
+build: gnoland gnokey goscan logos gnoweb gnotxport gnofaucet
 
 install: install_gnodev install_gnokey
 

--- a/gnoland/website/pages/HOME.md
+++ b/gnoland/website/pages/HOME.md
@@ -1,35 +1,35 @@
 # Welcome to **Gno.land**
 
  * [About Gno.land](/about)
- * [Blogs](https://test3.gno.land/r/gnoland/blog)
+ * [Blogs](/r/gnoland/blog)
  * [Install `gnokey`](https://github.com/gnolang/gno/)
- * [Acquire testnet tokens](https://test3.gno.land/faucet)
+ * [Acquire testnet tokens](/faucet)
  * [Game of Realms](/game-of-realms) - An open worldwide competition for developers to build the best Gnolang smart-contracts.
 
 # Explore new packages.
 
 * r/gnoland
-  * [/r/gnoland/blog](https://test3.gno.land/r/gnoland/blog)
-  * [/r/gnoland/faucet](https://test3.gno.land/r/gnoland/faucet)
+    * [/r/gnoland/blog](/r/gnoland/blog)
+    * [/r/gnoland/faucet](/r/gnoland/faucet)
 * r/system
-  * [/r/system/names](https://test3.gno.land/r/system/names)
-  * [/r/system/rewards](https://test3.gno.land/r/system/rewards)
-  * [/r/system/validators](https://test3.gno.land/r/system/validators)
+    * [/r/system/names](/r/system/names)
+    * [/r/system/rewards](/r/system/rewards)
+    * [/r/system/validators](/r/system/validators)
 * r/demo
-  * [/r/demo/banktest](https://test3.gno.land/r/demo/banktest)
-  * [/r/demo/boards](https://test3.gno.land/r/demo/boards)
-  * [/r/demo/foo20](https://test3.gno.land/r/demo/foo20)
-  * [/r/demo/nft](https://test3.gno.land/r/demo/nft)
-  * [/r/demo/types](https://test3.gno.land/r/demo/types)
-  * [/r/demo/users](https://test3.gno.land/r/demo/users)
+    * [/r/demo/banktest](/r/demo/banktest)
+    * [/r/demo/boards](/r/demo/boards)
+    * [/r/demo/foo20](/r/demo/foo20)
+    * [/r/demo/nft](/r/demo/nft)
+    * [/r/demo/types](/r/demo/types)
+    * [/r/demo/users](/r/demo/users)
 * p/demo
-  * [/p/demo/avl](https://test3.gno.land/p/demo/avl)
-  * [/p/demo/blog](https://test3.gno.land/p/demo/blog)
-  * [/p/demo/flow](https://test3.gno.land/p/demo/flow)
-  * [/p/demo/gnode](https://test3.gno.land/p/demo/gnode)
-  * [/p/demo/grc/exts](https://test3.gno.land/p/demo/grc/exts)
-  * [/p/demo/grc/grc20](https://test3.gno.land/p/demo/grc/grc20)
-  * [/p/demo/grc/grc721](https://test3.gno.land/p/demo/grc/grc721)
+    * [/p/demo/avl](/p/demo/avl)
+    * [/p/demo/blog](/p/demo/blog)
+    * [/p/demo/flow](/p/demo/flow)
+    * [/p/demo/gnode](/p/demo/gnode)
+    * [/p/demo/grc/exts](/p/demo/grc/exts)
+    * [/p/demo/grc/grc20](/p/demo/grc/grc20)
+    * [/p/demo/grc/grc721](/p/demo/grc/grc721)
 
 # Other Testnets
 


### PR DESCRIPTION
# Description

This PR simply modifies the `HOME.md` file in the gno website module to utilize relative link paths, instead of hardcoded link paths.

As pointed out in #458, spinning up a local version of the website will link to the testnet, and not the local running instance, on the homepage.

Additionally, a build step was added to the `all` directive in the `Makefile`, so existing READMEs are valid - the `gnofaucet` binary is not being built in the `build` folder, but the [README on the faucet](https://github.com/gnolang/gno/blob/master/cmd/gnofaucet/README.md) assumes it is.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests

Deployed the website using the `./build/website` command and checked that links are relative instead of absolute.
