### PR TITLE
fix(r/demo/boards): correctly render reposts

### DIFF
--- a/examples/gno.land/r/demo/boards/post.gno
+++ b/examples/gno.land/r/demo/boards/post.gno
@@ -162,6 +162,15 @@ func (post *Post) GetReplyFormURL() string {
 		"&body.type=textarea"
 }
 
+func (post *Post) GetRepostFormURL() string {
+	return "/r/demo/boards?help&__func=CreateRepost" +
+		"&bid=" + post.board.id.String() +
+		"&postid=" + post.id.String() +
+		"&title.type=textarea" +
+		"&body.type=textarea" +
+		"&dstBoardID.type=textarea"
+}
+
 func (post *Post) GetDeleteFormURL() string {
 	return "/r/demo/boards?help&__func=DeletePost" +
 		"&bid=" + post.board.id.String() +
@@ -170,6 +179,17 @@ func (post *Post) GetDeleteFormURL() string {
 }
 
 func (post *Post) RenderSummary() string {
+	if post.repostBoard != 0 {
+		dstBoard := getBoard(post.repostBoard)
+		if dstBoard == nil {
+			panic("repostBoard does not exist")
+		}
+		thread := dstBoard.GetThread(PostID(post.parentID))
+		if thread == nil {
+			return "reposted post does not exist"
+		}
+		return "Repost: " + post.GetSummary() + "\n" + thread.RenderSummary()
+	}
 	str := ""
 	if post.title != "" {
 		str += "## [" + summaryOf(post.title, 80) + "](" + post.GetURL() + ")\n"
@@ -179,7 +199,8 @@ func (post *Post) RenderSummary() string {
 	str += "\\- " + displayAddressMD(post.creator) + ","
 	str += " [" + post.createdAt.Format("2006-01-02 3:04pm MST") + "](" + post.GetURL() + ")"
 	str += " \\[[x](" + post.GetDeleteFormURL() + ")]"
-	str += " (" + strconv.Itoa(post.replies.Size()) + " replies)" + "\n"
+	str += " (" + strconv.Itoa(post.replies.Size()) + " replies)"
+	str += " (" + strconv.Itoa(post.reposts.Size()) + " reposts)" + "\n"
 	return str
 }
 
@@ -196,6 +217,9 @@ func (post *Post) RenderPost(indent string, levels int) string {
 	str += indent + "\\- " + displayAddressMD(post.creator) + ", "
 	str += "[" + post.createdAt.Format("2006-01-02 3:04pm (MST)") + "](" + post.GetURL() + ")"
 	str += " \\[[reply](" + post.GetReplyFormURL() + ")]"
+	if post.IsThread() {
+		str += " \\[[repost](" + post.GetRepostFormURL() + ")]"
+	}
 	str += " \\[[x](" + post.GetDeleteFormURL() + ")]\n"
 	if levels > 0 {
 		if post.replies.Size() > 0 {

--- a/examples/gno.land/r/demo/boards/z_0_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_0_filetest.gno
@@ -30,10 +30,10 @@ func main() {
 // ## [First Post (title)](/r/demo/boards:test_board/1)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/1) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)] (0 replies)
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/1) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)] (0 replies) (0 reposts)
 //
 // ----------------------------------------
 // ## [Second Post (title)](/r/demo/boards:test_board/2)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/2) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)] (1 replies)
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/2) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)] (1 replies) (0 reposts)

--- a/examples/gno.land/r/demo/boards/z_10_c_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_10_c_filetest.gno
@@ -35,7 +35,7 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // > First reply of the First post
 // >
@@ -45,4 +45,4 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]

--- a/examples/gno.land/r/demo/boards/z_10_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_10_filetest.gno
@@ -33,7 +33,7 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // ----------------------------------------------------
 // thread does not exist with id: 1

--- a/examples/gno.land/r/demo/boards/z_11_d_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_11_d_filetest.gno
@@ -35,7 +35,7 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // > First reply of the First post
 // >
@@ -45,7 +45,7 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // > Edited: First reply of the First post
 // >

--- a/examples/gno.land/r/demo/boards/z_11_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_11_filetest.gno
@@ -33,10 +33,10 @@ func main() {
 // # First Post in (title)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // ----------------------------------------------------
 // # Edited: First Post in (title)
 //
 // Edited: Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]

--- a/examples/gno.land/r/demo/boards/z_12_a_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_12_a_filetest.gno
@@ -1,0 +1,32 @@
+// PKGPATH: gno.land/r/boards_test
+package boards_test
+
+// SEND: 200000000ugnot
+
+import (
+	"std"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/r/demo/boards"
+	"gno.land/r/demo/users"
+)
+
+func main() {
+	users.Register("", "gnouser", "my profile")
+	// create a post via registered user
+	bid1 := boards.CreateBoard("test_board1")
+	pid := boards.CreateThread(bid1, "First Post (title)", "Body of the first post. (body)")
+	bid2 := boards.CreateBoard("test_board2")
+
+	// create a repost via anon user
+	test2 := testutils.TestAddress("test2")
+	std.TestSetOrigCaller(test2)
+	std.TestSetOrigSend(std.Coins{{"ugnot", 9000000}}, nil)
+
+	rid := boards.CreateRepost(bid1, pid, "", "Check this out", bid2)
+	println(rid)
+	println(boards.Render("test_board1"))
+}
+
+// Error:
+// please register, otherwise minimum fee 100000000 is required if anonymous

--- a/examples/gno.land/r/demo/boards/z_12_b_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_12_b_filetest.gno
@@ -1,0 +1,24 @@
+// PKGPATH: gno.land/r/boards_test
+package boards_test
+
+// SEND: 200000000ugnot
+
+import (
+	"gno.land/r/demo/boards"
+	"gno.land/r/demo/users"
+)
+
+func main() {
+	users.Register("", "gnouser", "my profile")
+	bid1 := boards.CreateBoard("test_board1")
+	pid := boards.CreateThread(bid1, "First Post (title)", "Body of the first post. (body)")
+	bid2 := boards.CreateBoard("test_board2")
+
+	// create a repost to a non-existing board
+	rid := boards.CreateRepost(5, pid, "", "Check this out", bid2)
+	println(rid)
+	println(boards.Render("test_board1"))
+}
+
+// Error:
+// src board not exist

--- a/examples/gno.land/r/demo/boards/z_12_c_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_12_c_filetest.gno
@@ -1,0 +1,24 @@
+// PKGPATH: gno.land/r/boards_test
+package boards_test
+
+// SEND: 200000000ugnot
+
+import (
+	"gno.land/r/demo/boards"
+	"gno.land/r/demo/users"
+)
+
+func main() {
+	users.Register("", "gnouser", "my profile")
+	bid1 := boards.CreateBoard("test_board1")
+	boards.CreateThread(bid1, "First Post (title)", "Body of the first post. (body)")
+	bid2 := boards.CreateBoard("test_board2")
+
+	// create a repost to a non-existing thread
+	rid := boards.CreateRepost(bid1, 5, "", "Check this out", bid2)
+	println(rid)
+	println(boards.Render("test_board1"))
+}
+
+// Error:
+// thread not exist

--- a/examples/gno.land/r/demo/boards/z_12_d_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_12_d_filetest.gno
@@ -1,0 +1,24 @@
+// PKGPATH: gno.land/r/boards_test
+package boards_test
+
+// SEND: 200000000ugnot
+
+import (
+	"gno.land/r/demo/boards"
+	"gno.land/r/demo/users"
+)
+
+func main() {
+	users.Register("", "gnouser", "my profile")
+	bid1 := boards.CreateBoard("test_board1")
+	pid := boards.CreateThread(bid1, "First Post (title)", "Body of the first post. (body)")
+	boards.CreateBoard("test_board2")
+
+	// create a repost to a non-existing destination board
+	rid := boards.CreateRepost(bid1, pid, "", "Check this out", 5)
+	println(rid)
+	println(boards.Render("test_board1"))
+}
+
+// Error:
+// dst board not exist

--- a/examples/gno.land/r/demo/boards/z_12_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_12_filetest.gno
@@ -1,0 +1,40 @@
+// PKGPATH: gno.land/r/boards_test
+package boards_test
+
+// SEND: 200000000ugnot
+
+import (
+	"gno.land/r/demo/boards"
+	"gno.land/r/demo/users"
+)
+
+var (
+	bid1 boards.BoardID
+	bid2 boards.BoardID
+	pid  boards.PostID
+)
+
+func init() {
+	users.Register("", "gnouser", "my profile")
+
+	bid1 = boards.CreateBoard("test_board1")
+	pid = boards.CreateThread(bid1, "First Post (title)", "Body of the first post. (body)")
+	bid2 = boards.CreateBoard("test_board2")
+}
+
+func main() {
+	rid := boards.CreateRepost(bid1, pid, "", "Check this out", bid2)
+	println(rid)
+	println(boards.Render("test_board2"))
+}
+
+// Output:
+// 1
+// \[[post](/r/demo/boards?help&__func=CreateThread&bid=2&body.type=textarea)]
+//
+// ----------------------------------------
+// Repost: Check this out
+// ## [First Post (title)](/r/demo/boards:test_board1/1)
+//
+// Body of the first post. (body)
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board1/1) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)] (0 replies) (1 reposts)

--- a/examples/gno.land/r/demo/boards/z_2_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_2_filetest.gno
@@ -32,7 +32,7 @@ func main() {
 // # Second Post (title)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=2&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
 //
 // > Reply of the second post
 // > \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2/3) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=3&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=3)]

--- a/examples/gno.land/r/demo/boards/z_3_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_3_filetest.gno
@@ -34,7 +34,7 @@ func main() {
 // # Second Post (title)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=2&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
 //
 // > Reply of the second post
 // > \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2/3) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=3&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=3)]

--- a/examples/gno.land/r/demo/boards/z_4_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_4_filetest.gno
@@ -37,7 +37,7 @@ func main() {
 // # Second Post (title)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=2&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
 //
 // > Reply of the second post
 // > \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2/3) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=3&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=3)]

--- a/examples/gno.land/r/demo/boards/z_5_c_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_5_c_filetest.gno
@@ -33,7 +33,7 @@ func main() {
 // # First Post (title)
 //
 // Body of the first post. (body)
-// \- [g1w3jhxapjta047h6lta047h6lta047h6laqcyu4](/r/demo/users:g1w3jhxapjta047h6lta047h6lta047h6laqcyu4), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
+// \- [g1w3jhxapjta047h6lta047h6lta047h6laqcyu4](/r/demo/users:g1w3jhxapjta047h6lta047h6lta047h6laqcyu4), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=1&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=1&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)]
 //
 // > Reply of the first post
 // > \- [g1w3jhxapjta047h6lta047h6lta047h6laqcyu4](/r/demo/users:g1w3jhxapjta047h6lta047h6lta047h6laqcyu4), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/1/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=1&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=2)]

--- a/examples/gno.land/r/demo/boards/z_5_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_5_filetest.gno
@@ -33,7 +33,7 @@ func main() {
 // # Second Post (title)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=2&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
 //
 // > Reply of the second post
 // > \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2/3) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=3&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=3)]

--- a/examples/gno.land/r/demo/boards/z_6_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_6_filetest.gno
@@ -35,7 +35,7 @@ func main() {
 // # Second Post (title)
 //
 // Body of the second post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=2&body.type=textarea)] \[[repost](/r/demo/boards?help&__func=CreateRepost&bid=1&postid=2&title.type=textarea&body.type=textarea&dstBoardID.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=2)]
 //
 // > Reply of the second post
 // > \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm (UTC)](/r/demo/boards:test_board/2/3) \[[reply](/r/demo/boards?help&__func=CreateReply&bid=1&threadid=2&postid=3&body.type=textarea)] \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=2&postid=3)]

--- a/examples/gno.land/r/demo/boards/z_7_filetest.gno
+++ b/examples/gno.land/r/demo/boards/z_7_filetest.gno
@@ -28,4 +28,4 @@ func main() {
 // ## [First Post (title)](/r/demo/boards:test_board/1)
 //
 // Body of the first post. (body)
-// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/1) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)] (0 replies)
+// \- [@gnouser](/r/demo/users:gnouser), [2009-02-13 11:31pm UTC](/r/demo/boards:test_board/1) \[[x](/r/demo/boards?help&__func=DeletePost&bid=1&threadid=1&postid=1)] (0 replies) (0 reposts)


### PR DESCRIPTION
r/demo/boards already implements the data structures for reposts and the API function [CreateRepost](https://github.com/gnolang/gno/blob/a1c9a8c142038a9624a035262b899a24e16ff3cd/examples/gno.land/r/demo/boards/public.gno#L87). But the Render display doesn't handle reposts correctly. I did a repost on test3 with:
```
gnokey maketx call -pkgpath "gno.land/r/demo/boards" -func "CreateRepost" -gas-fee 1000000ugnot -gas-wanted 5000000 -send "" -broadcast -chainid "test3" -args "1" -args "2" -args "" -args "check out this NFT post" -args "3" -remote "test3.gno.land:36657" jefft0
```

This should display on board number 3 "boardtest". https://test3.gno.land/r/demo/boards:boardtest . Indeed, it shows
```
check out this NFT post - @jefft0, 2024-01-12 4:24pm UTC [x] (0 replies)
```

But when I click on the date to see the post, [the page](https://test3.gno.land/r/demo/boards:boardtest/2/2) shows "reply does not exist with id: 2" because Render incorrectly treats a repost as a reply.

This pull request is one approach to displaying reposts. It has three commits. The first commit adds `GetRepostFormURL` (similar to `GetReplyFormURL`) and updates `RenderPost` with a helper for [repost] (similar to [reply]). It also updates `RenderSummary` to check if the post is a repost and displays the reposted post along with the comment for the repost, and an indicator like "(2 reposts)". With this change, it shows something like the following where "mytitle" is the title of the original post with its body.

![Screenshot 2024-01-12 at 17 50 19](https://github.com/gnolang/gno/assets/1999543/48c0ec39-3716-45e4-b20d-bc01b900ea8f)

The second commit updates existing tests to have the correct expected output. 

The third commit adds a tests for `CreateRepost` with an expected output and errors. 

(Why did we bother with fixing reposts? Because we implemented reposts in GnoSocial which is a modification of r/demo/boards. Since we fixed this in GnoSocial it's easy to contribute the same fix here, and maybe get some good feedback on the approach.)

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
