### PR TITLE
chore: In processSig, clarify the signature verification failed error message

### DIFF
--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -238,7 +238,7 @@ func processSig(
 	}
 
 	if !simulate && !pubKey.VerifyBytes(signBytes, sig.Signature) {
-		return nil, abciResult(std.ErrUnauthorized("signature verification failed; verify correct account sequence and chain-id"))
+		return nil, abciResult(std.ErrUnauthorized("signature verification failed; verify correct account, sequence, and chain-id"))
 	}
 
 	if err := acc.SetSequence(acc.GetSequence() + 1); err != nil {


### PR DESCRIPTION
There are three ways that a signature verification can fail: bad account number, bad sequence number and wrong chain ID. The current error message says "verify correct account sequence and chain-id". This is confusing. For example, it may seem that "account sequence" is one thing. This PR clarifies the error message by adding commas: "verify correct account, sequence, and chain-id".