### PR TITLE
[performance] use btree for object cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/tidwall/btree v1.6.0 // indirect
 	go.opencensus.io v0.22.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
+github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
+github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkgs/gnolang/ownership.go
+++ b/pkgs/gnolang/ownership.go
@@ -44,6 +44,10 @@ type ObjectID struct {
 	NewTime uint64 // time created
 }
 
+func (i ObjectID) ObjectID() ObjectID {
+	return i
+}
+
 func (oid ObjectID) MarshalAmino() (string, error) {
 	pid := hex.EncodeToString(oid.PkgID.Hashlet[:])
 	return fmt.Sprintf("%s:%d", pid, oid.NewTime), nil

--- a/pkgs/gnolang/store.go
+++ b/pkgs/gnolang/store.go
@@ -96,8 +96,9 @@ type GetObjectID interface {
 
 func byKeys(a, b interface{}) bool {
 	id1, id2 := a.(GetObjectID).ObjectID(), b.(GetObjectID).ObjectID()
-	return id1.PkgID.String() < id2.PkgID.String() &&
-		id1.NewTime < id2.NewTime
+	l := id1.PkgID.String()
+	r := id2.PkgID.String()
+	return l < r || id1.NewTime < id2.NewTime
 }
 
 func NewStore(alloc *Allocator, baseStore, iavlStore store.Store) *defaultStore {
@@ -140,11 +141,6 @@ func (ds *defaultStore) GetPackage(pkgPath string, isImport bool) *PackageValue 
 	}
 	// first, check cache.
 	oid := ObjectIDFromPkgPath(pkgPath)
-	ds.cacheObjects.Ascend(nil, func(item any) bool {
-		item1 := item.(*Item)
-		fmt.Printf("%+v\n", item1)
-		return true
-	})
 	oo := ds.cacheObjects.Get(oid)
 	if oo != nil {
 		item := oo.(*Item)


### PR DESCRIPTION
This uses a btree for the object cache for 2 reasons.
1. it is faster than the builtin map
2. it is deterministic, while the builtin map isn't.


Benchmarks on master

```
BenchmarkPreprocess-8                	    1952	    736169 ns/op
BenchmarkLoopyMain-8                 	       1	5493570400 ns/op
BenchmarkMapSet-8                    	85774654	        12.16 ns/op
BenchmarkMapCreateSet-8              	92109302	        14.16 ns/op
BenchmarkMapCreateSetString-8        	71222534	        18.07 ns/op
BenchmarkSliceIterate10-8            	100000000	        12.47 ns/op
BenchmarkStructStack-8                  1000000000	         1.083 ns/op
BenchmarkStructGC-8                  	1000000000	         1.070 ns/op
BenchmarkTypeAssertionMethodCall/Int32().Int32()_(no_interface)-8         	1000000000	         0.3046 ns/op
BenchmarkTypeAssertionMethodCall/BenchValue().Int32()_(interface_method)-8         	778061769	         1.977 ns/op
BenchmarkTypeAssertionMethodCall/v.(Int32).Int32()_(concrete_assert_method)-8      	1000000000	         0.5902 ns/op
BenchmarkTypeAssertionMethodCall/case_v.(Int32).Int32()_(type_switch_concrete_assert_method)-8         	1000000000	         0.9090 ns/op
BenchmarkTypeAssertionMethodCall/MyStruct{Value:Int32(i)}_(struct_interface_field_init)-8              	1000000000	         0.3042 ns/op
BenchmarkTypeAssertionMethodCall/v.(BenchValue).Int32()_(interface_assert_method)-8                    	148655521	         8.056 ns/op
BenchmarkTypeSwitchOrCreate/type-switch-8                                                              	558304	      2169 ns/op
BenchmarkTypeSwitchOrCreate/super-struct-8                                                             	760971	      1547 ns/op
BenchmarkReflectAddInt64-8                                                                             	565599928	         2.398 ns/op
BenchmarkArrayEquality/ArrayEquality[1]-8                                                              	1000000000	         0.7473 ns/op
BenchmarkArrayEquality/ArrayEquality[8]-8                                                              	1000000000	         1.062 ns/op
BenchmarkArrayEquality/ArrayEquality[16]-8                                                             	639341563	         1.916 ns/op
BenchmarkArrayEquality/ArrayEquality[20]-8                                                             	128369622	         9.407 ns/op
BenchmarkArrayEquality/ArrayEquality[32]-8                                                             	148411623	         7.513 ns/op
BenchmarkArrayEquality/ArrayEquality[64]-8                                                             	100638350	        11.75 ns/op
BenchmarkArrayEquality/ArrayEquality[256]-8                                                            	56279106	        22.41 ns/op
```

Benchmarks with a btree

```
BenchmarkPreprocess-8                	    2619	    488234 ns/op
BenchmarkLoopyMain-8                 	       1	3521497000 ns/op
BenchmarkMapSet-8                    	100000000	        11.94 ns/op
BenchmarkMapCreateSet-8              	88771840	        14.17 ns/op
BenchmarkMapCreateSetString-8        	69721231	        17.73 ns/op
BenchmarkSliceIterate10-8            	94301545	        11.86 ns/op
BenchmarkStructStack-8                1000000000	         1.098 ns/op
BenchmarkStructGC-8                  	1000000000	         1.069 ns/op
BenchmarkTypeAssertionMethodCall/Int32().Int32()_(no_interface)-8         	1000000000	         0.3100 ns/op
BenchmarkTypeAssertionMethodCall/BenchValue().Int32()_(interface_method)-8         	796941338	         1.512 ns/op
BenchmarkTypeAssertionMethodCall/v.(Int32).Int32()_(concrete_assert_method)-8      	1000000000	         0.3149 ns/op
BenchmarkTypeAssertionMethodCall/case_v.(Int32).Int32()_(type_switch_concrete_assert_method)-8         	1000000000	         0.9127 ns/op
BenchmarkTypeAssertionMethodCall/MyStruct{Value:Int32(i)}_(struct_interface_field_init)-8              	1000000000	         0.3060 ns/op
BenchmarkTypeAssertionMethodCall/v.(BenchValue).Int32()_(interface_assert_method)-8                    	163830598	         7.254 ns/op
BenchmarkTypeSwitchOrCreate/type-switch-8                                                              	559197	      2173 ns/op
BenchmarkTypeSwitchOrCreate/super-struct-8                                                             	757675	      1530 ns/op
BenchmarkReflectAddInt64-8                                                                             	701443453	         1.808 ns/op
BenchmarkArrayEquality/ArrayEquality[1]-8                                                              	1000000000	         0.3253 ns/op
BenchmarkArrayEquality/ArrayEquality[8]-8                                                              	1000000000	         1.173 ns/op
BenchmarkArrayEquality/ArrayEquality[16]-8                                                             	625828244	         1.817 ns/op
BenchmarkArrayEquality/ArrayEquality[20]-8                                                             	154459993	         7.691 ns/op
BenchmarkArrayEquality/ArrayEquality[32]-8                                                             	185210908	         6.208 ns/op
BenchmarkArrayEquality/ArrayEquality[64]-8                                                             	98414702	        11.93 ns/op
BenchmarkArrayEquality/ArrayEquality[256]-8                                                            	52833178	        23.72 ns/op
```