### PR TITLE
fix: Error string in decryptPrivKey. Use errors.As in IsErrWrongPassword.

### DIFF
--- a/tm2/pkg/crypto/keys/armor/armor.go
+++ b/tm2/pkg/crypto/keys/armor/armor.go
@@ -128,7 +128,7 @@ func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privK
 	}
 	key = crypto.Sha256(key) // Get 32 bytes
 	privKeyBytes, err := xsalsa20symmetric.DecryptSymmetric(encBytes, key)
-	if err != nil && err.Error() == "Ciphertext decryption failed" {
+	if err != nil && err.Error() == "ciphertext decryption failed" {
 		return privKey, keyerror.NewErrWrongPassword()
 	} else if err != nil {
 		return privKey, err

--- a/tm2/pkg/crypto/keys/keyerror/errors.go
+++ b/tm2/pkg/crypto/keys/keyerror/errors.go
@@ -1,6 +1,7 @@
 package keyerror
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -40,7 +41,8 @@ func IsErrKeyNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	if keyErr, ok := err.(keybaseError); ok {
+	var keyErr keybaseError
+	if errors.As(err, &keyErr) {
 		if keyErr.Code() == codeKeyNotFound {
 			return true
 		}
@@ -72,7 +74,8 @@ func IsErrWrongPassword(err error) bool {
 	if err == nil {
 		return false
 	}
-	if keyErr, ok := err.(keybaseError); ok {
+	var keyErr keybaseError
+	if errors.As(err, &keyErr) {
 		if keyErr.Code() == codeWrongPassword {
 			return true
 		}


### PR DESCRIPTION
This PR fixes bugs with error handling:
* `decryptPrivKey` checks if `DecryptSymmetric` [returns the error "Ciphertext decryption failed"](https://github.com/gnolang/gno/blob/a3bdd2bb25b76b17176c3c59a1ce2522f8a75e53/tm2/pkg/crypto/keys/armor/armor.go#L131) and converts it to `ErrWrongPassword`. The problem is that `DecryptSymmetric` [returns "ciphertext decryption failed"](https://github.com/gnolang/gno/blob/a3bdd2bb25b76b17176c3c59a1ce2522f8a75e53/tm2/pkg/crypto/xsalsa20symmetric/symmetric.go#L53C27-L53C55) (spelled differently). This PR fixes the string in the error check.
* `IsErrWrongPassword` checks if the [error type is `keybaseError`](https://github.com/gnolang/gno/blob/a3bdd2bb25b76b17176c3c59a1ce2522f8a75e53/tm2/pkg/crypto/keys/keyerror/errors.go#L75C24-L75C36) . But the error can be wrapped as it is [in `signAndBroadcastTxCommit`](https://github.com/gnolang/gno/blob/60e05e83f57558843c0808f78500b6a51b2a22c1/gno.land/pkg/gnoclient/client_txs.go#L104). Therefore, instead of a simple error type check, this PR updates `IsErrWrongPassword` (and `IsErrKeyNotFound`) to use `errors.As` to check the error type (which unwraps the error if needed).