### PR TITLE
hotfix: set correct `deposit` flag in flagset for addpkg

### DIFF
--- a/pkgs/crypto/keys/client/addpkg.go
+++ b/pkgs/crypto/keys/client/addpkg.go
@@ -56,7 +56,7 @@ func (c *addPkgCfg) RegisterFlags(fs *flag.FlagSet) {
 	)
 
 	fs.StringVar(
-		&c.pkgDir,
+		&c.deposit,
 		"deposit",
 		"",
 		"deposit coins",


### PR DESCRIPTION
# Description

This PR fixes a single incorrectly set flag for `maketx addpkg`.
I've scanned over all of the other commands and subcommands, this is the single flag that was not set properly.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests
Manually executed a `maketx addpkg` command that made sure `deposit` was set, ex:
```bash
./build/gnokey maketx addpkg \
--pkgpath "gno.land/p/demo/stack" \
--pkgdir "examples/gno.land/p/demo/stack" \
--deposit 100000000ugnot \
--gas-fee 1000000ugnot \
--gas-wanted 2000000 \
--broadcast \
--chainid dev \
--remote localhost:26657 \
UserKey
```

# Additional Comments

Noticed while executing command from #576 
