### PR TITLE
feat: v0 web package with routing/rendering/utility functions

### DIFF
--- a/examples/gno.land/p/demo/web/README.md
+++ b/examples/gno.land/p/demo/web/README.md
@@ -1,0 +1,192 @@
+# `web` Framework
+
+This is a simple web framework made to simplify routing/rendering logic. Made for Gno, it could likely be generalized into a handy grab-n-go Go native framework as well with the addition of an HTTP handling/serving component. 
+
+## Core Structs
+
+### `Router`
+
+The central component, the router can have new routes added with `AddRoute(string,RouteAction)`, and can also have a fallback/404 renderer set with `SetFallback(RouteAction)`. To resolve a path, simply call `Resolve(string)` from the realm's `Render(path)` function, which returns a `Request` pointer and the `RouteAction` function associated with the `Route`. Paths support keys in the form of `{someVar}` which are then available via the `Request` object returned on resolve. 
+
+Example usage: 
+
+```
+_r := web.NewRouter()
+_r.SetFallback(NotFound)
+_r.AddRoute("",Home)
+_r.AddRoute("{communeID}/proposals/{proposalID}",ProposalProfile)
+_r.AddRoute("{communeID}",CommuneProfile)
+
+[...]
+// inside realm's Render(path) function 
+_req, _action := _r.Resolve(path_)
+return _action(_req).Render()
+```
+
+### `Route`
+
+The `Route` struct is how the `Resolve` function is able to determine matching routes. It tracks the `PatternStr` as passed to the `AddRoute` call, `Parts` as a `[]string`, the number of parts at `PartsLength`, and the `RouteAction` conforming function is stored at `Action`. 
+
+When matching routes, first the list of routes is iterated through looking for exact matches between the request's path and the `PatternStr`. If no exact match is found it iterates through a second time, first comparing `PartsLength` to the request's split part length to skip routes that obviously won't match, and then comparing each part first exactly, then as a key, tallying the matched number of parts for final comparison.
+
+### `Request`
+
+The `Request` struct tracks a string `Path` representing the path the user is requesting, along with `Keys` (`[]string`), `Values` (`avl.Tree`) and `Data` (`avl.Tree`) fields. 
+
+URL matched keys are accessible with request struct's `Value(key)` function. The struct also has `Set` and `Get` functions mapping to the same functions on the `Data` tree to load arbitrary data onto the request object. Most importantly, the request struct has a `Respond(interface{}, Renderer)` function that takes in data and the desired `Renderer` conforming function and returns a `Response` pointer.
+
+### `Response`
+
+The `Response` struct tracks the `Request` pointer at  `req`, and contains `Body` (`string`) and `Data` (`avl.Tree`) fields. Like the `Request` struct, `Set` and `Get` functions mapping to the same functions on the `Data` tree also exist on `Response` to load arbitrary data onto the response object. Its `Render()` function is used to return the contents of `Body`, which is set in the request's `Respond` function using the `Renderer` and data passed.
+
+
+### `KV`
+
+The `KV` struct simplifies dealing with keyed lists, providing an iterable `[]string` field at `keys`, and an `avl.Tree` at `values`. It has an `Add(string,interface{})` function to add new k=>v state, a `Keys()` function to return the keys, and `Values()` to return the values. This simplifies some things, particularly templating. A future version will likely leverage it internally (like in `Request` or `Template` for their keys/values). You can generate a new empty KV pointer with `NewKV()`, or alternatively can load a keys string and values avl.Tree into a KV wrapped version with `KVLoad([]string, avl.Tree)`.
+
+## Function Types
+
+## `RouteAction`
+
+The `RouteAction` type is what devs will implement for handling their app logic and mapping it to a template or otherwise generating the response body. It takes in a `Request` pointer, and returns a `Response` pointer by calling `Respond(interface{},Renderer)` on the passed request struct. 
+
+## `Renderer`
+
+A renderer function is any that takes in an `interface{}` param, and returns a `string`. This allows for both an assortment of base renderers like `Stringer`, `Selfer`, `Linker`, etc (see `renderers.gno` for full list), as well as custom render functions, which could then be used to handle view partials before final/top-level template rendering.
+
+## `RouteAction` & `Renderer` Usage Example
+
+Below is an example of a `RouteAction` function as implemented by `CommuneProfile`, along with how `KV` and the `web.Templater` `Renderer` might be used together.
+
+```
+router.AddRoute("{communeID}",CommuneProfile)
+
+[...]
+
+const viewCommune string = 
+`# {communeID}
+  
+Admin: {admin}
+
+Link: {link}
+
+List: 
+  {list}
+
+
+Link List: 
+
+  {linkList}`
+
+[...]    
+
+func CommuneProfile(req_ *web.Request) *web.Response {
+	_communeStr := req_.Value("communeID")
+	_communeID := identity.IDString(_communeStr)
+	_exists := daoRegistry.Exists(_communeID)
+	if !_exists {
+		_res := ufmt.Sprintf("You are on commune: %s. Does not exist.",_communeStr)
+		return req_.Respond(_res, web.Stringer)
+	}
+
+	_kv := web.NewKV()	
+	_d := daoRegistry.DAO(_communeID)
+	
+	_list := []string{"one","three","two","apple"}
+	_link := web.NewLink("google","https://google.com")
+	_links := []*web.Link{_link,_link,_link}
+
+
+	// return req_.Respond(_d, web.Selfer)
+	_kv.Add("communeID", _communeID)
+	_kv.Add("admin",string(_d.Identity.Account()))
+	_kv.Add("link",web.Linker(_link))
+	_kv.Add("list",web.Lister(_list))
+	_kv.Add("linkList",web.LinkLister(_links))
+	_template := web.NewTemplate(viewCommune, _kv.Keys(), _kv.Values(), avl.Tree{})	
+
+	return req_.Respond(_template, web.Templater)
+}
+```
+
+## Renderer Related Structs
+
+### `Link`
+
+This struct type expects a `Text` field and a `Link` field, and is used by the `Linker` and `LinkLister` renderers. Links can be generated with `web.NewLink(text_,link_)`.
+
+### `Template`
+
+This struct type expects a `TemplateRaw` field containing a string template, a `Keys` field that's `[]string`, a `Values` field that's an `avl.Tree` of the keyed values, and a `Renderers` field that's an `avl.Tree` tracking per-key Renderers. This is used by the `Templater` and `MarkdownTemplater` renderers (currently the same thing). Templates can be generated with `web.NewTemplate(raw_, keys_, values_, renderers_)`.
+
+The `Templater` renderer uses `{}` wrapped keys in the `TemplateRaw`, and then for each key simply calls `ReplaceAll` on the wrapped key, replacing it with the data from `Values`, processed through a `Renderer` (defaults to `Stringer` if no key-renderer specified). The `viewCommune` const in the above snippet shows an example of what this looks like (could also be loaded from template files).
+
+Alternate method to the above using per-key `Renderer` functions: 
+
+```
+_renderers := avl.Tree{}
+_renderers.Set("link",web.Linker)
+_renderers.Set("list",web.Lister)
+_renderers.Set("linkList",web.LinkLister)
+
+[...]
+
+_kv.Add("link",_link)
+_kv.Add("list",_list)
+_kv.Add("linkList",_links)
+
+_template := web.NewTemplate(viewCommune, _kv.Keys(), _kv.Values(), _renderers)	
+return req_.Respond(_template, web.Templater)
+```
+
+This method allows for default/app level key renderers to be defined, enabling consistent rules like using `web.H1` for any `{title}` keys, or assigning a custom renderer to `{username}` that converts it to a link to their profile (which could leverage `web.Linker` internally once creating the user's `Link` struct).
+
+### Markdown Renderers
+
+Effectively a carbon copy of the functions defined in the `ui` package, the following functions have been adapted to conform to the `Renderer` function requirements, allowing them to be used like any other Renderer. This could be especially helpful for per-key renderers, allowing for template files that focus on structure rather than style while style is moved to a global template key=>Renderer tree.
+
+```
+func H1(data_ interface{}) string     	{ return "# " + Stringer(data_) + "\n" }
+func H2(data_ interface{}) string     	{ return "## " + Stringer(data_) + "\n" }
+func H3(data_ interface{}) string     	{ return "### " + Stringer(data_) + "\n" }
+func H4(data_ interface{}) string     	{ return "#### " + Stringer(data_) + "\n" }
+func H5(data_ interface{}) string     	{ return "##### " + Stringer(data_) + "\n" }
+func H6(data_ interface{}) string     	{ return "###### " + Stringer(data_) + "\n" }
+func Bold(data_ interface{}) string   	{ return "**" + Stringer(data_) + "**"} 
+func Italic(data_ interface{}) string 	{ return "_" + Stringer(data_) + "_"} 
+func Code(data_ interface{}) string   	{ return "`" + Stringer(data_) + "`"} 
+func HR(data_ interface{}) string       { return "\n---\n"}
+```
+
+## Utility Functions
+
+While other internal utility functions exist, the public facing functions are most of note and for the moment deal mostly with type conversions. String=>Int conversions under the hood just use `strconv.Atoi` before casting/returning the desired type. Supported conversion functions are:
+
+- `Str(interface{}) string` <- just shorthand for `Stringer`
+- `Int(interface{}) int`
+- `UI64(int) uint64`
+- `I64(int) int64`
+- `UI32(int) uint32`
+- `I32(int) int32`
+- `UI16(int) uint16`
+- `I16(int) int16`
+- `UI8(int) uint8`
+- `I8(int) int8`
+- `StrUI64(string) uint64` 
+- `StrI64(string) int64` 
+- `StrUI32(string) uint32` 
+- `StrI32(string) int32` 
+- `StrUI16(string) uint16` 
+- `StrI16(string) int16` 
+- `StrUI8(string) uint8` 
+- `StrI8(string) int8` 
+
+## Experimental Structs
+
+### `KR`
+
+Not used/tested yet, `KR` extends the idea of the `KV` construct into records of values. It tracks `keys` as `[]string` like `KV`, and `records` as a `[]avl.Tree`. It has `AddKey(string)` and `AddRecord(avl.Tree)` functions, as well as getters for both `Keys()` and `Records()`. It also has both `RecordAt(int)` and `ValueAt(int, string)` functions for selecting records/values at known indexes. It can also return the number of records with `Count()`.
+
+More ambitiously, it contains a `Filter(selKeys_ []string, whereKeys_ []string, whereValues_ avl.Tree)` function that returns a new `KR` pointer of the resultset, along with a count of the number of matches. Internally it compares the results of the values after passing them through `Stringer` to avoid type issues (while likely creating some more).
+
+Again... this is not tested. Assume borked. 

--- a/examples/gno.land/p/demo/web/generators.gno
+++ b/examples/gno.land/p/demo/web/generators.gno
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"std"
+	"strings"
+	"regexp"
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/demo/avl"
+)
+
+func NewRouter() *Router{
+	return &Router{}
+}
+
+func NewRoute(pattern_ string, action_ RouteAction) *Route {
+	pattern_ = attify(pattern_)	
+	_pathParts := trimSplit(pattern_)
+	// _parts := []string{}
+	// for _, _part := range _pathParts {
+	// 	_parts = append(_parts, string(_part))
+	// }
+	return &Route{
+		PatternStr: pattern_,
+		Parts: _pathParts,
+		PartsLength: len(_pathParts),
+		Action: action_, 
+	}	
+}
+
+func NewRequestExact(path_ string) *Request {
+	return &Request{
+		Path: path_,
+		Keys: []string{},
+		Values: avl.Tree{}, 
+		Data: avl.Tree{},
+	}
+}
+
+func NewRequest(path_ string, keys_ []string, values_ avl.Tree) *Request {
+	// var _keys []string = []string{}
+	// var _values avl.Tree = avl.Tree{}
+
+	// for _k, _part := range _pathParts {
+		
+	// }
+	return &Request{
+		Path: path_,
+		Keys: keys_,
+		Values: values_,
+		Data: avl.Tree{},
+	}
+}
+
+func NewResponse(req_ *Request, body_ string) *Response {
+	return &Response{
+		req: req_,
+		Body: body_,
+		Data: req_.Data,
+	}
+}
+
+
+
+func NewKV() *KV {
+	return &KV{}
+}
+
+func KVLoad(keys_ []string, values_ avl.Tree) *KV {
+	_kv := NewKV()
+	_kv.Load(keys_,values_)
+	return _kv
+}
+
+//KR is untested. use at own risk
+func NewKR() *KR {
+	return &KR{}
+}
+
+func KRLoad(keys_ []string, records_ []avl.Tree) *KR {
+	_kr := NewKR()
+	_kr.Load(keys_,records_)
+	return _kr
+}
+
+func NewLink(text_ string, link_ string) *Link {
+	return &Link{
+		Text: text_,
+		Link: link_,
+	}
+}
+
+func NewTemplate(template_ string, keys_ []string, values_ avl.Tree, renderers_ avl.Tree) *Template {
+	return &Template{
+		TemplateRaw: template_,
+		Keys: keys_,
+		Values: values_,
+		Renderers: renderers_,
+	}
+}

--- a/examples/gno.land/p/demo/web/iweb.gno
+++ b/examples/gno.land/p/demo/web/iweb.gno
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"std"
+	"strconv"
+	"strings"
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+)
+
+type RouteAction func (*Request) *Response
+
+type Renderer func(interface{}) string
+
+type Renderable interface {
+	Render() string
+}
+
+type IRouter interface {
+	AddRoute(string, RouteAction) bool 
+	SetFallback(RouteAction) bool
+	Resolve(string) (*Request, RouteAction)	
+}
+
+type IRequest interface {	
+	Respond(interface{},Renderer) *Response	
+	Value(string) string
+	Get(string) (interface{}, bool)
+	Set(string,interface{})
+}
+
+type IResponse interface {
+	Render() string
+	Get(string) (interface{}, bool)
+	Set(string,interface{})
+}
+
+type IKV interface {
+	Load([]string, avl.Tree) bool
+	Add(string, interface{}) bool
+	Keys() []string
+	Values() avl.Tree
+}
+
+type IKR interface {
+	Load([]string, []avl.Tree) bool
+	Filter([]string, []string, avl.Tree) (*KR, int)
+	AddKey(string) bool
+	AddRecord(interface{}) bool
+	RecordAt(int) avl.Tree
+	ValueAt(int, string) interface{}
+	Keys() []string
+	Records() avl.Tree
+	Count() int
+}

--- a/examples/gno.land/p/demo/web/renderers.gno
+++ b/examples/gno.land/p/demo/web/renderers.gno
@@ -1,0 +1,113 @@
+package web
+
+import (
+	"std"
+	"strings"
+	"regexp"
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/demo/avl"
+)
+
+// BASE RENDERER FUNCTIONS
+
+func Stringer(data_ interface{}) string {
+	return string(data_)
+}
+
+func Selfer(data_ interface{}) string {
+	return Renderable(data_).Render()
+}
+
+func Linker(data_ interface{}) string {
+	_link := data_.(*Link)
+	return "[" + _link.Text + "](" + _link.Link + ")"
+}
+
+func Lister(data_ interface{}) string {
+	_items := data_.([]string)
+	_list := ""
+	for _k, _item := range _items {
+		_list += "* " + _item + "\n"
+	}
+	return _list
+}
+
+func LinkLister(data_ interface{}) string {
+	_items := []string{}
+	_links := data_.([]*Link)
+	for _i, _link := range _links {
+		_linked := Linker(_link)
+		_items = append(_items, _linked)
+	}
+
+	return Lister(_items) 
+}
+
+//ie: likely the most used renderer, mapping KV=>placeholders
+func Templater(data_ interface{}) string {
+	_template := data_.(*Template)
+	_tmp := _template.TemplateRaw 
+	for _k, _key := range _template.Keys {
+		_value, _ := _template.Values.Get(_key)
+		_key = string(_key)
+		_keyed := keyify(_key)	
+		_r, _exists := _template.Renderers.Get(_key)
+		if _exists {			
+			_renderer := _r.(func(interface{})(string))
+			_tmp = strings.ReplaceAll(_tmp, _keyed, _renderer(_value))
+		} else {
+			_tmp = strings.ReplaceAll(_tmp, _keyed, Stringer(_value))
+		}		
+	}
+	return _tmp
+}
+
+func MarkdownRaw(data_ interface{}) string {
+	return Stringer(data_) // think this would actually just be same.
+}
+
+func MarkdownTemplater(data_ interface{}) string {
+	return Templater(data_) // ditto for this
+}
+
+//// Markdown Helpers/Renderers 
+//// (adapted from ui package to comply with Renderer 
+//// Note re: HR: keys with an HR key renderer will need an arbitrary value for the key 
+//// or it will be skipped
+
+func H1(data_ interface{}) string     	{ return "# " + Stringer(data_) + "\n" }
+func H2(data_ interface{}) string     	{ return "## " + Stringer(data_) + "\n" }
+func H3(data_ interface{}) string     	{ return "### " + Stringer(data_) + "\n" }
+func H4(data_ interface{}) string     	{ return "#### " + Stringer(data_) + "\n" }
+func H5(data_ interface{}) string     	{ return "##### " + Stringer(data_) + "\n" }
+func H6(data_ interface{}) string     	{ return "###### " + Stringer(data_) + "\n" }
+func Bold(data_ interface{}) string   	{ return "**" + Stringer(data_) + "**"} 
+func Italic(data_ interface{}) string 	{ return "_" + Stringer(data_) + "_"} 
+func Code(data_ interface{}) string   	{ return "`" + Stringer(data_) + "`"} 
+func HR(data_ interface{}) string	  	{ return "\n---\n"}
+
+// RENDERER SPECIFIC TYPES
+
+type Link struct {
+	Text string 
+	Link string
+}
+
+type Template struct {
+	TemplateRaw string 
+	Keys []string 
+	Values avl.Tree
+	Renderers avl.Tree
+}
+
+// TODO: noodle on "loaders" to simplify loading template files?
+
+func TemplateLoader() string {
+	panic("Not yet implemented!")
+	return ""
+}
+
+func MarkdownLoader() string {
+	panic("Not yet implemented!")
+	return ""
+}

--- a/examples/gno.land/p/demo/web/utils.gno
+++ b/examples/gno.land/p/demo/web/utils.gno
@@ -1,0 +1,191 @@
+package web
+
+import (
+	"std"
+	"strings"
+	"strconv"
+	"regexp"
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/demo/avl"
+)
+
+// PUBLIC
+
+//// INT=>INT CONVERSIONS (+ Stringer shorthand helper function)
+
+func Str(str_ interface{}) string {
+	return Stringer(str_)
+}
+
+func Int(int_ interface{}) int {
+	return int(int_)
+}
+
+func UI64(int_ int) uint64 {
+	return uint64(int_)
+}
+
+func I64(int_ int) int64 {
+	return int64(int_)
+}
+
+func UI32(int_ int) uint32 {
+	return uint32(int_)
+}
+
+func I32(int_ int) int32 {
+	return int32(int_)
+}
+
+func UI16(int_ int) uint16 {
+	return uint16(int_)
+}
+
+func I16(int_ int) int16 {
+	return int16(int_)
+}
+
+func UI8(int_ int) uint8 {
+	return uint8(int_)
+}
+
+func I8(int_ int) int8 {
+	return int8(int_)
+}
+
+
+//// STR=>INT CONVERSION
+
+func StrInt(str_ string) int {
+	_num, _err := strconv.Atoi(str_)
+	if _err != nil {
+		panic(ufmt.Sprintf("Error converting '%s' to int",str_))
+	}
+	return _num
+}
+
+func StrUI64(str_ string) uint64 {
+	return UI64(StrInt(str_))	
+}
+
+func StrI64(str_ string) int64 {
+	return I64(StrInt(str_))	
+}
+
+func StrUI32(str_ string) uint32 {
+	return UI32(StrInt(str_))	
+}
+
+func StrI32(str_ string) int32 {
+	return I32(StrInt(str_))	
+}
+
+func StrUI16(str_ string) uint16 {
+	return UI16(StrInt(str_))	
+}
+
+func StrI16(str_ string) int16 {
+	return I16(StrInt(str_))	
+}
+
+func StrUI8(str_ string) uint8 {
+	return UI8(StrInt(str_))	
+}
+
+func StrI8(str_ string) int8 {
+	return I8(StrInt(str_))	
+}
+
+// INTERNAL
+
+func attify(pattern_ string) string {
+	if pattern_ == "" || pattern_ == "/" {
+		return "@"
+	}
+	return pattern_
+}
+
+func trimSplit(pattern_ string) []string {
+	_path := trimLeadingSlash(pattern_)
+	return strings.Split(_path, "/")	
+}
+
+func subSplit(pattern_ string) []string {
+	return strings.Split(pattern_, ":")	
+}
+
+func keyify(key_ string ) string {
+	return "{" + key_ + "}"
+}
+
+func partKey(part_ string) string {
+	_partChars := []rune(part_)
+	_first := string(_partChars[0])
+	_last := string(_partChars[len(_partChars)-1])
+	if _first == "{" && _last == "}" {
+		_key := strings.TrimPrefix(part_,"{")
+		return strings.TrimSuffix(_key,"}")
+	}
+	return ""
+}
+
+func trimLeadingSlash(path_ string) string {
+	_pathChars := []rune(path_)
+	_first := string(_pathChars[0])
+	if _first != "/" {
+		return path_
+	}
+
+	for _i := range path_ {
+		if _i > 0 {
+			return path_[_i:]
+		}
+	}
+	return path_[:0]
+}
+
+// TODO: implement?
+// _matched, _subKeys, _subValues := subPathResolve(_rtPart, _reqParts[_i])					
+// if _matched {
+// 	for _j, _subKey := range _subKeys {
+// 		_keys = append(_keys, _subKey)
+// 		_values.Set(_subKey,_subValues[_j])
+// 	}
+// 	_matches++
+// }
+
+func subPathResolve(routePart_ string, pathPart_ string) (bool, []string, []string) {
+	_matched := false 
+	_keys := []string{}
+	_values := []string{}
+
+	return _matched, _keys, _values
+	// TODO: update to support `thing:{id}` and `{id}:thing` style "part" resolution
+					// _splitRoutePart := subSplit(_part)
+					// _splitPathPart := subSplit(_pathParts[_i])
+					// _splitLength := len(_splitRoutePart)
+					// _splitPathLength := len(_splitPathPart)
+					// if _splitLength == 1 || _splitLength != _splitPathLength {
+					// 	continue
+					// }
+					// _subMatches := 0
+					// for _j, _sub := range _splitRoutePart {
+					// 	if _sub == _splitPathPart[_j] {
+					// 		_subMatches++
+					// 		_keys = append(_keys, _sub)
+					// 		_values.Set(_sub,_sub)
+					// 	} else {
+					// 		_sk := partKey(_sub)
+					// 		if _sk != "" {
+					// 			_subMatches++ 
+					// 			_keys = append(_keys, _sk)
+					// 			_values.Set(_sk,_splitPathPart[_j])
+					// 		}
+					// 	}
+					// }
+					// if _splitLength == _subMatches {
+					// 	_matches++
+					// } else {
+					// 	continue
+					// }
+}

--- a/examples/gno.land/p/demo/web/web.gno
+++ b/examples/gno.land/p/demo/web/web.gno
@@ -1,0 +1,272 @@
+package web
+
+import (
+	"std"
+	"strconv"
+	"strings"
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+)
+
+// Example Usage: 
+// _router := NewRouter()
+// _router.SetFallback(RouteAction)
+// _router.AddRoute(string, RouteAction)
+// ...
+// _req, _action := _router.Resolve(path_)
+// return _action(_req).Render()
+
+
+// ROUTE
+
+type Route struct{
+	PatternStr string
+	Parts []string
+	PartsLength int	
+	Action RouteAction		
+}
+
+// ROUTER
+
+type Router struct{
+	routes []*Route
+	fallback RouteAction
+}
+
+func (r *Router) AddRoute(pattern_ string, action_ RouteAction) bool {
+	_route := NewRoute(pattern_, action_)
+	r.routes = append(r.routes, _route)
+	return true
+}
+
+func (r *Router) SetFallback(action_ RouteAction) bool {
+	r.fallback = action_
+	return true
+}
+
+func (r *Router) Resolve(path_ string) (*Request, RouteAction) {
+	path_ = attify(path_)
+	// Loop through first looking for exact string pattern matches
+	for _, _route := range r.routes {
+		if path_ == _route.PatternStr {
+			_req := NewRequestExact(path_)
+			return _req, _route.Action
+		}		
+	}	
+	
+    _reqParts := trimSplit(path_)
+	_reqLength := len(_reqParts)
+
+	// If no exact match, loop through processing pattern keys
+	for _, _route := range r.routes {
+		if _reqLength != _route.PartsLength {				
+			continue			
+		}		
+		
+		_matches := 0
+		_keys := []string{}
+		_values := avl.Tree{}
+		for _i, _rtPart := range _route.Parts {
+			if _rtPart == _reqParts[_i] { 
+				_matches++ 
+				_keys = append(_keys, _rtPart)
+				_values.Set(_rtPart,_rtPart)
+				continue
+			}
+
+			_k := partKey(_rtPart)
+			if _k != "" {
+				_matches++ 
+				_keys = append(_keys, _k)
+				_values.Set(_k,_reqParts[_i])
+			} else {
+				//see `subPathResolve` for start of subpath support. will likely cull
+				//example url of idea: `a:{ID1}/{ID2}:b` matching `a:noun/person:b`
+			}			
+		}
+
+		if _matches == _route.PartsLength {
+			_req := NewRequest(path_, _keys, _values)
+			return _req, _route.Action
+		}		
+	}	
+
+	if r.fallback != nil {
+		_req := NewRequestExact(path_)
+		return _req, r.fallback
+	}
+	
+	panic("Router: No matching route")	
+}
+
+// REQUEST
+
+type Request struct{
+	Path string
+	Keys []string
+	Values avl.Tree
+	Data avl.Tree
+}
+
+func (r *Request) Get(key_ string) (interface{}, bool) {
+	return r.Data.Get(key_)	
+}
+
+func (r *Request) Set(key_ string, value_ interface{}) {
+	r.Data.Set(key_, value_)	
+}
+
+func (r *Request) Value(key_ string) string {
+	_value, _exists := r.Values.Get(key_)
+	if !_exists {
+		return ""
+	}
+
+	return string(_value)
+}
+
+func (r *Request) Respond(data_ interface{}, renderer_ Renderer) *Response {
+	_body := renderer_(data_)
+	return NewResponse(r, _body)
+}
+
+// RESPONSE
+
+type Response struct{
+	req *Request
+	Body string
+	Data avl.Tree
+}
+
+//TODO: determine if Response cloning Req data makes sense/is useful, otherwise cull?
+func (r *Response) Render() string{
+	return r.Body
+}
+
+func (r *Response) Get(key_ string) (interface{}, bool) {
+	return r.Data.Get(key_)
+}
+
+func (r *Response) Set(key_ string, value_ interface{}) {
+	r.Data.Set(key_, value_)
+}
+
+// KV 
+
+type KV struct {
+	keys []string
+	values avl.Tree
+}
+
+func (k *KV) Load(keys_ []string, values_ avl.Tree) bool {
+	k.keys = keys_
+	k.values = values_
+	return true
+}
+
+func (k *KV) Add(key_ string, value_ interface{}) bool {
+	if k.values.Has(key_) {
+		return false
+	}
+	k.keys = append(k.keys, key_)
+	k.values.Set(key_, value_)
+	return true
+}
+
+func (k *KV) Keys() []string {	
+	return k.keys
+}
+
+func (k *KV) Values() avl.Tree {	
+	return k.values
+}
+
+// KR (untested, use at own risk)
+//TODO out of bounds/existance checking
+
+type KR struct {
+	keys []string
+	records []avl.Tree
+}
+
+func (k *KR) Load(keys_ []string, records_ []avl.Tree) bool {
+	k.keys = keys_
+	k.records = records_
+	return true
+}
+
+func (k *KR) Count() int {
+	return len(k.records)
+}
+
+func (k *KR) AddKey(key_ string) bool {
+	k.keys = append(k.keys, key_)
+	return true
+}
+
+func (k *KR) AddRecord(record_ avl.Tree) bool {
+	k.records = append(k.records, record_)
+	return true
+}
+
+func (k *KR) RecordAt(idx_ int) avl.Tree {	
+	if idx_ < 0 || idx_ > (k.Count()-1) {
+		panic(ufmt.Sprintf("Invalid record index requested: %d",idx_))
+	}
+	return k.records[idx_]
+}
+
+func (k *KR) ValueAt(idx_ int, key_ string) interface{} {	
+	_v, _e := k.RecordAt(idx_).Get(key_)
+	if !_e {
+		panic(ufmt.Sprintf("Invalid value requested: %d,%s",idx_,key_))
+	}
+	return _v
+}
+
+func (k *KR) Filter(selKeys_ []string, whereKeys_ []string, whereValues_ avl.Tree) (*KR, int) {	
+	_kr := KRLoad(selKeys_, []avl.Tree{})
+	_whereCount := len(whereKeys_)
+	_matchedRecordCount := 0
+	for _c, _record := range k.records {
+		_whereMatches := 0		
+		for _wk, _whereKey := range whereKeys_ {			
+			_v, _e := _record.Get(_whereKey)
+			_qv, _qe := whereValues_.Get(_whereKey)
+			//key doesn't exist at record or in the where (would be weird, but possible)
+			if !_e || !_qe {
+				break
+			}
+			//value at record doesn't match where value (TODO: add operand support?)			
+			if Stringer(_qv) != Stringer(_v) {
+				break
+			}			
+			_whereMatches++
+		}		
+		if _whereMatches == _whereCount {
+			_sel := avl.Tree{}
+			if len(selKeys_) == 0 {
+				//NOTE: this will have a weird behaviour, returning a KR with no keys.
+				//spose the object being filtered would still have its keys, but worth noting
+				_sel = _record
+			}else {
+				for _sk, _selKey := range selKeys_ {
+					_sv, _se := _record.Get(_selKey)
+					_sel.Set(_selKey,_sv)
+				}
+			}			
+			_kr.AddRecord(_sel)	
+			_matchedRecordCount++		
+		}
+	}
+	return _kr, _matchedRecordCount
+}
+
+
+func (k *KR) Keys() []string {	
+	return k.keys
+}
+
+func (k *KR) Records() []avl.Tree {	
+	return k.records
+}

--- a/examples/gno.land/p/demo/web/web_test.gno
+++ b/examples/gno.land/p/demo/web/web_test.gno
@@ -1,0 +1,89 @@
+package web
+
+ import (
+ 	"std"
+ 	"testing"	 
+	 "gno.land/p/demo/ufmt"
+ )
+
+const (
+	helloString string = "Hello World"
+	thingsString string = "Hello Things"
+	thingString string = "Hello Thing: %s"
+	thingName string = "bob"
+)
+
+ func HelloWorld(req_ *Request) *Response {
+	return req_.Respond(helloString, Stringer)
+ }
+ 
+ func Things(req_ *Request) *Response {
+	return req_.Respond(thingsString, Stringer)
+ }
+ 
+ func Thing(req_ *Request) *Response {	
+	return req_.Respond(ufmt.Sprintf(thingString, req_.Value("thingID")), Stringer)
+ }
+
+func ThingsRouter() *Router {
+	_r := NewRouter()
+	_r.AddRoute("",HelloWorld)
+	_r.AddRoute("things",Things)
+	_r.AddRoute("thing/{thingID}",Thing)
+	return _r
+}
+
+ func TestWeb(t *testing.T) {
+ 	type BooleanTest struct {
+ 		name    string
+ 		response bool
+ 		fn      func() bool
+ 	}
+
+ 	// walk through creating organic and org ids, asserting only one of each per person
+ 	{
+		t.Logf("Starting WebApp Test")
+		_router := ThingsRouter()
+		t.Logf("Created Things Router")
+
+		tests := []BooleanTest{
+			{"Hello World", true, func() bool { 
+				_req, _action := _router.Resolve("")				
+				return _action(_req).Render() == helloString
+			}},
+			{"Hello Things", true, func() bool { 
+				_req, _action := _router.Resolve("things")
+				return _action(_req).Render() == thingsString
+			}},
+			{"Hello Thing", true, func() bool { 
+				_req, _action := _router.Resolve(ufmt.Sprintf("thing/%s", thingName))
+				return _action(_req).Render() == ufmt.Sprintf(thingString, thingName)
+			}},
+		}
+		for _, tc := range tests {
+			if tc.fn() != tc.response {
+				t.Errorf("%s: have: %t want: %t", tc.name, tc.fn(), tc.response)
+			}
+		}
+		
+		// _helloReq, _helloAction := _router.Resolve("/")
+		// t.Logf("Hello World Response: %s", _helloAction(_helloReq).Render())
+		
+		// _thingsReq, _thingsAction := _router.Resolve("/things")
+		// t.Logf("Things Response: %s", _thingsAction(_thingsReq).Render())
+		
+		// _thingReq, _thingAction := _router.Resolve("/thing/bob")
+		// t.Logf("Thing Response: %s", _thingAction(_thingReq).Render())
+
+		// t.Errorf("SUCCESS! FAILING NOW!")					
+ 	}	
+ }
+
+
+ func panicValue(fn func()) (recovered interface{}) {
+     defer func() {
+         recovered = recover()
+     }()
+     fn()    
+ 	return
+ }


### PR DESCRIPTION
# Description

I noticed routing for the moment in realms is handled mostly with ad-hoc if statements and had a bit more complex needs for the commune hacking now tracked on the [commune-realms](https://github.com/proggR/gno-dev/tree/commune-realms) branch, so I've rolled a simple `web` package aiming to simplify handling gnoweb requests. Includes a `Templater` renderer that supports per-key sub Renderers, allowing for things like globally defined custom renderers for keys like `username` or `postURL`, etc.

## Contributors Checklist

- Tests with a `ThingsRouter` are present in `web_test`. Could use more coverage after feature scope creep.
- README.md captures the package's constructs and includes example snippets

Example usage copy pasted from README:

```
_r := web.NewRouter()
_r.SetFallback(NotFound)
_r.AddRoute("",Home)
_r.AddRoute("{communeID}/proposals/{proposalID}",ProposalProfile)
_r.AddRoute("{communeID}",CommuneProfile)

[...]

// inside realm's Render(path) function 
_req, _action := _r.Resolve(path_)
return _action(_req).Render()

[...]

const viewCommune string = 
`# {communeID}
  
Admin: {admin}

Link: {link}

List: 
  {list}


Link List: 

  {linkList}`

[...]

func CommuneProfile(req_ *web.Request) *web.Response {
	_communeStr := req_.Value("communeID")
	_communeID := identity.IDString(_communeStr)
	_exists := daoRegistry.Exists(_communeID)
	if !_exists {
		_res := ufmt.Sprintf("You are on commune: %s. Does not exist.",_communeStr)
		return req_.Respond(_res, web.Stringer)
	}

	_kv := web.NewKV()	
	_d := daoRegistry.DAO(_communeID)
	
	_list := []string{"one","three","two","apple"}
	_link := web.NewLink("google","https://google.com")
	_links := []*web.Link{_link,_link,_link}


	// return req_.Respond(_d, web.Selfer)
	_kv.Add("communeID", _communeID)
	_kv.Add("admin",string(_d.Identity.Account()))
	_kv.Add("link",web.Linker(_link))
	_kv.Add("list",web.Lister(_list))
	_kv.Add("linkList",web.LinkLister(_links))
	_template := web.NewTemplate(viewCommune, _kv.Keys(), _kv.Values(), avl.Tree{})	

	return req_.Respond(_template, web.Templater)
}

// Alternative to above example

_renderers := avl.Tree{}
_renderers.Set("link",web.Linker)
_renderers.Set("list",web.Lister)
_renderers.Set("linkList",web.LinkLister)

[...]

_kv.Add("link",_link)
_kv.Add("list",_list)
_kv.Add("linkList",_links)

_template := web.NewTemplate(viewCommune, _kv.Keys(), _kv.Values(), _renderers)	
return req_.Respond(_template, web.Templater)

```


