### PR TITLE
docs(fix): remove leftover paragraph

### DIFF
--- a/docs/concepts/gno-test.md
+++ b/docs/concepts/gno-test.md
@@ -82,12 +82,6 @@ Replacing the second test case with the following will successfully fix the issu
   }
 ```
 
-## Blockchain context in tests
-Running `gno test` executes files within the directory that end with `_test.gno` and `_filetest.gno`.
-Internally, a GnoVM instance is initialized to run the test, and, at that moment, 
-a blockchain-related context is injected into the GnoVM. Utilizing this context, the transaction sender, 
-coins, block height, etc. can be mocked.
-
 ## Manipulating blockchain context in tests
 Some functions in the `std` package are exclusively accessible in `_test.gno`
 and `_filetest.gno` files. These are located in the `std` package, and their primary role

--- a/docs/concepts/gno-test.md
+++ b/docs/concepts/gno-test.md
@@ -82,9 +82,10 @@ Replacing the second test case with the following will successfully fix the issu
   }
 ```
 
-## Manipulating blockchain context in tests
-Some functions in the `std` package are exclusively accessible in `_test.gno`
-and `_filetest.gno` files. These are located in the `std` package, and their primary role
-is to alter the blockchain context for test runs.
+## Blockchain context in tests
+Running `gno test` executes files within the directory that end with `_test.gno` and `_filetest.gno`.
+Internally, a GnoVM instance is initialized to run the test, and, at that moment, 
+a blockchain-related context is injected into the GnoVM. Utilizing this context, the transaction sender, 
+coins, block height, etc. can be mocked.
 
 For detailed information on these functions, refer to their [reference page](../reference/standard-library/std/testing.md).

--- a/docs/reference/standard-library/std/testing.md
+++ b/docs/reference/standard-library/std/testing.md
@@ -80,7 +80,7 @@ func TestIssueCoins(addr Address, coins Coins)
 Issues testing context **coins** to **addr**.
 #### Usage
 ```go
-issue:= std.Coins{{"coin1", 100}, {"coin2", 200}}
+issue := std.Coins{{"coin1", 100}, {"coin2", 200}}
 addr := "g1ecely4gjy0yl6s9kt409ll330q9hk2lj9ls3ec"
 std.TestIssueCoins(addr, issue)
 ```


### PR DESCRIPTION
## Description

This PR removes a leftover duplicate paragraph & fixes a typo.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
