### PR TITLE
feat: set MAX VM cycles from cli

### DIFF
--- a/gno.land/cmd/gnoland/main.go
+++ b/gno.land/cmd/gnoland/main.go
@@ -33,6 +33,7 @@ type gnolandCfg struct {
 	chainID               string
 	genesisRemote         string
 	rootDir               string
+	maxCycles             int64
 }
 
 func main() {
@@ -105,6 +106,13 @@ func (c *gnolandCfg) RegisterFlags(fs *flag.FlagSet) {
 		"localhost:26657",
 		"replacement for '%%REMOTE%%' in genesis",
 	)
+
+	fs.Int64Var(
+		&c.maxCycles,
+		"max-vm-cycles",
+		10*1000*1000,
+		"set maximum allowed vm cycles per operation. Zero means no limit.",
+	)
 }
 
 func exec(c *gnolandCfg) error {
@@ -135,7 +143,7 @@ func exec(c *gnolandCfg) error {
 	}
 
 	// create application and node.
-	gnoApp, err := gnoland.NewApp(rootDir, c.skipFailingGenesisTxs, logger)
+	gnoApp, err := gnoland.NewApp(rootDir, c.skipFailingGenesisTxs, logger, c.maxCycles)
 	if err != nil {
 		return fmt.Errorf("error in creating new app: %w", err)
 	}

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewApp creates the GnoLand application.
-func NewApp(rootDir string, skipFailingGenesisTxs bool, logger log.Logger) (abci.Application, error) {
+func NewApp(rootDir string, skipFailingGenesisTxs bool, logger log.Logger, maxCycles int64) (abci.Application, error) {
 	// Get main DB.
 	db, err := dbm.NewDB("gnolang", dbm.GoLevelDBBackend, filepath.Join(rootDir, "data"))
 	if err != nil {
@@ -44,7 +44,7 @@ func NewApp(rootDir string, skipFailingGenesisTxs bool, logger log.Logger) (abci
 	acctKpr := auth.NewAccountKeeper(mainKey, ProtoGnoAccount)
 	bankKpr := bank.NewBankKeeper(acctKpr)
 	stdlibsDir := filepath.Join("..", "gnovm", "stdlibs")
-	vmKpr := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, stdlibsDir)
+	vmKpr := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, stdlibsDir, maxCycles)
 
 	// Set InitChainer
 	baseApp.SetInitChainer(InitChainer(baseApp, acctKpr, bankKpr, skipFailingGenesisTxs))

--- a/tm2/pkg/sdk/vm/common_test.go
+++ b/tm2/pkg/sdk/vm/common_test.go
@@ -8,7 +8,6 @@ import (
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/log"
-
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	authm "github.com/gnolang/gno/tm2/pkg/sdk/auth"
 	bankm "github.com/gnolang/gno/tm2/pkg/sdk/bank"
@@ -40,7 +39,7 @@ func setupTestEnv() testEnv {
 	acck := authm.NewAccountKeeper(iavlCapKey, std.ProtoBaseAccount)
 	bank := bankm.NewBankKeeper(acck)
 	stdlibsDir := filepath.Join("..", "..", "..", "..", "gnovm", "stdlibs")
-	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir)
+	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir, 10*1000*1000)
 
 	vmk.Initialize(ms.MultiCacheWrap())
 

--- a/tm2/pkg/sdk/vm/common_test.go
+++ b/tm2/pkg/sdk/vm/common_test.go
@@ -39,7 +39,7 @@ func setupTestEnv() testEnv {
 	acck := authm.NewAccountKeeper(iavlCapKey, std.ProtoBaseAccount)
 	bank := bankm.NewBankKeeper(acck)
 	stdlibsDir := filepath.Join("..", "..", "..", "..", "gnovm", "stdlibs")
-	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir, 10*1000*1000)
+	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir, 10_000_000)
 
 	vmk.Initialize(ms.MultiCacheWrap())
 

--- a/tm2/pkg/sdk/vm/keeper.go
+++ b/tm2/pkg/sdk/vm/keeper.go
@@ -54,6 +54,7 @@ func NewVMKeeper(
 	stdlibsDir string,
 	maxCycles int64,
 ) *VMKeeper {
+	// TODO: create an Options struct to avoid too many constructor parameters
 	vmk := &VMKeeper{
 		baseKey:    baseKey,
 		iavlKey:    iavlKey,

--- a/tm2/pkg/sdk/vm/keeper.go
+++ b/tm2/pkg/sdk/vm/keeper.go
@@ -41,16 +41,26 @@ type VMKeeper struct {
 
 	// cached, the DeliverTx persistent state.
 	gnoStore gno.Store
+
+	maxCycles int64 // max allowed cylces on VM executions
 }
 
 // NewVMKeeper returns a new VMKeeper.
-func NewVMKeeper(baseKey store.StoreKey, iavlKey store.StoreKey, acck auth.AccountKeeper, bank bank.BankKeeper, stdlibsDir string) *VMKeeper {
+func NewVMKeeper(
+	baseKey store.StoreKey,
+	iavlKey store.StoreKey,
+	acck auth.AccountKeeper,
+	bank bank.BankKeeper,
+	stdlibsDir string,
+	maxCycles int64,
+) *VMKeeper {
 	vmk := &VMKeeper{
 		baseKey:    baseKey,
 		iavlKey:    iavlKey,
 		acck:       acck,
 		bank:       bank,
 		stdlibsDir: stdlibsDir,
+		maxCycles:  maxCycles,
 	}
 	return vmk
 }
@@ -174,7 +184,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
 			Store:     store,
 			Alloc:     store.GetAllocator(),
 			Context:   msgCtx,
-			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+			MaxCycles: vm.maxCycles,
 		})
 	defer m2.Release()
 	m2.RunMemPackage(memPkg, true)
@@ -248,7 +258,7 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 			Store:     store,
 			Context:   msgCtx,
 			Alloc:     store.GetAllocator(),
-			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+			MaxCycles: vm.maxCycles,
 		})
 	m.SetActivePackage(mpv)
 	defer func() {
@@ -369,7 +379,7 @@ func (vm *VMKeeper) QueryEval(ctx sdk.Context, pkgPath string, expr string) (res
 			Store:     store,
 			Context:   msgCtx,
 			Alloc:     alloc,
-			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+			MaxCycles: vm.maxCycles,
 		})
 	defer func() {
 		if r := recover(); r != nil {
@@ -429,7 +439,7 @@ func (vm *VMKeeper) QueryEvalString(ctx sdk.Context, pkgPath string, expr string
 			Store:     store,
 			Context:   msgCtx,
 			Alloc:     alloc,
-			MaxCycles: 10 * 1000 * 1000, // 10M cycles // XXX
+			MaxCycles: vm.maxCycles,
 		})
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
# Description

Before this change, some VM operations like loading a package or calling a public realm method had a hardcoded limit of 10M max allowed cycles. With this change that limit can be modified.

Usage: `gnoland --max-vm-cycles=0`

It closes #821 

## Contributors Checklist

- [X] Added new tests, or not needed, or not feasible
- [X] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [X] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
