### PR TITLE
Fix615

### DIFF
--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gnolang/gno/pkgs/errors"
 	gno "github.com/gnolang/gno/pkgs/gnolang"
 	"github.com/gnolang/gno/pkgs/std"
-	"github.com/gnolang/gno/pkgs/testutils"
 	"github.com/gnolang/gno/tests"
 	"go.uber.org/multierr"
 )
@@ -285,11 +284,6 @@ func gnoTestPkg(
 				io.ErrPrintfln("=== RUN   %s", testName)
 			}
 
-			var closer func() (string, error)
-			if !verbose {
-				closer = testutils.CaptureStdoutAndStderr()
-			}
-
 			testFilePath := filepath.Join(pkgPath, testFileName)
 			err := tests.RunFileTest(rootDir, testFilePath, tests.WithSyncWanted(cfg.updateGoldenTests))
 			duration := time.Since(startedAt)
@@ -298,13 +292,6 @@ func gnoTestPkg(
 			if err != nil {
 				errs = multierr.Append(errs, err)
 				io.ErrPrintfln("--- FAIL: %s (%s)", testName, dstr)
-				if verbose {
-					stdouterr, err := closer()
-					if err != nil {
-						panic(err)
-					}
-					fmt.Fprintln(os.Stderr, stdouterr)
-				}
 				continue
 			} else if verbose {
 				io.ErrPrintfln("--- PASS: %s (%s)", testName, dstr)

--- a/cmd/gnodev/test.go
+++ b/cmd/gnodev/test.go
@@ -306,9 +306,7 @@ func gnoTestPkg(
 					fmt.Fprintln(os.Stderr, stdouterr)
 				}
 				continue
-			}
-
-			if verbose {
+			} else if verbose {
 				io.ErrPrintfln("--- PASS: %s (%s)", testName, dstr)
 			}
 		}

--- a/tests/file.go
+++ b/tests/file.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io"
 	"os"
 	"regexp"
 	rtdb "runtime/debug"
@@ -15,47 +14,9 @@ import (
 	gno "github.com/gnolang/gno/pkgs/gnolang"
 	osm "github.com/gnolang/gno/pkgs/os"
 	"github.com/gnolang/gno/pkgs/std"
-	"github.com/gnolang/gno/stdlibs"
 )
 
 type loggerFunc func(args ...interface{})
-
-func TestMachine(store gno.Store, stdout io.Writer, pkgPath string) *gno.Machine {
-	// default values
-	var (
-		send     std.Coins
-		maxAlloc int64
-	)
-
-	return testMachineCustom(store, pkgPath, stdout, maxAlloc, send)
-}
-
-func testMachineCustom(store gno.Store, pkgPath string, stdout io.Writer, maxAlloc int64, send std.Coins) *gno.Machine {
-	// FIXME: create a better package to manage this, with custom constructors
-	pkgAddr := gno.DerivePkgAddr(pkgPath)                      // the addr of the pkgPath called.
-	caller := gno.DerivePkgAddr(pkgPath)                       // NOTE: for the purpose of testing, the caller is generally the "main" package, same as pkgAddr.
-	pkgCoins := std.MustParseCoins("200000000ugnot").Add(send) // >= send.
-	banker := newTestBanker(pkgAddr.Bech32(), pkgCoins)
-	ctx := stdlibs.ExecContext{
-		ChainID:       "dev",
-		Height:        123,
-		Timestamp:     1234567890,
-		Msg:           nil,
-		OrigCaller:    caller.Bech32(),
-		OrigPkgAddr:   pkgAddr.Bech32(),
-		OrigSend:      send,
-		OrigSendSpent: new(std.Coins),
-		Banker:        banker,
-	}
-	m := gno.NewMachineWithOptions(gno.MachineOptions{
-		PkgPath:       "", // set later.
-		Output:        stdout,
-		Store:         store,
-		Context:       ctx,
-		MaxAllocBytes: maxAlloc,
-	})
-	return m
-}
 
 type runFileTestOptions struct {
 	nativeLibs bool

--- a/tests/file.go
+++ b/tests/file.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gnolang/gno/pkgs/errors"
 	gno "github.com/gnolang/gno/pkgs/gnolang"
 	osm "github.com/gnolang/gno/pkgs/os"
 	"github.com/gnolang/gno/pkgs/std"
@@ -90,9 +91,9 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 					// print stack if unexpected error.
 					pnc = r
 					if errWanted == "" {
-						fmt.Printf("Got panic: %s\n", r)
 						// no -verbose here, let's use f.logger()
 						// to show stack when -verbose used from cmd
+						fmt.Printf("Got panic: %v\n", r)
 						if f.logger != nil {
 							f.logger(string(rtdb.Stack()))
 						}
@@ -193,7 +194,9 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 				}
 			}
 		}()
-
+		if pnc != nil {
+			return errors.New("Test failed because of panic. Use -verbose to show the call stack")
+		}
 		for _, directive := range directives {
 			switch directive {
 			case "Error":

--- a/tests/file.go
+++ b/tests/file.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gnolang/gno/pkgs/crypto"
 	gno "github.com/gnolang/gno/pkgs/gnolang"
 	osm "github.com/gnolang/gno/pkgs/os"
 	"github.com/gnolang/gno/pkgs/std"
@@ -438,68 +437,4 @@ func trimTrailingSpaces(result string) string {
 		lines[i] = strings.TrimRight(line, " \t")
 	}
 	return strings.Join(lines, "\n")
-}
-
-// ----------------------------------------
-// testBanker
-
-type testBanker struct {
-	coinTable map[crypto.Bech32Address]std.Coins
-}
-
-func newTestBanker(args ...interface{}) *testBanker {
-	coinTable := make(map[crypto.Bech32Address]std.Coins)
-	if len(args)%2 != 0 {
-		panic("newTestBanker requires even number of arguments; addr followed by coins")
-	}
-	for i := 0; i < len(args); i += 2 {
-		addr := args[i].(crypto.Bech32Address)
-		amount := args[i+1].(std.Coins)
-		coinTable[addr] = amount
-	}
-	return &testBanker{
-		coinTable: coinTable,
-	}
-}
-
-func (tb *testBanker) GetCoins(addr crypto.Bech32Address) (dst std.Coins) {
-	return tb.coinTable[addr]
-}
-
-func (tb *testBanker) SendCoins(from, to crypto.Bech32Address, amt std.Coins) {
-	fcoins, fexists := tb.coinTable[from]
-	if !fexists {
-		panic(fmt.Sprintf(
-			"source address %s does not exist",
-			from.String()))
-	}
-	if !fcoins.IsAllGTE(amt) {
-		panic(fmt.Sprintf(
-			"source address %s has %s; cannot send %s",
-			from.String(), fcoins, amt))
-	}
-	// First, subtract from 'from'.
-	frest := fcoins.Sub(amt)
-	tb.coinTable[from] = frest
-	// Second, add to 'to'.
-	// NOTE: even works when from==to, due to 2-step isolation.
-	tcoins, _ := tb.coinTable[to]
-	tsum := tcoins.Add(amt)
-	tb.coinTable[to] = tsum
-}
-
-func (tb *testBanker) TotalCoin(denom string) int64 {
-	panic("not yet implemented")
-}
-
-func (tb *testBanker) IssueCoin(addr crypto.Bech32Address, denom string, amt int64) {
-	coins, _ := tb.coinTable[addr]
-	sum := coins.Add(std.Coins{{denom, amt}})
-	tb.coinTable[addr] = sum
-}
-
-func (tb *testBanker) RemoveCoin(addr crypto.Bech32Address, denom string, amt int64) {
-	coins, _ := tb.coinTable[addr]
-	rest := coins.Sub(std.Coins{{denom, amt}})
-	tb.coinTable[addr] = rest
 }

--- a/tests/file.go
+++ b/tests/file.go
@@ -90,7 +90,12 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 					// print stack if unexpected error.
 					pnc = r
 					if errWanted == "" {
-						rtdb.PrintStack()
+						fmt.Printf("Got panic: %s\n", r)
+						// no -verbose here, let's use f.logger()
+						// to show stack when -verbose used from cmd
+						if f.logger != nil {
+							f.logger(string(rtdb.Stack()))
+						}
 					}
 					err := strings.TrimSpace(fmt.Sprintf("%v", pnc))
 					if !strings.Contains(err, errWanted) {

--- a/tests/file.go
+++ b/tests/file.go
@@ -91,12 +91,8 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 					// print stack if unexpected error.
 					pnc = r
 					if errWanted == "" {
-						// no -verbose here, let's use f.logger()
-						// to show stack when -verbose used from cmd
 						fmt.Printf("Got panic: %v\n", r)
-						if f.logger != nil {
-							f.logger(string(rtdb.Stack()))
-						}
+						rtdb.PrintStack()
 					}
 					err := strings.TrimSpace(fmt.Sprintf("%v", pnc))
 					if !strings.Contains(err, errWanted) {

--- a/tests/file.go
+++ b/tests/file.go
@@ -191,7 +191,7 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 			}
 		}()
 		if pnc != nil {
-			return errors.New("Test failed because of panic. Use -verbose to show the call stack")
+			return errors.New("Test failed because of panic.")
 		}
 		for _, directive := range directives {
 			switch directive {

--- a/tests/testbanker.go
+++ b/tests/testbanker.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/gnolang/gno/pkgs/crypto"
+	"github.com/gnolang/gno/pkgs/std"
+)
+
+type testBanker struct {
+	coinTable map[crypto.Bech32Address]std.Coins
+}
+
+func newTestBanker(args ...interface{}) *testBanker {
+	coinTable := make(map[crypto.Bech32Address]std.Coins)
+	if len(args)%2 != 0 {
+		panic("newTestBanker requires even number of arguments; addr followed by coins")
+	}
+	for i := 0; i < len(args); i += 2 {
+		addr := args[i].(crypto.Bech32Address)
+		amount := args[i+1].(std.Coins)
+		coinTable[addr] = amount
+	}
+	return &testBanker{
+		coinTable: coinTable,
+	}
+}
+
+func (tb *testBanker) GetCoins(addr crypto.Bech32Address) (dst std.Coins) {
+	return tb.coinTable[addr]
+}
+
+func (tb *testBanker) SendCoins(from, to crypto.Bech32Address, amt std.Coins) {
+	fcoins, fexists := tb.coinTable[from]
+	if !fexists {
+		panic(fmt.Sprintf(
+			"source address %s does not exist",
+			from.String()))
+	}
+	if !fcoins.IsAllGTE(amt) {
+		panic(fmt.Sprintf(
+			"source address %s has %s; cannot send %s",
+			from.String(), fcoins, amt))
+	}
+	// First, subtract from 'from'.
+	frest := fcoins.Sub(amt)
+	tb.coinTable[from] = frest
+	// Second, add to 'to'.
+	// NOTE: even works when from==to, due to 2-step isolation.
+	tcoins, _ := tb.coinTable[to]
+	tsum := tcoins.Add(amt)
+	tb.coinTable[to] = tsum
+}
+
+func (tb *testBanker) TotalCoin(denom string) int64 {
+	panic("not yet implemented")
+}
+
+func (tb *testBanker) IssueCoin(addr crypto.Bech32Address, denom string, amt int64) {
+	coins, _ := tb.coinTable[addr]
+	sum := coins.Add(std.Coins{{denom, amt}})
+	tb.coinTable[addr] = sum
+}
+
+func (tb *testBanker) RemoveCoin(addr crypto.Bech32Address, denom string, amt int64) {
+	coins, _ := tb.coinTable[addr]
+	rest := coins.Sub(std.Coins{{denom, amt}})
+	tb.coinTable[addr] = rest
+}

--- a/tests/testmachine.go
+++ b/tests/testmachine.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"io"
+
+	gno "github.com/gnolang/gno/pkgs/gnolang"
+	"github.com/gnolang/gno/pkgs/std"
+	"github.com/gnolang/gno/stdlibs"
+)
+
+func TestMachine(store gno.Store, stdout io.Writer, pkgPath string) *gno.Machine {
+	// default values
+	var (
+		send     std.Coins
+		maxAlloc int64
+	)
+
+	return testMachineCustom(store, pkgPath, stdout, maxAlloc, send)
+}
+
+func testMachineCustom(store gno.Store, pkgPath string, stdout io.Writer, maxAlloc int64, send std.Coins) *gno.Machine {
+	// FIXME (Manfred): create a better package to manage this, with custom constructors
+	pkgAddr := gno.DerivePkgAddr(pkgPath)                      // the addr of the pkgPath called.
+	caller := gno.DerivePkgAddr(pkgPath)                       // NOTE: for the purpose of testing, the caller is generally the "main" package, same as pkgAddr.
+	pkgCoins := std.MustParseCoins("200000000ugnot").Add(send) // >= send.
+	banker := newTestBanker(pkgAddr.Bech32(), pkgCoins)
+	ctx := stdlibs.ExecContext{
+		ChainID:       "dev",
+		Height:        123,
+		Timestamp:     1234567890,
+		Msg:           nil,
+		OrigCaller:    caller.Bech32(),
+		OrigPkgAddr:   pkgAddr.Bech32(),
+		OrigSend:      send,
+		OrigSendSpent: new(std.Coins),
+		Banker:        banker,
+	}
+	m := gno.NewMachineWithOptions(gno.MachineOptions{
+		PkgPath:       "", // set later.
+		Output:        stdout,
+		Store:         store,
+		Context:       ctx,
+		MaxAllocBytes: maxAlloc,
+	})
+	return m
+}


### PR DESCRIPTION
These commits fix both bugs mentionned in #615 for me.

I think it is easier for the reviewer to first revise commit after commit.
The changes are simple but the files modified are long and complicated, it can be daunting if not considering the logic.

So two bugs:

1. When testing a `<file>_testfile` and there were some panics (because for example the file was not placed in `file/` folder, or because bad package name), **panics** were not shown (see output in #615)

2. tests that panic-ed this way were unexpectedly shown as PASSED

The tests would need a major overhaul, but I tried to operate chirurgically to facilitate review.
Still, I decided to create two small files, as there is nothing to lose in doing that (see the 2 commits in question).

## How was it tested
It was only tested only manually, using combinations of foo_test.gno and bar_filetest.gno, with and without panics or `t.Fail()`. There might be edge cases. I recommend someone more experimented with realms tests it too.