### PR TITLE
[WIP]fix: check copy func param type

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -1008,10 +1008,16 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 						}
 					} else if fv.PkgPath == uversePkgPath && fv.Name == "copy" {
 						if len(n.Args) == 2 {
+							args0T := evalStaticTypeOf(store, last, n.Args[0])
+							args1T := evalStaticTypeOf(store, last, n.Args[1])
+							if args0T.Elem().TypeID() != args1T.Elem().TypeID() {
+								panic(fmt.Sprintf(
+									"arguments to copy have different element types, want %s, got %s", args0T.Elem().TypeID(), args1T.Elem().TypeID()))
+							}
 							// If the second argument is a string,
 							// convert to byteslice.
 							args1 := n.Args[1]
-							if evalStaticTypeOf(store, last, args1).Kind() == StringKind {
+							if args1T.Kind() == StringKind {
 								bsx := constType(nil, gByteSliceType)
 								args1 = Call(bsx, args1)
 								args1 = Preprocess(nil, last, args1).(Expr)

--- a/gnovm/tests/files/copy3.gno
+++ b/gnovm/tests/files/copy3.gno
@@ -1,0 +1,21 @@
+package main
+
+type word uint
+type nat []word
+
+func (n nat) add() bool {
+	return true
+}
+
+// parameter
+func main() {
+	des := make([]nat, 2)
+	src := make([][]word, 2)
+
+	src[0] = []word{0}
+
+	copy(des, src)
+}
+
+// Error:
+// main/files/copy3.gno:17: arguments to copy have different element types, want main.nat, got []main.word


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

The copy function has also been fixed. 

According to the Go specification, "The core types of both arguments must be slices with identical element types".

 Our previous implementation lacked this necessary check, so we have now added it for improved robustness.


## Contributors Checklist

- [✅] Added new tests, or not needed, or not feasible
- [✅] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [✅ ] Updated the official documentation or not needed
- [✅] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [✅] Provided any useful hints for running manual tests

## Maintainers Checklist

- [✅] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [✅] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
