### PR TITLE
docs(gno-tooling/cli): remove `gno build`

### DIFF
--- a/docs/concepts/gno-tooling/cli/gno.md
+++ b/docs/concepts/gno-tooling/cli/gno.md
@@ -18,19 +18,9 @@ gno {SUB_COMMAND}
 
 | Name         | Description                                |
 | ------------ | ------------------------------------------ |
-| `build`      | Builds a gno package.                      |
 | `test`       | Tests a gno package.                       |
 | `precompile` | Precompiles a `.gno` file to a `.go` file. |
 | `repl`       | Starts a GnoVM REPL.                       |
-
-### `build`
-
-#### **Options**
-
-| Name      | Type    | Description                                    |
-| --------- | ------- | ---------------------------------------------- |
-| `verbose` | Boolean | Displays extended information.                 |
-| go-binary | String  | Go binary to use for building (default: `go`). |
 
 ### `test`
 
@@ -52,6 +42,7 @@ gno {SUB_COMMAND}
 | ----------- | ------- | --------------------------------------------------------------- |
 | `verbose`   | Boolean | Displays extended information.                                  |
 | `skip-fmt`  | Boolean | Skips the syntax checking of generated `.go` files.             |
+| `gobuild`   | Boolean | Run `go build` on generated `.go` files, ignoring test files.   |
 | `go-binary` | String  | The go binary to use for building (default: `go`).              |
 | `gofmt`     | String  | The gofmt binary to use for syntax checking (default: `gofmt`). |
 | `output`    | String  | The output directory (default: `.`).                            |

--- a/docs/concepts/gno-tooling/cli/gno.md
+++ b/docs/concepts/gno-tooling/cli/gno.md
@@ -53,7 +53,7 @@ gno {SUB_COMMAND}
 | `verbose`   | Boolean | Displays extended information.                                  |
 | `skip-fmt`  | Boolean | Skips the syntax checking of generated `.go` files.             |
 | `go-binary` | String  | The go binary to use for building (default: `go`).              |
-| `go-binary` | String  | The gofmt binary to use for syntax checking (default: `gofmt`). |
+| `gofmt`     | String  | The gofmt binary to use for syntax checking (default: `gofmt`). |
 | `output`    | String  | The output directory (default: `.`).                            |
 
 ### `repl`


### PR DESCRIPTION
- Remove `gno build` as it doesn't exist anymore (see: #1297)
- s/go-binary/gofmt

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
