### PR TITLE
chore: add a tm2/errors.Panic wrapper to panic()

### DIFF
--- a/tm2/pkg/errors/panic.go
+++ b/tm2/pkg/errors/panic.go
@@ -1,0 +1,8 @@
+package errors
+
+// Panic is a deliberate wrapper around the built-in panic function, emphasizing intentional usage.
+//
+// It is intended to be used in situations where there is no way to recover from an error, and where the blockchain should halt immediately.
+func Panic(v any) {
+	panic(v)
+}

--- a/tm2/pkg/errors/panic_test.go
+++ b/tm2/pkg/errors/panic_test.go
@@ -1,9 +1,10 @@
-package errors
+package errors_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +15,7 @@ func TestPanic(t *testing.T) {
 				v = r.(error)
 			}
 		}()
-		Panic(fmt.Errorf("just a test: %d", 1337))
+		errors.Panic(fmt.Errorf("just a test: %d", 1337))
 		return
 	}
 

--- a/tm2/pkg/errors/panic_test.go
+++ b/tm2/pkg/errors/panic_test.go
@@ -1,0 +1,24 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanic(t *testing.T) {
+	capturePanic := func() (v error) {
+		defer func() {
+			if r := recover(); r != nil {
+				v = r.(error)
+			}
+		}()
+		Panic(fmt.Errorf("just a test: %d", 1337))
+		return
+	}
+
+	v := capturePanic()
+
+	assert.Contains(t, fmt.Sprintf("%#v", v), "just a test: 1337")
+}


### PR DESCRIPTION
This PR is a proposal to address the concerns raised in the discussion on #738.

Its primary objective is to introduce `errors.Panic(...)` as an alternative to `panic(...)` to make it more explicit that a panic is a deliberate choice in certain circumstances.

When refactoring the code, we can opt to replace some `panic()` with `return err` or `errors.Panic()` to eliminate ambiguous use of `panic()`.

See also #754.