### PR TITLE
feat: add support for toml configuration files + recursive flag definitions for subcommands

### DIFF
--- a/tm2/pkg/commands/command.go
+++ b/tm2/pkg/commands/command.go
@@ -83,6 +83,13 @@ func (c *Command) AddSubCommands(cmds ...*Command) {
 			// subcommands of the child as well
 			// (ex. grandparent flags are available in child commands)
 			registerFlagsWithSubcommands(c.cfg, &cmd.Command)
+
+			// Register the parent options with the child.
+			cmd.Options = append(cmd.Options, c.Options...)
+
+			// Register the parent options with all the
+			// subcommands of the child as well
+			registerOptionsWithSubcommands(&cmd.Command)
 		}
 
 		// Append the subcommand to the parent
@@ -109,4 +116,24 @@ func registerFlagsWithSubcommands(cfg Config, root *ffcli.Command) {
 			subcommands = append(subcommands, subcommand)
 		}
 	}
+}
+
+// registerOptionsWithSubcommands recursively registers the passed in
+// options with the subcommand tree. At the point of calling
+func registerOptionsWithSubcommands(root *ffcli.Command) {
+	subcommands := []*ffcli.Command{root}
+
+	// Traverse the direct subcommand tree,
+	// and register the top-level flagset with each
+	// direct line subcommand
+	for len(subcommands) > 0 {
+		current := subcommands[0]
+		subcommands = subcommands[1:]
+
+		for _, subcommand := range current.Subcommands {
+			subcommand.Options = append(subcommand.Options, root.Options...)
+			subcommands = append(subcommands, subcommand)
+		}
+	}
+
 }

--- a/tm2/pkg/commands/command.go
+++ b/tm2/pkg/commands/command.go
@@ -135,5 +135,4 @@ func registerOptionsWithSubcommands(root *ffcli.Command) {
 			subcommands = append(subcommands, subcommand)
 		}
 	}
-
 }

--- a/tm2/pkg/crypto/keys/client/common.go
+++ b/tm2/pkg/crypto/keys/client/common.go
@@ -11,6 +11,7 @@ type BaseOptions struct {
 	Remote                string
 	Quiet                 bool
 	InsecurePasswordStdin bool
+	Config                string
 }
 
 var DefaultBaseOptions = BaseOptions{
@@ -18,6 +19,7 @@ var DefaultBaseOptions = BaseOptions{
 	Remote:                "127.0.0.1:26657",
 	Quiet:                 false,
 	InsecurePasswordStdin: false,
+	Config:                "",
 }
 
 func HomeDir() string {

--- a/tm2/pkg/crypto/keys/client/root.go
+++ b/tm2/pkg/crypto/keys/client/root.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/peterbourgon/ff/v3"
 )
 
 const (
@@ -22,6 +23,10 @@ func NewRootCmd() *commands.Command {
 		commands.Metadata{
 			ShortUsage: "<subcommand> [flags] [<arg>...]",
 			LongHelp:   "Manages private keys for the node",
+			Options: []ff.Option{
+				ff.WithConfigFileFlag("config"),
+				ff.WithConfigFileParser(ff.PlainParser),
+			},
 		},
 		cfg,
 		commands.HelpExec,
@@ -72,5 +77,12 @@ func (c *baseCfg) RegisterFlags(fs *flag.FlagSet) {
 		"insecure-password-stdin",
 		DefaultBaseOptions.Quiet,
 		"WARNING! take password from stdin",
+	)
+
+	fs.StringVar(
+		&c.Config,
+		"config",
+		DefaultBaseOptions.Config,
+		"config file (optional)",
 	)
 }

--- a/tm2/pkg/crypto/keys/client/root.go
+++ b/tm2/pkg/crypto/keys/client/root.go
@@ -5,7 +5,9 @@ import (
 	"flag"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
+
 	"github.com/peterbourgon/ff/v3"
+	"github.com/peterbourgon/ff/v3/fftoml"
 )
 
 const (
@@ -25,7 +27,7 @@ func NewRootCmd() *commands.Command {
 			LongHelp:   "Manages private keys for the node",
 			Options: []ff.Option{
 				ff.WithConfigFileFlag("config"),
-				ff.WithConfigFileParser(ff.PlainParser),
+				ff.WithConfigFileParser(fftoml.Parser),
 			},
 		},
 		cfg,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

`ffcli` can take arguments to a config file and process them as follows (available with arguments) 
IMHO, I think this is useful if you have a lot of arguments, like the `gnokey` cli. Unlike ENV, it is explicit  e.g.`-config=maketx.local`

```
gnokey maketx call -config ./maketx.local.toml  -pkgpath "gno.land/r/demo/boards" -func "GetBoardIDFromName" -args test anarcher
```

maketx.local.toml
```
gas-fee = "1000000ugnot"
gas-wanted = 2000000
broadcast = true
chainid = "dev"
remote = "127.0.0.1:26657"
```



## Contributors Checklist

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests

## Maintainers Checklist

- [x] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [x] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [x] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
