### PR TITLE
fix: properly mark array elements when an realm slice is updated

### DIFF
--- a/gno.land/cmd/gnoland/testdata/append.txtar
+++ b/gno.land/cmd/gnoland/testdata/append.txtar
@@ -39,6 +39,27 @@ gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot
 stdout '("2-3-42-" string)'
 stdout OK!
 
+gnokey maketx call -pkgpath gno.land/r/append -func CopyAppend -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/append -func PopB -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+# Call render
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
+stdout '("2-3-42-" string)'
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/append -func AppendMoreAndC -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/append -func ReassignC -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
+stdout '("2-3-42-70-100-" string)'
+stdout OK!
+
 -- append.gno --
 package append
 
@@ -48,7 +69,9 @@ import (
 
 type T struct{ i int }
 
-var a []T
+var a, b []T
+var c = []T{{i: 100}}
+
 
 func init() {
 	a = make([]T, 0, 1)
@@ -60,6 +83,25 @@ func Pop() {
 
 func Append(i int) {
 	a = append(a, T{i: i})
+}
+
+func CopyAppend() {
+	b = append(a, T{i: 50}, T{i: 60})
+}
+
+func PopB() {
+	b = append(b[:0], b[1:]...)
+}
+
+func AppendMoreAndC() {
+	// Fill to capacity
+	a = append(a, T{i: 70})
+	// Above capacity; make new array
+	a = append(a, c...)
+}
+
+func ReassignC() {
+	c[0] = T{i: 200}
 }
 
 func Render(path string) string {

--- a/gno.land/cmd/gnoland/testdata/append.txtar
+++ b/gno.land/cmd/gnoland/testdata/append.txtar
@@ -8,6 +8,9 @@ stdout OK!
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '1' -broadcast -chainid=tendermint_test test1
 stdout OK!
 
+gnokey maketx call -pkgpath gno.land/r/append -func AppendNil -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
 # Call Append 2
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '2' -broadcast -chainid=tendermint_test test1
 stdout OK!
@@ -60,6 +63,10 @@ gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot
 stdout '("2-3-42-70-100-" string)'
 stdout OK!
 
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args 'd' -broadcast -chainid=tendermint_test test1
+stdout '("1-" string)'
+stdout OK!
+
 -- append.gno --
 package append
 
@@ -69,7 +76,7 @@ import (
 
 type T struct{ i int }
 
-var a, b []T
+var a, b, d []T
 var c = []T{{i: 100}}
 
 
@@ -104,10 +111,19 @@ func ReassignC() {
 	c[0] = T{i: 200}
 }
 
+func AppendNil() {
+	d = append(d, a...)
+}
+
 func Render(path string) string {
+	source := a
+	if path == "d" {
+		source = d
+	}
+
 	var s string
-	for i:=0;i<len(a);i++{
-		s+=ufmt.Sprintf("%d-", a[i].i)
+	for i:=0;i<len(source);i++{
+		s+=ufmt.Sprintf("%d-", source[i].i)
 	}
 	return s
 }

--- a/gno.land/cmd/gnoland/testdata/append.txtar
+++ b/gno.land/cmd/gnoland/testdata/append.txtar
@@ -1,0 +1,77 @@
+# start a new node
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/append -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+
+# Call Append 1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '1' -broadcast -chainid=tendermint_test test1
+# Call Append 2
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '2' -broadcast -chainid=tendermint_test test1
+# Call Append 3
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '3' -broadcast -chainid=tendermint_test test1
+
+# Call render
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
+
+cmp stdout stdout.golden.1
+
+# Call Pop
+gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+# Call render
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
+
+cmp stdout stdout.golden.2
+
+# Call Append 42
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '42' -broadcast -chainid=tendermint_test test1
+
+# Call render
+gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
+
+cmp stdout stdout.golden.3
+
+-- append.gno --
+package append
+
+import (
+	"gno.land/p/demo/ufmt"
+)
+
+type T struct{ i int }
+
+var a []T
+
+func init() {
+	a = make([]T, 0, 1)
+}
+
+func Pop() {
+	a = append(a[:0], a[1:]...)
+}
+
+func Append(i int) {
+	a = append(a, T{i: i})
+}
+
+func Render(path string) string {
+	var s string
+	for i:=0;i<len(a);i++{
+		s+=ufmt.Sprintf("%d-", a[i].i)
+	}
+	return s
+}
+-- stdout.golden.1 --
+("1-2-3-" string)
+OK!
+GAS WANTED: 2000000
+GAS USED:   95179
+-- stdout.golden.2 --
+("2-3-" string)
+OK!
+GAS WANTED: 2000000
+GAS USED:   93546
+-- stdout.golden.3 --
+("2-3-42-" string)
+OK!
+GAS WANTED: 2000000
+GAS USED:   95191

--- a/gno.land/cmd/gnoland/testdata/append.txtar
+++ b/gno.land/cmd/gnoland/testdata/append.txtar
@@ -2,33 +2,42 @@
 gnoland start
 
 gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/append -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
 
 # Call Append 1
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '1' -broadcast -chainid=tendermint_test test1
+stdout OK!
+
 # Call Append 2
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '2' -broadcast -chainid=tendermint_test test1
+stdout OK!
+
 # Call Append 3
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '3' -broadcast -chainid=tendermint_test test1
+stdout OK!
 
 # Call render
 gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
-
-cmp stdout stdout.golden.1
+stdout '("1-2-3-" string)'
+stdout OK!
 
 # Call Pop
 gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
 # Call render
 gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
-
-cmp stdout stdout.golden.2
+stdout '("2-3-" string)'
+stdout OK!
 
 # Call Append 42
 gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 1000000ugnot -gas-wanted 2000000 -args '42' -broadcast -chainid=tendermint_test test1
+stdout OK!
 
 # Call render
 gnokey maketx call -pkgpath gno.land/r/append -func Render -gas-fee 1000000ugnot -gas-wanted 2000000 -args '' -broadcast -chainid=tendermint_test test1
-
-cmp stdout stdout.golden.3
+stdout '("2-3-42-" string)'
+stdout OK!
 
 -- append.gno --
 package append
@@ -60,18 +69,3 @@ func Render(path string) string {
 	}
 	return s
 }
--- stdout.golden.1 --
-("1-2-3-" string)
-OK!
-GAS WANTED: 2000000
-GAS USED:   95179
--- stdout.golden.2 --
-("2-3-" string)
-OK!
-GAS WANTED: 2000000
-GAS USED:   93546
--- stdout.golden.3 --
-("2-3-42-" string)
-OK!
-GAS WANTED: 2000000
-GAS USED:   95191

--- a/gno.land/cmd/gnoland/testdata/issue-1167.txtar
+++ b/gno.land/cmd/gnoland/testdata/issue-1167.txtar
@@ -1,0 +1,114 @@
+# Reproducible Test for https://github.com/gnolang/gno/issues/1167
+
+gnoland start
+
+# add contract
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+# execute New
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func New -args X -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+# execute Delta for the first time
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout '"1,1,1;" string'
+
+# execute Delta for the second time
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout '1,1,1;2,2,2;" string'
+
+# execute Delta for the third time
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout '1,1,1;2,2,2;3,3,3;" string'
+
+# execute Render
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Render -args X -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout '1,1,1;2,2,2;3,3,3;" string'
+
+-- gno.mod --
+module gno.land/r/demo/xx
+
+require (
+	gno.land/p/demo/avl v0.0.0-latest
+)
+
+-- realm.gno --
+package xx
+
+import (
+	"strconv"
+
+	"gno.land/p/demo/avl"
+)
+
+type Move struct {
+	N1, N2, N3 byte
+}
+
+type Position struct {
+	Moves []Move
+}
+
+func (p Position) clone() Position {
+	mv := p.Moves
+	return Position{Moves: mv}
+}
+
+func (oldp Position) update() Position {
+	p := oldp.clone()
+
+	counter++
+	// This is a workaround for the wrong behaviour (ie. uncomment this line):
+	// p.Moves = append([]Move{}, p.Moves...)
+	p.Moves = append(p.Moves, Move{counter, counter, counter})
+	return p
+}
+
+type Game struct {
+	Position Position
+}
+
+var games avl.Tree // id -> *Game
+
+var counter byte
+
+func New(s string) string {
+	// Bug shows if Moves has a cap > 0 when initialised.
+	el := &Game{Position: Position{Moves: make([]Move, 0, 2)}}
+	games.Set(s, el)
+	return values(el.Position)
+}
+
+func Delta(s string) string {
+	v, _ := games.Get(s)
+	g, ok := v.(*Game)
+	if !ok {
+		panic("invalid game")
+	}
+	n := g.Position.update()
+	g.Position = n
+	ret := values(n)
+	return ret
+}
+
+func Render(s string) string {
+	v, _ := games.Get(s)
+	g, ok := v.(*Game)
+	if !ok {
+		panic("invalid game")
+	}
+	return values(g.Position)
+}
+
+func values(x Position) string {
+	s := ""
+	for _, val := range x.Moves {
+		s += strconv.Itoa(int(val.N1)) + "," + strconv.Itoa(int(val.N2)) + "," + strconv.Itoa(int(val.N3)) + ";"
+	}
+	return s
+}

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1524,7 +1524,23 @@ func refOrCopyValue(parent Object, tv TypedValue) TypedValue {
 }
 
 func isUnsaved(oo Object) bool {
-	return oo.GetIsNewReal() || oo.GetIsDirty() || oo.GetObjectID().IsZero()
+	return oo.GetIsNewReal() || oo.GetIsDirty() ||
+		(oo.GetObjectID().IsZero() && objCanBeSavedDynamically(oo))
+}
+
+// objCanBeSavedDynamically returns true if the object's underlying type is one
+// that can consist of additional levels of composite typed members; it is not always
+// the case that marking parent object as dirty will cause new child objects to be
+// created and saved correctly.
+func objCanBeSavedDynamically(oo Object) bool {
+	switch oo.(type) {
+	case *ArrayValue:
+		return true
+	case *StructValue:
+		return true
+	}
+
+	return false
 }
 
 func IsRealmPath(pkgPath string) bool {

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -153,8 +153,12 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 	rlm.MarkDirty(po)
 	if co != nil {
 		co.IncRefCount()
-		if co.GetRefCount() > 1 && !co.GetIsEscaped() {
-			rlm.MarkNewEscaped(co)
+		if co.GetRefCount() > 1 {
+			if co.GetIsEscaped() {
+				// already escaped
+			} else {
+				rlm.MarkNewEscaped(co)
+			}
 		} else if co.GetIsReal() {
 			rlm.MarkDirty(co)
 

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -163,6 +163,22 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 		// Marking a value as dirty and increasing its reference count are mutually exclusive operations.
 		if co.GetIsReal() {
 			rlm.MarkDirty(co)
+
+			// A lot of slices are assigned to themselves using the append function. When this assignment happens,
+			// the underlying array may not need to be reallocated if it has the required capacity. In such a case,
+			// the array itself would be marked as dirty, but none of the elements that have been appended. This
+			// is a unique case that requires the solution below -- traverse the array's elements and call `DidUpdate`
+			// for any of the newly allocated values. We know if they are newly allocated by checking for the
+			// presence of an object ID.
+			if value, ok := co.(*ArrayValue); ok {
+				for _, elem := range value.List {
+					if obj, ok := elem.V.(Object); ok {
+						if obj.GetObjectID().IsZero() {
+							rlm.DidUpdate(co, nil, obj)
+						}
+					}
+				}
+			}
 		} else {
 			co.SetOwner(po)
 			rlm.MarkNewReal(co)
@@ -687,12 +703,10 @@ func (rlm *Realm) saveUnsavedObjectRecursively(store Store, oo Object) {
 	for _, uch := range unsaved {
 		if uch.GetIsEscaped() || uch.GetIsNewEscaped() {
 			// no need to save preemptively.
-			continue
+		} else {
+			rlm.saveUnsavedObjectRecursively(store, uch)
 		}
-
-		rlm.saveUnsavedObjectRecursively(store, uch)
 	}
-
 	// then, save self.
 	if oo.GetIsNewReal() {
 		// save created object.
@@ -701,13 +715,6 @@ func (rlm *Realm) saveUnsavedObjectRecursively(store Store, oo Object) {
 				panic("should not happen")
 			}
 		}
-
-		// This is a nested object that hasn't been created yet.
-		// Assign of object ID so it can be saved properly.
-		if oo.GetObjectID().IsZero() {
-			rlm.assignNewObjectID(oo)
-		}
-
 		rlm.saveObject(store, oo)
 		oo.SetIsNewReal(false)
 	} else {
@@ -925,12 +932,6 @@ func getUnsavedChildObjects(val Value) []Object {
 		} else if obj, ok := val.(Object); ok {
 			// if object...
 			if isUnsaved(obj) {
-				// This is likely a nested composite type that was never "created", so mark it
-				// at this point so that an ID is assigned and it gets saved correctly.
-				if obj.GetObjectID().IsZero() {
-					obj.SetIsNewReal(true)
-				}
-
 				unsaved = append(unsaved, obj)
 			}
 		} else {
@@ -1524,23 +1525,7 @@ func refOrCopyValue(parent Object, tv TypedValue) TypedValue {
 }
 
 func isUnsaved(oo Object) bool {
-	return oo.GetIsNewReal() || oo.GetIsDirty() ||
-		(oo.GetObjectID().IsZero() && objCanBeSavedDynamically(oo))
-}
-
-// objCanBeSavedDynamically returns true if the object's underlying type is one
-// that can consist of additional levels of composite typed members; it is not always
-// the case that marking parent object as dirty will cause new child objects to be
-// created and saved correctly.
-func objCanBeSavedDynamically(oo Object) bool {
-	switch oo.(type) {
-	case *ArrayValue:
-		return true
-	case *StructValue:
-		return true
-	}
-
-	return false
+	return oo.GetIsNewReal() || oo.GetIsDirty()
 }
 
 func IsRealmPath(pkgPath string) bool {

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -164,6 +164,8 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 		if co.GetIsReal() {
 			rlm.MarkDirty(co)
 
+			// XX: there may be a more efficient way to do this; to be revisited.
+			//
 			// A lot of slices are assigned to themselves using the append function. When this assignment happens,
 			// the underlying array may not need to be reallocated if it has the required capacity. In such a case,
 			// the array itself would be marked as dirty, but none of the elements that have been appended. This

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -189,14 +189,16 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 				}
 			}
 		} else {
-			if co.GetIsNewEscaped() {
-				panic("should not happen")
-			}
-			if co.GetIsEscaped() {
-				panic("should not happen")
-			}
-			if co.GetRefCount() >= 2 {
-				panic("should not happen")
+			if debug {
+				if co.GetIsNewEscaped() {
+					panic("should not happen")
+				}
+				if co.GetIsEscaped() {
+					panic("should not happen")
+				}
+				if co.GetRefCount() >= 2 {
+					panic("should not happen")
+				}
 			}
 
 			co.SetOwner(po)

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -176,10 +176,29 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 						if obj.GetObjectID().IsZero() {
 							rlm.DidUpdate(co, nil, obj)
 						}
+					} else if sv, ok := elem.V.(*SliceValue); ok {
+						if av, ok := sv.Base.(*ArrayValue); ok {
+							if av.GetObjectID().IsZero() {
+								// An array has no owner. This is a new instance so increase the reference count and
+								// mark it as new real so that it and all of its elements get persisted.
+								av.IncRefCount()
+								rlm.MarkNewReal(av)
+							}
+						}
 					}
 				}
 			}
 		} else {
+			if co.GetIsNewEscaped() {
+				panic("should not happen")
+			}
+			if co.GetIsEscaped() {
+				panic("should not happen")
+			}
+			if co.GetRefCount() >= 2 {
+				panic("should not happen")
+			}
+
 			co.SetOwner(po)
 			rlm.MarkNewReal(co)
 		}

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -376,7 +376,7 @@ func UverseNode() *PackageNode {
 						if 0 < xvl {
 							if xvb.Data == nil {
 								for i := 0; i < xvl; i++ {
-									list[i] = xvb.List[xvo+i].Copy(m.Alloc)
+									list[i] = xvb.List[xvo+i].DeepCopy(m.Alloc, m.Store)
 								}
 							} else {
 								panic("should not happen")
@@ -392,7 +392,7 @@ func UverseNode() *PackageNode {
 						if 0 < argsl {
 							if argsb.Data == nil {
 								for i := 0; i < argsl; i++ {
-									list[xvl+i] = argsb.List[argso+i].Copy(m.Alloc)
+									list[xvl+i] = argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
 								}
 							} else {
 								copyDataToList(

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -211,7 +211,7 @@ func UverseNode() *PackageNode {
 						list := make([]TypedValue, argsl)
 						if 0 < argsl {
 							for i := 0; i < argsl; i++ {
-								list[i] = argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
+								list[i] = argsb.List[argso+i].unrefCopy(m.Alloc, m.Store)
 							}
 						}
 						m.PushValue(TypedValue{
@@ -296,9 +296,9 @@ func UverseNode() *PackageNode {
 								if argsb.Data == nil {
 									for i := 0; i < argsl; i++ {
 										oldElem := list[xvo+xvl+i]
-										// DeepCopy will resolve references and copy their values to prevent
-										// reference copying rather than copying the underlying values.
-										newElem := argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
+										// unrefCopy will resolve references and copy their values
+										// to copy by value rather than by reference.
+										newElem := argsb.List[argso+i].unrefCopy(m.Alloc, m.Store)
 										list[xvo+xvl+i] = newElem
 
 										m.Realm.DidUpdate(
@@ -376,7 +376,7 @@ func UverseNode() *PackageNode {
 						if 0 < xvl {
 							if xvb.Data == nil {
 								for i := 0; i < xvl; i++ {
-									list[i] = xvb.List[xvo+i].DeepCopy(m.Alloc, m.Store)
+									list[i] = xvb.List[xvo+i].unrefCopy(m.Alloc, m.Store)
 								}
 							} else {
 								panic("should not happen")
@@ -392,7 +392,7 @@ func UverseNode() *PackageNode {
 						if 0 < argsl {
 							if argsb.Data == nil {
 								for i := 0; i < argsl; i++ {
-									list[xvl+i] = argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
+									list[xvl+i] = argsb.List[argso+i].unrefCopy(m.Alloc, m.Store)
 								}
 							} else {
 								copyDataToList(
@@ -473,7 +473,7 @@ func UverseNode() *PackageNode {
 						list := make([]TypedValue, listLen)
 						if 0 < xvl {
 							for i := 0; i < listLen; i++ {
-								list[i] = xvb.List[xvo+i].DeepCopy(m.Alloc, m.Store)
+								list[i] = xvb.List[xvo+i].unrefCopy(m.Alloc, m.Store)
 							}
 						}
 						if 0 < argsl {

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -210,9 +210,9 @@ func UverseNode() *PackageNode {
 						// append(nil, *SliceValue) new list ---------
 						list := make([]TypedValue, argsl)
 						if 0 < argsl {
-							copy(
-								list[:argsl],
-								argsb.List[argso:argso+argsl])
+							for i := 0; i < argsl; i++ {
+								list[i] = argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
+							}
 						}
 						m.PushValue(TypedValue{
 							T: xt,
@@ -469,11 +469,12 @@ func UverseNode() *PackageNode {
 						return
 					} else {
 						// append(*SliceValue, *NativeValue) new list --------
-						list := make([]TypedValue, xvl+argsl)
+						listLen := xvl + argsl
+						list := make([]TypedValue, listLen)
 						if 0 < xvl {
-							copy(
-								list[:xvl],
-								xvb.List[xvo:xvo+xvl])
+							for i := 0; i < listLen; i++ {
+								list[i] = xvb.List[xvo+i].DeepCopy(m.Alloc, m.Store)
+							}
 						}
 						if 0 < argsl {
 							copyNativeToList(

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -294,14 +294,25 @@ func UverseNode() *PackageNode {
 								// append(*SliceValue.List, *SliceValue) ---------
 								list := xvb.List
 								if argsb.Data == nil {
-									copy(
-										list[xvo+xvl:xvo+xvl+argsl],
-										argsb.List[argso:argso+argsl])
+									for i := 0; i < argsl; i++ {
+										oldElem := list[xvo+xvl+i]
+										// DeepCopy will resolve references and copy their values to prevent
+										// reference copying rather than copying the underlying values.
+										newElem := argsb.List[argso+i].DeepCopy(m.Alloc, m.Store)
+										list[xvo+xvl+i] = newElem
+
+										m.Realm.DidUpdate(
+											xvb,
+											oldElem.GetFirstObject(m.Store),
+											newElem.GetFirstObject(m.Store),
+										)
+									}
 								} else {
 									copyDataToList(
 										list[xvo+xvl:xvo+xvl+argsl],
 										argsb.Data[argso:argso+argsl],
 										xt.Elem())
+									m.Realm.DidUpdate(xvb, nil, nil)
 								}
 							} else {
 								// append(*SliceValue.Data, *SliceValue) ---------
@@ -310,6 +321,7 @@ func UverseNode() *PackageNode {
 									copyListToData(
 										data[xvo+xvl:xvo+xvl+argsl],
 										argsb.List[argso:argso+argsl])
+									m.Realm.DidUpdate(xvb, nil, nil)
 								} else {
 									copy(
 										data[xvo+xvl:xvo+xvl+argsl],
@@ -363,9 +375,9 @@ func UverseNode() *PackageNode {
 						list := make([]TypedValue, xvl+argsl)
 						if 0 < xvl {
 							if xvb.Data == nil {
-								copy(
-									list[:xvl],
-									xvb.List[xvo:xvo+xvl])
+								for i := 0; i < xvl; i++ {
+									list[i] = xvb.List[xvo+i].Copy(m.Alloc)
+								}
 							} else {
 								panic("should not happen")
 								/*
@@ -379,9 +391,9 @@ func UverseNode() *PackageNode {
 						}
 						if 0 < argsl {
 							if argsb.Data == nil {
-								copy(
-									list[xvl:xvl+argsl],
-									argsb.List[argso:argso+argsl])
+								for i := 0; i < argsl; i++ {
+									list[xvl+i] = argsb.List[argso+i].Copy(m.Alloc)
+								}
 							} else {
 								copyDataToList(
 									list[xvl:xvl+argsl],

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1027,6 +1027,28 @@ func (tv TypedValue) Copy(alloc *Allocator) (cp TypedValue) {
 	return
 }
 
+// DeepCopy makes of copy of the underlying value in the case of reference values.
+// It copies other values as expected using the normal Copy method.
+func (tv TypedValue) DeepCopy(alloc *Allocator, store Store) (cp TypedValue) {
+	switch tv.V.(type) {
+	case RefValue:
+		cp.T = tv.T
+		refObject := tv.GetFirstObject(store)
+		switch refObjectValue := refObject.(type) {
+		case *ArrayValue:
+			cp.V = refObjectValue.Copy(alloc)
+		case *StructValue:
+			cp.V = refObjectValue.Copy(alloc)
+		default:
+			cp = tv
+		}
+	default:
+		cp = tv.Copy(alloc)
+	}
+
+	return
+}
+
 // Returns encoded bytes for primitive values.
 // These bytes are used for both value hashes as well
 // as hash key bytes.

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1027,9 +1027,9 @@ func (tv TypedValue) Copy(alloc *Allocator) (cp TypedValue) {
 	return
 }
 
-// DeepCopy makes of copy of the underlying value in the case of reference values.
+// unrefCopy makes a copy of the underlying value in the case of reference values.
 // It copies other values as expected using the normal Copy method.
-func (tv TypedValue) DeepCopy(alloc *Allocator, store Store) (cp TypedValue) {
+func (tv TypedValue) unrefCopy(alloc *Allocator, store Store) (cp TypedValue) {
 	switch tv.V.(type) {
 	case RefValue:
 		cp.T = tv.T

--- a/gnovm/tests/files/a47.gno
+++ b/gnovm/tests/files/a47.gno
@@ -1,0 +1,32 @@
+package main
+
+type S struct {
+	i int
+}
+
+func main() {
+	sArr := make([]S, 0, 4)
+	sArr = append(sArr, S{1}, S{2}, S{3})
+	println(sArr[0].i, sArr[1].i, sArr[2].i)
+
+	newArr := append(sArr[:0], sArr[1:]...)
+
+	// The append modified the underlying array because it was within capacity.
+	println(len(sArr) == 3)
+	println(sArr[0].i, sArr[1].i, sArr[2].i)
+
+	// It generated a new slice that references the same array.
+	println(len(newArr) == 2)
+	println(newArr[0].i, newArr[1].i)
+
+	// The struct should have been copied, not referenced.
+	println(&sArr[2] != &newArr[1])
+}
+
+// Output:
+// 1 2 3
+// true
+// 2 3 3
+// true
+// 2 3
+// true


### PR DESCRIPTION
Addresses #1167,  #960, and #1170 

Consider the following situation:
- A slice of structs exists with a length of zero and a capacity of one
- A new struct literal is appended to the slice
- The code panics because the newly allocated struct literal was never marked as "new"

``` go
package append

import (
	"gno.land/p/demo/ufmt"
)

type T struct{ i int }

var a []T

func init() {
        a = make([]T, 0, 1)
}

func Append(i int) {
	a = append(a, T{i: i})
}

```

Invoking the `Append` function will cause a panic.

The solution is to traverse each of the array elements after slice append assignment to make sure any new or updated elements are marked as such.

This PR also includes a change to ensure that marking an object as dirty and managing references to the object are mutually exclusive.  I think this is correct but am not sure.

The changes include txtar test cases that incorporate the issue described by @tbruyelle in #1170 