### PR TITLE
feat!: use os.UserConfigDir() if $GNO_HOME not set

### DIFF
--- a/pkgs/crypto/keys/client/common.go
+++ b/pkgs/crypto/keys/client/common.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type BaseOptions struct {
@@ -24,17 +25,17 @@ func HomeDir() string {
 	// if not, check whether can get os.UserHomeDir()
 	// if not, fall back to home directory
 	var err error
-	hd := os.Getenv("GNO_HOME")
-	if hd != "" {
-		return hd
+	dir := os.Getenv("GNO_HOME")
+	if dir != "" {
+		return dir
 	}
-	hd, err = os.UserConfigDir()
+	dir, err = os.UserConfigDir()
 	if err == nil {
-		return fmt.Sprintf("%s/gno", hd)
+		return fmt.Sprintf("%s/gno", dir)
 	}
-	hd, err = os.UserHomeDir()
+	dir, err = os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
-	return fmt.Sprintf("%s/.gno", hd)
+	return fmt.Sprintf("%s/.gno", dir)
 }

--- a/pkgs/crypto/keys/client/common.go
+++ b/pkgs/crypto/keys/client/common.go
@@ -21,17 +21,18 @@ var DefaultBaseOptions = BaseOptions{
 
 func HomeDir() string {
 	// if environment set, always use that.
-	// if not, check $XDG_CONFIG_HOME
+	// if not, check whether can get os.UserHomeDir()
 	// if not, fall back to home directory
+	var err error
 	hd := os.Getenv("GNO_HOME")
 	if hd != "" {
 		return hd
 	}
-	hd = os.Getenv("XDG_CONFIG_HOME")
-	if hd != "" {
+	hd, err = os.UserConfigDir()
+	if err == nil {
 		return fmt.Sprintf("%s/gno", hd)
 	}
-	hd, err := os.UserHomeDir()
+	hd, err = os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}

--- a/pkgs/crypto/keys/client/common.go
+++ b/pkgs/crypto/keys/client/common.go
@@ -31,7 +31,7 @@ func HomeDir() string {
 	}
 	dir, err = os.UserConfigDir()
 	if err == nil {
-		return filepath.Join(hd, "gno")
+		return filepath.Join(dir, "gno")
 	}
 	dir, err = os.UserHomeDir()
 	if err != nil {

--- a/pkgs/crypto/keys/client/common.go
+++ b/pkgs/crypto/keys/client/common.go
@@ -21,12 +21,16 @@ var DefaultBaseOptions = BaseOptions{
 
 func HomeDir() string {
 	// if environment set, always use that.
+	// if not, check $XDG_CONFIG_HOME
+	// if not, fall back to home directory
 	hd := os.Getenv("GNO_HOME")
 	if hd != "" {
 		return hd
 	}
-
-	// look for dir in home directory.
+	hd = os.Getenv("XDG_CONFIG_HOME")
+	if hd != "" {
+		return fmt.Sprintf("%s/gno", hd)
+	}
 	hd, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Description
In #652 Moul talked about supporting *nix stardard XDG variables.
I'm also a fan of this. 

Propose going for $XDG_CONFIG_HOME.
So the order would become:

1. `$GNO_HOME`
2. `$XDG_CONFIG_HOME/gno` (usually this variable is `$HOME/.config`)
3. `.gno` in the home directory

Fixes #655

# How has this been tested?
I just introduced a panic:
```
if hd != "" {
        panic(fmt.Sprintf("%s/gno", hd))
        return fmt.Sprintf("%s/gno", hd)
    }
```
and it returned `/home/bob/.config/gno`
