### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,35 +1,32 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-
 # Primary repo maintainers.
-*                            @gnolang/core-tech
+*                            @gnolang/tech-staff
 
 
 # Tendermint2 (Gno version).
-pkgs/*                       @gnolang/core-tech
+tm2/*                        @gnolang/tech-staff
 
 
 # Docs & Content.
-docs/                        @gnolang/core-tech
-*.md                         @gnolang/core-tech
+docs/                        @gnolang/tech-staff
+*.md                         @gnolang/tech-staff
 # TODO: add non-tech people here.
 
 
 # Gno examples and default contracts.
-examples/*                   @gnolang/core-tech
+examples/*                   @gnolang/tech-staff
 # TODO: add people from the community here.
 
 
-# Gnoland, Gno.land.
-examples/gno.land/system/*   @gnolang/core-tech
-examples/gno.land/gnoland/*  @gnolang/core-tech
-gnoland/*                    @gnolang/core-tech
-cmd/gnoland/*                @gnolang/core-tech
+# Gno.land.
+gno.land/*                   @gnolang/tech-staff
+cmd/gnoland/*                @gnolang/tech-staff
 
 
 # GnoVM/Gnolang.
-pkgs/gnolang/*               @gnolang/core-tech
-stdlibs/*                    @gnolang/core-tech
+gnovm/*                      @gnolang/tech-staff
+stdlibs/*                    @gnolang/tech-staff
 
 
 # Special files.
@@ -37,3 +34,4 @@ PLAN.md                      @jaekwon @moul
 PHILOSOPHY.md                @jaekwon @moul
 CONTRIBUTING.md              @jaekwon @moul
 LICENSE.md                   @jaekwon @moul
+.github/CODEOWNERS           @jaekwon @moul

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,12 +21,10 @@ examples/*                   @gnolang/tech-staff
 
 # Gno.land.
 gno.land/*                   @gnolang/tech-staff
-cmd/gnoland/*                @gnolang/tech-staff
 
 
 # GnoVM/Gnolang.
 gnovm/*                      @gnolang/tech-staff
-stdlibs/*                    @gnolang/tech-staff
 
 
 # Special files.


### PR DESCRIPTION
core-tech team has changed name - changing the team name and updating the paths.