### PR TITLE
Instruction to reproduce weird bug on append

### DIFF
--- a/append_bug.sh
+++ b/append_bug.sh
@@ -1,0 +1,27 @@
+# cd gno.land && go run ./cmd/gnoland start in an other terminal first
+#
+# Call Append 1
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Append" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "1" -remote "127.0.0.1:26657" $1
+# Call Append 2
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Append" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "2" -remote "127.0.0.1:26657" $1
+# Call Append 3
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Append" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "3" -remote "127.0.0.1:26657" $1
+
+# Call render
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Render" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "" -remote "127.0.0.1:26657" $1
+# Outputs ("1</br>2</br>3</br>" string) -> OK
+
+# Call Pop
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Pop" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -remote "127.0.0.1:26657" $1
+# Call render
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Render" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "" -remote "127.0.0.1:26657" $1
+# Outputs ("1</br>2</br>" string) -> WRONG! Pop removes the first item so
+# it should be ("2</br>3</br>" string)
+
+# Call Append 42
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Append" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "42" -remote "127.0.0.1:26657" $1
+
+# Call render
+gnokey maketx call -pkgpath "gno.land/r/demo/bug/append" -func "Render" -gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "dev" -args "" -remote "127.0.0.1:26657" $1
+# Ouputs ("1</br>2</br>3</br>" string) -> WTF where is 42 ???
+

--- a/examples/gno.land/r/demo/bug/append/append.gno
+++ b/examples/gno.land/r/demo/bug/append/append.gno
@@ -1,0 +1,25 @@
+package append
+
+import (
+	"gno.land/p/demo/ufmt"
+)
+
+type T struct{ i int }
+
+var a []T
+
+func Append(i int) {
+	a = append(a, T{i: i})
+}
+
+func Pop() {
+	a = append(a[:0], a[1:]...)
+}
+
+func Render(_ string) string {
+	var s string
+	for i := 0; i < len(a); i++ {
+		s += ufmt.Sprintf("%d</br>", a[i].i)
+	}
+	return s
+}

--- a/examples/gno.land/r/demo/bug/append/gno.mod
+++ b/examples/gno.land/r/demo/bug/append/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/demo/bug/append


### PR DESCRIPTION
start a node, then execute `append_bug.sh <YOURKEY>` or copy paste the commands one by one.

The realm that has been added to reproduce exposes 2 functions,`Append` and `Pop`, and the script does the following:

```
Append 1
Append 2
Append 3
Render -> 1,2,3 -> OK
Pop
Render -> 1,2 -> WRONG, should be 2,3 !!
Append 42
Render -> 1,2,3 -> WTF Where is 42 ???
```
