### PR TITLE
chore: use newcli format in realm help and demos

### DIFF
--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -59,7 +59,7 @@ Go to https://gno.land/faucet
 NOTE: `BOARDNAME` will be the slug of the board, and should be changed.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateBoard" --args "BOARDNAME" --gas-fee "1000000ugnot" --gas-wanted "2000000" --broadcast true --chainid testchain --remote gno.land:36657
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateBoard
@@ -67,8 +67,8 @@ Interactive documentation: https://gno.land/r/boards?help&__func=CreateBoard
 Next, query for the permanent board ID by querying (you need this to create a new post):
 
 ```bash
-./build/gnokey query "vm/qeval" --data "gno.land/r/boards
-GetBoardIDFromName(\"BOARDNAME\")" --remote gno.land:36657
+./build/gnokey query "vm/qeval" -data "gno.land/r/boards
+GetBoardIDFromName(\"BOARDNAME\")" -remote gno.land:36657
 ```
 
 ### Create a post of a board with a smart contract call.
@@ -76,7 +76,7 @@ GetBoardIDFromName(\"BOARDNAME\")" --remote gno.land:36657
 NOTE: If a board was created successfully, your SEQUENCE_NUMBER would have increased.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateThread" --args BOARD_ID --args "Hello gno.land" --args\#file "./examples/gno.land/r/boards/example_post.md" --gas-fee 1000000ugnot --gas-wanted 2000000 --broadcast true --chainid testchain --remote gno.land:36657
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateThread
@@ -84,14 +84,14 @@ Interactive documentation: https://gno.land/r/boards?help&__func=CreateThread
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call KEYNAME --pkgpath "gno.land/r/boards" --func "CreateReply" --args "BOARD_ID" --args "1" --args "1" --args "Nice to meet you too." --gas-fee 1000000ugnot --gas-wanted 2000000 --broadcast true --chainid testchain --remote gno.land:36657
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateReply
 
 ```bash
-./build/gnokey query "vm/qrender" --data "gno.land/r/boards
-BOARDNAME/1" --remote gno.land:36657
+./build/gnokey query "vm/qrender" -data "gno.land/r/boards
+BOARDNAME/1" -remote gno.land:36657
 ```
 
 ### Render page with optional path expression.
@@ -100,7 +100,7 @@ The contents of `https://gno.land/r/boards:` and `https://gno.land/r/boards:gnol
 the `Render(path string)` function like so:
 
 ```bash
-./build/gnokey query "vm/qrender" --data "gno.land/r/boards
+./build/gnokey query "vm/qrender" -data "gno.land/r/boards
 gnolang"
 ```
 
@@ -109,7 +109,7 @@ gnolang"
 ### Add test account.
 
 ```bash
-./build/gnokey add test1 --recover
+./build/gnokey add -recover test1
 ```
 
 Use this mneonic:
@@ -126,11 +126,11 @@ NOTE: This can be reset with `make reset`
 ### Publish the "gno.land/p/demo/avl" package.
 
 ```bash
-./build/gnokey maketx addpkg test1 --pkgpath "gno.land/p/demo/avl" --pkgdir "examples/gno.land/p/demo/avl" --deposit 100000000ugnot --gas-fee 1000000ugnot --gas-wanted 2000000 --broadcast true --chainid dev --remote localhost:26657
+./build/gnokey maketx addpkg -pkgpath "gno.land/p/demo/avl" -pkgdir "examples/gno.land/p/demo/avl" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid dev -remote localhost:26657 test1
 ```
 
 ### Publish the "gno.land/r/boards" realm package.
 
 ```bash
-./build/gnokey maketx addpkg test1 --pkgpath "gno.land/r/boards" --pkgdir "examples/gno.land/r/boards" --deposit 100000000ugnot --gas-fee 1000000ugnot --gas-wanted 300000000 --broadcast true --chainid dev --remote localhost:26657
+./build/gnokey maketx addpkg -pkgpath "gno.land/r/boards" -pkgdir "examples/gno.land/r/boards" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 300000000 -broadcast -chainid dev -remote localhost:26657 test1
 ```

--- a/examples/gno.land/r/demo/groups/README.md
+++ b/examples/gno.land/r/demo/groups/README.md
@@ -4,20 +4,21 @@
 
 ### - add pkg
 
-    ./build/gnokey maketx addpkg test1 --pkgdir "examples/gno.land/r/demo/groups" --deposit 100000000ugnot --gas-fee 1000000ugnot --gas-wanted 10000000 --broadcast true --chainid dev --remote 0.0.0.0:26657 --pkgpath "gno.land/r/demo/groups"
+    ./build/gnokey maketx addpkg -pkgdir "examples/gno.land/r/demo/groups" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid dev -remote 0.0.0.0:26657 -pkgpath "gno.land/r/demo/groups" test1 
 
 ### - create group
 
-    ./build/gnokey maketx call test1 --func "CreateGroup" --args "dao_trinity_ngo" --gas-fee "1000000ugnot" --gas-wanted "4000000" --broadcast true --chainid dev --remote 0.0.0.0:26657 --pkgpath "gno.land/r/demo/groups"
+    ./build/gnokey maketx call -func "CreateGroup" -args "dao_trinity_ngo" -gas-fee "1000000ugnot" -gas-wanted 4000000 -broadcast true -chainid dev -remote 0.0.0.0:26657 -pkgpath "gno.land/r/demo/groups" test1 
 
 ### - add member
 
-    ./build/gnokey maketx call test1 --func "AddMember" --args "1" --args "g1hd3gwzevxlqmd3jsf64mpfczag8a8e5j2wdn3c" --args 12 --args "i am new user" --gas-fee "1000000ugnot" --gas-wanted "4000000" --broadcast true --chainid dev --remote 0.0.0.0:26657 --pkgpath "gno.land/r/demo/groups"
+    ./build/gnokey maketx call -func "AddMember" -args "1" -args "g1hd3gwzevxlqmd3jsf64mpfczag8a8e5j2wdn3c" -args 12 -args "i am new user" -gas-fee "1000000ugnot" -gas-wanted "4000000" -broadcast -chainid dev -remote 0.0.0.0:26657 -pkgpath "gno.land/r/demo/groups" test1
 
 ### - delete member
 
-    ./build/gnokey maketx call test1 --func "DeleteMember" --args "1" --args "0" --gas-fee "1000000ugnot" --gas-wanted "4000000" --broadcast true --chainid dev --remote 0.0.0.0:26657 --pkgpath "gno.land/r/demo/groups"
+    ./build/gnokey maketx call -func "DeleteMember" -args "1" -args "0" -gas-fee "1000000ugnot" -gas-wanted "4000000" -broadcast -chainid dev -remote 0.0.0.0:26657 -pkgpath "gno.land/r/demo/groups" test1
 
 ### - delete group
 
-    ./build/gnokey maketx call test1 --func "DeleteGroup" --args "1" --gas-fee "1000000ugnot" --gas-wanted "4000000" --broadcast true --chainid dev --remote 0.0.0.0:26657 --pkgpath "gno.land/r/demo/groups"
+    ./build/gnokey maketx call -func "DeleteGroup" -args "1" -gas-fee "1000000ugnot" -gas-wanted "4000000" -broadcast -chainid dev -remote 0.0.0.0:26657 -pkgpath "gno.land/r/demo/groups" test1
+

--- a/gnoland/website/static/js/realm_help.js
+++ b/gnoland/website/static/js/realm_help.js
@@ -51,16 +51,16 @@ function updateCommand(x) {
 
   // command Z: all in one.
   shell.append(u("<span>").text("### INSECURE BUT QUICK ###")).append(u("<br>"));
-  var args = ["gnokey", "maketx", "call", myAddr,
-    "--pkgpath", shq(realmPath), "--func", shq(funcName),
-    "--gas-fee", "1000000ugnot", "--gas-wanted", "2000000",
-    "--send", shq(""),
-    "--broadcast", "true", "--chainid", shq(chainid)];
+  var args = ["gnokey", "maketx", "call", 
+    "-pkgpath", shq(realmPath), "-func", shq(funcName),
+    "-gas-fee", "1000000ugnot", "-gas-wanted", "2000000",
+    "-send", shq(""),
+    "-broadcast", "-chainid", shq(chainid), myAddr];
   vals.forEach(function(arg) {
-    args.push("--args");
+    args.push("-args");
     args.push(shq(arg));
   });
-  args.push("--remote", shq(remote));
+  args.push("-remote", shq(remote));
   var command = args.join(" ");
   shell.append(u("<span>").text(command)).append(u("<br>")).append(u("<br>"));
 
@@ -68,17 +68,17 @@ function updateCommand(x) {
   shell.append(u("<span>").text("### FULL SECURITY WITH AIRGAP ###")).append(u("<br>"));
 
   // command 0: query account info.
-  var args = ["gnokey", "query", "auth/accounts/" + myAddr, "--remote", shq(remote)];
+  var args = ["gnokey", "query", "auth/accounts/" + myAddr, "-remote", shq(remote)];
   var command = args.join(" ");
   shell.append(u("<span>").text(command)).append(u("<br>"));
 
   // command 1: construct tx.
-  var args = ["gnokey", "maketx", "call", myAddr,
-    "--pkgpath", shq(realmPath), "--func", shq(funcName),
-    "--gas-fee", "1000000ugnot", "--gas-wanted", "2000000",
-    "--send", shq("")];
+  var args = ["gnokey", "maketx", "call",
+    "-pkgpath", shq(realmPath), "-func", shq(funcName),
+    "-gas-fee", "1000000ugnot", "-gas-wanted", "2000000",
+    "-send", shq(""), myAddr];
   vals.forEach(function(arg) {
-    args.push("--args");
+    args.push("-args");
     args.push(shq(arg));
   });
   var command = args.join(" ");
@@ -86,16 +86,16 @@ function updateCommand(x) {
   shell.append(u("<span>").text(command)).append(u("<br>"));
 
   // command 2: sign tx.
-  var args = ["gnokey", "sign", myAddr,
-    "--txpath", "unsigned.tx", "--chainid", shq(chainid),
-    "--number", "ACCOUNTNUMBER",
-    "--sequence", "SEQUENCENUMBER"];
+  var args = ["gnokey", "sign",
+    "-txpath", "unsigned.tx", "-chainid", shq(chainid),
+    "-number", "ACCOUNTNUMBER",
+    "-sequence", "SEQUENCENUMBER", myAddr];
   var command = args.join(" ");
   command = command + " > signed.tx";
   shell.append(u("<span>").text(command)).append(u("<br>"));
 
   // command 3: broadcast tx.
-  var args = ["gnokey", "broadcast", "signed.tx", "--remote", shq(remote)];
+  var args = ["gnokey", "broadcast", "signed.tx", "-remote", shq(remote)];
   var command = args.join(" ");
   command = command;
   shell.append(u("<span>").text(command)).append(u("<br>"));


### PR DESCRIPTION
When we go to a page such as https://test3.gno.land/r/demo/boards?help, we are still instructed copy/pasting in the old style:

    `gnokey maketx call ADDRESS --pkgpath "gno.land/r/demo/boards" --func "GetBoardIDFromName" --gas-fee 1000000ugnot --gas-wanted 2000000 --send "" --broadcast true --chainid "test3" --args "" --remote "test3.gno.land:36657"`

This commit changes gnoland/website/static/js/realm_help.js so it gives instructions with new cli format instead.

It also updates two demo:
* examples/gno.land/r/demo/boards/README.md
* examples/gno.land/r/demo/groups/README.md

# How has this been tested?
Manually from the `?help` page from some links. 