### PR TITLE
feat: ExecAsPkg

### DIFF
--- a/pkgs/gnolang/machine.go
+++ b/pkgs/gnolang/machine.go
@@ -804,6 +804,9 @@ const (
 	OpValueDecl Op = 0x90 // var/const ...
 	OpTypeDecl  Op = 0x91 // type ...
 
+	/* Context operators */
+	OpSetContext Op = 0xA0
+
 	/* Loop (sticky) operators (>= 0xD0) */
 	OpSticky            Op = 0xD0 // not a real op.
 	OpBody              Op = 0xD1 // if/block/switch/select.
@@ -937,6 +940,9 @@ const (
 	/* Decl operators */
 	OpCPUValueDecl = 1
 	OpCPUTypeDecl  = 1
+
+	/* Context operators */
+	OpCPUContext = 1
 
 	/* Loop (sticky) operators (>= 0xD0) */
 	OpCPUSticky            = 1
@@ -1275,6 +1281,9 @@ func (m *Machine) Run() {
 		case OpReturnCallDefers:
 			m.incrCPU(OpCPUReturnCallDefers)
 			m.doOpReturnCallDefers()
+		case OpSetContext:
+			m.incrCPU(OpCPUContext)
+			m.doOpSetContext()
 		default:
 			panic(fmt.Sprintf("unexpected opcode %s", op.String()))
 		}

--- a/pkgs/gnolang/op_call.go
+++ b/pkgs/gnolang/op_call.go
@@ -407,3 +407,8 @@ func (m *Machine) doOpPanic2() {
 		m.PushOp(OpReturnCallDefers) // XXX rename, not return?
 	}
 }
+
+func (m *Machine) doOpSetContext() {
+	cv := m.PopValue().V.(ContextValue)
+	m.Context = cv.Context
+}

--- a/pkgs/gnolang/values.go
+++ b/pkgs/gnolang/values.go
@@ -40,6 +40,7 @@ func (*PackageValue) assertValue()     {}
 func (*NativeValue) assertValue()      {}
 func (*Block) assertValue()            {}
 func (RefValue) assertValue()          {}
+func (ContextValue) assertValue()      {}
 
 const (
 	nilStr = "nil"
@@ -62,6 +63,7 @@ var (
 	_ Value = &NativeValue{}
 	_ Value = &Block{}
 	_ Value = RefValue{}
+	_ Value = ContextValue{}
 )
 
 // ----------------------------------------
@@ -2182,6 +2184,17 @@ func (tv *TypedValue) GetSlice2(alloc *Allocator, low, high, max int) TypedValue
 		panic(fmt.Sprintf("unexpected type for GetSlice2(): %s",
 			tv.T.String()))
 	}
+}
+
+// ----------------------------------------
+// ContextValue
+
+type ContextValue struct {
+	Context interface{}
+}
+
+func (ctx ContextValue) String() string {
+	return fmt.Sprintf("%v", ctx.Context)
 }
 
 // ----------------------------------------

--- a/stdlibs/stdlibs.go
+++ b/stdlibs/stdlibs.go
@@ -275,6 +275,34 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 				m.PushValue(res0)
 			},
 		)
+		pn.DefineNative("ExecAsPkg",
+			// TODO: rename UnsafeExecAsPkg?
+			gno.Flds( // params
+				"fn", gno.FuncT(nil, nil),
+			),
+			gno.Flds( // results
+			),
+			func(m *gno.Machine) {
+				// TODO: limit stack size: 1? 32?.
+				// TODO: limit usage in goroutines?
+				// TODO: build a new sub-context instead of patching the root one.
+				//       to support multiple concurrent contexts and advanced flows.
+				arg0 := m.LastBlock().GetParams1().TV
+				fn := arg0.GetFunc()
+				println("#####################", arg0, fn.GetType(m.Store).String())
+				//gno.Call(fn, "nil")
+				//m.Eval(gno.Call(fn))
+				// m.Eval(gno.Call(gno.FuncT(nil, nil), fn))
+				println("@@@@@@@@@@")
+				//println(fn)
+
+				/*
+					ctx := m.Context.(stdlibs.ExecContext)
+					ctx.OrigCaller = crypto.Bech32Address(addr)
+					m.Context = ctx
+				*/
+			},
+		)
 		pn.DefineNative("GetCallerAt",
 			gno.Flds( // params
 				"n", "int",

--- a/stdlibs/stdshim/stdshim.gno
+++ b/stdlibs/stdshim/stdshim.gno
@@ -78,3 +78,7 @@ func DecodeBech32(addr Address) (prefix string, bytes [20]byte, ok bool) {
 func DerivePkgAddr(pkgPath string) (addr Address) {
 	panic(shimWarn)
 }
+
+func ExecAsPkg(fn func()) {
+	panic(shimWarn)
+}

--- a/tests/file.go
+++ b/tests/file.go
@@ -34,7 +34,7 @@ func TestMachine(store gno.Store, stdout io.Writer, pkgPath string) *gno.Machine
 func testMachineCustom(store gno.Store, pkgPath string, stdout io.Writer, maxAlloc int64, send std.Coins) *gno.Machine {
 	// FIXME: create a better package to manage this, with custom constructors
 	pkgAddr := gno.DerivePkgAddr(pkgPath)                      // the addr of the pkgPath called.
-	caller := gno.DerivePkgAddr(pkgPath)                       // NOTE: for the purpose of testing, the caller is generally the "main" package, same as pkgAddr.
+	caller := gno.DerivePkgAddr("caller")                      // NOTE: for the purpose of testing, the caller is generally the "main" package, same as pkgAddr.
 	pkgCoins := std.MustParseCoins("200000000ugnot").Add(send) // >= send.
 	banker := newTestBanker(pkgAddr.Bech32(), pkgCoins)
 	ctx := stdlibs.ExecContext{

--- a/tests/files/zrealm_std6.gno
+++ b/tests/files/zrealm_std6.gno
@@ -6,12 +6,14 @@ import (
 	"std"
 )
 
+func printOrigCaller() {
+	println(std.GetOrigCaller())
+}
+
 func main() {
-	println(std.GetOrigCaller())
-	std.ExecAsPkg(func() {
-		println(std.GetOrigCaller())
-	})
-	println(std.GetOrigCaller())
+	printOrigCaller()
+	std.ExecAsPkg(printOrigCaller)
+	printOrigCaller()
 }
 
 // Output:

--- a/tests/files/zrealm_std6.gno
+++ b/tests/files/zrealm_std6.gno
@@ -1,0 +1,20 @@
+// PKGPATH: gno.land/r/std_test
+package std_test
+
+import (
+	"fmt"
+	"std"
+)
+
+func main() {
+	println(std.GetOrigCaller())
+	std.ExecAsPkg(func() {
+		println(std.GetOrigCaller())
+	})
+	println(std.GetOrigCaller())
+}
+
+// Output:
+// g1fahslvxakc058u0wa98ytfc9fd6trhe5qfh9ld
+// g157y5v3k529jyzhjjz4fn49tzzhf4gess6v39xg
+// g1fahslvxakc058u0wa98ytfc9fd6trhe5qfh9ld


### PR DESCRIPTION
With @tbruyelle we continue @moul 's works on #335 to add an `ExecAsPkg` function.

This solution will be able to solve the issue on #634

# Description

We add a new OpCall for setting the `m *Machine` context, this allow to update the context

# How has this been tested?

see `tests/files/zrealm_std6.gno`