### PR TITLE
chore: remove `std.TestDerivePkgAddr`

### DIFF
--- a/examples/gno.land/r/demo/banktest/z_0_filetest.gno
+++ b/examples/gno.land/r/demo/banktest/z_0_filetest.gno
@@ -10,10 +10,10 @@ import (
 )
 
 func main() {
-	banktestAddr := std.TestDerivePkgAddr("gno.land/r/banktest")
+	banktestAddr := std.DerivePkgAddr("gno.land/r/banktest")
 
 	// print main balance before.
-	mainaddr := std.TestDerivePkgAddr("main")
+	mainaddr := std.DerivePkgAddr("main")
 	std.TestSetOrigCaller(mainaddr)
 
 	banker := std.GetBanker(std.BankerTypeReadonly)

--- a/examples/gno.land/r/demo/banktest/z_1_filetest.gno
+++ b/examples/gno.land/r/demo/banktest/z_1_filetest.gno
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	banktestAddr := std.TestDerivePkgAddr("gno.land/r/banktest")
+	banktestAddr := std.DerivePkgAddr("gno.land/r/banktest")
 
 	// simulate a Deposit call.
 	std.TestSetOrigPkgAddr(banktestAddr)

--- a/examples/gno.land/r/demo/banktest/z_2_filetest.gno
+++ b/examples/gno.land/r/demo/banktest/z_2_filetest.gno
@@ -7,11 +7,12 @@ import (
 )
 
 func main() {
-	banktestAddr := std.TestDerivePkgAddr("gno.land/r/demo/banktest")
+	banktestAddr := std.DerivePkgAddr("gno.land/r/demo/banktest")
 
 	// print main balance before.
-	mainaddr := std.TestDerivePkgAddr("main")
+	mainaddr := std.DerivePkgAddr("main")
 	std.TestSetOrigCaller(mainaddr)
+
 	banker := std.GetBanker(std.BankerTypeReadonly)
 	mainbal := banker.GetCoins(mainaddr)
 	println("main before:", mainbal) // plus OrigSend equals 300.

--- a/examples/gno.land/r/gnoland/faucet/faucet_test.gno
+++ b/examples/gno.land/r/gnoland/faucet/faucet_test.gno
@@ -12,7 +12,7 @@ import (
 func TestPackage(t *testing.T) {
 	var (
 		adminaddr        = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
-		faucetaddr       = std.TestDerivePkgAddr("gno.land/r/faucet")
+		faucetaddr       = std.DerivePkgAddr("gno.land/r/faucet")
 		controlleraddr1  = testutils.TestAddress("controller1")
 		controlleraddr2  = testutils.TestAddress("controller2")
 		controlleraddr3  = testutils.TestAddress("controller3")

--- a/gnovm/tests/imports.go
+++ b/gnovm/tests/imports.go
@@ -636,27 +636,6 @@ func testPackageInjector(store gno.Store, pn *gno.PackageNode) {
 				m.Context = ctx
 			},
 		)
-		pn.DefineNative("TestDerivePkgAddr",
-			gno.Flds( // params
-				"pkgPath", "string",
-			),
-			gno.Flds( // results
-				"addr", "Address",
-			),
-			func(m *gno.Machine) {
-				arg0 := m.LastBlock().GetParams1().TV
-				pkgPath := arg0.GetString()
-				pkgAddr := gno.DerivePkgAddr(pkgPath).Bech32()
-				res0 := gno.Go2GnoValue(
-					m.Alloc,
-					m.Store,
-					reflect.ValueOf(pkgAddr),
-				)
-				addrT := store.GetType(gno.DeclaredTypeID("std", "Address"))
-				res0.T = addrT
-				m.PushValue(res0)
-			},
-		)
 		// TODO: move elsewhere.
 		pn.DefineNative("ClearStoreCache",
 			gno.Flds( // params


### PR DESCRIPTION
This function declared in the test native functions, can be superseded by `std.DerivePkdAddr`, which has been added afterward. The 2 functions share exactly the same code.