### PR TITLE
refactor: ReadMemPackage() only process .gno files

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1097,8 +1097,18 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 	}
 	memPkg := &std.MemPackage{Path: pkgPath}
 	var pkgName Name
+	allowedFiles := []string{ // make case insensitive?
+		"gno.mod",
+		"LICENSE",
+		"README.md",
+	}
+	allowedFileExtensions := []string{
+		".gno",
+	}
 	for _, file := range files {
-		if file.IsDir() || strings.HasPrefix(file.Name(), ".") || !strings.HasSuffix(file.Name(), ".gno") {
+		if file.IsDir() ||
+			strings.HasPrefix(file.Name(), ".") ||
+			(!endsWith(allowedFileExtensions, file.Name()) && !contains(allowedFiles, file.Name())) {
 			continue
 		}
 		fpath := filepath.Join(dir, file.Name())
@@ -1106,7 +1116,7 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 		if err != nil {
 			panic(err)
 		}
-		if pkgName == "" {
+		if pkgName == "" && strings.HasSuffix(file.Name(), ".gno") {
 			pkgName = PackageNameFromFileBody(file.Name(), string(bz))
 			if strings.HasSuffix(string(pkgName), "_test") {
 				pkgName = pkgName[:len(pkgName)-len("_test")]

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1098,15 +1098,7 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 	memPkg := &std.MemPackage{Path: pkgPath}
 	var pkgName Name
 	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-		// skip files starting with a dot.
-		if strings.HasPrefix(file.Name(), ".") {
-			continue
-		}
-		// skip precompile cache.
-		if strings.HasSuffix(file.Name(), ".gno.gen.go") {
+		if file.IsDir() || strings.HasPrefix(file.Name(), ".") || !strings.HasSuffix(file.Name(), ".gno") {
 			continue
 		}
 		fpath := filepath.Join(dir, file.Name())
@@ -1114,13 +1106,11 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 		if err != nil {
 			panic(err)
 		}
-		if pkgName == "" && strings.HasSuffix(file.Name(), "_test.gno") {
+		if pkgName == "" {
 			pkgName = PackageNameFromFileBody(file.Name(), string(bz))
 			if strings.HasSuffix(string(pkgName), "_test") {
 				pkgName = pkgName[:len(pkgName)-len("_test")]
 			}
-		} else if pkgName == "" && strings.HasSuffix(file.Name(), ".gno") {
-			pkgName = PackageNameFromFileBody(file.Name(), string(bz))
 		}
 		memPkg.Files = append(memPkg.Files,
 			&std.MemFile{

--- a/gnovm/pkg/gnolang/utils.go
+++ b/gnovm/pkg/gnolang/utils.go
@@ -1,0 +1,21 @@
+package gnolang
+
+import "strings"
+
+func contains(list []string, item string) bool {
+	for _, i := range list {
+		if i == item {
+			return true
+		}
+	}
+	return false
+}
+
+func endsWith(list []string, item string) bool {
+	for _, i := range list {
+		if strings.HasSuffix(item, i) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Description

`gnovm/pkg/gnolang/nodes.go/ReadMemPackage()` now only processes `gno.mod`, `LICENSE`, `README.md`, `*.gno` files. 

At present, the code only ignores .gno.gen.go files and allows rest of the files.
