### PR TITLE
fix(gnovm): binary.Write

### DIFF
--- a/gnovm/tests/files/a47.gno
+++ b/gnovm/tests/files/a47.gno
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func main() {
+	buf := new(bytes.Buffer)
+
+	str := []byte("Hello World")
+
+	binary.Write(buf, binary.BigEndian, str)
+
+	println(buf.String())
+}
+
+// Output:
+// Hello World

--- a/gnovm/tests/imports.go
+++ b/gnovm/tests/imports.go
@@ -169,7 +169,11 @@ func TestStore(rootDir, filesPath string, stdin io.Reader, stdout, stderr io.Wri
 				pkg := gno.NewPackageNode("binary", pkgPath, nil)
 				pkg.DefineGoNativeValue("LittleEndian", binary.LittleEndian)
 				pkg.DefineGoNativeValue("BigEndian", binary.BigEndian)
-				pkg.DefineGoNativeValue("Write", binary.BigEndian) // warn: use reflection
+				// pkg.DefineGoNativeValue("Write", binary.Write) // warn: use reflection
+
+				pkg.DefineGoNativeValue("Write", func(w io.Writer, order binary.ByteOrder, data interface{}) error {
+					return binary.Write(w, order, data)
+				})
 				return pkg, pkg.NewPackage()
 			case "encoding/json":
 				pkg := gno.NewPackageNode("json", pkgPath, nil)


### PR DESCRIPTION
# Description

There was a mistake on the imports of `encoding/binary.Write` in the definition.

But i'm writting a test and i don't manage to make it works... there is no output.

Also, using `-update-golden-tests` i have the error

```
panic: fail on files/a47.gno: got unexpected error: main/files/a47.gno:13: name Write not declared
```

But i don't know what to put inside of `binary.gno` :/ 

## How to tests

```
go test -v ./gnovm/tests/ -run "/a47.gno" 

go test -v ./gnovm/tests/ -run "/a47.gno" -update-golden-tests
```