### PR TITLE
fix(tm2): rpc unhandled panic

### DIFF
--- a/tm2/pkg/bft/rpc/lib/server/http_server.go
+++ b/tm2/pkg/bft/rpc/lib/server/http_server.go
@@ -153,7 +153,6 @@ func RecoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 			// at least to my localhost.
 			if e := recover(); e != nil {
 				switch e := e.(type) {
-
 				case types.RPCResponse:
 					WriteRPCResponseHTTP(rww, e)
 


### PR DESCRIPTION
# Description

When panic is called with a string argument, that triggers an other panic in the recover handler, because it tries to convert the argument to [an error type][1]. Fortunately this second panic is catched by the recover of the stdlib in [net/http/server.go][0], so the node doesn't halt.

# How has this been tested?

To trigger the problem, you can run the following command:

```sh
$ gnokey query -data xxx vm/qrender
Post "http://127.0.0.1:26657": EOF
```

Because the handler behind `vm/qrender` expects to have some data in a particular format and it's not, it [panics with a string][2].

[0]: https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/net/http/server.go;l=1851
[1]: https://github.com/gnolang/gno/blob/0eb5ff762eeb7e6b98d1f8afdb1214566352cabf/tm2/pkg/bft/rpc/lib/server/http_server.go#L164
[2]: https://github.com/gnolang/gno/blob/0eb5ff762eeb7e6b98d1f8afdb1214566352cabf/tm2/pkg/sdk/vm/handler.go#L131-L134
