### PR TITLE
fix(gnofaucet): fix transactions by querying account number and sequence each time

### DIFF
--- a/gno.land/cmd/gnofaucet/serve.go
+++ b/gno.land/cmd/gnofaucet/serve.go
@@ -182,31 +182,6 @@ func execServe(cfg *config, args []string, io commands.IO) error {
 	if err != nil {
 		return err
 	}
-	info, err := kb.GetByName(name)
-	if err != nil {
-		return err
-	}
-	fromAddr := info.GetAddress()
-
-	// query for initial number and sequence.
-	path := fmt.Sprintf("auth/accounts/%s", fromAddr.String())
-	data := []byte(nil)
-	opts2 := rpcclient.ABCIQueryOptions{}
-	qres, err := cli.ABCIQueryWithOptions(
-		path, data, opts2)
-	if err != nil {
-		return errors.Wrap(err, "querying")
-	}
-	if qres.Response.Error != nil {
-		fmt.Printf("Log: %s\n",
-			qres.Response.Log)
-		return qres.Response.Error
-	}
-	resdata := qres.Response.Data
-	var acc gnoland.GnoAccount
-	amino.MustUnmarshalJSON(resdata, &acc)
-	accountNumber := acc.BaseAccount.AccountNumber
-	sequence := acc.BaseAccount.Sequence
 
 	// Get password for supply account.
 	// Test by signing a dummy message;
@@ -239,7 +214,7 @@ func execServe(cfg *config, args []string, io commands.IO) error {
 		if err != nil {
 			return err
 		}
-		err = sendAmountTo(cfg, cli, io, name, pass, testToAddr, accountNumber, sequence, send)
+		err = sendAmountTo(cfg, cli, io, name, pass, testToAddr, send)
 		return err
 	}
 
@@ -318,13 +293,12 @@ func execServe(cfg *config, args []string, io commands.IO) error {
 			w.Write([]byte("invalid address format"))
 			return
 		}
-		err = sendAmountTo(cfg, cli, io, name, pass, toAddr, accountNumber, sequence, send)
+		err = sendAmountTo(cfg, cli, io, name, pass, toAddr, send)
 		if err != nil {
 			fmt.Println(ip, "faucet failed", err)
 			w.Write([]byte("faucet failed"))
 			return
 		} else {
-			sequence += 1
 			fmt.Println(ip, "faucet success")
 			w.Write([]byte("faucet success"))
 		}
@@ -349,8 +323,6 @@ func sendAmountTo(
 	name,
 	pass string,
 	toAddr crypto.Address,
-	accountNumber,
-	sequence uint64,
 	send std.Coins,
 ) error {
 	// Read supply account pubkey.
@@ -399,6 +371,26 @@ func sendAmountTo(
 		return err
 	}
 	// fmt.Println("will sign:", string(amino.MustMarshalJSON(tx)))
+
+	// query for the account number and sequence each time in case the node is reset
+	path := fmt.Sprintf("auth/accounts/%s", fromAddr.String())
+	data := []byte(nil)
+	opts2 := rpcclient.ABCIQueryOptions{}
+	qres, err := cli.ABCIQueryWithOptions(
+		path, data, opts2)
+	if err != nil {
+		return errors.Wrap(err, "querying")
+	}
+	if qres.Response.Error != nil {
+		fmt.Printf("Log: %s\n",
+			qres.Response.Log)
+		return qres.Response.Error
+	}
+	resdata := qres.Response.Data
+	var acc gnoland.GnoAccount
+	amino.MustUnmarshalJSON(resdata, &acc)
+	accountNumber := acc.BaseAccount.AccountNumber
+	sequence := acc.BaseAccount.Sequence
 
 	// get sign-bytes and make signature.
 	chainID := cfg.ChainID


### PR DESCRIPTION
Currently, `gnofaucet` [queries the blockchain once](https://github.com/gnolang/gno/blob/c3a4993335f8881989eb49e4efea6a3c1310061d/gno.land/cmd/gnofaucet/serve.go#L191-L209) for the account number and sequence number, and [increments the sequence number](https://github.com/gnolang/gno/blob/master/gno.land/cmd/gnofaucet/serve.go#L327) each time that it sends coins. We are using `gnofaucet` with `gnodev`. When `gnodev` restarts the chain, it also resets the sequence number. This means that we also have to restart `gnofaucet` (to re-query the sequence number), which is inconvenient for the development workflow.

If you agree that it would be nice for `gnofaucet` to continue to work after `gnodev` does a reset, then this pull request moves the query for the account number and sequence number into the `sendAmountTo` function so that it queries each time it signs a transaction. Now `gnofaucet` continues to function even if the sequence number is unexpectedly changed (because the blockchain is reset or because some other transaction is signed with the same key).