### PR TITLE
feat: Add the stdlib_diff tool to compare gno and go standard libraries

### DIFF
--- a/misc/stdlib_diff/README.md
+++ b/misc/stdlib_diff/README.md
@@ -4,7 +4,28 @@ Stdlibs_diff is a tool that generates an html report indicating differences betw
 
 ## Usage
 
+Compare the `go` standard libraries the `gno` standard libraries
+
 ```shell
-./stdlibs_diff --src <path to gno standard libraries> --dst <path to go standard libraries> --out <output directory>
+./stdlibs_diff --src <path to go standard libraries> --dst <path to gno standard libraries> --out <output directory>
 ```
 
+Compare the `gno` standard libraries the `go` standard libraries
+
+```shell
+./stdlibs_diff --src <path to gno standard libraries> --dst <path to go standard libraries> --out <output directory> --src_is_gno
+```
+
+
+## Parameters
+
+| Flag       | Description                                                        | Default value |
+| ---------- | ------------------------------------------------------------------ | ------------- |
+| src        | Directory containing packages that will be compared to destination | None          |
+| dst        | Directory containing packages; used to compare src packages        | None          |
+| out        | Directory where the report will be created                         | None          |
+| src_is_gno | Indicates if the src parameters is the gno standard library        | false         |
+
+## Tips
+
+An index.html is generated at the root of the report location. Utilize it to navigate easily through the report.

--- a/misc/stdlib_diff/README.md
+++ b/misc/stdlib_diff/README.md
@@ -1,0 +1,10 @@
+# Stdlibs_diff
+
+Stdlibs_diff is a tool that generates an html report indicating differences between gno standard libraries and go standrad libraries
+
+## Usage
+
+```shell
+./stdlibs_diff --src <path to gno standard libraries> --dst <path to go standard libraries> --out <output directory>
+```
+

--- a/misc/stdlib_diff/algorithm.go
+++ b/misc/stdlib_diff/algorithm.go
@@ -1,20 +1,5 @@
 package main
 
-import "errors"
-
-const (
-	MYERS = "myers"
-)
-
 type Algorithm interface {
-	Do() (srcDiff []LineDifferrence, dstDiff []LineDifferrence)
-}
-
-func AlgorithmFactory(src, dst []string, algoType string) (Algorithm, error) {
-	switch algoType {
-	case MYERS:
-		return NewMyers(src, dst), nil
-	default:
-		return nil, errors.New("unknown algorithm type")
-	}
+	Diff() (srcDiff []LineDifferrence, dstDiff []LineDifferrence)
 }

--- a/misc/stdlib_diff/algorithm.go
+++ b/misc/stdlib_diff/algorithm.go
@@ -1,0 +1,20 @@
+package main
+
+import "errors"
+
+const (
+	MYERS = "myers"
+)
+
+type Algorithm interface {
+	Do() (srcDiff []LineDifferrence, dstDiff []LineDifferrence)
+}
+
+func AlgorithmFactory(src, dst []string, algoType string) (Algorithm, error) {
+	switch algoType {
+	case MYERS:
+		return NewMyers(src, dst), nil
+	default:
+		return nil, errors.New("unknown algorithm type")
+	}
+}

--- a/misc/stdlib_diff/diffstatus.go
+++ b/misc/stdlib_diff/diffstatus.go
@@ -3,21 +3,21 @@ package main
 type diffStatus uint
 
 const (
-	MISSING_IN_SRC diffStatus = 1
-	MISSING_IN_DST diffStatus = 2
-	HAS_DIFF       diffStatus = 3
-	NO_DIFF        diffStatus = 4
+	missingInSrc diffStatus = iota
+	missingInDst
+	hasDiff
+	noDiff
 )
 
 func (status diffStatus) String() string {
 	switch status {
-	case MISSING_IN_SRC:
+	case missingInSrc:
 		return "missing in src"
-	case MISSING_IN_DST:
+	case missingInDst:
 		return "missing in dst"
-	case HAS_DIFF:
+	case hasDiff:
 		return "files differ"
-	case NO_DIFF:
+	case noDiff:
 		return "files are equal"
 	default:
 		return "Unknown"

--- a/misc/stdlib_diff/diffstatus.go
+++ b/misc/stdlib_diff/diffstatus.go
@@ -1,0 +1,25 @@
+package main
+
+type diffStatus uint
+
+const (
+	MISSING_IN_SRC diffStatus = 1
+	MISSING_IN_DST diffStatus = 2
+	HAS_DIFF       diffStatus = 3
+	NO_DIFF        diffStatus = 4
+)
+
+func (status diffStatus) String() string {
+	switch status {
+	case MISSING_IN_SRC:
+		return "missing in src"
+	case MISSING_IN_DST:
+		return "missing in dst"
+	case HAS_DIFF:
+		return "files differ"
+	case NO_DIFF:
+		return "files are equal"
+	default:
+		return "Unknown"
+	}
+}

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -7,9 +7,9 @@ import (
 
 // FileDiff is a struct for comparing differences between two files.
 type FileDiff struct {
-	Src           []string  // Lines of the source file.
-	Dst           []string  // Lines of the destination file.
-	DiffAlgorithm Algorithm // Algorithm used for comparison.
+	Src       []string // Lines of the source file.
+	Dst       []string // Lines of the destination file.
+	Algorithm          // Algorithm used for comparison.
 }
 
 // LineDifferrence represents a difference in a line during file comparison.
@@ -20,27 +20,22 @@ type LineDifferrence struct {
 
 // NewFileDiff creates a new FileDiff instance for comparing differences between
 // the specified source and destination files. It initializes the source and
-// destination file lines and the specified diff algorithm.
-func NewFileDiff(srcPath, dstPath, algoType string) (*FileDiff, error) {
+// destination file lines .
+func NewFileDiff(srcPath, dstPath string) (*FileDiff, error) {
 	src := getFileLines(srcPath)
 	dst := getFileLines(dstPath)
 
-	diffAlgorithm, err := AlgorithmFactory(src, dst, algoType)
-	if err != nil {
-		return nil, err
-	}
-
 	return &FileDiff{
-		Src:           src,
-		Dst:           dst,
-		DiffAlgorithm: diffAlgorithm,
+		Src:       src,
+		Dst:       dst,
+		Algorithm: NewMyers(src, dst),
 	}, nil
 }
 
 // Differences returns the differences in lines between the source and
 // destination files using the configured diff algorithm.
 func (f *FileDiff) Differences() (src, dst []LineDifferrence) {
-	return f.DiffAlgorithm.Do()
+	return f.Diff()
 }
 
 // getFileLines reads and returns the lines of a file given its path.

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -39,7 +39,7 @@ func NewFileDiff(srcPath, dstPath, algoType string) (*FileDiff, error) {
 
 // Differences returns the differences in lines between the source and
 // destination files using the configured diff algorithm.
-func (f *FileDiff) Differences() ([]LineDifferrence, []LineDifferrence) {
+func (f *FileDiff) Differences() (src, dst []LineDifferrence) {
 	return f.DiffAlgorithm.Do()
 }
 

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"bufio"
+	"fmt"
 	"os"
+	"strings"
 )
 
 // FileDiff is a struct for comparing differences between two files.
@@ -22,8 +23,15 @@ type LineDifferrence struct {
 // the specified source and destination files. It initializes the source and
 // destination file lines .
 func NewFileDiff(srcPath, dstPath string) (*FileDiff, error) {
-	src := getFileLines(srcPath)
-	dst := getFileLines(dstPath)
+	src, err := getFileLines(srcPath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read src file: %w", err)
+	}
+
+	dst, err := getFileLines(dstPath)
+	if err != nil {
+		return nil, fmt.Errorf("can't read dst file: %w", err)
+	}
 
 	return &FileDiff{
 		Src:       src,
@@ -39,23 +47,14 @@ func (f *FileDiff) Differences() (src, dst []LineDifferrence) {
 }
 
 // getFileLines reads and returns the lines of a file given its path.
-func getFileLines(p string) []string {
-	lines := make([]string, 0)
-
-	f, err := os.Open(p)
+func getFileLines(p string) ([]string, error) {
+	data, err := os.ReadFile(p)
 	if err != nil {
-		return lines
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
 	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
-	if err := scanner.Err(); err != nil {
-		return lines
-	}
-
-	return lines
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	return lines, nil
 }

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -14,8 +14,8 @@ type FileDiff struct {
 
 // LineDifferrence represents a difference in a line during file comparison.
 type LineDifferrence struct {
-	Line      string // The line content.
-	Operation string // The operation performed on the line (e.g., "add", "delete", "equal").
+	Line      string    // The line content.
+	Operation operation // The operation performed on the line (e.g., "add", "delete", "equal").
 }
 
 // NewFileDiff creates a new FileDiff instance for comparing differences between

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -40,8 +40,7 @@ func NewFileDiff(srcPath, dstPath, algoType string) (*FileDiff, error) {
 // Differences returns the differences in lines between the source and
 // destination files using the configured diff algorithm.
 func (f *FileDiff) Differences() ([]LineDifferrence, []LineDifferrence) {
-	srcDiff, dstDiff := f.DiffAlgorithm.Do()
-	return srcDiff, dstDiff
+	return f.DiffAlgorithm.Do()
 }
 
 // getFileLines reads and returns the lines of a file given its path.

--- a/misc/stdlib_diff/filediff.go
+++ b/misc/stdlib_diff/filediff.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"os"
+)
+
+// FileDiff is a struct for comparing differences between two files.
+type FileDiff struct {
+	Src           []string  // Lines of the source file.
+	Dst           []string  // Lines of the destination file.
+	DiffAlgorithm Algorithm // Algorithm used for comparison.
+}
+
+// LineDifferrence represents a difference in a line during file comparison.
+type LineDifferrence struct {
+	Line      string // The line content.
+	Operation string // The operation performed on the line (e.g., "add", "delete", "equal").
+}
+
+// NewFileDiff creates a new FileDiff instance for comparing differences between
+// the specified source and destination files. It initializes the source and
+// destination file lines and the specified diff algorithm.
+func NewFileDiff(srcPath, dstPath, algoType string) (*FileDiff, error) {
+	src := getFileLines(srcPath)
+	dst := getFileLines(dstPath)
+
+	diffAlgorithm, err := AlgorithmFactory(src, dst, algoType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileDiff{
+		Src:           src,
+		Dst:           dst,
+		DiffAlgorithm: diffAlgorithm,
+	}, nil
+}
+
+// Differences returns the differences in lines between the source and
+// destination files using the configured diff algorithm.
+func (f *FileDiff) Differences() ([]LineDifferrence, []LineDifferrence) {
+	srcDiff, dstDiff := f.DiffAlgorithm.Do()
+	return srcDiff, dstDiff
+}
+
+// getFileLines reads and returns the lines of a file given its path.
+func getFileLines(p string) []string {
+	lines := make([]string, 0)
+
+	f, err := os.Open(p)
+	if err != nil {
+		return lines
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return lines
+	}
+
+	return lines
+}

--- a/misc/stdlib_diff/main.go
+++ b/misc/stdlib_diff/main.go
@@ -11,10 +11,10 @@ func main() {
 	var outDirectory string
 	var srcIsGno bool
 
-	flag.StringVar(&srcPath, "src", "", "Path to Gnoland standard libraries directory")
-	flag.StringVar(&dstPath, "dst", "", "Path to Goland standard libraries directory")
-	flag.StringVar(&outDirectory, "out", "", "Path to the directory where the report will be generated")
-	flag.BoolVar(&srcIsGno, "src_is_gno", false, "If true, indicates that the src parameter correponds to the gno standard libraries")
+	flag.StringVar(&srcPath, "src", "", "Directory containing packages that will be compared to destination")
+	flag.StringVar(&dstPath, "dst", "", "Directory containing packages; used to compare src packages")
+	flag.StringVar(&outDirectory, "out", "", "Directory where the report will be created")
+	flag.BoolVar(&srcIsGno, "src_is_gno", false, "If true, indicates that the src parameter corresponds to the gno standard libraries")
 	flag.Parse()
 
 	reportBuilder, err := NewReportBuilder(srcPath, dstPath, outDirectory, srcIsGno)

--- a/misc/stdlib_diff/main.go
+++ b/misc/stdlib_diff/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"log"
+)
+
+func main() {
+	var srcPath string
+	var dstPath string
+	var outDirectory string
+
+	flag.StringVar(&srcPath, "src", "", "Path to Gnoland standard libraries directory")
+	flag.StringVar(&dstPath, "dst", "", "Path to Goland standard libraries directory")
+	flag.StringVar(&outDirectory, "out", "", "Path to the directory where the report will be generated")
+	flag.Parse()
+
+	reportBuilder, err := NewReportBuilder(srcPath, dstPath, outDirectory)
+	if err != nil {
+		log.Fatal("can't build report builder: ", err.Error())
+	}
+
+	log.Println("Building report...")
+	if err := reportBuilder.Build(); err != nil {
+		log.Fatalln("can't build report: ", err.Error())
+	}
+	log.Println("Report generation done!")
+}

--- a/misc/stdlib_diff/main.go
+++ b/misc/stdlib_diff/main.go
@@ -9,13 +9,15 @@ func main() {
 	var srcPath string
 	var dstPath string
 	var outDirectory string
+	var srcIsGno bool
 
 	flag.StringVar(&srcPath, "src", "", "Path to Gnoland standard libraries directory")
 	flag.StringVar(&dstPath, "dst", "", "Path to Goland standard libraries directory")
 	flag.StringVar(&outDirectory, "out", "", "Path to the directory where the report will be generated")
+	flag.BoolVar(&srcIsGno, "src_is_gno", false, "If true, indicates that the src parameter correponds to the gno standard libraries")
 	flag.Parse()
 
-	reportBuilder, err := NewReportBuilder(srcPath, dstPath, outDirectory)
+	reportBuilder, err := NewReportBuilder(srcPath, dstPath, outDirectory, srcIsGno)
 	if err != nil {
 		log.Fatal("can't build report builder: ", err.Error())
 	}

--- a/misc/stdlib_diff/myers.go
+++ b/misc/stdlib_diff/myers.go
@@ -25,10 +25,9 @@ func NewMyers(src, dst []string) *Myers {
 func (m *Myers) Do() ([]LineDifferrence, []LineDifferrence) {
 	operations := m.doMyers()
 
-	srcIndex, dstIndex := 0, 0
+	srcIndex, dstIndex, insertCount, deleteCount := 0, 0, 0, 0
 	dstDiff := make([]LineDifferrence, 0)
 	srcDiff := make([]LineDifferrence, 0)
-	insertCount := 0
 	for _, op := range operations {
 		switch op {
 		case INSERT:
@@ -49,6 +48,7 @@ func (m *Myers) Do() ([]LineDifferrence, []LineDifferrence) {
 			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
 			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op.String()})
 			srcIndex += 1
+			deleteCount++
 			continue
 		}
 	}
@@ -56,6 +56,10 @@ func (m *Myers) Do() ([]LineDifferrence, []LineDifferrence) {
 	// Means that src file is empty.
 	if insertCount == len(srcDiff) {
 		srcDiff = make([]LineDifferrence, 0)
+	}
+	// Means that dst file is empty.
+	if deleteCount == len(dstDiff) {
+		dstDiff = make([]LineDifferrence, 0)
 	}
 	return srcDiff, dstDiff
 }

--- a/misc/stdlib_diff/myers.go
+++ b/misc/stdlib_diff/myers.go
@@ -33,23 +33,23 @@ func (m *Myers) Diff() ([]LineDifferrence, []LineDifferrence) {
 
 	for _, op := range operations {
 		switch op {
-		case INSERT:
-			dstDiff = append(dstDiff, LineDifferrence{Line: "+" + m.dst[dstIndex], Operation: op.String()})
-			srcDiff = append(srcDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
+		case insert:
+			dstDiff = append(dstDiff, LineDifferrence{Line: "+" + m.dst[dstIndex], Operation: op})
+			srcDiff = append(srcDiff, LineDifferrence{Line: "", Operation: equal})
 			dstIndex++
 			insertCount++
 			continue
 
-		case MOVE:
-			dstDiff = append(dstDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
-			srcDiff = append(srcDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
+		case equal:
+			dstDiff = append(dstDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op})
+			srcDiff = append(srcDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op})
 			srcIndex++
 			dstIndex++
 			continue
 
-		case DELETE:
-			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
-			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op.String()})
+		case delete:
+			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: equal})
+			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op})
 			srcIndex++
 			deleteCount++
 			continue
@@ -141,15 +141,15 @@ func (m *Myers) getAllOperations(tree []map[int]int) []operation {
 		prevY = prevX - prevK
 
 		for x > prevX && y > prevY {
-			operations = append(operations, MOVE)
+			operations = append(operations, equal)
 			x -= 1
 			y -= 1
 		}
 
 		if x == prevX {
-			operations = append(operations, INSERT)
+			operations = append(operations, insert)
 		} else {
-			operations = append(operations, DELETE)
+			operations = append(operations, delete)
 		}
 
 		x, y = prevX, prevY
@@ -157,7 +157,7 @@ func (m *Myers) getAllOperations(tree []map[int]int) []operation {
 
 	if tree[0][0] != 0 {
 		for i := 0; i < tree[0][0]; i++ {
-			operations = append(operations, MOVE)
+			operations = append(operations, equal)
 		}
 	}
 

--- a/misc/stdlib_diff/myers.go
+++ b/misc/stdlib_diff/myers.go
@@ -34,7 +34,7 @@ func (m *Myers) Diff() ([]LineDifferrence, []LineDifferrence) {
 	for _, op := range operations {
 		switch op {
 		case insert:
-			dstDiff = append(dstDiff, LineDifferrence{Line: "+" + m.dst[dstIndex], Operation: op})
+			dstDiff = append(dstDiff, LineDifferrence{Line: m.dst[dstIndex], Operation: op})
 			srcDiff = append(srcDiff, LineDifferrence{Line: "", Operation: equal})
 			dstIndex++
 			insertCount++
@@ -49,7 +49,7 @@ func (m *Myers) Diff() ([]LineDifferrence, []LineDifferrence) {
 
 		case delete:
 			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: equal})
-			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op})
+			srcDiff = append(srcDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op})
 			srcIndex++
 			deleteCount++
 			continue

--- a/misc/stdlib_diff/myers.go
+++ b/misc/stdlib_diff/myers.go
@@ -22,32 +22,35 @@ func NewMyers(src, dst []string) *Myers {
 
 // Do performs the Myers algorithm to find the differences between source and destination files.
 // It returns the differences as two slices of LineDifferrence representing source and destination changes.
-func (m *Myers) Do() ([]LineDifferrence, []LineDifferrence) {
+func (m *Myers) Diff() ([]LineDifferrence, []LineDifferrence) {
+	var (
+		srcIndex, dstIndex       int
+		insertCount, deleteCount int
+		dstDiff, srcDiff         []LineDifferrence
+	)
+
 	operations := m.doMyers()
 
-	srcIndex, dstIndex, insertCount, deleteCount := 0, 0, 0, 0
-	dstDiff := make([]LineDifferrence, 0)
-	srcDiff := make([]LineDifferrence, 0)
 	for _, op := range operations {
 		switch op {
 		case INSERT:
 			dstDiff = append(dstDiff, LineDifferrence{Line: "+" + m.dst[dstIndex], Operation: op.String()})
 			srcDiff = append(srcDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
-			dstIndex += 1
+			dstIndex++
 			insertCount++
 			continue
 
 		case MOVE:
 			dstDiff = append(dstDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
 			srcDiff = append(srcDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
-			srcIndex += 1
-			dstIndex += 1
+			srcIndex++
+			dstIndex++
 			continue
 
 		case DELETE:
 			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
 			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op.String()})
-			srcIndex += 1
+			srcIndex++
 			deleteCount++
 			continue
 		}

--- a/misc/stdlib_diff/myers.go
+++ b/misc/stdlib_diff/myers.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"slices"
+)
+
+var _ Algorithm = (*Myers)(nil)
+
+// Myers is a struct representing the Myers algorithm for line-based difference.
+type Myers struct {
+	src []string // Lines of the source file.
+	dst []string // Lines of the destination file.
+}
+
+// NewMyers creates a new Myers instance with the specified source and destination lines.
+func NewMyers(src, dst []string) *Myers {
+	return &Myers{
+		src: src,
+		dst: dst,
+	}
+}
+
+// Do performs the Myers algorithm to find the differences between source and destination files.
+// It returns the differences as two slices of LineDifferrence representing source and destination changes.
+func (m *Myers) Do() ([]LineDifferrence, []LineDifferrence) {
+	operations := m.doMyers()
+
+	srcIndex, dstIndex := 0, 0
+	dstDiff := make([]LineDifferrence, 0)
+	srcDiff := make([]LineDifferrence, 0)
+	insertCount := 0
+	for _, op := range operations {
+		switch op {
+		case INSERT:
+			dstDiff = append(dstDiff, LineDifferrence{Line: "+" + m.dst[dstIndex], Operation: op.String()})
+			srcDiff = append(srcDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
+			dstIndex += 1
+			insertCount++
+			continue
+
+		case MOVE:
+			dstDiff = append(dstDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
+			srcDiff = append(srcDiff, LineDifferrence{Line: m.src[srcIndex], Operation: op.String()})
+			srcIndex += 1
+			dstIndex += 1
+			continue
+
+		case DELETE:
+			dstDiff = append(dstDiff, LineDifferrence{Line: "", Operation: MOVE.String()})
+			srcDiff = append(srcDiff, LineDifferrence{Line: "-" + m.src[srcIndex], Operation: op.String()})
+			srcIndex += 1
+			continue
+		}
+	}
+
+	// Means that src file is empty.
+	if insertCount == len(srcDiff) {
+		srcDiff = make([]LineDifferrence, 0)
+	}
+	return srcDiff, dstDiff
+}
+
+// doMyers performs the Myers algorithm and returns the list of operations.
+func (m *Myers) doMyers() []operation {
+	var tree []map[int]int
+	var x, y int
+
+	srcLen := len(m.src)
+	dstLen := len(m.dst)
+	max := srcLen + dstLen
+
+	for pathLen := 0; pathLen <= max; pathLen++ {
+		optimalCoordinates := make(map[int]int, pathLen+2)
+		tree = append(tree, optimalCoordinates)
+
+		if pathLen == 0 {
+			commonPrefixLen := 0
+			for srcLen > commonPrefixLen && dstLen > commonPrefixLen && m.src[commonPrefixLen] == m.dst[commonPrefixLen] {
+				commonPrefixLen++
+			}
+			optimalCoordinates[0] = commonPrefixLen
+
+			if commonPrefixLen == srcLen && commonPrefixLen == dstLen {
+				return m.getAllOperations(tree)
+			}
+			continue
+		}
+
+		lastV := tree[pathLen-1]
+
+		for k := -pathLen; k <= pathLen; k += 2 {
+			if k == -pathLen || (k != pathLen && lastV[k-1] < lastV[k+1]) {
+				x = lastV[k+1]
+			} else {
+				x = lastV[k-1] + 1
+			}
+
+			y = x - k
+
+			for x < srcLen && y < dstLen && m.src[x] == m.dst[y] {
+				x, y = x+1, y+1
+			}
+
+			optimalCoordinates[k] = x
+
+			if x == srcLen && y == dstLen {
+				return m.getAllOperations(tree)
+			}
+		}
+	}
+
+	return m.getAllOperations(tree)
+}
+
+// getAllOperations retrieves the list of operations from the calculated tree.
+func (m *Myers) getAllOperations(tree []map[int]int) []operation {
+	var operations []operation
+	var k, prevK, prevX, prevY int
+
+	x := len(m.src)
+	y := len(m.dst)
+
+	for pathLen := len(tree) - 1; pathLen > 0; pathLen-- {
+		k = x - y
+		lastV := tree[pathLen-1]
+
+		if k == -pathLen || (k != pathLen && lastV[k-1] < lastV[k+1]) {
+			prevK = k + 1
+		} else {
+			prevK = k - 1
+		}
+
+		prevX = lastV[prevK]
+		prevY = prevX - prevK
+
+		for x > prevX && y > prevY {
+			operations = append(operations, MOVE)
+			x -= 1
+			y -= 1
+		}
+
+		if x == prevX {
+			operations = append(operations, INSERT)
+		} else {
+			operations = append(operations, DELETE)
+		}
+
+		x, y = prevX, prevY
+	}
+
+	if tree[0][0] != 0 {
+		for i := 0; i < tree[0][0]; i++ {
+			operations = append(operations, MOVE)
+		}
+	}
+
+	slices.Reverse(operations)
+	return operations
+}

--- a/misc/stdlib_diff/operation.go
+++ b/misc/stdlib_diff/operation.go
@@ -1,0 +1,28 @@
+package main
+
+// operation is an enumeration type representing different types of operations. Used in diff algorithm
+// to indicates differences between files.
+type operation uint
+
+const (
+	// INSERT represents an insertion operation.
+	INSERT operation = 1
+	// DELETE represents a deletion operation.
+	DELETE operation = 2
+	// MOVE represents a move operation.
+	MOVE operation = 3
+)
+
+// String returns a string representation of the operation.
+func (op operation) String() string {
+	switch op {
+	case INSERT:
+		return "INS"
+	case DELETE:
+		return "DEL"
+	case MOVE:
+		return "MOV"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/misc/stdlib_diff/operation.go
+++ b/misc/stdlib_diff/operation.go
@@ -5,23 +5,23 @@ package main
 type operation uint
 
 const (
-	// INSERT represents an insertion operation.
-	INSERT operation = 1
-	// DELETE represents a deletion operation.
-	DELETE operation = 2
-	// MOVE represents a move operation.
-	MOVE operation = 3
+	// insert represents an insertion operation.
+	insert operation = iota + 1
+	// delete represents a deletion operation.
+	delete
+	// equal represents an equal operation.
+	equal
 )
 
 // String returns a string representation of the operation.
 func (op operation) String() string {
 	switch op {
-	case INSERT:
+	case insert:
 		return "INS"
-	case DELETE:
+	case delete:
 		return "DEL"
-	case MOVE:
-		return "MOV"
+	case equal:
+		return "EQ"
 	default:
 		return "UNKNOWN"
 	}

--- a/misc/stdlib_diff/packagediff.go
+++ b/misc/stdlib_diff/packagediff.go
@@ -132,6 +132,11 @@ func (p *PackageDiffChecker) getStatus(srcDiff, dstDiff []LineDifferrence) diffS
 	return 0
 }
 
+// hasSameNumberOfFiles checks if the source and destination have the same number of files.
+func (p *PackageDiffChecker) hasSameNumberOfFiles() bool {
+	return len(p.SrcFiles) == len(p.DstFiles)
+}
+
 // listDirFiles returns a list of file names in the specified directory.
 func listDirFiles(dirPath string) ([]string, error) {
 	f, err := os.Open(dirPath)
@@ -156,9 +161,4 @@ func listDirFiles(dirPath string) ([]string, error) {
 	}
 
 	return fileNames, nil
-}
-
-// hasSameNumberOfFiles checks if the source and destination have the same number of files.
-func (p *PackageDiffChecker) hasSameNumberOfFiles() bool {
-	return len(p.SrcFiles) == len(p.DstFiles)
 }

--- a/misc/stdlib_diff/packagediff.go
+++ b/misc/stdlib_diff/packagediff.go
@@ -72,7 +72,7 @@ func (p *PackageDiffChecker) Differences() (*Differences, error) {
 		dstFileName := trimmedFileName + dstFileExt
 		dstFilePath := p.DstPath + "/" + dstFileName
 
-		fileDiff, err := NewFileDiff(srcFilePath, dstFilePath, "myers")
+		fileDiff, err := NewFileDiff(srcFilePath, dstFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/misc/stdlib_diff/packagediff.go
+++ b/misc/stdlib_diff/packagediff.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// PackageDiffChecker is a struct for comparing and identifying differences
+// between files in two directories.
+type PackageDiffChecker struct {
+	SrcFiles []string // List of source files.
+	SrcPath  string   // Source directory path.
+	DstFiles []string // List of destination files.
+	DstPath  string   // Destination directory path.
+}
+
+// Differences represents the differences between source and destination packages.
+type Differences struct {
+	SameNumberOfFiles bool             // Indicates whether the source and destination have the same number of files.
+	FilesDifferences  []FileDifference // Differences in individual files.
+}
+
+// FileDifference represents the differences between source and destination files.
+type FileDifference struct {
+	Status          string            // Diff status of the processed files.
+	SourceName      string            // Name of the source file.
+	DestinationName string            // Name of the destination file.
+	SrcLineDiff     []LineDifferrence // Differences in source file lines.
+	DstLineDiff     []LineDifferrence // Differences in destination file lines.
+}
+
+// NewPackageDiffChecker creates a new PackageDiffChecker instance with the specified
+// source and destination paths. It initializes the SrcFiles and DstFiles fields by
+// listing files in the corresponding directories.
+func NewPackageDiffChecker(srcPath, dstPath string) (*PackageDiffChecker, error) {
+	srcFiles, err := listDirFiles(srcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dstFiles, err := listDirFiles(dstPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PackageDiffChecker{
+		SrcFiles: srcFiles,
+		SrcPath:  srcPath,
+		DstFiles: dstFiles,
+		DstPath:  dstPath,
+	}, nil
+}
+
+// Differences calculates and returns the differences between source and destination
+// packages. It compares files line by line using the Myers algorithm.
+func (p *PackageDiffChecker) Differences() (*Differences, error) {
+	d := &Differences{
+		SameNumberOfFiles: p.hasSameNumberOfFiles(),
+		FilesDifferences:  make([]FileDifference, 0),
+	}
+
+	allFiles := p.listAllPossibleFiles()
+
+	for _, trimmedFileName := range allFiles {
+		srcFilePath := p.SrcPath + "/" + trimmedFileName + ".gno"
+		dstFilePath := p.DstPath + "/" + trimmedFileName + ".go"
+
+		fileDiff, err := NewFileDiff(srcFilePath, dstFilePath, "myers")
+		if err != nil {
+			return nil, err
+		}
+
+		srcDiff, dstDiff := fileDiff.Differences()
+
+		d.FilesDifferences = append(d.FilesDifferences, FileDifference{
+			Status:          p.getStatus(srcDiff, dstDiff).String(),
+			SourceName:      trimmedFileName + ".gno",
+			DestinationName: trimmedFileName + ".go",
+			SrcLineDiff:     srcDiff,
+			DstLineDiff:     dstDiff,
+		})
+	}
+
+	return d, nil
+}
+
+// listAllPossibleFiles returns a list of unique file names without extensions
+// from both source and destination directories.
+func (p *PackageDiffChecker) listAllPossibleFiles() []string {
+	files := p.SrcFiles
+	files = append(files, p.DstFiles...)
+
+	for i := 0; i < len(files); i++ {
+		files[i] = strings.TrimSuffix(files[i], ".go")
+		files[i] = strings.TrimSuffix(files[i], ".gno")
+	}
+
+	unique := make(map[string]bool, len(files))
+	uniqueFiles := make([]string, len(unique))
+	for _, file := range files {
+		if len(file) != 0 {
+			if !unique[file] {
+				uniqueFiles = append(uniqueFiles, file)
+				unique[file] = true
+			}
+		}
+	}
+
+	return uniqueFiles
+}
+
+func (p *PackageDiffChecker) getStatus(srcDiff, dstDiff []LineDifferrence) diffStatus {
+	slicesAreEquals := slices.Equal(srcDiff, dstDiff)
+	if slicesAreEquals {
+		return NO_DIFF
+	}
+
+	if len(srcDiff) == 0 {
+		return MISSING_IN_SRC
+	}
+
+	if len(dstDiff) == 0 {
+		return MISSING_IN_DST
+	}
+
+	if !slicesAreEquals {
+		return HAS_DIFF
+	}
+
+	return 0
+}
+
+// listDirFiles returns a list of file names in the specified directory.
+func listDirFiles(dirPath string) ([]string, error) {
+	f, err := os.Open(dirPath)
+	if err != nil {
+		return []string{}, nil
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "can't close "+dirPath)
+		}
+	}()
+
+	filesInfo, err := f.Readdir(0)
+	if err != nil {
+		return nil, fmt.Errorf("can't list file in directory :%w", err)
+	}
+
+	fileNames := make([]string, 0)
+	for _, info := range filesInfo {
+		fileNames = append(fileNames, info.Name())
+	}
+
+	return fileNames, nil
+}
+
+// hasSameNumberOfFiles checks if the source and destination have the same number of files.
+func (p *PackageDiffChecker) hasSameNumberOfFiles() bool {
+	return len(p.SrcFiles) == len(p.DstFiles)
+}

--- a/misc/stdlib_diff/packagediff.go
+++ b/misc/stdlib_diff/packagediff.go
@@ -116,6 +116,7 @@ func (p *PackageDiffChecker) listAllPossibleFiles() []string {
 	return uniqueFiles
 }
 
+// inferFileExtensions by returning the src and dst files extensions.
 func (p *PackageDiffChecker) inferFileExtensions() (string, string) {
 	if p.SrcIsGno {
 		return ".gno", ".go"
@@ -124,6 +125,8 @@ func (p *PackageDiffChecker) inferFileExtensions() (string, string) {
 	return ".go", ".gno"
 }
 
+// getStatus determines the diff status based on the differences in source and destination.
+// It returns a diffStatus indicating whether there is no difference, missing in source, missing in destination, or differences exist.
 func (p *PackageDiffChecker) getStatus(srcDiff, dstDiff []LineDifferrence) diffStatus {
 	slicesAreEquals := slices.Equal(srcDiff, dstDiff)
 	if slicesAreEquals {

--- a/misc/stdlib_diff/packagediff.go
+++ b/misc/stdlib_diff/packagediff.go
@@ -130,19 +130,19 @@ func (p *PackageDiffChecker) inferFileExtensions() (string, string) {
 func (p *PackageDiffChecker) getStatus(srcDiff, dstDiff []LineDifferrence) diffStatus {
 	slicesAreEquals := slices.Equal(srcDiff, dstDiff)
 	if slicesAreEquals {
-		return NO_DIFF
+		return noDiff
 	}
 
 	if len(srcDiff) == 0 {
-		return MISSING_IN_SRC
+		return missingInSrc
 	}
 
 	if len(dstDiff) == 0 {
-		return MISSING_IN_DST
+		return missingInDst
 	}
 
 	if !slicesAreEquals {
-		return HAS_DIFF
+		return hasDiff
 	}
 
 	return 0

--- a/misc/stdlib_diff/report.go
+++ b/misc/stdlib_diff/report.go
@@ -22,10 +22,10 @@ type ReportBuilder struct {
 // differences between source and destination directories.
 type PackageDiffTemplateData struct {
 	PackageName        string           // Package name.
-	GnoFileCount       int              // Number of Gno files in the package.
-	GnoPackageLocation string           // Location of Gno files in the source directory.
-	GoFileCount        int              // Number of Go files in the package.
-	GoPackageLocation  string           // Location of Go files in the destination directory.
+	SrcFilesCount      int              // Number of files in the source package.
+	SrcPackageLocation string           // Location of source files in the source directory.
+	DstFileCount       int              // Number of destination files in the package.
+	DstPackageLocation string           // Location of destination files in the destination directory.
 	FilesDifferences   []FileDifference // Differences in individual files.
 }
 
@@ -92,10 +92,10 @@ func (builder *ReportBuilder) Build() error {
 
 		data := &PackageDiffTemplateData{
 			PackageName:        directory,
-			GnoFileCount:       len(packageChecker.SrcFiles),
-			GnoPackageLocation: srcPackagePath,
-			GoFileCount:        len(packageChecker.DstFiles),
-			GoPackageLocation:  dstPackagePath,
+			SrcFilesCount:      len(packageChecker.SrcFiles),
+			SrcPackageLocation: srcPackagePath,
+			DstFileCount:       len(packageChecker.DstFiles),
+			DstPackageLocation: dstPackagePath,
 			FilesDifferences:   differences.FilesDifferences,
 		}
 

--- a/misc/stdlib_diff/report.go
+++ b/misc/stdlib_diff/report.go
@@ -2,9 +2,17 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"html/template"
 	"os"
+)
+
+var (
+	//go:embed templates/package_diff_template.html
+	packageDiffTemplate string
+	//go:embed templates/index_template.html
+	indexTemplate string
 )
 
 // ReportBuilder is a struct for building reports based on the differences
@@ -42,12 +50,12 @@ type LinkToReport struct {
 // source path, destination path, and output directory. It also initializes
 // the packageTemplate using the provided HTML template file.
 func NewReportBuilder(srcPath, dstPath, outDir string, srcIsGno bool) (*ReportBuilder, error) {
-	packageTemplate, err := template.ParseFiles("templates/package_diff_template.html")
+	packageTemplate, err := template.New("").Parse(packageDiffTemplate)
 	if err != nil {
 		return nil, err
 	}
 
-	indexTemplate, err := template.ParseFiles("templates/index_template.html")
+	indexTemplate, err := template.New("").Parse(indexTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/misc/stdlib_diff/report.go
+++ b/misc/stdlib_diff/report.go
@@ -13,6 +13,7 @@ type ReportBuilder struct {
 	SrcPath         string             // Source directory path.
 	DstPath         string             // Destination directory path.
 	OutDir          string             // Output directory path for the reports.
+	SrcIsGno        bool               // Indicates if the Src files are gno files.
 	packageTemplate *template.Template // Template for generating reports.
 	indexTemplate   *template.Template // Template for generating index file of the reports.
 }
@@ -40,7 +41,7 @@ type LinkToReport struct {
 // NewReportBuilder creates a new ReportBuilder instance with the specified
 // source path, destination path, and output directory. It also initializes
 // the packageTemplate using the provided HTML template file.
-func NewReportBuilder(srcPath, dstPath, outDir string) (*ReportBuilder, error) {
+func NewReportBuilder(srcPath, dstPath, outDir string, srcIsGno bool) (*ReportBuilder, error) {
 	packageTemplate, err := template.ParseFiles("templates/package_diff_template.html")
 	if err != nil {
 		return nil, err
@@ -55,6 +56,7 @@ func NewReportBuilder(srcPath, dstPath, outDir string) (*ReportBuilder, error) {
 		SrcPath:         srcPath,
 		DstPath:         dstPath,
 		OutDir:          outDir,
+		SrcIsGno:        srcIsGno,
 		packageTemplate: packageTemplate,
 		indexTemplate:   indexTemplate,
 	}, nil
@@ -78,7 +80,7 @@ func (builder *ReportBuilder) Build() error {
 		srcPackagePath := builder.SrcPath + "/" + directory
 		dstPackagePath := builder.DstPath + "/" + directory
 
-		packageChecker, err := NewPackageDiffChecker(srcPackagePath, dstPackagePath)
+		packageChecker, err := NewPackageDiffChecker(srcPackagePath, dstPackagePath, builder.SrcIsGno)
 		if err != nil {
 			return fmt.Errorf("can't create new PackageDiffChecker: %w", err)
 		}

--- a/misc/stdlib_diff/report.go
+++ b/misc/stdlib_diff/report.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"os"
+)
+
+// ReportBuilder is a struct for building reports based on the differences
+// between source and destination directories.
+type ReportBuilder struct {
+	SrcPath         string             // Source directory path.
+	DstPath         string             // Destination directory path.
+	OutDir          string             // Output directory path for the reports.
+	packageTemplate *template.Template // Template for generating reports.
+	indexTemplate   *template.Template // Template for generating index file of the reports.
+}
+
+// PackageDiffTemplateData represents the template data structure for a package's
+// differences between source and destination directories.
+type PackageDiffTemplateData struct {
+	PackageName        string           // Package name.
+	GnoFileCount       int              // Number of Gno files in the package.
+	GnoPackageLocation string           // Location of Gno files in the source directory.
+	GoFileCount        int              // Number of Go files in the package.
+	GoPackageLocation  string           // Location of Go files in the destination directory.
+	FilesDifferences   []FileDifference // Differences in individual files.
+}
+
+type IndexTemplate struct {
+	Reports []LinkToReport
+}
+
+type LinkToReport struct {
+	PathToReport string
+	PackageName  string
+}
+
+// NewReportBuilder creates a new ReportBuilder instance with the specified
+// source path, destination path, and output directory. It also initializes
+// the packageTemplate using the provided HTML template file.
+func NewReportBuilder(srcPath, dstPath, outDir string) (*ReportBuilder, error) {
+	packageTemplate, err := template.ParseFiles("templates/package_diff_template.html")
+	if err != nil {
+		return nil, err
+	}
+
+	indexTemplate, err := template.ParseFiles("templates/index_template.html")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReportBuilder{
+		SrcPath:         srcPath,
+		DstPath:         dstPath,
+		OutDir:          outDir,
+		packageTemplate: packageTemplate,
+		indexTemplate:   indexTemplate,
+	}, nil
+}
+
+// Build generates reports for differences between packages in the source and
+// destination directories. It iterates through each directory, calculates
+// differences using PackageDiffChecker, and generates reports using the
+// packageTemplate.
+func (builder *ReportBuilder) Build() error {
+	directories, err := builder.listSrcDirectories()
+	if err != nil {
+		return err
+	}
+
+	indexTemplateData := &IndexTemplate{
+		Reports: make([]LinkToReport, 0),
+	}
+
+	for _, directory := range directories {
+		srcPackagePath := builder.SrcPath + "/" + directory
+		dstPackagePath := builder.DstPath + "/" + directory
+
+		packageChecker, err := NewPackageDiffChecker(srcPackagePath, dstPackagePath)
+		if err != nil {
+			return fmt.Errorf("can't create new PackageDiffChecker: %w", err)
+		}
+
+		differences, err := packageChecker.Differences()
+		if err != nil {
+			return fmt.Errorf("can't compute differences: %w", err)
+		}
+
+		data := &PackageDiffTemplateData{
+			PackageName:        directory,
+			GnoFileCount:       len(packageChecker.SrcFiles),
+			GnoPackageLocation: srcPackagePath,
+			GoFileCount:        len(packageChecker.DstFiles),
+			GoPackageLocation:  dstPackagePath,
+			FilesDifferences:   differences.FilesDifferences,
+		}
+
+		if err := builder.writePackageTemplate(data, directory); err != nil {
+			return err
+		}
+
+		indexTemplateData.Reports = append(indexTemplateData.Reports, LinkToReport{
+			PathToReport: "./" + directory + "/report.html",
+			PackageName:  directory,
+		})
+	}
+
+	if err := builder.writeIndexTemplate(indexTemplateData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// listSrcDirectories retrieves a list of directories in the source path.
+func (builder *ReportBuilder) listSrcDirectories() ([]string, error) {
+	dirEntries, err := os.ReadDir(builder.SrcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	directories := make([]string, 0)
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			directories = append(directories, dirEntry.Name())
+		}
+	}
+
+	return directories, nil
+}
+
+// writeIndexTemplate generates and writes the index template with the given output paths.
+func (builder *ReportBuilder) writeIndexTemplate(data *IndexTemplate) error {
+	resolvedTemplate := new(bytes.Buffer)
+	if err := builder.indexTemplate.Execute(resolvedTemplate, data); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(builder.OutDir+"/index.html", resolvedTemplate.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writePackageTemplate executes the template with the provided data and
+// writes the generated report to the output directory.
+func (builder *ReportBuilder) writePackageTemplate(templateData any, packageName string) error {
+	resolvedTemplate := new(bytes.Buffer)
+	if err := builder.packageTemplate.Execute(resolvedTemplate, templateData); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(builder.OutDir+"/"+packageName, 0777); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(builder.OutDir+"/"+packageName+"/report.html", resolvedTemplate.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/misc/stdlib_diff/templates/index_template.html
+++ b/misc/stdlib_diff/templates/index_template.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" >
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Index</title>
+    <style>
+        body, html {
+            height: 100vh;
+            font-family: "Roboto Mono","Courier New",sans-serif;
+            background-color: #1e1e1e;
+            color: #c7c7c7;
+        }
+        h1,h2,h3,h4,nav {
+            font-family: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+            font-weight: 600;
+            letter-spacing: .08rem
+        }
+        p {
+            margin: 0;
+            font-size: 1rem;
+            font-weight: 400;
+        }
+        a {
+            color: var(--link-color,#c7c7c7)
+        }   
+        .file-container {
+            display: flex;
+            flex-direction: column;
+            width: 50%;
+            max-width: 50%;
+            min-height: 100%;
+        }
+        .file-viewer{
+            border-style: solid;
+            border-width: 2px;
+            border-radius: 15px;
+            border-color: #c7c7c7;
+            padding: 1rem;
+            height: 100%;
+        }
+    </style>
+</head>
+<body style="padding: 2rem 5rem; ">
+    <H1>List of packages processed</H1>
+    <ul style="margin-bottom: 2rem;">
+    {{- range .Reports}}
+    <li><a href="{{.PathToReport}}">{{.PackageName}}</a>
+    </li>
+    {{- end}}
+    </ul>
+</body>
+</html>

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -2,11 +2,14 @@
 <div class="file-viewer">
     {{- range .}}
     {{- if eq .Operation 1}}
-    <p style="color: #07ca07;">{{.Line}}</p> 
+    <div style="display: flex; color: #07ca07;"></div>
+    <span style="user-select: none;">-</span><p>{{.Line}}</p> 
+    </div>
     {{- else if eq .Operation 2}}
-    <p style="color: red;">{{.Line}}</p> 
-    {{- else}}
-    {{- if eq .Line ""}}
+    <div style="display: flex; color: red;">
+        <span style="user-select: none;">+</span><p>{{.Line}}</p> 
+    </div>
+    {{- else if eq .Line ""}}
     <br />
     {{- else}}
     <p style="opacity: 0.65;">{{.Line}}</p>

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -1,9 +1,9 @@
 {{define "file-viewer" }}
 <div class="file-viewer">
     {{- range .}}
-    {{- if eq .Operation "INS"}}
+    {{- if eq .Operation 1}}
     <p style="color: #07ca07;">{{.Line}}</p> 
-    {{- else if eq .Operation "DEL"}}
+    {{- else if eq .Operation 2}}
     <p style="color: red;">{{.Line}}</p> 
     {{- else}}
     {{- if eq .Line ""}}

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -2,7 +2,7 @@
 <div class="file-viewer">
     {{- range .}}
     {{- if eq .Operation 1}}
-    <div style="display: flex; color: #07ca07;"></div>
+    <div style="display: flex; color: #07ca07;">
     <span style="user-select: none;">-</span><p>{{.Line}}</p> 
     </div>
     {{- else if eq .Operation 2}}
@@ -13,7 +13,6 @@
     <br />
     {{- else}}
     <p style="opacity: 0.65;">{{.Line}}</p>
-    {{- end}}
     {{- end}}
     {{- end}}
 </div>

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -36,9 +36,11 @@
             letter-spacing: .08rem
         }
         p {
+            white-space-collapse: preserve;
             margin: 0;
             font-size: 1rem;
             font-weight: 400;
+            tab-size: 4;
         }
 
         .file-container {

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -70,14 +70,14 @@
 
     <h3>Sources location</h3>
     <ul style="margin-bottom: 2rem;">
-        <li>SRC: {{.GnoPackageLocation}}</li>
-        <li>DST: {{.GoPackageLocation}}</li>
+        <li>SRC: {{.SrcPackageLocation}}</li>
+        <li>DST: {{.DstPackageLocation}}</li>
     </ul>
 
     <h3>Number of files</h3>
     <ul style="margin-bottom: 2rem;">
-        <li>SRC: {{.GnoFileCount}}</li>
-        <li>DST: {{.GoFileCount}}</li>
+        <li>SRC: {{.SrcFilesCount}}</li>
+        <li>DST: {{.DstFileCount}}</li>
     </ul>
 
     {{- range .FilesDifferences}}

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -9,7 +9,7 @@
     {{- if eq .Line ""}}
     <br />
     {{- else}}
-    <p>{{.Line}}</p> 
+    <p style="opacity: 0.65;">{{.Line}}</p>
     {{- end}}
     {{- end}}
     {{- end}}

--- a/misc/stdlib_diff/templates/package_diff_template.html
+++ b/misc/stdlib_diff/templates/package_diff_template.html
@@ -1,0 +1,98 @@
+{{define "file-viewer" }}
+<div class="file-viewer">
+    {{- range .}}
+    {{- if eq .Operation "INS"}}
+    <p style="color: #07ca07;">{{.Line}}</p> 
+    {{- else if eq .Operation "DEL"}}
+    <p style="color: red;">{{.Line}}</p> 
+    {{- else}}
+    {{- if eq .Line ""}}
+    <br />
+    {{- else}}
+    <p>{{.Line}}</p> 
+    {{- end}}
+    {{- end}}
+    {{- end}}
+</div>
+{{end}}
+
+<!DOCTYPE html>
+<html lang="en" >
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ .PackageName }}</title>
+    <style>
+        body, html {
+            height: 100vh;
+            font-family: "Roboto Mono","Courier New",sans-serif;
+            color: #eee;
+            background-color: #1e1e1e;
+            color: #c7c7c7;
+        }
+        h1,h2,h3,h4,nav {
+            font-family: ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+            font-weight: 600;
+            letter-spacing: .08rem
+        }
+        p {
+            margin: 0;
+            font-size: 1rem;
+            font-weight: 400;
+        }
+
+        .file-container {
+            display: flex;
+            flex-direction: column;
+            width: 50%;
+            max-width: 50%;
+            min-height: 100%;
+        }
+        .file-viewer{
+            border-style: solid;
+            border-width: 2px;
+            border-radius: 15px;
+            border-color: #c7c7c7;
+            padding: 1rem;
+            height: 100%;
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+    </style>
+</head>
+<body style="padding: 2rem 5rem; ">
+
+    <H1>{{ .PackageName }} package differences</H1>
+
+    <h2>Package information</h2>
+
+    <h3>Sources location</h3>
+    <ul style="margin-bottom: 2rem;">
+        <li>SRC: {{.GnoPackageLocation}}</li>
+        <li>DST: {{.GoPackageLocation}}</li>
+    </ul>
+
+    <h3>Number of files</h3>
+    <ul style="margin-bottom: 2rem;">
+        <li>SRC: {{.GnoFileCount}}</li>
+        <li>DST: {{.GoFileCount}}</li>
+    </ul>
+
+    {{- range .FilesDifferences}}
+    <details>
+        <summary>{{.SourceName}} ({{.Status}})</summary>
+        <div style="display: flex; flex-direction: row; align-items: stretch; padding-bottom: 2rem;"> 
+            <div name="gno_file_container" class="file-container" style="margin-right: 1rem;">
+                <h2>{{.SourceName}}</h2>
+                {{template "file-viewer" .SrcLineDiff}}
+            </div>
+
+            <div name="go_file_container" class="file-container">
+                <h2>{{.DestinationName}}</h2>
+                {{template "file-viewer" .DstLineDiff}}
+            </div>
+        </div>
+    </details>
+    {{- end}}
+</body>
+</html>


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
As requested by the issue [https://github.com/gnolang/gno/issues/1310](#1310),  the aim of this pull request is to add a tool under the misc directory to compare the Gno and Go standard libraries.

The tool generates a differences report per package.

To test the tool, build it, and refer to the README for usage instructions. The tool can be used in both ways: comparing Go to Gno or comparing Gno to Go.

I'm questioning the relevance of adding unit tests to this tool. If you believe it needs some, just let me know!

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x ] Provided any useful hints for running manual tests
- [x ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
