### PR TITLE
feat(website): add dark theme

### DIFF
--- a/gnoland/website/static/css/app.css
+++ b/gnoland/website/static/css/app.css
@@ -1,9 +1,47 @@
 @import url("../font/font.css");
 
-html{
-    -moz-text-size-adjust: none;
-    -webkit-text-size-adjust: none;
-    text-size-adjust: none;
+:root {
+  --background-color: #eee;
+  --input-background-color: #eee;
+  --text-color: #000;
+  --link-color: #25172a;
+
+  --quote-background: #ddd;
+  --quote-2-background: #aaa4;
+  --code-background: #d7d9db;
+  --header-background: #d7d9db;
+
+  --realm-help-background-color: #d7d9db9e;
+  --realm-help-odd-background-color: #d7d9db45;
+  --realm-help-code-color: #5d5d5d;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #2e2e2e;
+    --input-background-color: #393939;
+    --text-color: #eee;
+    --link-color: #ebe6ff;
+
+    --quote-background: #404040;
+    --quote-2-background: #555555;
+    --code-background: #454545;
+    --header-background: #454545;
+
+    --realm-help-background-color: #45454545;
+    --realm-help-odd-background-color: #4545459e;
+    --realm-help-code-color: #b6b6b6;
+  }
+
+  #header img {
+    filter: invert(1);
+  }
+}
+
+html {
+  -moz-text-size-adjust: none;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 
 html,
@@ -11,7 +49,8 @@ body {
   padding: 0;
   margin: 0;
   font-family: "Roboto Mono", "Courier New", "sans-serif";
-  background-color: #eee;
+  background-color: var(--background-color, #eee);
+  color: var(--text-color, #000);
   font-size: 15px;
 }
 
@@ -27,41 +66,41 @@ input {
 }
 
 a {
-  color: #25172a;
+  color: var(--link-color, #25172a);
 }
 
 input {
   font-family: "Roboto Mono", "Monaco", monospace;
-  background-color: #eee;
+  background-color: var(--input-background-color, #eee);
   border: 1px solid #ccc;
-  color: black;
+  color: var(--text-color, #000);
   width: 25em;
 }
 
 blockquote {
-  background-color: #ddd;
+  background-color: var(--quote-background, #ddd);
 }
 
 blockquote blockquote {
   margin: 0;
-  background-color: #aaa2;
+  background-color: var(--quote-2-background, #aaa4);
 }
 
 pre {
-  background-color: #d7d9db;
+  background-color: var(--code-background, #d7d9db);
   margin: 0;
 }
 
 #root {
   display: flex;
   flex-direction: column;
-  border: 1px solid #d7d9db;
+  border: 1px solid var(--header-background, #d7d9db);
   margin: 20px;
   /* height: calc(100vh - 40px); */
 }
 
 #header {
-  background-color: #d7d9db;
+  background-color: var(--header-background, #d7d9db);
   padding: 22px;
   display: flex;
   align-items: center;
@@ -69,7 +108,7 @@ pre {
 }
 
 #logo {
-  color: #25172a;
+  color: var(--link-color, #25172a);
   position: relative;
   top: 4px;
   height: 45px;
@@ -99,7 +138,8 @@ pre {
   margin-left: auto;
 }
 
-#home, #subscribe {
+#home,
+#subscribe {
   padding: 0 22px;
 }
 
@@ -116,18 +156,18 @@ pre {
 
 #realm_help .func_spec {
   padding: 22px;
-  background: #d7d9db9e;
+  background: var(--realm-help-background-color, #d7d9db9e);
   margin-top: 22px;
 }
 #realm_help .func_spec:nth-child(odd) {
-  background: #d7d9db45;
+  background: var(--realm-help-odd-background-color, #d7d9db45);
 }
 
 #realm_help .func_spec > table > tbody > tr > th {
   width: 50px;
   vertical-align: top;
   text-align: right;
-  color: #000;
+  color: var(--text-color, #000);
 }
 
 #realm_help .func_spec > table th,
@@ -144,7 +184,7 @@ pre {
 }
 
 #realm_help .func_spec .shell_command {
-  color: #5d5d5d;
+  color: var(--realm-help-code-color, #5d5d5d);
 }
 
 #realm_help .func_name td {
@@ -152,5 +192,5 @@ pre {
 }
 
 #source {
-	display: none;
+  display: none;
 }


### PR DESCRIPTION
Adds support for [prefers-color-scheme: dark](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) (ie. color scheme in browser settings) on the gnoland website. Just a personal itch I wanted to scratch :)

Screenshots from Firefox 109 on Linux:

![image](https://user-images.githubusercontent.com/4681308/218526022-21d1effb-7183-4ee0-b1b0-e9c60f916564.png)

![image](https://user-images.githubusercontent.com/4681308/218526138-cedb59c0-4ced-4f7c-b358-01bd0c1bc3ea.png)


![image](https://user-images.githubusercontent.com/4681308/218525740-3d06902a-c243-4b3d-89a0-197e9ae395bd.png)

![image](https://user-images.githubusercontent.com/4681308/218525874-a278e0c3-c44f-4c60-8bd0-474bb6abe057.png)