### PR TITLE
feat: grc20 registry

### DIFF
--- a/examples/gno.land/r/demo/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/foo20/foo20.gno
@@ -6,6 +6,7 @@ import (
 
 	"gno.land/p/demo/grc/grc20"
 	"gno.land/p/demo/ufmt"
+	"gno.land/r/demo/grc20_registry"
 	"gno.land/r/demo/users"
 )
 
@@ -16,6 +17,7 @@ var (
 
 func init() {
 	foo = grc20.NewAdminToken("Foo", "FOO", 4)
+	grc20_registry.Register(foo.GRC20())
 	foo.Mint(admin, 1000000*10000)                                    // @administrator (1M)
 	foo.Mint("g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq", 10000*10000) // @manfred (10k)
 }

--- a/examples/gno.land/r/demo/foo20/gno.mod
+++ b/examples/gno.land/r/demo/foo20/gno.mod
@@ -4,4 +4,5 @@ require (
         "gno.land/p/demo/ufmt" v0.0.0-latest
         "gno.land/p/demo/grc/grc20" v0.0.0-latest
         "gno.land/r/demo/users" v0.0.0-latest
+        "gno.land/r/demo/grc20_registry" v0.0.0-latest
 )

--- a/examples/gno.land/r/demo/grc20_registry/gno.mod
+++ b/examples/gno.land/r/demo/grc20_registry/gno.mod
@@ -1,0 +1,6 @@
+module gno.land/r/demo/grc20_registry
+
+require (
+    "gno.land/p/demo/avl" v0.0.0-latest
+    "gno.land/p/demo/grc/grc20" v0.0.0-latest
+)

--- a/examples/gno.land/r/demo/grc20_registry/grc20_registry.gno
+++ b/examples/gno.land/r/demo/grc20_registry/grc20_registry.gno
@@ -1,0 +1,44 @@
+package grc20_registry
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/grc/grc20"
+)
+
+var registry = avl.NewTree() // pkg path -> IGRC20
+
+func Register(token grc20.IGRC20) {
+	caller := std.PrevRealm().PkgPath()
+	registry.Set(caller, token)
+}
+
+func Get(pkgPath string) (grc20.IGRC20, bool) {
+	coinI, ok := registry.Get(pkgPath)
+	if !ok {
+		return nil, false
+	}
+	coin, ok := coinI.(grc20.IGRC20)
+	if !ok {
+		panic("internal error: registered object is not a GRC20 token")
+	}
+	return coin, true
+}
+
+func Render(path string) string {
+	s := "# GRC20 Registry\n\n" +
+		"## Registered Tokens\n\n"
+	registry.Iterate("", "", func(pkgPath string, tokenI interface{}) bool {
+		token, ok := tokenI.(grc20.IGRC20)
+		pkgWebPath := strings.TrimPrefix(pkgPath, "gno.land")
+		if ok {
+			s += "- [" + token.GetName() + " (" + pkgPath + ")](" + pkgWebPath + ")\n"
+		} else {
+			s += "- [internal error: registered object is not a GRC20 token (" + pkgPath + ")](" + pkgWebPath + ")\n"
+		}
+		return false
+	})
+	return s
+}

--- a/examples/gno.land/r/demo/grc20_registry/grc20_registry_test.gno
+++ b/examples/gno.land/r/demo/grc20_registry/grc20_registry_test.gno
@@ -1,0 +1,55 @@
+package grc20_registry
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/grc/grc20"
+)
+
+func TestRegistry(t *testing.T) {
+	coin := &dummyImpl{}
+	realmAddr := std.CurrentRealm().PkgPath()
+	Register(coin)
+	regCoin, ok := Get(realmAddr)
+	if !ok {
+		t.Fatal("expected to find coin")
+	}
+	if coin.GetSymbol() != "TST" {
+		t.Fatal("expected coin to have symbol TST")
+	}
+	expected := `# GRC20 Registry
+
+## Registered Tokens
+
+* [TestToken ()]()
+`
+	got := Render("")
+	if got != expected {
+		t.Fatalf("expected `%s`, got `%s`", expected, got)
+	}
+
+	// we test this here because there is more chance to find a bug after a token has been registered
+	if _, ok := Get("0xdeadbeef"); ok {
+		t.Fatal("expected not to find coin")
+	}
+}
+
+type dummyImpl struct{}
+
+// FIXME: this should fail.
+var _ grc20.IGRC20 = (*dummyImpl)(nil)
+
+func (impl *dummyImpl) GetName() string                               { return "TestToken" }
+func (impl *dummyImpl) GetSymbol() string                             { return "TST" }
+func (impl *dummyImpl) GetDecimals() uint                             { panic("not implemented") }
+func (impl *dummyImpl) TotalSupply() uint64                           { panic("not implemented") }
+func (impl *dummyImpl) BalanceOf(account std.Address) (uint64, error) { panic("not implemented") }
+func (impl *dummyImpl) Transfer(to std.Address, amount uint64) error  { panic("not implemented") }
+func (impl *dummyImpl) Allowance(owner, spender std.Address) (uint64, error) {
+	panic("not implemented")
+}
+func (impl *dummyImpl) Approve(spender std.Address, amount uint64) error { panic("not implemented") }
+func (impl *dummyImpl) TransferFrom(from, to std.Address, amount uint64) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

This is a contract that allows to get a GRC20 user interface from a realm pkg path
It's an example of the registry pattern that allows to dynamically access realms interfaces

Caveat: this depends on #974 being fixed, if this would be merged now, it would steal ownership of the foo20 token object and make it unusable

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
