### PR TITLE
chore(gnolang): add challenges

### DIFF
--- a/gnovm/tests/challenges/map0.gno
+++ b/gnovm/tests/challenges/map0.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	m := map[string]string{
+		"hello": "foo",
+		"world": "bar",
+		"hello": "",
+	}
+}
+
+// Error:
+// duplicate key "hello" in map literal

--- a/gnovm/tests/challenges/panic0b.gno
+++ b/gnovm/tests/challenges/panic0b.gno
@@ -1,0 +1,16 @@
+package main
+
+func main() {
+	f()
+}
+
+func f() {
+	defer func() {
+		panic("second")
+	}()
+	panic("first")
+}
+
+// Error:
+// first
+//	second

--- a/gnovm/tests/challenges/recover5b.gno
+++ b/gnovm/tests/challenges/recover5b.gno
@@ -1,0 +1,27 @@
+package main
+
+func main() {
+	f()
+}
+
+func f() {
+	defer func() { println("f recover", recover()) }()
+	defer g()
+	panic("wtf")
+}
+
+func g() {
+	defer func() {
+		// g() shouldn't be able to recover from f()'s panic, because the recover
+		// is declared in a deferred closure that is absent from the stack at the
+		// time of the panic.
+		// See go behavior here https://go.dev/play/p/CcMGgY606O-
+		// See Rob's examples https://groups.google.com/g/golang-nuts/c/HOXNBQu5c-Q/m/Je0qo1hbxIsJ
+		println("g recover", recover())
+	}()
+}
+
+// Output:
+// g recover undefined
+// f recover wtf
+// false

--- a/gnovm/tests/challenges/slice0.gno
+++ b/gnovm/tests/challenges/slice0.gno
@@ -1,0 +1,8 @@
+package main
+
+func main() {
+	_ = []string{0: "foo", 2: "bar", 2: "baz"}
+}
+
+// Error:
+// duplicate index 2 in array or slice literal

--- a/gnovm/tests/files/recover1b.gno
+++ b/gnovm/tests/files/recover1b.gno
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	defer func() {
+		recover()
+		panic("other panic")
+	}()
+	panic("test panic")
+}
+
+// Error:
+// other panic

--- a/gnovm/tests/files/recover5.gno
+++ b/gnovm/tests/files/recover5.gno
@@ -1,0 +1,19 @@
+package main
+
+func main() {
+	f()
+}
+
+func f() {
+	defer func() { println("f recover", recover()) }()
+	defer g()
+	panic("wtf")
+}
+
+func g() {
+	println("g recover", recover())
+}
+
+// Output:
+// g recover wtf
+// f recover undefined

--- a/gnovm/tests/files/recover6.gno
+++ b/gnovm/tests/files/recover6.gno
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"errors"
+)
+
+func main() {
+	println(f(false))
+	println(f(true))
+}
+
+func f(dopanic bool) (err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			err = x.(error)
+		}
+	}()
+	q(dopanic)
+	return
+}
+
+func q(dopanic bool) {
+	if dopanic {
+		panic(errors.New("wtf"))
+	}
+}
+
+// Output:
+// undefined
+// wtf


### PR DESCRIPTION
- Add 2 challenges for map and slice literals, as described in #758
- Add a challenge to handle chained panics, as described in #756
- Add a challenge to handle a specific rule of recover, as described in this [comment][0]

If you manage to solve one of these challenges by updating the gnovm code, move those files into the `gnovm/test/files` folder (eventually increment the number suffix in the name according to existing files).

[0]: https://github.com/gnolang/gno/issues/756#issuecomment-1516385898

