### PR TITLE
docs: update gnokey url

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -17,7 +17,7 @@
         <br />
         These are the realm's exposed functions ("public smart contracts").<br />
         <br />
-        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://github.com/gnolang/gno">`gnokey list`</a>)<br />
+        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://docs.gnoteam.com/getting-started/working-with-key-pairs">`gnokey list`</a>)<br />
         <br />
         <br />
         {{ template "func_specs" . }}


### PR DESCRIPTION
This pull request updates the URL for the gnokey documentation in the realm_help.html file. The previous URL was pointing to GITHUB which doesn't help.

The new URL directs users to the correct documentation on how to work with key pairs in the gnokey tool.

<img width="1077" alt="Screenshot 2023-12-20 at 00 01 58" src="https://github.com/gnolang/gno/assets/689440/d9f0deed-9e41-4b80-8abb-b9a3aae5f9db">


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
