### PR TITLE
proposition to split the css

### DIFF
--- a/gnoland/website/static/css/app.css
+++ b/gnoland/website/static/css/app.css
@@ -1,82 +1,22 @@
 @import url("../font/font.css");
+@import "color-light.css" screen;
+@import "color-dark.css" screen;
+/* @import "color-dark.css" screen and (prefers-color-scheme: dark); */
+@import "hljs.css";
 
-/*** DARK/LIGHT THEME COLORS ***/
-
-html:not([data-theme="dark"]),
-html[data-theme="light"] {
-  --background-color: #eee;
-  --input-background-color: #eee;
-  --text-color: #000;
-  --link-color: #25172a;
-
-  --quote-background: #ddd;
-  --quote-2-background: #aaa4;
-  --code-background: #d7d9db;
-  --header-background: #d7d9db;
-
-  --realm-help-background-color: #d7d9db9e;
-  --realm-help-odd-background-color: #d7d9db45;
-  --realm-help-code-color: #5d5d5d;
-
-  --highlight-color: #2f3337;
-  --highlight-bg: #f6f6f6;
-  --highlight-color: #2f3337;
-  --highlight-comment: #656e77;
-  --highlight-keyword: #015692;
-  --highlight-attribute: #015692;
-  --highlight-symbol: #803378;
-  --highlight-namespace: #b75501;
-  --highlight-keyword: #015692;
-  --highlight-variable: #54790d;
-  --highlight-keyword: #015692;
-  --highlight-literal: #b75501;
-  --highlight-punctuation: #535a60;
-  --highlight-variable: #54790d;
-  --highlight-deletion: #c02d2e;
-  --highlight-addition: #2f6f44;
-}
-
-html[data-theme="dark"] {
-  --background-color: #2e2e2e;
-  --input-background-color: #393939;
-  --text-color: #eee;
-  --link-color: #ebe6ff;
-
-  --quote-background: #404040;
-  --quote-2-background: #555555;
-  --code-background: #454545;
-  --header-background: #454545;
-
-  --realm-help-background-color: #45454545;
-  --realm-help-odd-background-color: #4545459e;
-  --realm-help-code-color: #b6b6b6;
-
-  --highlight-color: #ffffff;
-  --highlight-bg: #1c1b1b;
-  --highlight-color: #ffffff;
-  --highlight-comment: #999999;
-  --highlight-keyword: #88aece;
-  --highlight-attribute: #88aece;
-  --highlight-symbol: #c59bc1;
-  --highlight-namespace: #f08d49;
-  --highlight-keyword: #88aece;
-  --highlight-variable: #b5bd68;
-  --highlight-keyword: #88aece;
-  --highlight-literal: #f08d49;
-  --highlight-punctuation: #cccccc;
-  --highlight-variable: #b5bd68;
-  --highlight-deletion: #de7176;
-  --highlight-addition: #76c490;
-}
-
-html[data-theme="dark"] #header img {
-  filter: invert(1);
-}
+/* this is the main stylesheet.
+ * we should strive to not put colors inside.
+ * (see color-*.css for day/night and hljs.css for code highlighting)
+ */
 
 #theme-toggle {
   height: 32px;
   width: 32px;
   display: inline-block;
+}
+
+html[data-theme="dark"] #header img {
+  filter: invert(1);
 }
 
 html[data-theme="dark"] #theme-toggle-moon,
@@ -97,8 +37,6 @@ body {
   padding: 0;
   margin: 0;
   font-family: "Roboto Mono", "Courier New", "sans-serif";
-  background-color: var(--background-color, #eee);
-  color: var(--text-color, #000);
   font-size: 15px;
   transition: 0.25s all ease;
 }
@@ -114,135 +52,19 @@ input {
   appearance: none;
 }
 
-a {
-  color: var(--link-color, #25172a);
-}
-
 input {
   font-family: "Roboto Mono", "Monaco", monospace;
-  background-color: var(--input-background-color, #eee);
-  border: 1px solid #ccc;
-  color: var(--text-color, #000);
+  border-width: 1px;
+  border-style: solid;
   width: 25em;
-}
-
-blockquote {
-  background-color: var(--quote-background, #ddd);
 }
 
 blockquote blockquote {
   margin: 0;
-  background-color: var(--quote-2-background, #aaa4);
 }
 
 pre {
-  background-color: var(--code-background, #d7d9db);
   margin: 0;
-}
-
-/*** HLJS ***/
-
-/* Copyright (c) 2006, Ivan Sagalaev.
- * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/default.css */
-pre code.hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 1em;
-}
-
-code.hljs {
-  padding: 3px 5px;
-}
-
-/* Copyright 2017-2020 Stack Exchange Inc.
- * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/stackoverflow-light.css
- * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/stackoverflow-dark.css */
-.hljs {
-  color: var(--highlight-color, #2f3337);
-  background: var(--highlight-bg, #f6f6f6);
-}
-
-.hljs-subst {
-  color: var(--highlight-color, #2f3337);
-}
-
-.hljs-comment {
-  color: var(--highlight-comment, #656e77);
-}
-
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-meta .hljs-keyword,
-.hljs-doctag,
-.hljs-section {
-  color: var(--highlight-keyword, #015692);
-}
-
-.hljs-attr {
-  color: var(--highlight-attribute, #015692);
-}
-
-.hljs-attribute {
-  color: var(--highlight-symbol, #803378);
-}
-
-.hljs-name,
-.hljs-type,
-.hljs-number,
-.hljs-selector-id,
-.hljs-quote,
-.hljs-template-tag {
-  color: var(--highlight-namespace, #b75501);
-}
-
-.hljs-selector-class {
-  color: var(--highlight-keyword, #015692);
-}
-
-.hljs-string,
-.hljs-regexp,
-.hljs-symbol,
-.hljs-variable,
-.hljs-template-variable,
-.hljs-link,
-.hljs-selector-attr {
-  color: var(--highlight-variable, #54790d);
-}
-
-.hljs-meta,
-.hljs-selector-pseudo {
-  color: var(--highlight-keyword, #015692);
-}
-
-.hljs-built_in,
-.hljs-title,
-.hljs-literal {
-  color: var(--highlight-literal, #b75501);
-}
-
-.hljs-bullet,
-.hljs-code {
-  color: var(--highlight-punctuation, #535a60);
-}
-
-.hljs-meta .hljs-string {
-  color: var(--highlight-variable, #54790d);
-}
-
-.hljs-deletion {
-  color: var(--highlight-deletion, #c02d2e);
-}
-
-.hljs-addition {
-  color: var(--highlight-addition, #2f6f44);
-}
-
-.hljs-emphasis {
-  font-style: italic;
-}
-
-.hljs-strong {
-  font-weight: bold;
 }
 
 /*** PAGE LAYOUT ***/
@@ -250,13 +72,13 @@ code.hljs {
 #root {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--header-background, #d7d9db);
+  border-width: 1px;
+  border-style: solid;
   margin: 20px;
   /* height: calc(100vh - 40px); */
 }
 
 #header {
-  background-color: var(--header-background, #d7d9db);
   padding: 22px;
   display: flex;
   align-items: center;
@@ -264,7 +86,6 @@ code.hljs {
 }
 
 #logo {
-  color: var(--link-color, #25172a);
   position: relative;
   top: 4px;
   height: 45px;
@@ -321,18 +142,13 @@ code.hljs {
 
 #realm_help .func_spec {
   padding: 22px;
-  background: var(--realm-help-background-color, #d7d9db9e);
   margin-top: 22px;
-}
-#realm_help .func_spec:nth-child(odd) {
-  background: var(--realm-help-odd-background-color, #d7d9db45);
 }
 
 #realm_help .func_spec > table > tbody > tr > th {
   width: 50px;
   vertical-align: top;
   text-align: right;
-  color: var(--text-color, #000);
 }
 
 #realm_help .func_spec > table th,
@@ -346,10 +162,6 @@ code.hljs {
 
 #realm_help .func_spec > table th + td table td {
   padding-left: 12px;
-}
-
-#realm_help .func_spec .shell_command {
-  color: var(--realm-help-code-color, #5d5d5d);
 }
 
 #realm_help .func_name td {

--- a/gnoland/website/static/css/color-dark.css
+++ b/gnoland/website/static/css/color-dark.css
@@ -1,0 +1,20 @@
+/* this is the dark color stylesheet
+ * it should only contain colors.
+ */
+
+html[data-theme="dark"] body { background-color: #2e2e2e; }
+html[data-theme="dark"] body, input { color: #eee; }
+html[data-theme="dark"] a, #logo { color: #ebe6ff; }
+html[data-theme="dark"] input { background-color: #393939; border-color: #ccc; }
+html[data-theme="dark"] blockquote { background-color: #404040; }
+html[data-theme="dark"] blockquote blockquote { background-color: #555555; }
+
+html[data-theme="dark"] pre { background-color: #454545; }
+
+html[data-theme="dark"] #root { border-color: #454545; }
+html[data-theme="dark"] #header { background-color: #454545; }
+
+html[data-theme="dark"] #realm_help .func_spec { background-color: #45454545; }
+html[data-theme="dark"] #realm_help .func_spec:nth-child(odd) { background: #4545459e; }
+html[data-theme="dark"] #realm_help .func_spec .shell_command { color: #b6b6b6; }
+html[data-theme="dark"] #realm_help .func_spec > table > tbody > tr > th { color: #eee; }

--- a/gnoland/website/static/css/color-dark.css
+++ b/gnoland/website/static/css/color-dark.css
@@ -3,8 +3,8 @@
  */
 
 html[data-theme="dark"] body { background-color: #2e2e2e; }
-html[data-theme="dark"] body, input { color: #eee; }
-html[data-theme="dark"] a, #logo { color: #ebe6ff; }
+html[data-theme="dark"] body, html[data-theme="dark"] input { color: #eee; }
+html[data-theme="dark"] a, html[data-theme="dark"] #logo { color: #ebe6ff; }
 html[data-theme="dark"] input { background-color: #393939; border-color: #ccc; }
 html[data-theme="dark"] blockquote { background-color: #404040; }
 html[data-theme="dark"] blockquote blockquote { background-color: #555555; }

--- a/gnoland/website/static/css/color-light.css
+++ b/gnoland/website/static/css/color-light.css
@@ -2,18 +2,18 @@
  * it should only contain colors.
  */
 
-html, body {  background-color: #eee; }
-html, body, input { color: #000; }
-a, #logo { color: #25172a; }
-input { background-color: #eee; border-color: #ccc; }
-blockquote { background-color: #ddd; }
-blockquote blockquote { background-color: #aaa4; }
-pre { background-color: #d7d9db; }
+html[data-theme="light"] html, html[data-theme="light"] body {  background-color: #eee; }
+html[data-theme="light"] html, html[data-theme="light"] body, html[data-theme="light"] input { color: #000; }
+html[data-theme="light"] a, html[data-theme="light"] #logo { color: #25172a; }
+html[data-theme="light"] input { background-color: #eee; border-color: #ccc; }
+html[data-theme="light"] blockquote { background-color: #ddd; }
+html[data-theme="light"] blockquote blockquote { background-color: #aaa4; }
+html[data-theme="light"] pre { background-color: #d7d9db; }
 
-#root { border-color: #d7d9db; }
-#header { background-color: #d7d9db; }
+html[data-theme="light"] #root { border-color: #d7d9db; }
+html[data-theme="light"] #header { background-color: #d7d9db; }
 
-#realm_help .func_spec { background-color: #d7d9db9e; }
-#realm_help .func_spec:nth-child(odd) { background: #d7d9db45; }
-#realm_help .func_spec .shell_command { color: #5d5d5d; }
-#realm_help .func_spec > table > tbody > tr > th { color: #000; }
+html[data-theme="light"] #realm_help .func_spec { background-color: #d7d9db9e; }
+html[data-theme="light"] #realm_help .func_spec:nth-child(odd) { background: #d7d9db45; }
+html[data-theme="light"] #realm_help .func_spec .shell_command { color: #5d5d5d; }
+html[data-theme="light"] #realm_help .func_spec > table > tbody > tr > th { color: #000; }

--- a/gnoland/website/static/css/color-light.css
+++ b/gnoland/website/static/css/color-light.css
@@ -1,0 +1,19 @@
+/* this is the light color stylesheet 
+ * it should only contain colors.
+ */
+
+html, body {  background-color: #eee; }
+html, body, input { color: #000; }
+a, #logo { color: #25172a; }
+input { background-color: #eee; border-color: #ccc; }
+blockquote { background-color: #ddd; }
+blockquote blockquote { background-color: #aaa4; }
+pre { background-color: #d7d9db; }
+
+#root { border-color: #d7d9db; }
+#header { background-color: #d7d9db; }
+
+#realm_help .func_spec { background-color: #d7d9db9e; }
+#realm_help .func_spec:nth-child(odd) { background: #d7d9db45; }
+#realm_help .func_spec .shell_command { color: #5d5d5d; }
+#realm_help .func_spec > table > tbody > tr > th { color: #000; }

--- a/gnoland/website/static/css/hljs.css
+++ b/gnoland/website/static/css/hljs.css
@@ -1,0 +1,145 @@
+
+html:not([data-theme="dark"]),
+html[data-theme="light"] {
+  --highlight-color: #2f3337;
+  --highlight-bg: #f6f6f6;
+  --highlight-color: #2f3337;
+  --highlight-comment: #656e77;
+  --highlight-keyword: #015692;
+  --highlight-attribute: #015692;
+  --highlight-symbol: #803378;
+  --highlight-namespace: #b75501;
+  --highlight-keyword: #015692;
+  --highlight-variable: #54790d;
+  --highlight-keyword: #015692;
+  --highlight-literal: #b75501;
+  --highlight-punctuation: #535a60;
+  --highlight-variable: #54790d;
+  --highlight-deletion: #c02d2e;
+  --highlight-addition: #2f6f44;
+}
+
+html[data-theme="dark"] {
+  --highlight-color: #ffffff;
+  --highlight-bg: #1c1b1b;
+  --highlight-color: #ffffff;
+  --highlight-comment: #999999;
+  --highlight-keyword: #88aece;
+  --highlight-attribute: #88aece;
+  --highlight-symbol: #c59bc1;
+  --highlight-namespace: #f08d49;
+  --highlight-keyword: #88aece;
+  --highlight-variable: #b5bd68;
+  --highlight-keyword: #88aece;
+  --highlight-literal: #f08d49;
+  --highlight-punctuation: #cccccc;
+  --highlight-variable: #b5bd68;
+  --highlight-deletion: #de7176;
+  --highlight-addition: #76c490;
+}
+
+/*** HLJS ***/
+
+/* Copyright (c) 2006, Ivan Sagalaev.
+ * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/default.css */
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+
+code.hljs {
+  padding: 3px 5px;
+}
+
+/* Copyright 2017-2020 Stack Exchange Inc.
+ * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/stackoverflow-light.css
+ * https://github.com/highlightjs/highlight.js/blob/86dcb210227ef130a00b5ece50605ea1ec887be8/src/styles/stackoverflow-dark.css */
+.hljs {
+  color: var(--highlight-color, #2f3337);
+  background: var(--highlight-bg, #f6f6f6);
+}
+
+.hljs-subst {
+  color: var(--highlight-color, #2f3337);
+}
+
+.hljs-comment {
+  color: var(--highlight-comment, #656e77);
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-meta .hljs-keyword,
+.hljs-doctag,
+.hljs-section {
+  color: var(--highlight-keyword, #015692);
+}
+
+.hljs-attr {
+  color: var(--highlight-attribute, #015692);
+}
+
+.hljs-attribute {
+  color: var(--highlight-symbol, #803378);
+}
+
+.hljs-name,
+.hljs-type,
+.hljs-number,
+.hljs-selector-id,
+.hljs-quote,
+.hljs-template-tag {
+  color: var(--highlight-namespace, #b75501);
+}
+
+.hljs-selector-class {
+  color: var(--highlight-keyword, #015692);
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr {
+  color: var(--highlight-variable, #54790d);
+}
+
+.hljs-meta,
+.hljs-selector-pseudo {
+  color: var(--highlight-keyword, #015692);
+}
+
+.hljs-built_in,
+.hljs-title,
+.hljs-literal {
+  color: var(--highlight-literal, #b75501);
+}
+
+.hljs-bullet,
+.hljs-code {
+  color: var(--highlight-punctuation, #535a60);
+}
+
+.hljs-meta .hljs-string {
+  color: var(--highlight-variable, #54790d);
+}
+
+.hljs-deletion {
+  color: var(--highlight-deletion, #c02d2e);
+}
+
+.hljs-addition {
+  color: var(--highlight-addition, #2f6f44);
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+


### PR DESCRIPTION
# Description

I find the css file starts to be a bit large. (As an empiric rule, a large css file edited manually is going to be a mess; with sections and what not). Besides we don't need to put all rules in 1 file right now, we are not trying to optimize.

I propose 2 things:

1. Move the hljs styles to `hljs.css`,
2. Take out colors from `app.css`, and put them in `color-light.css` and `color-dark.css` respectively.

I don't think (1) is a big deal. 
But (2) is more radical. It removes the css variables (see the note below). It also require some prefixes in the dark css. As a result of those hard choices, we obtain very small files, and a clear separation between geometry and colors, but the price to pay is a somewhat weird dark css file.

(Note even if we remove the css vars we can easily have them later.)

-- 
Why no variables: *As I started to refactor the css I tried a personnal rule where if a variable was mentionned <= 2 times, I would remove it. Turns out they were all mentionned <= 2 times, so at the end of this algorigthm all variables were gone. We should note vars have a little cost, not only in the file itself -it is a little bit less direct- but also in the inspector browser where it becomes more difficult to tinker. These costs are of course massively amortized when a certain variable is used a lot.*

# How has this been tested?
Locally. It produces the same exact presentation as before.