### PR TITLE
fix(gnovm): zero-in Ops and Values correctly in (*Machine).Release

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -158,8 +158,8 @@ func (m *Machine) Release() {
 	m.NumOps = 0
 	m.NumValues = 0
 	// this is the fastest way to zero-in a slice in Go
-	copy(m.Ops, opZeroed[:0])
-	copy(m.Values, valueZeroed[:0])
+	copy(m.Ops, opZeroed[:])
+	copy(m.Values, valueZeroed[:])
 
 	machinePool.Put(m)
 }


### PR DESCRIPTION
```
$ go doc builtin.copy
package builtin // import "builtin"

func copy(dst, src []Type) int
    The copy built-in function copies elements from a source slice into a
    destination slice. (As a special case, it also will copy bytes from a string
    to a slice of bytes.) The source and destination may overlap. Copy returns
    the number of elements copied, which will be the minimum of len(src) and
    len(dst).
```

doing `copy(m.Ops, opZeroed[:0])` is effectively a no-op, as `len(src) == 0` and 0 items will be copied.