### PR TITLE
chore: bool type support for ufmt

### DIFF
--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -48,6 +48,14 @@ func Sprintf(format string, args ...interface{}) string {
 			default:
 				buf += "(unhandled)"
 			}
+		case 't':
+			if v, ok := arg.(bool); ok {
+				if v == true {
+					buf += "true"
+				} else {
+					buf += "false"
+				}
+			}
 		case '%':
 			buf += "%"
 		default:

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -55,6 +55,8 @@ func Sprintf(format string, args ...interface{}) string {
 				} else {
 					buf += "false"
 				}
+			} else {
+				buf += "(unhandled)"
 			}
 		case '%':
 			buf += "%"

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -49,13 +49,14 @@ func Sprintf(format string, args ...interface{}) string {
 				buf += "(unhandled)"
 			}
 		case 't':
-			if v, ok := arg.(bool); ok {
-				if v == true {
+			switch v := arg.(type) {
+			case bool:
+				if v {
 					buf += "true"
 				} else {
 					buf += "false"
 				}
-			} else {
+			default:
 				buf += "(unhandled)"
 			}
 		case '%':

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -34,7 +34,12 @@ func Sprintf(format string, args ...interface{}) string {
 
 		switch verb {
 		case 's':
-			buf += arg.(string)
+			switch v := arg.(type) {
+			case string:
+				buf += v
+			default:
+				buf += "(unhandled)"
+			}
 		case 'd':
 			switch v := arg.(type) {
 			case int:

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -20,6 +20,7 @@ func TestSprintf(t *testing.T) {
 		{"uint64 [%d]", []interface{}{uint64(42)}, "uint64 [42]"},
 		{"bool [%t]", []interface{}{true}, "bool [true]"},
 		{"bool [%t]", []interface{}{false}, "bool [false]"},
+		{"invalid bool [%t]", []interface{}{1}, "invalid bool [(unhandled)]"},
 		{"invalid [%d]", []interface{}{"invalid"}, "invalid [(unhandled)]"},
 		{"no args", nil, "no args"},
 		{"finish with %", nil, "finish with %"},

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -18,6 +18,8 @@ func TestSprintf(t *testing.T) {
 		{"uint [%d]", []interface{}{uint(42)}, "uint [42]"},
 		{"int64 [%d]", []interface{}{int64(42)}, "int64 [42]"},
 		{"uint64 [%d]", []interface{}{uint64(42)}, "uint64 [42]"},
+		{"bool [%t]", []interface{}{true}, "bool [true]"},
+		{"bool [%t]", []interface{}{false}, "bool [false]"},
 		{"invalid [%d]", []interface{}{"invalid"}, "invalid [(unhandled)]"},
 		{"no args", nil, "no args"},
 		{"finish with %", nil, "finish with %"},

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -20,8 +20,9 @@ func TestSprintf(t *testing.T) {
 		{"uint64 [%d]", []interface{}{uint64(42)}, "uint64 [42]"},
 		{"bool [%t]", []interface{}{true}, "bool [true]"},
 		{"bool [%t]", []interface{}{false}, "bool [false]"},
-		{"invalid bool [%t]", []interface{}{1}, "invalid bool [(unhandled)]"},
-		{"invalid [%d]", []interface{}{"invalid"}, "invalid [(unhandled)]"},
+		{"invalid bool [%t]", []interface{}{"invalid"}, "invalid bool [(unhandled)]"},
+		{"invalid integer [%d]", []interface{}{"invalid"}, "invalid integer [(unhandled)]"},
+		{"invalid string [%s]", []interface{}{1}, "invalid string [(unhandled)]"},
 		{"no args", nil, "no args"},
 		{"finish with %", nil, "finish with %"},
 	}


### PR DESCRIPTION
Add bool type support to ufmt package's print formatting for improved efficiency and readability when working with boolean values.