### PR TITLE
hotfix: apply `gnokey` subcommand flagset

### DIFF
--- a/pkgs/crypto/keys/client/broadcast.go
+++ b/pkgs/crypto/keys/client/broadcast.go
@@ -34,7 +34,7 @@ func newBroadcastCmd(rootCfg *baseCfg) *commands.Command {
 			ShortUsage: "broadcast [flags] <file-name>",
 			ShortHelp:  "Broadcasts a signed document",
 		},
-		nil,
+		cfg,
 		func(_ context.Context, args []string) error {
 			return execBroadcast(cfg, args, commands.NewDefaultIO())
 		},

--- a/pkgs/crypto/keys/client/list.go
+++ b/pkgs/crypto/keys/client/list.go
@@ -12,7 +12,7 @@ func newListCmd(rootCfg *baseCfg) *commands.Command {
 	return commands.NewCommand(
 		commands.Metadata{
 			Name:       "list",
-			ShortUsage: "list [flags]",
+			ShortUsage: "list",
 			ShortHelp:  "Lists all keys in the keybase",
 		},
 		nil,

--- a/pkgs/crypto/keys/client/query.go
+++ b/pkgs/crypto/keys/client/query.go
@@ -33,7 +33,7 @@ func newQueryCmd(rootCfg *baseCfg) *commands.Command {
 			ShortUsage: "query [flags] <path>",
 			ShortHelp:  "Makes an ABCI query",
 		},
-		nil,
+		cfg,
 		func(_ context.Context, args []string) error {
 			return execQuery(cfg, args)
 		},


### PR DESCRIPTION
# Description

This PR fixes a small bug where flagsets were not being applied for nested `gnokey` subcommands, namely:
- `gnokey query`
- `gnokey broadcast`

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests

Manually made sure the flags for `query` and `broadcast` are recognized.

# Additional comments

Resolves #607 
