### PR TITLE
Pretty integers and floats with `_` #630

### DIFF
--- a/pkgs/gnolang/op_eval.go
+++ b/pkgs/gnolang/op_eval.go
@@ -42,6 +42,7 @@ func (m *Machine) doOpEval() {
 		m.PopExpr()
 		switch x.Kind {
 		case INT:
+			x.Value = strings.ReplaceAll(x.Value, "_", "")
 			// temporary optimization
 			bi := big.NewInt(0)
 			// TODO optimize.

--- a/pkgs/gnolang/op_eval.go
+++ b/pkgs/gnolang/op_eval.go
@@ -77,6 +77,8 @@ func (m *Machine) doOpEval() {
 				V: BigintValue{V: bi},
 			})
 		case FLOAT:
+			x.Value = strings.ReplaceAll(x.Value, "_", "")
+
 			if matched, _ := regexp.MatchString(`^[0-9\.]+([eE][\-\+]?[0-9]+)?$`, x.Value); matched {
 				value := x.Value
 				bd, c, err := apd.NewFromString(value)

--- a/tests/files/const22.gno
+++ b/tests/files/const22.gno
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+)
+
+const (
+	ia = 1_000_000
+	ib = 1_00_00_00
+	ic = 1_000
+
+	fa = 1_000_000.000
+	fb = 1_000_000.000_000
+
+	// Imaginary number aren't supported at the moment
+	// ima = 100_000i
+	// imb = 1 + 100_000i
+
+	ha = 0x_16_32
+	hb = 0b_0110_1001
+	ho = 0o_644_755
+)
+
+func main() {
+	fmt.Printf("%d\n", ia)
+	fmt.Printf("%d\n", ib)
+	fmt.Printf("%d\n", ic)
+
+	fmt.Printf("%f\n", fa)
+	fmt.Printf("%f\n", fb)
+
+	fmt.Printf("%x", ha)
+	fmt.Printf("%x", hb)
+	fmt.Printf("%x", ho)
+}
+
+// Output:
+// 1000000
+// 1000000
+// 1000
+// 1000000.000000
+// 1000000.000000
+// 163269349ed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

close: #630 

# Description

This PR allow to use integer and floats containing `_` like:

```go
_ = 1_000_000

_ = 1_00_000.00_000
```

# How has this been tested?

N/A