### PR TITLE
chore: fix workflow typo in `go-version` matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: [ "1.19.x", "1.20.x" ]
+        go-version: [ "1.19.x", "1.20.x" ]
         goarch: [ "amd64" ]
         goos: [ "linux" ]
         program: [ "genproto", "gnofaucet", "gnokey", "gnoland", "gnotxport", "goscan", "gnodev", "gnoweb" ]

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.19.x", "1.20.x"]
+        go-version: [ "1.19.x", "1.20.x" ]
         tags:
           - cleveldb
           - memdb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.19.x", "1.20.x"]
+        go-version: [ "1.19.x", "1.20.x" ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.19.x", "1.20.x"]
+        go-version: [ "1.19.x", "1.20.x" ]
         args:
           - test.go1
           - test.go2


### PR DESCRIPTION
# Description

This PR fixes a typo in the workflow files that resulted in workflows being run on go `1.18`, instead of the matrix versions.
The matrix version being queried in the workflow is `go-version`, instead of `goversion`.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually
