### PR TITLE
hotfix: apply CLI flags to entire subtree

### DIFF
--- a/pkgs/commands/command.go
+++ b/pkgs/commands/command.go
@@ -94,8 +94,8 @@ func (c *Command) AddSubCommands(cmds ...*Command) {
 // configuration's flagset with the subcommand tree. At the point of calling
 // this method, the child subcommand tree should already be present, due to the
 // way subcommands are built (LIFO)
-func registerFlagsWithSubcommands(cfg Config, cmd *ffcli.Command) {
-	subcommands := []*ffcli.Command{cmd}
+func registerFlagsWithSubcommands(cfg Config, root *ffcli.Command) {
+	subcommands := []*ffcli.Command{root}
 
 	// Traverse the direct subcommand tree,
 	// and register the top-level flagset with each

--- a/pkgs/commands/commands_test.go
+++ b/pkgs/commands/commands_test.go
@@ -1,0 +1,155 @@
+package commands
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/stretchr/testify/assert"
+)
+
+type configDelegate func(*flag.FlagSet)
+
+type mockConfig struct {
+	configFn configDelegate
+}
+
+func (c *mockConfig) RegisterFlags(fs *flag.FlagSet) {
+	if c.configFn != nil {
+		c.configFn(fs)
+	}
+}
+
+func TestCommand_AddSubCommands(t *testing.T) {
+	t.Parallel()
+
+	// Test setup //
+
+	type testCmd struct {
+		cmd     *Command
+		subCmds []*testCmd
+	}
+
+	getSubcommands := func(t *testCmd) []*Command {
+		res := make([]*Command, len(t.subCmds))
+
+		for i, subCmd := range t.subCmds {
+			res[i] = subCmd.cmd
+		}
+
+		return res
+	}
+
+	generateTestCmd := func(name string) *Command {
+		return NewCommand(
+			Metadata{
+				Name: name,
+			},
+			&mockConfig{
+				func(fs *flag.FlagSet) {
+					fs.String(
+						name,
+						"",
+						"",
+					)
+				},
+			},
+			HelpExec,
+		)
+	}
+
+	var postorderCommands func(root *testCmd) []*testCmd
+
+	postorderCommands = func(root *testCmd) []*testCmd {
+		if root == nil {
+			return nil
+		}
+
+		res := make([]*testCmd, 0)
+
+		for _, child := range root.subCmds {
+			res = append(res, postorderCommands(child)...)
+		}
+
+		return append(res, root)
+	}
+
+	// Cases //
+
+	testTable := []struct {
+		name   string
+		topCmd *testCmd
+	}{
+		{
+			name: "no subcommands",
+			topCmd: &testCmd{
+				cmd:     generateTestCmd("level0"),
+				subCmds: nil,
+			},
+		},
+		{
+			name: "single subcommand level",
+			topCmd: &testCmd{
+				cmd: generateTestCmd("level0"),
+				subCmds: []*testCmd{
+					{
+						cmd:     generateTestCmd("level1"),
+						subCmds: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple subcommand levels",
+			topCmd: &testCmd{
+				cmd: generateTestCmd("level0"),
+				subCmds: []*testCmd{
+					{
+						cmd: generateTestCmd("level1"),
+						subCmds: []*testCmd{
+							{
+								cmd:     generateTestCmd("level2"),
+								subCmds: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var validateSubcommandTree func(flag string, root *ffcli.Command)
+
+			validateSubcommandTree = func(flag string, root *ffcli.Command) {
+				assert.NotNil(t, root.FlagSet.Lookup(flag))
+
+				for _, subcommand := range root.Subcommands {
+					validateSubcommandTree(flag, subcommand)
+				}
+			}
+
+			// Register the subcommands in LIFO order (postorder), starting from the
+			// leaf of the command tree (mimics how the commands package is used)
+			commandOrder := postorderCommands(testCase.topCmd)
+
+			for _, currCmd := range commandOrder {
+				// For the current command, register its subcommand tree
+				currCmd.cmd.AddSubCommands(getSubcommands(currCmd)...)
+
+				// Validate that the entire subcommand tree has root command flags
+				for _, subCmd := range currCmd.cmd.Subcommands {
+					// For each root command flag, validate
+					currCmd.cmd.FlagSet.VisitAll(func(f *flag.Flag) {
+						validateSubcommandTree(f.Name, subCmd)
+					})
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

As pointed out in #555, the current command flag registration flow does not register flags with grandchild commands, and beyond.
This PR introduces a fix for allowing the most nested child commands to have flags of their entire ancestor tree.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [x] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests

* Manually verified that the issue has been resolved
* Added unit tests that covered the issue functionality

# Additional comments

Resolves #555 
