### PR TITLE
fix: add missing `consensus_params` RPC call to HTTP clients

### DIFF
--- a/pkgs/bft/rpc/client/httpclient.go
+++ b/pkgs/bft/rpc/client/httpclient.go
@@ -67,7 +67,7 @@ var (
 	_ rpcClient = (*baseRPCClient)(nil)
 )
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // HTTP
 
 // NewHTTP takes a remote endpoint in the form <protocol>://<host>:<port> and
@@ -106,7 +106,7 @@ func (c *HTTP) NewBatch() *BatchHTTP {
 	}
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // BatchHTTP
 
 // Send is a convenience function for an HTTP batch that will trigger the
@@ -128,7 +128,7 @@ func (b *BatchHTTP) Count() int {
 	return b.rpcBatch.Count()
 }
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // baseRPCClient
 
 func (c *baseRPCClient) Status() (*ctypes.ResultStatus, error) {
@@ -232,6 +232,22 @@ func (c *baseRPCClient) ConsensusState() (*ctypes.ResultConsensusState, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "ConsensusState")
 	}
+	return result, nil
+}
+
+func (c *baseRPCClient) ConsensusParams(height *int64) (*ctypes.ResultConsensusParams, error) {
+	result := new(ctypes.ResultConsensusParams)
+
+	if _, err := c.caller.Call(
+		"consensus_params",
+		map[string]interface{}{
+			"height": height,
+		},
+		result,
+	); err != nil {
+		return nil, errors.Wrap(err, "ConsensusParams")
+	}
+
 	return result, nil
 }
 

--- a/pkgs/bft/rpc/client/interface.go
+++ b/pkgs/bft/rpc/client/interface.go
@@ -85,6 +85,7 @@ type NetworkClient interface {
 	NetInfo() (*ctypes.ResultNetInfo, error)
 	DumpConsensusState() (*ctypes.ResultDumpConsensusState, error)
 	ConsensusState() (*ctypes.ResultConsensusState, error)
+	ConsensusParams(height *int64) (*ctypes.ResultConsensusParams, error)
 	Health() (*ctypes.ResultHealth, error)
 }
 

--- a/pkgs/bft/rpc/client/localclient.go
+++ b/pkgs/bft/rpc/client/localclient.go
@@ -97,6 +97,10 @@ func (c *Local) ConsensusState() (*ctypes.ResultConsensusState, error) {
 	return core.ConsensusState(c.ctx)
 }
 
+func (c *Local) ConsensusParams(height *int64) (*ctypes.ResultConsensusParams, error) {
+	return core.ConsensusParams(c.ctx, height)
+}
+
 func (c *Local) Health() (*ctypes.ResultHealth, error) {
 	return core.Health(c.ctx)
 }

--- a/pkgs/bft/rpc/client/mock/client.go
+++ b/pkgs/bft/rpc/client/mock/client.go
@@ -111,6 +111,10 @@ func (c Client) ConsensusState() (*ctypes.ResultConsensusState, error) {
 	return core.ConsensusState(&rpctypes.Context{})
 }
 
+func (c Client) ConsensusParams(height *int64) (*ctypes.ResultConsensusParams, error) {
+	return core.ConsensusParams(&rpctypes.Context{}, height)
+}
+
 func (c Client) DumpConsensusState() (*ctypes.ResultDumpConsensusState, error) {
 	return core.DumpConsensusState(&rpctypes.Context{})
 }


### PR DESCRIPTION
# Description

This PR adds a missing `consensus_params` RPC call to existing HTTP clients.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist (for contributors)

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

# Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

## Manual tests

Manually verified the client can return `ConsensusParams` for a given height.
