### PR TITLE
fix(vm): Release VM properly

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -154,13 +154,16 @@ var (
 // and prevent objects that were not taken from
 // the pool, to call Release
 func (m *Machine) Release() {
-	// copy()
 	// here we zero in the values for the next user
 	m.NumOps = 0
 	m.NumValues = 0
-	// this is the fastest way to zero-in a slice in Go
-	copy(m.Ops, opZeroed[:])
-	copy(m.Values, valueZeroed[:])
+
+	m.Ops = make([]Op, 1024)
+	m.Values = make([]TypedValue, 1024)
+	m.Exprs = make([]Expr, 1024)
+	m.Stmts = make([]Stmt, 1024)
+	m.Blocks = make([]*Block, 1024)
+	m.Frames = make([]Frame, 1024)
 
 	machinePool.Put(m)
 }

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -81,8 +81,8 @@ type MachineOptions struct {
 var machinePool = sync.Pool{
 	New: func() interface{} {
 		return &Machine{
-			Ops:    make([]Op, OpSize),
-			Values: make([]TypedValue, ValueSize),
+			Ops:    make([]Op, VMSliceSize),
+			Values: make([]TypedValue, VMSliceSize),
 		}
 	},
 }
@@ -139,13 +139,7 @@ func NewMachineWithOptions(opts MachineOptions) *Machine {
 }
 
 const (
-	OpSize    = 1024
-	ValueSize = 1024
-)
-
-var (
-	opZeroed    [OpSize]Op
-	valueZeroed [ValueSize]TypedValue
+	VMSliceSize = 1024
 )
 
 // m should not be used after this call
@@ -158,12 +152,12 @@ func (m *Machine) Release() {
 	m.NumOps = 0
 	m.NumValues = 0
 
-	m.Ops = make([]Op, 1024)
-	m.Values = make([]TypedValue, 1024)
-	m.Exprs = make([]Expr, 1024)
-	m.Stmts = make([]Stmt, 1024)
-	m.Blocks = make([]*Block, 1024)
-	m.Frames = make([]Frame, 1024)
+	m.Ops = make([]Op, VMSliceSize)
+	m.Values = make([]TypedValue, VMSliceSize)
+	m.Exprs = nil
+	m.Stmts = nil
+	m.Blocks = nil
+	m.Frames = nil
 
 	machinePool.Put(m)
 }

--- a/gnovm/pkg/gnolang/machine_test.go
+++ b/gnovm/pkg/gnolang/machine_test.go
@@ -1,0 +1,10 @@
+package gnolang
+
+import "testing"
+
+func BenchmarkCreateNewMachine(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m := NewMachineWithOptions(MachineOptions{})
+		m.Release()
+	}
+}


### PR DESCRIPTION
Properly clean slices using make (the internal logic is expecting slices to not be nil).

It closes #1033

- [X] Added new tests, or not needed, or not feasible
- [X] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [X] Updated the official documentation or not needed
- [X] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [X] Added references to related issues and PRs
- [X] Provided any useful hints for running manual tests
- [X] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
