### PR TITLE
chore(gnolang/utils): change endsWith() args order

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1108,7 +1108,7 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 	for _, file := range files {
 		if file.IsDir() ||
 			strings.HasPrefix(file.Name(), ".") ||
-			(!endsWith(allowedFileExtensions, file.Name()) && !contains(allowedFiles, file.Name())) {
+			(!endsWith(file.Name(), allowedFileExtensions) && !contains(allowedFiles, file.Name())) {
 			continue
 		}
 		fpath := filepath.Join(dir, file.Name())

--- a/gnovm/pkg/gnolang/utils.go
+++ b/gnovm/pkg/gnolang/utils.go
@@ -11,8 +11,8 @@ func contains(list []string, item string) bool {
 	return false
 }
 
-func endsWith(list []string, item string) bool {
-	for _, i := range list {
+func endsWith(item string, suffixes []string) bool {
+	for _, i := range suffixes {
 		if strings.HasSuffix(item, i) {
 			return true
 		}


### PR DESCRIPTION
# Description

This change ensures that endsWith() function follows the same pattern as Go standard library functions.

See https://github.com/gnolang/gno/commit/2c43ea3911a54fae77df125312e9137f8e32b3ce#r109150771