### PR TITLE
WIP: POC:  `std.Call` to support dynamic import and call

### DIFF
--- a/stdlibs/std/call.gno
+++ b/stdlibs/std/call.gno
@@ -1,5 +1,5 @@
 package std
 
 type CallResult struct {
-	Value interface{}
+	Value []interface{}
 }

--- a/stdlibs/std/call.gno
+++ b/stdlibs/std/call.gno
@@ -1,0 +1,5 @@
+package std
+
+type CallResult struct {
+	Value interface{}
+}

--- a/tests/stdlibs_test.go
+++ b/tests/stdlibs_test.go
@@ -26,15 +26,23 @@ func TestStdCall(t *testing.T) {
 
 	c := `package main
 	import "std"
+	import "gno.land/p/demo/grc/grc721"
+	import "gno.land/p/demo/testutils"
+
+	type Token interface {
+		Mint(std.Address,string) grc721.TokenID 
+	}
+
 	func main() {
 		result := std.Call("gno.land/r/demo/nft","GetToken",nil)
 		println(result.Value)
 		println(len(result.Value))
-		tt := result.Value[0]
-		println(tt)
+		tt := result.Value[0].(Token)
 
-		//token := result.Value[0].(nft.Token)
-		//println(token)
+		addr1 := testutils.TestAddress("addr1")
+		tid := tt.Mint(addr1,"hello")
+		println("tid: ",tid)
+
 	}
 `
 	n := gno.MustParseFile("test", c)

--- a/tests/stdlibs_test.go
+++ b/tests/stdlibs_test.go
@@ -35,21 +35,20 @@ func TestStdCall(t *testing.T) {
 
 	func main() {
 		result := std.Call("gno.land/r/demo/nft","GetToken",nil)
-		println(result.Value)
-		println(len(result.Value))
+		println("result.Value:",result.Value)
+		println("result.Value: len:",len(result.Value))
 		tt := result.Value[0].(Token)
 
 		addr1 := testutils.TestAddress("addr1")
 		tid := tt.Mint(addr1,"hello")
 		println("tid: ",tid)
-
 	}
 `
 	n := gno.MustParseFile("test", c)
 	m.RunFiles(n)
 	m.RunMain()
 
-	fmt.Printf("output: %v\n", stdout)
+	t.Logf("output: %v\n", stdout)
 
 	err := m.CheckEmpty()
 	if err != nil {

--- a/tests/stdlibs_test.go
+++ b/tests/stdlibs_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	gno "github.com/gnolang/gno/pkgs/gnolang"
+)
+
+func TestStdCall(t *testing.T) {
+	stdin := new(bytes.Buffer)
+	//stdout := new(bytes.Buffer)
+	stdout := os.Stdout
+	stderr := new(bytes.Buffer)
+	store := TestStore("..", "", stdin, stdout, stderr, ImportModeStdlibsPreferred)
+	store.SetLogStoreOps(true)
+
+	m := gno.NewMachineWithOptions(gno.MachineOptions{
+		PkgPath: "main",
+		Output:  stdout,
+		Store:   store,
+		Context: nil,
+	})
+
+	c := `package main
+	import "std"
+	func main() {
+		result := std.Call("gno.land/r/demo/nft","GetToken",nil)
+		println(result.Value)
+		println(len(result.Value))
+		tt := result.Value[0]
+		println(tt)
+
+		//token := result.Value[0].(nft.Token)
+		//println(token)
+	}
+`
+	n := gno.MustParseFile("test", c)
+	m.RunFiles(n)
+	m.RunMain()
+
+	fmt.Printf("output: %v\n", stdout)
+
+	err := m.CheckEmpty()
+	if err != nil {
+		t.Log("last state: \n", m.String())
+		panic(fmt.Sprintf("machine not empty after main: %v", err))
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

This idea originated in https://github.com/gnolang/gno/pull/473#issuecomment-1402148115 . This is not intended for general use, but may be useful in special situations (e.g. multi token management contract?). 

```go
import (
        "std"
)

func TotalSupply() uint64 {
        result := std.Call("gno.land/r/demo/foo20", "TotalSupply", nil)
        ts := result.Value[0].(uint64)
        return ts
}

func Faucet() {
        std.Call("gno.land/r/demo/foo20", "Faucet", nil)
}

```

It's POC. I'm not sure if this is the right way to go. and it needs more testing, there are still things to add (e.g. `std.CallArgs`). 

```go
// gno.land/r/test/stdcall/foo20
package main

import (
        "std"
)

func TotalSupply() uint64 {
        result := std.Call("gno.land/r/demo/foo20", "TotalSupply", nil)
        println("result:", result)
        ts := result.Value[0].(uint64)
        return ts
}

func Faucet() {
        result := std.Call("gno.land/r/demo/foo20", "Faucet", nil)
        println("result:", result)
}

func Render(p string) string {
        return "not implemented"
}
```

```shell
$ ~/bin/gnokey maketx call anarcher --pkgpath "gno.land/r/test/stdcall/foo20" --func "Faucet" --gas-fee 1000000ugnot --gas-wanted 2000000 --send "" --broadcast true --chainid "dev"   --remote "127.0.0.1:26657"
Enter password.

OK!
GAS WANTED: 2000000
GAS USED:   460042

$ ~/bin/gnokey maketx call anarcher --pkgpath "gno.land/r/test/stdcall/foo20" --func "TotalSupply" --gas-fee 1000000ugnot --gas-wanted 2000000 --send "" --broadcast true --chainid "dev"   --remote "127.0.0.1:26657"
Enter password.
(10160000000 uint64)
OK!
GAS WANTED: 2000000
GAS USED:   256703

```


# How has this been tested?

It hasn't yet.

Please complete this section if you ran tests for this functionality, otherwise delete it
