### PR TITLE
chore: Fix codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,34 +7,28 @@ ignore:
   - misc
 
 comment:
-  layout: "header, diff, flags, components"
-  require_changes: true
+  require_changes: false
 
 coverage:
-  #range: 50..100
   round: down
   precision: 2
-  status:
-    project:
-      default:
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
         target: auto
         threshold: 0.5%
-        #informational: true
-    patch:
-      default:
+      - type: patch
         target: auto
-
-component_management:
-  individual_components:
-    - component_id: tm2
-      name: tm2
+  individual_flags:
+    - name: tm2
       paths:
-        - tm2
-    - component_id: gnovm
-      name: gnovm
+      - tm2
+    - name: gnovm
       paths:
-        - gnovm
-    - component_id: gno.land
-      name: gno.land
+      - gnovm
+    - name: gno.land
       paths:
-        - gno.land
+      - gno.land


### PR DESCRIPTION
Split coverages by component.

Check if it works better than prev iteration after doing some research: https://docs.codecov.com/docs/carryforward-flags

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
