### PR TITLE
refactor(tm2/pkg/db): DB interface uses errors.

### DIFF
--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -213,7 +213,10 @@ func (ds *defaultStore) SetCachePackage(pv *PackageValue) {
 func (ds *defaultStore) GetPackageRealm(pkgPath string) (rlm *Realm) {
 	oid := ObjectIDFromPkgPath(pkgPath)
 	key := backendRealmKey(oid)
-	bz := ds.baseStore.Get([]byte(key))
+	bz, err := ds.baseStore.Get([]byte(key))
+	if err != nil {
+		panic(err)
+	}
 	if bz == nil {
 		return nil
 	}
@@ -271,7 +274,10 @@ func (ds *defaultStore) GetObjectSafe(oid ObjectID) Object {
 // CONTRACT: object isn't already in the cache.
 func (ds *defaultStore) loadObjectSafe(oid ObjectID) Object {
 	key := backendObjectKey(oid)
-	hashbz := ds.baseStore.Get([]byte(key))
+	hashbz, err := ds.baseStore.Get([]byte(key))
+	if err != nil {
+		panic(err)
+	}
 	if hashbz != nil {
 		hash := hashbz[:HashSize]
 		bz := hashbz[HashSize:]
@@ -384,7 +390,10 @@ func (ds *defaultStore) GetTypeSafe(tid TypeID) Type {
 	// check backend.
 	if ds.baseStore != nil {
 		key := backendTypeKey(tid)
-		bz := ds.baseStore.Get([]byte(key))
+		bz, err := ds.baseStore.Get([]byte(key))
+		if err != nil {
+			panic(err)
+		}
 		if bz != nil {
 			var tt Type
 			amino.MustUnmarshal(bz, &tt)
@@ -455,7 +464,10 @@ func (ds *defaultStore) GetBlockNodeSafe(loc Location) BlockNode {
 	// check backend.
 	if ds.baseStore != nil {
 		key := backendNodeKey(loc)
-		bz := ds.baseStore.Get([]byte(key))
+		bz, err := ds.baseStore.Get([]byte(key))
+		if err != nil {
+			panic(err)
+		}
 		if bz != nil {
 			var bn BlockNode
 			amino.MustUnmarshal(bz, &bn)
@@ -491,7 +503,10 @@ func (ds *defaultStore) SetBlockNode(bn BlockNode) {
 
 func (ds *defaultStore) NumMemPackages() int64 {
 	ctrkey := []byte(backendPackageIndexCtrKey())
-	ctrbz := ds.baseStore.Get(ctrkey)
+	ctrbz, err := ds.baseStore.Get(ctrkey)
+	if err != nil {
+		panic(err)
+	}
 	if ctrbz == nil {
 		return 0
 	} else {
@@ -505,7 +520,10 @@ func (ds *defaultStore) NumMemPackages() int64 {
 
 func (ds *defaultStore) incGetPackageIndexCounter() uint64 {
 	ctrkey := []byte(backendPackageIndexCtrKey())
-	ctrbz := ds.baseStore.Get(ctrkey)
+	ctrbz, err := ds.baseStore.Get(ctrkey)
+	if err != nil {
+		panic(err)
+	}
 	if ctrbz == nil {
 		nextbz := strconv.Itoa(1)
 		ds.baseStore.Set(ctrkey, []byte(nextbz))
@@ -533,7 +551,10 @@ func (ds *defaultStore) AddMemPackage(memPkg *std.MemPackage) {
 
 func (ds *defaultStore) GetMemPackage(path string) *std.MemPackage {
 	pathkey := []byte(backendPackagePathKey(path))
-	bz := ds.iavlStore.Get(pathkey)
+	bz, err := ds.iavlStore.Get(pathkey)
+	if err != nil {
+		panic(err)
+	}
 	if bz == nil {
 		panic(fmt.Sprintf(
 			"missing package at path %s", string(pathkey)))
@@ -551,7 +572,10 @@ func (ds *defaultStore) GetMemFile(path string, name string) *std.MemFile {
 
 func (ds *defaultStore) IterMemPackage() <-chan *std.MemPackage {
 	ctrkey := []byte(backendPackageIndexCtrKey())
-	ctrbz := ds.baseStore.Get(ctrkey)
+	ctrbz, err := ds.baseStore.Get(ctrkey)
+	if err != nil {
+		panic(err)
+	}
 	if ctrbz == nil {
 		return nil
 	} else {
@@ -563,7 +587,10 @@ func (ds *defaultStore) IterMemPackage() <-chan *std.MemPackage {
 		go func() {
 			for i := uint64(1); i <= uint64(ctr); i++ {
 				idxkey := []byte(backendPackageIndexKey(i))
-				path := ds.baseStore.Get(idxkey)
+				path, err := ds.baseStore.Get(idxkey)
+				if err != nil {
+					panic(err)
+				}
 				if path == nil {
 					panic(fmt.Sprintf(
 						"missing package index %d", i))

--- a/tm2/pkg/bft/abci/example/kvstore/kvstore.go
+++ b/tm2/pkg/bft/abci/example/kvstore/kvstore.go
@@ -25,7 +25,11 @@ type State struct {
 }
 
 func loadState(db dbm.DB) State {
-	stateBytes := db.Get(stateKey)
+	stateBytes, err := db.Get(stateKey)
+	if err != nil {
+		panic(err)
+	}
+
 	var state State
 	if len(stateBytes) != 0 {
 		err := json.Unmarshal(stateBytes, &state)
@@ -112,7 +116,10 @@ func (app *KVStoreApplication) Commit() (res abci.ResponseCommit) {
 // Returns an associated value or nil if missing.
 func (app *KVStoreApplication) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
 	if reqQuery.Prove {
-		value := app.state.db.Get(prefixKey(reqQuery.Data))
+		value, err := app.state.db.Get(prefixKey(reqQuery.Data))
+		if err != nil {
+			panic(err)
+		}
 		// resQuery.Index = -1 // TODO make Proof return index
 		resQuery.Key = reqQuery.Data
 		resQuery.Value = value
@@ -124,7 +131,11 @@ func (app *KVStoreApplication) Query(reqQuery abci.RequestQuery) (resQuery abci.
 		return
 	} else {
 		resQuery.Key = reqQuery.Data
-		value := app.state.db.Get(prefixKey(reqQuery.Data))
+		value, err := app.state.db.Get(prefixKey(reqQuery.Data))
+		if err != nil {
+			panic(err)
+		}
+
 		resQuery.Value = value
 		if value != nil {
 			resQuery.Log = "exists"
@@ -136,6 +147,5 @@ func (app *KVStoreApplication) Query(reqQuery abci.RequestQuery) (resQuery abci.
 }
 
 func (app *KVStoreApplication) Close() error {
-	app.state.db.Close()
-	return nil
+	return app.state.db.Close()
 }

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -916,12 +916,15 @@ func LoadStateFromDBOrGenesisDocProvider(stateDB dbm.DB, genesisDocProvider Gene
 
 // panics if failed to unmarshal bytes
 func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
-	b := db.Get(genesisDocKey)
+	b, err := db.Get(genesisDocKey)
+	if err != nil {
+		return nil, fmt.Errorf("error getting genesis doc: %w", err)
+	}
 	if len(b) == 0 {
 		return nil, errors.New("Genesis doc not found")
 	}
 	var genDoc *types.GenesisDoc
-	err := amino.UnmarshalJSON(b, &genDoc)
+	err = amino.UnmarshalJSON(b, &genDoc)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load genesis doc due to unmarshaling error: %v (bytes: %X)", err, b))
 	}

--- a/tm2/pkg/bft/state/store.go
+++ b/tm2/pkg/bft/state/store.go
@@ -73,12 +73,16 @@ func LoadState(db dbm.DB) State {
 }
 
 func loadState(db dbm.DB, key []byte) (state State) {
-	buf := db.Get(key)
+	buf, err := db.Get(key)
+	if err != nil {
+		osm.Exit(fmt.Sprintf(`LoadState: Key %q cannot be obtained: %v\n`, string(key), err))
+	}
+
 	if len(buf) == 0 {
 		return state
 	}
 
-	err := amino.Unmarshal(buf, &state)
+	err = amino.Unmarshal(buf, &state)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		osm.Exit(fmt.Sprintf(`LoadState: Data has been corrupted or its spec has changed:
@@ -148,13 +152,17 @@ func (arz *ABCIResponses) ResultsHash() []byte {
 // This is useful for recovering from crashes where we called app.Commit and before we called
 // s.Save(). It can also be used to produce Merkle proofs of the result of txs.
 func LoadABCIResponses(db dbm.DB, height int64) (*ABCIResponses, error) {
-	buf := db.Get(calcABCIResponsesKey(height))
+	buf, err := db.Get(calcABCIResponsesKey(height))
+	if err != nil {
+		osm.Exit(fmt.Sprintf(`LoadABCIResponses: Key %q cannot be obtained: %v\n`, string(calcABCIResponsesKey(height)), err))
+	}
+
 	if buf == nil {
 		return nil, NoABCIResponsesForHeightError{height}
 	}
 
 	abciResponses := new(ABCIResponses)
-	err := amino.Unmarshal(buf, abciResponses)
+	err = amino.Unmarshal(buf, abciResponses)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		osm.Exit(fmt.Sprintf(`LoadABCIResponses: Data has been corrupted or its spec has
@@ -226,13 +234,16 @@ func lastStoredHeightFor(height, lastHeightChanged int64) int64 {
 
 // CONTRACT: Returned ValidatorsInfo can be mutated.
 func loadValidatorsInfo(db dbm.DB, height int64) *ValidatorsInfo {
-	buf := db.Get(calcValidatorsKey(height))
+	buf, err := db.Get(calcValidatorsKey(height))
+	if err != nil {
+		osm.Exit(fmt.Sprintf(`LoadValidators: Key %q cannot be obtained: %v\n`, string(calcValidatorsKey(height)), err))
+	}
 	if len(buf) == 0 {
 		return nil
 	}
 
 	v := new(ValidatorsInfo)
-	err := amino.Unmarshal(buf, v)
+	err = amino.Unmarshal(buf, v)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		osm.Exit(fmt.Sprintf(`LoadValidators: Data has been corrupted or its spec has changed:
@@ -303,13 +314,16 @@ func LoadConsensusParams(db dbm.DB, height int64) (abci.ConsensusParams, error) 
 }
 
 func loadConsensusParamsInfo(db dbm.DB, height int64) *ConsensusParamsInfo {
-	buf := db.Get(calcConsensusParamsKey(height))
+	buf, err := db.Get(calcConsensusParamsKey(height))
+	if err != nil {
+		osm.Exit(fmt.Sprintf(`LoadConsensusParams: Key %q cannot be obtained: %v\n`, string(calcConsensusParamsKey(height)), err))
+	}
 	if len(buf) == 0 {
 		return nil
 	}
 
 	paramsInfo := new(ConsensusParamsInfo)
-	err := amino.Unmarshal(buf, paramsInfo)
+	err = amino.Unmarshal(buf, paramsInfo)
 	if err != nil {
 		// DATA HAS BEEN CORRUPTED OR THE SPEC HAS CHANGED
 		osm.Exit(fmt.Sprintf(`LoadConsensusParams: Data has been corrupted or its spec has changed:

--- a/tm2/pkg/bft/state/store.go
+++ b/tm2/pkg/bft/state/store.go
@@ -75,7 +75,7 @@ func LoadState(db dbm.DB) State {
 func loadState(db dbm.DB, key []byte) (state State) {
 	buf, err := db.Get(key)
 	if err != nil {
-		osm.Exit(fmt.Sprintf(`LoadState: Key %q cannot be obtained: %v\n`, string(key), err))
+		panic(fmt.Sprintf(`LoadState: Key %q cannot be obtained: %v\n`, string(key), err))
 	}
 
 	if len(buf) == 0 {
@@ -154,7 +154,7 @@ func (arz *ABCIResponses) ResultsHash() []byte {
 func LoadABCIResponses(db dbm.DB, height int64) (*ABCIResponses, error) {
 	buf, err := db.Get(calcABCIResponsesKey(height))
 	if err != nil {
-		osm.Exit(fmt.Sprintf(`LoadABCIResponses: Key %q cannot be obtained: %v\n`, string(calcABCIResponsesKey(height)), err))
+		panic(fmt.Sprintf(`LoadABCIResponses: Key %q cannot be obtained: %v\n`, string(calcABCIResponsesKey(height)), err))
 	}
 
 	if buf == nil {
@@ -236,7 +236,7 @@ func lastStoredHeightFor(height, lastHeightChanged int64) int64 {
 func loadValidatorsInfo(db dbm.DB, height int64) *ValidatorsInfo {
 	buf, err := db.Get(calcValidatorsKey(height))
 	if err != nil {
-		osm.Exit(fmt.Sprintf(`LoadValidators: Key %q cannot be obtained: %v\n`, string(calcValidatorsKey(height)), err))
+		panic(fmt.Sprintf(`LoadValidators: Key %q cannot be obtained: %v\n`, string(calcValidatorsKey(height)), err))
 	}
 	if len(buf) == 0 {
 		return nil
@@ -316,7 +316,7 @@ func LoadConsensusParams(db dbm.DB, height int64) (abci.ConsensusParams, error) 
 func loadConsensusParamsInfo(db dbm.DB, height int64) *ConsensusParamsInfo {
 	buf, err := db.Get(calcConsensusParamsKey(height))
 	if err != nil {
-		osm.Exit(fmt.Sprintf(`LoadConsensusParams: Key %q cannot be obtained: %v\n`, string(calcConsensusParamsKey(height)), err))
+		panic(fmt.Sprintf(`LoadConsensusParams: Key %q cannot be obtained: %v\n`, string(calcConsensusParamsKey(height)), err))
 	}
 	if len(buf) == 0 {
 		return nil

--- a/tm2/pkg/bft/store/store.go
+++ b/tm2/pkg/bft/store/store.go
@@ -77,11 +77,14 @@ func (bs *BlockStore) LoadBlock(height int64) *types.Block {
 // If no part is found for the given height and index, it returns nil.
 func (bs *BlockStore) LoadBlockPart(height int64, index int) *types.Part {
 	part := new(types.Part)
-	bz := bs.db.Get(calcBlockPartKey(height, index))
+	bz, err := bs.db.Get(calcBlockPartKey(height, index))
+	if err != nil {
+		panic(errors.Wrap(err, "Error reading block part"))
+	}
 	if len(bz) == 0 {
 		return nil
 	}
-	err := amino.Unmarshal(bz, part)
+	err = amino.Unmarshal(bz, part)
 	if err != nil {
 		panic(errors.Wrap(err, "Error reading block part"))
 	}
@@ -92,11 +95,14 @@ func (bs *BlockStore) LoadBlockPart(height int64, index int) *types.Part {
 // If no block is found for the given height, it returns nil.
 func (bs *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	blockMeta := new(types.BlockMeta)
-	bz := bs.db.Get(calcBlockMetaKey(height))
+	bz, err := bs.db.Get(calcBlockMetaKey(height))
+	if err != nil {
+		panic(errors.Wrap(err, "Error reading block meta"))
+	}
 	if len(bz) == 0 {
 		return nil
 	}
-	err := amino.Unmarshal(bz, blockMeta)
+	err = amino.Unmarshal(bz, blockMeta)
 	if err != nil {
 		panic(errors.Wrap(err, "Error reading block meta"))
 	}
@@ -109,11 +115,15 @@ func (bs *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 // If no commit is found for the given height, it returns nil.
 func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
 	commit := new(types.Commit)
-	bz := bs.db.Get(calcBlockCommitKey(height))
+	bz, err := bs.db.Get(calcBlockCommitKey(height))
+	if err != nil {
+		panic(errors.Wrap(err, "Error reading block commit"))
+	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	err := amino.Unmarshal(bz, commit)
+	err = amino.Unmarshal(bz, commit)
 	if err != nil {
 		panic(errors.Wrap(err, "Error reading block commit"))
 	}
@@ -125,11 +135,14 @@ func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
 // a new block at `height + 1` that includes this commit in its block.LastCommit.
 func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 	commit := new(types.Commit)
-	bz := bs.db.Get(calcSeenCommitKey(height))
+	bz, err := bs.db.Get(calcSeenCommitKey(height))
+	if err != nil {
+		panic(errors.Wrap(err, "Error reading block seen commit"))
+	}
 	if len(bz) == 0 {
 		return nil
 	}
-	err := amino.Unmarshal(bz, commit)
+	err = amino.Unmarshal(bz, commit)
 	if err != nil {
 		panic(errors.Wrap(err, "Error reading block seen commit"))
 	}
@@ -152,7 +165,7 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 		panic(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", w, g))
 	}
 	if !blockParts.IsComplete() {
-		panic(fmt.Sprintf("BlockStore can only save complete block part sets"))
+		panic("BlockStore can only save complete block part sets")
 	}
 
 	// Save block meta
@@ -234,14 +247,17 @@ func (bsj BlockStoreStateJSON) Save(db dbm.DB) {
 // LoadBlockStoreStateJSON returns the BlockStoreStateJSON as loaded from disk.
 // If no BlockStoreStateJSON was previously persisted, it returns the zero value.
 func LoadBlockStoreStateJSON(db dbm.DB) BlockStoreStateJSON {
-	bytes := db.Get(blockStoreKey)
+	bytes, err := db.Get(blockStoreKey)
+	if err != nil {
+		panic(fmt.Errorf("error obtaining blockStoreKey from DB: %w", err))
+	}
 	if len(bytes) == 0 {
 		return BlockStoreStateJSON{
 			Height: 0,
 		}
 	}
 	bsj := BlockStoreStateJSON{}
-	err := amino.UnmarshalJSON(bytes, &bsj)
+	err = amino.UnmarshalJSON(bytes, &bsj)
 	if err != nil {
 		panic(fmt.Sprintf("Could not unmarshal bytes: %X", bytes))
 	}

--- a/tm2/pkg/db/backend_test.go
+++ b/tm2/pkg/db/backend_test.go
@@ -16,28 +16,40 @@ func testBackendGetSetDelete(t *testing.T, backend BackendType) {
 	require.NoError(t, err)
 
 	// A nonexistent key should return nil, even if the key is empty
-	require.Nil(t, db.Get([]byte("")))
+	v, err := db.Get([]byte(""))
+	require.NoError(t, err)
+	require.Nil(t, v)
 
 	// A nonexistent key should return nil, even if the key is nil
-	require.Nil(t, db.Get(nil))
+	v, err = db.Get(nil)
+	require.Nil(t, v)
+	require.NoError(t, err)
 
 	// A nonexistent key should return nil.
 	key := []byte("abc")
-	require.Nil(t, db.Get(key))
+	v, err = db.Get(key)
+	require.NoError(t, err)
+	require.Nil(t, v)
 
 	// Set empty value.
 	db.SetSync(key, []byte(""))
-	require.NotNil(t, db.Get(key))
-	require.Empty(t, db.Get(key))
+	v, err = db.Get(key)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.Empty(t, v)
 
 	// Set nil value.
 	db.SetSync(key, nil)
-	require.NotNil(t, db.Get(key))
-	require.Empty(t, db.Get(key))
+	v, err = db.Get(key)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.Empty(t, v)
 
 	// Delete.
 	db.DeleteSync(key)
-	require.Nil(t, db.Get(key))
+	v, err = db.Get(key)
+	require.NoError(t, err)
+	require.Nil(t, v)
 }
 
 func TestBackendsGetSetDelete(t *testing.T) {
@@ -66,11 +78,28 @@ func TestBackendsNilKeys(t *testing.T) {
 				// Nil keys are treated as the empty key for most operations.
 				expect := func(key, value []byte) {
 					if len(key) == 0 { // nil or empty
-						assert.Equal(t, db.Get(nil), db.Get([]byte("")))
-						assert.Equal(t, db.Has(nil), db.Has([]byte("")))
+						v1, err := db.Get(nil)
+						require.NoError(t, err)
+						v2, err := db.Get([]byte(""))
+						require.NoError(t, err)
+
+						h1, err := db.Has(nil)
+						require.NoError(t, err)
+						h2, err := db.Has([]byte(""))
+						require.NoError(t, err)
+
+						assert.Equal(t, v1, v2)
+						assert.Equal(t, h1, h2)
 					}
-					assert.Equal(t, db.Get(key), value)
-					assert.Equal(t, db.Has(key), value != nil)
+
+					v, err := db.Get(key)
+					require.NoError(t, err)
+
+					h, err := db.Has(key)
+					require.NoError(t, err)
+
+					assert.Equal(t, v, value)
+					assert.Equal(t, h, value != nil)
 				}
 
 				// Not set
@@ -168,51 +197,54 @@ func testDBIterator(t *testing.T, backend BackendType) {
 		}
 	}
 
-	verifyIterator(t, db.Iterator(nil, nil), []int64{0, 1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator")
-	verifyIterator(t, db.ReverseIterator(nil, nil), []int64{9, 8, 7, 5, 4, 3, 2, 1, 0}, "reverse iterator")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(nil, nil) }, []int64{0, 1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(nil, nil) }, []int64{9, 8, 7, 5, 4, 3, 2, 1, 0}, "reverse iterator")
 
-	verifyIterator(t, db.Iterator(nil, int642Bytes(0)), []int64(nil), "forward iterator to 0")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(10), nil), []int64(nil), "reverse iterator from 10 (ex)")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(nil, int642Bytes(0)) }, []int64(nil), "forward iterator to 0")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(10), nil) }, []int64(nil), "reverse iterator from 10 (ex)")
 
-	verifyIterator(t, db.Iterator(int642Bytes(0), nil), []int64{0, 1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator from 0")
-	verifyIterator(t, db.Iterator(int642Bytes(1), nil), []int64{1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator from 1")
-	verifyIterator(t, db.ReverseIterator(nil, int642Bytes(10)),
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(0), nil) }, []int64{0, 1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator from 0")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(1), nil) }, []int64{1, 2, 3, 4, 5, 7, 8, 9}, "forward iterator from 1")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(nil, int642Bytes(10)) },
 		[]int64{9, 8, 7, 5, 4, 3, 2, 1, 0}, "reverse iterator from 10 (ex)")
-	verifyIterator(t, db.ReverseIterator(nil, int642Bytes(9)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(nil, int642Bytes(9)) },
 		[]int64{8, 7, 5, 4, 3, 2, 1, 0}, "reverse iterator from 9 (ex)")
-	verifyIterator(t, db.ReverseIterator(nil, int642Bytes(8)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(nil, int642Bytes(8)) },
 		[]int64{7, 5, 4, 3, 2, 1, 0}, "reverse iterator from 8 (ex)")
 
-	verifyIterator(t, db.Iterator(int642Bytes(5), int642Bytes(6)), []int64{5}, "forward iterator from 5 to 6")
-	verifyIterator(t, db.Iterator(int642Bytes(5), int642Bytes(7)), []int64{5}, "forward iterator from 5 to 7")
-	verifyIterator(t, db.Iterator(int642Bytes(5), int642Bytes(8)), []int64{5, 7}, "forward iterator from 5 to 8")
-	verifyIterator(t, db.Iterator(int642Bytes(6), int642Bytes(7)), []int64(nil), "forward iterator from 6 to 7")
-	verifyIterator(t, db.Iterator(int642Bytes(6), int642Bytes(8)), []int64{7}, "forward iterator from 6 to 8")
-	verifyIterator(t, db.Iterator(int642Bytes(7), int642Bytes(8)), []int64{7}, "forward iterator from 7 to 8")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(5), int642Bytes(6)) }, []int64{5}, "forward iterator from 5 to 6")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(5), int642Bytes(7)) }, []int64{5}, "forward iterator from 5 to 7")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(5), int642Bytes(8)) }, []int64{5, 7}, "forward iterator from 5 to 8")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(6), int642Bytes(7)) }, []int64(nil), "forward iterator from 6 to 7")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(6), int642Bytes(8)) }, []int64{7}, "forward iterator from 6 to 8")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(7), int642Bytes(8)) }, []int64{7}, "forward iterator from 7 to 8")
 
-	verifyIterator(t, db.ReverseIterator(int642Bytes(4), int642Bytes(5)), []int64{4}, "reverse iterator from 5 (ex) to 4")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(4), int642Bytes(6)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(4), int642Bytes(5)) }, []int64{4}, "reverse iterator from 5 (ex) to 4")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(4), int642Bytes(6)) },
 		[]int64{5, 4}, "reverse iterator from 6 (ex) to 4")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(4), int642Bytes(7)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(4), int642Bytes(7)) },
 		[]int64{5, 4}, "reverse iterator from 7 (ex) to 4")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(5), int642Bytes(6)), []int64{5}, "reverse iterator from 6 (ex) to 5")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(5), int642Bytes(7)), []int64{5}, "reverse iterator from 7 (ex) to 5")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(6), int642Bytes(7)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(5), int642Bytes(6)) }, []int64{5}, "reverse iterator from 6 (ex) to 5")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(5), int642Bytes(7)) }, []int64{5}, "reverse iterator from 7 (ex) to 5")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(6), int642Bytes(7)) },
 		[]int64(nil), "reverse iterator from 7 (ex) to 6")
 
-	verifyIterator(t, db.Iterator(int642Bytes(0), int642Bytes(1)), []int64{0}, "forward iterator from 0 to 1")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(8), int642Bytes(9)), []int64{8}, "reverse iterator from 9 (ex) to 8")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(0), int642Bytes(1)) }, []int64{0}, "forward iterator from 0 to 1")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(8), int642Bytes(9)) }, []int64{8}, "reverse iterator from 9 (ex) to 8")
 
-	verifyIterator(t, db.Iterator(int642Bytes(2), int642Bytes(4)), []int64{2, 3}, "forward iterator from 2 to 4")
-	verifyIterator(t, db.Iterator(int642Bytes(4), int642Bytes(2)), []int64(nil), "forward iterator from 4 to 2")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(2), int642Bytes(4)),
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(2), int642Bytes(4)) }, []int64{2, 3}, "forward iterator from 2 to 4")
+	verifyIterator(t, func() (Iterator, error) { return db.Iterator(int642Bytes(4), int642Bytes(2)) }, []int64(nil), "forward iterator from 4 to 2")
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(2), int642Bytes(4)) },
 		[]int64{3, 2}, "reverse iterator from 4 (ex) to 2")
-	verifyIterator(t, db.ReverseIterator(int642Bytes(4), int642Bytes(2)),
+	verifyIterator(t, func() (Iterator, error) { return db.ReverseIterator(int642Bytes(4), int642Bytes(2)) },
 		[]int64(nil), "reverse iterator from 2 (ex) to 4")
 }
 
-func verifyIterator(t *testing.T, itr Iterator, expected []int64, msg string) {
+func verifyIterator(t *testing.T, mitr func() (Iterator, error), expected []int64, msg string) {
 	t.Helper()
+
+	itr, err := mitr()
+	require.NoError(t, err)
 
 	var list []int64
 	for itr.Valid() {

--- a/tm2/pkg/db/c_level_db_test.go
+++ b/tm2/pkg/db/c_level_db_test.go
@@ -49,7 +49,8 @@ func BenchmarkRandomReadsWrites2(b *testing.B) {
 			idx := (int64(rand.Int()) % numItems)
 			val := internal[idx]
 			idxBytes := int642Bytes(int64(idx))
-			valBytes := db.Get(idxBytes)
+			valBytes, err := db.Get(idxBytes)
+			require.NoError(b, err)
 			// fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
 			if val == 0 {
 				if !bytes.Equal(valBytes, nil) {
@@ -104,5 +105,7 @@ func TestCLevelDBStats(t *testing.T) {
 	db, err := NewDB(name, CLevelDBBackend, t.TempDir())
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, db.Stats())
+	s, err := db.Stats()
+	require.NoError(t, err)
+	assert.NotEmpty(t, s)
 }

--- a/tm2/pkg/db/common_test.go
+++ b/tm2/pkg/db/common_test.go
@@ -18,7 +18,8 @@ import (
 func checkValue(t *testing.T, db DB, key []byte, valueWanted []byte) {
 	t.Helper()
 
-	valueGot := db.Get(key)
+	valueGot, err := db.Get(key)
+	require.NoError(t, err)
 	assert.Equal(t, valueWanted, valueGot)
 }
 
@@ -244,7 +245,8 @@ func benchmarkRandomReadsWrites(b *testing.B, db DB) {
 			idx := int64(rand.Int()) % numItems
 			valExp := internal[idx]
 			idxBytes := int642Bytes(idx)
-			valBytes := db.Get(idxBytes)
+			valBytes, err := db.Get(idxBytes)
+			require.NoError(b, err)
 			// fmt.Printf("Get %X -> %X\n", idxBytes, valBytes)
 			if valExp == 0 {
 				if !bytes.Equal(valBytes, nil) {

--- a/tm2/pkg/db/db_test.go
+++ b/tm2/pkg/db/db_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDBIteratorSingleKey(t *testing.T) {
@@ -13,7 +14,8 @@ func TestDBIteratorSingleKey(t *testing.T) {
 			db := newTempDB(t, backend)
 
 			db.SetSync(bz("1"), bz("value_1"))
-			itr := db.Iterator(nil, nil)
+			itr, err := db.Iterator(nil, nil)
+			require.NoError(t, err)
 
 			checkValid(t, itr, true)
 			checkNext(t, itr, false)
@@ -35,7 +37,9 @@ func TestDBIteratorTwoKeys(t *testing.T) {
 			db.SetSync(bz("2"), bz("value_1"))
 
 			{ // Fail by calling Next too much
-				itr := db.Iterator(nil, nil)
+				itr, err := db.Iterator(nil, nil)
+				require.NoError(t, err)
+
 				checkValid(t, itr, true)
 
 				checkNext(t, itr, true)
@@ -68,10 +72,14 @@ func TestDBIteratorMany(t *testing.T) {
 				db.Set(k, value)
 			}
 
-			itr := db.Iterator(nil, nil)
+			itr, err := db.Iterator(nil, nil)
+			require.NoError(t, err)
+
 			defer itr.Close()
 			for ; itr.Valid(); itr.Next() {
-				assert.Equal(t, db.Get(itr.Key()), itr.Value())
+				v, err := db.Get(itr.Key())
+				require.NoError(t, err)
+				assert.Equal(t, v, itr.Value())
 			}
 		})
 	}
@@ -82,8 +90,8 @@ func TestDBIteratorEmpty(t *testing.T) {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
 
-			itr := db.Iterator(nil, nil)
-
+			itr, err := db.Iterator(nil, nil)
+			require.NoError(t, err)
 			checkInvalid(t, itr)
 		})
 	}
@@ -94,7 +102,8 @@ func TestDBIteratorEmptyBeginAfter(t *testing.T) {
 		t.Run(fmt.Sprintf("Backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
 
-			itr := db.Iterator(bz("1"), nil)
+			itr, err := db.Iterator(bz("1"), nil)
+			require.NoError(t, err)
 
 			checkInvalid(t, itr)
 		})
@@ -107,7 +116,8 @@ func TestDBIteratorNonemptyBeginAfter(t *testing.T) {
 			db := newTempDB(t, backend)
 
 			db.SetSync(bz("1"), bz("value_1"))
-			itr := db.Iterator(bz("2"), nil)
+			itr, err := db.Iterator(bz("2"), nil)
+			require.NoError(t, err)
 
 			checkInvalid(t, itr)
 		})

--- a/tm2/pkg/db/immutable.go
+++ b/tm2/pkg/db/immutable.go
@@ -2,6 +2,8 @@ package db
 
 import "fmt"
 
+var _ DB = &ImmutableDB{}
+
 type ImmutableDB struct {
 	db DB
 }
@@ -15,53 +17,53 @@ func NewImmutableDB(db DB) *ImmutableDB {
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Get(key []byte) []byte {
+func (idb *ImmutableDB) Get(key []byte) ([]byte, error) {
 	return idb.db.Get(key)
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Has(key []byte) bool {
+func (idb *ImmutableDB) Has(key []byte) (bool, error) {
 	return idb.db.Has(key)
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Set(key []byte, value []byte) {
-	panic("Cannot mutate *ImmutableDB by calling .Set()")
+func (idb *ImmutableDB) Set(key []byte, value []byte) error {
+	return fmt.Errorf("cannot mutate *ImmutableDB by calling .Set()")
 }
 
 // Implements DB.
-func (idb *ImmutableDB) SetSync(key []byte, value []byte) {
-	panic("Cannot mutate *ImmutableDB by calling .SetSync()")
+func (idb *ImmutableDB) SetSync(key []byte, value []byte) error {
+	return fmt.Errorf("cannot mutate *ImmutableDB by calling .SetSync()")
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Delete(key []byte) {
-	panic("Cannot mutate *ImmutableDB by calling .Delete()")
+func (idb *ImmutableDB) Delete(key []byte) error {
+	return fmt.Errorf("cannot mutate *ImmutableDB by calling .Delete()")
 }
 
 // Implements DB.
-func (idb *ImmutableDB) DeleteSync(key []byte) {
-	panic("Cannot mutate *ImmutableDB by calling .DeleteSync()")
+func (idb *ImmutableDB) DeleteSync(key []byte) error {
+	return fmt.Errorf("cannot mutate *ImmutableDB by calling .DeleteSync()")
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Iterator(start, end []byte) Iterator {
+func (idb *ImmutableDB) Iterator(start, end []byte) (Iterator, error) {
 	return idb.db.Iterator(start, end)
 }
 
 // Implements DB.
-func (idb *ImmutableDB) ReverseIterator(start, end []byte) Iterator {
+func (idb *ImmutableDB) ReverseIterator(start, end []byte) (Iterator, error) {
 	return idb.db.ReverseIterator(start, end)
 }
 
 // Implements DB.
-func (idb *ImmutableDB) NewBatch() Batch {
-	return nil // XXX
+func (idb *ImmutableDB) NewBatch() (Batch, error) {
+	return nil, nil // XXX
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Close() {
-	idb.db.Close()
+func (idb *ImmutableDB) Close() error {
+	return idb.db.Close()
 }
 
 // Implements DB.
@@ -71,6 +73,6 @@ func (idb *ImmutableDB) Print() {
 }
 
 // Implements DB.
-func (idb *ImmutableDB) Stats() map[string]string {
+func (idb *ImmutableDB) Stats() (map[string]string, error) {
 	return idb.db.Stats()
 }

--- a/tm2/pkg/db/prefix_db_test.go
+++ b/tm2/pkg/db/prefix_db_test.go
@@ -1,6 +1,10 @@
 package db
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func mockDBWithStuff() DB {
 	db := NewMemDB()
@@ -39,7 +43,9 @@ func TestPrefixDBIterator1(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.Iterator(nil, nil)
+	itr, err := pdb.Iterator(nil, nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, nil, nil)
 	checkItem(t, itr, bz(""), bz("value"))
 	checkNext(t, itr, true)
@@ -57,7 +63,9 @@ func TestPrefixDBIterator2(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.Iterator(nil, bz(""))
+	itr, err := pdb.Iterator(nil, bz(""))
+	require.NoError(t, err)
+
 	checkDomain(t, itr, nil, bz(""))
 	checkInvalid(t, itr)
 	itr.Close()
@@ -67,7 +75,9 @@ func TestPrefixDBIterator3(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.Iterator(bz(""), nil)
+	itr, err := pdb.Iterator(bz(""), nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz(""), nil)
 	checkItem(t, itr, bz(""), bz("value"))
 	checkNext(t, itr, true)
@@ -85,7 +95,9 @@ func TestPrefixDBIterator4(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.Iterator(bz(""), bz(""))
+	itr, err := pdb.Iterator(bz(""), bz(""))
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz(""), bz(""))
 	checkInvalid(t, itr)
 	itr.Close()
@@ -95,7 +107,9 @@ func TestPrefixDBReverseIterator1(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(nil, nil)
+	itr, err := pdb.ReverseIterator(nil, nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, nil, nil)
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, true)
@@ -113,7 +127,9 @@ func TestPrefixDBReverseIterator2(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(bz(""), nil)
+	itr, err := pdb.ReverseIterator(bz(""), nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz(""), nil)
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, true)
@@ -131,7 +147,9 @@ func TestPrefixDBReverseIterator3(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(nil, bz(""))
+	itr, err := pdb.ReverseIterator(nil, bz(""))
+	require.NoError(t, err)
+
 	checkDomain(t, itr, nil, bz(""))
 	checkInvalid(t, itr)
 	itr.Close()
@@ -141,7 +159,9 @@ func TestPrefixDBReverseIterator4(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(bz(""), bz(""))
+	itr, err := pdb.ReverseIterator(bz(""), bz(""))
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz(""), bz(""))
 	checkInvalid(t, itr)
 	itr.Close()
@@ -151,7 +171,9 @@ func TestPrefixDBReverseIterator5(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(bz("1"), nil)
+	itr, err := pdb.ReverseIterator(bz("1"), nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz("1"), nil)
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, true)
@@ -167,7 +189,9 @@ func TestPrefixDBReverseIterator6(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(bz("2"), nil)
+	itr, err := pdb.ReverseIterator(bz("2"), nil)
+	require.NoError(t, err)
+
 	checkDomain(t, itr, bz("2"), nil)
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, true)
@@ -181,7 +205,9 @@ func TestPrefixDBReverseIterator7(t *testing.T) {
 	db := mockDBWithStuff()
 	pdb := NewPrefixDB(db, bz("key"))
 
-	itr := pdb.ReverseIterator(nil, bz("2"))
+	itr, err := pdb.ReverseIterator(nil, bz("2"))
+	require.NoError(t, err)
+
 	checkDomain(t, itr, nil, bz("2"))
 	checkItem(t, itr, bz("1"), bz("value1"))
 	checkNext(t, itr, true)

--- a/tm2/pkg/db/types.go
+++ b/tm2/pkg/db/types.go
@@ -5,24 +5,24 @@ type DB interface {
 	// Get returns nil iff key doesn't exist.
 	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
-	Get([]byte) []byte
+	Get([]byte) ([]byte, error)
 
 	// Has checks if a key exists.
 	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
-	Has(key []byte) bool
+	Has(key []byte) (bool, error)
 
 	// Set sets the key.
 	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
-	Set([]byte, []byte)
-	SetSync([]byte, []byte)
+	Set([]byte, []byte) error
+	SetSync([]byte, []byte) error
 
 	// Delete deletes the key.
 	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key readonly []byte
-	Delete([]byte)
-	DeleteSync([]byte)
+	Delete([]byte) error
+	DeleteSync([]byte) error
 
 	// Iterate over a domain of keys in ascending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
@@ -30,7 +30,7 @@ type DB interface {
 	// If end is nil, iterates up to the last item (inclusive).
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// CONTRACT: start, end readonly []byte
-	Iterator(start, end []byte) Iterator
+	Iterator(start, end []byte) (Iterator, error)
 
 	// Iterate over a domain of keys in descending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
@@ -38,19 +38,19 @@ type DB interface {
 	// If end is nil, iterates from the last/greatest item (inclusive).
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// CONTRACT: start, end readonly []byte
-	ReverseIterator(start, end []byte) Iterator
+	ReverseIterator(start, end []byte) (Iterator, error)
 
 	// Closes the connection.
-	Close()
+	Close() error
 
 	// Creates a batch for atomic updates.
-	NewBatch() Batch
+	NewBatch() (Batch, error)
 
 	// For debugging
 	Print()
 
 	// Stats returns a map of property values for all keys and the size of the cache.
-	Stats() map[string]string
+	Stats() (map[string]string, error)
 }
 
 //----------------------------------------

--- a/tm2/pkg/db/util.go
+++ b/tm2/pkg/db/util.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"bytes"
-	"os"
 )
 
 func cp(bz []byte) (ret []byte) {
@@ -43,9 +42,4 @@ func IsKeyInDomain(key, start, end []byte) bool {
 		return false
 	}
 	return true
-}
-
-func FileExists(filePath string) bool {
-	_, err := os.Stat(filePath)
-	return !os.IsNotExist(err)
 }

--- a/tm2/pkg/db/util_test.go
+++ b/tm2/pkg/db/util_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Empty iterator for empty db.
@@ -10,7 +12,8 @@ func TestPrefixIteratorNoMatchNil(t *testing.T) {
 	for backend := range backends {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
-			itr := IteratePrefix(db, []byte("2"))
+			itr, err := IteratePrefix(db, []byte("2"))
+			require.NoError(t, err)
 
 			checkInvalid(t, itr)
 		})
@@ -27,7 +30,9 @@ func TestPrefixIteratorNoMatch1(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
-			itr := IteratePrefix(db, []byte("2"))
+			itr, err := IteratePrefix(db, []byte("2"))
+			require.NoError(t, err)
+
 			db.SetSync(bz("1"), bz("value_1"))
 
 			checkInvalid(t, itr)
@@ -41,7 +46,8 @@ func TestPrefixIteratorNoMatch2(t *testing.T) {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
 			db.SetSync(bz("3"), bz("value_3"))
-			itr := IteratePrefix(db, []byte("4"))
+			itr, err := IteratePrefix(db, []byte("4"))
+			require.NoError(t, err)
 
 			checkInvalid(t, itr)
 		})
@@ -54,7 +60,8 @@ func TestPrefixIteratorMatch1(t *testing.T) {
 		t.Run(fmt.Sprintf("Prefix w/ backend %s", backend), func(t *testing.T) {
 			db := newTempDB(t, backend)
 			db.SetSync(bz("2"), bz("value_2"))
-			itr := IteratePrefix(db, bz("2"))
+			itr, err := IteratePrefix(db, bz("2"))
+			require.NoError(t, err)
 
 			checkValid(t, itr, true)
 			checkItem(t, itr, bz("2"), bz("value_2"))
@@ -81,7 +88,8 @@ func TestPrefixIteratorMatches1N(t *testing.T) {
 			db.SetSync(bz("a-3"), bz("value_3"))
 			db.SetSync(bz("a.3"), bz("value_3"))
 			db.SetSync(bz("abcdefg"), bz("value_3"))
-			itr := IteratePrefix(db, bz("a/"))
+			itr, err := IteratePrefix(db, bz("a/"))
+			require.NoError(t, err)
 
 			checkValid(t, itr, true)
 			checkItem(t, itr, bz("a/1"), bz("value_1"))

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -56,7 +56,10 @@ func (ak AccountKeeper) NewAccountWithAddress(ctx sdk.Context, addr crypto.Addre
 // GetAccount implements AccountKeeper.
 func (ak AccountKeeper) GetAccount(ctx sdk.Context, addr crypto.Address) std.Account {
 	stor := ctx.Store(ak.key)
-	bz := stor.Get(AddressStoreKey(addr))
+	bz, err := stor.Get(AddressStoreKey(addr))
+	if err != nil {
+		panic(err)
+	}
 	if bz == nil {
 		return nil
 	}
@@ -134,7 +137,10 @@ func (ak AccountKeeper) GetSequence(ctx sdk.Context, addr crypto.Address) (uint6
 func (ak AccountKeeper) GetNextAccountNumber(ctx sdk.Context) uint64 {
 	var accNumber uint64
 	stor := ctx.Store(ak.key)
-	bz := stor.Get([]byte(GlobalAccountNumberKey))
+	bz, err := stor.Get([]byte(GlobalAccountNumberKey))
+	if err != nil {
+		panic(err)
+	}
 	if bz == nil {
 		accNumber = 0 // start with 0.
 	} else {

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -172,7 +172,11 @@ func (app *BaseApp) initFromMainStore() error {
 	// nil, it will be saved later during InitChain.
 	//
 	// TODO: assert that InitChain hasn't yet been called.
-	consensusParamsBz := mainStore.Get(mainConsensusParamsKey)
+	consensusParamsBz, err := mainStore.Get(mainConsensusParamsKey)
+	if err != nil {
+		return fmt.Errorf("error obtaining consensus params from store: %w", err)
+	}
+
 	if consensusParamsBz != nil {
 		consensusParams := &abci.ConsensusParams{}
 		err := amino.Unmarshal(consensusParamsBz, consensusParams)
@@ -185,7 +189,10 @@ func (app *BaseApp) initFromMainStore() error {
 
 	// Load the consensus header from the main store.
 	// This is needed to setCheckState with the right chainID etc.
-	lastHeaderBz := baseStore.Get(mainLastHeaderKey)
+	lastHeaderBz, err := baseStore.Get(mainLastHeaderKey)
+	if err != nil {
+		return fmt.Errorf("error obtaining consensus headers from store: %w", err)
+	}
 	if lastHeaderBz != nil {
 		lastHeader := &bft.Header{}
 		err := amino.Unmarshal(lastHeaderBz, lastHeader)

--- a/tm2/pkg/sdk/baseapp_test.go
+++ b/tm2/pkg/sdk/baseapp_test.go
@@ -449,7 +449,11 @@ func i2b(i int64) []byte {
 }
 
 func getIntFromStore(store store.Store, key []byte) int64 {
-	bz := store.Get(key)
+	bz, err := store.Get(key)
+	if err != nil {
+		panic(err)
+	}
+
 	if len(bz) == 0 {
 		return 0
 	}
@@ -523,7 +527,10 @@ func TestCheckTx(t *testing.T) {
 	app.Commit()
 
 	checkStateStore = app.checkState.ctx.Store(mainKey)
-	storedBytes := checkStateStore.Get(counterKey)
+	storedBytes, err := checkStateStore.Get(counterKey)
+	if err != nil {
+		panic(err)
+	}
 	require.Nil(t, storedBytes)
 }
 

--- a/tm2/pkg/store/cache/store.go
+++ b/tm2/pkg/store/cache/store.go
@@ -149,8 +149,10 @@ func (store *cacheStore) iterator(start, end []byte, ascending bool) (types.Iter
 	store.mtx.Lock()
 	defer store.mtx.Unlock()
 
-	var parent, cache types.Iterator
-	var err error
+	var (
+		parent, cache types.Iterator
+		err           error
+	)
 	if ascending {
 		parent, err = store.parent.Iterator(start, end)
 	} else {

--- a/tm2/pkg/store/cache/store_bench_test.go
+++ b/tm2/pkg/store/cache/store_bench_test.go
@@ -5,8 +5,9 @@ import (
 	"sort"
 	"testing"
 
-	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/jaekwon/testify/require"
 
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/store/cache"
 	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
 )
@@ -32,7 +33,8 @@ func benchmarkCacheStoreIterator(b *testing.B, numKVs int) {
 	sort.Strings(keys)
 
 	for n := 0; n < b.N; n++ {
-		iter := cstore.Iterator([]byte(keys[0]), []byte(keys[numKVs-1]))
+		iter, err := cstore.Iterator([]byte(keys[0]), []byte(keys[numKVs-1]))
+		require.NoError(b, err)
 
 		for _ = iter.Key(); iter.Valid(); iter.Next() {
 		}

--- a/tm2/pkg/store/firstlast.go
+++ b/tm2/pkg/store/firstlast.go
@@ -9,7 +9,11 @@ import (
 
 // Gets the first item.
 func First(st Store, start, end []byte) (kv std.KVPair, ok bool) {
-	iter := st.Iterator(start, end)
+	iter, err := st.Iterator(start, end)
+	if err != nil {
+		panic(err)
+	}
+
 	if !iter.Valid() {
 		return kv, false
 	}
@@ -20,9 +24,18 @@ func First(st Store, start, end []byte) (kv std.KVPair, ok bool) {
 
 // Gets the last item.  `end` is exclusive.
 func Last(st Store, start, end []byte) (kv std.KVPair, ok bool) {
-	iter := st.ReverseIterator(end, start)
+	iter, err := st.ReverseIterator(end, start)
+	if err != nil {
+		panic(err)
+	}
+
 	if !iter.Valid() {
-		if v := st.Get(start); v != nil {
+		v, err := st.Get(start)
+		if err != nil {
+			panic(err)
+		}
+
+		if v != nil {
 			return std.KVPair{Key: types.Cp(start), Value: types.Cp(v)}, true
 		}
 		return kv, false

--- a/tm2/pkg/store/gas/store.go
+++ b/tm2/pkg/store/gas/store.go
@@ -86,8 +86,10 @@ func (gs *Store) Write() {
 }
 
 func (gs *Store) iterator(start, end []byte, ascending bool) (types.Iterator, error) {
-	var parent types.Iterator
-	var err error
+	var (
+		parent types.Iterator
+		err    error
+	)
 	if ascending {
 		parent, err = gs.parent.Iterator(start, end)
 	} else {

--- a/tm2/pkg/store/iavl/store.go
+++ b/tm2/pkg/store/iavl/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/iavl"
 	"github.com/gnolang/gno/tm2/pkg/std"
-
 	"github.com/gnolang/gno/tm2/pkg/store/cache"
 	serrors "github.com/gnolang/gno/tm2/pkg/store/errors"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
@@ -163,29 +162,33 @@ func (st *Store) Write() {
 }
 
 // Implements types.Store.
-func (st *Store) Set(key, value []byte) {
+func (st *Store) Set(key, value []byte) error {
 	types.AssertValidValue(value)
 	st.tree.Set(key, value)
+
+	return nil
 }
 
 // Implements types.Store.
-func (st *Store) Get(key []byte) (value []byte) {
+func (st *Store) Get(key []byte) ([]byte, error) {
 	_, v := st.tree.Get(key)
-	return v
+	return v, nil
 }
 
 // Implements types.Store.
-func (st *Store) Has(key []byte) (exists bool) {
-	return st.tree.Has(key)
+func (st *Store) Has(key []byte) (bool, error) {
+	return st.tree.Has(key), nil
 }
 
 // Implements types.Store.
-func (st *Store) Delete(key []byte) {
+func (st *Store) Delete(key []byte) error {
 	st.tree.Remove(key)
+
+	return nil
 }
 
 // Implements types.Store.
-func (st *Store) Iterator(start, end []byte) types.Iterator {
+func (st *Store) Iterator(start, end []byte) (types.Iterator, error) {
 	var iTree *iavl.ImmutableTree
 
 	switch tree := st.tree.(type) {
@@ -195,11 +198,11 @@ func (st *Store) Iterator(start, end []byte) types.Iterator {
 		iTree = tree.ImmutableTree
 	}
 
-	return newIAVLIterator(iTree, start, end, true)
+	return newIAVLIterator(iTree, start, end, true), nil
 }
 
 // Implements types.Store.
-func (st *Store) ReverseIterator(start, end []byte) types.Iterator {
+func (st *Store) ReverseIterator(start, end []byte) (types.Iterator, error) {
 	var iTree *iavl.ImmutableTree
 
 	switch tree := st.tree.(type) {
@@ -209,7 +212,7 @@ func (st *Store) ReverseIterator(start, end []byte) types.Iterator {
 		iTree = tree.ImmutableTree
 	}
 
-	return newIAVLIterator(iTree, start, end, false)
+	return newIAVLIterator(iTree, start, end, false), nil
 }
 
 // Handle gatest the latest height, if height is 0

--- a/tm2/pkg/store/iavl/store_test.go
+++ b/tm2/pkg/store/iavl/store_test.go
@@ -11,7 +11,6 @@ import (
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/iavl"
 	"github.com/gnolang/gno/tm2/pkg/random"
-	// "github.com/gnolang/gno/tm2/pkg/store/errors"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
 

--- a/tm2/pkg/store/immut/store.go
+++ b/tm2/pkg/store/immut/store.go
@@ -1,6 +1,8 @@
 package immut
 
 import (
+	"errors"
+
 	"github.com/gnolang/gno/tm2/pkg/store/cache"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
@@ -29,12 +31,12 @@ func (is immutStore) Has(key []byte) (bool, error) {
 
 // Implements Store
 func (is immutStore) Set(key, value []byte) error {
-	panic("unexpected .Set() on immutStore")
+	return errors.New("unexpected .Set() on immutStore")
 }
 
 // Implements Store
 func (is immutStore) Delete(key []byte) error {
-	panic("unexpected .Delete() on immutStore")
+	return errors.New("unexpected .Delete() on immutStore")
 }
 
 // Implements Store

--- a/tm2/pkg/store/immut/store.go
+++ b/tm2/pkg/store/immut/store.go
@@ -18,32 +18,32 @@ func New(parent types.Store) immutStore {
 }
 
 // Implements Store
-func (is immutStore) Get(key []byte) []byte {
+func (is immutStore) Get(key []byte) ([]byte, error) {
 	return is.parent.Get(key)
 }
 
 // Implements Store
-func (is immutStore) Has(key []byte) bool {
+func (is immutStore) Has(key []byte) (bool, error) {
 	return is.parent.Has(key)
 }
 
 // Implements Store
-func (is immutStore) Set(key, value []byte) {
+func (is immutStore) Set(key, value []byte) error {
 	panic("unexpected .Set() on immutStore")
 }
 
 // Implements Store
-func (is immutStore) Delete(key []byte) {
+func (is immutStore) Delete(key []byte) error {
 	panic("unexpected .Delete() on immutStore")
 }
 
 // Implements Store
-func (is immutStore) Iterator(start, end []byte) types.Iterator {
+func (is immutStore) Iterator(start, end []byte) (types.Iterator, error) {
 	return is.parent.Iterator(start, end)
 }
 
 // Implements Store
-func (is immutStore) ReverseIterator(start, end []byte) types.Iterator {
+func (is immutStore) ReverseIterator(start, end []byte) (types.Iterator, error) {
 	return is.parent.ReverseIterator(start, end)
 }
 

--- a/tm2/pkg/store/prefix/store.go
+++ b/tm2/pkg/store/prefix/store.go
@@ -50,31 +50,30 @@ func (s Store) Write() {
 }
 
 // Implements Store
-func (s Store) Get(key []byte) []byte {
-	res := s.parent.Get(s.key(key))
-	return res
+func (s Store) Get(key []byte) ([]byte, error) {
+	return s.parent.Get(s.key(key))
 }
 
 // Implements Store
-func (s Store) Has(key []byte) bool {
+func (s Store) Has(key []byte) (bool, error) {
 	return s.parent.Has(s.key(key))
 }
 
 // Implements Store
-func (s Store) Set(key, value []byte) {
+func (s Store) Set(key, value []byte) error {
 	types.AssertValidKey(key)
 	types.AssertValidValue(value)
-	s.parent.Set(s.key(key), value)
+	return s.parent.Set(s.key(key), value)
 }
 
 // Implements Store
-func (s Store) Delete(key []byte) {
-	s.parent.Delete(s.key(key))
+func (s Store) Delete(key []byte) error {
+	return s.parent.Delete(s.key(key))
 }
 
 // Implements Store
 // Check https://github.com/tendermint/classic/blob/master/libs/db/prefix_db.go#L106
-func (s Store) Iterator(start, end []byte) types.Iterator {
+func (s Store) Iterator(start, end []byte) (types.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 
 	var newend []byte
@@ -84,14 +83,17 @@ func (s Store) Iterator(start, end []byte) types.Iterator {
 		newend = cloneAppend(s.prefix, end)
 	}
 
-	iter := s.parent.Iterator(newstart, newend)
+	iter, err := s.parent.Iterator(newstart, newend)
+	if err != nil {
+		return nil, err
+	}
 
-	return newPrefixIterator(s.prefix, start, end, iter)
+	return newPrefixIterator(s.prefix, start, end, iter), nil
 }
 
 // Implements Store
 // Check https://github.com/tendermint/classic/blob/master/libs/db/prefix_db.go#L129
-func (s Store) ReverseIterator(start, end []byte) types.Iterator {
+func (s Store) ReverseIterator(start, end []byte) (types.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 
 	var newend []byte
@@ -101,9 +103,12 @@ func (s Store) ReverseIterator(start, end []byte) types.Iterator {
 		newend = cloneAppend(s.prefix, end)
 	}
 
-	iter := s.parent.ReverseIterator(newstart, newend)
+	iter, err := s.parent.ReverseIterator(newstart, newend)
+	if err != nil {
+		return nil, err
+	}
 
-	return newPrefixIterator(s.prefix, start, end, iter)
+	return newPrefixIterator(s.prefix, start, end, iter), nil
 }
 
 var _ types.Iterator = (*prefixIterator)(nil)

--- a/tm2/pkg/store/rootmulti/store_test.go
+++ b/tm2/pkg/store/rootmulti/store_test.go
@@ -9,7 +9,6 @@ import (
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/merkle"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
-
 	"github.com/gnolang/gno/tm2/pkg/store/iavl"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
@@ -64,7 +63,9 @@ func TestCacheMultiStoreWithVersion(t *testing.T) {
 	// require a valid key lookup yields the correct value
 	kvStore := cms.GetStore(ms.keysByName["store1"])
 	require.NotNil(t, kvStore)
-	require.Equal(t, kvStore.Get(k), v)
+	kv, err := kvStore.Get(k)
+	require.NoError(t, err)
+	require.Equal(t, kv, v)
 
 	// require we cannot commit (write) to a cache-versioned multi-store
 	require.Panics(t, func() {

--- a/tm2/pkg/store/store.go
+++ b/tm2/pkg/store/store.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
-	"github.com/gnolang/gno/tm2/pkg/strings"
-
 	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
+	"github.com/gnolang/gno/tm2/pkg/strings"
 )
 
 func NewCommitMultiStore(db dbm.DB) types.CommitMultiStore {
@@ -32,7 +31,11 @@ func NewPruningOptionsFromString(strategy string) (opt PruningOptions) {
 func Print(store Store) {
 	fmt.Println("//----------------------------------------")
 	fmt.Println("// store:", store)
-	itr := store.Iterator(nil, nil)
+	itr, err := store.Iterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
 	defer itr.Close()
 	for ; itr.Valid(); itr.Next() {
 		key, value := itr.Key(), itr.Value()

--- a/tm2/pkg/store/types/store.go
+++ b/tm2/pkg/store/types/store.go
@@ -10,17 +10,17 @@ import (
 )
 
 type Store interface {
-	// Get returns nil iff key doesn't exist. Panics on nil key.
-	Get(key []byte) []byte
+	// Get returns nil iff key doesn't exist.
+	Get(key []byte) ([]byte, error)
 
-	// Has checks if a key exists. Panics on nil key.
-	Has(key []byte) bool
+	// Has checks if a key exists.
+	Has(key []byte) (bool, error)
 
-	// Set sets the key. Panics on nil key or value.
-	Set(key, value []byte)
+	// Set sets the key.
+	Set(key, value []byte) error
 
-	// Delete deletes the key. Panics on nil key.
-	Delete(key []byte)
+	// Delete deletes the key.
+	Delete(key []byte) error
 
 	// Iterator over a domain of keys in ascending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
@@ -28,14 +28,14 @@ type Store interface {
 	// To iterate over entire domain, use store.Iterator(nil, nil)
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	Iterator(start, end []byte) Iterator
+	Iterator(start, end []byte) (Iterator, error)
 
 	// Iterator over a domain of keys in descending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
 	// Iterator must be closed by caller.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	ReverseIterator(start, end []byte) Iterator
+	ReverseIterator(start, end []byte) (Iterator, error)
 
 	// Returns a cache-wrapped store.
 	CacheWrap() Store

--- a/tm2/pkg/store/types/utils.go
+++ b/tm2/pkg/store/types/utils.go
@@ -6,20 +6,38 @@ import (
 
 // Iterator over all the keys with a certain prefix in ascending order
 func PrefixIterator(kvs Store, prefix []byte) Iterator {
-	return kvs.Iterator(prefix, PrefixEndBytes(prefix))
+	iter, err := kvs.Iterator(prefix, PrefixEndBytes(prefix))
+	if err != nil {
+		panic(err)
+	}
+
+	return iter
 }
 
 // Iterator over all the keys with a certain prefix in descending order.
 func ReversePrefixIterator(kvs Store, prefix []byte) Iterator {
-	return kvs.ReverseIterator(prefix, PrefixEndBytes(prefix))
+	iter, err := kvs.ReverseIterator(prefix, PrefixEndBytes(prefix))
+	if err != nil {
+		panic(err)
+	}
+
+	return iter
 }
 
 // Compare two stores, return either the first key/value pair
 // at which they differ and whether or not they are equal, skipping
 // value comparison for a set of provided prefixes
 func DiffStores(a Store, b Store, prefixesToSkip [][]byte) (kvA KVPair, kvB KVPair, count int64, equal bool) {
-	iterA := a.Iterator(nil, nil)
-	iterB := b.Iterator(nil, nil)
+	iterA, err := a.Iterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	iterB, err := b.Iterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
 	count = int64(0)
 	for {
 		if !iterA.Valid() && !iterB.Valid() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Refactoring of the DB interface and all its implementations to return errors.

Panic is not designed for error handling. Panic is designed for handling exceptional situations, like out-of-bounds array indexing. Using panic for error handling, we are swallowing some errors and we might cause inconsistent behavior, not cleaning resources properly.

I tried to do this refactor as small as possible, modifying one interface and its implementations at a time, moving panics up into the stack, until eventually all panics are removed.

# How has this been tested?

All existing tests have been refactored to check for errors.


Related issue: https://github.com/gnolang/gno/issues/532