### PR TITLE
feat: add `genesis validator` subcommand

### DIFF
--- a/gno.land/cmd/genesis/main.go
+++ b/gno.land/cmd/genesis/main.go
@@ -31,6 +31,7 @@ func newRootCmd(io *commands.IO) *commands.Command {
 
 	cmd.AddSubCommands(
 		newGenerateCmd(io),
+		newValidatorCmd(io),
 	)
 
 	return cmd

--- a/gno.land/cmd/genesis/validator.go
+++ b/gno.land/cmd/genesis/validator.go
@@ -27,6 +27,7 @@ func newValidatorCmd(io *commands.IO) *commands.Command {
 
 	cmd.AddSubCommands(
 		newValidatorAddCmd(cfg, io),
+		newValidatorRemoveCmd(cfg, io),
 	)
 
 	return cmd

--- a/gno.land/cmd/genesis/validator.go
+++ b/gno.land/cmd/genesis/validator.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+type validatorCfg struct {
+	genesisPath string
+	address     string
+}
+
+// newValidatorCmd creates the genesis validator subcommand
+func newValidatorCmd(io *commands.IO) *commands.Command {
+	cfg := &validatorCfg{}
+
+	cmd := commands.NewCommand(
+		commands.Metadata{
+			Name:       "validator",
+			ShortUsage: "validator <subcommand> [flags]",
+			LongHelp:   "Manipulates the genesis.json validator set",
+		},
+		cfg,
+		commands.HelpExec,
+	)
+
+	cmd.AddSubCommands(
+		newValidatorAddCmd(cfg, io),
+	)
+
+	return cmd
+}
+
+func (c *validatorCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.genesisPath,
+		"genesis-path",
+		"./genesis.json",
+		"the path to the genesis.json",
+	)
+
+	fs.StringVar(
+		&c.address,
+		"address",
+		"",
+		"the output path for the genesis.json",
+	)
+}

--- a/gno.land/cmd/genesis/validator_add.go
+++ b/gno.land/cmd/genesis/validator_add.go
@@ -20,7 +20,7 @@ var (
 )
 
 type validatorAddCfg struct {
-	validatorCfg *validatorCfg
+	rootCfg *validatorCfg
 
 	pubKey string
 	name   string
@@ -30,7 +30,7 @@ type validatorAddCfg struct {
 // newValidatorAddCmd creates the genesis validator add subcommand
 func newValidatorAddCmd(validatorCfg *validatorCfg, io *commands.IO) *commands.Command {
 	cfg := &validatorAddCfg{
-		validatorCfg: validatorCfg,
+		rootCfg: validatorCfg,
 	}
 
 	return commands.NewCommand(
@@ -71,13 +71,13 @@ func (c *validatorAddCfg) RegisterFlags(fs *flag.FlagSet) {
 
 func execValidatorAdd(cfg *validatorAddCfg, io *commands.IO) error {
 	// Load the genesis
-	genesis, loadErr := types.GenesisDocFromFile(cfg.validatorCfg.genesisPath)
+	genesis, loadErr := types.GenesisDocFromFile(cfg.rootCfg.genesisPath)
 	if loadErr != nil {
 		return fmt.Errorf("unable to load genesis, %w", loadErr)
 	}
 
 	// Check the validator address
-	address, err := crypto.AddressFromString(cfg.validatorCfg.address)
+	address, err := crypto.AddressFromString(cfg.rootCfg.address)
 	if err != nil {
 		return fmt.Errorf("invalid validator address, %w", err)
 	}
@@ -124,13 +124,13 @@ func execValidatorAdd(cfg *validatorAddCfg, io *commands.IO) error {
 	genesis.Validators = append(genesis.Validators, validator)
 
 	// Save the updated genesis
-	if err := genesis.SaveAs(cfg.validatorCfg.genesisPath); err != nil {
+	if err := genesis.SaveAs(cfg.rootCfg.genesisPath); err != nil {
 		return fmt.Errorf("unable to save genesis.json, %w", err)
 	}
 
 	io.Printfln(
 		"Validator with address %s added to genesis file",
-		cfg.validatorCfg.address,
+		cfg.rootCfg.address,
 	)
 
 	return nil

--- a/gno.land/cmd/genesis/validator_add.go
+++ b/gno.land/cmd/genesis/validator_add.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	_ "github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+var (
+	errInvalidPower      = errors.New("invalid validator power")
+	errInvalidName       = errors.New("invalid validator name")
+	errPublicKeyMismatch = errors.New("provided public key and address do not match")
+	errAddressPresent    = errors.New("validator with same address already present in genesis.json")
+	errPubKeyPresent     = errors.New("validator with same public key already present in genesis.json")
+)
+
+type validatorAddCfg struct {
+	validatorCfg *validatorCfg
+
+	pubKey string
+	name   string
+	power  int64
+}
+
+// newValidatorAddCmd creates the genesis validator add subcommand
+func newValidatorAddCmd(validatorCfg *validatorCfg, io *commands.IO) *commands.Command {
+	cfg := &validatorAddCfg{
+		validatorCfg: validatorCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "add",
+			ShortUsage: "validator add [flags]",
+			LongHelp:   "Adds a new validator to the genesis.json",
+		},
+		cfg,
+		func(_ context.Context, _ []string) error {
+			return execValidatorAdd(cfg, io)
+		},
+	)
+}
+
+func (c *validatorAddCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.pubKey,
+		"pub-key",
+		"",
+		"the bech32 string representation of the validator's public key",
+	)
+
+	fs.StringVar(
+		&c.name,
+		"name",
+		"",
+		"the name of the validator (must be unique)",
+	)
+
+	fs.Int64Var(
+		&c.power,
+		"power",
+		1,
+		"the voting power of the validator (must be > 0)",
+	)
+}
+
+func execValidatorAdd(cfg *validatorAddCfg, io *commands.IO) error {
+	// Load the genesis
+	genesis, loadErr := types.GenesisDocFromFile(cfg.validatorCfg.genesisPath)
+	if loadErr != nil {
+		return fmt.Errorf("unable to load genesis, %w", loadErr)
+	}
+
+	// Check the validator address
+	address, err := crypto.AddressFromString(cfg.validatorCfg.address)
+	if err != nil {
+		return fmt.Errorf("invalid validator address, %w", err)
+	}
+
+	// Check the voting power
+	if cfg.power < 1 {
+		return errInvalidPower
+	}
+
+	// Check the name
+	if cfg.name == "" {
+		return errors.New("invalid validator name")
+	}
+
+	// Check the public key
+	pubKey, err := crypto.PubKeyFromBech32(cfg.pubKey)
+	if err != nil {
+		return fmt.Errorf("invalid validator public key, %w", err)
+	}
+
+	// Check the public key matches the address
+	if pubKey.Address() != address {
+		return errors.New("provided public key and address do not match")
+	}
+
+	validator := types.GenesisValidator{
+		Address: address,
+		PubKey:  pubKey,
+		Power:   cfg.power,
+		Name:    cfg.name,
+	}
+
+	// Check if the validator exists
+	for _, genesisValidator := range genesis.Validators {
+		// There is no need to check if the public keys match
+		// since the address is derived from it, and the derivation
+		// is checked already
+		if validator.Address == genesisValidator.Address {
+			return errAddressPresent
+		}
+	}
+
+	// Add the validator
+	genesis.Validators = append(genesis.Validators, validator)
+
+	// Save the updated
+	if err := genesis.SaveAs(cfg.validatorCfg.genesisPath); err != nil {
+		return fmt.Errorf("unable to save genesis.json, %w", err)
+	}
+
+	io.Printfln(
+		"Validator with address %s added to genesis file",
+		cfg.validatorCfg.address,
+	)
+
+	return nil
+}

--- a/gno.land/cmd/genesis/validator_add.go
+++ b/gno.land/cmd/genesis/validator_add.go
@@ -17,7 +17,6 @@ var (
 	errInvalidName       = errors.New("invalid validator name")
 	errPublicKeyMismatch = errors.New("provided public key and address do not match")
 	errAddressPresent    = errors.New("validator with same address already present in genesis.json")
-	errPubKeyPresent     = errors.New("validator with same public key already present in genesis.json")
 )
 
 type validatorAddCfg struct {
@@ -124,7 +123,7 @@ func execValidatorAdd(cfg *validatorAddCfg, io *commands.IO) error {
 	// Add the validator
 	genesis.Validators = append(genesis.Validators, validator)
 
-	// Save the updated
+	// Save the updated genesis
 	if err := genesis.SaveAs(cfg.validatorCfg.genesisPath); err != nil {
 		return fmt.Errorf("unable to save genesis.json, %w", err)
 	}

--- a/gno.land/cmd/genesis/validator_add_test.go
+++ b/gno.land/cmd/genesis/validator_add_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesis_Validator_Add(t *testing.T) {
+	t.Parallel()
+
+	getDummyKey := func() keys.Info {
+		mnemonic, err := client.GenerateMnemonic(256)
+		require.NoError(t, err)
+
+		kb := keys.NewInMemory()
+
+		info, err := kb.CreateAccount(
+			"dummy",
+			mnemonic,
+			"",
+			"",
+			uint32(0),
+			uint32(0),
+		)
+		require.NoError(t, err)
+
+		return info
+	}
+
+	t.Run("invalid genesis file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			"dummy-path",
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, "unable to load genesis")
+	})
+
+	t.Run("invalid validator address", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			"dummyaddress",
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, "invalid validator address")
+	})
+
+	t.Run("invalid voting power", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		key := getDummyKey()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			key.GetPubKey().Address().String(),
+			"--power",
+			"-1", // invalid voting power
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorIs(t, cmdErr, errInvalidPower)
+	})
+
+	t.Run("invalid validator name", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		key := getDummyKey()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			key.GetPubKey().Address().String(),
+			"--name",
+			"", // invalid validator name
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errInvalidName.Error())
+	})
+
+	t.Run("invalid public key", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		key := getDummyKey()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			key.GetPubKey().Address().String(),
+			"--name",
+			"example",
+			"--pub-key",
+			"invalidkey", // invalid pub key
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, "invalid validator public key")
+	})
+
+	t.Run("public key address mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		dummyKeys := []keys.Info{
+			getDummyKey(),
+			getDummyKey(),
+		}
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			dummyKeys[0].GetPubKey().Address().String(),
+			"--name",
+			"example",
+			"--pub-key",
+			crypto.PubKeyToBech32(dummyKeys[1].GetPubKey()), // another key
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errPublicKeyMismatch.Error())
+	})
+
+	t.Run("validator with same address exists", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		dummyKeys := []keys.Info{
+			getDummyKey(),
+			getDummyKey(),
+		}
+
+		genesis := getDefaultGenesis()
+
+		// Set an existing validator
+		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
+			Address: dummyKeys[0].GetAddress(),
+			PubKey:  dummyKeys[0].GetPubKey(),
+			Power:   1,
+			Name:    "example",
+		})
+
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			dummyKeys[0].GetPubKey().Address().String(),
+			"--name",
+			"example",
+			"--pub-key",
+			crypto.PubKeyToBech32(dummyKeys[0].GetPubKey()), // another key
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errAddressPresent.Error())
+	})
+
+	t.Run("valid genesis validator", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		key := getDummyKey()
+		genesis := getDefaultGenesis()
+
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"add",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			key.GetPubKey().Address().String(),
+			"--name",
+			"example",
+			"--pub-key",
+			crypto.PubKeyToBech32(key.GetPubKey()), // another key
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		require.NoError(t, cmdErr)
+	})
+}

--- a/gno.land/cmd/genesis/validator_add_test.go
+++ b/gno.land/cmd/genesis/validator_add_test.go
@@ -14,27 +14,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// getDummyKey generates a random public key,
+// and returns the key info
+func getDummyKey(t *testing.T) keys.Info {
+	t.Helper()
+
+	mnemonic, err := client.GenerateMnemonic(256)
+	require.NoError(t, err)
+
+	kb := keys.NewInMemory()
+
+	info, err := kb.CreateAccount(
+		"dummy",
+		mnemonic,
+		"",
+		"",
+		uint32(0),
+		uint32(0),
+	)
+	require.NoError(t, err)
+
+	return info
+}
+
 func TestGenesis_Validator_Add(t *testing.T) {
 	t.Parallel()
-
-	getDummyKey := func() keys.Info {
-		mnemonic, err := client.GenerateMnemonic(256)
-		require.NoError(t, err)
-
-		kb := keys.NewInMemory()
-
-		info, err := kb.CreateAccount(
-			"dummy",
-			mnemonic,
-			"",
-			"",
-			uint32(0),
-			uint32(0),
-		)
-		require.NoError(t, err)
-
-		return info
-	}
 
 	t.Run("invalid genesis file", func(t *testing.T) {
 		t.Parallel()
@@ -87,7 +91,7 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		genesis := getDefaultGenesis()
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
 
-		key := getDummyKey()
+		key := getDummyKey(t)
 
 		// Create the command
 		cmd := newRootCmd(commands.NewTestIO())
@@ -116,7 +120,7 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		genesis := getDefaultGenesis()
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
 
-		key := getDummyKey()
+		key := getDummyKey(t)
 
 		// Create the command
 		cmd := newRootCmd(commands.NewTestIO())
@@ -145,7 +149,7 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		genesis := getDefaultGenesis()
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
 
-		key := getDummyKey()
+		key := getDummyKey(t)
 
 		// Create the command
 		cmd := newRootCmd(commands.NewTestIO())
@@ -177,8 +181,8 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
 
 		dummyKeys := []keys.Info{
-			getDummyKey(),
-			getDummyKey(),
+			getDummyKey(t),
+			getDummyKey(t),
 		}
 
 		// Create the command
@@ -208,8 +212,8 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		t.Cleanup(cleanup)
 
 		dummyKeys := []keys.Info{
-			getDummyKey(),
-			getDummyKey(),
+			getDummyKey(t),
+			getDummyKey(t),
 		}
 
 		genesis := getDefaultGenesis()
@@ -250,7 +254,7 @@ func TestGenesis_Validator_Add(t *testing.T) {
 		tempGenesis, cleanup := testutils.NewTestFile(t)
 		t.Cleanup(cleanup)
 
-		key := getDummyKey()
+		key := getDummyKey(t)
 		genesis := getDefaultGenesis()
 
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))

--- a/gno.land/cmd/genesis/validator_remove.go
+++ b/gno.land/cmd/genesis/validator_remove.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+)
+
+var errValidatorNotPresent = errors.New("validator not present in genesis.json")
+
+// newValidatorRemoveCmd creates the genesis validator remove subcommand
+func newValidatorRemoveCmd(validatorCfg *validatorCfg, io *commands.IO) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "remove",
+			ShortUsage: "validator remove [flags]",
+			LongHelp:   "Removes a validator from the genesis.json",
+		},
+		commands.NewEmptyConfig(),
+		func(_ context.Context, _ []string) error {
+			return execValidatorRemove(validatorCfg, io)
+		},
+	)
+}
+
+func execValidatorRemove(cfg *validatorCfg, io *commands.IO) error {
+	// Load the genesis
+	genesis, loadErr := types.GenesisDocFromFile(cfg.genesisPath)
+	if loadErr != nil {
+		return fmt.Errorf("unable to load genesis, %w", loadErr)
+	}
+
+	// Check the validator address
+	address, err := crypto.AddressFromString(cfg.address)
+	if err != nil {
+		return fmt.Errorf("invalid validator address, %w", err)
+	}
+
+	index := -1
+
+	for indx, validator := range genesis.Validators {
+		if validator.Address == address {
+			index = indx
+
+			break
+		}
+	}
+
+	if index < 0 {
+		return errors.New("validator not present in genesis.json")
+	}
+
+	// Drop the validator
+	genesis.Validators = append(genesis.Validators[:index], genesis.Validators[index+1:]...)
+
+	// Save the updated genesis
+	if err := genesis.SaveAs(cfg.genesisPath); err != nil {
+		return fmt.Errorf("unable to save genesis.json, %w", err)
+	}
+
+	io.Printfln(
+		"Validator with address %s removed from genesis file",
+		cfg.address,
+	)
+
+	return nil
+}

--- a/gno.land/cmd/genesis/validator_remove.go
+++ b/gno.land/cmd/genesis/validator_remove.go
@@ -13,7 +13,7 @@ import (
 var errValidatorNotPresent = errors.New("validator not present in genesis.json")
 
 // newValidatorRemoveCmd creates the genesis validator remove subcommand
-func newValidatorRemoveCmd(validatorCfg *validatorCfg, io *commands.IO) *commands.Command {
+func newValidatorRemoveCmd(rootCfg *validatorCfg, io *commands.IO) *commands.Command {
 	return commands.NewCommand(
 		commands.Metadata{
 			Name:       "remove",
@@ -22,7 +22,7 @@ func newValidatorRemoveCmd(validatorCfg *validatorCfg, io *commands.IO) *command
 		},
 		commands.NewEmptyConfig(),
 		func(_ context.Context, _ []string) error {
-			return execValidatorRemove(validatorCfg, io)
+			return execValidatorRemove(rootCfg, io)
 		},
 	)
 }

--- a/gno.land/cmd/genesis/validator_remove_test.go
+++ b/gno.land/cmd/genesis/validator_remove_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesis_Validator_Remove(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid genesis file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"remove",
+			"--genesis-path",
+			"dummy-path",
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, "unable to load genesis")
+	})
+
+	t.Run("invalid validator address", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"remove",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			"dummyaddress",
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, "invalid validator address")
+	})
+
+	t.Run("validator not found", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		dummyKeys := []keys.Info{
+			getDummyKey(t),
+			getDummyKey(t),
+		}
+
+		genesis := getDefaultGenesis()
+
+		// Set an existing validator
+		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
+			Address: dummyKeys[0].GetAddress(),
+			PubKey:  dummyKeys[0].GetPubKey(),
+			Power:   1,
+			Name:    "example",
+		})
+
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"remove",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			dummyKeys[1].GetPubKey().Address().String(),
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errValidatorNotPresent.Error())
+	})
+
+	t.Run("validator removed", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		dummyKey := getDummyKey(t)
+
+		genesis := getDefaultGenesis()
+
+		// Set an existing validator
+		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
+			Address: dummyKey.GetAddress(),
+			PubKey:  dummyKey.GetPubKey(),
+			Power:   1,
+			Name:    "example",
+		})
+
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"validator",
+			"remove",
+			"--genesis-path",
+			tempGenesis.Name(),
+			"--address",
+			dummyKey.GetPubKey().Address().String(),
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.NoError(t, cmdErr)
+	})
+}

--- a/tm2/pkg/crypto/keys/client/add.go
+++ b/tm2/pkg/crypto/keys/client/add.go
@@ -259,7 +259,7 @@ func execAdd(cfg *addCfg, args []string, io *commands.IO) error {
 	}
 
 	if len(mnemonic) == 0 {
-		mnemonic, err = generateMnemonic(mnemonicEntropySize)
+		mnemonic, err = GenerateMnemonic(mnemonicEntropySize)
 		if err != nil {
 			return err
 		}

--- a/tm2/pkg/crypto/keys/client/export_test.go
+++ b/tm2/pkg/crypto/keys/client/export_test.go
@@ -44,7 +44,7 @@ func addRandomKeyToKeybase(
 	encryptPassword string,
 ) (keys.Info, error) {
 	// Generate a random mnemonic
-	mnemonic, err := generateMnemonic(mnemonicEntropySize)
+	mnemonic, err := GenerateMnemonic(mnemonicEntropySize)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"unable to generate a mnemonic phrase, %w",

--- a/tm2/pkg/crypto/keys/client/helper.go
+++ b/tm2/pkg/crypto/keys/client/helper.go
@@ -2,9 +2,9 @@ package client
 
 import "github.com/gnolang/gno/tm2/pkg/crypto/bip39"
 
-// generateMnemonic generates a new BIP39 mnemonic using the
+// GenerateMnemonic generates a new BIP39 mnemonic using the
 // provided entropy size
-func generateMnemonic(entropySize int) (string, error) {
+func GenerateMnemonic(entropySize int) (string, error) {
 	// Generate the entropy seed
 	entropySeed, err := bip39.NewEntropy(entropySize)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR adds support for the `genesis validator` sub-commands, as outlined in #1228.

Closes #1228 

Example `genesis validator add` command you can use to test out the functionality:
```bash
genesis validator add --name milos -pub-key gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqvknvnspy43c9zp0ts7wgvupldfzkws8kmvvz2eelfmzzupfymwpwzhh9m3 -address g1wpewvuxtyvqqwysndt4f8425tpdg3lf0mhu6fm
```
<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
