### PR TITLE
fix: In gnoweb realm_help.html, update to Data.Flags.HelpChainID and Data.Flags.HelpRemote

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -7,7 +7,7 @@
   </head>
   <body onload="main()">
     <div id="root">
-      <div id="data" data-realm-path="{{ .Data.RealmPath }}" data-remote="{{ .Data.Remote }}" data-chainid="{{ .Data.ChainID }}" />
+      <div id="data" data-realm-path="{{ .Data.RealmPath }}" data-remote="{{ .Data.Flags.HelpRemote }}" data-chainid="{{ .Data.Flags.HelpChainID }}" />
       <div id="header">{{ template "header_logo" }} {{ template "header_buttons" }}</div>
       <div class="inline-list">
         <span id="logo_path"> <a href="{{ .Data.DirPath }}">{{ .Data.DirPath }}</a>?help </span>


### PR DESCRIPTION
In [gnoweb main.go](https://github.com/gnolang/gno/blob/9262c1a8f9495e8195a964a9a4a9963b19c61d33/gno.land/cmd/gnoweb/main.go#L23-L24), the names for flags `-help-chainid` and `-help-remote` are `HelpChainID` and `HelpRemote` . In realm_help.html, we need to refer to these with the prefix `Data.Flags` . Without this change, the chain ID and remote  on the help pages are blank (on our Berty testnet node). With this change, they display correctly. (This fix was discovered at the Rouen retreat with the help of @moul .)