### PR TITLE
chore: add challenge for "is not a type" error

### DIFF
--- a/gnovm/tests/challenges/not_a_type.gno
+++ b/gnovm/tests/challenges/not_a_type.gno
@@ -1,0 +1,10 @@
+package main
+
+var T struct{}
+
+func (t T) do() {}
+
+func main() {}
+
+// Error:
+// T (variable of type struct{}) is not a type


### PR DESCRIPTION
When you declare a method and the method type refers to a variable (due to a code error), the error message returned by the VM is not clear:
```
interface conversion: gnolang.Value is nil, not gnolang.TypeValue
```
The [same code][0] under the go compiler returns something more explicit:
```
T (variable of type struct{}) is not a type
```
where T is the name of the expected type that is wrongly declared as a variable in the code (the code I'm referring is inside the challenge).

The patch requires updates in the preprocess code, so until I have time to work on it, I push this challenge in case anyone is ready for it :)

[0]: https://go.dev/play/p/Ls1m47Oprdm

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Full stack trace</summary>

```
goroutine 7 [running]:
runtime/debug.Stack()
	/usr/lib/go/src/runtime/debug/stack.go:24 +0x5e
runtime/debug.PrintStack()
	/usr/lib/go/src/runtime/debug/stack.go:16 +0x13
github.com/gnolang/gno/gnovm/tests.RunFileTest.func1.1()
	/home/tom/src/gno/gnovm/tests/file.go:142 +0x1af
panic({0xc64ae0?, 0xc000325e80?})
	/usr/lib/go/src/runtime/panic.go:914 +0x21f
github.com/gnolang/gno/gnovm/pkg/gnolang.predefineNow.func1()
	/home/tom/src/gno/gnovm/pkg/gnolang/preprocess.go:2851 +0x185
panic({0xc0cda0?, 0xc000391140?})
	/usr/lib/go/src/runtime/panic.go:914 +0x21f
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).doOpFieldType(0xc00038dc20?)
	/home/tom/src/gno/gnovm/pkg/gnolang/op_types.go:10 +0x1da
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).Run(0xc00038dc20)
	/home/tom/src/gno/gnovm/pkg/gnolang/machine.go:1244 +0x110e
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).EvalStatic(0xc00038dc20, {0xedce60, 0xc0003a2580}, {0xed5df8?, 0xc0003a42d8})
	/home/tom/src/gno/gnovm/pkg/gnolang/machine.go:662 +0x34a
github.com/gnolang/gno/gnovm/pkg/gnolang.evalStaticType({0xedfbb8, 0xc000262480}, {0xedce60, 0xc0003a2580}, {0xed5df8, 0xc0003a42d8?})
	/home/tom/src/gno/gnovm/pkg/gnolang/preprocess.go:1980 +0x1d6
github.com/gnolang/gno/gnovm/pkg/gnolang.predefineNow2({0xedfbb8, 0xc000262480}, {0xedce60?, 0xc0003a2580}, {0xed7080, 0xc0003a4000?}, 0xc00038b600?)
	/home/tom/src/gno/gnovm/pkg/gnolang/preprocess.go:2902 +0x3f3
github.com/gnolang/gno/gnovm/pkg/gnolang.predefineNow({0xedfbb8, 0xc000262480}, {0xedce60?, 0xc0003a2580}, {0xed7080?, 0xc0003a4000?})
	/home/tom/src/gno/gnovm/pkg/gnolang/preprocess.go:2859 +0x14d
github.com/gnolang/gno/gnovm/pkg/gnolang.PredefineFileSet({0xedfbb8, 0xc000262480}, 0xc000317b80, 0xc000012ed0)
	/home/tom/src/gno/gnovm/pkg/gnolang/preprocess.go:74 +0x3d5
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).runFiles(0xc0002ec7e0, {0xc000062928, 0x1, 0x1})
	/home/tom/src/gno/gnovm/pkg/gnolang/machine.go:432 +0x275
github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).RunFiles(...)
	/home/tom/src/gno/gnovm/pkg/gnolang/machine.go:398
github.com/gnolang/gno/gnovm/tests.RunFileTest.func1(0x1?, 0x0?, {0xc00031a150?, 0x0?}, 0xc000012cf0, {0xce6817, 0x4}, {0xce6817, 0x4}, {0xedfbb8, ...}, ...)
	/home/tom/src/gno/gnovm/tests/file.go:159 +0x8a8
github.com/gnolang/gno/gnovm/tests.RunFileTest({0xc0002ffe08, 0x5}, {0xc000302340, 0x19}, {0xc00033b3a0, 0x3, 0x4?})
	/home/tom/src/gno/gnovm/tests/file.go:233 +0x37a
github.com/gnolang/gno/gnovm/tests.runFileTest(0xc0003481a0, {0xc000302340, 0x19}, {0xc000062730, 0x1, 0x1270c08?})
	/home/tom/src/gno/gnovm/tests/file_test.go:98 +0x2a9
github.com/gnolang/gno/gnovm/tests.runFileTests.func1(0x0?)
	/home/tom/src/gno/gnovm/tests/file_test.go:83 +0x9f
testing.tRunner(0xc0003481a0, 0xc0002e9ce0)
	/usr/lib/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 6
	/usr/lib/go/src/testing/testing.go:1648 +0x3ad
```

</details>

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
