### PR TITLE
fix: correct panic message for ParseMemPackage()

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1161,8 +1161,8 @@ func ParseMemPackage(memPkg *std.MemPackage) (fset *FileSet) {
 			fset.AddFiles(n)
 		} else {
 			panic(fmt.Sprintf(
-				"expected package name [%s] or [%s_test] but got [%s]",
-				memPkg.Name, memPkg.Name, n.PkgName))
+				"expected package name [%s] but got [%s]",
+				memPkg.Name, n.PkgName))
 		}
 	}
 	return fset


### PR DESCRIPTION
The ParseMemPackage() function panics when encountering a
package name mismatch. The panic message stated,
"expected package name [%s] or [%s_test], but got [%s]". However,
since we are skipping the _test.gno files, we should never expect
`[%s_test]` as a package name. This commit fixes the error message
to accurately reflect this condition.

Signed-off-by: Hariom Verma <hariom.verma@tendermint.com>

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
