### PR TITLE
refactor(tm2/pkg/autofile): use SIGTERM

### DIFF
--- a/tm2/pkg/autofile/autofile.go
+++ b/tm2/pkg/autofile/autofile.go
@@ -38,7 +38,7 @@ const (
 )
 
 // AutoFile automatically closes and re-opens file for writing. The file is
-// automatically setup to close itself every 1s and upon receiving SIGHUP.
+// automatically setup to close itself every 1s and upon receiving SIGTERM.
 //
 // This is useful for using a log file with the logrotate tool.
 type AutoFile struct {
@@ -68,9 +68,9 @@ func OpenAutoFile(path string) (*AutoFile, error) {
 		return nil, err
 	}
 
-	// Close file on SIGHUP.
+	// Close file on SIGTERM.
 	af.hupc = make(chan os.Signal, 1)
-	signal.Notify(af.hupc, syscall.SIGHUP)
+	signal.Notify(af.hupc, syscall.SIGTERM)
 	go func() {
 		for range af.hupc {
 			af.closeFile()
@@ -82,7 +82,7 @@ func OpenAutoFile(path string) (*AutoFile, error) {
 	return af, nil
 }
 
-// Close shuts down the closing goroutine, SIGHUP handler and closes the
+// Close shuts down the closing goroutine, SIGTERM handler and closes the
 // AutoFile.
 func (af *AutoFile) Close() error {
 	af.closeTicker.Stop()

--- a/tm2/pkg/autofile/autofile_test.go
+++ b/tm2/pkg/autofile/autofile_test.go
@@ -12,7 +12,7 @@ import (
 	osm "github.com/gnolang/gno/tm2/pkg/os"
 )
 
-func TestSIGHUP(t *testing.T) {
+func TestSIGTERM(t *testing.T) {
 	// First, create an AutoFile writing to a tempfile dir
 	file, err := ioutil.TempFile("", "sighup_test")
 	require.NoError(t, err)
@@ -34,8 +34,8 @@ func TestSIGHUP(t *testing.T) {
 	err = os.Rename(name, name+"_old")
 	require.NoError(t, err)
 
-	// Send SIGHUP to self.
-	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+	// Send SIGTERM to self.
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 
 	// Wait a bit... signals are not handled synchronously.
 	time.Sleep(time.Millisecond * 10)


### PR DESCRIPTION
In order to make gnovm compatible with WASM target we need to use a signal other than SIGHUP. [Here](https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/syscall/syscall_js.go;l=91-98) is the full list of support signals.

I changed the code to use SIGTERM instead, as it seemed closest to what SIGHUP does.