### PR TITLE
fix: Revert "Improve BFT Tests Stability (#1385)"

### DIFF
--- a/tm2/pkg/bft/consensus/common_test.go
+++ b/tm2/pkg/bft/consensus/common_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"sync"
 	"testing"
@@ -246,34 +245,8 @@ func validatePrevoteAndPrecommit(t *testing.T, cs *ConsensusState, thisRound, lo
 	validatePrecommit(t, cs, thisRound, lockRound, privVal, votedBlockHash, lockedBlockHash)
 }
 
-func bufferedEventChannel(in <-chan events.Event, size int) (out chan events.Event) {
-	out = make(chan events.Event, size)
-	go func() {
-		defer close(out)
-		for evt := range in {
-			out <- evt
-		}
-	}()
-
-	return out
-}
-
-func subscribe(evsw events.EventSwitch, protoevent events.Event) <-chan events.Event {
-	name := reflect.ValueOf(protoevent).Type().Name()
-	listenerID := fmt.Sprintf("%s-%s", testSubscriber, name)
-	ch := events.SubscribeToEvent(evsw, listenerID, protoevent)
-
-	// Similar to subscribeToVoter, this modification introduces
-	// a buffered channel to ensures that events are consumed
-	// asynchronously, thereby avoiding the deadlock situation described in
-	// #1320 where the eventSwitch.FireEvent method was blocked.
-	bch := bufferedEventChannel(ch, 16)
-
-	return bch
-}
-
 func subscribeToVoter(cs *ConsensusState, addr crypto.Address) <-chan events.Event {
-	ch := events.SubscribeFiltered(cs.evsw, testSubscriber, func(event events.Event) bool {
+	return events.SubscribeFiltered(cs.evsw, testSubscriber, func(event events.Event) bool {
 		if vote, ok := event.(types.EventVote); ok {
 			if vote.Vote.ValidatorAddress == addr {
 				return true
@@ -281,15 +254,6 @@ func subscribeToVoter(cs *ConsensusState, addr crypto.Address) <-chan events.Eve
 		}
 		return false
 	})
-
-	// This modification addresses the deadlock issue outlined in issue
-	// #1320. By creating a buffered channel, we ensure that events are
-	// consumed even if the main thread is blocked. This prevents the
-	// deadlock that occurred when eventSwitch.FireEvent was blocked due to
-	// no available consumers for the event.
-	bch := bufferedEventChannel(ch, 16)
-
-	return bch
 }
 
 // -------------------------------------------------------------------------------

--- a/tm2/pkg/bft/consensus/state_test.go
+++ b/tm2/pkg/bft/consensus/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	cstypes "github.com/gnolang/gno/tm2/pkg/bft/consensus/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/events"
 	p2pmock "github.com/gnolang/gno/tm2/pkg/p2p/mock"
 	"github.com/gnolang/gno/tm2/pkg/random"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
@@ -1776,4 +1777,8 @@ func TestStateOutputVoteStats(t *testing.T) {
 		t.Errorf("Should not output stats message after receiving the known vote or vote from bigger height")
 	case <-time.After(50 * time.Millisecond):
 	}
+}
+
+func subscribe(evsw events.EventSwitch, protoevent events.Event) <-chan events.Event {
+	return events.SubscribeToEvent(evsw, testSubscriber, protoevent)
 }


### PR DESCRIPTION
This PR reverts #1385 following @jaekwon https://github.com/gnolang/gno/issues/1320#issuecomment-1857414586

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
