### PR TITLE
fix: [gnoweb] fix unset binding

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -41,9 +41,9 @@ func main() {
 	logger := log.NewTMLogger(os.Stdout)
 	logger.SetLevel(log.LevelDebug)
 
-	logger.Debug("", "Running", "http://"+cfg.BindAddr)
+	logger.Info("Running", "listener", "http://"+bindAddress)
 	server := &http.Server{
-		Addr:              cfg.BindAddr,
+		Addr:              bindAddress,
 		ReadHeaderTimeout: 60 * time.Second,
 		Handler:           gnoweb.MakeApp(logger, cfg).Router,
 	}

--- a/gno.land/pkg/gnoweb/gnoweb.go
+++ b/gno.land/pkg/gnoweb/gnoweb.go
@@ -43,8 +43,6 @@ type Config struct {
 	HelpChainID   string
 	HelpRemote    string
 	WithAnalytics bool
-
-	BindAddr string
 }
 
 func NewDefaultConfig() Config {


### PR DESCRIPTION
fix empty binding on gnoweb, was a lefthover of #1386 that didn't take the correct flags into account

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
