### PR TITLE
fix(gnodev): time drifting in gnodev

### DIFF
--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -408,6 +408,8 @@ func newNode(logger log.Logger, genesis gnoland.GnoGenesisState) (*node.Node, er
 
 	nodeConfig := gnoland.NewDefaultInMemoryNodeConfig(rootdir)
 	nodeConfig.SkipFailingGenesisTxs = true
+	nodeConfig.TMConfig.Consensus.SkipTimeoutCommit = false // avoid time drifting, see issue #1507
+
 	nodeConfig.Genesis.AppState = genesis
 	return gnoland.NewInMemoryNode(logger, nodeConfig)
 }


### PR DESCRIPTION
fix #1507 

It appears that using `TestConsensusConfig` as the default consensus configuration in gnodev causes time drift. This can be fixed by setting `cfg.Consensus.SkipTimeoutCommit` to `false`. However, I'm not certain about the exact reason why this setting actually corrects the time drifting issue.