### PR TITLE
feat: allow Args on main run

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -565,7 +565,7 @@ func (m *Machine) RunFunc(fn Name) {
 	m.RunStatement(S(Call(Nx(fn))))
 }
 
-func (m *Machine) RunMain() {
+func (m *Machine) RunMain(args ...string) {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("Machine.RunMain() panic: %v\n%s\n",

--- a/gnovm/stdlibs/os/proc.go
+++ b/gnovm/stdlibs/os/proc.go
@@ -1,0 +1,10 @@
+package os
+
+// Args hold the command-line arguments, starting with the program name.
+var Args []string
+
+func init() {
+	Args = runtime_args()
+}
+
+func runtime_args() []string // in package runtime

--- a/tm2/pkg/sdk/vm/keeper_test.go
+++ b/tm2/pkg/sdk/vm/keeper_test.go
@@ -67,7 +67,7 @@ func TestVMKeeperOrigSend1(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -112,7 +112,7 @@ func TestVMKeeperOrigSend2(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -166,7 +166,7 @@ func TestVMKeeperOrigSend3(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -210,7 +210,7 @@ func TestVMKeeperRealmSend1(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -254,7 +254,7 @@ func TestVMKeeperRealmSend2(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -298,7 +298,7 @@ func TestVMKeeperOrigCallerInit(t *testing.T) {
 
 	// Create test package.
 	files := []*std.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"
@@ -336,4 +336,18 @@ func GetAdmin() string {
 	addrString := fmt.Sprintf("(\"%s\" string)", addr.String())
 	assert.NoError(t, err)
 	assert.Equal(t, res, addrString)
+}
+
+func TestVMKeeperMainWithArgs(t *testing.T) {
+	m := NewMachine("test", nil)
+	c := `package test
+	import "fmt"
+	import "os"
+func main() {
+	args := os.Args
+	fmt.Println(args)
+}`
+	n := MustParseFile("main.go", c)
+	m.RunFiles(n)
+	m.RunMain()
 }


### PR DESCRIPTION
Attempt to implement Args on main() runs.

Problem: I didn't find a clean way to inject os.Args values.

## Contributors Checklist

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).

