### PR TITLE
Revert "chore: bcrypt cost adjustment (#670)"

### DIFF
--- a/pkgs/crypto/keys/armor/armor.go
+++ b/pkgs/crypto/keys/armor/armor.go
@@ -16,7 +16,7 @@ const (
 	blockTypePrivKey        = "TENDERMINT PRIVATE KEY"
 	blockTypeKeyInfo        = "TENDERMINT KEY INFO"
 	blockTypePubKey         = "TENDERMINT PUBLIC KEY"
-	bcryptSecurityParameter = 11
+	bcryptSecurityParameter = 12
 )
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
This reverts commit e0c50ece928e965ffb0d7fad6e7f06fef165d230.
