### PR TITLE
refactor(gnolang): handle duplicate method decls using TryDefineMethod

### DIFF
--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -1458,7 +1458,7 @@ func (dt *DeclaredType) DefineMethod(fv *FuncValue) {
 }
 
 // TryDefineMethod attempts to define the method fv on type dt.
-// It returns false if this succeeds, because it would be a re-declaration.
+// It returns false if this does not succeeds, as a result of a re-declaration.
 func (dt *DeclaredType) TryDefineMethod(fv *FuncValue) bool {
 	name := fv.Name
 


### PR DESCRIPTION
A (IMHO) better method of handling this. Related discussion: https://github.com/gnolang/gno/pull/859#discussion_r1423798535

Avoids creating a panic/recover in Preprocess by handling the "redeclaration" case directly when it happens.

cc/ @jaekwon to confirm whether he agrees it's a good solution.

(suggestion: review with whitespace hidden)