### PR TITLE
fix(tests): don't use 127.0.0.2 as an address for testing

### DIFF
--- a/pkgs/bft/rpc/test/helpers.go
+++ b/pkgs/bft/rpc/test/helpers.go
@@ -65,8 +65,8 @@ func createConfig() *cfg.Config {
 	c := cfg.ResetTestRoot(pathname)
 
 	// and we use random ports to run in parallel
-	c.P2P.ListenAddress = "tcp://127.0.0.2:0"
-	c.RPC.ListenAddress = "tcp://127.0.0.2:0"
+	c.P2P.ListenAddress = "tcp://127.0.0.1:0"
+	c.RPC.ListenAddress = "tcp://127.0.0.1:0"
 	c.RPC.CORSAllowedOrigins = []string{"https://tendermint.com/"}
 	// c.TxIndex.IndexTags = "app.creator,tx.height" // see kvstore application
 	return c


### PR DESCRIPTION
From @zivkovicmilos:

>The test.go3 goblin seems to be back locally, as it always fails on my machine :upside_down_face:
The test that fails locally is [this one](https://github.com/gnolang/gno/blob/eabc5c40d31a00adf8cf97e6460b40704e0dba1a/pkgs/bft/rpc/client/main_test.go#L15-L29), and I’ve found the culprit:
>
>```
>panic: failed to listen on 127.0.0.2:0: listen tcp 127.0.0.2:0: bind: can't assign requested address
>
>goroutine 1 [running]:
>github.com/gnolang/gno/pkgs/bft/rpc/test.StartTendermint({0x185a6f8, 0xc000388300}, {0x0, 0x0, 0x98?})
>	/Users/zmilos/Work/gno/pkgs/bft/rpc/test/helpers.go:92 +0xff
>github.com/gnolang/gno/pkgs/bft/rpc/client_test.TestMain(0x1041051?)
>	/Users/zmilos/Work/gno/pkgs/bft/rpc/client/main_test.go:22 +0x5b
>main.main()
>	_testmain.go:97 +0x1d3
>FAIL	github.com/gnolang/gno/pkgs/bft/rpc/client	1.235s
>```
>
>[Changing these IPs](https://github.com/gnolang/gno/blob/eabc5c40d31a00adf8cf97e6460b40704e0dba1a/pkgs/bft/rpc/test/helpers.go#L68-L69) to 127.0.0.1  instead of 127.0.0.2 solves the issue and the address binds without a problem when starting the Tendermint node
I have no idea why it won’t bind the 127.0.0.2 address on my local mac, since it should be a loopback address range :man_shrugging: 