### PR TITLE
chore: fix codecov config (h/t @the-howl)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,5 @@
 codecov:
   require_ci_to_pass: false
-  require_changes: true
   notify:
     wait_for_ci: false
 
@@ -23,7 +22,6 @@ coverage:
     patch:
       default:
         target: auto
-    changes:
 
 flags:
   default_rules:


### PR DESCRIPTION
See https://github.com/gnolang/gno/pull/1122#issuecomment-1720164847

```console
❯ cat codecov.yml | curl --data-binary @/dev/stdin https://codecov.io/validate
Valid!

{
  "codecov": {
    "require_ci_to_pass": false,
...
```