### PR TITLE
refactor(gnovm): consistent map type evaluation for *IndexExpr

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -1538,13 +1538,8 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 							lhs0 := n.Lhs[0].(*NameExpr).Name
 							lhs1 := n.Lhs[1].(*NameExpr).Name
 
-							var mt *MapType
-							st := evalStaticTypeOf(store, last, cx.X)
-							if dt, ok := st.(*DeclaredType); ok {
-								mt = dt.Base.(*MapType)
-							} else if mt, ok = st.(*MapType); !ok {
-								panic("should not happen")
-							}
+							dt := evalStaticTypeOf(store, last, cx.X)
+							mt := baseOf(dt).(*MapType)
 							// re-definitions
 							last.Define(lhs0, anyValue(mt.Value))
 							last.Define(lhs1, anyValue(BoolType))


### PR DESCRIPTION
# Description

The previous fix works. However, we should use the existing baseOf() function for a consistent implementation when we retrieve the base type of a declared type

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->


# How has this been tested?
Same test for the previous fix
tests/files/map28c.gno


