### PR TITLE
chore(gnolang): revamp switch fallthrough

### DIFF
--- a/pkgs/gnolang/nodes.go
+++ b/pkgs/gnolang/nodes.go
@@ -2006,14 +2006,13 @@ func (x *BasicLitExpr) GetInt() int {
 type GnoAttribute string
 
 const (
-	ATTR_PREPROCESSED      GnoAttribute = "ATTR_PREPROCESSED"
-	ATTR_PREDEFINED        GnoAttribute = "ATTR_PREDEFINED"
-	ATTR_TYPE_VALUE        GnoAttribute = "ATTR_TYPE_VALUE"
-	ATTR_TYPEOF_VALUE      GnoAttribute = "ATTR_TYPEOF_VALUE"
-	ATTR_IOTA              GnoAttribute = "ATTR_IOTA"
-	ATTR_LOCATIONED        GnoAttribute = "ATTR_LOCATIONED"
-	ATTR_INJECTED          GnoAttribute = "ATTR_INJECTED"
-	ATTR_SWITCH_CLAUSE_IDX GnoAttribute = "ATTR_CLAUSE_IDX"
+	ATTR_PREPROCESSED GnoAttribute = "ATTR_PREPROCESSED"
+	ATTR_PREDEFINED   GnoAttribute = "ATTR_PREDEFINED"
+	ATTR_TYPE_VALUE   GnoAttribute = "ATTR_TYPE_VALUE"
+	ATTR_TYPEOF_VALUE GnoAttribute = "ATTR_TYPEOF_VALUE"
+	ATTR_IOTA         GnoAttribute = "ATTR_IOTA"
+	ATTR_LOCATIONED   GnoAttribute = "ATTR_LOCATIONED"
+	ATTR_INJECTED     GnoAttribute = "ATTR_INJECTED"
 )
 
 // TODO: consider length restrictions.

--- a/pkgs/gnolang/preprocess.go
+++ b/pkgs/gnolang/preprocess.go
@@ -1626,7 +1626,19 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 					n.Depth = depth
 					n.BodyIndex = index
 				case FALLTHROUGH:
-					// TODO CHALLENGE implement fallthrough
+					if swchC, ok := last.(*SwitchClauseStmt); ok {
+						// last is a switch clause, find its index in the switch and assign
+						// it to the fallthrough node BodyIndex. This will be used at
+						// runtime to determine the next switch clause to run.
+						swch := lastSwitch(ns)
+						for i, c := range swch.Clauses {
+							if &c == swchC {
+								// switch clause found
+								n.BodyIndex = i
+								break
+							}
+						}
+					}
 				default:
 					panic("should not happen")
 				}
@@ -2225,6 +2237,15 @@ func findGotoLabel(last BlockNode, label Name) (
 func lastDecl(ns []Node) Decl {
 	for i := len(ns) - 1; 0 <= i; i-- {
 		if d, ok := ns[i].(Decl); ok {
+			return d
+		}
+	}
+	return nil
+}
+
+func lastSwitch(ns []Node) *SwitchStmt {
+	for i := len(ns) - 1; 0 <= i; i-- {
+		if d, ok := ns[i].(*SwitchStmt); ok {
 			return d
 		}
 	}

--- a/pkgs/gnolang/preprocess.go
+++ b/pkgs/gnolang/preprocess.go
@@ -1631,8 +1631,8 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 						// it to the fallthrough node BodyIndex. This will be used at
 						// runtime to determine the next switch clause to run.
 						swch := lastSwitch(ns)
-						for i, c := range swch.Clauses {
-							if &c == swchC {
+						for i := range swch.Clauses {
+							if &swch.Clauses[i] == swchC {
 								// switch clause found
 								n.BodyIndex = i
 								break


### PR DESCRIPTION
# Description

Found out there's an other `TODO CHALLENGE switch fallthrough` in pre-process, which makes me realize the proper way of dealing with jump statements like fallthrough.

In the [initial version][1], a new attribute `ATTR_SWITCH_CLAUSE_IDX` was introduced to store the clause index, but it appears this kind of thing should be handled in the pre-process step.

As a result the attribute is removed and replaced with some code in pre-process step, that stores the clause index in node.BodyIndex, only in case we're dealing with a fallthrough.

[1]: https://github.com/gnolang/gno/pull/504



# How has this been tested?

The tests remain unchanged, which proves this still works as expected.

```sh
$ go test ./tests -v -run `/switch'
```
