### PR TITLE
test(gnovm): migrate 'gno build' test to testscript

### DIFF
--- a/gnovm/cmd/gno/build_test.go
+++ b/gnovm/cmd/gno/build_test.go
@@ -1,17 +1,11 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-func TestBuildApp(t *testing.T) {
-	tc := []testMainCase{
-		{
-			args:        []string{"build"},
-			errShouldBe: "flag: help requested",
-		},
+	"github.com/rogpeppe/go-internal/testscript"
+)
 
-		// {args: []string{"build", "..."}, stdoutShouldContain: "..."},
-		// TODO: auto precompilation
-		// TODO: error handling
-	}
-	testMainCaseRun(t, tc)
+func TestBuild(t *testing.T) {
+	testscript.Run(t, setupTestScript(t, "testdata/gno_build"))
 }

--- a/gnovm/cmd/gno/testdata/gno_build/empty_dir.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/empty_dir.txtar
@@ -1,0 +1,6 @@
+# Run gno build on an empty dir
+
+gno build .
+
+! stdout .+
+! stderr .+

--- a/gnovm/cmd/gno/testdata/gno_build/invalid_gno_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/invalid_gno_files.txtar
@@ -1,0 +1,27 @@
+# Run gno build with invalid gno files (still success)
+
+gno build .
+
+! stdout .+
+! stderr .+
+
+-- go.mod --
+module gnobuild
+
+-- file1.go --
+package file1
+
+-- main.gno --
+package main
+
+invalid
+
+func main() {}
+
+-- sub/sub.gno --
+package sub
+
+invalid
+
+-- sub/file2.go --
+package file2

--- a/gnovm/cmd/gno/testdata/gno_build/invalid_go_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/invalid_go_files.txtar
@@ -1,0 +1,30 @@
+# Run gno build with invalid go files
+
+! gno build .
+
+! stdout .+
+stderr '\./file1\.go:3:1: syntax error: non-declaration statement outside function body'
+stderr '\./\.: build pkg: std go compiler: exit status 1'
+stderr 'sub/file2\.go:3:1: syntax error: non-declaration statement outside function body'
+stderr '\./sub: build pkg: std go compiler: exit status 1'
+
+-- go.mod --
+module gnobuild
+
+-- file1.go --
+package file1
+
+invalid1
+
+-- main.gno --
+package main
+
+func main() {}
+
+-- sub/sub.gno --
+package sub
+
+-- sub/file2.go --
+package file2
+
+invalid2

--- a/gnovm/cmd/gno/testdata/gno_build/no_args.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_args.txtar
@@ -1,0 +1,6 @@
+# Run gno build without args
+
+! gno build
+
+! stdout .+ 
+stderr 'flag: help requested'

--- a/gnovm/cmd/gno/testdata/gno_build/no_gno_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_gno_files.txtar
@@ -1,0 +1,12 @@
+# Run gno build on a dir w/o gno files
+
+gno build .
+
+! stdout .+
+! stderr .+
+
+-- README --
+Hello world
+
+-- sub/README --
+Hello world

--- a/gnovm/cmd/gno/testdata/gno_build/no_go_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_go_files.txtar
@@ -1,0 +1,19 @@
+# Run gno build in a dir without go files
+
+! gno build .
+
+! stdout .+
+stderr -count=2 'no Go files in '$WORK
+stderr '\./\.: build pkg: std go compiler: exit status 1'
+stderr '\./sub: build pkg: std go compiler: exit status 1'
+
+-- go.mod --
+module gnobuild
+
+-- main.gno --
+package main
+
+func main() {}
+
+-- sub/sub.gno --
+package sub

--- a/gnovm/cmd/gno/testdata/gno_build/no_gomod.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_gomod.txtar
@@ -1,0 +1,16 @@
+# Run gno build on a dir without go.mod
+
+! gno build .
+
+! stdout .+
+stderr -count=2 'go: go.mod file not found in current directory or any parent directory'
+stderr './.: build pkg: std go compiler: exit status 1'
+stderr './sub: build pkg: std go compiler: exit status 1'
+
+-- main.gno --
+package main
+
+func main() {}
+
+-- sub/sub.gno --
+package sub

--- a/gnovm/cmd/gno/testdata/gno_build/ok.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/ok.txtar
@@ -1,0 +1,23 @@
+# Run gno build successfully
+
+gno build .
+
+! stdout .+
+! stderr .+
+
+-- go.mod --
+module gnobuild
+
+-- file1.go --
+package file1
+
+-- main.gno --
+package main
+
+func main() {}
+
+-- sub/sub.gno --
+package sub
+
+-- sub/file2.go --
+package file2


### PR DESCRIPTION
Like done for 'gno test', use testscript and txtar files to define the different test cases.

The previous test was only testing `gno build` without arguments and files, so this PR adds more cases.

Interestingly, the gno files are only used to determine the directories where the 'go build' command will be passed. This means only go file syntax is checked (gno file syntax is ignored, as pictured in `invalid_gno_files.txtar` case). Also a `go.mod` is required or else the command fails.

Like the previous test, the new test can be run via

```
$ go test ./gnovm/cmd/gno -v -run Build
```

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
