### PR TITLE
fix(mempkg): don't attempt to validate name of an empty package

### DIFF
--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -235,6 +235,10 @@ func makeGenesisDoc(
 	for _, pkg := range nonDraftPkgs {
 		// open files in directory as MemPackage.
 		memPkg := gno.ReadMemPackage(pkg.Dir, pkg.Name)
+		if len(memPkg.Files) == 0 { // skip empty package
+			continue
+		}
+
 		var tx std.Tx
 		tx.Msgs = []std.Msg{
 			vmm.MsgAddPackage{

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1132,8 +1132,13 @@ func ReadMemPackage(dir string, pkgPath string) *std.MemPackage {
 				Body: string(bz),
 			})
 	}
-	validatePkgName(string(pkgName))
-	memPkg.Name = string(pkgName)
+
+	// If no .gno files are present, package simply does not exist.
+	if len(memPkg.Files) > 0 {
+		validatePkgName(string(pkgName))
+		memPkg.Name = string(pkgName)
+	}
+
 	return memPkg
 }
 

--- a/gnovm/tests/imports.go
+++ b/gnovm/tests/imports.go
@@ -97,15 +97,20 @@ func TestStore(rootDir, filesPath string, stdin io.Reader, stdout, stderr io.Wri
 			stdlibPath := filepath.Join(rootDir, "gnovm", "stdlibs", pkgPath)
 			if osm.DirExists(stdlibPath) {
 				memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
-				m2 := gno.NewMachineWithOptions(gno.MachineOptions{
-					// NOTE: see also pkgs/sdk/vm/builtins.go
-					// XXX: why does this fail when just pkgPath?
-					PkgPath: "gno.land/r/stdlibs/" + pkgPath,
-					Output:  stdout,
-					Store:   store,
-				})
-				save := pkgPath != "testing" // never save the "testing" package
-				return m2.RunMemPackage(memPkg, save)
+				if len(memPkg.Files) > 0 {
+					m2 := gno.NewMachineWithOptions(gno.MachineOptions{
+						// NOTE: see also pkgs/sdk/vm/builtins.go
+						// XXX: why does this fail when just pkgPath?
+						PkgPath: "gno.land/r/stdlibs/" + pkgPath,
+						Output:  stdout,
+						Store:   store,
+					})
+					save := pkgPath != "testing" // never save the "testing" package
+					return m2.RunMemPackage(memPkg, save)
+				}
+
+				// There is no package there, but maybe we have a
+				// native counterpart below.
 			}
 		}
 
@@ -413,6 +418,10 @@ func TestStore(rootDir, filesPath string, stdin io.Reader, stdout, stderr io.Wri
 			stdlibPath := filepath.Join(rootDir, "gnovm", "stdlibs", pkgPath)
 			if osm.DirExists(stdlibPath) {
 				memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
+				if len(memPkg.Files) == 0 {
+					panic(fmt.Sprintf("found an empty package `%s`", pkgPath))
+				}
+
 				m2 := gno.NewMachineWithOptions(gno.MachineOptions{
 					PkgPath: "test",
 					Output:  stdout,
@@ -427,6 +436,10 @@ func TestStore(rootDir, filesPath string, stdin io.Reader, stdout, stderr io.Wri
 		examplePath := filepath.Join(rootDir, "examples", pkgPath)
 		if osm.DirExists(examplePath) {
 			memPkg := gno.ReadMemPackage(examplePath, pkgPath)
+			if len(memPkg.Files) == 0 {
+				panic(fmt.Sprintf("found an empty package `%s`", pkgPath))
+			}
+
 			m2 := gno.NewMachineWithOptions(gno.MachineOptions{
 				PkgPath: "test",
 				Output:  stdout,

--- a/gnovm/tests/package_test.go
+++ b/gnovm/tests/package_test.go
@@ -60,6 +60,9 @@ func runPackageTest(t *testing.T, dir string, path string) {
 	t.Helper()
 
 	memPkg := gno.ReadMemPackage(dir, path)
+	if len(memPkg.Files) == 0 {
+		panic(fmt.Sprintf("found an empty package `%s`", path))
+	}
 
 	stdin := new(bytes.Buffer)
 	// stdout := new(bytes.Buffer)

--- a/tm2/pkg/crypto/keys/client/addpkg.go
+++ b/tm2/pkg/crypto/keys/client/addpkg.go
@@ -98,6 +98,9 @@ func execAddPkg(cfg *addPkgCfg, args []string, io *commands.IO) error {
 
 	// open files in directory as MemPackage.
 	memPkg := gno.ReadMemPackage(cfg.pkgDir, cfg.pkgPath)
+	if len(memPkg.Files) == 0 {
+		panic(fmt.Sprintf("found an empty package `%s`", cfg.pkgPath))
+	}
 
 	// precompile and validate syntax
 	err = gno.PrecompileAndCheckMempkg(memPkg)

--- a/tm2/pkg/sdk/vm/builtins.go
+++ b/tm2/pkg/sdk/vm/builtins.go
@@ -25,6 +25,11 @@ func (vm *VMKeeper) initBuiltinPackagesAndTypes(store gno.Store) {
 			return nil, nil
 		}
 		memPkg := gno.ReadMemPackage(stdlibPath, pkgPath)
+		if len(memPkg.Files) == 0 {
+			// no gno files are present, skip this package
+			return nil, nil
+		}
+
 		m2 := gno.NewMachineWithOptions(gno.MachineOptions{
 			PkgPath: "gno.land/r/stdlibs/" + pkgPath,
 			// PkgPath: pkgPath,


### PR DESCRIPTION
This PR adjusts the behavior of `ReadMemPackage`. It now skips the package name validation when no gno files are found in the package directory. This modification allows for the utilization of empty parent packages that have a native fallback. For instance, in the `foo/bar` scenario, where `foo` is an empty package but has a native implementation defined in `imports.go`, and `bar` is a standard package containing gno files. Previously, this would have triggered a panic on `foo` import due to the empty package name rather than appropriately using the native `foo` fallback. 

While I haven't been able to introduce tests for this change, PR #1066, which incorporates the `net/url` package, would fail in the absence of this modification due to empty `net` dependencies.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
