### PR TITLE
chore: add tshirt-size labels for worx effort estimation

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -68,5 +68,30 @@
     "name": "investigating",
     "color": "8c008c",
     "description": "This behavior is still being tested out"
+  },
+  {
+    "name": "worx-XS",
+    "color": "888888",
+    "description": "extra-small worx"
+  },
+  {
+    "name": "worx-S",
+    "color": "888888",
+    "description": "small worx"
+  },
+  {
+    "name": "worx-M",
+    "color": "888888",
+    "description": "medium worx"
+  },
+  {
+    "name": "worx-L",
+    "color": "888888",
+    "description": "large worx"
+  },
+  {
+    "name": "worx-XL",
+    "color": "888888",
+    "description": "extra-large worx"
   }
 ]


### PR DESCRIPTION
## Context

Depends on https://github.com/gnolang/gh-labels/issues/127

We are exploring the implementation of a label system for our automatic pull request bot (#1134) to go beyond merely incentivizing the creation of many small pull requests. This label system aims to align with the actual effort put into a pull request, which is influenced by both expertise (years of learning) and time.

For instance, if a junior developer requires 1 year to complete a task, while an expert can do it in 5 in 1 week, the assigned label should reflect the proportional effort. In practice, this could translate to an "XL" label. Alternatively, we might consider defining a standard effort level for an "average joe." Importantly, this effort isn't solely based on time; it's a combination of expertise ratio multiplied by time.

The objective is not to label everything, but rather to allow certain pull requests to benefit from this system.

By default, if a pull request receives a label from a team member, we should trust the reputation of the reviewer to determine the appropriate value, eliminating the need for additional voting or discussions. However, I still recommend that label assignment be primarily handled by recognized experts in the specific area of the change. Having a preliminary label assigned can still be valuable.

When a pull request fixes an issue that was previously qualified, we should inherit the issue's label if the PR doesn't already have a label.

Additionally, we should encourage contributors to provide their estimation of the work in plain English, making it easier for us to reach consensus or explore alternative assessments. We can update the pull-request template accordingly.
Example: `I think it is worth a L, I spent 2 days digging and 2h fixing + writing tests`.

When conflicts or disagreements arise, we should aim to have constructive discussions in the comments section. Alternatively, we can defer to the leaders to have the final say by giving their reason. The amount of `worx` earned does not directly determine their revenue, but it contributes to building their portfolio. This portfolio is then used by humans to globally review profiles and promote and showcase the combination of their work.

Ultimately, this system aims to resemble a freelancer or bug bounty system, where 8 hours of an expert's time equate to a certain amount of "work units" (e.g., `^worx`) instead of monetary compensation.

## TODO

- [x] Add labels.
- [ ] Address color and syntax concerns (also consider merging with #995, if applicable).
- [ ] Ensure that the label applier doesn't remove existing labels (see also #995).
- [ ] Update `CONTRIBUTING.md` to provide guidance on how to use these labels effectively.
- [ ] When we have interesting discussions related to an issue, pull request, or comment like this one, we should reference the discussions and update meta issues accordingly. For example, here I am providing useful updates on how we plan to manage work points, membership tiers, and rewards.

Related to #995 (potentially blocking or dependent on)
Assigned to @gnolang/devrels