### PR TITLE
feat: add std.CreatePackage

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -108,6 +109,13 @@ const (
 )
 
 type Name string
+
+// Returns if the name is an exported identifier,
+// according to the golang's canonical exported name rule,
+// namely, starting with a capitalized alphabet.
+func (name Name) IsExportedName() bool {
+	return unicode.IsUpper([]rune(name)[0])
+}
 
 // ----------------------------------------
 // Location

--- a/gnovm/tests/call_test.go
+++ b/gnovm/tests/call_test.go
@@ -1,0 +1,15 @@
+package	tests
+
+import (
+	"testing"
+	"bytes"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+)
+
+func TestCreatePackage(t *testing.T) {
+	stdin := new(bytes.Buffer)
+	stdout := os.Stdout
+	stderr := new(bytes.Buffer)
+	store := TestStore("..", "", stdin)
+}

--- a/tm2/pkg/std/memfile.go
+++ b/tm2/pkg/std/memfile.go
@@ -21,6 +21,10 @@ type MemPackage struct {
 	Files []*MemFile
 }
 
+func (mempkg *MemPackage) RenamePath(newPath string) {
+	mempkg.Path = newPath
+} 
+
 func (mempkg *MemPackage) GetFile(name string) *MemFile {
 	for _, memFile := range mempkg.Files {
 		if memFile.Name == name {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Dynamically create a package from an existing package code, similar to Solidity `new` keyword.

Design decisions:
- Add `std.CreatePackage` native binding. The `CreatePackage` takes three arguments, the template package path(gno code to duplicate from), the new path for the package, and the initial arguments for `init()` function for the package. 
- Use `Store.GetMemPackage()` to retrieve an existing package code. Unlike `Store.GetPackage()`, this methods returns the raw strings(without the realm state) for a package code, the same type that user provides when creating a package. 
- After the package is deployed, iterate through the result `PackageNode.FileSet.Files[i].Decls[j].(*FuncDecl).NameExpr.Name`. Filter all exported(first letter capitalized non-method) functions.
- Create a gnolang struct with methods that internally calls `std.CallPackage`(temporary name) targeting for corresponding exported functions. It will spin off new `machine`, load realm, and execute the function with the provided arguments. Will be implemented in a separated PR.
- `std.CreatePackage` will return this dynamically created gnolang interface, `PackageInterface`, in a form of `interface{}`. 
- The user(contract invoked `std.CreatePackage`) will type assert the interface with appropriate GRC interface. The type assertion logic will automatically check if the new package satisfies the interface(and panic if not).
- The package struct could be stored in a variable or a mapping to be invoked later.

User ergonomic example:
```go
package tokenfactory

import (
  "gno.land/r/std/grc20"
)

var tokens map[string]grc20.Interface

func init() {
  tokens = make(map[string]grc20.Interface)
}

func DeployTokenContract(tokenName, tokenSymbol string, maxSupply bigint) string {
  tokenContract := std.CreatePackage("std/grc20", tokenName, maxSupply).(grc20.Interface)
  tokens[tokenName] = tokenContract
  return tokenContract.PackageName()
}

func SendToken(tokenName string, from, to string, amount bigint) {
  tokenContract := tokens[tokenName]
  tokenContract.Send(from, to, amount)
  // Internally calls std.CallPackage("tokenfactory/{tokenName}/grc20", "Send", from, to, amount)
}
```

The same UX can be used for dynamically importing a package - `std.ImportPackage()` can return a `PackageInterface` that maps function call to exported functions in the package. For statically importing a package, typical golang style top level import is more secure. ref: https://github.com/gnolang/gno/pull/566

# How has this been tested?

Please complete this section if you ran tests for this functionality, otherwise delete it
