### PR TITLE
fix: revert #670 (bcrypt cost) to fix #680

### DIFF
--- a/pkgs/crypto/keys/armor/armor.go
+++ b/pkgs/crypto/keys/armor/armor.go
@@ -16,7 +16,7 @@ const (
 	blockTypePrivKey        = "TENDERMINT PRIVATE KEY"
 	blockTypeKeyInfo        = "TENDERMINT KEY INFO"
 	blockTypePubKey         = "TENDERMINT PUBLIC KEY"
-	bcryptSecurityParameter = 11
+	bcryptSecurityParameter = 12
 )
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
This reverts e0c50ece928e (#670), fixing #680.
It breaks decoding of existing accounts.
For instance if you addpkg, it gives:

Enter password.
ciphertext decryption failed

Changing bcryptSecurityParameter = 12 (from 11) makes it work again.

Better change until we find a better solution.

