### PR TITLE
chore: bcrypt cost adjustment

### DIFF
--- a/pkgs/crypto/keys/armor/armor.go
+++ b/pkgs/crypto/keys/armor/armor.go
@@ -16,7 +16,7 @@ const (
 	blockTypePrivKey        = "TENDERMINT PRIVATE KEY"
 	blockTypeKeyInfo        = "TENDERMINT KEY INFO"
 	blockTypePubKey         = "TENDERMINT PUBLIC KEY"
-	bcryptSecurityParameter = 12
+	bcryptSecurityParameter = 11
 )
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
In this PR, we reduce the `bcrypt` cost from `12` to `11`.
@zivkovicmilos  expressed concerns that `CreateAccount` was too slow.
It seems like this is safe to do. As far as i understand this refers to local storage.