### PR TITLE
feat: foo20 check an error from grc20 package

### DIFF
--- a/examples/gno.land/r/demo/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/foo20/foo20.gno
@@ -49,17 +49,26 @@ func Allowance(owner, spender users.AddressOrName) uint64 {
 
 func Transfer(to users.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	foo.Transfer(caller, to.Resolve(), amount)
+	err := foo.Transfer(caller, to.Resolve(), amount)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func Approve(spender users.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	foo.Approve(caller, spender.Resolve(), amount)
+	err := foo.Approve(caller, spender.Resolve(), amount)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func TransferFrom(from, to users.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	foo.TransferFrom(caller, from.Resolve(), to.Resolve(), amount)
+	err := foo.TransferFrom(caller, from.Resolve(), to.Resolve(), amount)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // faucet.
@@ -68,7 +77,10 @@ func Faucet() {
 	// FIXME: add limits?
 	// FIXME: add payment in gnot?
 	caller := std.PrevRealm().Addr()
-	foo.Mint(caller, 1000*10000) // 1k
+	err := foo.Mint(caller, 1000*10000) // 1k
+	if err != nil {
+		panic(err)
+	}
 }
 
 // administration.
@@ -76,13 +88,19 @@ func Faucet() {
 func Mint(address users.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
 	assertIsAdmin(caller)
-	foo.Mint(address.Resolve(), amount)
+	err := foo.Mint(address.Resolve(), amount)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func Burn(address users.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
 	assertIsAdmin(caller)
-	foo.Burn(address.Resolve(), amount)
+	err := foo.Burn(address.Resolve(), amount)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // render.

--- a/examples/gno.land/r/demo/foo20/foo20_test.gno
+++ b/examples/gno.land/r/demo/foo20/foo20_test.gno
@@ -68,17 +68,13 @@ func TestErrConditions(t *testing.T) {
 	std.TestSetOrigCaller(admin)
 	{
 		tests := []test{
-			{"Transfer(admin, 1)", "cannot send transfer to self", func() { Transfer(a2u(admin), 1) }},
-			{"Approve(empty, 1))", "invalid address", func() { Approve(a2u(empty), 1) }},
+			{"Transfer(admin, 1)", "cannot send transfer to self", func() { Transfer(users.AddressOrName(admin), 1) }},
+			{"Approve(empty, 1))", "invalid address", func() { Approve(users.AddressOrName(empty), 1) }},
 		}
 		for _, tc := range tests {
 			shouldPanicWithMsg(t, tc.fn, tc.msg)
 		}
 	}
-}
-
-func a2u(addr std.Address) users.AddressOrName {
-	return users.AddressOrName(addr)
 }
 
 func shouldPanicWithMsg(t *testing.T, f func(), msg string) {

--- a/examples/gno.land/r/demo/foo20/foo20_test.gno
+++ b/examples/gno.land/r/demo/foo20/foo20_test.gno
@@ -54,3 +54,43 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 		}
 	}
 }
+
+func TestErrConditions(t *testing.T) {
+	admin := std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj")
+	empty := std.Address("")
+
+	type test struct {
+		name string
+		msg  string
+		fn   func()
+	}
+
+	std.TestSetOrigCaller(admin)
+	{
+		tests := []test{
+			{"Transfer(admin, 1)", "cannot send transfer to self", func() { Transfer(a2u(admin), 1) }},
+			{"Approve(empty, 1))", "invalid address", func() { Approve(a2u(empty), 1) }},
+		}
+		for _, tc := range tests {
+			shouldPanicWithMsg(t, tc.fn, tc.msg)
+		}
+	}
+}
+
+func a2u(addr std.Address) users.AddressOrName {
+	return users.AddressOrName(addr)
+}
+
+func shouldPanicWithMsg(t *testing.T, f func(), msg string) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		} else {
+			errMsg := error(r).Error()
+			if errMsg != msg {
+				t.Errorf("excepted panic(%v), got(%v)", msg, errMsg)
+			}
+		}
+	}()
+	f()
+}


### PR DESCRIPTION
detailed infos are described in #857 

TL;DR
`foo20` relam doesn't check error from `grc20` package. 
- for example sending to address itself should fail, but currently runs fine


<details><summary>Checklists...</summary>

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
</details>
