### PR TITLE
chore:  HTTP server error handling

### DIFF
--- a/gno.land/cmd/gnofaucet/serve.go
+++ b/gno.land/cmd/gnofaucet/serve.go
@@ -337,7 +337,9 @@ func execServe(cfg *config, args []string, io commands.IO) error {
 		Addr:              ":5050",
 		ReadHeaderTimeout: 60 * time.Second,
 	}
-	server.ListenAndServe()
+	if err := server.ListenAndServe(); err != nil {
+		return fmt.Errorf("http server stopped. %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a simple error handler for gnofaucet server.

We currently have NO feedback on any failure in the gnofaucet HTTP server, which makes troubleshooting more difficult.

Imagine the scenario where the port 5050 is already busy!

To test:
1 - run gnofaucet in a terminal.
2 - try to run another instance of gnofaucet in a different terminal.
3 - a clear error message is expected on step n2.


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
