### PR TITLE
docs: fix demo/boards/README, fix typos and change to a local node

### DIFF
--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -78,7 +78,7 @@ Leave this running in the terminal. In a new terminal, cd to the same folder `gn
 
 ### Register a board username with a smart contract call.
 
-The `USERNAME` for posting can different than your `KEYNAME`. It is internally linked to your `ACCOUNT_ADDR`. It must be at least 6 characters.
+The `USERNAME` for posting can different than your `KEYNAME`. It is internally linked to your `ACCOUNT_ADDR`. It must be at least 6 characters, lowercase alphanumeric with underscore.
 
 ```bash
 ./build/gnokey maketx call -pkgpath "gno.land/r/demo/users" -func "Register" -args "" -args "USERNAME" -args "Profile description" -gas-fee "10000000ugnot" -gas-wanted "2000000" -send "200000000ugnot" -broadcast -chainid dev -remote 127.0.0.1:26657 KEYNAME

--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -7,15 +7,16 @@ name ["gno.land/r/demo/boards"](https://gno.land/r/demo/boards/)
 
 ## Build `gnokey`, create your account, and interact with Gno.
 
-NOTE: Where you see `--remote test3.gno.land:36657` here, that flag can be replaced
-with `--remote localhost:26657` for local testnets.
+NOTE: Where you see `-remote localhost:26657` here, that flag can be replaced
+with `-remote test3.gno.land:36657` if you have $GNOT on the testnet.
+(To use the testnet, also replace `-chainid dev` with `-chainid testchain` .)
 
-### Build `gnokey`.
+### Build `gnokey` (and other tools).
 
 ```bash
 git clone git@github.com:gnolang/gno.git
-cd ./gno
-make
+cd gno/gno.land
+make build
 ```
 
 ### Generate a seed/mnemonic code.
@@ -29,7 +30,7 @@ NOTE: You can generate 24 words with any good bip39 generator.
 ### Create a new account using your mnemonic.
 
 ```bash
-./build/gnokey add --recover KEYNAME
+./build/gnokey add -recover KEYNAME
 ```
 
 NOTE: `KEYNAME` is your key identifier, and should be changed.
@@ -40,35 +41,64 @@ NOTE: `KEYNAME` is your key identifier, and should be changed.
 ./build/gnokey list
 ```
 
-## Interact with the blockchain:
+Take note of your `addr` which looks something like `g17sphqax3kasjptdkmuqvn740u8dhtx4kxl6ljf` .
+You will use this as your `ACCOUNT_ADDR`.
+
+## Interact with the blockchain.
+
+### Add $GNOT for your account.
+
+Before starting the `gnoland` node for the first time, your new account can be given $GNOT in the node genesis.
+Edit the file `gno.land/genesis/genesis_balances.txt` and add the following line (simlar to the others), using
+your `ACCOUNT_ADDR` and `KEYNAME`
+
+`ACCOUNT_ADDR=10000000000ugnot # @KEYNAME`
+
+### Alternative: Run a faucet to add $GNOT.
+
+Instead of editing `gno.land/genesis/genesis_balances.txt`, a more general solution (with more steps)
+is to run a local "faucet" and use the web browser to add $GNOT. (This can be done at any time.)
+See this page: https://github.com/gnolang/gno/blob/master/gno.land/cmd/gnofaucet/README.md 
+
+### Start the `gnoland` node.
+
+```bash
+./build/gnoland start
+```
+
+NOTE: The node already has the "boards" realm.
+
+Leave this running in the terminal. In a new terminal, cd to the same folder `gno/gno.land` .
 
 ### Get your current balance, account number, and sequence number.
 
 ```bash
-./build/gnokey query auth/accounts/ACCOUNT_ADDR --remote test3.gno.land:36657
+./build/gnokey query auth/accounts/ACCOUNT_ADDR -remote localhost:26657
 ```
 
-NOTE: you can retrieve your `ACCOUNT_ADDR` with `./build/gnokey list`.
+### Register a board username with a smart contract call.
 
-### Acquire testnet tokens using the official faucet.
+The `USERNAME` for posting can different than your `KEYNAME`. It is internally linked to your `ACCOUNT_ADDR`. It must be at least 6 characters.
 
-Go to https://test3.gno.land/faucet
+```bash
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/users" -func "Register" -args "" -args "USERNAME" -args "Profile description" -gas-fee "10000000ugnot" -gas-wanted "2000000" -send "200000000ugnot" -broadcast -chainid dev -remote 127.0.0.1:26657 KEYNAME
+```
+
+Interactive documentation: https://test3.gno.land/r/demo/users?help&__func=Register
 
 ### Create a board with a smart contract call.
 
-NOTE: `BOARDNAME` will be the slug of the board, and should be changed.
-
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "2000000" -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateBoard" -args "BOARDNAME" -gas-fee "1000000ugnot" -gas-wanted "10000000" -broadcast -chainid dev -remote localhost:26657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateBoard
+Interactive documentation: https://test3.gno.land/r/demo/boards?help&__func=CreateBoard
 
 Next, query for the permanent board ID by querying (you need this to create a new post):
 
 ```bash
 ./build/gnokey query "vm/qeval" -data "gno.land/r/demo/boards
-GetBoardIDFromName(\"BOARDNAME\")" -remote test3.gno.land:36657
+GetBoardIDFromName(\"BOARDNAME\")" -remote localhost:26657
 ```
 
 ### Create a post of a board with a smart contract call.
@@ -76,22 +106,22 @@ GetBoardIDFromName(\"BOARDNAME\")" -remote test3.gno.land:36657
 NOTE: If a board was created successfully, your SEQUENCE_NUMBER would have increased.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args\#file "./examples/gno.land/r/demo/boards/example_post.md" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateThread" -args BOARD_ID -args "Hello gno.land" -args "Text of the post" -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid dev -remote localhost:26657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateThread
+Interactive documentation: https://test3.gno.land/r/demo/boards?help&__func=CreateThread
 
 ### Create a comment to a post.
 
 ```bash
-./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateReply" -args "BOARD_ID" -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid testchain -remote test3.gno.land:36657 KEYNAME
+./build/gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateReply" -args BOARD_ID -args "1" -args "1" -args "Nice to meet you too." -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid dev -remote localhost:26657 KEYNAME
 ```
 
-Interactive documentation: https://gno.land/r/demo/boards?help&__func=CreateReply
+Interactive documentation: https://test3.gno.land/r/demo/boards?help&__func=CreateReply
 
 ```bash
 ./build/gnokey query "vm/qrender" -data "gno.land/r/demo/boards
-BOARDNAME/1" -remote test3.gno.land:36657
+BOARDNAME/1" -remote localhost:26657
 ```
 
 ### Render page with optional path expression.
@@ -103,34 +133,17 @@ the `Render(path string)` function like so:
 ./build/gnokey query "vm/qrender" -data "gno.land/r/demo/boards
 gnolang"
 ```
+## View the board in the browser.
 
-## Starting a local `gnoland` node:
-
-### Add test account.
-
-```bash
-./build/gnokey add -recover test1
-```
-
-Use this mneonic:
-> source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast
-
-### Start `gnoland` node.
+### Start the web server.
 
 ```bash
-./build/gnoland start
+./build/gnoweb
 ```
 
-NOTE: This can be reset with `make reset`
+This should print something like `Running on http://127.0.0.1:8888` . Leave this running in the terminal.
 
-### Publish the "gno.land/p/demo/avl" package.
+### View in the browser
 
-```bash
-./build/gnokey maketx addpkg -pkgpath "gno.land/p/demo/avl" -pkgdir "examples/gno.land/p/demo/avl" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid dev -remote localhost:26657 test1
-```
-
-### Publish the "gno.land/r/demo/boards" realm package.
-
-```bash
-./build/gnokey maketx addpkg -pkgpath "gno.land/r/demo/boards" -pkgdir "examples/gno.land/r/demo/boards" -deposit 100000000ugnot -gas-fee 1000000ugnot -gas-wanted 300000000 -broadcast -chainid dev -remote localhost:26657 test1
-```
+In your browser, navigate to the printed address http://127.0.0.1:8888 .
+To see you post, click on the package `/r/demo/boards` .


### PR DESCRIPTION
The README for demo/boards shows how to create a key and interact with the "boards" realm. It was originally written for the testnet, but the testnet faucet doesn't work anymore. So, in this pull request we:

* Rewrite the README to explain how to run a local node by adding $GNOT to `genesis_balances.txt` . (Also mention the README for running a local faucet.)
* Add the step to `Register` with `/r/demo/users` which must be done before creating a board.
* Fix the links for viewing [interactive documentation](https://test3.gno.land/r/demo/boards?help&__func=CreateBoard) on the testnet.
* For consistency in the README and with the online help, change `--recover` to `-recover`, etc. with one dash.
* Remove the instructions to publish the realm since it is already included in the node genesis (and on the testnet).


(NOTE: This PR is a follow-up to #1030 which was already approved but is much smaller.)
(NOTE: This PR is an alternative to #831 which can be closed.)