### PR TITLE
chore: fix CI not testing the examples/ folder

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,4 +28,18 @@ jobs:
       - run: go install -v ./gnovm/cmd/gno
       - run: go run ./gnovm/cmd/gno precompile --verbose ./examples
       - run: go run ./gnovm/cmd/gno build --verbose ./examples
-  # unittests: TODO: matrix with contracts
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ "1.19.x", "1.20.x" ]
+        # unittests: TODO: matrix with contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v3
+      - run: go install -v ./gnovm/cmd/gno
+      - run: go run ./gnovm/cmd/gno test --verbose ./examples

--- a/examples/gno.land/r/demo/releases_example/releases1_filetest.gno
+++ b/examples/gno.land/r/demo/releases_example/releases1_filetest.gno
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"gno.land/r/demo/releases-example"
+	"gno.land/r/demo/releases_example"
 )
 
 func main() {
@@ -17,18 +17,18 @@ func main() {
 
 // Output:
 // -----------
-// # example-app
+// # example_app
 //
-// ## [example-app v2 (latest)](r/demo/examples-example-v2)
+// ## [example_app v2 (latest)](r/demo/examples_example_v2)
 //
 // various improvements
 //
-// ## [example-app v1](r/demo/examples-example-v1)
+// ## [example_app v1](r/demo/examples_example_v1)
 //
 // initial release
 //
 // -----------
-// ## [example-app v1](r/demo/examples-example-v1)
+// ## [example_app v1](r/demo/examples_example_v1)
 //
 // initial release
 //

--- a/gnovm/tests/imports.go
+++ b/gnovm/tests/imports.go
@@ -457,11 +457,18 @@ func testPackageInjector(store gno.Store, pn *gno.PackageNode) {
 	// Also inject stdlibs native functions.
 	stdlibs.InjectPackage(store, pn)
 	isOriginCall := func(m *gno.Machine) bool {
-		switch m.Frames[0].Func.Name {
+		tname := m.Frames[0].Func.Name
+		switch tname {
 		case "main": // test is a _filetest
 			return len(m.Frames) == 3
 		case "runtest": // test is a _test
 			return len(m.Frames) == 7
+		}
+		// support init() in _filetest
+		// XXX do we need to distinguish from 'runtest'/_test?
+		// XXX pretty hacky even if not.
+		if strings.HasPrefix(string(tname), "init.") {
+			return len(m.Frames) == 3
 		}
 		panic("unable to determine if test is a _test or a _filetest")
 	}


### PR DESCRIPTION
* Re-enable the `gno test ./examples` on the CI.
* Fix a broken test.
* Allow `init()` to call `GetOrigCaller` in testing context.

Fix #782 