### PR TITLE
chore: print newline after error in command exit

### DIFF
--- a/gno.land/cmd/gnofaucet/main.go
+++ b/gno.land/cmd/gnofaucet/main.go
@@ -23,7 +23,7 @@ func main() {
 	)
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}

--- a/gno.land/cmd/gnokey/main.go
+++ b/gno.land/cmd/gnokey/main.go
@@ -12,7 +12,7 @@ func main() {
 	cmd := client.NewRootCmd()
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}

--- a/gno.land/cmd/gnoland/main.go
+++ b/gno.land/cmd/gnoland/main.go
@@ -50,7 +50,7 @@ func main() {
 	)
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}

--- a/gnovm/cmd/gno/main.go
+++ b/gnovm/cmd/gno/main.go
@@ -12,7 +12,7 @@ func main() {
 	cmd := newGnocliCmd(commands.NewDefaultIO())
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}
@@ -38,7 +38,6 @@ func newGnocliCmd(io *commands.IO) *commands.Command {
 		newReplCmd(),
 		newDocCmd(io),
 		// fmt -- gofmt
-		// clean
 		// graph
 		// vendor -- download deps from the chain in vendor/
 		// list -- list packages

--- a/misc/genproto/genproto.go
+++ b/misc/genproto/genproto.go
@@ -39,7 +39,7 @@ func main() {
 	)
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}

--- a/misc/goscan/goscan.go
+++ b/misc/goscan/goscan.go
@@ -23,7 +23,7 @@ func main() {
 	)
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}

--- a/tm2/cmd/tm2txsync/main.go
+++ b/tm2/cmd/tm2txsync/main.go
@@ -36,7 +36,7 @@ func main() {
 	)
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%+v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
 
 		os.Exit(1)
 	}


### PR DESCRIPTION
# Description

my shell automatically fixes that adding a newline, but less fancy ones including bash without too much configurations don't:

![image](https://github.com/gnolang/gno/assets/4681308/523dce7f-702e-4ca5-a92f-c1a831c526a2)

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
