### PR TITLE
feat: sanitize gno.mod

### DIFF
--- a/cmd/gnodev/mod.go
+++ b/cmd/gnodev/mod.go
@@ -59,6 +59,8 @@ func runModDownload(opts *modFlags) error {
 	if err != nil {
 		return fmt.Errorf("parse: %w", err)
 	}
+	// sanitize gno.mod
+	gnoMod.Sanitize()
 
 	// validate gno.mod
 	if err := gnoMod.Validate(); err != nil {

--- a/cmd/gnodev/mod.go
+++ b/cmd/gnodev/mod.go
@@ -70,12 +70,13 @@ func runModDownload(opts *modFlags) error {
 		return fmt.Errorf("fetch: %w", err)
 	}
 
-	if err := gnomod.Sanitize(gnoMod); err != nil {
+	gomod, err := gnomod.GnoToGoMod(*gnoMod)
+	if err != nil {
 		return fmt.Errorf("sanitize: %w", err)
 	}
 
 	// write go.mod file
-	err = gnoMod.WriteToPath(path)
+	err = gomod.WriteToPath(path)
 	if err != nil {
 		return fmt.Errorf("write go.mod file: %w", err)
 	}

--- a/pkgs/gnolang/gnomod/file.go
+++ b/pkgs/gnolang/gnomod/file.go
@@ -98,3 +98,7 @@ func (f *File) WriteToPath(absPath string) error {
 
 	return nil
 }
+
+func (f *File) Sanitize() {
+	removeDups(f.Syntax, &f.Require, &f.Replace)
+}

--- a/pkgs/gnolang/gnomod/gnomod.go
+++ b/pkgs/gnolang/gnomod/gnomod.go
@@ -69,12 +69,12 @@ func writePackage(basePath, pkgPath string) error {
 	return nil
 }
 
-// Sanitize make necessary modifications in the gno.mod
-// before writing it to go.mod file.
-func Sanitize(f *File) error {
+// GnoToGoMod make necessary modifications in the gno.mod
+// and return go.mod file.
+func GnoToGoMod(f File) (*File, error) {
 	gnoModPath, err := GetGnoModPath()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if strings.HasPrefix(f.Module.Mod.Path, "gno.land/r/") ||
@@ -100,5 +100,5 @@ func Sanitize(f *File) error {
 		})
 	}
 
-	return nil
+	return &f, nil
 }

--- a/pkgs/gnolang/gnomod/preprocess.go
+++ b/pkgs/gnolang/gnomod/preprocess.go
@@ -1,0 +1,99 @@
+package gnomod
+
+import (
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+func removeDups(syntax *modfile.FileSyntax, require *[]*modfile.Require, replace *[]*modfile.Replace) {
+	if require != nil {
+		purged := removeRequireDups(require)
+		cleanSyntaxTree(syntax, purged)
+	}
+	if replace != nil {
+		purged := removeReplaceDups(replace)
+		cleanSyntaxTree(syntax, purged)
+	}
+}
+
+// removeRequireDups removes duplicate requirements.
+// Requirements with higher version takes priority.
+func removeRequireDups(require *[]*modfile.Require) map[*modfile.Line]bool {
+	purge := make(map[*modfile.Line]bool)
+
+	keepRequire := make(map[string]string)
+	for _, r := range *require {
+		if v, ok := keepRequire[r.Mod.Path]; ok {
+			if semver.Compare(r.Mod.Version, v) == 1 {
+				keepRequire[r.Mod.Path] = r.Mod.Version
+			}
+			continue
+		}
+		keepRequire[r.Mod.Path] = r.Mod.Version
+	}
+	var req []*modfile.Require
+	added := make(map[string]bool)
+	for _, r := range *require {
+		if v, ok := keepRequire[r.Mod.Path]; ok && !added[r.Mod.Path] && v == r.Mod.Version {
+			req = append(req, r)
+			added[r.Mod.Path] = true
+			continue
+		}
+		purge[r.Syntax] = true
+	}
+	*require = req
+
+	return purge
+}
+
+// removeReplaceDups removes duplicate replacements.
+// Later replacements take priority over earlier ones.
+func removeReplaceDups(replace *[]*modfile.Replace) map[*modfile.Line]bool {
+	purge := make(map[*modfile.Line]bool)
+
+	haveReplace := make(map[module.Version]bool)
+	for i := len(*replace) - 1; i >= 0; i-- {
+		x := (*replace)[i]
+		if haveReplace[x.Old] { // duplicate detected
+			purge[x.Syntax] = true
+			continue
+		}
+		haveReplace[x.Old] = true
+	}
+	var repl []*modfile.Replace
+	for _, r := range *replace {
+		if !purge[r.Syntax] {
+			repl = append(repl, r)
+		}
+	}
+	*replace = repl
+
+	return purge
+}
+
+// cleanSyntaxTree removes purged statements from the syntax tree.
+func cleanSyntaxTree(syntax *modfile.FileSyntax, purge map[*modfile.Line]bool) {
+	stmts := make([]modfile.Expr, 0, len(syntax.Stmt))
+	for _, stmt := range syntax.Stmt {
+		switch stmt := stmt.(type) {
+		case *modfile.Line:
+			if purge[stmt] {
+				continue
+			}
+		case *modfile.LineBlock:
+			var lines []*modfile.Line
+			for _, line := range stmt.Line {
+				if !purge[line] {
+					lines = append(lines, line)
+				}
+			}
+			stmt.Line = lines
+			if len(lines) == 0 {
+				continue
+			}
+		}
+		stmts = append(stmts, stmt)
+	}
+	syntax.Stmt = stmts
+}

--- a/pkgs/gnolang/gnomod/preprocess_test.go
+++ b/pkgs/gnolang/gnomod/preprocess_test.go
@@ -1,0 +1,314 @@
+package gnomod
+
+import (
+	"testing"
+
+	"github.com/jaekwon/testify/assert"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+)
+
+func TestRemoveRequireDups(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		in       []*modfile.Require
+		expected []*modfile.Require
+	}{
+		{
+			desc: "no_duplicate",
+			in: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+			expected: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+		},
+		{
+			desc: "one_duplicate",
+			in: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+			expected: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+		},
+		{
+			desc: "multiple_duplicate",
+			in: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.2.0",
+					},
+				},
+			},
+			expected: []*modfile.Require{
+				{
+					Mod: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+				{
+					Mod: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.2.0",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			in := tc.in
+			removeRequireDups(&in)
+
+			assert.Equal(t, in, tc.expected)
+		})
+	}
+}
+
+func TestRemoveReplaceDups(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		in       []*modfile.Replace
+		expected []*modfile.Replace
+	}{
+		{
+			desc: "no_duplicate",
+			in: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+			expected: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+				},
+			},
+		},
+		{
+			desc: "one_duplicate",
+			in: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"1"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"2"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"3"},
+					},
+				},
+			},
+			expected: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"2"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"3"},
+					},
+				},
+			},
+		},
+		{
+			desc: "multiple_duplicate",
+			in: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"1"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"2"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"3"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"4"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.2.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"5"},
+					},
+				},
+			},
+			expected: []*modfile.Replace{
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.0.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"2"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/z",
+						Version: "v1.1.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"4"},
+					},
+				},
+				{
+					Old: module.Version{
+						Path:    "x.y/w",
+						Version: "v1.2.0",
+					},
+					Syntax: &modfile.Line{
+						Token: []string{"5"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			in := tc.in
+			removeReplaceDups(&in)
+
+			assert.Equal(t, in, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR implements logic to sanitize `gno.mod` file. Sanitization includes:
- Removing duplicate `require` modules. (Higher version takes priority)
- Removing duplicate `replace` modules. (Later replacements take priority over earlier ones)

# How has this been tested?

test suite and manually

Related #462 
Related #479 