### PR TITLE
Add iavl test proving forgery

### DIFF
--- a/pkgs/iavl/proof_forgery_test.go
+++ b/pkgs/iavl/proof_forgery_test.go
@@ -1,0 +1,106 @@
+package iavl_test
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"strings"
+	"testing"
+
+	db "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/iavl"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/tmhash"
+)
+
+func TestProofFogery(t *testing.T) {
+	source := rand.NewSource(0)
+	r := rand.New(source)
+	cacheSize := 0
+	tree, err := iavl.NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false)
+	require.NoError(t, err)
+
+	// two keys only
+	keys := []byte{0x11, 0x32}
+	values := make([][]byte, len(keys))
+	// make random values and insert into tree
+	for i, ikey := range keys {
+		key := []byte{ikey}
+		v := r.Intn(255)
+		values[i] = []byte{byte(v)}
+		tree.Set(key, values[i])
+	}
+
+	// get root
+	root, err := tree.WorkingHash()
+	require.NoError(t, err)
+	// use the rightmost kv pair in the tree so the inner nodes will populate left
+	k := []byte{keys[1]}
+	v := values[1]
+
+	val, proof, err := tree.GetWithProof(k)
+	require.NoError(t, err)
+
+	err = proof.Verify(root)
+	require.NoError(t, err)
+	err = proof.VerifyItem(k, val)
+	require.NoError(t, err)
+
+	// ------------------- FORGE PROOF -------------------
+
+	forgedPayloadBytes := mustDecode("0xabcd")
+	forgedValueHash := tmhash.Sum(forgedPayloadBytes)
+	// make a forgery of the proof by adding:
+	// - a new leaf node to the right
+	// - an empty inner node
+	// - a right entry in the path
+	_, proof2, _ := tree.GetWithProof(k)
+	forgedNode := proof2.Leaves[0]
+	forgedNode.Key = []byte{0xFF}
+	forgedNode.ValueHash = forgedValueHash
+	proof2.Leaves = append(proof2.Leaves, forgedNode)
+	proof2.InnerNodes = append(proof2.InnerNodes, iavl.PathToLeaf{})
+	// figure out what hash we need via https://twitter.com/samczsun/status/1578181160345034752
+	proof2.LeftPath[0].Right = mustDecode("82C36CED85E914DAE8FDF6DD11FD5833121AA425711EB126C470CE28FF6623D5")
+
+	rootHashValid := proof.ComputeRootHash()
+	verifyErr := proof.Verify(rootHashValid)
+	require.NoError(t, verifyErr, "should verify")
+	// forgery gives empty root hash (previously it returned the same one!)
+	rootHashForged := proof2.ComputeRootHash()
+	require.Empty(t, rootHashForged, "roothash must be empty if both left and right are set")
+	verifyErr = proof2.Verify(rootHashForged)
+	require.Error(t, verifyErr, "should not verify")
+
+	// verify proof two fails with valid proof
+	err = proof2.Verify(rootHashValid)
+	require.Error(t, err, "should not verify different root hash")
+
+	{
+		// legit node verifies against legit proof (expected)
+		verifyErr = proof.VerifyItem(k, v)
+		require.NoError(t, verifyErr, "valid proof should verify")
+		// forged node fails to verify against legit proof (expected)
+		verifyErr = proof.VerifyItem(forgedNode.Key, forgedPayloadBytes)
+		require.Error(t, verifyErr, "forged proof should fail to verify")
+	}
+	{
+		// legit node fails to verify against forged proof (expected)
+		verifyErr = proof2.VerifyItem(k, v)
+		require.Error(t, verifyErr, "valid proof should verify, but has a forged sister node")
+
+		// forged node fails to verify against forged proof (previously this succeeded!)
+		verifyErr = proof2.VerifyItem(forgedNode.Key, forgedPayloadBytes)
+		require.Error(t, verifyErr, "forged proof should fail verify")
+	}
+}
+
+func mustDecode(str string) []byte {
+	if strings.HasPrefix(str, "0x") {
+		str = str[2:]
+	}
+	b, err := hex.DecodeString(str)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/pkgs/iavl/proof_forgery_test.go
+++ b/pkgs/iavl/proof_forgery_test.go
@@ -64,15 +64,12 @@ func TestProofForgery(t *testing.T) {
 	rootHashValid := proof.ComputeRootHash()
 	verifyErr := proof.Verify(rootHashValid)
 	require.NoError(t, verifyErr, "should verify")
-	// forgery gives empty root hash (previously it returned the same one!)
-	rootHashForged := proof2.ComputeRootHash()
-	require.Empty(t, rootHashForged, "roothash must be empty if both left and right are set")
-	verifyErr = proof2.Verify(rootHashForged)
-	require.Error(t, verifyErr, "should not verify")
 
-	// verify proof two fails with valid proof
-	err = proof2.Verify(rootHashValid)
-	require.Error(t, err, "should not verify different root hash")
+	// forged proofs now should make ComputeRootHash() and Verify() panic
+	var rootHashForged []byte
+	require.Panics(t, func() { rootHashForged = proof2.ComputeRootHash() }, "ComputeRootHash must panic if both left and right are set")
+	require.Panics(t, func() { proof2.Verify(rootHashForged) }, "forged proof should not verify")
+	require.Panics(t, func() { proof2.Verify(rootHashValid) }, "verify (tentatively forged) proof2 two fails with valid proof")
 
 	{
 		// legit node verifies against legit proof (expected)

--- a/pkgs/iavl/proof_forgery_test.go
+++ b/pkgs/iavl/proof_forgery_test.go
@@ -6,18 +6,18 @@ import (
 	"strings"
 	"testing"
 
-	db "github.com/cosmos/cosmos-db"
-	"github.com/cosmos/iavl"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto/tmhash"
+
+	"github.com/gnolang/gno/pkgs/crypto/tmhash"
+	"github.com/gnolang/gno/pkgs/db"
+	"github.com/gnolang/gno/pkgs/iavl"
 )
 
-func TestProofFogery(t *testing.T) {
+func TestProofForgery(t *testing.T) {
 	source := rand.NewSource(0)
 	r := rand.New(source)
 	cacheSize := 0
-	tree, err := iavl.NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false)
-	require.NoError(t, err)
+	tree := iavl.NewMutableTree(db.NewMemDB(), cacheSize)
 
 	// two keys only
 	keys := []byte{0x11, 0x32}
@@ -31,8 +31,7 @@ func TestProofFogery(t *testing.T) {
 	}
 
 	// get root
-	root, err := tree.WorkingHash()
-	require.NoError(t, err)
+	root := tree.WorkingHash()
 	// use the rightmost kv pair in the tree so the inner nodes will populate left
 	k := []byte{keys[1]}
 	v := values[1]


### PR DESCRIPTION
This is a test of the iavl proof forgery as exploited during **BSC 2022-10-07 hack**.

`proof_forgery_test.go` comes from https://github.com/cosmos/iavl/pull/582
Because of the discrepancy with gno/pkgs/iavl, it was adapted to compile.

Test now compiles, and fails the test as expected (-> vulnerable).

Output of `go test pkgs/iavl/proof_forgery_test.go` follows:

```
--- FAIL: TestProofForgery (0.00s)
    proof_forgery_test.go:69:
                Error Trace:    /home/bob/opt/src/COINS/Cosmos/GNO/gno/pkgs/iavl/proof_forgery_test.go:69
                Error:          Should be empty, but was [73 209 82 89 222 179 131 99 170 27 180 58 80 20 211 (...) 94 7 254 45 183 20 244]
                Test:           TestProofForgery
                Messages:       roothash must be empty if both left and right are set
FAIL
FAIL    command-line-arguments  0.003s
FAIL
```
A fix is coming. 