### PR TITLE
chore: remove reviewers checklist from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,10 +11,4 @@ Please provide a detailed description of the changes made in this pull request.
 - [ ] Added references to related issues and PRs
 - [ ] Provided any useful hints for running manual tests
 - [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).
-
-## Maintainers Checklist
-
-- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
-- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
-- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
 </details>


### PR DESCRIPTION
Wasn’t used.

Could make sense to keep the main description for the contributors. While having the reviewers checklist posted as a comment by a bot.

<details><summary>Checklists...</summary>

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).

## Maintainers Checklist

- [ ] Checked that the author followed the guidelines in `CONTRIBUTING.md`
- [ ] Checked the conventional-commit (especially PR title and verb, presence of `BREAKING CHANGE:` in the body)
- [ ] Ensured that this PR is not a significant change or confirmed that the review/consideration process was appropriate for the change
</details>
