### PR TITLE
chore: disable codecov flags that can overlap

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: gno.land
-          flags: gno.land,gno.land-${{matrix.args}},go-${{ matrix.go-version }}
+          flags: gno.land-${{matrix.args}}
           files: ./gno.land/coverage.out
           #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
           fail_ci_if_error: false # temporarily

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: gnovm
-          flags: gnovm,gnovm-${{matrix.args}},go-${{ matrix.go-version }}
+          flags: gnovm-${{matrix.args}}
           files: ./gnovm/coverage.out
           #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
           fail_ci_if_error: false # temporarily

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: tm2
-          flags: tm2,tm2-${{matrix.args}},go-${{ matrix.go-version }}
+          flags: tm2-${{matrix.args}}
           files: ./tm2/coverage.out
           #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
           fail_ci_if_error: false # temporarily


### PR DESCRIPTION
Proposed Fix for #1139.

Given that we're only executing specific GitHub actions based on file changes, shared codecov flags might fluctuate between PRs due to variable testing targets. While this PR retains the recommended flag structure for monorepos, it aims to eliminate potential overlaps.

However, overlap could still occur with Go versions like 1.19, 1.20, and so on. Personally, I suggest we retain this overlap for now to gauge its potential inconsistencies. If issues arise, appending the Go version as a suffix to the flag could be considered.

Admittedly, I'm charting unfamiliar waters with this solution. Insights from those experienced with Codecov would be greatly appreciated.