### PR TITLE
fix(amino): stack overflow with TypeInfo.String

### DIFF
--- a/tm2/pkg/amino/typeinfo_test.go
+++ b/tm2/pkg/amino/typeinfo_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestTypeInfoString(t *testing.T) {
 	type T struct {
-		N string
 		T *T
 	}
 	typeInfo := gcdc.newTypeInfoUnregisteredWLocked(reflect.TypeOf(T{}))

--- a/tm2/pkg/amino/typeinfo_test.go
+++ b/tm2/pkg/amino/typeinfo_test.go
@@ -1,0 +1,15 @@
+package amino
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTypeInfoString(t *testing.T) {
+	type T struct {
+		N string
+		T *T
+	}
+	typeInfo := gcdc.newTypeInfoUnregisteredWLocked(reflect.TypeOf(T{}))
+	_ = typeInfo.String()
+}


### PR DESCRIPTION
### *The PR just demonstrates the bug, I didn't find the fix yet*

Add a test that demonstrates a bug when the underlying type represented by `TypeInfo` has fields of the same type: `TypeInfo.String()` triggers a stack overflow because the codec reuses the same `TypeInfo` instance when affecting the master `TypeInfo.Fields`.

This happens when `cdc.fullnameToTypeInfo` is printed (in case of error for instance see [codec.go:535](https://github.com/gnolang/gno/blob/5a7d005fc14ff2b31483dfe0b6d5990653707f5f/tm2/pkg/amino/codec.go#L535)), causing all registered `TypeInfo` to be printed too, which calls their `String()` method.

Example of type that can triggers this issue:
`tm2/pkg/crypto/merkle.SimpleProofNode`

This is partly fixed by #1179, but ideally stack overflow should be fixed inside `TypeInfo.String()`.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
