### PR TITLE
fix: typo in p/demo/blog imports

### DIFF
--- a/examples/gno.land/p/demo/blog/gno.mod
+++ b/examples/gno.land/p/demo/blog/gno.mod
@@ -3,5 +3,5 @@ module gno.land/p/demo/blog
 require (
         "gno.land/p/demo/avl" v0.0.0-latest
         "gno.land/p/demo/ufmt" v0.0.0-latest
-        "gno.land/p/demo/blog" v0.0.0-latest
+        "gno.land/p/demo/mux" v0.0.0-latest
 )


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes in the Title above -->

# Description

Currently `master` is failing because #882 was merged and there was a typo in `/p/demo/blog`'s gno.mod file. which is leading to import cycle error. Fixed it. 

Since we are now automatically loading pkgs from `/examples` when the chain starts. Can we trigger `gno.land/test` even on package/realm change? To prevent such oversights in the future.
