### PR TITLE
fix: In TestGnoDoc, fix expected output for "doc", "avl"

### DIFF
--- a/gnovm/cmd/gno/doc_test.go
+++ b/gnovm/cmd/gno/doc_test.go
@@ -10,7 +10,7 @@ func TestGnoDoc(t *testing.T) {
 		},
 		{
 			args:                []string{"doc", "avl"},
-			stdoutShouldContain: "func NewNode",
+			stdoutShouldContain: "func NewTree",
 		},
 		{
 			args:                []string{"doc", "-u", "avl.Node"},


### PR DESCRIPTION
In the root folder, `make test` has one failure: `FAIL: TestGnoDoc/doc_avl (0.01s)` . This is a failure of [this test](https://github.com/gnolang/gno/blob/eb421578ec72d70d2cbd930576856623376f2daa/gnovm/cmd/gno/doc_test.go#L12-L13) which expects "func NewNode". However in folder gnovm/cmd/gno, `go run . doc avl` prints:

```
package avl // import "gno.land/p/demo/avl"

type MutTree struct{ ... }
    func NewMutTree() *MutTree
type Tree struct{ ... }
    func NewTree(key string, value interface{}) *Tree
```

Therefore, this PR changes the test to expect "func NewTree". With this fix, `make test` passes.

(Of course, maybe `go run . doc avl` really should have "func NewNode". But I'm assuming that there was an update after the test was written.)