### PR TITLE
feat: allow viewing some .md and .txt files in gnoweb

### DIFF
--- a/gnoland/website/main.go
+++ b/gnoland/website/main.go
@@ -72,7 +72,7 @@ func makeApp() gotuna.App {
 	app.Router.Handle("/faucet", handlerFaucet(app))
 	app.Router.Handle("/r/demo/boards:gnolang/6", handlerRedirect(app))
 	// NOTE: see rePathPart.
-	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/{filename:(?:.*\\.gno$)?}", handlerRealmFile(app))
+	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}/{filename:(?:.*\\.(?:gno|md|txt)$)?}", handlerRealmFile(app))
 	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}", handlerRealmMain(app))
 	app.Router.Handle("/r/{rlmname:[a-z][a-z0-9_]*(?:/[a-z][a-z0-9_]*)+}:{querystr:.*}", handlerRealmRender(app))
 	app.Router.Handle("/p/{filepath:.*}", handlerPackageFile(app))


### PR DESCRIPTION
This allows .txt and .md files to be shown in addition to .gno files.

For instance r/demo/boards contains README.md and example_post.md The regex was a tad too restrictive in that it only allowed .gno files to be shown.

# How has this been tested?
Locally.
To test it, visit a location such as `/r/demo/boards/README.md`.
On test3 where an old version is running it works, but not on https://staging.gno.land/r/demo/boards/README.md
This PR fixes it.