### PR TITLE
feat: add GNOROOT environment variables

### DIFF
--- a/gnovm/cmd/gno/util.go
+++ b/gnovm/cmd/gno/util.go
@@ -105,10 +105,16 @@ func fmtDuration(d time.Duration) string {
 }
 
 func guessRootDir() string {
+	// try to get the root directory from the GNOROOT environment variable.
+	if rootdir := os.Getenv("GNOROOT"); rootdir != "" {
+		return filepath.Clean(rootdir)
+	}
+
+	// if GNOROOT is not set, try to guess the root directory using the `go list` command.
 	cmd := exec.Command("go", "list", "-m", "-mod=mod", "-f", "{{.Dir}}", "github.com/gnolang/gno")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatal("can't guess --root-dir, please fill it manually.")
+		log.Fatal("can't guess --root-dir, please fill it manually or define the GNOROOT environment variable globally.")
 	}
 	rootDir := strings.TrimSpace(string(out))
 	return rootDir


### PR DESCRIPTION
This small PR adds the ability to obtain the root directory from the `GNOROOT` environment variable. If this variable is not set, the root directory is then guessed using the `go list` command.
This enable the user to manually set gno root dir globally and not bother setting the `root-dir` parameter every time he need need it

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
