### PR TITLE
Fix panic when Render method is not declared in smart contract

### DIFF
--- a/gnoland/website/main.go
+++ b/gnoland/website/main.go
@@ -268,6 +268,7 @@ func handleRealmRender(app gotuna.App, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// XXX hack
 		if strings.Contains(err.Error(), "Render not declared") {
+			res = &abci.ResponseQuery{}
 			res.Data = []byte("realm package has no Render() function")
 		} else {
 			writeError(w, err)


### PR DESCRIPTION
In function handleRealmRender, when the error returned by makeRequest is "Render not declared", the code tries to write to the res variable, which is nil. This causes a panic in the server.

Steps to reproduce:
1. Make a request to the server for a realm that has no Render() function
2. Observe the server panic

Fix:
I added the line "res = &abci.ResponseQuery{}" before writing to the res.Data variable. This creates an instance of abci.ResponseQuery and prevents the panic.

