### PR TITLE
chore(website): improve markdown rendering

### DIFF
--- a/gnoland/website/pages/HOME.md
+++ b/gnoland/website/pages/HOME.md
@@ -48,22 +48,3 @@ Check out our [community projects](https://github.com/gnolang/awesome-gno).
 Official channel: [Discord](https://discord.gg/S8nKUqwkPn)<br />
 Other channels: [Telegram](https://t.me/gnoland) [Twitter](https://twitter.com/_gnoland)
 
-<!-- mailchimp -->
-<div id="mc_embed_signup">
-<form action="https://land.us18.list-manage.com/subscribe/post?u=8befe3303cf82796d2c1a1aff&amp;id=271812000b&amp;f_id=009170e7f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">
-  <label for="mce-EMAIL">Subscribe by email:</label>
-  <div id="mc_embed_signup_scroll">
-  	<div class="mc-field-group">
-  		<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Type your email here" required>
-  		<input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
-  		<span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
-  	</div>
-  	<div id="mce-responses" class="clear">
-  		<div class="response" id="mce-error-response" style="display:none"></div>
-  		<div class="response" id="mce-success-response" style="display:none"></div>
-  	</div>
-  	<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_8befe3303cf82796d2c1a1aff_271812000b" tabindex="-1" value=""></div>
-  </div>
-</form>
-</div>
-<!-- /mailchimp -->

--- a/gnoland/website/static/css/app.css
+++ b/gnoland/website/static/css/app.css
@@ -99,7 +99,7 @@ pre {
   margin-left: auto;
 }
 
-#home {
+#home, #subscribe {
   padding: 0 22px;
 }
 
@@ -149,4 +149,8 @@ pre {
 
 #realm_help .func_name td {
   font-weight: bold;
+}
+
+#source {
+	display: none;
 }

--- a/gnoland/website/views/funcs.html
+++ b/gnoland/website/views/funcs.html
@@ -8,6 +8,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <link rel="stylesheet" href="/static/css/app.css"/>
   <link rel="stylesheet" href="/static/css/normalize.css"/>
+  <noscript>
+   	<style type="text/css">
+      #source { display:block; }
+   	</style>
+  </noscript>
 {{ end }}
 
 {{ define "header_logo" }}<a id="logo" href="/"><img src="/static/img/logo.png" alt="Gno.land" title="Gno.land" height="38" /> </a>{{ end }}
@@ -29,4 +34,26 @@
         document.getElementById("home").innerHTML = DOMPurify.sanitize(parsed, { USE_PROFILES: { html: true } });
     };
   </script>
+{{ end }}
+
+{{ define "subscribe" }}
+<!-- mailchimp -->
+<div id="mc_embed_signup">
+<form action="https://land.us18.list-manage.com/subscribe/post?u=8befe3303cf82796d2c1a1aff&amp;id=271812000b&amp;f_id=009170e7f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">
+  <label for="mce-EMAIL">Subscribe by email:</label>
+  <div id="mc_embed_signup_scroll">
+  	<div class="mc-field-group">
+  		<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Type your email here" required>
+  		<input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+  		<span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
+  	</div>
+  	<div id="mce-responses" class="clear">
+  		<div class="response" id="mce-error-response" style="display:none"></div>
+  		<div class="response" id="mce-success-response" style="display:none"></div>
+  	</div>
+  	<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_8befe3303cf82796d2c1a1aff_271812000b" tabindex="-1" value=""></div>
+  </div>
+</form>
+</div>
+<!-- /mailchimp -->
 {{ end }}

--- a/gnoland/website/views/home.html
+++ b/gnoland/website/views/home.html
@@ -15,6 +15,9 @@
       <div id="home">
         <pre id="source">{{ .Data.HomeContent }}</pre>
       </div>
+      <div id="subscribe">
+        {{ template "subscribe" }}
+      </div>
       {{ template "footer" }}
     </div>
     {{ template "js" }}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Current md rendering involves a small blinking because the md is displayed first in a `<pre>` tag, and then it is replaced by the html transformed by the marked.js library. The change ensures the `<pre>` tag is hidden by default, which removes the blinking effect.

To be compliant with browser that doesn't have javascript enabled, a `<noscript>` tag has also been added, to override the `<pre>` tag display. So when javascript is not enabled, the `<pre>` is visible.

Because the mailchimp form was inside the `<pre>` tag, it was not rendered as a form when JS was disabled, only the html tags were visible. To fix that I moved the mailchimp form outside the `<pre>`.

# How has this been tested?

- Run `gnoland` and `website` binary, and visit http://localhost:8888.
- to disable Javascript, open chrome debugger tool, type Ctrl+Shift+P, type `javascript` and select the `Disable Javascript` option, then refresh the page. Same operation to re-enable it.

