### PR TITLE
chore(vscode): associate .gno files with Go syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ build
 *.log
 *.gno.gen.go
 *.gno.gen_test.go
-.vscode
+.vscode/**/*
+!.vscode/settings.json
 .idea
 *.pb.go
 pbbindings.go

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "harry-hov.gno"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.gno": "go"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.associations": {
-    "*.gno": "go"
-  }
-}


### PR DESCRIPTION
# Description

1. Associate `*.gno` files with Go for syntax highlighting purposes in VSCode, through a repository-committed `.vscode/settings.json`.
1. Git ignore all files in the `.vscode` directory EXCEPT `.vscode/settings.json`

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
