### PR TITLE
fix: Execute tm2 tests on PRs too

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -3,7 +3,7 @@ name: db-tests
 on:
   pull_request:
     paths:
-      - "t2/pkg/db/**.go"
+      - "tm2/pkg/db/**.go"
       - "go.sum"
       - ".github/workflows/db-tests.yml"
   push:

--- a/tm2/pkg/db/c_level_db_test.go
+++ b/tm2/pkg/db/c_level_db_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkRandomReadsWrites2(b *testing.B) {
@@ -91,7 +92,8 @@ func TestCLevelDBBackend(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	// Can't use "" (current directory) or "./" here because levigo.Open returns:
 	// "Error initializing DB: IO error: test_XXX.db: Invalid argument"
-	db := NewDB(name, CLevelDBBackend, t.TempDir())
+	db, err := NewDB(name, CLevelDBBackend, t.TempDir())
+	require.NoError(t, err)
 
 	_, ok := db.(*CLevelDB)
 	assert.True(t, ok)
@@ -99,7 +101,8 @@ func TestCLevelDBBackend(t *testing.T) {
 
 func TestCLevelDBStats(t *testing.T) {
 	name := fmt.Sprintf("test_%x", randStr(12))
-	db := NewDB(name, CLevelDBBackend, t.TempDir())
+	db, err := NewDB(name, CLevelDBBackend, t.TempDir())
+	require.NoError(t, err)
 
 	assert.NotEmpty(t, db.Stats())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Fix outdated path used in GitHub actions to execute tm2 tests on PRs when some files on db package changed.
