### PR TITLE
docs(grammatical): correct typos and improve grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Likewise, if you have an idea on how to improve this guide, go for it as well.
 
 ### Environment
 
-The gno repository is primarily based on Golang (Go), and Gnolang (Gno).
+The gno repository is primarily based on Golang (Go) and Gnolang (Gno).
 
 The primary tech stack for working on the repository:
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -26,7 +26,7 @@
 
 * Correct, debuggable software is more important than extreme performance.
 * Multicore concurrency makes Tendermint within the range of theoretical performance.
-* Go is chosen for the faster development of modular components, not for maximum speed.
+* Go is chosen for faster development of modular components, not for maximum speed.
 * Real bottleneck is in the application layer, not in supporting large validator sets.
 * Focus on feature completeness, debuggability, and maintainability over extreme performance.
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -5,7 +5,7 @@
  * Readability is paramount - beautiful is better than fast.
  * Minimal code - keep total footprint small.
  * Minimal dependencies - all dependencies must get audited, and become part of the repo.
- * Modular dependencies - whereever reasonable, make components modular.
+ * Modular dependencies - wherever reasonable, make components modular.
  * Finished - software projects that don't become finished are projects that
    are forever vulnerable. One of the primary goals of the Gno language and
    related works is to become finished within a reasonable timeframe.
@@ -26,7 +26,7 @@
 
 * Correct, debuggable software is more important than extreme performance.
 * Multicore concurrency makes Tendermint within the range of theoretical performance.
-* Go is chosen for faster development of modular components, not for maximum speed.
+* Go is chosen for the faster development of modular components, not for maximum speed.
 * Real bottleneck is in the application layer, not in supporting large validator sets.
 * Focus on feature completeness, debuggability, and maintainability over extreme performance.
 


### PR DESCRIPTION
This pull request addresses and corrects several grammatical errors found throughout the codebase.
The changes include fixing typos, punctuation, and ensuring proper sentence structure for improved readability and clarity.
No functional changes have been made; this is purely a maintenance update.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
