### PR TITLE
fix(misc/gendocs): convert paths for async-loaded scripts

### DIFF
--- a/misc/gendocs/gendocs.sh
+++ b/misc/gendocs/gendocs.sh
@@ -5,6 +5,8 @@ set -u
 
 DOC_DIR=godoc
 PKG=github.com/gnolang/gno
+# Used to load /static content
+STATIC_PREFIX=/gno
 
 # Run a pkgsite server which we will scrape. Use env to run it from our repo's root directory.
 env -C ../.. pkgsite &
@@ -30,7 +32,11 @@ wget \
 	--page-requisites \
 	-erobots=off \
 	--accept-regex='8080/((search|license-policy|about|)$|(static|images)/|github.com/gnolang/)' \
-	http://localhost:8080/
+	http://localhost:8080/ \
+	http://localhost:8080/static/frontend/frontend.js \
+	http://localhost:8080/static/frontend/unit/unit.js \
+	http://localhost:8080/static/frontend/unit/main/main.js \
+	http://localhost:8080/third_party/dialog-polyfill/dialog-polyfill.js
 
 # Stop the pkgsite server
 kill -9 $DOC_PID
@@ -46,6 +52,7 @@ mv localhost\:8080 $DOC_DIR
 find godoc -type f -exec sed -ri 's#http://localhost:8080/files/[^"]*/github.com/gnolang/([^/"]+)/([^"]*)#https://github.com/gnolang/\1/blob/master/\2#g
 s#http://localhost:8080/[^"?]*\?tab=(importedby|versions)#\##g
 s#http://localhost:8080([^")]*)#https://pkg.go.dev\1#g
-s#/files/[^" ]*/(github.com/[^" ]*)/#\1#g' {} +
+s#/files/[^" ]*/(github.com/[^" ]*)/#\1#g
+s#s\.src = src;#s.src = "'"$STATIC_PREFIX"'" + src;#g' {} +
 
 echo "Docs can be found in $DOC_DIR"


### PR DESCRIPTION
This should allow js to fully load correctly on gnolang.github.io :)