### PR TITLE
chore: wrap precompile filename and tags logic

### DIFF
--- a/cmd/gnodev/precompile.go
+++ b/cmd/gnodev/precompile.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/gnolang/gno/pkgs/command"
 	"github.com/gnolang/gno/pkgs/errors"
@@ -125,20 +124,7 @@ func precompileFile(srcPath string, opts *precompileOptions) error {
 	}
 
 	// compute attributes based on filename.
-	var targetFilename string
-	var tags string
-	nameNoExtension := strings.TrimSuffix(filepath.Base(srcPath), ".gno")
-	switch {
-	case strings.HasSuffix(srcPath, "_filetest.gno"):
-		tags = "gno,filetest"
-		targetFilename = "." + nameNoExtension + ".gno.gen.go"
-	case strings.HasSuffix(srcPath, "_test.gno"):
-		tags = "gno,test"
-		targetFilename = "." + nameNoExtension + ".gno.gen_test.go"
-	default:
-		tags = "gno"
-		targetFilename = nameNoExtension + ".gno.gen.go"
-	}
+	targetFilename, tags := gno.GetPrecompileFilenameAndTags(srcPath)
 
 	// preprocess.
 	precompileRes, err := gno.Precompile(string(source), tags, srcPath)

--- a/pkgs/gnolang/precompile.go
+++ b/pkgs/gnolang/precompile.go
@@ -90,6 +90,23 @@ func guessRootDir(fileOrPkg string, goBinary string) (string, error) {
 	return rootDir, nil
 }
 
+// GetPrecompileFilenameAndTags returns the filename and tags for precompiled files.
+func GetPrecompileFilenameAndTags(gnoFilePath string) (targetFilename, tags string) {
+	nameNoExtension := strings.TrimSuffix(filepath.Base(gnoFilePath), ".gno")
+	switch {
+	case strings.HasSuffix(gnoFilePath, "_filetest.gno"):
+		tags = "gno,filetest"
+		targetFilename = "." + nameNoExtension + ".gno.gen.go"
+	case strings.HasSuffix(gnoFilePath, "_test.gno"):
+		tags = "gno,test"
+		targetFilename = "." + nameNoExtension + ".gno.gen_test.go"
+	default:
+		tags = "gno"
+		targetFilename = nameNoExtension + ".gno.gen.go"
+	}
+	return
+}
+
 func PrecompileAndCheckMempkg(mempkg *std.MemPackage) error {
 	gofmt := "gofmt"
 


### PR DESCRIPTION
Make precompile targetFilename and tags logic reusable by wrapping it in a function.
