### PR TITLE
fix(codecov): increase codecov upload attempt

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -75,13 +75,18 @@ jobs:
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        uses: codecov/codecov-action@v3
+        name: Upload coverage to Codecov.io
+        uses: Wandalen/wretry.action@v1.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: gno.land
-          flags: gno.land-${{matrix.args}}
-          files: ./gno.land/coverage.out
-          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          attempt_limit: 3
+          attempt_delay: 30000
+          action: codecov/codecov-action@v3
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            name: gno.land
+            flags: gno.land-${{matrix.args}}
+            files: ./gno.land/coverage.out
+            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
 
   docker-integration:
     strategy:

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -74,6 +74,9 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
+
+      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
+      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         name: Upload coverage to Codecov.io
         uses: Wandalen/wretry.action@v1.3.0

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -78,6 +78,9 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
+
+      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
+      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         name: Upload coverage to Codecov.io
         uses: Wandalen/wretry.action@v1.3.0

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -79,11 +79,16 @@ jobs:
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        uses: codecov/codecov-action@v3
+        name: Upload coverage to Codecov.io
+        uses: Wandalen/wretry.action@v1.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: gnovm
-          verbose: true
-          flags: gnovm-${{matrix.args}}
-          files: ./gnovm/coverage.out
-          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          attempt_limit: 3
+          attempt_delay: 30000
+          action: codecov/codecov-action@v3
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            name: gnovm
+            verbose: true
+            flags: gnovm-${{matrix.args}}
+            files: ./gnovm/coverage.out
+            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -68,6 +68,9 @@ jobs:
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
           touch coverage.out
+
+      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
+      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         name: Upload coverage to Codecov.io
         uses: Wandalen/wretry.action@v1.3.0

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -69,11 +69,16 @@ jobs:
           make ${{ matrix.args }}
           touch coverage.out
       - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        uses: codecov/codecov-action@v3
+        name: Upload coverage to Codecov.io
+        uses: Wandalen/wretry.action@v1.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: tm2
-          verbose: true
-          flags: tm2-${{matrix.args}}
-          files: ./tm2/coverage.out
-          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          attempt_limit: 3
+          attempt_delay: 30000
+          action: codecov/codecov-action@v3
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            name: tm2
+            verbose: true
+            flags: tm2-${{matrix.args}}
+            files: ./tm2/coverage.out
+            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}


### PR DESCRIPTION
multiple workflows were failing randomly with `Unable to locate build via Github Actions API` error like:
- https://github.com/gnolang/gno/actions/runs/6349517658/job/17247838334?pr=1179
- https://github.com/gnolang/gno/actions/runs/6378366330/job/17308780300?pr=1117
- ...

based on this [issue#3954](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) from `community.codecov.com` adding `codecov upload token` should resolve most issues. However, in some rare instances where API limits are still reached, a re-upload attempt should be made.

This PR introduces a retry action to allow codecov to reattempt the upload if it fails the first time.