### PR TITLE
feat(cmd/gno): allow dirs and arbitrary expressions on gno run

### DIFF
--- a/gnovm/cmd/gno/run_test.go
+++ b/gnovm/cmd/gno/run_test.go
@@ -13,20 +13,57 @@ func TestRunApp(t *testing.T) {
 			stdoutShouldContain: "hello world!",
 		},
 		{
-			args:                 []string{"run", "../../tests/integ/run-main/"},
-			recoverShouldContain: "read ../../tests/integ/run-main/: is a directory", // FIXME: should work
+			args:                []string{"run", "../../tests/integ/run-main/"},
+			stdoutShouldContain: "hello world!",
 		},
 		{
-			args:                 []string{"run", "../../tests/integ/does-not-exist"},
-			recoverShouldContain: "open ../../tests/integ/does-not-exist: no such file or directory",
+			args:             []string{"run", "../../tests/integ/does-not-exist"},
+			errShouldContain: "no such file or directory",
 		},
 		{
-			args:                 []string{"run", "../../tests/integ/run-namedpkg/main.gno"},
-			recoverShouldContain: "expected package name [main] but got [namedpkg]", // FIXME: should work
+			args:                []string{"run", "../../tests/integ/run-namedpkg/main.gno"},
+			stdoutShouldContain: "hello, other world!",
 		},
-		// TODO: multiple files
+		{
+			args:                 []string{"run", "../../tests/integ/run-package"},
+			recoverShouldContain: "name main not declared",
+		},
+		{
+			args:                []string{"run", "-expr", "Hello()", "../../tests/integ/run-package"},
+			stdoutShouldContain: "called Hello",
+		},
+		{
+			args:                []string{"run", "-expr", "World()", "../../tests/integ/run-package"},
+			stdoutShouldContain: "called World",
+		},
+		{
+			args:                []string{"run", "-expr", "otherFile()", "../../tests/integ/run-package"},
+			stdoutShouldContain: "hello from package2.gno",
+		},
+		{
+			args: []string{
+				"run", "-expr", "otherFile()",
+				"../../tests/integ/run-package/package.gno",
+			},
+			recoverShouldContain: "name otherFile not declared",
+		},
+		{
+			args: []string{
+				"run", "-expr", "otherFile()",
+				"../../tests/integ/run-package/package.gno",
+				"../../tests/integ/run-package/package2.gno",
+			},
+			stdoutShouldContain: "hello from package2.gno",
+		},
+		{
+			args:                []string{"run", "-expr", "WithArg(1)", "../../tests/integ/run-package"},
+			stdoutShouldContain: "one",
+		},
+		{
+			args:                []string{"run", "-expr", "WithArg(-255)", "../../tests/integ/run-package"},
+			stdoutShouldContain: "out of range!",
+		},
 		// TODO: a test file
-		// TODO: a file without main
 		// TODO: args
 		// TODO: nativeLibs VS stdlibs
 		// TODO: with gas meter

--- a/gnovm/tests/integ/run-namedpkg/main.gno
+++ b/gnovm/tests/integ/run-namedpkg/main.gno
@@ -1,5 +1,5 @@
 package namedpkg
 
 func main() {
-	println("hello world!")
+	println("hello, other world!")
 }

--- a/gnovm/tests/integ/run-package/package.gno
+++ b/gnovm/tests/integ/run-package/package.gno
@@ -1,0 +1,26 @@
+package pkg
+
+func Hello() {
+	println("called Hello")
+}
+
+func World() {
+	println("called World")
+}
+
+func hello() {
+	println("called hello")
+}
+
+func WithArg(i int) {
+	switch i {
+	case 0:
+		println("zero")
+	case 1:
+		println("one")
+	case 2:
+		println("two")
+	default:
+		println("out of range! :S")
+	}
+}

--- a/gnovm/tests/integ/run-package/package2.gno
+++ b/gnovm/tests/integ/run-package/package2.gno
@@ -1,0 +1,5 @@
+package pkg
+
+func otherFile() {
+	println("hello from package2.gno!")
+}


### PR DESCRIPTION
extend the capabilities of `gno run` to allow for passing directories, running non-main packages, and executing arbitrary expression. should make for a better general interactive testing experience.

cc/ @ilgooz, this should be a step in a good direction to add support for executing individual functions in IDE and playground.

<details><summary>Checklists...</summary>

## Contributors Checklist

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).
</details>
