### PR TITLE
chore(ci): update tm2 timeout on CI

### DIFF
--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -55,7 +55,7 @@ jobs:
           - _test.pkg.bft
           - _test.pkg.others
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 21
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -65,7 +65,7 @@ jobs:
         working-directory: tm2
         run: |
           export GOPATH=$HOME/go
-          export GOTEST_FLAGS="-v -p 1 -timeout=30m -coverprofile=coverage.out -covermode=atomic"
+          export GOTEST_FLAGS="-v -p 1 -timeout=20m -coverprofile=coverage.out -covermode=atomic"
           make ${{ matrix.args }}
           touch coverage.out
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
It should prevent certain flaky tests from failing on GH.
In any case, it increases the high-level timeout to be greater than the timeout for running 'go test'.

Related to issue #1320.