### PR TITLE
feat(avl): implement (*Node).TraverseByOffset

### DIFF
--- a/examples/gno.land/p/demo/avl/node.gno
+++ b/examples/gno.land/p/demo/avl/node.gno
@@ -359,6 +359,85 @@ func (node *Node) TraverseInRange(start, end string, ascending bool, leavesOnly 
 	return stop
 }
 
+// TraverseByOffset traverses all nodes, including inner nodes.
+// A limit of math.MaxInt means no limit.
+func (node *Node) TraverseByOffset(offset, limit int, descending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	if node == nil {
+		return false
+	}
+
+	// fast paths. these happen only if TraverseByOffset is called directly on a leaf.
+	if limit <= 0 || offset >= node.size {
+		return false
+	}
+	if node.IsLeaf() {
+		if offset > 0 {
+			return false
+		}
+		return cb(node)
+	}
+
+	// go to the actual recursive function.
+	return node.traverseByOffset(offset, limit, descending, leavesOnly, cb)
+}
+
+func (node *Node) traverseByOffset(offset, limit int, descending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	// caller guarantees: offset < node.size; limit > 0.
+
+	if !leavesOnly {
+		if cb(node) {
+			return true
+		}
+	}
+	first, second := node.getLeftNode(), node.getRightNode()
+	if descending {
+		first, second = second, first
+	}
+	if first.IsLeaf() {
+		// either run or skip, based on offset
+		if offset > 0 {
+			offset--
+		} else {
+			cb(first)
+			limit--
+			if limit <= 0 {
+				return false
+			}
+		}
+	} else {
+		// possible cases:
+		// 1 the offset given skips the first node entirely
+		// 2 the offset skips none or part of the first node, but the limit requires some of the second node.
+		// 3 the offset skips none or part of the first node, and the limit stops our search on the first node.
+		if offset >= first.size {
+			offset -= first.size // 1
+		} else {
+			if first.traverseByOffset(offset, limit, descending, leavesOnly, cb) {
+				return true
+			}
+			// number of leaves which could actually be called from inside
+			delta := first.size - offset
+			offset = 0
+			if delta >= limit {
+				return true // 3
+			}
+			limit -= delta // 2
+		}
+	}
+
+	// because of the caller guarantees and the way we handle the first node,
+	// at this point we know that limit > 0 and there must be some values in
+	// this second node that we include.
+
+	// => if the second node is a leaf, it has to be included.
+	if second.IsLeaf() {
+		return cb(second)
+	}
+	// => if it is not a leaf, it will still be enough to recursively call this
+	// function with the updated offset and limit
+	return second.traverseByOffset(offset, limit, descending, leavesOnly, cb)
+}
+
 // Only used in testing...
 func (node *Node) lmd() *Node {
 	if node.height == 0 {

--- a/examples/gno.land/p/demo/avl/node_test.gno
+++ b/examples/gno.land/p/demo/avl/node_test.gno
@@ -1,0 +1,100 @@
+package avl
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestTraverseByOffset(t *testing.T) {
+	const testStrings = `Alfa
+Alfred
+Alpha
+Alphabet
+Beta
+Beth
+Book
+Browser`
+	tt := []struct {
+		name string
+		desc bool
+	}{
+		{"ascending", false},
+		{"descending", true},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			sl := strings.Split(testStrings, "\n")
+
+			// sort a first time in the order opposite to how we'll be traversing
+			// the tree, to ensure that we are not just iterating through with
+			// insertion order.
+			sort.Sort(sort.StringSlice(sl))
+			if !tc.desc {
+				reverseSlice(sl)
+			}
+
+			r := NewNode(sl[0], nil)
+			for _, v := range sl[1:] {
+				r, _ = r.Set(v, nil)
+			}
+
+			// then sort sl in the order we'll be traversing it, so that we can
+			// compare the result with sl.
+			reverseSlice(sl)
+
+			var result []string
+			for i := 0; i < len(sl); i++ {
+				r.TraverseByOffset(i, 1, tc.desc, true, func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+			}
+
+			if !slicesEqual(sl, result) {
+				t.Errorf("want %v got %v", sl, result)
+			}
+
+			for l := 2; l <= len(sl); l++ {
+				// "slices"
+				for i := 0; i <= len(sl); i++ {
+					max := i + l
+					if max > len(sl) {
+						max = len(sl)
+					}
+					exp := sl[i:max]
+					actual := []string{}
+
+					r.TraverseByOffset(i, l, tc.desc, true, func(tr *Node) bool {
+						actual = append(actual, tr.Key())
+						return false
+					})
+					// t.Log(exp, actual)
+					if !slicesEqual(exp, actual) {
+						t.Errorf("want %v got %v", exp, actual)
+					}
+				}
+			}
+		})
+	}
+}
+
+func slicesEqual(w1, w2 []string) bool {
+	if len(w1) != len(w2) {
+		return false
+	}
+	for i := 0; i < len(w1); i++ {
+		if w1[0] != w2[0] {
+			return false
+		}
+	}
+	return true
+}
+
+func reverseSlice(ss []string) {
+	for i := 0; i < len(ss)/2; i++ {
+		j := len(ss) - 1 - i
+		ss[i], ss[j] = ss[j], ss[i]
+	}
+}


### PR DESCRIPTION
Add a TraverseByOffset function similar to what is implemented in #447. Allows traversing through parts of the tree with the specified offset and limit, optimising for going through as few child nodes as possible (taking advantage of the length).