### PR TITLE
fix: change default rpc config + upgrade CORS library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.4
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/gdamore/tcell/v2 v2.1.0
-	github.com/gnolang/cors v1.8.1
 	github.com/gnolang/goleveldb v0.0.9
 	github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216
 	github.com/golang/protobuf v1.5.3
@@ -28,6 +27,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rogpeppe/go-internal v1.11.0
+	github.com/rs/cors v1.10.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c
 	go.etcd.io/bbolt v1.3.7

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.1.0 h1:UnSmozHgBkQi2PGsFr+rpdXuAPRRucMegpQp3Z3kDro=
 github.com/gdamore/tcell/v2 v2.1.0/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
-github.com/gnolang/cors v1.8.1 h1:D3y1DMoWcgGpCefHwD4UHjy1w1163sfczZyy7b5wH8o=
-github.com/gnolang/cors v1.8.1/go.mod h1:g7HJhHH+N1r+oRrb7ckR2J6xp5es4EizpAP0JpfgVgU=
 github.com/gnolang/goleveldb v0.0.9 h1:Q7rGko9oXMKtQA+Apeeed5a3sjba/mcDhzJGoTVLCKE=
 github.com/gnolang/goleveldb v0.0.9/go.mod h1:Dz6p9bmpy/FBESTgduiThZt5mToVDipcHGzj/zUOo8E=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
@@ -152,6 +150,8 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rs/cors v1.10.0 h1:62NOS1h+r8p1mW6FM0FSB0exioXLhd/sh15KpjWBZ+8=
+github.com/rs/cors v1.10.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gnolang/cors"
+	"github.com/rs/cors"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
@@ -41,7 +41,7 @@ import (
 	verset "github.com/gnolang/gno/tm2/pkg/versionset"
 )
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 // DBContext specifies config information for loading a new DB.
 type DBContext struct {
@@ -134,7 +134,7 @@ func CustomReactors(reactors map[string]p2p.Reactor) Option {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 // Node is the highest level interface to a full Tendermint node.
 // It includes all configuration information and running services.
@@ -819,7 +819,7 @@ func (n *Node) Config() *cfg.Config {
 	return n.config
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 func (n *Node) Listeners() []string {
 	return []string{
@@ -887,7 +887,7 @@ func makeNodeInfo(
 	return nodeInfo, err
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var genesisDocKey = []byte("genesisDoc")
 

--- a/tm2/pkg/bft/rpc/config/config.go
+++ b/tm2/pkg/bft/rpc/config/config.go
@@ -90,7 +90,7 @@ func DefaultRPCConfig() *RPCConfig {
 	return &RPCConfig{
 		ListenAddress:          "tcp://127.0.0.1:26657",
 		CORSAllowedOrigins:     []string{"*"},
-		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost},
+		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost, http.MethodOptions},
 		CORSAllowedHeaders:     []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time"},
 		GRPCListenAddress:      "",
 		GRPCMaxOpenConnections: 900,

--- a/tm2/pkg/bft/rpc/config/config.go
+++ b/tm2/pkg/bft/rpc/config/config.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-//-----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // RPCConfig
 
 const (
@@ -89,7 +89,7 @@ type RPCConfig struct {
 func DefaultRPCConfig() *RPCConfig {
 	return &RPCConfig{
 		ListenAddress:          "tcp://127.0.0.1:26657",
-		CORSAllowedOrigins:     []string{},
+		CORSAllowedOrigins:     []string{"*"},
 		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost},
 		CORSAllowedHeaders:     []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time"},
 		GRPCListenAddress:      "",


### PR DESCRIPTION
## Description

This PR introduces several changes to the default JSON-RPC config of the Gno node:
- allow all (`*`) origin requests by default. The reasoning behind this is that local development setups that require the RPC layer will have their requests rejected by the CORS policy, and will require a custom RPC config to be specified to the node. This is more of a convenience on the side of development, as production Gno RPC setups will have a concrete RPC configuration that is more limited
- explicitly allow `OPTIONS` requests (preflight requests) in the default configuration
- change the CORS library used in the project from [gnolang/cors](https://github.com/gnolang/cors) to [rs/cors](https://github.com/rs/cors). The [gnolang/cors](https://github.com/gnolang/cors) library is a fork of [rs/cors](https://github.com/rs/cors), with seemingly no functionality changes. Therefore, to stay up to date with the latest fixes and upstream changes, I've updated the library gno uses to the original one, which is actively maintained by the original authors

### How can I test this out?

Essentially, you can run the local node with the default RPC params, and try to do an HTTP request from a frontend application:

```ts
import { GnoJSONRPCProvider } from "@gnolang/gno-js-client";

const exampleMethod = async () => {
  // Local node as the endpoint
  const provider = new GnoJSONRPCProvider("http://127.0.0.1:26657");

  const blockNumber: number = await provider.getBlockNumber();

  console.log(blockNumber);
};

exampleMethod()
  .then(() => {
    console.log("success");
  })
  .catch((e) => {
    console.error(e);
  });

```

Example error:
<img width="1192" alt="Screenshot 2023-09-13 at 12 27 22" src="https://github.com/gnolang/gno/assets/16712663/603b58c7-577d-4970-80eb-1c5984e0744b">


<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
