### PR TITLE
feat(repl): improve support of multi-line statements

### DIFF
--- a/gnovm/cmd/gno/repl.go
+++ b/gnovm/cmd/gno/repl.go
@@ -120,7 +120,7 @@ func runRepl(cfg *replCfg) error {
 		if err := handleInput(r, line); err != nil {
 			var goScanError scanner.ErrorList
 			if errors.As(err, &goScanError) {
-				// We assune that a Go scanner error indicates an incomplete Go statement.
+				// We assume that a Go scanner error indicates an incomplete Go statement.
 				// Append next line and retry.
 				prevline = line
 			} else {

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -161,7 +161,7 @@ func (r *Repl) Process(input string) (out string, err error) {
 		return r.handleExpression(exp)
 	}
 
-	return "", fmt.Errorf("error parsing code:\n\t- as expression (error: %q)\n\t- as declarations (error: %q)", expErr.Error(), declErr.Error())
+	return "", fmt.Errorf("error parsing code:\n\t- as expression: %w\n\t- as declarations: %w", expErr, declErr)
 }
 
 func (r *Repl) handleExpression(e *ast.File) (string, error) {


### PR DESCRIPTION
![demo](https://github.com/gnolang/gno/assets/5792239/308e61bc-bdf9-498b-9fa7-cd756835f774)

This is a followup of #978. Instead of starting in multi-line mode prior to submit, the line is parsed, and new inputs are appended to it as long as the statment is not complete, as detected by the Go scanner.

This is simpler and more general than previous attempt. The secondary prompt is "...", different from primary "gno>", similarly to many REPL programs (node, python, bash, ...).

The "/editor" command is removed as not useful anymore. Note also that it is now possible to exit using Ctrl-D.

Related issues: #446 #950

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>