### PR TITLE
feat: `gno test` support external pkgs

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -157,9 +157,12 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 		return flag.ErrHelp
 	}
 
-	// guess opts.RootDir
+	// Guess GNOROOT, if [rootDir] not set
 	if cfg.rootDir == "" {
 		cfg.rootDir = gnoenv.RootDir()
+		if cfg.rootDir == "" {
+			return errors.New("GNOROOT not set")
+		}
 	}
 
 	paths, err := targetsFromPatterns(args)


### PR DESCRIPTION
Also look for pkg/realm in `GNOHOME` (pkgs fetched from chain via `mod download`)

Now developers can run `gno mod download` before `gno test` to support packages that are not part of `/examples` directory
