### PR TITLE
fix: Deactivate benchmarks until we have a self-hosted runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,8 @@ on:
         type: string
 jobs:
   benchmarks:
+    # Deactivate temporally this workflow until we have a self hosted runner.
+    if: ${{ false }} 
     runs-on: ubuntu-latest
     steps:
     - name: checkout


### PR DESCRIPTION

# Description

Deactivate benchmarks until we have a self-hosted runner

## Contributors Checklist

- [X] Added new tests, or not needed, or not feasible
- [X] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [X] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [X] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
- [X] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).
