### PR TITLE
chore(amino): improve error readability

### DIFF
--- a/tm2/pkg/amino/codec.go
+++ b/tm2/pkg/amino/codec.go
@@ -532,7 +532,7 @@ func (cdc *Codec) getTypeInfoFromFullnameRLock(fullname string, fopts FieldOptio
 
 	info, ok := cdc.fullnameToTypeInfo[fullname]
 	if !ok {
-		err = fmt.Errorf("unrecognized concrete type full name %s of %v", fullname, cdc.fullnameToTypeInfo)
+		err = fmt.Errorf("amino: unrecognized concrete type full name %s", fullname)
 		cdc.mtx.RUnlock()
 		return
 	}


### PR DESCRIPTION
Following #1178 

This fix change the error from being a stack overflow to a simple error message

### BEFORE (from #1178  )

```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020780390 stack=[0xc020780000, 0xc040780000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x9842fa?, 0xd4dea0?})
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/runtime/panic.go:1047 +0x5d fp=0x7f681368cc18 sp=0x7f681368cbe8 pc=0x43907d
runtime.newstack()
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/runtime/stack.go:1103 +0x5cc fp=0x7f681368cdd0 sp=0x7f681368cc18 pc=0x452d0c
runtime.morestack()
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/runtime/asm_amd64.s:570 +0x8b fp=0x7f681368cdd8 sp=0x7f681368cdd0 pc=0x46a32b

goroutine 1 [running]:
fmt.(*fmt).padString(0xc00de1ff20?, {0x8961be, 0x7})
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/fmt/format.go:108 +0x299 fp=0xc0207803a0 sp=0xc020780398 pc=0x4dac39
fmt.(*fmt).fmtS(0xc0207803f8?, {0x8961be?, 0x8961bd?})
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/fmt/format.go:359 +0x3f fp=0xc0207803d8 sp=0xc0207803a0 pc=0x4db75f
fmt.(*pp).fmtString(0x8ca000?, {0x8961be?, 0x8ca000?}, 0x0?)
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/fmt/print.go:474 +0x86 fp=0xc020780428 sp=0xc0207803d8 pc=0x4de566
fmt.(*pp).handleMethods(0xc00de1fee0, 0x100800?)
        /nix/store/akhjsmrrsakcnj8x3xgygvizhccbyn0v-go-1.19.3/share/go/src/fmt/print.go:65

[....] It's a stack overflow due to recursion
````

### AFTER

```
amino: unrecognized concrete type full name tm.PubKeySecp256k1
```

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
