### PR TITLE
chore: Fix codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,6 +7,7 @@ ignore:
   - misc
 
 comment:
+  layout: "header, diff, flags, components"
   require_changes: true
 
 coverage:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,18 +23,17 @@ coverage:
       default:
         target: auto
 
-flags:
-  default_rules:
-    carryforward: true
-  tm2:
-    paths:
-      - tm2
-    after_n_builds: 4
-  gnovm:
-    paths:
-      - gnovm
-    after_n_builds: 9
-  gno.land:
-    paths:
-      - gno.land
-    after_n_builds: 3
+component_management:
+  individual_components:
+    - component_id: tm2
+      name: tm2
+      paths:
+        - tm2
+    - component_id: gnovm
+      name: gnovm
+      paths:
+        - gnovm
+    - component_id: gno.land
+      name: gno.land
+      paths:
+        - gno.land

--- a/gnovm/pkg/doc/dirs_test.go
+++ b/gnovm/pkg/doc/dirs_test.go
@@ -67,6 +67,7 @@ func tNewDirs(t *testing.T) (string, *bfsDirs) {
 	// dependency lookup by dirs.
 	old, ex := os.LookupEnv("GNO_HOME")
 	os.Setenv("GNO_HOME", wdJoin(t, "testdata/dirsdep"))
+
 	t.Cleanup(func() {
 		if ex {
 			os.Setenv("GNO_HOME", old)


### PR DESCRIPTION
Split coverages by component.

Related to #1139

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).

