### PR TITLE
chore: update staging deployment config

### DIFF
--- a/misc/deployments/staging.gno.land/Makefile
+++ b/misc/deployments/staging.gno.land/Makefile
@@ -11,7 +11,7 @@ logs:
 down:
 	docker compose down
 	docker volume rm -f staginggnoland_gnonode
-	docker compose run gnoland rm -rf /opt/gno/src/testdir/data /opt/gno/src/testdir/config
+	docker compose run gnoland rm -rf /opt/gno/src/gno.land/testdir/data /opt/gno/src/gno.land/testdir/config
 
 pull:
 	git pull


### PR DESCRIPTION
It was stuck at a very high height (around 300k) even after running `make down`. Now, it has restarted from block 0 as expected for this staging.

![CleanShot 2024-01-06 at 22 19 40@2x](https://github.com/gnolang/gno/assets/94029/0b6204d1-8a05-4706-995d-70d8d2801dc4)
