### PR TITLE
chore: improve tests

### DIFF
--- a/gno.land/cmd/gnoweb/main_test.go
+++ b/gno.land/cmd/gnoweb/main_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestRoutes(t *testing.T) {
-	t.Skip("depends on an inmemory gnoland node.")
 	ok := http.StatusOK
 	routes := []struct {
 		route     string

--- a/gno.land/cmd/gnoweb/main_test.go
+++ b/gno.land/cmd/gnoweb/main_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRoutes(t *testing.T) {
+	t.Skip("depends on an inmemory gnoland node.")
 	ok := http.StatusOK
 	routes := []struct {
 		route     string

--- a/gno.land/pkg/integration/testdata/gnokey.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey.txtar
@@ -6,27 +6,19 @@ gnoland start
 
 ## test1 account should be available on default
 gnokey query auth/accounts/${USER_ADDR_test1}
-cmp stdout gnokey-query-valid.stdout.golden
-cmp stderr gnokey-query-valid.stderr.golden
+stdout 'height: 0'
+stdout 'data: {'
+stdout '  "BaseAccount": {'
+stdout '    "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",'
+stdout '    "coins": "[0-9]*ugnot",' # dynamic
+stdout '    "public_key": null,'
+stdout '    "account_number": "0",'
+stdout '    "sequence": "0"'
+stdout '  }'
+stdout '}'
+! stderr '.+' # empty
 
 ## invalid gnokey command should raise an error
 ! gnokey query foo/bar
-cmp stdout gnokey-query-invalid.stdout.golden
-cmp stderr gnokey-query-invalid.stderr.golden
-
--- gnokey-query-valid.stdout.golden --
-height: 0
-data: {
-  "BaseAccount": {
-    "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-    "coins": "9999892000000ugnot",
-    "public_key": null,
-    "account_number": "0",
-    "sequence": "0"
-  }
-}
--- gnokey-query-valid.stderr.golden --
--- gnokey-query-invalid.stdout.golden --
-Log: 
--- gnokey-query-invalid.stderr.golden --
-"gnokey" error: unknown request error
+stdout 'Log:'
+stderr '"gnokey" error: unknown request error'


### PR DESCRIPTION
- chore: Ensure consistency in txtar test (found in issue #1138).
- ~chore: Temporarily disable malfunctioning tests (discovered by Jae, who manually executed `make test` locally without a gnoland node running).~

@gfanton, could you assist in integrating the new `gnoland/pkg/integration` package you created into `gno.land/cmd/gnoweb/*_test.go`? Please remove my `t.Skip()` as well.

Additionally, it seems that the CI was not testing `gnoweb` or running a `gnoland` node to ensure its functionality. We should review the configuration to determine if it is adequate or requires improvement.
