### PR TITLE
feat: msgEval support

### DIFF
--- a/pkgs/sdk/vm/msgs.go
+++ b/pkgs/sdk/vm/msgs.go
@@ -135,3 +135,58 @@ func (msg MsgCall) GetSigners() []crypto.Address {
 func (msg MsgCall) GetReceived() std.Coins {
 	return msg.Send
 }
+
+//----------------------------------------
+// MsgEval
+
+// MsgCall - executes a Gno statement.
+type MsgEval struct {
+	Caller  crypto.Address `json:"caller" yaml:"caller"`
+	Send    std.Coins      `json:"send" yaml:"send"`
+	PkgPath string         `json:"pkg_path" yaml:"pkg_path"`
+	Expr    string         `json:"expr" yaml:"expr"`
+}
+
+func NewMsgEval(caller crypto.Address, send sdk.Coins, pkgPath, expr string) MsgEval {
+	return MsgEval{
+		Caller:  caller,
+		Send:    send,
+		PkgPath: pkgPath,
+		Expr:    expr,
+	}
+}
+
+// Implements Msg.
+func (msg MsgEval) Route() string { return RouterKey }
+
+// Implements Msg.
+func (msg MsgEval) Type() string { return "eval" }
+
+// Implements Msg.
+func (msg MsgEval) ValidateBasic() error {
+	if msg.Caller.IsZero() {
+		return std.ErrInvalidAddress("missing caller address")
+	}
+	if msg.PkgPath == "" { // XXX
+		return ErrInvalidPkgPath("missing package path")
+	}
+	if msg.Expr == "" { // XXX
+		return ErrInvalidPkgPath("missing expr")
+	}
+	return nil
+}
+
+// Implements Msg.
+func (msg MsgEval) GetSignBytes() []byte {
+	return std.MustSortJSON(amino.MustMarshalJSON(msg))
+}
+
+// Implements Msg.
+func (msg MsgEval) GetSigners() []crypto.Address {
+	return []crypto.Address{msg.Caller}
+}
+
+// Implements ReceiveMsg.
+func (msg MsgEval) GetReceived() std.Coins {
+	return msg.Send
+}

--- a/pkgs/sdk/vm/package.go
+++ b/pkgs/sdk/vm/package.go
@@ -14,6 +14,7 @@ var Package = amino.RegisterPackage(amino.NewPackage(
 ).WithTypes(
 	MsgCall{}, "m_call",
 	MsgAddPackage{}, "m_addpkg", // TODO rename both to MsgAddPkg?
+	MsgEval{}, "m_eval",
 
 	// errors
 	InvalidPkgPathError{}, "InvalidPkgPathError",

--- a/pkgs/sdk/vm/vm.proto
+++ b/pkgs/sdk/vm/vm.proto
@@ -21,6 +21,13 @@ message m_addpkg {
 	string Deposit = 3;
 }
 
+message m_eval {
+	string Caller = 1;
+	string Send = 2;
+	string PkgPath = 3;
+	string Expr = 4;
+}
+
 message InvalidPkgPathError {
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

support msgEval protocol , can evaluate an GNO expression from query and msgEval as well.

# How has this been tested?

tests passed.