### PR TITLE
feat: support marking pkg as Draft

### DIFF
--- a/gnovm/pkg/gnomod/file.go
+++ b/gnovm/pkg/gnomod/file.go
@@ -15,7 +15,7 @@ import (
 
 // Parsed gno.mod file.
 type File struct {
-	Wip     bool
+	Draft   bool
 	Module  *modfile.Module
 	Go      *modfile.Go
 	Require []*modfile.Require

--- a/gnovm/pkg/gnomod/file.go
+++ b/gnovm/pkg/gnomod/file.go
@@ -15,6 +15,7 @@ import (
 
 // Parsed gno.mod file.
 type File struct {
+	Wip     bool
 	Module  *modfile.Module
 	Go      *modfile.Go
 	Require []*modfile.Require

--- a/gnovm/pkg/gnomod/parse.go
+++ b/gnovm/pkg/gnomod/parse.go
@@ -49,6 +49,10 @@ func Parse(file string, data []byte) (*File, error) {
 					f.add(&errs, x, l, x.Token[0], l.Token)
 				}
 			}
+		case *modfile.CommentBlock:
+			if x.Start.Line == 1 {
+				f.Wip = parseWip(x)
+			}
 		}
 	}
 

--- a/gnovm/pkg/gnomod/parse.go
+++ b/gnovm/pkg/gnomod/parse.go
@@ -51,7 +51,7 @@ func Parse(file string, data []byte) (*File, error) {
 			}
 		case *modfile.CommentBlock:
 			if x.Start.Line == 1 {
-				f.Wip = parseWip(x)
+				f.Draft = parseDraft(x)
 			}
 		}
 	}

--- a/gnovm/pkg/gnomod/parse_test.go
+++ b/gnovm/pkg/gnomod/parse_test.go
@@ -117,7 +117,7 @@ func TestModuleDeprecated(t *testing.T) {
 	}
 }
 
-func TestParseWip(t *testing.T) {
+func TestParseDraft(t *testing.T) {
 	for _, tc := range []struct {
 		desc, in string
 		expected bool
@@ -131,39 +131,39 @@ func TestParseWip(t *testing.T) {
 			in:   `// yo`,
 		},
 		{
-			desc:     "wip_no_space",
-			in:       `//WIP`,
+			desc:     "draft_no_space",
+			in:       `//Draft`,
 			expected: true,
 		},
 		{
-			desc:     "wip_simple",
-			in:       `// WIP`,
+			desc:     "draft_simple",
+			in:       `// Draft`,
 			expected: true,
 		},
 		{
-			desc: "wip_lowercase",
-			in:   `// wip`,
+			desc: "draft_lowercase",
+			in:   `// draft`,
 		},
 		{
-			desc: "wip_multiline",
-			in: `// wip
+			desc: "draft_multiline",
+			in: `// Draft
 			// yo`,
 		},
 		{
-			desc: "wip_mixed",
+			desc: "draft_mixed",
 			in: `// some other comment
-			// WIP`,
+			// Draft`,
 		},
 		{
-			desc: "wip_not_first_line",
+			desc: "draft_not_first_line",
 			in: `
-			// WIP`,
+			// Draft`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			f, err := Parse("in", []byte(tc.in))
 			assert.Nil(t, err)
-			assert.Equal(t, tc.expected, f.Wip)
+			assert.Equal(t, tc.expected, f.Draft)
 		})
 	}
 }

--- a/gnovm/pkg/gnomod/parse_test.go
+++ b/gnovm/pkg/gnomod/parse_test.go
@@ -116,3 +116,54 @@ func TestModuleDeprecated(t *testing.T) {
 		})
 	}
 }
+
+func TestParseWip(t *testing.T) {
+	for _, tc := range []struct {
+		desc, in string
+		expected bool
+	}{
+		{
+			desc: "no_comment",
+			in:   `module m`,
+		},
+		{
+			desc: "other_comment",
+			in:   `// yo`,
+		},
+		{
+			desc:     "wip_no_space",
+			in:       `//WIP`,
+			expected: true,
+		},
+		{
+			desc:     "wip_simple",
+			in:       `// WIP`,
+			expected: true,
+		},
+		{
+			desc: "wip_lowercase",
+			in:   `// wip`,
+		},
+		{
+			desc: "wip_multiline",
+			in: `// wip
+			// yo`,
+		},
+		{
+			desc: "wip_mixed",
+			in: `// some other comment
+			// WIP`,
+		},
+		{
+			desc: "wip_not_first_line",
+			in: `
+			// WIP`,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := Parse("in", []byte(tc.in))
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, f.Wip)
+		})
+	}
+}

--- a/gnovm/pkg/gnomod/read.go
+++ b/gnovm/pkg/gnomod/read.go
@@ -833,3 +833,15 @@ func parseDirectiveComment(block *modfile.LineBlock, line *modfile.Line) string 
 	}
 	return strings.Join(lines, "\n")
 }
+
+// parseWip returns whether the module is marked as a work in progress.
+func parseWip(block *modfile.CommentBlock) bool {
+	if len(block.Before) != 1 {
+		return false
+	}
+	comment := block.Before[0]
+	if strings.TrimSpace(strings.TrimPrefix(comment.Token, "//")) != "WIP" {
+		return false
+	}
+	return true
+}

--- a/gnovm/pkg/gnomod/read.go
+++ b/gnovm/pkg/gnomod/read.go
@@ -834,13 +834,13 @@ func parseDirectiveComment(block *modfile.LineBlock, line *modfile.Line) string 
 	return strings.Join(lines, "\n")
 }
 
-// parseWip returns whether the module is marked as a work in progress.
-func parseWip(block *modfile.CommentBlock) bool {
+// parseDraft returns whether the module is marked as draft.
+func parseDraft(block *modfile.CommentBlock) bool {
 	if len(block.Before) != 1 {
 		return false
 	}
 	comment := block.Before[0]
-	if strings.TrimSpace(strings.TrimPrefix(comment.Token, "//")) != "WIP" {
+	if strings.TrimSpace(strings.TrimPrefix(comment.Token, "//")) != "Draft" {
 		return false
 	}
 	return true


### PR DESCRIPTION
# Description

See (https://github.com/gnolang/gno/pull/763#issuecomment-1526938105)
> > @harry-hov Thanks for the clarification, indeed I missed that part where the `gnoland` binary pushes all that list of packages. I understand well the usage now. A better name than `deprecated` would be good (like `experimental` ?), but since it's already supported by `golang.org/x/mod` let's go with that 🙏 .
>
> @tbruyelle we can still change the name to something better. What about something self-explaining like `draft` (hugo), `unpublishable`, `restricted` or `private` (NPM).

--- 

Suggested candidates: 
- `WIP` (work-in-progress)
- `Experimental`
- `Draft` (hugo)
- `Unpublishable`
- `Restricted`
- `Private` (NPM)

PS: _Open for better names._

cc: @tbruyelle @moul 


