### PR TITLE
fix(gnokey): Resolve nil error in gnokey maketx

### DIFF
--- a/pkgs/crypto/keys/client/addpkg.go
+++ b/pkgs/crypto/keys/client/addpkg.go
@@ -155,9 +155,9 @@ func signAndBroadcast(
 	accountAddr := info.GetAddress()
 
 	qopts := &queryCfg{
-		path: fmt.Sprintf("auth/accounts/%s", accountAddr),
+		rootCfg: baseopts,
+		path:    fmt.Sprintf("auth/accounts/%s", accountAddr),
 	}
-	qopts.rootCfg.Remote = baseopts.Remote
 	qres, err := queryHandler(qopts)
 	if err != nil {
 		return errors.Wrap(err, "query account")
@@ -172,13 +172,13 @@ func signAndBroadcast(
 	accountNumber := qret.BaseAccount.AccountNumber
 	sequence := qret.BaseAccount.Sequence
 	sopts := &signCfg{
+		rootCfg:       baseopts,
 		sequence:      sequence,
 		accountNumber: accountNumber,
 		chainID:       txopts.chainID,
 		nameOrBech32:  nameOrBech32,
 		txJSON:        amino.MustMarshalJSON(tx),
 	}
-	sopts.rootCfg.Home = baseopts.Home
 	if baseopts.Quiet {
 		sopts.pass, err = io.GetPassword("", baseopts.InsecurePasswordStdin)
 	} else {
@@ -195,9 +195,9 @@ func signAndBroadcast(
 
 	// broadcast signed tx
 	bopts := &broadcastCfg{
-		tx: signedTx,
+		rootCfg: baseopts,
+		tx:      signedTx,
 	}
-	bopts.rootCfg.Remote = baseopts.Remote
 	bres, err := broadcastHandler(bopts)
 	if err != nil {
 		return errors.Wrap(err, "broadcast tx")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

When using `gnokey maketx`, I get the following nil pointer error.  

```go
$ gnokey maketx addpkg -pkgdir=. -gas-fee="1ugnot" -gas-wanted="5000000" -pkgpath="gno.land/r/test1" -broadcast=true anarcher
Enter password.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102679954]

goroutine 1 [running]:
github.com/gnolang/gno/pkgs/crypto/keys/client.signAndBroadcast(0x140005b6370, {0x140001b4080?, 0x10?, 0x140000fdab8?}, {{0x140003826d0, 0x1, 0x1}, {0x4c4b40, {{0x16ddab131, 0x5}, ...}}, ...}, ...)
        /Users/anarch/go/blockchain/src/gno/pkgs/crypto/keys/client/addpkg.go:200 +0x374
github.com/gnolang/gno/pkgs/crypto/keys/client.execAddPkg(0x140005a7000, {0x140001b4080?, 0x1, 0x1}, 0x6?)
        /Users/anarch/go/blockchain/src/gno/pkgs/crypto/keys/client/addpkg.go:126 +0x2c0
github.com/gnolang/gno/pkgs/crypto/keys/client.newAddPkgCmd.func1({0x0?, 0x0?}, {0x140001b4080, 0x1, 0x1})
        /Users/anarch/go/blockchain/src/gno/pkgs/crypto/keys/client/addpkg.go:38 +0x48
github.com/peterbourgon/ff/v3/ffcli.(*Command).Run(0x0?, {0x102a35db0?, 0x140001a2000?})
        /Users/anarch/go/blockchain/pkg/mod/github.com/peterbourgon/ff/v3@v3.3.0/ffcli/command.go:153 +0x140
github.com/peterbourgon/ff/v3/ffcli.(*Command).Run(0x7?, {0x102a35db0?, 0x140001a2000?})
        /Users/anarch/go/blockchain/pkg/mod/github.com/peterbourgon/ff/v3@v3.3.0/ffcli/command.go:157 +0xf0
github.com/peterbourgon/ff/v3/ffcli.(*Command).Run(0x140005ca0c0?, {0x102a35db0?, 0x140001a2000?})
        /Users/anarch/go/blockchain/pkg/mod/github.com/peterbourgon/ff/v3@v3.3.0/ffcli/command.go:157 +0xf0
github.com/peterbourgon/ff/v3/ffcli.(*Command).ParseAndRun(0x14000085f28?, {0x102a35db0, 0x140001a2000}, {0x140001b4010?, 0x1020554c4?, 0x0?})
        /Users/anarch/go/blockchain/pkg/mod/github.com/peterbourgon/ff/v3@v3.3.0/ffcli/command.go:169 +0x4c
main.main()
        /Users/anarch/go/blockchain/src/gno/cmd/gnokey/main.go:14 +0x74
```

# How has this been tested?

Please complete this section if you ran tests for this functionality, otherwise delete it
