### PR TITLE
test(gno build): remove exit code assertion

### DIFF
--- a/gnovm/cmd/gno/testdata/gno_build/invalid_go_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/invalid_go_files.txtar
@@ -4,9 +4,9 @@
 
 ! stdout .+
 stderr '\./file1\.go:3:1: syntax error: non-declaration statement outside function body'
-stderr '\./\.: build pkg: std go compiler: exit status 1'
+stderr '\./\.: build pkg: std go compiler'
 stderr 'sub/file2\.go:3:1: syntax error: non-declaration statement outside function body'
-stderr '\./sub: build pkg: std go compiler: exit status 1'
+stderr '\./sub: build pkg: std go compiler'
 
 -- go.mod --
 module gnobuild

--- a/gnovm/cmd/gno/testdata/gno_build/no_go_files.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_go_files.txtar
@@ -4,8 +4,8 @@
 
 ! stdout .+
 stderr -count=2 'no Go files in '$WORK
-stderr '\./\.: build pkg: std go compiler: exit status 1'
-stderr '\./sub: build pkg: std go compiler: exit status 1'
+stderr '\./\.: build pkg: std go compiler'
+stderr '\./sub: build pkg: std go compiler'
 
 -- go.mod --
 module gnobuild

--- a/gnovm/cmd/gno/testdata/gno_build/no_gomod.txtar
+++ b/gnovm/cmd/gno/testdata/gno_build/no_gomod.txtar
@@ -4,8 +4,8 @@
 
 ! stdout .+
 stderr -count=2 'go: go.mod file not found in current directory or any parent directory'
-stderr './.: build pkg: std go compiler: exit status 1'
-stderr './sub: build pkg: std go compiler: exit status 1'
+stderr './.: build pkg: std go compiler'
+stderr './sub: build pkg: std go compiler'
 
 -- main.gno --
 package main


### PR DESCRIPTION
Closes #1258

Can't explain why but Jae has exit code 2 where most people have exit code 1.

Decided to remove the code assertion since it doesn't really matter.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
