### PR TITLE
chore: In gnodev serveGnoWebServer, set webConfig HelpChainID and HelpRemote

### DIFF
--- a/contribs/gnodev/main.go
+++ b/contribs/gnodev/main.go
@@ -317,6 +317,8 @@ func serveGnoWebServer(l net.Listener, dnode *gnodev.Node, rt *rawterm.RawTerm) 
 
 	webConfig := gnoweb.NewDefaultConfig()
 	webConfig.RemoteAddr = dnode.GetRemoteAddress()
+	webConfig.HelpChainID = dnode.Config().ChainID()
+	webConfig.HelpRemote = dnode.GetRemoteAddress()
 
 	loggerweb := tmlog.NewTMLogger(rt.NamespacedWriter("GnoWeb"))
 	loggerweb.SetLevel(tmlog.LevelDebug)


### PR DESCRIPTION
In gnodev, `serveGnoWebServer` sets up the `webConfig`. Here we set `HelpChainID` and `HelpRemote` to the same values that are printed when gnodev starts. Now these appear in gnoweb in "-chain-id" and "-remote" on the help pages as shown below.

NOTE: This PR depends on the fix in PR #1496 .

```
gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "GetBoardIDFromName"
-gas-fee 1000000ugnot -gas-wanted 2000000 -send "" -broadcast -chainid "tendermint_test" -args ""
-remote "tcp://0.0.0.0:36657" ADDRESS
```