### PR TITLE
fix(ci): remove unused func `parseBalance`

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
-	"github.com/gnolang/gno/tm2/pkg/crypto"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
@@ -173,22 +172,6 @@ func InitChainer(baseApp *sdk.BaseApp, acctKpr auth.AccountKeeperI, bankKpr bank
 			Validators: req.Validators,
 		}
 	}
-}
-
-func parseBalance(bal string) (crypto.Address, std.Coins) {
-	parts := strings.Split(bal, "=")
-	if len(parts) != 2 {
-		panic(fmt.Sprintf("invalid balance string %s", bal))
-	}
-	addr, err := crypto.AddressFromBech32(parts[0])
-	if err != nil {
-		panic(fmt.Sprintf("invalid balance addr %s (%v)", bal, err))
-	}
-	coins, err := std.ParseCoins(parts[1])
-	if err != nil {
-		panic(fmt.Sprintf("invalid balance coins %s (%v)", bal, err))
-	}
-	return addr, coins
 }
 
 // XXX not used yet.


### PR DESCRIPTION
Currently CI is complaining about unused func `parseBalance`. Fixed it. 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
