### PR TITLE
ci: tell codecov to wait_for_ci to avoid flappy reports

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: false
   notify:
-    wait_for_ci: false
+    wait_for_ci: true
 
 ignore:
   - misc
@@ -12,6 +12,15 @@ comment:
 coverage:
   round: down
   precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
 
 flag_management:
   default_rules:
@@ -22,6 +31,7 @@ flag_management:
         threshold: 0.5%
       - type: patch
         target: auto
+        threshold: 1%
   individual_flags:
     - name: tm2
       paths:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,8 +16,7 @@ coverage:
     project:
       default:
         target: auto
-        # Let's decrease this later.
-        threshold: 10
+        threshold: 10 # Let's decrease this later.
         base: parent
         if_no_uploads: error
         if_not_found: success
@@ -26,8 +25,7 @@ coverage:
     patch:
       default:
         target: auto
-        # Allows PRs without tests, overall stats count.
-        threshold: 100
+        threshold: 100 # Allows PRs without tests, overall stats count.
         base: auto
         if_no_uploads: error
         if_not_found: success
@@ -40,10 +38,10 @@ flag_management:
     statuses:
       - type: project
         target: auto
-        threshold: 0.5%
+        threshold: 10 # Let's decrease this later.
       - type: patch
-        target: auto
-        threshold: 1%
+        target: auto # Allows PRs without tests, overall stats count.
+        threshold: 100
   individual_flags:
     - name: tm2
       paths:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,11 +16,23 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.5%
+        # Let's decrease this later.
+        threshold: 10
+        base: parent
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
     patch:
       default:
         target: auto
-        threshold: 1%
+        # Allows PRs without tests, overall stats count.
+        threshold: 100
+        base: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
 
 flag_management:
   default_rules:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 1
     - uses: actions/setup-go@v4
       with:
-        goversion: "1.21.x"
+        go-version: "1.21.x"
     - name: "gobenchdata publish: ${{ inputs.publish }}"
       run: go run go.bobheadxi.dev/gobenchdata@v1 action
       env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 1
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.21.x"
+        goversion: "1.21.x"
     - name: "gobenchdata publish: ${{ inputs.publish }}"
       run: go run go.bobheadxi.dev/gobenchdata@v1 action
       env:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ on:
         type: string
 jobs:
   benchmarks:
+    if: ${{ github.repository == 'gnolang/gno' }}
     runs-on: [self-hosted, Linux, X64, benchmark-v1]
     steps:
     - name: checkout

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -29,10 +29,12 @@ jobs:
           - fsdb
           - boltdb
     steps:
+      - uses: actions/checkout@v4
+
       # golang
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
+          go-version: ${{ matrix.goversion }}
 
       # leveldb
       - name: install leveldb
@@ -46,6 +48,5 @@ jobs:
           sudo dpkg -i *.deb
 
       # test ./pkgs/db
-      - uses: actions/checkout@v4
       - name: test ./tm2/pkg/db
         run: go test -tags ${{ matrix.tags }} ./tm2/pkg/db/...

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         tags:
@@ -32,7 +32,7 @@ jobs:
       # golang
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
 
       # leveldb
       - name: install leveldb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - run: go install -v ./gnovm/cmd/gno
       - run: go run ./gnovm/cmd/gno precompile --verbose ./examples
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         # unittests: TODO: matrix with contracts
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - run: go install -v ./gnovm/cmd/gno
       - run: go run ./gnovm/cmd/gno test --verbose ./examples
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         # unittests: TODO: matrix with contracts
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - run: go install -v ./gnovm/cmd/gno
       # testing official directories, basically examples/ minus examples/.../x/.

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - run: go install -v ./gnovm/cmd/gno
       - run: go run ./gnovm/cmd/gno precompile --verbose ./examples
       - run: go run ./gnovm/cmd/gno build --verbose ./examples
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - run: go install -v ./gnovm/cmd/gno
       - run: go run ./gnovm/cmd/gno test --verbose ./examples
   lint:
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - run: go install -v ./gnovm/cmd/gno
       # testing official directories, basically examples/ minus examples/.../x/.
       - run: go run ./gnovm/cmd/gno lint --verbose ./examples/gno.land/p

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository == 'gnolang/gno' }} # Alternatively, validate based on provided tokens and permissions.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +31,7 @@ jobs:
           path: ./misc/gendocs/godoc
 
   deploy:
+    if: ${{ github.repository == 'gnolang/gno' }} # Alternatively, validate based on provided tokens and permissions.
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         goarch: [ "amd64" ]
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: go install
         working-directory: gno.land
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         args:
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: test
         working-directory: gno.land
@@ -68,15 +68,14 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: runner.os == 'Linux'
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: gno.land
           flags: gno.land-${{matrix.args}}
           files: ./gno.land/coverage.out
-          #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
-          fail_ci_if_error: false # temporarily
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
 
   docker-integration:
     strategy:

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: go install
         working-directory: gno.land
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go install ./cmd/${{ matrix.program }}
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: test
         working-directory: gno.land
         run: |

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -9,6 +9,12 @@ on:
       - "tm2/**.go"
       - "gno.land/**"
       - ".github/workflows/gnovm.yml"
+      # Until the codecov issue is resolved, it's essential to run the tests for gnovm, tm2, and gno.land concurrently.
+      - "gnovm/**"
+      - "tm2/**"
+      - "gno.land/**"
+      - "examples/**"
+      - ".github/workflows/**"
   push:
     branches: [ "master" ]
 

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -68,7 +68,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -72,7 +72,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: # two latest versions
+        goversion: # two latest versions
           - "1.20.x"
           - "1.21.x"
         goenv: # TODO: replace with pairs, so it's easier to read in the GH interface.
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: go install
         working-directory: gnovm
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         args:
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: test
         working-directory: gnovm
@@ -72,12 +72,11 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: runner.os == 'Linux'
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: gnovm
           flags: gnovm-${{matrix.args}}
           files: ./gnovm/coverage.out
-          #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
-          fail_ci_if_error: false # temporarily
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: go install
         working-directory: gnovm
         run: ${{ matrix.goenv }} go install ./cmd/${{ matrix.program }}
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: test
         working-directory: gnovm
         run: |
@@ -77,6 +77,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: gnovm
+          verbose: true
           flags: gnovm-${{matrix.args}}
           files: ./gnovm/coverage.out
           fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -11,6 +11,12 @@ on:
       - "gnovm/Makefile"
       - "tm2/**.go"
       - ".github/workflows/gnovm.yml"
+      # Until the codecov issue is resolved, it's essential to run the tests for gnovm, tm2, and gno.land concurrently.
+      - "gnovm/**"
+      - "tm2/**"
+      - "gno.land/**"
+      - "examples/**"
+      - ".github/workflows/**"
   push:
     branches: [ "master" ]
 

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -13,13 +13,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          goversion: 1.21.x
-
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version: 1.21.x
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
@@ -31,16 +31,16 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          goversion: 1.20.x
+          go-version: 1.21.x
 
       - name: Install make
         run: sudo apt-get install -y make
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       # prefill dependencies so that mod messages don't show up in make output
       - name: Fetch dependencies
@@ -61,13 +61,13 @@ jobs:
   modtidy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          goversion: 1.20.x
-
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version: 1.21.x
 
       - name: Check go.mods
         run: |

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          goversion: 1.21.x
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          goversion: 1.20.x
 
       - name: Install make
         run: sudo apt-get install -y make
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          goversion: 1.20.x
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         goarch: [ "amd64" ]
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: go install
         working-directory: tm2
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version:
+        goversion:
           - "1.20.x"
           - "1.21.x"
         args:
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          goversion: ${{ matrix.goversion }}
       - uses: actions/checkout@v4
       - name: test
         working-directory: tm2
@@ -61,12 +61,11 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: runner.os == 'Linux'
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: tm2
           flags: tm2-${{matrix.args}}
           files: ./tm2/coverage.out
-          #fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
-          fail_ci_if_error: false # temporarily
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: go install
         working-directory: tm2
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go install ${{ matrix.program }}
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          goversion: ${{ matrix.goversion }}
-      - uses: actions/checkout@v4
+          go-version: ${{ matrix.goversion }}
       - name: test
         working-directory: tm2
         run: |
@@ -66,6 +66,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: tm2
+          verbose: true
           flags: tm2-${{matrix.args}}
           files: ./tm2/coverage.out
           fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -61,6 +61,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
+          touch coverage.out
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -7,6 +7,12 @@ on:
       - "tm2/Makefile"
       - "tm2/**.go"
       - ".github/workflows/tm2.yml"
+      # Until the codecov issue is resolved, it's essential to run the tests for gnovm, tm2, and gno.land concurrently.
+      - "gnovm/**"
+      - "tm2/**"
+      - "gno.land/**"
+      - "examples/**"
+      - ".github/workflows/**"
   push:
     branches: [ "master" ]
 
@@ -61,7 +67,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-          touch coverage.out
+          touch coverage.outf
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -67,7 +67,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-          touch coverage.outf
+          touch coverage.out
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -61,7 +61,7 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == "1.21.x" }}
+      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/tm2/pkg/tmp.go
+++ b/tm2/pkg/tmp.go
@@ -1,1 +1,0 @@
-package tmp

--- a/tm2/pkg/tmp.go
+++ b/tm2/pkg/tmp.go
@@ -1,0 +1,1 @@
+package tmp


### PR DESCRIPTION
I've conducted tests on my fork, which you can find at https://github.com/moul/gno.

The 'if' condition draws inspiration from @ajnavarro's contributions, so a shoutout to him for that.

Additionally, @ajnavarro pointed out gaps in our testing for certain packages. We need to strategize on expanding our test coverage to address these overlooked areas.

I suggest waiting for his alternative work before considering merging mine.