### PR TITLE
chore(cmd): print shortHelp if longHelp is empty

### DIFF
--- a/gnovm/cmd/gno/doc.go
+++ b/gnovm/cmd/gno/doc.go
@@ -28,7 +28,7 @@ func newDocCmd(io *commands.IO) *commands.Command {
 		commands.Metadata{
 			Name:       "doc",
 			ShortUsage: "doc [flags] <pkgsym>",
-			ShortHelp:  "get documentation for the specified package or symbol (type, function, method, or variable/constant).",
+			ShortHelp:  "get documentation for the specified package or symbol (type, function, method, or variable/constant)",
 		},
 		c,
 		func(_ context.Context, args []string) error {

--- a/tm2/pkg/commands/command.go
+++ b/tm2/pkg/commands/command.go
@@ -252,6 +252,8 @@ func usage(c *Command) string {
 
 	if c.longHelp != "" {
 		fmt.Fprintf(&b, "%s\n\n", c.longHelp)
+	} else if c.shortHelp != "" {
+		fmt.Fprintf(&b, "%s.\n\n", c.shortHelp)
 	}
 
 	if len(c.subcommands) > 0 {


### PR DESCRIPTION
Currenlty, `shortHelp` is used when the command is listed from its parent command, and `longHelp` is used when the command is executed with its help flag.

What I found a little annoying is if `longHelp` is not provided, which is the case for the majority of commands, there's no text at all when the command is invoked with the help flag.

This change ensures the `shortHelp` is printed if `longHelp` is empty.

<details><summary>Example with `gno test` : </summary>

### Before the change:
```
$ gno test -h
USAGE
  test [flags] <package> [<package>...]

FLAGS
  -precompile=false             precompile gno to go before testing
  -print-runtime-metrics=false  print runtime metrics (gas, memory, cpu cycles)
  -root-dir ...                 clone location of github.com/gnolang/gno (gnodev tries to guess it)
  -run ...                      test name filtering pattern
  -timeout 0s                   max execution time
  -update-golden-tests=false    writes actual as wanted in test comments
  -verbose=false                verbose output when running
  -with-native-fallback=false   use stdlibs/* if present, otherwise use supported native Go packages

error parsing commandline arguments: flag: help requested
```

### After the change:
```
$ gno test -h
USAGE
  test [flags] <package> [<package>...]

Runs the tests for the specified packages.

FLAGS
  -precompile=false             precompile gno to go before testing
  -print-runtime-metrics=false  print runtime metrics (gas, memory, cpu cycles)
  -root-dir ...                 clone location of github.com/gnolang/gno (gnodev tries to guess it)
  -run ...                      test name filtering pattern
  -timeout 0s                   max execution time
  -update-golden-tests=false    writes actual as wanted in test comments
  -verbose=false                verbose output when running
  -with-native-fallback=false   use stdlibs/* if present, otherwise use supported native Go packages

error parsing commandline arguments: flag: help requested
```
</details>

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
