### PR TITLE
feat: JIT example

### DIFF
--- a/gnovm/pkg/gnolang/jit.go
+++ b/gnovm/pkg/gnolang/jit.go
@@ -1,0 +1,87 @@
+package gnolang
+
+import (
+	"tinygo.org/x/go-llvm"
+)
+
+func compileFactoriel() (*llvm.ExecutionEngine, llvm.Value) {
+	llvm.LinkInMCJIT()
+	llvm.InitializeNativeTarget()
+	llvm.InitializeNativeAsmPrinter()
+
+	mod := llvm.NewModule("fac_module")
+
+	fac_args := []llvm.Type{llvm.Int32Type()}
+	fac_type := llvm.FunctionType(llvm.Int32Type(), fac_args, false)
+	fac := llvm.AddFunction(mod, "fac", fac_type)
+	fac.SetFunctionCallConv(llvm.CCallConv)
+	n := fac.Param(0)
+
+	entry := llvm.AddBasicBlock(fac, "entry")
+	iftrue := llvm.AddBasicBlock(fac, "iftrue")
+	iffalse := llvm.AddBasicBlock(fac, "iffalse")
+	end := llvm.AddBasicBlock(fac, "end")
+
+	builder := llvm.NewBuilder()
+	defer builder.Dispose()
+
+	builder.SetInsertPointAtEnd(entry)
+	If := builder.CreateICmp(llvm.IntEQ, n, llvm.ConstInt(llvm.Int32Type(), 0, false), "cmptmp")
+	builder.CreateCondBr(If, iftrue, iffalse)
+
+	builder.SetInsertPointAtEnd(iftrue)
+	res_iftrue := llvm.ConstInt(llvm.Int32Type(), 1, false)
+	builder.CreateBr(end)
+
+	builder.SetInsertPointAtEnd(iffalse)
+	n_minus := builder.CreateSub(n, llvm.ConstInt(llvm.Int32Type(), 1, false), "subtmp")
+	call_fac_args := []llvm.Value{n_minus}
+	call_fac := builder.CreateCall(fac_type, fac, call_fac_args, "calltmp")
+	res_iffalse := builder.CreateMul(n, call_fac, "multmp")
+	builder.CreateBr(end)
+
+	builder.SetInsertPointAtEnd(end)
+	res := builder.CreatePHI(llvm.Int32Type(), "result")
+	phi_vals := []llvm.Value{res_iftrue, res_iffalse}
+	phi_blocks := []llvm.BasicBlock{iftrue, iffalse}
+	res.AddIncoming(phi_vals, phi_blocks)
+	builder.CreateRet(res)
+
+	err := llvm.VerifyModule(mod, llvm.ReturnStatusAction)
+	if err != nil {
+		panic(err)
+	}
+
+	options := llvm.NewMCJITCompilerOptions()
+	options.SetMCJITOptimizationLevel(3)
+	options.SetMCJITEnableFastISel(true)
+	options.SetMCJITNoFramePointerElim(true)
+	options.SetMCJITCodeModel(llvm.CodeModelJITDefault)
+	engine, err := llvm.NewMCJITCompiler(mod, options)
+	if err != nil {
+		panic(err)
+	}
+
+	pass := llvm.NewPassManager()
+	defer pass.Dispose()
+
+	pass.AddSCCPPass()
+	pass.AddInstructionCombiningPass()
+	pass.AddPromoteMemoryToRegisterPass()
+	pass.AddGVNPass()
+	pass.AddCFGSimplificationPass()
+	pass.Run(mod)
+
+	return &engine, fac
+}
+
+//opt levl is 0 to 3
+/*
+	-O0 (default): This is the default optimization level, and it means that no optimization is performed. This can be useful for debugging, since it preserves the original code structure and makes it easier to step through the code.
+
+	-O1: This optimization level performs some simple optimizations that don't take much time to run. This includes things like inlining small functions, simplifying expressions, and removing dead code.
+
+	-O2: This optimization level performs more aggressive optimizations that take more time to run. This includes things like loop unrolling, function inlining, and instruction scheduling.
+
+	-O3: This optimization level performs even more aggressive optimizations than -O2. This can result in faster code, but can also increase compilation time and code size. This includes things like interprocedural optimization, loop vectorization, and function specialization.
+*/

--- a/gnovm/pkg/gnolang/jit_test.go
+++ b/gnovm/pkg/gnolang/jit_test.go
@@ -1,0 +1,44 @@
+package gnolang
+
+import (
+	"testing"
+	"tinygo.org/x/go-llvm"
+)
+
+func TestCompileJITFactoriel(t *testing.T) {
+	var expect uint64 = 10 * 9 * 8 * 7 * 6 * 5 * 4 * 3 * 2 * 1
+
+	engine, fac := compileFactoriel()
+	exec_args := []llvm.GenericValue{llvm.NewGenericValueFromInt(llvm.Int32Type(), 10, false)}
+	exec_res := engine.RunFunction(fac, exec_args)
+
+	got := exec_res.Int(false)
+
+	if got != expect {
+		t.Errorf("expected %v got %v\n", got, expect)
+	}
+}
+
+func BenchmarkJITFactoriel(b *testing.B) {
+	engine, fac := compileFactoriel()
+
+	for i := 0; i < b.N; i++ {
+		exec_args := []llvm.GenericValue{llvm.NewGenericValueFromInt(llvm.Int32Type(), uint64(i), false)}
+		exec_res := engine.RunFunction(fac, exec_args)
+
+		_ = exec_res.Int(false)
+	}
+}
+
+func factorial(n uint64) uint64 {
+	if n == 0 {
+		return 1
+	}
+	return n * factorial(n-1)
+}
+
+func BenchmarkGOFactorial(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = factorial(uint64(i))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/tools v0.6.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
+	tinygo.org/x/go-llvm v0.0.0-20221212185523-e80bc424a2b1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -314,3 +314,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+tinygo.org/x/go-llvm v0.0.0-20221212185523-e80bc424a2b1 h1:8AXVEr/YUtQll2KN2KkQYRJbLDfRK7W0fQjpPcJq0+c=
+tinygo.org/x/go-llvm v0.0.0-20221212185523-e80bc424a2b1/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
This is an example of a hardcoded factorial function compilation with LLVM.
It is being benchmarked against the same algorithm in Go.
On mac M1, both have nearly the same performance.

The results on different machines might vary but more or less,
roughly, they won't be too far off.

```
BenchmarkJITFactoriel-10    	   61669            144933 ns/op
BenchmarkGOFactorial
BenchmarkGOFactorial-10     	   39854	    119944 ns/op
BenchmarkGnoFactorial-10    	     116	  10284642 ns/op
```
It looks like the JIT is 2 orders of magnitude faster than Gno.

This means that in Gno, we can have identical performance as if we were writing compiled Go code.

To run these benchmarks, you need to install LLVM 15 on your machine.