### PR TITLE
refactor: proposal: Modularise VM Ops.

### DIFF
--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -1,7 +1,40 @@
 package gnolang
 
-func (m *Machine) doOpDefine() {
-	s := m.PopStmt().(*AssignStmt)
+import (
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/errors"
+)
+
+var ErrOpNotSupported = errors.New("operation not supported")
+
+var assignOps map[Op]func(s *AssignStmt, m *Machine) (cpuCycles int64) = map[Op]func(s *AssignStmt, m *Machine) int64{
+	OpDefine:      doOpDefine,
+	OpAssign:      doOpAssign,
+	OpAddAssign:   doOpAddAssign,
+	OpSubAssign:   doOpSubAssign,
+	OpMulAssign:   doOpMulAssign,
+	OpQuoAssign:   doOpQuoAssign,
+	OpRemAssign:   doOpRemAssign,
+	OpBandAssign:  doOpBandAssign,
+	OpBandnAssign: doOpBandnAssign,
+	OpBorAssign:   doOpBorAssign,
+	OpXorAssign:   doOpXorAssign,
+	OpShlAssign:   doOpShlAssign,
+	OpShrAssign:   doOpShrAssign,
+}
+
+func (s *AssignStmt) Exec(m *Machine, o Op) (int64, error) {
+	op, ok := assignOps[o]
+
+	if !ok {
+		return 0, fmt.Errorf("%w: %q is not valid for Assign Statements", ErrOpNotSupported, o)
+	}
+
+	return op(s, m), nil
+}
+
+func doOpDefine(s *AssignStmt, m *Machine) int64 {
 	// Define each value evaluated for Lhs.
 	// NOTE: PopValues() returns a slice in
 	// forward order, not the usual reverse.
@@ -22,10 +55,11 @@ func (m *Machine) doOpDefine() {
 		}
 		ptr.Assign2(m.Alloc, m.Store, m.Realm, rvs[i], true)
 	}
+
+	return OpCPUDefine
 }
 
-func (m *Machine) doOpAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpAssign(s *AssignStmt, m *Machine) int64 {
 	// Assign each value evaluated for Lhs.
 	// NOTE: PopValues() returns a slice in
 	// forward order, not the usual reverse.
@@ -43,10 +77,11 @@ func (m *Machine) doOpAssign() {
 		}
 		lv.Assign2(m.Alloc, m.Store, m.Realm, rvs[i], true)
 	}
+
+	return OpCPUAssign
 }
 
-func (m *Machine) doOpAddAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpAddAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -66,10 +101,11 @@ func (m *Machine) doOpAddAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUAddAssign
 }
 
-func (m *Machine) doOpSubAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpSubAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -89,10 +125,11 @@ func (m *Machine) doOpSubAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUSubAssign
 }
 
-func (m *Machine) doOpMulAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpMulAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -112,10 +149,11 @@ func (m *Machine) doOpMulAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUMulAssign
 }
 
-func (m *Machine) doOpQuoAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpQuoAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -135,10 +173,11 @@ func (m *Machine) doOpQuoAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUQuoAssign
 }
 
-func (m *Machine) doOpRemAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpRemAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -158,10 +197,11 @@ func (m *Machine) doOpRemAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPURemAssign
 }
 
-func (m *Machine) doOpBandAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpBandAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -181,10 +221,11 @@ func (m *Machine) doOpBandAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUBandAssign
 }
 
-func (m *Machine) doOpBandnAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpBandnAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -204,10 +245,11 @@ func (m *Machine) doOpBandnAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUBandnAssign
 }
 
-func (m *Machine) doOpBorAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpBorAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -227,10 +269,11 @@ func (m *Machine) doOpBorAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUBorAssign
 }
 
-func (m *Machine) doOpXorAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpXorAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
@@ -250,10 +293,11 @@ func (m *Machine) doOpXorAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUXorAssign
 }
 
-func (m *Machine) doOpShlAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpShlAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 
@@ -270,10 +314,11 @@ func (m *Machine) doOpShlAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUShlAssign
 }
 
-func (m *Machine) doOpShrAssign() {
-	s := m.PopStmt().(*AssignStmt)
+func doOpShrAssign(s *AssignStmt, m *Machine) int64 {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 
@@ -290,4 +335,6 @@ func (m *Machine) doOpShrAssign() {
 	if lv.Base != nil {
 		m.Realm.DidUpdate(lv.Base.(Object), nil, nil)
 	}
+
+	return OpCPUShrAssign
 }


### PR DESCRIPTION
# Description

This is a proposal to refactor the VM and modularize code on the nodes themselves, offloading complexity from the VM.

## Why?

IMHO the `Machine` struct is too complex and will benefit from a refactoring modularizing code into its own nodes.

This modularization will allow to evolve the VM much faster when adding new language expressions, tests, or fixing bugs.

Also, after implementing this PoC, I discovered that a lot of duplicated code can be avoided.

Another benefit will be that Operations, Nodes using these operations, and costs will all be in the same place.

## How?

We can define a new method on the Node interface:

```go
	Exec(m *Machine, o Op) (int64, error)
```

This method will be in charge of analyzing the operation, adding or removing elements into the stack, and returning the CPU usage depending on the executed instructions. This method is temporal, and eventually, instead of receiving the `*Machine` pointer, it will use a context containing the program stack (that can be serialized and mutated), the store (that can be queried), GC, Allocator..., making the VM stateless:

```go
	Exec(ctx *Context, o Op) (int64, error)
```
Also, all specific code for each node when calling OpExec can ve moved to its specific Node implementation too, simplifying `func (m *Machine) doOpExec(op Op)` method.

I think that this change, instead of having a list of Statements and Expressions, will also allow to have everything on the same list of Nodes. We can iterate over that list of nodes and call `Exec` method on each, simplifying `Run()` method.

On this PR you can see an example of only refactoring Assign Statements, to let you have an idea about how it will look.

Some cases are not fully covered yet (the main one is related to some logic on `PopStmt()`  method), that's why some tests are still failing.

I would love to know what you think about this.

# Checklist (for contributors)

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code