### PR TITLE
fix(cmd/gno): support new examples gno.mods

### DIFF
--- a/gnovm/pkg/doc/doc.go
+++ b/gnovm/pkg/doc/doc.go
@@ -206,7 +206,7 @@ func resolveDocumentable(dirs *bfsDirs, parsed docArgs, unexported bool) (Docume
 		parsed = docArgs{pkg: ".", sym: parsed.pkg, acc: parsed.sym}
 		return resolveDocumentable(dirs, parsed, unexported)
 	}
-	// we wanted documentabfsDirn about a package, and we found one!
+	// we wanted documentation about a package, and we found one!
 	if parsed.sym == "" {
 		return &documentable{bfsDir: candidates[0]}, nil
 	}


### PR DESCRIPTION
Master is currently not building because #829 was merged directly after #763. This PR fixes outstanding issues of migrating the examples/ directory to the new structures containing gno.mod, which with the current rules for scanning would be ignored.