### PR TITLE
fix(codecov): merge coverage for a single upload by workflow

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -74,22 +74,25 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-
-      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
-      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.3.0
+      - uses: actions/upload-artifact@v3
+        if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         with:
-          attempt_limit: 3
-          attempt_delay: 30000
-          action: codecov/codecov-action@v3
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            name: gno.land
-            flags: gno.land-${{matrix.args}}
-            files: ./gno.land/coverage.out
-            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          name: ${{runner.os}}-coverage-gnoland-${{ matrix.args}}-${{matrix.goversion}}
+          path: ./gno.land/coverage.out
+
+  upload-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all previous coverage artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ${{ runner.temp }}/coverage
+      - name: Upload combined coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ${{ runner.temp }}/coverage
+          # token: ${{ secrets.CODECOV_TOKEN }} 
 
   docker-integration:
     strategy:

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -92,7 +92,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ${{ runner.temp }}/coverage
-          # token: ${{ secrets.CODECOV_TOKEN }} 
+          token: ${{ secrets.CODECOV_TOKEN }} 
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
 
   docker-integration:
     strategy:

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -96,5 +96,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ${{ runner.temp }}/coverage
-          # token: ${{ secrets.CODECOV_TOKEN }} 
+          token: ${{ secrets.CODECOV_TOKEN }} 
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
 

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -78,20 +78,23 @@ jobs:
           export GOPATH=$HOME/go
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
-
-      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
-      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.3.0
+      - uses: actions/upload-artifact@v3
+        if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         with:
-          attempt_limit: 3
-          attempt_delay: 30000
-          action: codecov/codecov-action@v3
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            name: gnovm
-            verbose: true
-            flags: gnovm-${{matrix.args}}
-            files: ./gnovm/coverage.out
-            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          name: ${{runner.os}}-coverage-gnovm-${{ matrix.args}}-${{matrix.goversion}}
+          path: ./gnovm/coverage.out
+
+  upload-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all previous coverage artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ${{ runner.temp }}/coverage
+      - name: Upload combined coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ${{ runner.temp }}/coverage
+          # token: ${{ secrets.CODECOV_TOKEN }} 
+

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -68,20 +68,23 @@ jobs:
           export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
           touch coverage.out
-
-      # NOTE: Using retry action to manage occasional upload failures to codecov.io, due to API limits.
-      # Refer to issue#3954: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
-      - if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
-        name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.3.0
+      - uses: actions/upload-artifact@v3
+        if: ${{ runner.os == 'Linux' && matrix.goversion == '1.21.x' }}
         with:
-          attempt_limit: 3
-          attempt_delay: 30000
-          action: codecov/codecov-action@v3
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            name: tm2
-            verbose: true
-            flags: tm2-${{matrix.args}}
-            files: ./tm2/coverage.out
-            fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
+          name: ${{runner.os}}-coverage-tm2-${{ matrix.args}}-${{matrix.goversion}}
+          path: ./tm2/coverage.out
+
+  upload-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all previous coverage artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ${{ runner.temp }}/coverage
+      - name: Upload combined coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ${{ runner.temp }}/coverage
+          # token: ${{ secrets.CODECOV_TOKEN }} 
+

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -86,5 +86,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ${{ runner.temp }}/coverage
-          # token: ${{ secrets.CODECOV_TOKEN }} 
+          token: ${{ secrets.CODECOV_TOKEN }} 
+          fail_ci_if_error: ${{ github.repository == 'gnolang/gno' }}
 


### PR DESCRIPTION
It appears that the retry system introduced in #1186 was not sufficient, as we still hit API limits when running multiple checks concurrently. 
This PR merges all coverage files into a single upload at the of each testing workflows. As a result, we now have 3 uploads instead of 16, which should drastically reduce the number of Codecov upload failures.

Note: It still appears to fail randomly, but we might need to wait some time until our API rate decreases. I believe it's still preferable to have 3 uploads rather than 16, which seemed to overwhelm Codecov.