### PR TITLE
chore: regular block creation time (5s)

### DIFF
--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -123,8 +123,8 @@ func execStart(c *startCfg, args []string, io *commands.IO) error {
 	rootDir := c.rootDir
 
 	cfg := config.LoadOrMakeConfigWithOptions(rootDir, func(cfg *config.Config) {
-		cfg.Consensus.CreateEmptyBlocks = false
-		cfg.Consensus.CreateEmptyBlocksInterval = 60 * time.Second
+		cfg.Consensus.CreateEmptyBlocks = true
+		cfg.Consensus.CreateEmptyBlocksInterval = 0 * time.Second
 	})
 
 	// create priv validator first.

--- a/misc/deployments/staging.gno.land/overlay/config.toml
+++ b/misc/deployments/staging.gno.land/overlay/config.toml
@@ -222,14 +222,14 @@ timeout_prevote = "1s"
 timeout_prevote_delta = "500ms"
 timeout_precommit = "1s"
 timeout_precommit_delta = "500ms"
-timeout_commit = "1s"
+timeout_commit = "5s"
 
 # Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
 skip_timeout_commit = false
 
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks = true
-create_empty_blocks_interval = "1m0s"
+create_empty_blocks_interval = "0s"
 
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "100ms"

--- a/tm2/pkg/bft/consensus/config/config.go
+++ b/tm2/pkg/bft/consensus/config/config.go
@@ -50,7 +50,7 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		TimeoutPrevoteDelta:         500 * time.Millisecond,
 		TimeoutPrecommit:            1000 * time.Millisecond,
 		TimeoutPrecommitDelta:       500 * time.Millisecond,
-		TimeoutCommit:               1000 * time.Millisecond,
+		TimeoutCommit:               5000 * time.Millisecond,
 		SkipTimeoutCommit:           false,
 		CreateEmptyBlocks:           true,
 		CreateEmptyBlocksInterval:   0 * time.Second,


### PR DESCRIPTION
Thanks to @jaekwon's [comment](https://github.com/gnolang/gno/issues/863#issuecomment-1632052365)
I've modified some configurations, and now gno creates blocks regularly (every 5 seconds) regardless of the creation of new transactions.

It seems that function `WaitForTxs()` must return `false` in order to create blocks regularly. 
https://github.com/gnolang/gno/blob/5d32c39912190764faf25aa4fd0ef79845b122e7/tm2/pkg/bft/consensus/config/config.go#L79-L81
https://github.com/gnolang/gno/blob/5d32c39912190764faf25aa4fd0ef79845b122e7/tm2/pkg/bft/consensus/state.go#L838-L849
> BTW, I don't see any codes in #L844 for `// wait until mempool pings us.`


At least the problem from issue #863 can be solved in this way. However, I'm not entirely sure about the purpose of `CreateEmptyBlocksInterval`.

---

@moul 
Do you think it's better to edit the `.toml` file as you did in #899?
Also, do you have any estimated time for test4 (or test4-m1 for multi-node)? If the next testnet resolves the block time issue, the Onbloc team will be happy to work on the multinode testnet initiative [#9 META Multinode Testnet Initiative](https://github.com/gnolang/hackerspace/issues/9)

## Contributors Checklist

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
</details>
