### PR TITLE
chore: make gnokeykc use gnokey's basecfg

### DIFF
--- a/contribs/gnokeykc/main.go
+++ b/contribs/gnokeykc/main.go
@@ -14,10 +14,8 @@ import (
 func main() {
 	stdio := commands.NewDefaultIO()
 	wrappedio := &wrappedIO{IO: stdio}
-	baseCfg := client.BaseOptions{
-		Home:   gnoenv.HomeDir(),
-		Remote: "127.0.0.1:26657",
-	}
+	baseCfg := client.DefaultBaseOptions
+	baseCfg.Home = gnoenv.HomeDir()
 	cmd := client.NewRootCmdWithBaseConfig(wrappedio, baseCfg)
 	cmd.AddSubCommands(newKcCmd(stdio))
 

--- a/contribs/gnokeykc/main.go
+++ b/contribs/gnokeykc/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 	"github.com/zalando/go-keyring"
@@ -13,7 +14,11 @@ import (
 func main() {
 	stdio := commands.NewDefaultIO()
 	wrappedio := &wrappedIO{IO: stdio}
-	cmd := client.NewRootCmd(wrappedio)
+	baseCfg := client.BaseOptions{
+		Home:   gnoenv.HomeDir(),
+		Remote: "127.0.0.1:26657",
+	}
+	cmd := client.NewRootCmdWithBaseConfig(wrappedio, baseCfg)
 	cmd.AddSubCommands(newKcCmd(stdio))
 
 	if err := cmd.ParseAndRun(context.Background(), os.Args[1:]); err != nil {


### PR DESCRIPTION
Related with #1233.

## Before

```
$ gnokeykc --help                                                                                                                                                                                                                                                            
[...]
  -config ...                     config file (optional)                                                                                                                                                                                                                                                 
[...]
```

## After

```
$ gnokeykc --help                                                                                                                                                                                                                                                                 
[...]
  -home /Users/moul/Library/Application Support/gno  home directory                                                                                                                                                                                                                                      
[...]
```

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
