### PR TITLE
chore: stop recursive loop in TypeInfo error print

### DIFF
--- a/tm2/pkg/amino/codec.go
+++ b/tm2/pkg/amino/codec.go
@@ -129,7 +129,7 @@ func (info *TypeInfo) String() string {
 		buf.Write([]byte(fmt.Sprintf("ReprType:\"%v\",", info.ReprType)))
 	}
 	if info.Type.Kind() == reflect.Struct {
-		buf.Write([]byte(fmt.Sprintf("Fields:%v,", info.Fields)))
+		buf.Write([]byte(fmt.Sprintf("Fields:%#v,", info.Fields)))
 	}
 	buf.Write([]byte("}"))
 	return buf.String()
@@ -532,7 +532,11 @@ func (cdc *Codec) getTypeInfoFromFullnameRLock(fullname string, fopts FieldOptio
 
 	info, ok := cdc.fullnameToTypeInfo[fullname]
 	if !ok {
-		err = fmt.Errorf("amino: unrecognized concrete type full name %s", fullname)
+		if printLog {
+			err = fmt.Printf("unrecognized concrete type full name %s of  %v", fullname, cdc.fullnameToTypeInfo)
+		}else{
+			err = fmt.Errorf("amino: unrecognized concrete type full name %s", fullname)
+		}
 		cdc.mtx.RUnlock()
 		return
 	}


### PR DESCRIPTION
Fix the second issue in #1197

- Before fix, if a Amino type was not imported as registered Amino package, we got stack overflow 

runtime: goroutine stack exceeds 1000000000-byte limit runtime: sp=0xc02050c458 stack=[0xc02050c000, 0xc04050c000] fatal error: stack overflow

- After fix, if a Amino type was not imported as registered Amino package, we could print the message to verify what has been imported for debugging purpose

Error: unable to unmarshal with amino, unmarshal to std.Tx failed after 17 bytes (error reading slice contents: unrecognized concrete type full name vm.m_call of map[abci.BlockParams:TypeInfo{Type:abci.BlockParams,Registered:true,PointerPreferred:false,TypeURL:"/abci.BlockParams",ReprType:,Fields:[]amino.FieldInfo{amino.FieldInfo{Type:(*reflect.rtype)(0x104cfc920), TypeInfo:(*amino.TypeInfo)(0x1400011c6e0), Name:"MaxTxBytes", Index:0, ........

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
