### PR TITLE
chore: fix markdown links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ Add to your emacs configuration file:
 
 Notable contributions of fixes/features/refactors:
 
-* [https://github.com/gnolang/gno/pull/208](#208) - @anarcher, gnodev test with testing.T
-* [https://github.com/gnolang/gno/pull/167](#167) - @loicttn, website: Add syntax highlighting + security practices
-* [https://github.com/gnolang/gno/pull/136](#136) - @moul, foo20, a grc20 example smart contract
-* [https://github.com/gnolang/gno/pull/126](#126) - @moul, feat: use the new Precompile in gnodev and in the addpkg/execution flow (2/2)
-* [https://github.com/gnolang/gno/pull/119](#119) - @moul, add a Gno2Go precompiler (1/2)
-* [https://github.com/gnolang/gno/pull/112](#112) - @moul, feat: add 'gnokey maketx --broadcast' option
-* [https://github.com/gnolang/gno/pull/110](#110), [https://github.com/gnolang/gno/pull/109](#109), [https://github.com/gnolang/gno/pull/108](#108), [https://github.com/gnolang/gno/pull/106](#106), [https://github.com/gnolang/gno/pull/103](#103), [https://github.com/gnolang/gno/pull/102](#102), [https://github.com/gnolang/gno/pull/101](#101) - @moul, various chores.
+- [#208](https://github.com/gnolang/gno/pull/208) - @anarcher, gnodev test with testing.T
+- [#167](https://github.com/gnolang/gno/pull/167) - @loicttn, website: Add syntax highlighting + security practices
+- [#136](https://github.com/gnolang/gno/pull/136) - @moul, foo20, a grc20 example smart contract
+- [#126](https://github.com/gnolang/gno/pull/126) - @moul, feat: use the new Precompile in gnodev and in the addpkg/execution flow (2/2)
+- [#119](https://github.com/gnolang/gno/pull/119) - @moul, add a Gno2Go precompiler (1/2)
+- [#112](https://github.com/gnolang/gno/pull/112) - @moul, feat: add 'gnokey maketx --broadcast' option
+- [#110](https://github.com/gnolang/gno/pull/110), [#109](https://github.com/gnolang/gno/pull/109), [#108](https://github.com/gnolang/gno/pull/108), [#106](https://github.com/gnolang/gno/pull/106), [#103](https://github.com/gnolang/gno/pull/103), [#102](https://github.com/gnolang/gno/pull/102), [#101](https://github.com/gnolang/gno/pull/101) - @moul, various chores.


### PR DESCRIPTION
:wrench: Fixing links to issues in CONTRIBUTING.md file

I have corrected the links to issues in the "Notable Contributions" section by ensuring the proper format of the links. Specifically, I have:
- Replaced the issue titles with the correct links to the issues 
- Moved the issue titles to the correct position in the markdown link

This fix ensures that the links to issues are functional and that contributors can easily access the issues.

:memo: Let me know if there's any other problem
