### PR TITLE
chore: add cli commands to craft genesis file

### DIFF
--- a/gno.land/cmd/gnoland/add-genesis-account.go
+++ b/gno.land/cmd/gnoland/add-genesis-account.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+type addGenesisAccountCfg struct {
+	rootDir string
+
+	genesisBalancesFile string
+}
+
+func newAddGenesisAccountCmd(io *commands.IO) *commands.Command {
+	cfg := &addGenesisAccountCfg{}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "add-genesis-account",
+			ShortUsage: "add-genesis-account [address] [coin] [flags]",
+			ShortHelp:  "Add a genesis account to genesis.json",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execAddGenesisAccount(cfg, args, io)
+		},
+	)
+}
+
+func (c *addGenesisAccountCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.rootDir,
+		"root-dir",
+		"testdir",
+		"directory for config and data",
+	)
+
+	fs.StringVar(
+		&c.genesisBalancesFile,
+		"from-file",
+		"",
+		"parse genesis balances from file",
+	)
+}
+
+func execAddGenesisAccount(c *addGenesisAccountCfg, args []string, io *commands.IO) error {
+	rootDir := c.rootDir
+	genesisFile := rootDir + "/config/genesis.json"
+
+	gen, err := bft.GenesisDocFromFile(genesisFile)
+	if err != nil {
+		return err
+	}
+
+	appState, ok := gen.AppState.(gnoland.GnoGenesisState)
+	if !ok {
+		panic("failed to parse genesis state")
+	}
+
+	var balances []string
+
+	if c.genesisBalancesFile != "" {
+		balances = loadGenesisBalances(c.genesisBalancesFile)
+	} else {
+		balances = append(balances, args[0]+"="+args[1])
+	}
+
+	for _, balance := range balances {
+		for _, line := range appState.Balances {
+			if strings.HasPrefix(line, balance) {
+				return fmt.Errorf("cannot add account at existing address: %s", balance)
+			}
+		}
+		appState.Balances = append(appState.Balances, balance)
+	}
+
+	gen.AppState = appState
+
+	return gen.SaveAs(genesisFile)
+}

--- a/gno.land/cmd/gnoland/add-gno-genesis-message.go
+++ b/gno.land/cmd/gnoland/add-gno-genesis-message.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"flag"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+)
+
+type addGnoGenesisMessageCfg struct {
+	rootDir string
+
+	genesisTxsFile string
+}
+
+func newAddGnoGenesisMessageCmd(io *commands.IO) *commands.Command {
+	cfg := &addGnoGenesisMessageCfg{}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "add-gno-genesis-message",
+			ShortUsage: "add-gno-genesis-message [flags]",
+			ShortHelp:  "add-gno-genesis-message gno genesis import txs",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execAddGnoGenesisMessage(cfg, args, io)
+		},
+	)
+}
+
+func (c *addGnoGenesisMessageCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.rootDir,
+		"root-dir",
+		"testdir",
+		"directory for config and data",
+	)
+
+	fs.StringVar(
+		&c.genesisTxsFile,
+		"genesis-txs-file",
+		"./genesis/genesis_txs.txt",
+		"addGnoGenesisMessageial txs to replay",
+	)
+}
+
+func execAddGnoGenesisMessage(c *addGnoGenesisMessageCfg, args []string, io *commands.IO) error {
+	// logger := log.NewTMLogger(log.NewSyncWriter(io.Out))
+	rootDir := c.rootDir
+	genesisFile := rootDir + "/config/genesis.json"
+
+	gen, err := bft.GenesisDocFromFile(genesisFile)
+	if err != nil {
+		return err
+	}
+
+	appState, ok := gen.AppState.(gnoland.GnoGenesisState)
+	if !ok {
+		panic("failed to parse genesis state")
+	}
+	_ = appState
+
+	return nil
+}

--- a/gno.land/cmd/gnoland/init.go
+++ b/gno.land/cmd/gnoland/init.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/config"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	osm "github.com/gnolang/gno/tm2/pkg/os"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type initCfg struct {
+	chainID string
+	rootDir string
+
+	genesisTxsFile      string
+	genesisBalancesFile string
+	genesisMaxVMCycles  int64
+}
+
+func newInitCmd(io *commands.IO) *commands.Command {
+	cfg := &initCfg{}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "init",
+			ShortUsage: "init [flags]",
+			ShortHelp:  "Initialize validators's and node's configuration files.",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execInit(cfg, args, io)
+		},
+	)
+}
+
+func (c *initCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.chainID,
+		"chain-id",
+		"dev",
+		"the ID of the chain",
+	)
+
+	fs.StringVar(
+		&c.rootDir,
+		"root-dir",
+		"testdir",
+		"directory for config and data",
+	)
+
+	fs.StringVar(
+		&c.genesisBalancesFile,
+		"genesis-balances-file",
+		"./genesis/genesis_balances.txt",
+		"initial distribution file",
+	)
+
+	fs.StringVar(
+		&c.genesisTxsFile,
+		"genesis-txs-file",
+		"./genesis/genesis_txs.txt",
+		"initial txs to replay",
+	)
+
+	fs.Int64Var(
+		&c.genesisMaxVMCycles,
+		"genesis-max-vm-cycles",
+		10_000_000,
+		"set maximum allowed vm cycles per operation. Zero means no limit.",
+	)
+}
+
+func execInit(c *initCfg, args []string, io *commands.IO) error {
+	// logger := log.NewTMLogger(log.NewSyncWriter(io.Out))
+	rootDir := c.rootDir
+	genesisFile := rootDir + "/config/genesis.json"
+
+	if osm.FileExists(genesisFile) {
+		return fmt.Errorf("genesis.json file already exists: %s", genesisFile)
+	}
+
+	cfg := config.LoadOrMakeConfigWithOptions(rootDir, func(cfg *config.Config) {
+		cfg.Consensus.CreateEmptyBlocks = true
+		cfg.Consensus.CreateEmptyBlocksInterval = 0 * time.Second
+	})
+
+	// create priv validator first.
+	// need it to generate genesis.json
+	newPrivValKey := cfg.PrivValidatorKeyFile()
+	newPrivValState := cfg.PrivValidatorStateFile()
+	priv := privval.LoadOrGenFilePV(newPrivValKey, newPrivValState)
+
+	// write genesis file
+	genesisFilePath := filepath.Join(rootDir, cfg.Genesis)
+	genDoc := makeGenesisDoc(
+		priv.GetPubKey(),
+		c.chainID,
+		"",
+		// c.genesisBalancesFile,
+		[]std.Tx{},
+		// loadGenesisTxs(c.genesisTxsFile, c.chainID, c.genesisRemote),
+	)
+	writeGenesisFile(genDoc, genesisFilePath)
+
+	return nil
+}

--- a/gno.land/cmd/gnoland/root.go
+++ b/gno.land/cmd/gnoland/root.go
@@ -36,6 +36,9 @@ func newRootCmd(io *commands.IO) *commands.Command {
 
 	cmd.AddSubCommands(
 		newStartCmd(io),
+		newInitCmd(io),
+		newAddGenesisAccountCmd(io),
+		newAddGnoGenesisMessageCmd(io),
 	)
 
 	return cmd

--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -210,6 +210,7 @@ func makeGenesisDoc(
 	}
 
 	// Load distribution.
+	fmt.Println("genesisBalancesFile:", genesisBalancesFile)
 	balances := loadGenesisBalances(genesisBalancesFile)
 	// debug: for _, balance := range balances { fmt.Println(balance) }
 
@@ -219,6 +220,7 @@ func makeGenesisDoc(
 
 	// List initial packages to load from examples.
 	pkgs, err := gnomod.ListPkgs(filepath.Join("..", "examples"))
+	// pkgs, err := gnomod.ListPkgs(filepath.Join("examples"))
 	if err != nil {
 		panic(fmt.Errorf("listing gno packages: %w", err))
 	}
@@ -272,7 +274,12 @@ func loadGenesisTxs(
 	genesisRemote string,
 ) []std.Tx {
 	txs := []std.Tx{}
-	txsBz := osm.MustReadFile(path)
+	// txsBz := osm.MustReadFile(path)
+	txsBz, err := osm.ReadFile(path)
+	if err != nil {
+		fmt.Println("error loadGenesisTxs: ", err, "failed to open", path)
+		return txs
+	}
 	txsLines := strings.Split(string(txsBz), "\n")
 	for _, txLine := range txsLines {
 		if txLine == "" {
@@ -294,7 +301,12 @@ func loadGenesisTxs(
 func loadGenesisBalances(path string) []string {
 	// each balance is in the form: g1xxxxxxxxxxxxxxxx=100000ugnot
 	balances := []string{}
-	content := osm.MustReadFile(path)
+	// content := osm.MustReadFile(path)
+	content, err := osm.ReadFile(path)
+	if err != nil {
+		fmt.Println("error: LoadGenesisBalance", err, "failed to open", path)
+		return balances
+	}
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)


### PR DESCRIPTION
following @moul 's work on #1050 

To prepare the future multi-node testnet, we'll need in `gnoland` cli more subcommands

- [x] `gnoland init` to only init and setup genesis.json
- [x] `gnoland genesis add-account` to add an account
- [ ] `gnoland genesis add-txs` to add transactions in genesis
- [ ] `gnoland genesis gentx` to add validator gentx
- [ ] `gnoland genesis collect-gentxs` to get the gentx
- [ ] `gnoland genesis validate` to validate the genesis

The current `gnoland start` is good for single node and dev / testnets environment, but for production, we'll need some improvement.
I even propose to rename `gnoland start` into `gnoland dev`,


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
