### PR TITLE
fix(cmd/gno): log panic information in gno test

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -549,6 +549,8 @@ proc.go:250               runtime.main
 asm_amd64.s:1598          runtime.goexit
 */
 func smallStacktrace() string {
+	const unicodeEllipsis = "\u2026"
+
 	var buf bytes.Buffer
 	pc := make([]uintptr, 100)
 	pc = pc[:runtime.Callers(2, pc)]
@@ -560,7 +562,13 @@ func smallStacktrace() string {
 			f.Function = f.Function[idx+1:]
 		}
 
-		fmt.Fprintf(&buf, "%-25s %s\n", fmt.Sprintf("%s:%d", filepath.Base(f.File), f.Line), f.Function)
+		// trim full path to at most 30 characters
+		fullPath := fmt.Sprintf("%s:%-4d", f.File, f.Line)
+		if len(fullPath) > 30 {
+			fullPath = unicodeEllipsis + fullPath[len(fullPath)-29:]
+		}
+
+		fmt.Fprintf(&buf, "%30s %s\n", fullPath, f.Function)
 
 		if !more {
 			return buf.String()


### PR DESCRIPTION
Before:

```
gno test -verbose .
=== RUN   TestFtoa
panic: cannot convert BigintKind to Uint64Kind

goroutine 1 [running]:
github.com/gnolang/gno/gnovm/pkg/gnolang.ConvertTo(0x0, {0xecc8b8, 0xc00026c3f0}, 0xc00011e190, {0xebe6d8, 0xeb0d78})
        /home/howl/oc/gno/gnovm/pkg/gnolang/values_conversions.go:868 +0x6479
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).doOpConvert(0xc0000f4a20)
        /home/howl/oc/gno/gnovm/pkg/gnolang/op_expressions.go:699 +0x71
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).Run(0xc0000f4a20)
        /home/howl/oc/gno/gnovm/pkg/gnolang/machine.go:1227 +0xfce
[... more stacktrace ...]
```

After:

```
=== RUN   TestFtoa
.: test pkg: panic: cannot convert BigintKind to Uint32Kind
gno machine: Machine:
    CheckTypes: false
	Op: [OpHalt OpBody OpRangeIter OpPopBlock OpBody OpReturn OpBody OpPopResults OpExec OpBody OpPopResults OpExec OpBody OpForLoop OpPopBlock OpBody OpDefine OpBody OpReturn OpPrecall OpBody OpPopBlock OpBody OpPopBlock OpBody OpPopBlock OpBody OpPopResults OpExec OpBody OpDefine]
	Values: (len: 9)
          #8 (ryuFtoaFixed32 func(d *gno.land/r/fG5GBXmX.decimalSlice,mant uint32,exp int,prec int)())
          #7 (genericFtoa func(dst []uint8,val float64,fmt uint8,prec int,bitSize int)( []uint8))
          #6 (typeval{string} type{})
          #5 (FormatFloat func(f float64,fmt uint8,prec int,bitSize int)( string))
          #4 (TestFtoa func(t *testing.T)())
          #3 (tRunner func(t *testing.T,fn testing.testingFunc,logSteps bool)())
          #2 (RunTest func(runFlag string,verbose bool,test testing.InternalTest)(ret string))
          #1 (slice[(struct{("TestFtoa" string),(TestFtoa func(t *testing.T)())} testing.InternalTest),(struct{("TestFormatFloatInvalidBitSize" string),(TestFormatFloatInvalidBitSize func(t *testing.T)())} testing.InternalTest)] []testing.InternalTest)
          #0 (runtest func(name string)(report string))
	Exprs:
          #0 (const-type string)(genericFtoa<VPBlock(3,12)>((const (make func(t type{},z ...interface{})( []uint8)))([](const-type uint8), (const (0 int)), max<VPBlock(3,21)>(prec<VPBlock(1,2)> + (const (4 int)), (const (24 int)))), f<VPBlock(1,0)>, fmt<VPBlock(1,1)>, prec<VPBlock(1,2)>, bitSize<VPBlock(1,3)>))
	Stmts:
          #16 bodyStmt[0/0/12]=di<VPBlock(1,7)>, dfrac<VPBlock(1,12)> := di<VPBlock(1,7)> >> extra<VPBlock(1,10)>, di<VPBlock(1,7)> & extraMask<VPBlock(1,11)>*
          #15 return
          #14 bodyStmt[0/0/2]=ok<VPBlock(4,12)> = (const (true bool))
          #13 bodyStmt[0/0/4]=(end)
          #12 bodyStmt[0/0/1]=(end)
          #11 bodyStmt[0/0/14]=if !ok<VPBlock(2,12)> { return bigFtoa<VPBlock(4,13)>(dst<VPBlock(2,0)>, prec<VPBlock(2,3)>, fmt<VPBlock(2,2)>, (const-type bool)(neg<VPBlock(2,8)>), mant<VPBlock(2,10)>, exp<VPBlock(2,9)>, flt<VPBlock(2,7)>) }
          #10 bodyStmt[0/0/1]=(end)
          #9 bodyStmt[0/0/1]=if (const-type bool)(s<VPBlock(2,0)> != test<VPBlock(3,1)>.s) { t<VPBlock(4,0)>.Error((const ("testN=32" string)), test<VPBlock(3,1)>.f, (const-type string)(test<VPBlock(3,1)>.fmt), test<VPBlock(3,1)>.prec, (const ("want" string)), test<VPBlock(3,1)>.s, (const ("got" string)), s<VPBlock(2,0)>) }*
          #8 bodyStmt[0/0/6]=(end)
          #7 bodyStmt[0/0/1]=(end)
          #6 return
          #5 bodyStmt[0/0/4]=t<VPBlock(1,0)>.finished = (const (true bool))
          #4 return
          #3 bodyStmt[0/0/3]=report<VPBlock(1,5)> := t<VPBlock(1,4)>.report()
          #2 bodyStmt[0/0/1]=(end)
          #1 bodyStmt[2/0/1]=(end)
          #0 bodyStmt[0/0/1]=panic((const ("no such test: " string)) + name<VPBlock(1,0)>)*
	Blocks:
          @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2d2c0,Source:func ryuFtoaFixed32(d *(decimalS...,Parent:0xc000bf43c0)
            d: (&0xc004331cb8.(*gno.land/r/fG5GBXmX.decimalSlice) *gno.land/r/fG5GBXmX.decimalSlice)
            mant: (16777216 uint32)
            exp: (-23 int)
            prec: (6 int)
            e2: (-24 int)
            q: (5 int)
            exact: (true bool)
            di: (1638400000 uint32)
            dexp2: (-14 int)
            d0: (true bool)
            extra: (14 uint)
            extraMask: (undefined)
            dfrac: (undefined)
            roundUp: (undefined)
 (s vals) @(1) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc00036bc20,Source:func ryuFtoaFixed32(d *(decimalS...,Parent:0xc00052f620)
            d: (nil *gno.land/r/fG5GBXmX.decimalSlice)
            mant: (0 uint32)
            exp: (0 int)
            prec: (0 int)
            e2: (0 int)
            q: (0 int)
            exact: (false <untyped> bool)
            di: (0 uint32)
            dexp2: (0 int)
            d0: (false bool)
            extra: (0 uint)
            extraMask: (0 uint32)
            dfrac: (0 uint32)
            roundUp: (false bool)
 (s typs) @(1) [*gno.land/r/fG5GBXmX.decimalSlice uint32 int int int int <untyped> bool uint32 int bool uint uint32 uint32 bool]
          @(2) Block(ID:89285d5563b8e2373ce3416c367151d9c4102930:5,Addr:0xc000bf43c0,Source:file{ package strconv; import bi...,Parent:0xc0003325a0)
            bits: (package(bits math/bits) package{})
 (s vals) @(2) Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc00052f620,Source:file{ package strconv; import bi...,Parent:0xc00037ede0)
            bits: (package(bits math/bits) package{})
 (s typs) @(2) [package{}]
          @(3) gno.land/r/fG5GBXmX
	Blocks (other):
          #13 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2d0e0,Source:if (const-type bool)(bitSize<VPB...,Parent:0xc004f2cd20)
 (static) #13 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc00016b020,Source:if (const-type bool)(bitSize<VPB...,Parent:0xc00016bac8)
          #12 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2cd20,Source:if (const-type bool)(fmt<VPBlock...,Parent:0xc004f2cb40)
 (static) #12 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc00016b820,Source:if (const-type bool)(fmt<VPBlock...,Parent:0xc000170568)
          #11 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2cb40,Source:if (const-type bool)(shortest<VP...,Parent:0xc004f2be00)
 (static) #11 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc000170020,Source:if (const-type bool)(shortest<VP...,Parent:0xc000701420)
          #10 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2be00,Source:func genericFtoa(dst [](const-ty...,Parent:0xc0017a0000)
            dst: (slice[0x] []uint8)
            val: (1 float64)
            fmt: (101 uint8)
            prec: (5 int)
            bitSize: (32 int)
            .res_0: (nil []uint8)
            bits: (1065353216 uint64)
            flt: (&0xc005fd7668.(*gno.land/r/fG5GBXmX.floatInfo) *gno.land/r/fG5GBXmX.floatInfo)
            neg: (false bool)
            exp: (0 int)
            mant: (8388608 uint64)
            digs: (struct{(slice[0x000000000000000000000000000000000000000000000000] []uint8),(0 int),(0 int)} gno.land/r/fG5GBXmX.decimalSlice)
            ok: (false bool)
            shortest: (false bool)
 (static) #10 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc000701420,Source:func genericFtoa(dst [](const-ty...,Parent:0xc00023c2e0)
            dst: (nil []uint8)
            val: (0 float64)
            fmt: (0 uint8)
            prec: (0 int)
            bitSize: (0 int)
            .res_0: (nil []uint8)
            bits: (undefined)
            flt: (undefined)
            neg: (false <untyped> bool)
            exp: (0 int)
            mant: (0 uint64)
            digs: (undefined)
            ok: (false bool)
            shortest: (false <untyped> bool)
          #9 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2b680,Source:func FormatFloat(f (const-type f...,Parent:0xc0017a0000)
            f: (1 float64)
            fmt: (101 uint8)
            prec: (5 int)
            bitSize: (32 int)
            .res_0: ( string)
 (static) #9 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc000700c20,Source:func FormatFloat(f (const-type f...,Parent:0xc00023c2e0)
            f: (0 float64)
            fmt: (0 uint8)
            prec: (0 int)
            bitSize: (0 int)
            .res_0: ( string)
          #8 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004f2b4a0,Source:if (const-type bool)((const-type...,Parent:0xc004d60780)
 (static) #8 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0004e4020,Source:if (const-type bool)((const-type...,Parent:0xc0003fac20)
          #7 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004d60780,Source:for i<VPBlock(1,0)> := (const (0...,Parent:0xc004d605a0)
            i: (0 int)
            test: (&0xc0080f1300.(*gno.land/r/fG5GBXmX.ftoaTest) *gno.land/r/fG5GBXmX.ftoaTest)
            s: ("1.00000e+00" string)
            x: (slice[0x616263312E3030303030652B3030] []uint8)
 (static) #7 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0003fac20,Source:for i<VPBlock(1,0)> := (const (0...,Parent:0xc000101420)
            i: (0 int)
            test: (nil *gno.land/r/fG5GBXmX.ftoaTest)
            s: ( string)
            x: (nil []uint8)
          #6 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004d605a0,Source:func TestFtoa(t *(testing<VPBloc...,Parent:0xc008cd8000)
            t: (&0xc0049c01e0.(*testing.T) *testing.T)
 (static) #6 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc000101420,Source:func TestFtoa(t *(testing<VPBloc...,Parent:0xc0004ee020)
            t: (nil *testing.T)
          #5 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c39c20,Source:func tRunner(t *(T<VPBlock(2,3)>...,Parent:0xc0083aa780)
            t: (&0xc0049c01e0.(*testing.T) *testing.T)
            fn: (TestFtoa func(t *testing.T)())
            logSteps: (false bool)
 (static) #5 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc001ff8020,Source:func tRunner(t *(T<VPBlock(2,3)>...,Parent:0xc0008ed620)
            t: (nil *testing.T)
            fn: (nil testing.testingFunc)
            logSteps: (false bool)
          #4 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c39860,Source:func RunTest(runFlag (const-type...,Parent:0xc0083aa780)
            runFlag: ("" string)
            verbose: (true bool)
            test: (struct{("TestFtoa" string),(TestFtoa func(t *testing.T)())} testing.InternalTest)
            ret: ( string)
            t: (&0xc0049c01e0.(*testing.T) *testing.T)
            report: (undefined)
            out: (undefined)
 (static) #4 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc001fefc20,Source:func RunTest(runFlag (const-type...,Parent:0xc0008ed620)
            runFlag: ( string)
            verbose: (false bool)
            test: (nil testing.InternalTest)
            ret: ( string)
            t: (nil *testing.T)
            report: (nil testing.Report)
            out: (nil gonative{[]uint8})
          #3 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c39680,Source:if (const-type bool)(test<VPBloc...,Parent:0xc004c394a0)
 (static) #3 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc0083f1020,Source:if (const-type bool)(test<VPBloc...,Parent:0xc00bfc6f20)
          #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c394a0,Source:for _<VPBlock(0,0)>, test<VPBloc...,Parent:0xc004c392c0)
            test: (struct{("TestFtoa" string),(TestFtoa func(t *testing.T)())} testing.InternalTest)
 (static) #2 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc00bfc6f20,Source:for _<VPBlock(0,0)>, test<VPBloc...,Parent:0xc009e5e420)
            test: (nil testing.InternalTest)
          #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc004c392c0,Source:func runtest(name (const-type st...,Parent:0xc004c38f00)
            name: ("TestFtoa" string)
            report: ( string)
 (static) #1 Block(ID:0000000000000000000000000000000000000000:0,Addr:0xc009e5e420,Source:func runtest(name (const-type st...,Parent:0xc0082d1ba0)
            name: ( string)
            report: ( string)
	Frames:
          #8 [FRAME FUNC:ryuFtoaFixed32 RECV:(undefined) (4 args) 28/8/1/15/14 LASTPKG:gno.land/r/fG5GBXmX LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #7 [FRAME FUNC:genericFtoa RECV:(undefined) (5 args) 20/7/1/11/10 LASTPKG:gno.land/r/fG5GBXmX LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #6 [FRAME FUNC:FormatFloat RECV:(undefined) (4 args) 17/5/0/10/9 LASTPKG:gno.land/r/fG5GBXmX LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #5 [FRAME LABEL:  13/5/0/8/7]
          #4 [FRAME FUNC:TestFtoa RECV:(undefined) (1 args) 11/4/0/6/6 LASTPKG:testing LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #3 [FRAME FUNC:tRunner RECV:(undefined) (3 args) 8/3/0/4/5 LASTPKG:testing LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #2 [FRAME FUNC:RunTest RECV:(undefined) (3 args) 6/2/0/3/4 LASTPKG:gno.land/r/fG5GBXmX LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
          #1 [FRAME LABEL:  2/1/0/1/2]
          #0 [FRAME FUNC:runtest RECV:(undefined) (1 args) 1/0/0/0/1 LASTPKG:gno.land/r/fG5GBXmX LASTRLM:Realm{Path:"gno.land/r/fG5GBXmX",Time:881}#89285D5563B8E2373CE3416C367151D9C4102930]
	Realm:
	  gno.land/r/fG5GBXmX
	Exceptions:
	  []
	  
stracktrace:
test.go:446               main.runTestFiles.func1
panic.go:914              runtime.gopanic
values_conversions.go:868 gnolang.ConvertTo
op_expressions.go:699     gnolang.(*Machine).doOpConvert
machine.go:1227           gnolang.(*Machine).Run
machine.go:636            gnolang.(*Machine).Eval
test.go:478               main.runTestFiles
test.go:346               main.gnoTestPkg
test.go:257               main.execTest
test.go:99                main.newTestCmd.func1
command.go:233            commands.(*Command).Run
command.go:237            commands.(*Command).Run
command.go:118            commands.(*Command).ParseAndRun
main.go:14                main.main
proc.go:267               runtime.main
asm_amd64.s:1650          runtime.goexit
; panic: gno.land/r/fG5GBXmX_test/decimal_test.gno:5: dot imports not allowed in Gno
gno machine: Machine:
    CheckTypes: false
	Op: []
	Values: (len: 0)

	Exprs:

	Stmts:

	Blocks:
          @(1) gno.land/r/fG5GBXmX_test
	Blocks (other):

	Frames:

	Realm:
	  gno.land/r/fG5GBXmX_test
	Exceptions:
	  []
	  
stracktrace:
stracktrace:
…no/gnovm/cmd/gno/test.go:446  main.runTestFiles.func1
…/go/src/runtime/panic.go:914  runtime.gopanic
…kg/gnolang/preprocess.go:173  gnolang.Preprocess.func2.1
…/go/src/runtime/panic.go:920  runtime.gopanic
…o/src/math/big/natdiv.go:520  big.nat.div
…b/go/src/math/big/int.go:268  big.(*Int).Quo
…pkg/gnolang/op_binary.go:870  gnolang.quoAssign
…pkg/gnolang/op_binary.go:256  gnolang.(*Machine).doOpQuo
…m/pkg/gnolang/machine.go:1154 gnolang.(*Machine).Run
…m/pkg/gnolang/machine.go:662  gnolang.(*Machine).EvalStatic
…kg/gnolang/preprocess.go:2150 gnolang.evalConst
…kg/gnolang/preprocess.go:784  gnolang.Preprocess.func2
…kg/gnolang/transcribe.go:728  gnolang.transcribe
…kg/gnolang/transcribe.go:371  gnolang.transcribe
…kg/gnolang/transcribe.go:670  gnolang.transcribe
…kg/gnolang/transcribe.go:708  gnolang.transcribe
…kg/gnolang/transcribe.go:133  gnolang.Transcribe
…kg/gnolang/preprocess.go:149  gnolang.Preprocess
…m/pkg/gnolang/machine.go:443  gnolang.(*Machine).runFiles
…m/pkg/gnolang/machine.go:398  gnolang.(*Machine).RunFiles
…no/gnovm/cmd/gno/test.go:466  main.runTestFiles
…no/gnovm/cmd/gno/test.go:346  main.gnoTestPkg
…no/gnovm/cmd/gno/test.go:257  main.execTest
…no/gnovm/cmd/gno/test.go:99   main.newTestCmd.func1
…/pkg/commands/command.go:233  commands.(*Command).Run
…/pkg/commands/command.go:237  commands.(*Command).Run
…/pkg/commands/command.go:118  commands.(*Command).ParseAndRun
…no/gnovm/cmd/gno/main.go:14   main.main
…b/go/src/runtime/proc.go:267  runtime.main
…/src/runtime/asm_amd64.s:1650 runtime.goexit

FAIL
FAIL    . 	2.19s
FAIL
FAIL
FAIL: 0 build errors, 1 test errors
```