### PR TITLE
chore(.github): fix broken link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,5 @@ Please provide a detailed description of the changes made in this pull request.
 - [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
 - [ ] Added references to related issues and PRs
 - [ ] Provided any useful hints for running manual tests
-- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](../.benchmarks/README.md).
+- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
 </details>


### PR DESCRIPTION
Fix broken link using an absolute path instead of a relative one.

Related with: https://github.com/gnolang/gno/pull/998

## Contributors Checklist

- [X] Added new tests, or not needed, or not feasible
- [X] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [X] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [X] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
- [X] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
