### PR TITLE
fix: repair staging docker-compose by using the new gnoweb CLI

### DIFF
--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       - --faucet-url=https://faucet-staging.gno.land/
       - --help-chainid=staging
       - --help-remote=staging.gno.land:36657
-      - --views-dir=./gno.land/cmd/gnoweb/views
       - --with-analytics
     volumes:
       - "./overlay:/overlay:ro"


### PR DESCRIPTION
Before:
<img width="1590" alt="Capture d’écran   2023-12-21 à 12 08 25" src="https://github.com/gnolang/gno/assets/94029/21445293-1ddf-4f17-96a6-c21a8716e128">

After:
No problemo.