### PR TITLE
feat: unsafe reset all 

### DIFF
--- a/gno.land/cmd/gnoland/README.md
+++ b/gno.land/cmd/gnoland/README.md
@@ -11,3 +11,16 @@
     $> gnoland start
 
 Afterward, you can interact with [`gnokey`](../gnokey) or launch a [`gnoweb`](../gnoweb) interface.
+
+
+## Reset `gnoland` node back to genesis state. It's only suitable for testnets.
+
+    $> gnoland unsafe-reset-all 
+
+It removes the database and validator state but leaves the genesis.json and config.toml files unchanged.
+
+The `unsafe-reset-all` command is labeled "unsafe" because:
+
+1. It irreversibly deletes all node data, risking data loss.
+2. It may lead to double signing or chain forks in production
+3. It resets the `priv_validator_state.json`, and can cause network disruption if uncoordinated.

--- a/gno.land/cmd/gnoland/main.go
+++ b/gno.land/cmd/gnoland/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+func main() {
+	rootCmd := newRootCmd()
+	if err := rootCmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+}

--- a/gno.land/cmd/gnoland/mockio.go
+++ b/gno.land/cmd/gnoland/mockio.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+// This is for testing purpose only. We don't need to or should not use IOpipe in normal flow.
+// We redirect os.Stdin for mocking tests so that we don't need to pass commands.IO, which
+// included an os.Stdin, to all the server command. It is not safe to expose os.Stdin in the blockchain node
+
+type MockStdin struct {
+	origStdout   *os.File
+	stdoutReader *os.File
+
+	outCh chan []byte
+
+	origStdin   *os.File
+	stdinWriter *os.File
+}
+
+func NewMockStdin(input string) (*MockStdin, error) {
+	// Pipe for stdin. w ( stdinWriter ) -> r (stdin)
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Pipe for stdout. w( stdout ) -> r (stdoutReader)
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	origStdin := os.Stdin
+	os.Stdin = stdinReader
+
+	_, err = stdinWriter.Write([]byte(input))
+	if err != nil {
+		stdinWriter.Close()
+		os.Stdin = origStdin
+		return nil, err
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = stdoutWriter
+
+	outCh := make(chan []byte)
+
+	// This goroutine reads stdout into a buffer in the background.
+	go func() {
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, stdoutReader); err != nil {
+			log.Println(err)
+		}
+		outCh <- b.Bytes()
+	}()
+
+	return &MockStdin{
+		origStdout:   origStdout,
+		stdoutReader: stdoutReader,
+		outCh:        outCh,
+		origStdin:    origStdin,
+		stdinWriter:  stdinWriter,
+	}, nil
+}
+
+// ReadAndRestore collects all captured stdout and returns it; it also restores
+// os.Stdin and os.Stdout to their original values.
+func (i *MockStdin) ReadAndClose() ([]byte, error) {
+	if i.stdoutReader == nil {
+		return nil, fmt.Errorf("ReadAndRestore from closed FakeStdio")
+	}
+
+	// Close the writer side of the faked stdout pipe. This signals to the
+	// background goroutine that it should exit.
+	os.Stdout.Close()
+	out := <-i.outCh
+
+	os.Stdout = i.origStdout
+	os.Stdin = i.origStdin
+
+	if i.stdoutReader != nil {
+		i.stdoutReader.Close()
+		i.stdoutReader = nil
+	}
+
+	if i.stdinWriter != nil {
+		i.stdinWriter.Close()
+		i.stdinWriter = nil
+	}
+
+	return out, nil
+}

--- a/gno.land/cmd/gnoland/reset.go
+++ b/gno.land/cmd/gnoland/reset.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/privval"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+
+	"github.com/gnolang/gno/tm2/pkg/log"
+	osm "github.com/gnolang/gno/tm2/pkg/os"
+)
+
+type resetCfg struct {
+	baseCfg
+}
+
+func (rc *resetCfg) RegisterFlags(fs *flag.FlagSet) {}
+
+// XXX: this is totally unsafe.
+// it's only suitable for testnets.
+// It could result in data loss and network disrutpion while running the node and without coordination
+func newResetAllCmd(bc baseCfg) *commands.Command {
+	cfg := resetCfg{
+		baseCfg: bc,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "unsafe-reset-all",
+			ShortUsage: "unsafe-reset-all",
+			ShortHelp:  "(unsafe) Remove all the data and WAL, reset this node's validator to genesis state",
+		},
+		&cfg,
+		func(_ context.Context, args []string) error {
+			return execResetAll(cfg, args)
+		},
+	)
+}
+
+func execResetAll(rc resetCfg, args []string) (err error) {
+	config := rc.tmConfig
+
+	return resetAll(
+		config.DBDir(),
+		config.PrivValidatorKeyFile(),
+		config.PrivValidatorStateFile(),
+		logger,
+	)
+}
+
+// resetAll removes address book files plus all data, and resets the privValdiator data.
+func resetAll(dbDir, privValKeyFile, privValStateFile string, logger log.Logger) error {
+	if err := os.RemoveAll(dbDir); err == nil {
+		logger.Info("Removed all blockchain history", "dir", dbDir)
+	} else {
+		logger.Error("Error removing all blockchain history", "dir", dbDir, "err", err)
+	}
+
+	if err := osm.EnsureDir(dbDir, 0o700); err != nil {
+		logger.Error("unable to recreate dbDir", "err", err)
+	}
+
+	// recreate the dbDir since the privVal state needs to live there
+	resetFilePV(privValKeyFile, privValStateFile, logger)
+	return nil
+}
+
+// resetState removes address book files plus all databases.
+func resetState(dbDir string, logger log.Logger) error {
+	blockdb := filepath.Join(dbDir, "blockstore.db")
+	state := filepath.Join(dbDir, "state.db")
+	wal := filepath.Join(dbDir, "cs.wal")
+	gnolang := filepath.Join(dbDir, "gnolang.db")
+
+	if osm.FileExists(blockdb) {
+		if err := os.RemoveAll(blockdb); err == nil {
+			logger.Info("Removed all blockstore.db", "dir", blockdb)
+		} else {
+			logger.Error("error removing all blockstore.db", "dir", blockdb, "err", err)
+		}
+	}
+
+	if osm.FileExists(state) {
+		if err := os.RemoveAll(state); err == nil {
+			logger.Info("Removed all state.db", "dir", state)
+		} else {
+			logger.Error("error removing all state.db", "dir", state, "err", err)
+		}
+	}
+
+	if osm.FileExists(wal) {
+		if err := os.RemoveAll(wal); err == nil {
+			logger.Info("Removed all cs.wal", "dir", wal)
+		} else {
+			logger.Error("error removing all cs.wal", "dir", wal, "err", err)
+		}
+	}
+
+	if osm.FileExists(gnolang) {
+		if err := os.RemoveAll(gnolang); err == nil {
+			logger.Info("Removed all gnolang.db", "dir", gnolang)
+		} else {
+			logger.Error("error removing all gnolang.db", "dir", gnolang, "err", err)
+		}
+	}
+
+	if err := osm.EnsureDir(dbDir, 0o700); err != nil {
+		logger.Error("unable to recreate dbDir", "err", err)
+	}
+	return nil
+}
+
+func resetFilePV(privValKeyFile, privValStateFile string, logger log.Logger) {
+	if _, err := os.Stat(privValKeyFile); err == nil {
+		pv := privval.LoadFilePVEmptyState(privValKeyFile, privValStateFile)
+		pv.Reset()
+		logger.Info(
+			"Reset private validator file to genesis state",
+			"keyFile", privValKeyFile,
+			"stateFile", privValStateFile,
+		)
+	} else {
+		pv := privval.GenFilePV(privValKeyFile, privValStateFile)
+		pv.Save()
+		logger.Info(
+			"Generated private validator file",
+			"keyFile", privValKeyFile,
+			"stateFile", privValStateFile,
+		)
+	}
+}

--- a/gno.land/cmd/gnoland/reset_test.go
+++ b/gno.land/cmd/gnoland/reset_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	tmtime "github.com/gnolang/gno/tm2/pkg/bft/types/time"
+	"github.com/stretchr/testify/require"
+
+	cfg "github.com/gnolang/gno/tm2/pkg/bft/config"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval"
+	"github.com/gnolang/gno/tm2/pkg/p2p"
+)
+
+func TestResetAll(t *testing.T) {
+	config := cfg.TestConfig()
+	dir := t.TempDir()
+	config.SetRootDir(dir)
+	config.EnsureDirs()
+
+	require.NoError(t, initFilesWithConfig(config))
+	pv := privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	pv.LastSignState.Height = 10
+	pv.Save()
+
+	require.NoError(t, resetAll(config.DBDir(), config.PrivValidatorKeyFile(),
+		config.PrivValidatorStateFile(), logger))
+
+	require.DirExists(t, config.DBDir())
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "gnolang.db"))
+	require.FileExists(t, config.PrivValidatorStateFile())
+	require.FileExists(t, config.GenesisFile())
+	pv = privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+	require.Equal(t, int64(0), pv.LastSignState.Height)
+}
+
+func initFilesWithConfig(config *cfg.Config) error {
+	// private validator
+	privValKeyFile := config.PrivValidatorKeyFile()
+	privValStateFile := config.PrivValidatorStateFile()
+	var pv *privval.FilePV
+	pv = privval.GenFilePV(privValKeyFile, privValStateFile)
+	pv.Save()
+	nodeKeyFile := config.NodeKeyFile()
+	if _, err := p2p.LoadOrGenNodeKey(nodeKeyFile); err != nil {
+		return err
+	}
+
+	genFile := config.GenesisFile()
+	genDoc := bft.GenesisDoc{
+		ChainID:         "test-chain-%v",
+		GenesisTime:     tmtime.Now(),
+		ConsensusParams: bft.DefaultConsensusParams(),
+	}
+	key := pv.GetPubKey()
+	genDoc.Validators = []bft.GenesisValidator{{
+		Address: key.Address(),
+		PubKey:  key,
+		Power:   10,
+	}}
+	if err := genDoc.SaveAs(genFile); err != nil {
+		return err
+	}
+	return nil
+}

--- a/gno.land/cmd/gnoland/start_test.go
+++ b/gno.land/cmd/gnoland/start_test.go
@@ -23,6 +23,7 @@ func TestStartInitialize(t *testing.T) {
 	for _, tc := range cases {
 		name := strings.Join(tc.args, " ")
 		in, err := NewMockStdin(name)
+		defer in.Close()
 		if err != nil {
 			t.Fatal("failed creating test io pipe")
 		}

--- a/gno.land/cmd/gnoland/start_test.go
+++ b/gno.land/cmd/gnoland/start_test.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,24 +22,28 @@ func TestStartInitialize(t *testing.T) {
 
 	for _, tc := range cases {
 		name := strings.Join(tc.args, " ")
-		t.Run(name, func(t *testing.T) {
-			mockOut := bytes.NewBufferString("")
-			mockErr := bytes.NewBufferString("")
-			io := commands.NewTestIO()
-			io.SetOut(commands.WriteNopCloser(mockOut))
-			io.SetErr(commands.WriteNopCloser(mockErr))
-			cmd := newRootCmd(io)
+		in, err := NewMockStdin(name)
+		if err != nil {
+			t.Fatal("failed creating test io pipe")
+		}
 
+		t.Run(name, func(t *testing.T) {
+			cmd := newRootCmd()
 			t.Logf(`Running "gnoland %s"`, strings.Join(tc.args, " "))
 			err := cmd.ParseAndRun(context.Background(), tc.args)
 			require.NoError(t, err)
 
-			stdout := mockOut.String()
-			stderr := mockErr.String()
+			bz, err := in.ReadAndClose()
+			if err != nil {
+				t.Fatal("failed reading test io pipe")
+			}
 
-			require.Contains(t, stderr, "Node created.", "failed to create node")
-			require.Contains(t, stderr, "'--skip-start' is set. Exiting.", "not exited with skip-start")
-			require.NotContains(t, stdout, "panic:")
+			out := string(bz)
+
+			require.Contains(t, out, "Node created.", "failed to create node")
+
+			require.Contains(t, out, "'--skip-start' is set. Exiting.", "not exited with skip-start")
+			require.NotContains(t, out, "panic:")
 		})
 	}
 }


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation
- [x] No breaking changes were made
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>


For #1195 


The `unsafe-reset-all` is a method to hard reset the network to its genesis state. It's deemed unsafe and should only be used in a testing environment for several reasons:

1. It irreversibly deletes all node data, posing a significant risk of data loss.
2. There's a potential for double signing.
3. It resets the `priv_validator_state.json`, which could result in network disruptions and chain forks if not coordinated properly.

Additionally, in the PR, we made the following refactorings:

1. Removed the passing of `os.Stdin` wrapped in `commands.IO` to `gno.land`. Directly including `os.Stdin` in the command presents a vulnerability, as it isn't necessary for the program's main function. It's only required for testing purposes.

2. Introduced `MockIO`. This allows us to test with customized input strings, eliminating the need to pass `os.Stdin` directly to the node.

3. Stopped passing the config file via `ff` commands. The configuration required by `ff` demands that we expose all properties, not just a subset, for them to be defined in `config.toml` as flags in a CLI. This could result in more than 30 flags being listed. We now load the `tm2` config separately. The current limitation is that we cannot overwrite it through flag options, but we plan to address this in a future update.

I understood we plan to have a gno sdk package. That is a bigger topic and many more aspects need to be considered. We can address it in a separate PR
