### PR TITLE
docs(gnoweb): remove reference to gnoteam domain

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -17,7 +17,7 @@
         <br />
         These are the realm's exposed functions ("public smart contracts").<br />
         <br />
-        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://docs.gnoteam.com/getting-started/working-with-key-pairs">`gnokey list`</a>)<br />
+        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://docs.gno.land/getting-started/working-with-key-pairs">`gnokey list`</a>)<br />
         <br />
         <br />
         {{ template "func_specs" . }}


### PR DESCRIPTION
Fixes #1479