### PR TITLE
add first unit tests for gno.land website

### DIFF
--- a/cmd/gnoland/main.go
+++ b/cmd/gnoland/main.go
@@ -226,6 +226,7 @@ func makeGenesisDoc(
 		"r/system/validators",
 		"r/system/names",
 		"r/system/rewards",
+		"r/demo/deep/very/deep",
 	} {
 		// open files in directory as MemPackage.
 		memPkg := gno.ReadMemPackage(filepath.Join(".", "examples", "gno.land", path), "gno.land/"+path)

--- a/examples/gno.land/r/demo/deep/very/deep/render.gno
+++ b/examples/gno.land/r/demo/deep/very/deep/render.gno
@@ -1,0 +1,9 @@
+package deep
+
+func Render(path string) string {
+	if path == "" {
+		return "it works!"
+	} else {
+		return "hi " + path
+	}
+}

--- a/gnoland/website/main.go
+++ b/gnoland/website/main.go
@@ -59,16 +59,13 @@ func init() {
 	startedAt = time.Now()
 }
 
-func main() {
-	flag.Parse()
-
+func makeApp() gotuna.App {
 	app := gotuna.App{
 		ViewFiles: os.DirFS(flags.viewsDir),
 		Router:    gotuna.NewMuxRouter(),
 		Static:    static.EmbeddedStatic,
 		// StaticPrefix: "static/",
 	}
-
 	app.Router.Handle("/", handlerHome(app))
 	app.Router.Handle("/about", handlerAbout(app))
 	app.Router.Handle("/game-of-realms", handlerGor(app))
@@ -82,13 +79,16 @@ func main() {
 	app.Router.Handle("/static/{path:.+}", handlerStaticFile(app))
 	app.Router.Handle("/favicon.ico", handlerFavicon(app))
 	app.Router.Handle("/status.json", handlerStatusJSON(app))
+	return app
+}
 
+func main() {
+	flag.Parse()
 	fmt.Printf("Running on http://%s\n", flags.bindAddr)
-
 	server := &http.Server{
 		Addr:              flags.bindAddr,
 		ReadHeaderTimeout: 60 * time.Second,
-		Handler:           app.Router,
+		Handler:           makeApp().Router,
 	}
 
 	if err := server.ListenAndServe(); err != nil {

--- a/gnoland/website/main.go
+++ b/gnoland/website/main.go
@@ -75,10 +75,9 @@ func main() {
 	app.Router.Handle("/faucet", handlerFaucet(app))
 	app.Router.Handle("/r/demo/boards:gnolang/6", handlerRedirect(app))
 	// NOTE: see rePathPart.
-	// FIXME: use better regexp to support any depth.
-	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*/[a-z][a-z0-9_]*}", handlerRealmMain(app))
-	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*/[a-z][a-z0-9_]*}:{querystr:.*}", handlerRealmRender(app))
-	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*/[a-z][a-z0-9_]*}/{filename:.*}", handlerRealmFile(app))
+	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/{filename:(?:.*\\.gno$)?}", handlerRealmFile(app))
+	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}", handlerRealmMain(app))
+	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/:{querystr:.*}", handlerRealmRender(app))
 	app.Router.Handle("/p/{filepath:.*}", handlerPackageFile(app))
 	app.Router.Handle("/static/{path:.+}", handlerStaticFile(app))
 	app.Router.Handle("/favicon.ico", handlerFavicon(app))

--- a/gnoland/website/main.go
+++ b/gnoland/website/main.go
@@ -77,7 +77,7 @@ func main() {
 	// NOTE: see rePathPart.
 	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/{filename:(?:.*\\.gno$)?}", handlerRealmFile(app))
 	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}", handlerRealmMain(app))
-	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/:{querystr:.*}", handlerRealmRender(app))
+	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}:{querystr:.*}", handlerRealmRender(app))
 	app.Router.Handle("/p/{filepath:.*}", handlerPackageFile(app))
 	app.Router.Handle("/static/{path:.+}", handlerStaticFile(app))
 	app.Router.Handle("/favicon.ico", handlerFavicon(app))

--- a/gnoland/website/main_test.go
+++ b/gnoland/website/main_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/gotuna/gotuna/test/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/gotuna/gotuna/test/assert"
 )
 
 func TestRoutes(t *testing.T) {

--- a/gnoland/website/main_test.go
+++ b/gnoland/website/main_test.go
@@ -13,19 +13,19 @@ import (
 func TestRoutes(t *testing.T) {
 	ok := http.StatusOK
 	routes := []struct {
-		route  string
-		status int
-		ftest  func(string) bool
+		route     string
+		status    int
+		substring string
 	}{
-		{"/", ok, func(s string) bool { return strings.Contains(s, "Welcome") }},
-		{"/about", ok, func(s string) bool { return strings.Contains(s, "blockchain") }},
-		{"/r/gnoland/blog", ok, nil},
-		{"/r/gnoland/blog?help", ok, func(s string) bool { return strings.Contains(s, "exposed") }},
-		{"/r/gnoland/blog/", ok, func(s string) bool { return strings.Contains(s, "admin.gno") }},
-		{"/r/gnoland/blog/admin.gno", ok, func(s string) bool { return strings.Contains(s, "func ") }},
-		{"/r/demo/users:administrator", ok, func(s string) bool { return strings.Contains(s, "address") }},
-		{"/r/demo/users", ok, func(s string) bool { return strings.Contains(s, "manfred") }},
-		{"/r/demo/users/types.gno", ok, func(s string) bool { return strings.Contains(s, "type ") }},
+		{"/", ok, "Welcome"}, // assert / gives 200 (OK). assert / contains "Welcome".
+		{"/about", ok, "blockchain"},
+		{"/r/gnoland/blog", ok, ""}, // whatever content
+		{"/r/gnoland/blog?help", ok, "exposed"},
+		{"/r/gnoland/blog/", ok, "admin.gno"},
+		{"/r/gnoland/blog/admin.gno", ok, "func "},
+		{"/r/demo/users:administrator", ok, "address"},
+		{"/r/demo/users", ok, "manfred"},
+		{"/r/demo/users/types.gno", ok, "type "},
 	}
 	if wd, err := os.Getwd(); err == nil {
 		if strings.HasSuffix(wd, "gnoland/website") {
@@ -41,9 +41,7 @@ func TestRoutes(t *testing.T) {
 			response := httptest.NewRecorder()
 			app.Router.ServeHTTP(response, request)
 			assert.Equal(t, r.status, response.Code)
-			if r.ftest != nil {
-				assert.Equal(t, r.ftest(response.Body.String()), true)
-			}
+			assert.Equal(t, strings.Contains(response.Body.String(), r.substring), true)
 		})
 	}
 }

--- a/gnoland/website/main_test.go
+++ b/gnoland/website/main_test.go
@@ -26,6 +26,11 @@ func TestRoutes(t *testing.T) {
 		{"/r/demo/users:administrator", ok, "address"},
 		{"/r/demo/users", ok, "manfred"},
 		{"/r/demo/users/types.gno", ok, "type "},
+		{"/r/demo/deep/very/deep", ok, "it works!"},
+		{"/r/demo/deep/very/deep:bob", ok, "hi bob"},
+		{"/r/demo/deep/very/deep?help", ok, "exposed"},
+		{"/r/demo/deep/very/deep/", ok, "render.gno"},
+		{"/r/demo/deep/very/deep/render.gno", ok, "func Render("},
 	}
 	if wd, err := os.Getwd(); err == nil {
 		if strings.HasSuffix(wd, "gnoland/website") {

--- a/gnoland/website/main_test.go
+++ b/gnoland/website/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gotuna/gotuna/test/assert"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRoutes(t *testing.T) {
+	ok := http.StatusOK
+	routes := []struct {
+		route  string
+		status int
+		ftest  func(string) bool
+	}{
+		{"/", ok, func(s string) bool { return strings.Contains(s, "Welcome") }},
+		{"/about", ok, func(s string) bool { return strings.Contains(s, "blockchain") }},
+		{"/r/gnoland/blog", ok, nil},
+		{"/r/gnoland/blog?help", ok, func(s string) bool { return strings.Contains(s, "exposed") }},
+		{"/r/gnoland/blog/", ok, func(s string) bool { return strings.Contains(s, "admin.gno") }},
+		{"/r/gnoland/blog/admin.gno", ok, func(s string) bool { return strings.Contains(s, "func ") }},
+		{"/r/demo/users:administrator", ok, func(s string) bool { return strings.Contains(s, "address") }},
+		{"/r/demo/users", ok, func(s string) bool { return strings.Contains(s, "manfred") }},
+		{"/r/demo/users/types.gno", ok, func(s string) bool { return strings.Contains(s, "type ") }},
+	}
+	if wd, err := os.Getwd(); err == nil {
+		if strings.HasSuffix(wd, "gnoland/website") {
+			os.Chdir("../..")
+		}
+	} else {
+		panic("os.Getwd() -> err: " + err.Error())
+	}
+	app := makeApp()
+	for _, r := range routes {
+		t.Run(fmt.Sprintf("test route %s", r.route), func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, r.route, nil)
+			response := httptest.NewRecorder()
+			app.Router.ServeHTTP(response, request)
+			assert.Equal(t, r.status, response.Code)
+			if r.ftest != nil {
+				assert.Equal(t, r.ftest(response.Body.String()), true)
+			}
+		})
+	}
+}


### PR DESCRIPTION

This adds unit tests for the gno.land website, and also for PR #565  (website working with deep packages)

For now I don't have gnot on the testnet.
Someone must run an `addpkg` of `examples/gno.land/r/demo/deep/very/deep/render.gno` 
before the `r/demo/deep/very/deep/*` tests pass. Next time the testnet is reset it should be added automatically.

Then can test with `go test ./gnoland/website`,
and all tests should pass.