### PR TITLE
refactor(pkg/bft/blockchain): Return errors instead of panic.

### DIFF
--- a/tm2/pkg/bft/blockchain/reactor_test.go
+++ b/tm2/pkg/bft/blockchain/reactor_test.go
@@ -119,7 +119,10 @@ func newBlockchainReactor(logger log.Logger, genDoc *types.GenesisDoc, privVals 
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
 	}
 
-	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor, err := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	if err != nil {
+		panic(err)
+	}
 	bcReactor.SetLogger(logger.With("module", "blockchain"))
 
 	return BlockchainReactorPair{bcReactor, proxyApp}

--- a/tm2/pkg/bft/consensus/common_test.go
+++ b/tm2/pkg/bft/consensus/common_test.go
@@ -273,7 +273,10 @@ func newConsensusStateWithConfig(thisConfig *cfg.Config, state sm.State, pv type
 
 func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state sm.State, pv types.PrivValidator, app abci.Application, blockDB dbm.DB) *ConsensusState {
 	// Get BlockStore
-	blockStore := store.NewBlockStore(blockDB)
+	blockStore, err := store.NewBlockStore(blockDB)
+	if err != nil {
+		panic(err)
+	}
 
 	// one for mempool, one for consensus
 	mtx := new(sync.Mutex)

--- a/tm2/pkg/bft/consensus/reactor.go
+++ b/tm2/pkg/bft/consensus/reactor.go
@@ -164,9 +164,9 @@ func (conR *ConsensusReactor) InitPeer(peer p2p.Peer) p2p.Peer {
 
 // AddPeer implements Reactor by spawning multiple gossiping goroutines for the
 // peer.
-func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
+func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) error {
 	if !conR.IsRunning() {
-		return
+		return nil
 	}
 
 	peerState, ok := peer.Get(types.PeerStateKey).(*PeerState)
@@ -183,6 +183,8 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 	if !conR.FastSync() {
 		conR.sendNewRoundStepMessage(peer)
 	}
+
+	return nil
 }
 
 // RemovePeer is a noop.

--- a/tm2/pkg/bft/consensus/replay_file.go
+++ b/tm2/pkg/bft/consensus/replay_file.go
@@ -277,7 +277,10 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cnscfg.Consensu
 		osm.Exit(err.Error())
 	}
 
-	blockStore := store.NewBlockStore(blockStoreDB)
+	blockStore, err := store.NewBlockStore(blockStoreDB)
+	if err != nil {
+		osm.Exit(err.Error())
+	}
 
 	// Get State
 	stateDB, err := dbm.NewDB("state", dbType, config.DBDir())

--- a/tm2/pkg/bft/consensus/replay_test.go
+++ b/tm2/pkg/bft/consensus/replay_test.go
@@ -1076,6 +1076,7 @@ func (bs *mockBlockStore) Height() (int64, error) { return int64(len(bs.chain)),
 func (bs *mockBlockStore) LoadBlock(height int64) (*types.Block, error) {
 	return bs.chain[height-1], nil
 }
+
 func (bs *mockBlockStore) LoadBlockMeta(height int64) (*types.BlockMeta, error) {
 	block := bs.chain[height-1]
 	return &types.BlockMeta{
@@ -1083,9 +1084,11 @@ func (bs *mockBlockStore) LoadBlockMeta(height int64) (*types.BlockMeta, error) 
 		Header:  block.Header,
 	}, nil
 }
+
 func (bs *mockBlockStore) LoadBlockPart(height int64, index int) (*types.Part, error) {
 	return nil, nil
 }
+
 func (bs *mockBlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
 	return nil
 }

--- a/tm2/pkg/bft/consensus/wal_generator.go
+++ b/tm2/pkg/bft/consensus/wal_generator.go
@@ -59,7 +59,10 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	}
 	state.AppVersion = kvstore.AppVersion
 	sm.SaveState(stateDB, state)
-	blockStore := store.NewBlockStore(blockStoreDB)
+	blockStore, err := store.NewBlockStore(blockStoreDB)
+	if err != nil {
+		return fmt.Errorf("error creating blockstore: %w", err)
+	}
 
 	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app))
 	proxyApp.SetLogger(logger.With("module", "proxy"))

--- a/tm2/pkg/bft/mempool/reactor.go
+++ b/tm2/pkg/bft/mempool/reactor.go
@@ -138,9 +138,11 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
-func (memR *Reactor) AddPeer(peer p2p.Peer) {
+func (memR *Reactor) AddPeer(peer p2p.Peer) error {
 	memR.ids.ReserveForPeer(peer)
 	go memR.broadcastTxRoutine(peer)
+
+	return nil
 }
 
 // RemovePeer implements Reactor.

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -174,12 +174,12 @@ func initDBs(config *cfg.Config, dbProvider DBProvider) (blockStore *store.Block
 	if err != nil {
 		return
 	}
-	blockStore = store.NewBlockStore(blockStoreDB)
-
-	stateDB, err = dbProvider(&DBContext{"state", config})
+	blockStore, err = store.NewBlockStore(blockStoreDB)
 	if err != nil {
 		return
 	}
+
+	stateDB, err = dbProvider(&DBContext{"state", config})
 
 	return
 }

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -287,7 +287,10 @@ func createBlockchainReactor(config *cfg.Config,
 	fastSync bool,
 	logger log.Logger,
 ) (bcReactor p2p.Reactor, err error) {
-	bcReactor = bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	bcReactor, err = bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
+	if err != nil {
+		return nil, err
+	}
 
 	bcReactor.SetLogger(logger.With("module", "blockchain"))
 	return bcReactor, nil

--- a/tm2/pkg/bft/rpc/core/status.go
+++ b/tm2/pkg/bft/rpc/core/status.go
@@ -73,8 +73,10 @@ import (
 //
 // ```
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
-	var latestHeight int64
-	var err error
+	var (
+		latestHeight int64
+		err          error
+	)
 	if consensusReactor.FastSync() {
 		latestHeight, err = blockStore.Height()
 	} else {

--- a/tm2/pkg/bft/rpc/core/status.go
+++ b/tm2/pkg/bft/rpc/core/status.go
@@ -74,11 +74,17 @@ import (
 // ```
 func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 	var latestHeight int64
+	var err error
 	if consensusReactor.FastSync() {
-		latestHeight = blockStore.Height()
+		latestHeight, err = blockStore.Height()
 	} else {
 		latestHeight = consensusState.GetLastHeight()
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		latestBlockMeta     *types.BlockMeta
 		latestBlockHash     []byte
@@ -86,7 +92,11 @@ func Status(ctx *rpctypes.Context) (*ctypes.ResultStatus, error) {
 		latestBlockTimeNano int64
 	)
 	if latestHeight != 0 {
-		latestBlockMeta = blockStore.LoadBlockMeta(latestHeight)
+		latestBlockMeta, err = blockStore.LoadBlockMeta(latestHeight)
+		if err != nil {
+			return nil, err
+		}
+
 		latestBlockHash = latestBlockMeta.BlockID.Hash
 		latestAppHash = latestBlockMeta.Header.AppHash
 		latestBlockTimeNano = latestBlockMeta.Header.Time.UnixNano()

--- a/tm2/pkg/bft/state/services.go
+++ b/tm2/pkg/bft/state/services.go
@@ -14,18 +14,18 @@ import (
 
 // BlockStoreRPC is the block store interface used by the RPC.
 type BlockStoreRPC interface {
-	Height() int64
+	Height() (int64, error)
 
-	LoadBlockMeta(height int64) *types.BlockMeta
-	LoadBlock(height int64) *types.Block
-	LoadBlockPart(height int64, index int) *types.Part
+	LoadBlockMeta(height int64) (*types.BlockMeta, error)
+	LoadBlock(height int64) (*types.Block, error)
+	LoadBlockPart(height int64, index int) (*types.Part, error)
 
-	LoadBlockCommit(height int64) *types.Commit
-	LoadSeenCommit(height int64) *types.Commit
+	LoadBlockCommit(height int64) (*types.Commit, error)
+	LoadSeenCommit(height int64) (*types.Commit, error)
 }
 
 // BlockStore defines the BlockStore interface used by the ConsensusState.
 type BlockStore interface {
 	BlockStoreRPC
-	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit)
+	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error
 }

--- a/tm2/pkg/bft/store/store.go
+++ b/tm2/pkg/bft/store/store.go
@@ -1,14 +1,17 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
+	sm "github.com/gnolang/gno/tm2/pkg/bft/state"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
-	"github.com/gnolang/gno/tm2/pkg/errors"
 )
+
+var _ sm.BlockStore = &BlockStore{}
 
 /*
 BlockStore is a simple low level store for blocks.
@@ -21,9 +24,6 @@ There are three types of information stored:
 Currently the precommit signatures are duplicated in the Block parts as
 well as the Commit.  In the future this may change, perhaps by moving
 the Commit data outside the Block. (TODO)
-
-// NOTE: BlockStore methods will panic if they encounter errors
-// deserializing loaded data, indicating probable corruption on disk.
 */
 type BlockStore struct {
 	db dbm.DB
@@ -34,106 +34,121 @@ type BlockStore struct {
 
 // NewBlockStore returns a new BlockStore with the given DB,
 // initialized to the last height that was committed to the DB.
-func NewBlockStore(db dbm.DB) *BlockStore {
-	bsjson := LoadBlockStoreStateJSON(db)
+func NewBlockStore(db dbm.DB) (*BlockStore, error) {
+	bsjson, err := LoadBlockStoreStateJSON(db)
+	if err != nil {
+		return nil, err
+	}
+
 	return &BlockStore{
 		height: bsjson.Height,
 		db:     db,
-	}
+	}, nil
 }
 
 // Height returns the last known contiguous block height.
-func (bs *BlockStore) Height() int64 {
+func (bs *BlockStore) Height() (int64, error) {
 	bs.mtx.RLock()
 	defer bs.mtx.RUnlock()
-	return bs.height
+	return bs.height, nil
 }
 
 // LoadBlock returns the block with the given height.
 // If no block is found for that height, it returns nil.
-func (bs *BlockStore) LoadBlock(height int64) *types.Block {
-	blockMeta := bs.LoadBlockMeta(height)
+func (bs *BlockStore) LoadBlock(height int64) (*types.Block, error) {
+	blockMeta, err := bs.LoadBlockMeta(height)
+	if err != nil {
+		return nil, err
+	}
+
 	if blockMeta == nil {
-		return nil
+		return nil, nil
 	}
 
 	block := new(types.Block)
 	buf := []byte{}
 	for i := 0; i < blockMeta.BlockID.PartsHeader.Total; i++ {
-		part := bs.LoadBlockPart(height, i)
+		part, err := bs.LoadBlockPart(height, i)
+		if err != nil {
+			return nil, err
+		}
 		buf = append(buf, part.Bytes...)
 	}
-	err := amino.UnmarshalSized(buf, block)
-	if err != nil {
+
+	if err := amino.UnmarshalSized(buf, block); err != nil {
 		// NOTE: The existence of meta should imply the existence of the
 		// block. So, make sure meta is only saved after blocks are saved.
-		panic(errors.Wrap(err, "Error reading block"))
+		return nil, fmt.Errorf("error reading block: %w", err)
 	}
-	return block
+
+	return block, nil
 }
 
 // LoadBlockPart returns the Part at the given index
 // from the block at the given height.
 // If no part is found for the given height and index, it returns nil.
-func (bs *BlockStore) LoadBlockPart(height int64, index int) *types.Part {
+func (bs *BlockStore) LoadBlockPart(height int64, index int) (*types.Part, error) {
 	part := new(types.Part)
 	bz := bs.db.Get(calcBlockPartKey(height, index))
 	if len(bz) == 0 {
-		return nil
+		return nil, nil
 	}
-	err := amino.Unmarshal(bz, part)
-	if err != nil {
-		panic(errors.Wrap(err, "Error reading block part"))
+
+	if err := amino.Unmarshal(bz, part); err != nil {
+		return nil, fmt.Errorf("error reading block part: %w", err)
 	}
-	return part
+	return part, nil
 }
 
 // LoadBlockMeta returns the BlockMeta for the given height.
 // If no block is found for the given height, it returns nil.
-func (bs *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
+func (bs *BlockStore) LoadBlockMeta(height int64) (*types.BlockMeta, error) {
 	blockMeta := new(types.BlockMeta)
 	bz := bs.db.Get(calcBlockMetaKey(height))
 	if len(bz) == 0 {
-		return nil
+		return nil, nil
 	}
-	err := amino.Unmarshal(bz, blockMeta)
-	if err != nil {
-		panic(errors.Wrap(err, "Error reading block meta"))
+
+	if err := amino.Unmarshal(bz, blockMeta); err != nil {
+		return nil, fmt.Errorf("error reading block meta: %w", err)
 	}
-	return blockMeta
+
+	return blockMeta, nil
 }
 
 // LoadBlockCommit returns the Commit for the given height.
 // This commit consists of the +2/3 and other Precommit-votes for block at `height`,
 // and it comes from the block.LastCommit for `height+1`.
 // If no commit is found for the given height, it returns nil.
-func (bs *BlockStore) LoadBlockCommit(height int64) *types.Commit {
+func (bs *BlockStore) LoadBlockCommit(height int64) (*types.Commit, error) {
 	commit := new(types.Commit)
 	bz := bs.db.Get(calcBlockCommitKey(height))
 	if len(bz) == 0 {
-		return nil
+		return nil, nil
 	}
-	err := amino.Unmarshal(bz, commit)
-	if err != nil {
-		panic(errors.Wrap(err, "Error reading block commit"))
+
+	if err := amino.Unmarshal(bz, commit); err != nil {
+		return nil, fmt.Errorf("error reading block commit: %w", err)
 	}
-	return commit
+
+	return commit, nil
 }
 
 // LoadSeenCommit returns the locally seen Commit for the given height.
 // This is useful when we've seen a commit, but there has not yet been
 // a new block at `height + 1` that includes this commit in its block.LastCommit.
-func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
+func (bs *BlockStore) LoadSeenCommit(height int64) (*types.Commit, error) {
 	commit := new(types.Commit)
 	bz := bs.db.Get(calcSeenCommitKey(height))
 	if len(bz) == 0 {
-		return nil
+		return nil, nil
 	}
-	err := amino.Unmarshal(bz, commit)
-	if err != nil {
-		panic(errors.Wrap(err, "Error reading block seen commit"))
+
+	if err := amino.Unmarshal(bz, commit); err != nil {
+		return nil, fmt.Errorf("error reading block seen commit: %w", err)
 	}
-	return commit
+
+	return commit, nil
 }
 
 // SaveBlock persists the given block, blockParts, and seenCommit to the underlying db.
@@ -143,16 +158,20 @@ func (bs *BlockStore) LoadSeenCommit(height int64) *types.Commit {
 //	If all the nodes restart after committing a block,
 //	we need this to reload the precommits to catch-up nodes to the
 //	most recent height.  Otherwise they'd stall at H-1.
-func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
+func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
 	if block == nil {
-		panic("BlockStore can only save a non-nil block")
+		return errors.New("blockStore can only save a non-nil block")
 	}
 	height := block.Height
-	if g, w := height, bs.Height()+1; g != w {
-		panic(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", w, g))
+	bsh, err := bs.Height()
+	if err != nil {
+		return err
+	}
+	if g, w := height, bsh+1; g != w {
+		return fmt.Errorf("blockStore can only save contiguous blocks. Wanted %v, got %v", w, g)
 	}
 	if !blockParts.IsComplete() {
-		panic(fmt.Sprintf("BlockStore can only save complete block part sets"))
+		return errors.New("blockStore can only save complete block part sets")
 	}
 
 	// Save block meta
@@ -185,14 +204,22 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 
 	// Flush
 	bs.db.SetSync(nil, nil)
+
+	return nil
 }
 
-func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) {
-	if height != bs.Height()+1 {
-		panic(fmt.Sprintf("BlockStore can only save contiguous blocks. Wanted %v, got %v", bs.Height()+1, height))
+func (bs *BlockStore) saveBlockPart(height int64, index int, part *types.Part) error {
+	h, err := bs.Height()
+	if err != nil {
+		return err
+	}
+	if height != h+1 {
+		return fmt.Errorf("blockStore can only save contiguous blocks. Wanted %v, got %v", h+1, height)
 	}
 	partBytes := amino.MustMarshal(part)
 	bs.db.Set(calcBlockPartKey(height, index), partBytes)
+
+	return nil
 }
 
 //-----------------------------------------------------------------------------
@@ -223,27 +250,30 @@ type BlockStoreStateJSON struct {
 }
 
 // Save persists the blockStore state to the database as JSON.
-func (bsj BlockStoreStateJSON) Save(db dbm.DB) {
+func (bsj BlockStoreStateJSON) Save(db dbm.DB) error {
 	bytes, err := amino.MarshalJSON(bsj)
 	if err != nil {
-		panic(fmt.Sprintf("Could not marshal state bytes: %v", err))
+		return fmt.Errorf("error marshalling state bytes: %w", err)
 	}
+
 	db.SetSync(blockStoreKey, bytes)
+
+	return nil
 }
 
 // LoadBlockStoreStateJSON returns the BlockStoreStateJSON as loaded from disk.
 // If no BlockStoreStateJSON was previously persisted, it returns the zero value.
-func LoadBlockStoreStateJSON(db dbm.DB) BlockStoreStateJSON {
+func LoadBlockStoreStateJSON(db dbm.DB) (BlockStoreStateJSON, error) {
 	bytes := db.Get(blockStoreKey)
 	if len(bytes) == 0 {
 		return BlockStoreStateJSON{
 			Height: 0,
-		}
+		}, nil
 	}
 	bsj := BlockStoreStateJSON{}
 	err := amino.UnmarshalJSON(bytes, &bsj)
 	if err != nil {
-		panic(fmt.Sprintf("Could not unmarshal bytes: %X", bytes))
+		return bsj, fmt.Errorf("could not unmarshall bytes %X: %w", bytes, err)
 	}
-	return bsj
+	return bsj, nil
 }

--- a/tm2/pkg/bft/store/store_test.go
+++ b/tm2/pkg/bft/store/store_test.go
@@ -83,7 +83,7 @@ func TestNewBlockStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(10000), h, "failed to properly parse blockstore")
 
-	panicCausers := []struct {
+	errorCausers := []struct {
 		data    []byte
 		wantErr string
 	}{
@@ -91,7 +91,7 @@ func TestNewBlockStore(t *testing.T) {
 		{[]byte(" "), "could not unmarshall bytes 20: unexpected end of JSON input"},
 	}
 
-	for i, tt := range panicCausers {
+	for i, tt := range errorCausers {
 		// Expecting an error here on trying to parse an invalid blockStore
 		db.Set(blockStoreKey, tt.data)
 		_, err = NewBlockStore(db)

--- a/tm2/pkg/p2p/base_reactor.go
+++ b/tm2/pkg/p2p/base_reactor.go
@@ -32,7 +32,7 @@ type Reactor interface {
 
 	// AddPeer is called by the switch after the peer is added and successfully
 	// started. Use it to start goroutines communicating with the peer.
-	AddPeer(peer Peer)
+	AddPeer(peer Peer) error
 
 	// RemovePeer is called by the switch when the peer is stopped (due to error
 	// or other reason).
@@ -65,7 +65,7 @@ func (br *BaseReactor) SetSwitch(sw *Switch) {
 	br.Switch = sw
 }
 func (*BaseReactor) GetChannels() []*conn.ChannelDescriptor        { return nil }
-func (*BaseReactor) AddPeer(peer Peer)                             {}
+func (*BaseReactor) AddPeer(peer Peer) error                       { return nil }
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{})      {}
 func (*BaseReactor) Receive(chID byte, peer Peer, msgBytes []byte) {}
 func (*BaseReactor) InitPeer(peer Peer) Peer                       { return peer }

--- a/tm2/pkg/p2p/mock/reactor.go
+++ b/tm2/pkg/p2p/mock/reactor.go
@@ -18,6 +18,6 @@ func NewReactor() *Reactor {
 }
 
 func (r *Reactor) GetChannels() []*conn.ChannelDescriptor            { return []*conn.ChannelDescriptor{} }
-func (r *Reactor) AddPeer(peer p2p.Peer)                             {}
+func (r *Reactor) AddPeer(peer p2p.Peer) error                       { return nil }
 func (r *Reactor) RemovePeer(peer p2p.Peer, reason interface{})      {}
 func (r *Reactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {}

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -60,7 +60,7 @@ func (tr *TestReactor) GetChannels() []*conn.ChannelDescriptor {
 	return tr.channels
 }
 
-func (tr *TestReactor) AddPeer(peer Peer) {}
+func (tr *TestReactor) AddPeer(peer Peer) error { return nil }
 
 func (tr *TestReactor) RemovePeer(peer Peer, reason interface{}) {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you need to use a more detailed template, append the query param template=detailed_pr_template.md to the URL -->

# Description

Refactoring of the Blockchain interface and all its implementations to return errors.

Panic is not designed for error handling. Panic is designed for handling exceptional situations, like out-of-bounds array indexing. Using panic for error handling, we are swallowing some errors and we might cause inconsistent behavior, not cleaning resources properly.

I tried to do this refactor as small as possible, modifying one interface and its implementations at a time, moving panics up into the stack, until eventually all panics are removed.

# How has this been tested?

All existing tests have been refactored to check for errors.

Related issue: https://github.com/gnolang/gno/issues/532