### PR TITLE
feat: add 'gno test -print-runtime-metrics'

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -30,6 +30,7 @@ type testCfg struct {
 	timeout           time.Duration
 	precompile        bool // TODO: precompile should be the default, but it needs to automatically precompile dependencies in memory.
 	updateGoldenTests bool
+	printUsageMetrics bool
 }
 
 func newTestCmd(io *commands.IO) *commands.Command {
@@ -89,6 +90,13 @@ func (c *testCfg) RegisterFlags(fs *flag.FlagSet) {
 		"timeout",
 		0,
 		"max execution time",
+	)
+
+	fs.BoolVar(
+		&c.printUsageMetrics,
+		"print-usage-metrics",
+		false,
+		"print usage metrics (gas, memory, cpu cycles)",
 	)
 }
 

--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -420,20 +420,18 @@ func runTestFiles(
 
 		if printRuntimeMetrics {
 			imports := m.Store.NumMemPackages() - numPackagesBefore - 1
-			// XXX: pretty print big numbers
 			// XXX: store changes
-			// XXX: total alloc
 			// XXX: max mem consumption
 			allocsVal := "n/a"
 			if m.Alloc != nil {
 				maxAllocs, allocs := m.Alloc.Status()
-				allocsVal = fmt.Sprintf("%dk(%.2f%%)",
-					allocs/1000,
+				allocsVal = fmt.Sprintf("%s(%.2f%%)",
+					prettySize(allocs),
 					float64(allocs)/float64(maxAllocs)*100,
 				)
 			}
-			io.ErrPrintfln("---       runtime: cycle=%dk imports=%d allocs=%s memory=TODO store=TODO",
-				m.Cycles/1000,
+			io.ErrPrintfln("---       runtime: cycle=%s imports=%d allocs=%s",
+				prettySize(m.Cycles),
 				imports,
 				allocsVal,
 			)

--- a/gnovm/cmd/gno/test_test.go
+++ b/gnovm/cmd/gno/test_test.go
@@ -151,6 +151,11 @@ func TestTest(t *testing.T) {
 			stdoutShouldContain: "RUN   TestSprintf",
 			stderrShouldContain: "ok      ./../../../examples/gno.land/p/demo/ufmt",
 		},
+		{
+			args:                []string{"test", "--verbose", "--print-runtime-metrics", "../../../examples/gno.land/p/demo/ufmt"},
+			stdoutShouldContain: "runtime: cycle=",
+			stderrShouldContain: "ok      ./../../../examples/gno.land/p/demo/ufmt",
+		},
 
 		// TODO: when 'gnodev test' will by default imply running precompile, we should use the following tests.
 		// {args: []string{"test", "../../tests/integ/empty-gno1", "--no-precompile"}, stderrShouldBe: "?       ./../../tests/integ/empty-gno1 \t[no test files]\n"},

--- a/gnovm/cmd/gno/test_test.go
+++ b/gnovm/cmd/gno/test_test.go
@@ -153,8 +153,8 @@ func TestTest(t *testing.T) {
 		},
 		{
 			args:                []string{"test", "--verbose", "--print-runtime-metrics", "../../../examples/gno.land/p/demo/ufmt"},
-			stdoutShouldContain: "runtime: cycle=",
-			stderrShouldContain: "ok      ./../../../examples/gno.land/p/demo/ufmt",
+			stdoutShouldContain: "RUN   TestSprintf",
+			stderrShouldContain: "cycle=",
 		},
 
 		// TODO: when 'gnodev test' will by default imply running precompile, we should use the following tests.

--- a/gnovm/cmd/gno/util.go
+++ b/gnovm/cmd/gno/util.go
@@ -234,3 +234,17 @@ func copyFile(src, dst string) error {
 
 	return nil
 }
+
+// Adapted from https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
+func prettySize(nb int64) string {
+	const unit = 1000
+	if nb < unit {
+		return fmt.Sprintf("%d", nb)
+	}
+	div, exp := int64(unit), 0
+	for n := nb / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%c", float64(nb)/float64(div), "kMGTPE"[exp])
+}


### PR DESCRIPTION
The goal is to track usage metrics when using `gno`.

The initial version will report gas, time, and memory usage after execution, while a future update may track consumption on a per-test or per-line basis.

```console
$ go run ./gnovm/cmd/gno test --verbose --print-runtime-metrics ./examples/gno.land/r/demo/art
=== RUN   TestDraw
=== RUN   TestDraw/42
=== RUN   TestDraw/1337
=== RUN   TestDraw/123456789
--- PASS: TestDraw (0.01s)
---       runtime: cycle=157.1k imports=4 allocs=5.3M(1.07%)
=== RUN   TestRender
=== RUN   TestRender/42
=== RUN   TestRender/1337
=== RUN   TestRender/123456789
--- PASS: TestRender (0.02s)
---       runtime: cycle=316.3k imports=4 allocs=10.7M(2.14%)
ok      ./examples/gno.land/r/demo/art/gnoface  0.97s
=== RUN   TestRender
=== RUN   TestRender/
=== RUN   TestRender/4
--- PASS: TestRender (0.00s)
---       runtime: cycle=10.0k imports=4 allocs=358.3k(0.07%)
ok      ./examples/gno.land/r/demo/art/millipede        0.75s
```