### PR TITLE
chore: add a tm2/errors.Fatal helper

### DIFF
--- a/gno.land/cmd/gnoland/main.go
+++ b/gno.land/cmd/gnoland/main.go
@@ -19,6 +19,7 @@ import (
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/log"
 	osm "github.com/gnolang/gno/tm2/pkg/os"
 	vmm "github.com/gnolang/gno/tm2/pkg/sdk/vm"
@@ -49,7 +50,13 @@ func main() {
 		},
 	)
 
-	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
+	ctx := errors.FatalContext()
+	go func() {
+		<-ctx.Done()
+		os.Exit(1)
+	}()
+
+	if err := cmd.ParseAndRun(ctx, os.Args[1:]); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
 
 		os.Exit(1)

--- a/tm2/pkg/errors/panic.go
+++ b/tm2/pkg/errors/panic.go
@@ -1,0 +1,22 @@
+package errors
+
+import "context"
+
+var (
+	fatalCtx      context.Context
+	fatalCancelFn func()
+)
+
+func init() {
+	fatalCtx, fatalCancelFn = context.WithCancel(context.Background())
+}
+
+// FatalContext returns a context cancelled by Fatal to quickly exit the program at the top-level.
+func FatalContext() context.Context { return fatalCtx }
+
+// Fatal is the highest level of errors, indicating behavior that should not be handled or recovered.
+func Fatal(err error) error {
+	fatalCancelFn()
+	// additional logging could be done here.
+	return err
+}

--- a/tm2/pkg/errors/panic_test.go
+++ b/tm2/pkg/errors/panic_test.go
@@ -1,0 +1,23 @@
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanic(t *testing.T) {
+	ctx := errors.FatalContext()
+	assert.Nil(t, ctx.Err())
+
+	err := func() error {
+		return errors.Fatal(fmt.Errorf("should not happen"))
+	}()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "should not happen")
+	assert.NotNil(t, ctx.Err())
+	assert.Equal(t, ctx.Err().Error(), "context canceled")
+}

--- a/tm2/pkg/errors/panic_test.go
+++ b/tm2/pkg/errors/panic_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPanic(t *testing.T) {
+func TestFatal(t *testing.T) {
 	ctx := errors.FatalContext()
 	assert.Nil(t, ctx.Err())
 


### PR DESCRIPTION
This PR is a [another](https://github.com/gnolang/gno/pull/753) proposal to address the concerns raised in the discussion on #738.

The objective is to enable error handling that prevents ignoring Fatal errors and triggers them at the top-level.
This option eliminates all `panic()` calls and ensures immediate termination.

See also #753.