### PR TITLE
chore: add test to demonstrate PrevRealm var block bug

### DIFF
--- a/examples/gno.land/r/demo/bugs/var_prev_realm/gno.mod
+++ b/examples/gno.land/r/demo/bugs/var_prev_realm/gno.mod
@@ -1,0 +1,1 @@
+module "gno.land/r/demo/bugs/var_prev_realm"

--- a/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm.gno
+++ b/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm.gno
@@ -1,0 +1,16 @@
+package var_prev_realm
+
+import (
+	"std"
+
+	"gno.land/r/demo/tests"
+)
+
+var (
+	varRealm  = tests.GetPrevRealm()
+	initRealm std.Realm
+)
+
+func init() {
+	initRealm = tests.GetPrevRealm()
+}

--- a/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
+++ b/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
@@ -7,15 +7,15 @@ import (
 
 func TestVarPrevRealm(t *testing.T) {
 	if initRealm.Addr() != varRealm.Addr() {
-		t.Errorf("initRealm != varRealm")
+		t.Errorf("expected init realm  '%s' to be equal to var block realm '%s'", initRealm.Addr(), varRealm.Addr())
 	}
 
 	correctRealmAddr := std.CurrentRealm().Addr()
 	if correctRealmAddr != varRealm.Addr() {
-		t.Errorf("correctRealmAddr != varRealm.Addr()")
+		t.Errorf("var block realm address incorrect, expected '%s', got '%s'", correctRealmAddr, varRealm.Addr())
 	}
 
 	if correctRealmAddr != initRealm.Addr() {
-		t.Errorf("correctRealmAddr != initRealm.Addr()")
+		t.Errorf("init realm address incorrect, expected '%s', got '%s'", correctRealmAddr, initRealm.Addr())
 	}
 }

--- a/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
+++ b/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
@@ -10,7 +10,8 @@ func TestVarPrevRealm(t *testing.T) {
 		t.Errorf("expected init realm  '%s' to be equal to var block realm '%s'", initRealm.Addr(), varRealm.Addr())
 	}
 
-	correctRealmAddr := std.CurrentRealm().Addr()
+	correctRealmAddr := std.DerivePkgAddr("gno.land/r/demo/bugs/var_prev_realm")
+
 	if correctRealmAddr != varRealm.Addr() {
 		t.Errorf("var block realm address incorrect, expected '%s', got '%s'", correctRealmAddr, varRealm.Addr())
 	}

--- a/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
+++ b/examples/gno.land/r/demo/bugs/var_prev_realm/var_prev_realm_test.gno
@@ -1,0 +1,21 @@
+package var_prev_realm
+
+import (
+	"std"
+	"testing"
+)
+
+func TestVarPrevRealm(t *testing.T) {
+	if initRealm.Addr() != varRealm.Addr() {
+		t.Errorf("initRealm != varRealm")
+	}
+
+	correctRealmAddr := std.CurrentRealm().Addr()
+	if correctRealmAddr != varRealm.Addr() {
+		t.Errorf("correctRealmAddr != varRealm.Addr()")
+	}
+
+	if correctRealmAddr != initRealm.Addr() {
+		t.Errorf("correctRealmAddr != initRealm.Addr()")
+	}
+}


### PR DESCRIPTION
This adds a test to demonstrate the PrevRealm bug in var block outlined in https://github.com/gnolang/gno/issues/941

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
