### PR TITLE
chore: switch to go1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: [ "1.18.x", "1.19.x" ]
+        goversion: [ "1.19.x", "1.20.x" ]
         goarch: [ "amd64" ]
         goos: [ "linux" ]
         program: [ "genproto", "gnofaucet", "gnokey", "gnoland", "gnotxport", "goscan", "gnodev", "gnoweb" ]

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.19.x", "1.20.x"]
         tags:
           - cleveldb
           - memdb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.19.x", "1.20.x"]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.19.x", "1.20.x"]
         args:
           - test.go1
           - test.go2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM        golang:1.19 AS build
+FROM        golang:1.20 AS build
 RUN         mkdir -p /opt/gno/src /opt/build
 WORKDIR     /opt/build
 ADD         go.mod go.sum /opt/build/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnolang/gno
 
-go 1.18
+go 1.19
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c


### PR DESCRIPTION
By switching to go1.20 and supporting the N-1 version, we can safely use any feature added on go1.19.

-> https://tip.golang.org/doc/go1.19

