### PR TITLE
test(docker): address FIXMEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,5 @@ EXPOSE      8888
 FROM        runtime-tls AS all
 COPY        --from=build /opt/build/build/* /opt/gno/bin/
 COPY        --from=build /opt/gno/src /opt/gno/src
+# gofmt is required by `gnokey maketx addpkg`
+COPY        --from=build /usr/local/go/bin/gofmt /usr/bin

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/term v0.6.0
 	golang.org/x/tools v0.6.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -66,7 +67,6 @@ require (
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/gdamore/tcell/v2 => github.com/gnolang/tcell/v2 v2.1.0

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,10 +10,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gnolang/gno/gnoland"
+	"github.com/gnolang/gno/pkgs/amino"
+	"github.com/gnolang/gno/pkgs/sdk/vm"
+	"github.com/gnolang/gno/pkgs/std"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-const gnolandContainerName = "int_gnoland"
+const (
+	gnolandContainerName = "int_gnoland"
+
+	test1Addr = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+	test1Seed = "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+)
 
 func TestDockerIntegration(t *testing.T) {
 	tmpdir, err := os.MkdirTemp(os.TempDir(), "*-gnoland-integration")
@@ -29,19 +41,42 @@ func TestDockerIntegration(t *testing.T) {
 func runSuite(t *testing.T, tempdir string) {
 	t.Helper()
 
-	cmd := createCommand(t, []string{
-		"docker", "exec", gnolandContainerName,
-		"gnokey", "query", "auth/accounts/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", // test1
-	})
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
-	// FIXME: this will break frequently. we need a reliable test.
-	// require.Contains(t, string(output), "9999976000000ugnot")
-	require.Contains(t, string(output), "ugnot")
-	require.Contains(t, string(output), "999")
+	// add test1 account to docker container keys with "pass" password
+	dockerExec(t, fmt.Sprintf(
+		`echo "pass\npass\n%s\n" | gnokey add -recover -insecure-password-stdin test1`,
+		test1Seed,
+	))
+	// assert test1 account exists
+	var acc gnoland.GnoAccount
+	dockerExec_gnokeyQuery(t, "auth/accounts/"+test1Addr, &acc)
+	require.Equal(t, test1Addr, acc.Address.String(), "test1 account not found")
+	minCoins := std.MustParseCoins("9999900000000ugnot")
+	require.True(t, acc.Coins.IsAllGTE(minCoins),
+		"test1 account coins expected at least %s, got %s", minCoins, acc.Coins)
 
-	// FIXME: add packages.
-	// FIXME: perform TXs.
+	// add gno.land/r/demo/tests package
+	dockerExec(t,
+		`echo 'pass' | gnokey maketx addpkg -insecure-password-stdin \
+			-gas-fee 1000000ugnot -gas-wanted 2000000 \
+			-broadcast -chainid dev \
+			-pkgdir /opt/gno/src/examples/gno.land/r/demo/tests/ \
+			-pkgpath gno.land/r/demo/tests \
+			-deposit 100000000ugnot \
+			test1`,
+	)
+	// assert gno.land/r/demo/tests has been added
+	var qfuncs vm.FunctionSignatures
+	dockerExec_gnokeyQuery(t, `-data "gno.land/r/demo/tests" vm/qfuncs`, &qfuncs)
+	require.True(t, len(qfuncs) > 0, "gno.land/r/demo/tests not added")
+
+	// broadcast a package TX
+	dockerExec(t,
+		`echo 'pass' | gnokey maketx call -insecure-password-stdin \
+			-gas-fee 1000000ugnot -gas-wanted 2000000 \
+			-broadcast -chainid dev \
+			-pkgpath "gno.land/r/demo/tests" -func "InitTestNodes" \
+			test1`,
+	)
 }
 
 func checkDocker(t *testing.T) {
@@ -62,6 +97,36 @@ func buildDockerImage(t *testing.T) {
 	require.NoError(t, err, string(output))
 	// FIXME: is this check reliable?
 	require.Contains(t, string(output), "Successfully built")
+}
+
+// dockerExec runs docker exec with cmd as argument
+func dockerExec(t *testing.T, cmd string) []byte {
+	cmds := append(
+		[]string{"docker", "exec", gnolandContainerName, "sh", "-c"},
+		cmd,
+	)
+	bz, err := createCommand(t, cmds).CombinedOutput()
+	require.NoError(t, err, string(bz))
+	return bz
+}
+
+// dockerExec_gnokeyQuery runs dockerExec with gnokey query prefix and parses
+// the command output to out.
+func dockerExec_gnokeyQuery(t *testing.T, cmd string, out any) {
+	output := dockerExec(t, "gnokey query "+cmd)
+	// parses the output of gnokey query:
+	// height: h
+	// data: { JSON }
+	var resp struct {
+		Height int64 `yaml:"height"`
+		Data   any   `yaml:"data"`
+	}
+	err := yaml.Unmarshal(output, &resp)
+	require.NoError(t, err)
+	bz, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	err = amino.UnmarshalJSON(bz, out)
+	require.NoError(t, err)
 }
 
 func createCommand(t *testing.T, args []string) *exec.Cmd {

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -100,6 +100,8 @@ func buildDockerImage(t *testing.T) {
 
 // dockerExec runs docker exec with cmd as argument
 func dockerExec(t *testing.T, cmd string) []byte {
+	t.Helper()
+
 	cmds := append(
 		[]string{"docker", "exec", gnolandContainerName, "sh", "-c"},
 		cmd,
@@ -112,6 +114,8 @@ func dockerExec(t *testing.T, cmd string) []byte {
 // dockerExec_gnokeyQuery runs dockerExec with gnokey query prefix and parses
 // the command output to out.
 func dockerExec_gnokeyQuery(t *testing.T, cmd string, out any) {
+	t.Helper()
+
 	output := dockerExec(t, "gnokey query "+cmd)
 	// parses the output of gnokey query:
 	// height: h

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -155,10 +155,18 @@ func startGnoland(t *testing.T) {
 
 func waitGnoland(t *testing.T) {
 	t.Helper()
-
 	t.Log("waiting...")
-	// FIXME: tail logs and wait for blockchain to be ready.
-	time.Sleep(20000 * time.Millisecond)
+	for {
+		output, _ := createCommand(t,
+			[]string{"docker", "logs", gnolandContainerName},
+		).CombinedOutput()
+		if strings.Contains(string(output), "Committed state") {
+			// ok blockchain is ready
+			t.Log("gnoland ready")
+			break
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func cleanupGnoland(t *testing.T) {

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -96,8 +96,6 @@ func buildDockerImage(t *testing.T) {
 	})
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
-	// FIXME: is this check reliable?
-	require.Contains(t, string(output), "Successfully built")
 }
 
 // dockerExec runs docker exec with cmd as argument
@@ -172,12 +170,5 @@ func waitGnoland(t *testing.T) {
 
 func cleanupGnoland(t *testing.T) {
 	t.Helper()
-
-	// FIXME: detect if container exists before killing it.
-
-	cmd := createCommand(t, []string{"docker", "kill", gnolandContainerName})
-	_, _ = cmd.Output()
-
-	cmd = createCommand(t, []string{"docker", "rm", "-f", gnolandContainerName})
-	_, _ = cmd.Output()
+	createCommand(t, []string{"docker", "rm", "-f", gnolandContainerName}).Run()
 }

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -81,7 +81,8 @@ func runSuite(t *testing.T, tempdir string) {
 
 func checkDocker(t *testing.T) {
 	t.Helper()
-	// FIXME: check if `docker` is installed and compatible.
+	output, err := createCommand(t, []string{"docker", "info"}).CombinedOutput()
+	require.NoError(t, err, "docker daemon not running: %s", string(output))
 }
 
 func buildDockerImage(t *testing.T) {

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gnolang/gno/gnoland"
-	"github.com/gnolang/gno/pkgs/amino"
-	"github.com/gnolang/gno/pkgs/sdk/vm"
-	"github.com/gnolang/gno/pkgs/std"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/sdk/vm"
+	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -146,6 +146,7 @@ func startGnoland(t *testing.T) {
 		"docker", "run",
 		"-d",
 		"--name", gnolandContainerName,
+		"-w", "/opt/gno/src/gno.land",
 		"gno:integration",
 		"gnoland",
 	})


### PR DESCRIPTION
This change is originated by #495, in order to add an integration test that broadcast TXs.

The following cases have been added to docker integration tests:
- improve auth/account assertions
- add a package
- broadcast a TX

Note that to broadcast a tx I had to add the `test1` account key in the running container, thanks to the seed.

Also address others FIXMEs:
- `waitGnoland()`: improve by looking at the logs instead of waiting 20s
- `checkDocker()`: implement  by looking at `docker info` output
- `buildDockerImage()`: remove output check, assuming that if `docker build` fails, the command will return an error
- `cleanupGnoland()`: use only `docker rm -f` because it also kills the container if it's running.