### PR TITLE
chore(staging): expose rpc endpoint on https://rpc.staging.gno.land

### DIFF
--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: gnoland
     build: ../../..
     environment:
+      - VIRTUAL_HOST=rpc.staging.gno.land
+      - VIRTUAL_PORT=36657
+      - LETSENCRYPT_HOST=rpc.staging.gno.land
       - LOG_LEVEL=4
     working_dir: /opt/gno/src/gno.land
     command:


### PR DESCRIPTION
Depends on DNS updates: `rpc.staging.gno.land CNAME staging.gno.land`

Unlocks @gnolang/devx and probably @gnolang/onbloc.