### PR TITLE
fix(tm2): better error on AddPackage when package already exists

### DIFF
--- a/tm2/pkg/errors/errors.go
+++ b/tm2/pkg/errors/errors.go
@@ -94,6 +94,18 @@ func (err *cmnError) Error() string {
 	return fmt.Sprintf("%v", err)
 }
 
+// Implements Unwrap method for compat with stdlib errors.Is()/As().
+func (err *cmnError) Unwrap() error {
+	if err.data == nil {
+		return nil
+	}
+	werr, ok := err.data.(error)
+	if !ok {
+		return nil
+	}
+	return werr
+}
+
 // Captures a stacktrace if one was not already captured.
 func (err *cmnError) Stacktrace() Error {
 	if err.stacktrace == nil {

--- a/tm2/pkg/errors/errors_test.go
+++ b/tm2/pkg/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	fmt "fmt"
 	"testing"
 
@@ -102,4 +103,10 @@ func TestWrapError(t *testing.T) {
 	var err1 error = New("my message")
 	var err2 error = Wrap(err1, "another message")
 	assert.Equal(t, err1, err2)
+	assert.True(t, errors.Is(err2, err1))
+
+	err1 = fmt.Errorf("my message")
+	err2 = Wrap(err1, "another message")
+	assert.NotEqual(t, err1, err2)
+	assert.True(t, errors.Is(err2, err1))
 }

--- a/tm2/pkg/sdk/vm/errors.go
+++ b/tm2/pkg/sdk/vm/errors.go
@@ -9,11 +9,10 @@ func (abciError) AssertABCIError() {}
 
 // declare all script errors.
 // NOTE: these are meant to be used in conjunction with pkgs/errors.
-type InvalidPkgPathError struct{ abciError }
-
 type (
-	InvalidStmtError struct{ abciError }
-	InvalidExprError struct{ abciError }
+	InvalidPkgPathError struct{ abciError }
+	InvalidStmtError    struct{ abciError }
+	InvalidExprError    struct{ abciError }
 )
 
 func (e InvalidPkgPathError) Error() string { return "invalid package path" }

--- a/tm2/pkg/sdk/vm/keeper.go
+++ b/tm2/pkg/sdk/vm/keeper.go
@@ -148,8 +148,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
 		return ErrInvalidPkgPath(err.Error())
 	}
 	if pv := store.GetPackage(pkgPath, false); pv != nil {
-		// TODO: return error instead of panicking?
-		panic("package already exists: " + pkgPath)
+		return ErrInvalidPkgPath("package already exists: " + pkgPath)
 	}
 	// Pay deposit from creator.
 	pkgAddr := gno.DerivePkgAddr(pkgPath)


### PR DESCRIPTION


<!-- Please provide a brief summary of your changes in the Title above -->

# Description

Instead of 'internal error' and a long stack trace, now we have an understandable output 'package already exists: pkg/name'

Also added cmnError.Unwrap() for compatibility with stdlib.

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
