### PR TITLE
[RFC] change(gnokey): use filename as arg in `sign` cmd

### DIFF
--- a/tm2/pkg/crypto/keys/client/addpkg.go
+++ b/tm2/pkg/crypto/keys/client/addpkg.go
@@ -178,7 +178,7 @@ func signAndBroadcast(
 		sequence:      sequence,
 		accountNumber: accountNumber,
 		chainID:       txopts.chainID,
-		nameOrBech32:  nameOrBech32,
+		key:           nameOrBech32,
 		txJSON:        amino.MustMarshalJSON(tx),
 	}
 	if baseopts.Quiet {

--- a/tm2/pkg/crypto/keys/client/sign_test.go
+++ b/tm2/pkg/crypto/keys/client/sign_test.go
@@ -22,6 +22,11 @@ func Test_execSign(t *testing.T) {
 	assert.NotNil(t, kbHome)
 	defer kbCleanUp()
 
+	fakeKeyName1 := "signApp_Key1"
+	fakeKeyName2 := "signApp_Key2"
+	encPassword := "12345678"
+	args := []string{}
+
 	// initialize test options
 	cfg := &signCfg{
 		rootCfg: &baseCfg{
@@ -30,15 +35,11 @@ func Test_execSign(t *testing.T) {
 				InsecurePasswordStdin: true,
 			},
 		},
-		txPath:        "-", // stdin
+		key:           fakeKeyName1,
 		chainID:       "dev",
 		accountNumber: 0,
 		sequence:      0,
 	}
-
-	fakeKeyName1 := "signApp_Key1"
-	fakeKeyName2 := "signApp_Key2"
-	encPassword := "12345678"
 
 	io := commands.NewTestIO()
 
@@ -55,17 +56,15 @@ func Test_execSign(t *testing.T) {
 	tx := std.NewTx([]std.Msg{msg}, fee, nil, "")
 	txjson := string(amino.MustMarshalJSON(tx))
 
-	args := []string{fakeKeyName1}
 	io.SetIn(strings.NewReader(txjson))
 	err = execSign(cfg, args, io)
 	assert.Error(t, err)
 
-	args = []string{fakeKeyName1}
 	io.SetIn(strings.NewReader(txjson + "\n"))
 	err = execSign(cfg, args, io)
 	assert.Error(t, err)
 
-	args = []string{fakeKeyName2}
+	cfg.key = fakeKeyName2
 	io.SetIn(strings.NewReader(
 		fmt.Sprintf("%s\n%s\n",
 			txjson,
@@ -75,7 +74,7 @@ func Test_execSign(t *testing.T) {
 	err = execSign(cfg, args, io)
 	assert.Error(t, err)
 
-	args = []string{fakeKeyName1}
+	cfg.key = fakeKeyName1
 	io.SetIn(strings.NewReader(
 		fmt.Sprintf("%s\n%s\n",
 			txjson,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

Currently `gnokey sign` takes keyname/address as arg and filename from flag `--txPath`. This PR reverses that order. 
Now it takes filename as arg and keyname/address from flag `--key`. 

Because: 
- it makes more sense to me this way 
- it would be easier to accommodate multiple filenames in future (if we want to support that). 

    Something like:
    ```sh
    gnokey sign multiple-unsigned.tx unsigned1.tx unsigned2.tx ... --key=foo > combined-signed.tx
    ```
    (see #845)

I would like to have your opinion on this. Please consider this PR as a place to discuss about this. 

---

## Contributors Checklist

- [ ] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests

## Maintainers Checklist

- [x] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
