### PR TITLE
fix: In demo/boards/README.md, the chainid for test3.gno.land should be test3

### DIFF
--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -9,7 +9,7 @@ name ["gno.land/r/demo/boards"](https://gno.land/r/demo/boards/)
 
 NOTE: Where you see `-remote localhost:26657` here, that flag can be replaced
 with `-remote test3.gno.land:36657` if you have $GNOT on the testnet.
-(To use the testnet, also replace `-chainid dev` with `-chainid testchain` .)
+(To use the testnet, also replace `-chainid dev` with `-chainid test3` .)
 
 ### Build `gnokey` (and other tools).
 


### PR DESCRIPTION
This is a follow-up to PR #1034 which updated the documentation in demo/boards/README.md . The chainid for test3.gno.land should be "test3" (not "testnet").