### PR TITLE
fix: change net.GetFreePort to listening on port 0

### DIFF
--- a/pkgs/bft/privval/signer_client_test.go
+++ b/pkgs/bft/privval/signer_client_test.go
@@ -31,7 +31,7 @@ func getSignerTestCases(t *testing.T) []signerTestCase {
 		mockPV := types.NewMockPV()
 
 		// get a pair of signer listener, signer dialer endpoints
-		sl, sd := getMockEndpoints(t, dtc.addr, dtc.dialer)
+		sl, sd := getMockEndpoints(t, dtc.listener, dtc.dialer)
 		sc, err := NewSignerClient(sl)
 		require.NoError(t, err)
 		ss := NewSignerServer(sd, chainID, mockPV)

--- a/pkgs/bft/privval/socket_dialers_test.go
+++ b/pkgs/bft/privval/socket_dialers_test.go
@@ -2,6 +2,7 @@ package privval
 
 import (
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -15,26 +16,32 @@ import (
 func getDialerTestCases(t *testing.T) []dialerTestCase {
 	t.Helper()
 
-	tcpAddr := GetFreeLocalhostAddrPort()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Errorf("no open ports? error listening to 127.0.0.1:0: %w", err))
+	}
 	unixFilePath, err := testUnixAddr()
 	require.NoError(t, err)
-	unixAddr := fmt.Sprintf("unix://%s", unixFilePath)
+	ul, err := net.Listen("unix", unixFilePath)
+	if err != nil {
+		panic(err)
+	}
 
 	return []dialerTestCase{
 		{
-			addr:   tcpAddr,
-			dialer: DialTCPFn(tcpAddr, testTimeoutReadWrite, ed25519.GenPrivKey()),
+			listener: l,
+			dialer:   DialTCPFn(l.Addr().String(), testTimeoutReadWrite, ed25519.GenPrivKey()),
 		},
 		{
-			addr:   unixAddr,
-			dialer: DialUnixFn(unixFilePath),
+			listener: ul,
+			dialer:   DialUnixFn(unixFilePath),
 		},
 	}
 }
 
 func TestIsConnTimeoutForFundamentalTimeouts(t *testing.T) {
 	// Generate a networking timeout
-	tcpAddr := GetFreeLocalhostAddrPort()
+	tcpAddr := "127.0.0.1:34985"
 	dialer := DialTCPFn(tcpAddr, time.Millisecond, ed25519.GenPrivKey())
 	_, err := dialer()
 	assert.Error(t, err)
@@ -42,7 +49,7 @@ func TestIsConnTimeoutForFundamentalTimeouts(t *testing.T) {
 }
 
 func TestIsConnTimeoutForWrappedConnTimeouts(t *testing.T) {
-	tcpAddr := GetFreeLocalhostAddrPort()
+	tcpAddr := "127.0.0.1:34985"
 	dialer := DialTCPFn(tcpAddr, time.Millisecond, ed25519.GenPrivKey())
 	_, err := dialer()
 	assert.Error(t, err)

--- a/pkgs/bft/privval/utils.go
+++ b/pkgs/bft/privval/utils.go
@@ -50,12 +50,3 @@ func NewSignerListener(listenAddr string, logger log.Logger) (*SignerListenerEnd
 
 	return pve, nil
 }
-
-// GetFreeLocalhostAddrPort returns a free localhost:port address
-func GetFreeLocalhostAddrPort() string {
-	port, err := osm.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-	return fmt.Sprintf("127.0.0.1:%d", port)
-}

--- a/pkgs/bft/rpc/test/helpers.go
+++ b/pkgs/bft/rpc/test/helpers.go
@@ -15,7 +15,6 @@ import (
 	ctypes "github.com/gnolang/gno/pkgs/bft/rpc/core/types"
 	rpcclient "github.com/gnolang/gno/pkgs/bft/rpc/lib/client"
 	"github.com/gnolang/gno/pkgs/log"
-	osm "github.com/gnolang/gno/pkgs/os"
 	"github.com/gnolang/gno/pkgs/p2p"
 )
 
@@ -61,27 +60,13 @@ func makePathname() string {
 	return strings.Replace(p, sep, "_", -1)
 }
 
-func randPort() int {
-	port, err := osm.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-	return port
-}
-
-func makeAddrs() (string, string) {
-	return fmt.Sprintf("tcp://0.0.0.0:%d", randPort()),
-		fmt.Sprintf("tcp://0.0.0.0:%d", randPort())
-}
-
 func createConfig() *cfg.Config {
 	pathname := makePathname()
 	c := cfg.ResetTestRoot(pathname)
 
 	// and we use random ports to run in parallel
-	tm, rpc := makeAddrs()
-	c.P2P.ListenAddress = tm
-	c.RPC.ListenAddress = rpc
+	c.P2P.ListenAddress = "tcp://127.0.0.2:0"
+	c.RPC.ListenAddress = "tcp://127.0.0.2:0"
 	c.RPC.CORSAllowedOrigins = []string{"https://tendermint.com/"}
 	// c.TxIndex.IndexTags = "app.creator,tx.height" // see kvstore application
 	return c

--- a/pkgs/os/net.go
+++ b/pkgs/os/net.go
@@ -24,20 +24,3 @@ func ProtocolAndAddress(listenAddr string) (string, string) {
 	}
 	return protocol, address
 }
-
-// GetFreePort gets a free port from the operating system.
-// Ripped from https://github.com/phayes/freeport.
-// BSD-licensed.
-func GetFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
-}

--- a/pkgs/p2p/test_util.go
+++ b/pkgs/p2p/test_util.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gnolang/gno/pkgs/crypto/ed25519"
 	"github.com/gnolang/gno/pkgs/errors"
 	"github.com/gnolang/gno/pkgs/log"
-	osm "github.com/gnolang/gno/pkgs/os"
 	"github.com/gnolang/gno/pkgs/p2p/config"
 	"github.com/gnolang/gno/pkgs/p2p/conn"
 	"github.com/gnolang/gno/pkgs/random"
@@ -243,7 +242,7 @@ func testVersionSet() versionset.VersionSet {
 func testNodeInfoWithNetwork(id ID, name, network string) NodeInfo {
 	return NodeInfo{
 		VersionSet: testVersionSet(),
-		NetAddress: NewNetAddressFromIPPort(id, net.ParseIP("127.0.0.1"), getFreePort()),
+		NetAddress: NewNetAddressFromIPPort(id, net.ParseIP("127.0.0.1"), 0),
 		Network:    network,
 		Software:   "p2ptest",
 		Version:    "v1.2.3-rc.0-deadbeef",
@@ -251,15 +250,7 @@ func testNodeInfoWithNetwork(id ID, name, network string) NodeInfo {
 		Moniker:    name,
 		Other: NodeInfoOther{
 			TxIndex:    "on",
-			RPCAddress: fmt.Sprintf("127.0.0.1:%d", getFreePort()),
+			RPCAddress: fmt.Sprintf("127.0.0.1:%d", 0),
 		},
 	}
-}
-
-func getFreePort() uint16 {
-	port, err := osm.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-	return uint16(port)
 }

--- a/pkgs/p2p/transport.go
+++ b/pkgs/p2p/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/gnolang/gno/pkgs/amino"
@@ -239,6 +240,17 @@ func (mt *MultiplexTransport) Listen(addr NetAddress) error {
 	ln, err := net.Listen("tcp", addr.DialString())
 	if err != nil {
 		return err
+	}
+
+	if addr.Port == 0 {
+		// net.Listen on port 0 means the kernel will auto-allocate a port
+		// - find out which one has been given to us.
+		_, p, err := net.SplitHostPort(ln.Addr().String())
+		if err != nil {
+			return fmt.Errorf("error finding port (after listening on port 0): %w", err)
+		}
+		pInt, _ := strconv.Atoi(p)
+		addr.Port = uint16(pInt)
 	}
 
 	mt.netAddr = addr


### PR DESCRIPTION
Fixes #508 

There are some instances where the code is now modifying configurations retroactively (such as bft/node and pkgs/p2p). This should still largely not be a problem because it only happens when listening on port 0, which should mostly be done just on tests.