### PR TITLE
chore: remove misc/ directory from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-misc/
 *.sw[pon]
 cmd/foo.go
 unsorted.*


### PR DESCRIPTION
It's not ignored anyway...

(If somebody had files they want to keep hidden in misc/, there's `~/.git/info/exclude` which has the same syntax as gitignore)