### PR TITLE
feat: change docs paths to absolute 

### DIFF
--- a/contribs/gnokeykc/go.mod
+++ b/contribs/gnokeykc/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
-	go.etcd.io/bbolt v1.3.7 // indirect
+	go.etcd.io/bbolt v1.3.8 // indirect
 	go.opencensus.io v0.22.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/contribs/gnokeykc/go.mod
+++ b/contribs/gnokeykc/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
-	go.etcd.io/bbolt v1.3.8 // indirect
+	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opencensus.io v0.22.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/contribs/gnokeykc/go.sum
+++ b/contribs/gnokeykc/go.sum
@@ -147,6 +147,7 @@ github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
+go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.opencensus.io v0.22.5 h1:dntmOdLpSpHlVqbW5Eay97DelsZHe+55D+xC6i0dDS0=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/contribs/gnokeykc/go.sum
+++ b/contribs/gnokeykc/go.sum
@@ -147,7 +147,6 @@ github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
-go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.opencensus.io v0.22.5 h1:dntmOdLpSpHlVqbW5Eay97DelsZHe+55D+xC6i0dDS0=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=

--- a/docs/explanation/from-go-to-gno.md
+++ b/docs/explanation/from-go-to-gno.md
@@ -73,5 +73,5 @@ TODO
 
 ## See also
 
-- [go-gno-compatibility.md](../reference/go-gno-compatibility.md)
+- [go-gno-compatibility.md](/docs/reference/go-gno-compatibility.md)
 - ["go -> gno" presentation by Zack Scholl](https://github.com/gnolang/workshops/tree/main/presentations/2023-06-26--go-to-gno--schollz)

--- a/docs/explanation/gno-test.md
+++ b/docs/explanation/gno-test.md
@@ -7,7 +7,7 @@ id: gno-test
 There are two methods for testing a realm or package during the development phase:
 
 1. Calling the realm/package after deploying it on a local network (or testnet).
-2. Using the `test` option within the [`gno`](./gno-tooling/cli/gno.md) CLI.
+2. Using the `test` option within the [`gno`](/docs/explanation/gno-tooling/cli/gno.md) CLI.
 
 While the first method is recommended for its accuracy and similarity to the actual deployment environment, it is more efficient to initially utilize the second method for composing test cases and then proceed to the first method if no errors are detected.
 

--- a/docs/explanation/gnovm.md
+++ b/docs/explanation/gnovm.md
@@ -22,6 +22,6 @@ This enables non-web3 developers to contribute without requiring an understandin
 
 ## Getting started
 
-Install [`gno`](../getting-started/local-setup.md) and refer to the [`examples`](https://github.com/gnolang/gno/tree/master/examples) folder to start developing contracts.
+Install [`gno`](/docs/getting-started/local-setup.md) and refer to the [`examples`](https://github.com/gnolang/gno/tree/master/examples) folder to start developing contracts.
 
 Check the [Makefile](https://github.com/gnolang/gno/blob/master/gnovm/Makefile) to enhance GnoVM, Gnolang, and stdlibs.

--- a/docs/explanation/realms.md
+++ b/docs/explanation/realms.md
@@ -5,7 +5,7 @@ id: realms
 # Realms
 
 A realm refers to a specific instance of a smart contract that can be written
-in [Gnolang](./gno-language.md). The potentials of realms are endless - you can create virtually any
+in [Gnolang](/docs/explanation/gno-language.md). The potentials of realms are endless - you can create virtually any
 application in your mind with built-in composability,
 transparency, and censorship resistance. Here are some ideas of what you can build with realms:
 

--- a/docs/getting-started/browsing-gno-source-code.md
+++ b/docs/getting-started/browsing-gno-source-code.md
@@ -6,18 +6,18 @@ id: browsing-gno-source-code
 
 ## Overview
 
-In this tutorial, you will learn how to browse deployed Gno [Realms](../explanation/realms.md)
-and [Packages](../explanation/packages.md). Additionally, you will understand how the `Render` method is utilized
+In this tutorial, you will learn how to browse deployed Gno [Realms](/docs/explanation/realms.md)
+and [Packages](/docs/explanation/packages.md). Additionally, you will understand how the `Render` method is utilized
 to achieve Realm state visibility.
 
 ## Prerequisites
 
-- **`gnoweb` set up. Reference the [Local Setup](local-setup.md#3-installing-other-gno-tools) guide for steps**
+- **`gnoweb` set up. Reference the [Local Setup](/docs/getting-started/local-setup.md#3-installing-other-gno-tools) guide for steps**
 
 ## 1. Start the local chain
 
 In order for `gnoweb` to fetch realm and package source code, it needs to connect a running Gno node. For a better
-overview on running a local node, please reference the [Starting a Local Chain](setting-up-a-local-chain.md) guide.
+overview on running a local node, please reference the [Starting a Local Chain](/docs/getting-started/setting-up-a-local-chain.md) guide.
 
 In this guide, we will start a local node with the default configuration. Navigate to the `gno.land` sub-folder and run:
 
@@ -42,13 +42,13 @@ you can specify the remote URL with the `gnoweb` flag named `--remote`
 
 We should be able to access the website locally on http://127.0.0.1:8888/.
 
-![gnoweb screen](../assets/getting-started/browsing-gno-source-code/gnoweb.png)
+![gnoweb screen](/docs/assets/getting-started/browsing-gno-source-code/gnoweb.png)
 
 ## 3. Browse Package source code
 
 Packages in Gno.land usually have names resembling `gno.land/p/<name>`. Since packages do not contain state, we can only
 view their source code on-chain. To learn more about Packages, please check out
-the [Packages](../explanation/packages.md) explanation document.
+the [Packages](/docs/explanation/packages.md) explanation document.
 
 Using `gnoweb`, we can browse the source code in our browser.
 For example, the `avl` package is deployed at `gno.land/p/demo/avl`.
@@ -58,7 +58,7 @@ To access the source code of the `avl` package, we can append the `/p/demo/avl` 
 The final URL for the `avl` package source could be viewable at http://127.0.0.1:8888/p/demo/avl, if we followed
 default setup params, as we did in this guide.
 
-![gnoweb avl](../assets/getting-started/browsing-gno-source-code/gnoweb-avl.png)
+![gnoweb avl](/docs/assets/getting-started/browsing-gno-source-code/gnoweb-avl.png)
 
 From here, we can open any source code file of the deployed on-chain package and inspect its API.
 
@@ -68,7 +68,7 @@ In contrast to Packages, Realms in Gno.land usually have names resembling `gno.l
 
 Realms _do_ contain state, and in addition to being able to view their source code on-chain, users can also view their
 internal state representation in the form of the `Render()` output. To learn more about Realms, please
-check out the [Realms](../explanation/realms.md) explanation document.
+check out the [Realms](/docs/explanation/realms.md) explanation document.
 
 Using `gnoweb`, we can browse the Realm `Render()` method output and source code in our browser.
 For example, the `boards` Realm is deployed at `gno.land/r/demo/boards`.
@@ -80,7 +80,7 @@ The final URL for the `boards` Realm internal state could be viewable at http://
 followed
 default setup params, as we did in this guide.
 
-![gnoweb boards](../assets/getting-started/browsing-gno-source-code/gnoweb-boards.png)
+![gnoweb boards](/docs/assets/getting-started/browsing-gno-source-code/gnoweb-boards.png)
 
 :::info Render() is not required
 
@@ -93,4 +93,4 @@ Additionally, to view the source code for the realm, we simply need to append th
 
 http://127.0.0.1:8888/r/demo/boards/
 
-![gnoweb boards source](../assets/getting-started/browsing-gno-source-code/gnoweb-boards-source.png)
+![gnoweb boards source](/docs/assets/getting-started/browsing-gno-source-code/gnoweb-boards-source.png)

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -39,7 +39,7 @@ make build
 
 This will build out the necessary `gno` binary into the `gnovm/cmd` sub-folder:
 
-![gno tool build](../assets/getting-started/local-setup/make-build-gnovm.gif)
+![gno tool build](/docs/assets/getting-started/local-setup/make-build-gnovm.gif)
 
 Next, to make development easier, we need to make the binary available system-wide.
 From the same `gnovm` sub-folder, you can run:
@@ -56,7 +56,7 @@ gno --help
 
 You should get the help output from the command:
 
-![gno help](../assets/getting-started/local-setup/gno-help.gif)
+![gno help](/docs/assets/getting-started/local-setup/gno-help.gif)
 
 Alternatively, if you don't want to have the binary callable system-wide, you can run the binary directly:
 
@@ -68,10 +68,10 @@ go run ./cmd/gno --help
 
 The next step is to install several other tools that are required for the Gno development environment, like
 
-- `gnoland` - the Gno [blockchain node](setting-up-a-local-chain.md)
-- `gnokey` - the Gno [private key manager](working-with-key-pairs.md)
-- `gnoweb` - the Gno [source code viewer](browsing-gno-source-code.md)
-- `gnofaucet` - the Gno [native currency faucet](setting-up-funds/running-a-faucet.md)
+- `gnoland` - the Gno [blockchain node](/docs/getting-started/setting-up-a-local-chain.md)
+- `gnokey` - the Gno [private key manager](/docs/getting-started/working-with-key-pairs.md)
+- `gnoweb` - the Gno [source code viewer](/docs/getting-started/browsing-gno-source-code.md)
+- `gnofaucet` - the Gno [native currency faucet](/docs/getting-started/setting-up-funds/running-a-faucet.md)
 
 To build these tools, from the root directory navigate to the `gno.land` sub-folder, and run the `build` make
 directive:
@@ -83,7 +83,7 @@ make build
 
 This will build out the necessary binaries into the `gno.land/cmd` sub-folder:
 
-![gno tools build](../assets/getting-started/local-setup/make-build-gnoland.gif)
+![gno tools build](/docs/assets/getting-started/local-setup/make-build-gnoland.gif)
 
 Same as with the `gno` tool, we can make these binaries available system-wide.
 From the same `gno.land` sub-folder, you can run:
@@ -100,7 +100,7 @@ gnokey --help
 
 You should get the help output from the command:
 
-![gnokey help](../assets/getting-started/local-setup/gnokey-help.gif)
+![gnokey help](/docs/assets/getting-started/local-setup/gnokey-help.gif)
 
 ## Conclusion
 

--- a/docs/getting-started/setting-up-a-local-chain.md
+++ b/docs/getting-started/setting-up-a-local-chain.md
@@ -25,7 +25,7 @@ gnoland start
 The command will trigger a chain initialization process (if you haven't run the node before), and start the Gno node,
 which is ready to accept transactions and interact with other Gno nodes.
 
-![gnoland start](../assets/getting-started/setting-up-a-local-chain/gnoland-start.gif)
+![gnoland start](/docs/assets/getting-started/setting-up-a-local-chain/gnoland-start.gif)
 
 To view the command defaults, simply run the `help` command:
 

--- a/docs/getting-started/setting-up-funds/premining-balances.md
+++ b/docs/getting-started/setting-up-funds/premining-balances.md
@@ -15,7 +15,7 @@ have ample funds to interact with the chain and facilitate contract deployments.
 
 ## Prerequisites
 
-- **`gnoland` and `gnokey` set up. Reference the [Installation](../local-setup.md#3-installing-other-gno-tools) guide
+- **`gnoland` and `gnokey` set up. Reference the [Installation](/docs/getting-started/local-setup.md#3-installing-other-gno-tools) guide
   for steps**
 
 ## 1. Clean chain data
@@ -78,7 +78,7 @@ gnoland start
 This command will initialize the Gno node, generate the `genesis.json` with our newly added premine information, and
 start the chain.
 
-![gnoland start](../../assets/getting-started/setting-up-funds/gnoland-start.gif)
+![gnoland start](/docs/assets/getting-started/setting-up-funds/gnoland-start.gif)
 
 ## 3. Check the account balance
 
@@ -95,7 +95,7 @@ Let's break down this command:
 - **`bank/balances/g1qpymzwx4l4cy6cerdyajp9ksvjsf20rk5y9rtt`** - the ABCI query targets the `bank` module to find
   the `balances` for address `g1qpymzwx4l4cy6cerdyajp9ksvjsf20rk5y9rtt`. Replace the address with your desired address
 
-![gnokey query](../../assets/getting-started/setting-up-funds/gnokey-query.gif)
+![gnokey query](/docs/assets/getting-started/setting-up-funds/gnokey-query.gif)
 
 ## Conclusion
 

--- a/docs/getting-started/setting-up-funds/running-a-faucet.md
+++ b/docs/getting-started/setting-up-funds/running-a-faucet.md
@@ -13,20 +13,20 @@ haven't [premined a balance beforehand](premining-balances.md).
 ## Prerequisites
 
 - **`gnoland`, `gnofaucet` and `gnoweb` set up. Reference
-  the [Installation](../local-setup.md#3-installing-other-gno-tools) guide for steps**
+  the [Installation](/docs/getting-started/local-setup.md#3-installing-other-gno-tools) guide for steps**
 
 ## 1. Ensure a topped-up faucet address
 
 The Gno faucet works by designating a single address as a faucet address that will distribute funds.
 
-Ensure the faucet account will have enough funds by [premining its balance](premining-balances.md) to a high value.
+Ensure the faucet account will have enough funds by [premining its balance](/docs/getting-started/setting-up-funds/premining-balances.md) to a high value.
 In case you do not have an existing address added to `gnokey`, you can consult
-the [Working with Key Pairs](../working-with-key-pairs.md) guide.
+the [Working with Key Pairs](/docs/getting-started/working-with-key-pairs.md) guide.
 
 ## 2. Start the local chain
 
 After ensuring the faucet address will have enough funds in the premine, we
-can [run the local blockchain node](../setting-up-a-local-chain.md).
+can [run the local blockchain node](/docs/getting-started/setting-up-a-local-chain.md).
 Navigate to the `gno.land` sub-folder and run the appropriate make command:
 
 ```bash
@@ -50,7 +50,7 @@ The command will prompt you to enter the decryption password for the key you've 
 
 This will initialize the faucet to listen on port `5050`, by default.
 
-![gnofaucet serve](../../assets/getting-started/setting-up-funds/gnofaucet-serve.gif)
+![gnofaucet serve](/docs/assets/getting-started/setting-up-funds/gnofaucet-serve.gif)
 
 ## 4. Start the `gnoweb` interface
 
@@ -65,7 +65,7 @@ gnoweb
 
 This will initialize the `gnoweb` interface on `http://127.0.0.1:8888`.
 
-![gnoweb](../../assets/getting-started/setting-up-funds/gnoweb.gif)
+![gnoweb](/docs/assets/getting-started/setting-up-funds/gnoweb.gif)
 
 ## 5. Use the deployed faucet
 
@@ -73,7 +73,7 @@ Once `gnoweb` has been started, you can navigate to http://127.0.0.1:8888/faucet
 
 Simply input the desired address you wish to receive funds on (`1 GNOT` by default), and press the `GO` button.
 
-![gnofaucet page](../../assets/getting-started/setting-up-funds/faucet-page.png)
+![gnofaucet page](/docs/assets/getting-started/setting-up-funds/faucet-page.png)
 
 After you've added the address, you should see a success message in the browser:
 

--- a/docs/getting-started/working-with-key-pairs.md
+++ b/docs/getting-started/working-with-key-pairs.md
@@ -12,7 +12,7 @@ Gno.
 
 ## Prerequisites
 
-- **`gnokey` set up. Reference the [Local Setup](local-setup.md#3-installing-other-gno-tools) guide for steps**
+- **`gnokey` set up. Reference the [Local Setup](/docs/getting-started/local-setup.md#3-installing-other-gno-tools) guide for steps**
 
 ## Listing available keys
 
@@ -94,7 +94,7 @@ To generate the mnemonic phrase in the console, you can run:
 gnokey generate
 ```
 
-![gnokey generate](../assets/getting-started/creating-a-key-pair/gnokey-generate.gif)
+![gnokey generate](/docs/assets/getting-started/creating-a-key-pair/gnokey-generate.gif)
 
 ## Adding a random private key
 
@@ -111,7 +111,7 @@ After you enter the password, the `gnokey` tool will add the key to the keystore
 phrase](https://en.bitcoin.it/wiki/Seed_phrase), which you should remember somewhere if you want to recover the key at a
 future point in time.
 
-![gnokey add random](../assets/getting-started/creating-a-key-pair/gnokey-add-random.gif)
+![gnokey add random](/docs/assets/getting-started/creating-a-key-pair/gnokey-add-random.gif)
 
 You can check that the key was indeed added to the keystore, by listing available keys:
 
@@ -119,7 +119,7 @@ You can check that the key was indeed added to the keystore, by listing availabl
 gnokey list
 ```
 
-![gnokey list](../assets/getting-started/creating-a-key-pair/gnokey-list.gif)
+![gnokey list](/docs/assets/getting-started/creating-a-key-pair/gnokey-list.gif)
 
 ## Adding a private key using a mnemonic
 
@@ -136,7 +136,7 @@ Of course, you can replace `MyKey` with whatever name you want for your key.
 By following the prompts to encrypt the key on disk, and providing a BIP39 mnemonic, we can successfully add
 the key to the keystore.
 
-![gnokey add mnemonic](../assets/getting-started/creating-a-key-pair/gnokey-add-mnemonic.gif)
+![gnokey add mnemonic](/docs/assets/getting-started/creating-a-key-pair/gnokey-add-mnemonic.gif)
 
 ## Deleting a private key
 
@@ -171,7 +171,7 @@ Follow the prompts presented in the terminal. Namely, you will be asked to decry
 and later to encrypt the armor file on disk. It is worth noting that you can also export unencrypted key armor, using
 the `--unsafe` flag.
 
-![gnokey export](../assets/getting-started/creating-a-key-pair/gnokey-export.gif)
+![gnokey export](/docs/assets/getting-started/creating-a-key-pair/gnokey-export.gif)
 
 ## Importing a private key
 
@@ -188,4 +188,4 @@ flag), and then to provide an encryption password for storing the key in the key
 
 After executing the previous command, the `gnokey` keystore will have imported `ImportedKey`.
 
-![gnokey import](../assets/getting-started/creating-a-key-pair/gnokey-import.gif)
+![gnokey import](/docs/assets/getting-started/creating-a-key-pair/gnokey-import.gif)

--- a/docs/how-to-guides/creating-grc20.md
+++ b/docs/how-to-guides/creating-grc20.md
@@ -6,7 +6,7 @@ id: creating-grc20
 
 ## Overview
 
-This guide shows you how to write a simple _GRC20_ Smart Contract, or rather a [Realm](../explanation/realms.md), in [Gno (Gnolang)](../explanation/gno-language.md). For actually deploying the Realm, please see the [deployment](deploy.md) guide.
+This guide shows you how to write a simple _GRC20_ Smart Contract, or rather a [Realm](/docs/explanation/realms.md), in [Gno (Gnolang)](/docs/explanation/gno-language.md). For actually deploying the Realm, please see the [deployment](deploy.md) guide.
 
 Our _GRC20_ Realm will have the following functionality:
 
@@ -153,7 +153,7 @@ Detailing what is happening in the above code:
 - Calling the `Mint` method would create a configurable number of tokens by the administrator.
 - Calling the `Burn` method would destroy a configurable number of tokens by the administrator.
 - Calling the `Render` method would return a user's `balance` as a formatted string. Learn more about the `Render`
-  method and how it's used [here](../explanation/realms.md).
+  method and how it's used [here](/docs/explanation/realms.md).
 - Finally, we provide a local function to assert that the calling account is in fact the owner, otherwise panic. This is a very important function that serves to prevent abuse by non-administrators.
 
 ## Conclusion

--- a/docs/how-to-guides/creating-grc721.md
+++ b/docs/how-to-guides/creating-grc721.md
@@ -6,8 +6,8 @@ id: creating-grc721
 
 ## Overview
 
-This guide shows you how to write a simple _GRC721_ Smart Contract, or rather a [Realm](../explanation/realms.md),
-in [Gno (Gnolang)](../explanation/gno-language.md). For actually deploying the Realm, please see
+This guide shows you how to write a simple _GRC721_ Smart Contract, or rather a [Realm](/docs/explanation/realms.md),
+in [Gno (Gnolang)](/docs/explanation/gno-language.md). For actually deploying the Realm, please see
 the [deployment](deploy.md) guide.
 
 Our _GRC721_ Realm will have the following functionality:
@@ -186,7 +186,7 @@ Detailing what is happening in the above code:
   method on the `grc721` instance we instantiated at the top of the file; this method returns a formatted string that
   includes the token: symbol, supply and account balances (`balances avl.Tree`) which is a mapping denoted
   as: `OwnerAddress -> TokenCount`; otherwise returns false and renders a `404`; you can find more information about
-  this `Render` method and how it's used [here](../explanation/realms.md).
+  this `Render` method and how it's used [here](/docs/explanation/realms.md).
 - Finally, we provide a local function to assert that the calling account is in fact the owner, otherwise panic. This is
   a very important function that serves to prevent abuse by non-administrators.
 

--- a/docs/how-to-guides/interact-with-gnoland.md
+++ b/docs/how-to-guides/interact-with-gnoland.md
@@ -8,7 +8,7 @@ This tutorial will teach you how to interact with the gno.land blockchain by cre
 
 ## Prerequisites
 
-- [Installation](../getting-started/local-setup.md)
+- [Installation](/docs/getting-started/local-setup.md)
 
 ## Create an Account
 

--- a/docs/how-to-guides/simple-contract.md
+++ b/docs/how-to-guides/simple-contract.md
@@ -6,9 +6,9 @@ id: simple-contract
 
 ## Overview
 
-This guide shows you how to write a simple _Counter_ Smart Contract, or rather a [Realm](../explanation/realms.md),
-in [Gno (Gnolang)](../explanation/gno-language.md). For actually deploying the Realm, please see
-the [deployment](deploy.md) guide.
+This guide shows you how to write a simple _Counter_ Smart Contract, or rather a [Realm](/docs/explanation/realms.md),
+in [Gno (Gnolang)](/docs/explanation/gno-language.md). For actually deploying the Realm, please see
+the [deployment](/docs/how-to-guides/deploy.md) guide.
 
 Our _Counter_ Realm will have the following functionality:
 
@@ -50,8 +50,8 @@ cd counter-app
 mkdir r
 ```
 
-Alternatively, if we were writing a [Gno Package](../explanation/packages.md), we would denote this directory name
-as `p` (for `package`). You can learn more about Packages in our [Package development guide](simple-library.md).
+Alternatively, if we were writing a [Gno Package](/docs/explanation/packages.md), we would denote this directory name
+as `p` (for `package`). You can learn more about Packages in our [Package development guide](/docs/how-to-guides/simple-library.md).
 
 Additionally, we will create another sub-folder that will house our Realm code, named `counter`:
 
@@ -115,7 +115,7 @@ There are a few things happening here, so let's dissect them:
 - `Increment` and `Decrement` are public Realm (Smart Contract) methods, and as such are callable by users.
 - `Increment` and `Decrement` directly modify the `count` value by making it go up or down (change state).
 - Calling the `Render` method would return the `count` value as a formatted string. Learn more about the `Render`
-  method and how it's used [here](../explanation/realms.md).
+  method and how it's used [here](/docs/explanation/realms.md).
 
 :::info A note on constructors
 Gno Realms support a concept taken from other programming languages - _constructors_.

--- a/docs/how-to-guides/simple-library.md
+++ b/docs/how-to-guides/simple-library.md
@@ -8,7 +8,7 @@ id: simple-library
 
 This guide shows you how to write a simple library (Package) in Gnolang, which can be used by other Packages and Realms.
 Packages are _stateless_, meaning they do not hold state like regular Realms (Smart Contracts). To learn more about the
-intricacies of Packages, please see the [Packages reference](../explanation/packages.md).
+intricacies of Packages, please see the [Packages reference](/docs/explanation/packages.md).
 
 The Package we will be writing today will be a simple library for suggesting a random tapas dish.
 We will define a set list of tapas, and define a method that randomly selects a dish from the list.
@@ -30,7 +30,7 @@ and [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=har
 ## 1. Setting up the work directory
 
 We discussed Gno folder structures more in detail in
-the [simple Smart Contract guide](simple-contract.md#1-setting-up-the-work-directory).
+the [simple Smart Contract guide](/docs/how-to-guides/simple-contract.md#1-setting-up-the-work-directory).
 For now, we will just follow some rules outlined there.
 
 Create the main working directory for our Package:

--- a/docs/how-to-guides/testing-gno.md
+++ b/docs/how-to-guides/testing-gno.md
@@ -12,13 +12,13 @@ testing techniques that involve data mocking.
 
 ## Prerequisites
 
-- **`gno` set up. Reference the [Installation](../getting-started/local-setup.md#3-installing-other-gno-tools) guide
+- **`gno` set up. Reference the [Installation](/docs/getting-started/local-setup.md#3-installing-other-gno-tools) guide
   for steps**
 
 ## Example Realm
 
 For the purpose of this guide, we will be testing the simple *Counter* Realm created in
-the [How to write a simple Gno Smart Contract (Realm)](simple-contract.md) guide.
+the [How to write a simple Gno Smart Contract (Realm)](/docs/how-to-guides/simple-contract.md) guide.
 
 [embedmd]:# (../assets/how-to-guides/testing-gno/counter-1.gno go)
 ```go
@@ -175,7 +175,7 @@ Luckily, the Gno standard library provides ample support for functionality such 
 time, such as the request caller address, or the calling package address.
 
 You can learn more about these methods, that are importable using the `std` import declaration,
-in the [Standard Library](../reference/standard-library.md) reference section.
+in the [Standard Library](/docs/reference/standard-library.md) reference section.
 
 ## Conclusion
 

--- a/docs/how-to-guides/write-simple-dapp.md
+++ b/docs/how-to-guides/write-simple-dapp.md
@@ -116,7 +116,7 @@ A few remarks:
 
 :::info
 After testing the `Poll` package, we need to deploy it in order to use it in our realm.
-Check out the [deployment](deploy.md) guide to learn how to do this.
+Check out the [deployment](/docs/how-to-guides/deploy.md) guide to learn how to do this.
 :::
 
 ### Poll Factory Realm

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,4 +1,4 @@
- * [eris_agreement.pdf](./eris_agreement.pdf) - This 2015 agreement was
+ * [eris_agreement.pdf](/docs/legal/eris_agreement.pdf) - This 2015 agreement was
    necessary to publish Tendermint under Apache2.0. Since then Eris Industries
    has become Monax.  Ethan Buchman at the time was an external contributor
    from Eris Industries to the Tendermint project. Due to intermixing of

--- a/docs/reference/gno-js-client/gno-provider.md
+++ b/docs/reference/gno-js-client/gno-provider.md
@@ -5,7 +5,7 @@ id: gno-js-provider
 # Gno Provider
 
 The `Gno Provider` is an extension on the `tm2-js-client` `Provider`,
-outlined [here](../tm2-js-client/Provider/provider.md). Both JSON-RPC and WS providers are included with the package.
+outlined [here](/docs/reference/tm2-js-client/Provider/provider.md). Both JSON-RPC and WS providers are included with the package.
 
 ## Realm Methods
 

--- a/docs/reference/gno-js-client/gno-wallet.md
+++ b/docs/reference/gno-js-client/gno-wallet.md
@@ -4,7 +4,7 @@ id: gno-js-wallet
 
 # Gno Wallet
 
-The `Gno Wallet` is an extension on the `tm2-js-client` `Wallet`, outlined [here](../tm2-js-client/wallet.md).
+The `Gno Wallet` is an extension on the `tm2-js-client` `Wallet`, outlined [here](/docs/reference/tm2-js-client/wallet.md).
 
 ## Account Methods
 

--- a/docs/reference/standard-library.md
+++ b/docs/reference/standard-library.md
@@ -4,7 +4,7 @@ id: standard-library
 
 # Gno Standard Library
 
-When developing a realm in Gnolang, developers may utilize libraries in [stdlibs](https://github.com/gnolang/gno/tree/master/stdlibs). These are the core standard packages provided for Gnolang [Realms ](../explanation/realms.md)& [Packages](../explanation/packages.md).
+When developing a realm in Gnolang, developers may utilize libraries in [stdlibs](https://github.com/gnolang/gno/tree/master/stdlibs). These are the core standard packages provided for Gnolang [Realms ](/docs/explanation/realms.md)& [Packages](/docs/explanation/packages.md).
 
 Libraries can be imported in a manner similar to how libraries are imported in Golang.
 

--- a/docs/reference/tm2-js-client/Provider/provider.md
+++ b/docs/reference/tm2-js-client/Provider/provider.md
@@ -11,8 +11,8 @@ that users can use and expects concrete types in return.
 
 Currently, the `tm2-js-client` package provides support for two Provider implementations:
 
-- [JSON-RPC Provider](json-rpc-provider.md): executes each call as a separate HTTP RPC call.
-- [WS Provider](ws-provider.md): executes each call through an active WebSocket connection, which requires closing when
+- [JSON-RPC Provider](/docs/reference/tm2-js-client/Provider/json-rpc-provider.md): executes each call as a separate HTTP RPC call.
+- [WS Provider](/docs/reference/tm2-js-client/Provider/ws-provider.md): executes each call through an active WebSocket connection, which requires closing when
   not needed anymore.
 
 ## Account Methods

--- a/docs/reference/tm2-js-client/Signer/signer.md
+++ b/docs/reference/tm2-js-client/Signer/signer.md
@@ -9,8 +9,8 @@ signing data, verifying signatures, and getting metadata associated with the key
 
 Currently, the `tm2-js-client` package provides support for two `Signer` implementations:
 
-- [Key](key.md): a signer that is based on a raw Secp256k1 key pair.
-- [Ledger](ledger.md): a signer that is based on a Ledger device, with all interaction flowing through the user's
+- [Key](/docs/reference/tm2-js-client/Signer/key.md): a signer that is based on a raw Secp256k1 key pair.
+- [Ledger](/docs/reference/tm2-js-client/Signer/ledger.md): a signer that is based on a Ledger device, with all interaction flowing through the user's
   device.
 
 ## API


### PR DESCRIPTION
## Description

This PR updates all links within the `docs/` folder from relative paths to absolute paths (root is `/docs/`). 

Closes: #1354 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
