### PR TITLE
docs: fix outdated documentation in r/demo/boards

### DIFF
--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -1,7 +1,7 @@
 This is a demo of Gno smart contract programming.  This document was
 constructed by Gno onto a smart contract hosted on the data Realm
-name ["gno.land/r/boards"](https://gno.land/r/boards/)
-([github](https://github.com/gnolang/gno/tree/master/examples/gno.land/r/boards)).
+name ["gno.land/r/demo/boards"](https://gno.land/r/demo/boards/)
+([github](https://github.com/gnolang/gno/tree/master/examples/gno.land/r/demo/boards)).
 
 
 
@@ -59,15 +59,15 @@ Go to https://test3.gno.land/faucet
 NOTE: `BOARDNAME` will be the slug of the board, and should be changed.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/boards?help&__func=CreateBoard
+Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateBoard
 
 Next, query for the permanent board ID by querying (you need this to create a new post):
 
 ```bash
-./build/gnokey query "vm/qeval" -data "gno.land/r/boards
+./build/gnokey query "vm/qeval" -data "gno.land/r/demo/boards
 GetBoardIDFromName(\"BOARDNAME\")" -remote test3.gno.land:36657
 ```
 
@@ -76,31 +76,31 @@ GetBoardIDFromName(\"BOARDNAME\")" -remote test3.gno.land:36657
 NOTE: If a board was created successfully, your SEQUENCE_NUMBER would have increased.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/demo/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/boards?help&__func=CreateThread
+Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateThread
 
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/boards?help&__func=CreateReply
+Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateReply
 
 ```bash
-./build/gnokey query "vm/qrender" -data "gno.land/r/boards
+./build/gnokey query "vm/qrender" -data "gno.land/r/demo/boards
 BOARDNAME/1" -remote test3.gno.land:36657
 ```
 
 ### Render page with optional path expression.
 
-The contents of `https://gno.land/r/boards:` and `https://gno.land/r/boards:gnolang` are rendered by calling
+The contents of `https://gno.land/r/demo/boards:` and `https://gno.land/r/demo/boards:gnolang` are rendered by calling
 the `Render(path string)` function like so:
 
 ```bash
-./build/gnokey query "vm/qrender" -data "gno.land/r/boards
+./build/gnokey query "vm/qrender" -data "gno.land/r/demo/boards
 gnolang"
 ```
 
@@ -129,8 +129,8 @@ NOTE: This can be reset with `make reset`
 ./build/gnokey maketx addpkg -pkgpath "gno.land/p/demo/avl" -pkgdir "examples/gno.land/p/demo/avl" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid dev -remote localhost:26657 test1
 ```
 
-### Publish the "gno.land/r/boards" realm package.
+### Publish the "gno.land/r/demo/boards" realm package.
 
 ```bash
-./build/gnokey maketx addpkg -pkgpath "gno.land/r/boards" -pkgdir "examples/gno.land/r/boards" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 300000000 -broadcast -chainid dev -remote localhost:26657 test1
+./build/gnokey maketx addpkg -pkgpath "gno.land/r/demo/boards" -pkgdir "examples/gno.land/r/demo/boards" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 300000000 -broadcast -chainid dev -remote localhost:26657 test1
 ```

--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -7,7 +7,7 @@ name ["gno.land/r/boards"](https://gno.land/r/boards/)
 
 ## Build `gnokey`, create your account, and interact with Gno.
 
-NOTE: Where you see `--remote gno.land:36657` here, that flag can be replaced
+NOTE: Where you see `--remote test3.gno.land:36657` here, that flag can be replaced
 with `--remote localhost:26657` for local testnets.
 
 ### Build `gnokey`.
@@ -45,7 +45,7 @@ NOTE: `KEYNAME` is your key identifier, and should be changed.
 ### Get your current balance, account number, and sequence number.
 
 ```bash
-./build/gnokey query auth/accounts/ACCOUNT_ADDR --remote gno.land:36657
+./build/gnokey query auth/accounts/ACCOUNT_ADDR --remote test3.gno.land:36657
 ```
 
 NOTE: you can retrieve your `ACCOUNT_ADDR` with `./build/gnokey list`.
@@ -59,7 +59,7 @@ Go to https://test3.gno.land/faucet
 NOTE: `BOARDNAME` will be the slug of the board, and should be changed.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateBoard
@@ -68,7 +68,7 @@ Next, query for the permanent board ID by querying (you need this to create a ne
 
 ```bash
 ./build/gnokey query "vm/qeval" -data "gno.land/r/boards
-GetBoardIDFromName(\"BOARDNAME\")" -remote gno.land:36657
+GetBoardIDFromName(\"BOARDNAME\")" -remote test3.gno.land:36657
 ```
 
 ### Create a post of a board with a smart contract call.
@@ -76,7 +76,7 @@ GetBoardIDFromName(\"BOARDNAME\")" -remote gno.land:36657
 NOTE: If a board was created successfully, your SEQUENCE_NUMBER would have increased.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateThread
@@ -84,14 +84,14 @@ Interactive documentation: https://gno.land/r/boards?help&__func=CreateThread
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
 ```
 
 Interactive documentation: https://gno.land/r/boards?help&__func=CreateReply
 
 ```bash
 ./build/gnokey query "vm/qrender" -data "gno.land/r/boards
-BOARDNAME/1" -remote gno.land:36657
+BOARDNAME/1" -remote test3.gno.land:36657
 ```
 
 ### Render page with optional path expression.


### PR DESCRIPTION
corrects outdated documentation in `examples/gno.land/r/demo/boards/README.md`:

- The previous address `gno.land:36657` was replaced with the working address `test3.gno.land:36657` as the former is no longer functional. 
- The previous package path `gno.land/r/boards` was replaced with the new path `gno.land/r/demo/boards`

This change ensures that users following the instructions in the **README** will be able to successfully connect to gnoland node using the correct address, avoiding potential issues related to using an outdated address.

<details><summary>Contributors' checklist...</summary>

- [X] Added new tests, or not needed, or not feasible
- [X] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [X] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [X] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
- [X] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
