### PR TITLE
chore: repair-staging

### DIFF
--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       - --faucet-url=https://faucet-staging.gno.land/
       - --help-chainid=staging
       - --help-remote=staging.gno.land:36657
-      - --pages-dir=/overlay/pages
       - --views-dir=./gno.land/cmd/gnoweb/views
     volumes:
       - "./overlay:/overlay:ro"


### PR DESCRIPTION
Due to #1176 (removing `-pages-dir` flag from `gnoweb`)
Blocks #1108 