### PR TITLE
docs(contributing): add ViM instructions to setup gnols

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,6 @@ endif
 function! s:on_lsp_buffer_enabled() abort
     " Autocompletion
     setlocal omnifunc=lsp#complete
-    setlocal signcolumn=yes
     " Format on save
     autocmd BufWritePre <buffer> LspDocumentFormatSync
     " Some optionnal mappings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,8 @@ if (executable('gnols'))
         \ },
         \ 'languageId': {server_info->'gno'},
     \ })
+else
+	echomsg 'gnols binary not found: LSP disabled for Gno files'
 endif
 	
 function! s:on_lsp_buffer_enabled() abort

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,9 @@ plugin and then register the LSP server in your `.vimrc` file:
 ```vim
 augroup gno_autocmd
     autocmd!
-    autocmd BufNewFile,BufRead *.gno {
-        set filetype=gno
-        set syntax=go
-    }
+    autocmd BufNewFile,BufRead *.gno
+        \ set filetype=gno |
+        \ set syntax=go
 augroup END
 
 if (executable('gnols'))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,10 @@ Note that unlike the previous ViM setup without LSP, here it is required by
 `vim-lsp` to have a specific `filetype=gno`. Syntax highlighting is preserved
 thanks to `syntax=go`.
 
+Inside `lsp#register_server()`, you also have to replace
+`workspace_config.root` and `workspace_config.gno` with the correct directories
+from your machine.
+
 Additionaly, it's not possible to use `gofumpt` for code formatting with
 `gnols` for now.
 


### PR DESCRIPTION
Relates to #1274 

What works with this setup:
- code completion after `.` but only for stdlibs packages
- code hover tooltip with `:LspHover` command (again limited to stdlibs)
- format on save (only gofmt for now)
- code Lens with `:LspCodeLens` command (only when the buffer is `_test.gno` file) which display a list of possible `gno test` executions with different scopes (package, files or function). 
Note that test executions are using the LSP `workspace/executeCommand` and actually `vim-lsp` doesn't handle well the output of that. That means, tests are running, but you don't get the ouput. I'm still unsure about how to setup that properly (see https://github.com/prabirshrestha/vim-lsp/issues/1461).

The good thing is the limitations can be removed by contributing to [gnols](https://github.com/gno-playground/gnols), for instance : 
- Expand code completion to all imported types
- Expand code hover to all imported types
- Add the *go-to-definition* feature
- Add the *rename* feature
- ...