### PR TITLE
fix(gnolang): fix an indexExpr preprocess bug

### DIFF
--- a/pkgs/gnolang/preprocess.go
+++ b/pkgs/gnolang/preprocess.go
@@ -1537,7 +1537,14 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 							cx.HasOK = true
 							lhs0 := n.Lhs[0].(*NameExpr).Name
 							lhs1 := n.Lhs[1].(*NameExpr).Name
-							mt := evalStaticTypeOf(store, last, cx.X).(*MapType)
+
+							var mt *MapType
+							st := evalStaticTypeOf(store, last, cx.X)
+							if dt, ok := st.(*DeclaredType); ok {
+								mt = dt.Base.(*MapType)
+							} else if mt, ok = st.(*MapType); !ok {
+								panic("should not happen")
+							}
 							// re-definitions
 							last.Define(lhs0, anyValue(mt.Value))
 							last.Define(lhs1, anyValue(BoolType))

--- a/tests/files/map28c.gno
+++ b/tests/files/map28c.gno
@@ -1,0 +1,21 @@
+package main
+
+type Values map[string][]string
+
+func (v Values) Set(key, value string) {
+	v[key] = []string{value}
+}
+
+func main() {
+	value1 := Values{}
+
+	value1.Set("first", "v1")
+	value1.Set("second", "v2")
+
+	_, ok := value1["first"]
+
+	println(ok)
+}
+
+// Output:
+// true

--- a/tests/files/map28c.gno
+++ b/tests/files/map28c.gno
@@ -12,6 +12,7 @@ func main() {
 	value1.Set("first", "v1")
 	value1.Set("second", "v2")
 
+    // Index case: v, ok := x[k], x is map.
 	_, ok := value1["first"]
 
 	println(ok)

--- a/tests/files2/map28c.gno
+++ b/tests/files2/map28c.gno
@@ -1,0 +1,21 @@
+package main
+
+type Values map[string][]string
+
+func (v Values) Set(key, value string) {
+	v[key] = []string{value}
+}
+
+func main() {
+	value1 := Values{}
+
+	value1.Set("first", "v1")
+	value1.Set("second", "v2")
+
+	_, ok := value1["first"]
+
+	println(ok)
+}
+
+// Output:
+// true

--- a/tests/files2/map28c.gno
+++ b/tests/files2/map28c.gno
@@ -12,6 +12,7 @@ func main() {
 	value1.Set("first", "v1")
 	value1.Set("second", "v2")
 
+    // Index case: v, ok := x[k], x is map.
 	_, ok := value1["first"]
 
 	println(ok)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description
type assertion  to *MapType may fail  while preprocessing *IndexExpr, it may cause a  `v, ok := Values[k]` operation fail especially when it's declared like `type Values map[string][]string`,  detailed in map28c.gno test.

# How has this been tested?

passed.