### PR TITLE
fix: In gnoweb realm_help.html, update to Data.Config.HelpRemote and Data.Config.HelpChainID

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -7,7 +7,7 @@
   </head>
   <body onload="main()">
     <div id="root">
-      <div id="data" data-realm-path="{{ .Data.RealmPath }}" data-remote="{{ .Data.Flags.HelpRemote }}" data-chainid="{{ .Data.Flags.HelpChainID }}" />
+      <div id="data" data-realm-path="{{ .Data.RealmPath }}" data-remote="{{ .Data.Config.HelpRemote }}" data-chainid="{{ .Data.Config.HelpChainID }}" />
       <div id="header">{{ template "header_logo" }} {{ template "header_buttons" }}</div>
       <div class="inline-list">
         <span id="logo_path"> <a href="{{ .Data.DirPath }}">{{ .Data.DirPath }}</a>?help </span>


### PR DESCRIPTION
This is a followup to PR #1444 . In gnoweb.go, the configuration is [assigned to Config](https://github.com/gnolang/gno/blob/b525e8bd92efd1935c091c3491202a10ef4a5906/gno.land/pkg/gnoweb/gnoweb.go#L173) . Previously, it was assigned to Flags . (I tried to find the commit to blame but this file has been moved around and renamed too many times.) In realm_help.html, we need now to refer to these with the prefix Data.Config (not Data.Flags) . Without this change, the chain ID and remote on the help pages are blank (on our Berty testnet node). With this change, they display correctly.