### PR TITLE
feat: auto migrate old gno home to new

### DIFF
--- a/tm2/pkg/crypto/keys/client/common.go
+++ b/tm2/pkg/crypto/keys/client/common.go
@@ -49,7 +49,12 @@ func fixOldDefaultGnoHome(newDir string) {
 	if err != nil || !s.IsDir() {
 		return
 	}
-	if err = os.Rename(oldDir, newDir); err != nil && !os.IsExist(err) {
-		log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed with error: %v", oldDir, newDir, err)
+	if err = os.Rename(oldDir, newDir); err != nil {
+		if os.IsExist(err) {
+			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed because directory exists.", oldDir, newDir)
+			log.Printf("You may need to move files from the old directory manually, or set the env var GNO_HOME to %q to retain the old directory.", oldDir)
+		} else {
+			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed with error: %v", oldDir, newDir, err)
+		}
 	}
 }

--- a/tm2/pkg/crypto/keys/client/common.go
+++ b/tm2/pkg/crypto/keys/client/common.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -37,24 +36,4 @@ func HomeDir() string {
 	// XXX: added april 2023 as a transitory measure - remove after test4
 	fixOldDefaultGnoHome(gnoHome)
 	return gnoHome
-}
-
-func fixOldDefaultGnoHome(newDir string) {
-	dir, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-	oldDir := filepath.Join(dir, ".gno")
-	s, err := os.Stat(oldDir)
-	if err != nil || !s.IsDir() {
-		return
-	}
-	if err = os.Rename(oldDir, newDir); err != nil {
-		if os.IsExist(err) {
-			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed because directory exists.", oldDir, newDir)
-			log.Printf("You may need to move files from the old directory manually, or set the env var GNO_HOME to %q to retain the old directory.", oldDir)
-		} else {
-			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed with error: %v", oldDir, newDir, err)
-		}
-	}
 }

--- a/tm2/pkg/crypto/keys/client/migration.go
+++ b/tm2/pkg/crypto/keys/client/migration.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// XXX: added april 2023 as a transitory measure - remove after test4
+func fixOldDefaultGnoHome(newDir string) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	oldDir := filepath.Join(dir, ".gno")
+	s, err := os.Stat(oldDir)
+	if err != nil || !s.IsDir() {
+		return
+	}
+	if err = os.Rename(oldDir, newDir); err != nil {
+		if os.IsExist(err) {
+			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed because directory exists.", oldDir, newDir)
+			log.Printf("You may need to move files from the old directory manually, or set the env var GNO_HOME to %q to retain the old directory.", oldDir)
+		} else {
+			log.Printf("WARNING: attempted moving old default GNO_HOME (%q) to new (%q) but failed with error: %v", oldDir, newDir, err)
+		}
+	}
+}


### PR DESCRIPTION
See #719 .

I think we should do this to ease the migration during test4.

An alternative for me would be to not auto-move it but show a warning.

What do you guys think?