### PR TITLE
fix(gnolang): duplicate field name in struct literal

### DIFF
--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -624,6 +624,7 @@ func (m *Machine) doOpStructLit() {
 	} else {
 		// field values are by name and may be out of order.
 		fs = defaultStructFields(m.Alloc, st)
+		fsset := make([]bool, len(fs))
 		ftvs := m.PopValues(el)
 		for i := 0; i < el; i++ {
 			fnx := x.Elts[i].Key.(*NameExpr)
@@ -636,6 +637,11 @@ func (m *Machine) doOpStructLit() {
 					panic("should not happen")
 				}
 			}
+			if fsset[fnx.Path.Index] {
+				// already set
+				panic(fmt.Sprintf("duplicate field name %s in struct literal", fnx.Name))
+			}
+			fsset[fnx.Path.Index] = true
 			fs[fnx.Path.Index] = ftv
 		}
 	}

--- a/gnovm/tests/files/struct2b.gno
+++ b/gnovm/tests/files/struct2b.gno
@@ -1,0 +1,14 @@
+package main
+
+type T struct {
+	f int
+	g int
+	h int
+}
+
+func main() {
+	_ = T{f: 1, g: 2, h: 3, f: 4, h: 5}
+}
+
+// Error:
+// duplicate field name f in struct literal


### PR DESCRIPTION
Fix #629

# Description

The following code returns an error in go, but not in gno:
```go
type s struct {
  f int
}
s{f:1, f:2}
```
The change detects a field has already been set in a struct literal and panics.

Note that unlike go code, the parsing stops at the first duplicate field met, whereas in go all the duplicate fields are mentionned in the error.

See go playground link: https://go.dev/play/p/byJwYsIETBU

# How has this been tested?

A new testfile has been added.
```
go test ./gnovm//tests/ -v -run 'Files/struct2b'
```
