### PR TITLE
docs(vim-lsp): enable buildOnSave option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,9 @@ function! s:on_lsp_buffer_enabled() abort
     autocmd BufWritePre <buffer> LspDocumentFormatSync
     " Some optionnal mappings
     nmap <buffer> <leader>i <Plug>(lsp-hover) 
+    nmap <buffer> gd <plug>(lsp-definition)     
+    nmap <buffer> <leader>rf <plug>(lsp-references)
     " Following mappings are not supported yet by gnols
-    " nmap <buffer> gd <plug>(lsp-definition)     
     " nmap <buffer> <leader>rr <plug>(lsp-rename)
 endfunction
 augroup lsp_install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ if (executable('gnols'))
         \   'root' : '/path/to/gno_repo',
         \	'gno'  : '/path/to/gno_bin',
         \   'precompileOnSave' : v:true,
-        \   'buildOnSave'      : v:false,
+        \   'buildOnSave'      : v:true,
         \ },
         \ 'languageId': {server_info->'gno'},
     \ })


### PR DESCRIPTION
Enabling this option gives better error detection.

For example, this code returns no diagnostics (errors in LSP lexic) if buildOnSave is false:

```go
package main

func main() {
  xxx
}
```

While the `undefined: xxx` is part of the diagnostics when buildOnSave is true.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
