### PR TITLE
chore: use the Github version of the Boards realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Start your journey with Gno.land by:
 - sending transactions with [`gnokey`](./gno.land/cmd/gnokey),
 - writing smart-contracts with [`gno` (ex `gnodev`)](./gnovm/cmd/gno).
 
-Also, see the [quickstart guide](https://test3.gno.land/r/demo/boards:testboard/5).
+Also, see the [quickstart guide](https://github.com/gnolang/gno/blob/master/examples/gno.land/r/demo/boards/README.md).
 
 ## Contact
 

--- a/gno.land/cmd/gnokey/README.md
+++ b/gno.land/cmd/gnokey/README.md
@@ -8,4 +8,4 @@
     $> cd ./gno
     $> make install_gnokey
 
-Also, see the [quickstart guide](https://test2.gno.land/r/boards:testboard/5).
+Also, see the [quickstart guide](https://github.com/gnolang/gno/blob/master/examples/gno.land/r/demo/boards/README.md).


### PR DESCRIPTION
fixes https://github.com/gnolang/gno/issues/1031

This PR updates some Gno README which used an outdated version of the Board Realm tutorial. Now, we use the Github tutorial instead of the one on the Gno chain.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
