### PR TITLE
feat: std.TestSetPrevRealm

### DIFF
--- a/examples/gno.land/r/demo/inner/inner.gno
+++ b/examples/gno.land/r/demo/inner/inner.gno
@@ -1,0 +1,1 @@
+package inner

--- a/examples/gno.land/r/demo/inner/inner_test.gno
+++ b/examples/gno.land/r/demo/inner/inner_test.gno
@@ -1,0 +1,30 @@
+package inner
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/testutils"
+)
+
+var (
+	oc std.Address = testutils.TestAddress("origin caller ")
+	or string      = "gno.land/r/demo/outer_realm"
+)
+
+func TestOuterCallInner(t *testing.T) {
+	std.TestSetOrigCaller(oc)
+	shouldEQ(t, std.GetOrigCaller(), oc)
+
+	std.TestSetPrevRealm(or)
+	pr := std.PrevRealm()
+	shouldEQ(t, pr.Addr(), std.DerivePkgAddr(or))
+	shouldEQ(t, pr.PkgPath(), or)
+	shouldEQ(t, std.GetOrigCaller(), oc)
+}
+
+func shouldEQ(t *testing.T, got, want interface{}) {
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

Thanks to @albttx, we now have `std.PrevRealm` #667

However it seems like doesn't work on testcase(that can be run by `gno test` command) as what we expected.
> `gno test` uses its own Context which makes few other functions (like GetRealmPath) doesn't work neither.

So I made little helper very similar to `std.TestSetOrigCaller`


---
## Discussion Need
`std.TestSetOrigCaller` takes single parameter and two different type can be passed
1. If `std.Address` type is passed, -> TestSetPrevRealm will take it as user address => return user address not realm.
2. If `string` type is passed, -> TestSetPrevRealm will take it as pkg_path => return pkg address(using bech32) and pkg_path
> every string value can be passed, include string that doesn't look like pkg_path
> I think, we can re-use verification logic from here https://github.com/gnolang/gno/blob/408fc68d4b3c189dbc6a608c590a86c661ae232a/tm2/pkg/std/memfile.go#L33-L68




## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
