### PR TITLE
fix: copy value in `cv.map`

### DIFF
--- a/gno.land/cmd/gnoland/testdata/pr-1112.txtar
+++ b/gno.land/cmd/gnoland/testdata/pr-1112.txtar
@@ -1,0 +1,35 @@
+# Test for https://github.com/gnolang/gno/pull/1112
+
+gnoland start
+
+# add contract
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/mapindex -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+# call map
+gnokey maketx call -pkgpath gno.land/r/demo/mapindex -func FindMapWithKey -args 3 -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout '"three" string'
+
+# XXX without patching realm.go, expected stdout is
+# stdout ' string'
+
+
+-- gno.mod --
+module gno.land/r/demo/mapindex
+
+
+-- realm.gno --
+package mapindex
+
+var mapus map[uint64]string = make(map[uint64]string)
+
+func init() {
+	mapus[3] = "three"
+	mapus[5] = "five"
+	mapus[9] = "nine"
+}
+
+func FindMapWithKey(k uint64) string {
+	return mapus[k]
+}

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1356,6 +1356,7 @@ func fillTypesOfValue(store Store, val Value) Value {
 		for cur := cv.List.Head; cur != nil; cur = cur.Next {
 			fillTypesTV(store, &cur.Key)
 			fillTypesTV(store, &cur.Value)
+
 			cv.vmap[cur.Key.ComputeMapKey(store, false)] = cur
 		}
 		return cv

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1356,6 +1356,7 @@ func fillTypesOfValue(store Store, val Value) Value {
 		for cur := cv.List.Head; cur != nil; cur = cur.Next {
 			fillTypesTV(store, &cur.Key)
 			fillTypesTV(store, &cur.Value)
+			cv.vmap[cur.Key.ComputeMapKey(store, false)] = cur
 		}
 		return cv
 	case TypeValue:


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

```go
package mapindex

var mapus map[uint64]string = make(map[uint64]string)

func init() {
	mapus[3] = "three"
	mapus[5] = "five"
	mapus[9] = "nine"
}

func FindMapWithKey(k uint64) string {
	return mapus[k]
}

```


`println(mapus[5])` will return 'five' in test cases run by `gno test` which is expected

HOWEVER, with deployed package
```bash
$ gnokey maketx addpkg \
-remote 127.0.0.1:26657 \
-broadcast=true \
-chainid dev \
-gas-fee 1ugnot \
-gas-wanted 9000000 \
-memo "" \
-pkgdir ./ \
-pkgpath gno.land/r/demo/mapindex \
test1

```

calling
```bash
$ gnokey maketx call \
-remote 127.0.0.1:26657 \
-broadcast=true \
-chainid dev \
-gas-fee 1ugnot \
-gas-wanted 9000000 \
-memo "" \
-pkgpath gno.land/r/demo/mapindex \
-func FindMapWithKey \
-args "3" \
test1
```

will return nothing for value, and 'string' for type
```bash
$ gnokey maketx call \
-remote 127.0.0.1:26657 \
-broadcast=true \
-chainid dev \
-gas-fee 1ugnot \
-gas-wanted 9000000 \
-memo "" \
-pkgpath gno.land/r/demo/mapindex \
-func FindMapWithKey \
-args "3" \
test1
Enter password.

( string)
OK!
GAS WANTED: 9000000
GAS USED:   73301
```

## Related PR
- [x] #932 @tbruyelle 


<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
