### PR TITLE
perf: goleveldb backend to use native range limiter

### DIFF
--- a/tm2/pkg/db/common_test.go
+++ b/tm2/pkg/db/common_test.go
@@ -298,10 +298,9 @@ func benchmarkIterator(b *testing.B, db DB, reverse bool, subset bool) {
 			_, _ = iter.Key(), iter.Value()
 			n++
 		}
-		//fmt.Println(n)
 		iter.Close()
 		if n != maxIteration {
-			b.Errorf("Expected %d iterations, got %d, start=%s, end=%s", maxIteration, n, start, end)
+			b.Errorf("Expected %d iterations, got %d (start=%v, end=%v)", maxIteration, n, start, end)
 		}
 	}
 }

--- a/tm2/pkg/db/go_level_db.go
+++ b/tm2/pkg/db/go_level_db.go
@@ -248,7 +248,6 @@ func (itr *goLevelDBIterator) Valid() bool {
 func (itr *goLevelDBIterator) Key() []byte {
 	// Key returns a copy of the current key.
 	// See https://github.com/gnolang/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
-	itr.assertNoError()
 	itr.assertIsValid()
 	return cp(itr.source.Key())
 }
@@ -257,14 +256,12 @@ func (itr *goLevelDBIterator) Key() []byte {
 func (itr *goLevelDBIterator) Value() []byte {
 	// Value returns a copy of the current value.
 	// See https://github.com/gnolang/goleveldb/blob/52c212e6c196a1404ea59592d3f1c227c9f034b2/leveldb/iterator/iter.go#L88
-	itr.assertNoError()
 	itr.assertIsValid()
 	return cp(itr.source.Value())
 }
 
 // Implements Iterator.
 func (itr *goLevelDBIterator) Next() {
-	itr.assertNoError()
 	itr.assertIsValid()
 	if itr.isReverse {
 		itr.source.Prev()

--- a/tm2/pkg/db/go_level_db.go
+++ b/tm2/pkg/db/go_level_db.go
@@ -205,26 +205,26 @@ func (db *GoLevelDB) ReverseIterator(start, end []byte) Iterator {
 }
 
 type goLevelDBIterator struct {
-	source    iterator.Iterator
-	start     []byte
-	end       []byte
-	isReverse bool
+	source  iterator.Iterator
+	start   []byte
+	end     []byte
+	reverse bool
 }
 
 var _ Iterator = (*goLevelDBIterator)(nil)
 
-func (db *GoLevelDB) newGoLevelDBIterator(start, end []byte, isReverse bool) *goLevelDBIterator {
+func (db *GoLevelDB) newGoLevelDBIterator(start, end []byte, reverse bool) *goLevelDBIterator {
 	source := db.db.NewIterator(&util.Range{Start: start, Limit: end}, nil)
-	if isReverse {
+	if reverse {
 		source.Last()
 	} else {
 		source.First()
 	}
 	return &goLevelDBIterator{
-		source:    source,
-		start:     start,
-		end:       end,
-		isReverse: isReverse,
+		source:  source,
+		start:   start,
+		end:     end,
+		reverse: reverse,
 	}
 }
 
@@ -264,7 +264,7 @@ func (itr *goLevelDBIterator) Value() []byte {
 // Implements Iterator.
 func (itr *goLevelDBIterator) Next() {
 	itr.assertIsValid()
-	if itr.isReverse {
+	if itr.reverse {
 		itr.source.Prev()
 	} else {
 		itr.source.Next()

--- a/tm2/pkg/db/go_level_db.go
+++ b/tm2/pkg/db/go_level_db.go
@@ -209,7 +209,6 @@ type goLevelDBIterator struct {
 	start     []byte
 	end       []byte
 	isReverse bool
-	isInvalid bool
 }
 
 var _ Iterator = (*goLevelDBIterator)(nil)

--- a/tm2/pkg/db/go_level_db.go
+++ b/tm2/pkg/db/go_level_db.go
@@ -125,6 +125,8 @@ func (db *GoLevelDB) Stats() map[string]string {
 	keys := []string{
 		"leveldb.num-files-at-level{n}",
 		"leveldb.stats",
+		"leveldb.iostats",
+		"leveldb.writedelay",
 		"leveldb.sstables",
 		"leveldb.blockpool",
 		"leveldb.cachedblock",
@@ -234,7 +236,7 @@ func (itr *goLevelDBIterator) Domain() ([]byte, []byte) {
 
 // Implements Iterator.
 func (itr *goLevelDBIterator) Valid() bool {
-	// Panic on DB error.  No way to recover.
+	// Panic on DB error. No way to recover.
 	itr.assertNoError()
 
 	// If source is invalid, invalid.

--- a/tm2/pkg/db/go_level_db.go
+++ b/tm2/pkg/db/go_level_db.go
@@ -161,12 +161,12 @@ type goLevelDBBatch struct {
 
 // Implements Batch.
 func (mBatch *goLevelDBBatch) Set(key, value []byte) {
-	mBatch.batch.Put(key, value)
+	mBatch.batch.Put(nonNilBytes(key), nonNilBytes(value))
 }
 
 // Implements Batch.
 func (mBatch *goLevelDBBatch) Delete(key []byte) {
-	mBatch.batch.Delete(key)
+	mBatch.batch.Delete(nonNilBytes(key))
 }
 
 // Implements Batch.

--- a/tm2/pkg/db/go_level_db_test.go
+++ b/tm2/pkg/db/go_level_db_test.go
@@ -53,6 +53,7 @@ func BenchmarkGoLevelDBIteratorSubset(b *testing.B) {
 }
 
 func newDBb(b *testing.B) DB {
+	b.Helper()
 	name := fmt.Sprintf("test_%x", randStr(12))
 	db, err := NewGoLevelDB(name, b.TempDir())
 	if err != nil {

--- a/tm2/pkg/db/go_level_db_test.go
+++ b/tm2/pkg/db/go_level_db_test.go
@@ -29,12 +29,34 @@ func TestGoLevelDBNewGoLevelDB(t *testing.T) {
 }
 
 func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
+	db := newDBb(b)
+	defer db.Close()
+	benchmarkRandomReadsWrites(b, db)
+}
+
+func BenchmarkGoLevelDBIterator(b *testing.B) {
+	db := newDBb(b)
+	defer db.Close()
+	benchmarkIterator(b, db, false, false)
+}
+
+func BenchmarkGoLevelDBReverseIterator(b *testing.B) {
+	db := newDBb(b)
+	defer db.Close()
+	benchmarkIterator(b, db, true, false)
+}
+
+func BenchmarkGoLevelDBIteratorSubset(b *testing.B) {
+	db := newDBb(b)
+	defer db.Close()
+	benchmarkIterator(b, db, false, true)
+}
+
+func newDBb(b *testing.B) DB {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	db, err := NewGoLevelDB(name, b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer db.Close()
-
-	benchmarkRandomReadsWrites(b, db)
+	return db
 }


### PR DESCRIPTION
- iterator to use the native range limiter.
- remove duplicated error checks.
- fix: missing nonNilBytes conversion on the batch jobs.
- add benchmarks to measure iterator performance.
- up-to-date stat properties.
- possibly related to #1013.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>

Benchmarks were written to measure the performance difference. It measures the iteration time of 100 keys in a db with 1 million keys from different offsets in each run.

Here, we are particularly interested in _**Subset iteration**_  test result. (the 4th line, BenchmarkGoLevelDBIteratorSubset)

```
## current version
goos: darwin
noarch: arm64
pkg: github.com/gnolang/gno/tm2/pkg/db
BenchmarkGoLevelDBRandomReadsWrites-10    	  316495	      4077 ns/op	     679 B/op	      13 allocs/op
BenchmarkGoLevelDBIterator-10             	   71209	     14991 ns/op	    5534 B/op	     255 allocs/op
BenchmarkGoLevelDBReverseIterator-10      	   21982	     52273 ns/op	   11675 B/op	     302 allocs/op
BenchmarkGoLevelDBIteratorSubset-10       	   60451	     17119 ns/op	    5737 B/op	     259 allocs/op

## this PR
BenchmarkGoLevelDBRandomReadsWrites-10    	  313550	      4076 ns/op	     679 B/op	      13 allocs/op
BenchmarkGoLevelDBIterator-10             	   73024	     13740 ns/op	    5581 B/op	     256 allocs/op
BenchmarkGoLevelDBReverseIterator-10      	   22754	     51091 ns/op	   11716 B/op	     303 allocs/op
BenchmarkGoLevelDBIteratorSubset-10       	   76792	     13662 ns/op	    5120 B/op	     252 allocs/op
```

```
$ go test .
ok  	github.com/gnolang/gno/tm2/pkg/db
```
