### PR TITLE
chore: show logger messages in tests/ when -verbose with gnodev test

### DIFF
--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -291,7 +291,7 @@ func gnoTestPkg(
 			}
 
 			testFilePath := filepath.Join(pkgPath, testFileName)
-			var fLogger func(args ...interface{})
+			var fLogger tests.LoggerFunc
 			if verbose {
 				fLogger = func(args ...interface{}) {
 					io.ErrPrintfln("%v", args...)

--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -291,7 +291,13 @@ func gnoTestPkg(
 			}
 
 			testFilePath := filepath.Join(pkgPath, testFileName)
-			err := tests.RunFileTest(rootDir, testFilePath, tests.WithSyncWanted(cfg.updateGoldenTests))
+			var fLogger func(args ...interface{}) = nil // note: tests.loggerFunc is not exported...
+			if verbose {
+				fLogger = func(args ...interface{}) {
+					io.ErrPrintfln("%v", args...)
+				}
+			}
+			err := tests.RunFileTest(rootDir, testFilePath, tests.WithSyncWanted(cfg.updateGoldenTests), tests.WithLoggerFunc(fLogger))
 			duration := time.Since(startedAt)
 			dstr := fmtDuration(duration)
 

--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -291,7 +291,7 @@ func gnoTestPkg(
 			}
 
 			testFilePath := filepath.Join(pkgPath, testFileName)
-			var fLogger func(args ...interface{}) = nil // note: tests.loggerFunc is not exported...
+			var fLogger func(args ...interface{})
 			if verbose {
 				fLogger = func(args ...interface{}) {
 					io.ErrPrintfln("%v", args...)

--- a/cmd/gnodev/test_test.go
+++ b/cmd/gnodev/test_test.go
@@ -71,9 +71,9 @@ func TestTest(t *testing.T) {
 			recoverShouldBe:     "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop",
 			stderrShouldContain: "== RUN   file/failing_filetest.gno",
 		}, {
-			args:            []string{"test", "--verbose", "--precompile", "../../tests/integ/failing2"},
-			stderrShouldBe:  "=== PREC  ./../../tests/integ/failing2\n=== BUILD ./../../tests/integ/failing2\n=== RUN   file/failing_filetest.gno\n",
-			recoverShouldBe: "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop",
+			args:                []string{"test", "--verbose", "--precompile", "../../tests/integ/failing2"},
+			stderrShouldContain: "=== PREC  ./../../tests/integ/failing2\n=== BUILD ./../../tests/integ/failing2\n=== RUN   file/failing_filetest.gno\n",
+			recoverShouldBe:     "fail on ../../tests/integ/failing2/failing_filetest.gno: got unexpected error: beep boop",
 		}, {
 			args:                []string{"test", "../../examples/gno.land/p/demo/ufmt"},
 			stdoutShouldContain: "RUN   TestSprintf",

--- a/tests/file.go
+++ b/tests/file.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gnolang/gno/stdlibs"
 )
 
-type loggerFunc func(args ...interface{})
+type LoggerFunc func(args ...interface{})
 
 func TestMachine(store gno.Store, stdout io.Writer, pkgPath string) *gno.Machine {
 	// default values
@@ -60,7 +60,7 @@ func testMachineCustom(store gno.Store, pkgPath string, stdout io.Writer, maxAll
 
 type runFileTestOptions struct {
 	nativeLibs bool
-	logger     loggerFunc
+	logger     LoggerFunc
 	syncWanted bool
 }
 

--- a/tests/file_test.go
+++ b/tests/file_test.go
@@ -90,7 +90,7 @@ func runFileTest(t *testing.T, path string, opts ...RunFileTestOption) {
 
 	opts = append([]RunFileTestOption{WithSyncWanted(*withSync)}, opts...)
 
-	var logger loggerFunc
+	var logger LoggerFunc
 	if gno.IsDebug() && testing.Verbose() {
 		logger = t.Log
 	}


### PR DESCRIPTION
While working on https://github.com/gnolang/gno/issues/615

`f.logger(<...>)` calls in tests/file.go are not shown when `gnodev test -verbose (...)`. 

If the cmd user is specifying -verbose (and since we don't have -debug ATM) it seems those traces should be shown.

For instance this is called from .tests/file.go:
```
    if f.logger != nil {
            store.Print()
            f.logger("========================================")
            f.logger("PREPROCESS ALL FILES")
            f.logger("========================================")
    }
```

# How has this been tested?

With `gnodev test -verbose (...)`.