### PR TITLE
fix: repair gnoweb flag parsing

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -13,9 +13,12 @@ import (
 	// "github.com/gnolang/gno/tm2/pkg/sdk"               // for baseapp (info, status)
 )
 
-func parseConfigFlags(fs *flag.FlagSet, args []string) (gnoweb.Config, error) {
-	cfg := gnoweb.NewDefaultConfig()
-
+func main() {
+	var (
+		fs          = flag.NewFlagSet("gnoweb", flag.PanicOnError)
+		cfg         = gnoweb.NewDefaultConfig()
+		bindAddress string
+	)
 	fs.StringVar(&cfg.RemoteAddr, "remote", cfg.RemoteAddr, "remote gnoland node address")
 	fs.StringVar(&cfg.CaptchaSite, "captcha-site", cfg.CaptchaSite, "recaptcha site key (if empty, captcha are disabled)")
 	fs.StringVar(&cfg.FaucetURL, "faucet-url", cfg.FaucetURL, "faucet server URL")
@@ -23,17 +26,9 @@ func parseConfigFlags(fs *flag.FlagSet, args []string) (gnoweb.Config, error) {
 	fs.StringVar(&cfg.HelpChainID, "help-chainid", cfg.HelpChainID, "help page's chainid")
 	fs.StringVar(&cfg.HelpRemote, "help-remote", cfg.HelpRemote, "help page's remote addr")
 	fs.BoolVar(&cfg.WithAnalytics, "with-analytics", cfg.WithAnalytics, "enable privacy-first analytics")
-
-	return cfg, fs.Parse(args)
-}
-
-func main() {
-	fs := flag.NewFlagSet("gnoweb", flag.PanicOnError)
-
-	var bindAddress string
 	fs.StringVar(&bindAddress, "bind", "127.0.0.1:8888", "server listening address")
 
-	cfg, err := parseConfigFlags(fs, os.Args)
+	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		panic("unable to parse flags: " + err.Error())
 	}

--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -14,8 +15,16 @@ import (
 )
 
 func main() {
+	err := runMain(os.Args[1:])
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runMain(args []string) error {
 	var (
-		fs          = flag.NewFlagSet("gnoweb", flag.PanicOnError)
+		fs          = flag.NewFlagSet("gnoweb", flag.ContinueOnError)
 		cfg         = gnoweb.NewDefaultConfig()
 		bindAddress string
 	)
@@ -28,9 +37,8 @@ func main() {
 	fs.BoolVar(&cfg.WithAnalytics, "with-analytics", cfg.WithAnalytics, "enable privacy-first analytics")
 	fs.StringVar(&bindAddress, "bind", "127.0.0.1:8888", "server listening address")
 
-	err := fs.Parse(os.Args[1:])
-	if err != nil {
-		panic("unable to parse flags: " + err.Error())
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
 
 	logger := log.NewTMLogger(os.Stdout)
@@ -46,4 +54,5 @@ func main() {
 	if err := server.ListenAndServe(); err != nil {
 		logger.Error("HTTP server stopped", " error:", err)
 	}
+	return nil
 }

--- a/gno.land/cmd/gnoweb/main_test.go
+++ b/gno.land/cmd/gnoweb/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestFlagHelp(t *testing.T) {
+	err := runMain([]string{"-h"})
+	if err != flag.ErrHelp {
+		t.Errorf("should display usage")
+	}
+}

--- a/gno.land/cmd/gnoweb/main_test.go
+++ b/gno.land/cmd/gnoweb/main_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"testing"
 )
 
 func TestFlagHelp(t *testing.T) {
 	err := runMain([]string{"-h"})
-	if err != flag.ErrHelp {
+	if !errors.Is(err, flag.ErrHelp) {
 		t.Errorf("should display usage")
 	}
 }


### PR DESCRIPTION
Before:
![CleanShot 2023-12-21 at 00 31 36@2x](https://github.com/gnolang/gno/assets/94029/9587d366-adac-42a1-9527-0b14c97ff89f)

After:
![CleanShot 2023-12-21 at 00 59 08@2x](https://github.com/gnolang/gno/assets/94029/8560bf0c-a145-47a5-b456-80f38479f390)

Continues https://github.com/gnolang/gno/pull/1446

---

Flag parsing was broken because `fs.Parse` was expecting to use `os.Args[1:]` instead of `os.Args`. I fixed it, simplified the implementation and added a regression test.
