### PR TITLE
feat: event & emit in gno

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -249,6 +249,7 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 		OrigSendSpent: new(std.Coins),
 		OrigPkgAddr:   pkgAddr.Bech32(),
 		Banker:        NewSDKBanker(vm, ctx),
+		EventLogger:   ctx.EventLogger(),
 	}
 	// Construct machine and evaluate.
 	m := gno.NewMachineWithOptions(
@@ -277,6 +278,13 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 			res += "\n"
 		}
 	}
+
+	/*
+		// TODO:
+		ctx.EventLogger().EmitEvent(
+			sdk.NewEvent("CALL",
+				sdk.NewEventAttribute("result", "true")))
+	*/
 	return res, nil
 	// TODO pay for gas? TODO see context?
 }

--- a/gnovm/stdlibs/context.go
+++ b/gnovm/stdlibs/context.go
@@ -17,4 +17,5 @@ type ExecContext struct {
 	OrigSend      std.Coins
 	OrigSendSpent *std.Coins // mutable
 	Banker        Banker
+	EventLogger   *sdk.EventLogger
 }

--- a/gnovm/stdlibs/std/event.gno
+++ b/gnovm/stdlibs/std/event.gno
@@ -1,5 +1,7 @@
 package std
 
-type Event interface{}
+type Event interface {
+	AddAttribute(key, value string)
+}
 
 type EventAttribute interface{}

--- a/gnovm/stdlibs/std/event.gno
+++ b/gnovm/stdlibs/std/event.gno
@@ -1,0 +1,5 @@
+package std
+
+type Event interface{}
+
+type EventAttribute interface{}

--- a/gnovm/stdlibs/std/event.gno
+++ b/gnovm/stdlibs/std/event.gno
@@ -1,7 +1,0 @@
-package std
-
-type Event interface {
-	AddAttribute(key, value string)
-}
-
-type EventAttribute interface{}

--- a/gnovm/stdlibs/stdlibs.go
+++ b/gnovm/stdlibs/stdlibs.go
@@ -542,7 +542,6 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 			},
 		)
 		pn.DefineGoNativeValue("NewEvent", sdk.NewEvent)
-		pn.DefineGoNativeValue("NewEventAttribute", sdk.NewEventAttribute)
 	}
 }
 

--- a/gnovm/stdlibs/stdlibs.go
+++ b/gnovm/stdlibs/stdlibs.go
@@ -533,7 +533,7 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 			),
 			func(m *gno.Machine) {
 				arg0 := m.LastBlock().GetParams1()
-				event := arg0.TV.V.(*gno.NativeValue).Value.Interface().(sdk.AttributedEvent)
+				event := arg0.TV.V.(*gno.NativeValue).Value.Interface().(*sdk.AttributedEvent)
 
 				ctx := m.Context.(ExecContext)
 				// TODO: need this prefix?

--- a/gnovm/stdlibs/stdlibs.go
+++ b/gnovm/stdlibs/stdlibs.go
@@ -2,6 +2,7 @@ package stdlibs
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"math"
 	"reflect"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/tm2/pkg/bech32"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
@@ -523,6 +525,25 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 				m.PushValue(res0)
 			},
 		)
+		pn.DefineNative("EmitEvent",
+			gno.Flds( // params
+				"event", "Event",
+			),
+			gno.Flds( // results
+			),
+			func(m *gno.Machine) {
+				arg0 := m.LastBlock().GetParams1()
+				event := arg0.TV.V.(*gno.NativeValue).Value.Interface().(sdk.AttributedEvent)
+
+				ctx := m.Context.(ExecContext)
+				// TODO: need this prefix?
+				event.Type = fmt.Sprintf("gno-%s", event.Type) // prefix with gno-
+				ctx.EventLogger.EmitEvent(event)
+			},
+		)
+		pn.DefineGoNativeValue("NewEvent", sdk.NewEvent)
+		pn.DefineGoNativeValue("NewEventAttribute", sdk.NewEventAttribute)
+
 	}
 }
 

--- a/gnovm/stdlibs/stdlibs.go
+++ b/gnovm/stdlibs/stdlibs.go
@@ -560,7 +560,6 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 				ctx.EventLogger.EmitEvent(event)
 			},
 		)
-
 	}
 }
 

--- a/gnovm/stdlibs/stdlibs.go
+++ b/gnovm/stdlibs/stdlibs.go
@@ -543,7 +543,6 @@ func InjectPackage(store gno.Store, pn *gno.PackageNode) {
 		)
 		pn.DefineGoNativeValue("NewEvent", sdk.NewEvent)
 		pn.DefineGoNativeValue("NewEventAttribute", sdk.NewEventAttribute)
-
 	}
 }
 

--- a/tm2/pkg/crypto/keys/client/addpkg.go
+++ b/tm2/pkg/crypto/keys/client/addpkg.go
@@ -214,6 +214,7 @@ func signAndBroadcast(
 	io.Println("OK!")
 	io.Println("GAS WANTED:", bres.DeliverTx.GasWanted)
 	io.Println("GAS USED:  ", bres.DeliverTx.GasUsed)
+	io.Println("EVENTS:  ", bres.DeliverTx.Events)
 
 	return nil
 }

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -648,6 +648,7 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 		// each result.
 		data = append(data, msgResult.Data...)
 		events = append(events, msgResult.Events...)
+		events = append(events, ctx.EventLogger().Events()...)
 		// TODO append msgevent from ctx. XXX XXX
 
 		// stop execution and return on first failed message

--- a/tm2/pkg/sdk/events.go
+++ b/tm2/pkg/sdk/events.go
@@ -1,6 +1,8 @@
 package sdk
 
 import (
+	"fmt"
+
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 )
 
@@ -35,3 +37,31 @@ func (em *EventLogger) EmitEvents(events []Event) {
 // ----------------------------------------------------------------------------
 
 type Event = abci.Event
+
+type EventAttribute struct {
+	Key   string
+	Value string
+}
+
+type AttributedEvent struct {
+	Type       string
+	Attributes []EventAttribute
+}
+
+func NewEvent(ty string, attrs ...EventAttribute) Event {
+	return AttributedEvent{Type: ty, Attributes: attrs}
+}
+
+func NewEventAttribute(key, value string) EventAttribute {
+	return EventAttribute{Key: key, Value: value}
+}
+
+func (e AttributedEvent) AssertABCIEvent() {}
+
+func (e AttributedEvent) String() string {
+	return fmt.Sprintf("type: %s, attributes: %v", e.Type, e.Attributes)
+}
+
+func (ea EventAttribute) String() string {
+	return fmt.Sprintf("%s: %s", ea.Key, ea.Value)
+}

--- a/tm2/pkg/sdk/events.go
+++ b/tm2/pkg/sdk/events.go
@@ -48,18 +48,8 @@ type AttributedEvent struct {
 	Attributes []EventAttribute
 }
 
-func NewEvent(ty string, attrs ...string) *AttributedEvent {
-	if len(attrs)%2 == 1 {
-		attrs = append(attrs, "")
-	}
-
-	eventAttrs := make([]EventAttribute, 0, len(attrs)/2)
-	for i := 0; i < len(attrs); i += 2 {
-		attr := EventAttribute{Key: attrs[i], Value: attrs[i+1]}
-		eventAttrs = append(eventAttrs, attr)
-	}
-
-	return &AttributedEvent{Type: ty, Attributes: eventAttrs}
+func NewEvent(ty string, attrs ...EventAttribute) Event {
+	return AttributedEvent{Type: ty, Attributes: attrs}
 }
 
 func NewEventAttribute(key, value string) EventAttribute {
@@ -67,10 +57,6 @@ func NewEventAttribute(key, value string) EventAttribute {
 }
 
 func (e AttributedEvent) AssertABCIEvent() {}
-
-func (e *AttributedEvent) AddAttribute(key, value string) {
-	e.Attributes = append(e.Attributes, EventAttribute{Key: key, Value: value})
-}
 
 func (e AttributedEvent) String() string {
 	return fmt.Sprintf("type: %s, attributes: %v", e.Type, e.Attributes)

--- a/tm2/pkg/sdk/events.go
+++ b/tm2/pkg/sdk/events.go
@@ -48,8 +48,8 @@ type AttributedEvent struct {
 	Attributes []EventAttribute
 }
 
-func NewEvent(ty string, attrs ...EventAttribute) Event {
-	return AttributedEvent{Type: ty, Attributes: attrs}
+func NewEvent(ty string, attrs ...EventAttribute) *AttributedEvent {
+	return &AttributedEvent{Type: ty, Attributes: attrs}
 }
 
 func NewEventAttribute(key, value string) EventAttribute {
@@ -57,6 +57,10 @@ func NewEventAttribute(key, value string) EventAttribute {
 }
 
 func (e AttributedEvent) AssertABCIEvent() {}
+
+func (e *AttributedEvent) AddAttribute(key, value string) {
+	e.Attributes = append(e.Attributes, EventAttribute{Key: key, Value: value})
+}
 
 func (e AttributedEvent) String() string {
 	return fmt.Sprintf("type: %s, attributes: %v", e.Type, e.Attributes)

--- a/tm2/pkg/sdk/events.go
+++ b/tm2/pkg/sdk/events.go
@@ -48,8 +48,18 @@ type AttributedEvent struct {
 	Attributes []EventAttribute
 }
 
-func NewEvent(ty string, attrs ...EventAttribute) *AttributedEvent {
-	return &AttributedEvent{Type: ty, Attributes: attrs}
+func NewEvent(ty string, attrs ...string) *AttributedEvent {
+	if len(attrs)%2 == 1 {
+		attrs = append(attrs, "")
+	}
+
+	eventAttrs := make([]EventAttribute, 0, len(attrs)/2)
+	for i := 0; i < len(attrs); i += 2 {
+		attr := EventAttribute{Key: attrs[i], Value: attrs[i+1]}
+		eventAttrs = append(eventAttrs, attr)
+	}
+
+	return &AttributedEvent{Type: ty, Attributes: eventAttrs}
 }
 
 func NewEventAttribute(key, value string) EventAttribute {

--- a/tm2/pkg/sdk/package.go
+++ b/tm2/pkg/sdk/package.go
@@ -15,4 +15,6 @@ var Package = amino.RegisterPackage(amino.NewPackage(
 	).
 	WithTypes(
 		Result{},
+		AttributedEvent{},
+		EventAttribute{},
 	))

--- a/tm2/pkg/sdk/sdk.proto
+++ b/tm2/pkg/sdk/sdk.proto
@@ -13,3 +13,14 @@ message Result {
 	sint64 GasWanted = 2;
 	sint64 GasUsed = 3;
 }
+
+message EventAttribute {
+  string key = 1;
+  string value = 2;
+}
+
+message AttributedEvent {
+  string type = 1;
+  repeated EventAttribute attributes = 2;
+}
+


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

This is an implementation PR for #575. 
I think Events can be indexed by indexers by default, so I think they should be a structured data type, unlike logs. 
In the future, #546 will allow us to view events directly. For now, I think it would be helpful for debugging to be able to view `events` when doing a `gnokey maketx call`, like this :

```
$ gnokey maketx call -config ~/tmp/maketx.local.toml  -pkgpath "gno.land/r/test/event5" -func "Hello"  -broadcast  anarcher
Enter password.
("hello world!" string)
OK!
GAS WANTED: 2000000
GAS USED:   111997
EVENTS:   [type: gno-hello, attributes: [[world: hello world! foo: bar sender: g1ts24jjaxvqjcskdbqzu24r9e4n62ggye520ocv5]
```

Here's an example of its use in gno 
```go
package event

import "std"

const EventAttrKeySender = "sender"


func Hello() string {

     std.EmitEvent("hello",
             "world", "hello world!",
             "foo", "bar",
             EventAttrKeySender, string(std.GetOrigCaller()),
     )
     
     return "hello world!"
}
```




## Contributors Checklist

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
