### PR TITLE
fix(gnolang): don't print debug logs for package unicode

### DIFF
--- a/gnovm/pkg/gnolang/debug.go
+++ b/gnovm/pkg/gnolang/debug.go
@@ -100,10 +100,14 @@ func IsDebugEnabled() bool {
 	return bool(debug) && enabled
 }
 
-func DisableDebug() {
+func DisableDebug() (rollback func()) {
+	prev := enabled
 	enabled = false
+	return func() { enabled = prev }
 }
 
-func EnableDebug() {
+func EnableDebug() (rollback func()) {
+	prev := enabled
 	enabled = true
+	return func() { enabled = prev }
 }

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -225,6 +225,11 @@ func (m *Machine) RunMemPackage(memPkg *std.MemPackage, save bool) (*PackageNode
 		m.Store.SetCachePackage(pv)
 	}
 	m.SetActivePackage(pv)
+	// unicode is terribly slow at printing debug logs.
+	if debug && memPkg.Path == "unicode" {
+		// disable debug until end of function
+		defer DisableDebug()()
+	}
 	// run files.
 	m.RunFiles(files.Files...)
 	// maybe save package value and mempackage.
@@ -244,7 +249,7 @@ func (m *Machine) RunMemPackage(memPkg *std.MemPackage, save bool) (*PackageNode
 // afterwards from the same store.
 func (m *Machine) TestMemPackage(t *testing.T, memPkg *std.MemPackage) {
 	defer m.injectLocOnPanic()
-	DisableDebug()
+	enableDebug := DisableDebug()
 	fmt.Println("DEBUG DISABLED (FOR TEST DEPENDENCIES INIT)")
 	// parse test files.
 	tfiles, itfiles := ParseMemPackageTests(memPkg)
@@ -270,7 +275,7 @@ func (m *Machine) TestMemPackage(t *testing.T, memPkg *std.MemPackage) {
 		m.SetActivePackage(pv)
 		m.RunFiles(itfiles.Files...)
 		pn.PrepareNewValues(pv)
-		EnableDebug()
+		enableDebug()
 		fmt.Println("DEBUG ENABLED")
 		for i := 0; i < len(pvBlock.Values); i++ {
 			tv := pvBlock.Values[i]

--- a/gnovm/tests/file.go
+++ b/gnovm/tests/file.go
@@ -171,7 +171,7 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 			} else {
 				// realm case.
 				store.SetStrictGo2GnoMapping(true) // in gno.land, natives must be registered.
-				gno.DisableDebug()                 // until main call.
+				enableDebug := gno.DisableDebug()
 				// save package using realm crawl procedure.
 				memPkg := &std.MemPackage{
 					Name: string(pkgName),
@@ -217,7 +217,7 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 				}
 				pv2 := store.GetPackage(pkgPath, false)
 				m.SetActivePackage(pv2)
-				gno.EnableDebug()
+				enableDebug()
 				if rops != "" {
 					// clear store.opslog from init function(s),
 					// and PreprocessAllFilesAndSaveBlockNodes().


### PR DESCRIPTION
Anyone who's worked with `DEBUG=1` probably knows the pain of watching the screen scroll through for 5 minutes while you wait for the parsing of package `unicode` to have finished.

This PR aims to fix that. This is a scratch-an-itch PR, and I want to tackle debugging systems better in the future, but this should already improve massively the usefulness of `DEBUG=1`. 