### PR TITLE
feat(stdlibs): import crypto/sha256

### DIFF
--- a/stdlibs/crypto/sha256/sha256.gno
+++ b/stdlibs/crypto/sha256/sha256.gno
@@ -1,0 +1,12 @@
+package sha256
+
+import (
+	isha256 "internal/crypto/sha256"
+)
+
+const Size = 32
+
+// Sum returns the SHA-256 checksum of the data.
+func Sum256(data []byte) [Size]byte {
+	return isha256.Sum256(data)
+}

--- a/stdlibs/crypto/sha256/sha256_test.gno
+++ b/stdlibs/crypto/sha256/sha256_test.gno
@@ -1,0 +1,17 @@
+package sha256
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"std"
+	"testing"
+)
+
+func TestSha256Sum(t *testing.T) {
+	got := sha256.Sum256([]byte("sha256 this string"))[:]
+	expected := "1af1dfa857bf1d8814fe1af8983c18080019922e557f15a8a0d3db739d77aacb"
+
+	if hex.EncodeToString(got) != expected {
+		t.Errorf("got %v(%T), expected %v(%T)", hex.EncodeToString(got), got, expected, expected)
+	}
+}

--- a/stdlibs/internal/crypto/sha256/sha256.gno
+++ b/stdlibs/internal/crypto/sha256/sha256.gno
@@ -1,0 +1,3 @@
+package sha256
+
+// XXX injected via stdlibs/stdlibs.go


### PR DESCRIPTION
All credit to @r3v4s and his PR https://github.com/gnolang/gno/pull/570 

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Import function `Sum256` from package `crypto/sha256` .


My goal is to implement a merkle-airdrop contract, so i need Sum256 function.

# How has this been tested?

see unit test `TestSha256Sum`