### PR TITLE
WIP: ALT GNO Type Check

### DIFF
--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -50,7 +50,7 @@ func (m *Machine) doOpAddAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -73,7 +73,7 @@ func (m *Machine) doOpSubAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -96,7 +96,7 @@ func (m *Machine) doOpMulAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -119,7 +119,7 @@ func (m *Machine) doOpQuoAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -142,7 +142,7 @@ func (m *Machine) doOpRemAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -165,7 +165,7 @@ func (m *Machine) doOpBandAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -188,7 +188,7 @@ func (m *Machine) doOpBandnAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -211,7 +211,7 @@ func (m *Machine) doOpBorAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)
@@ -234,7 +234,7 @@ func (m *Machine) doOpXorAssign() {
 	rv := m.PopValue() // only one.
 	lv := m.PopAsPointer(s.Lhs[0])
 	if debug {
-		assertSameTypes(lv.TV.T, rv.T)
+		assertAssignable(lv.TV.T, rv.T)
 	}
 
 	// XXX HACK (until value persistence impl'd)

--- a/gnovm/pkg/gnolang/op_binary.go
+++ b/gnovm/pkg/gnolang/op_binary.go
@@ -45,7 +45,7 @@ func (m *Machine) doOpLor() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set result in lv.
@@ -60,7 +60,7 @@ func (m *Machine) doOpLand() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set result in lv.
@@ -76,9 +76,6 @@ func (m *Machine) doOpEql() {
 	// get right and left operands.
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
-	if debug {
-		assertEqualityTypes(lv.T, rv.T)
-	}
 
 	// set result in lv.
 	res := isEql(m.Store, lv, rv)
@@ -93,9 +90,6 @@ func (m *Machine) doOpNeq() {
 	// get right and left operands.
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
-	if debug {
-		assertEqualityTypes(lv.T, rv.T)
-	}
 
 	// set result in lv.
 	res := !isEql(m.Store, lv, rv)
@@ -111,7 +105,7 @@ func (m *Machine) doOpLss() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set the result in lv.
@@ -128,7 +122,7 @@ func (m *Machine) doOpLeq() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set the result in lv.
@@ -145,7 +139,7 @@ func (m *Machine) doOpGtr() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set the result in lv.
@@ -162,7 +156,7 @@ func (m *Machine) doOpGeq() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also the result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// set the result in lv.
@@ -179,7 +173,7 @@ func (m *Machine) doOpAdd() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// add rv to lv.
@@ -193,7 +187,7 @@ func (m *Machine) doOpSub() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// sub rv from lv.
@@ -207,7 +201,7 @@ func (m *Machine) doOpBor() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv | rv
@@ -221,7 +215,7 @@ func (m *Machine) doOpXor() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv ^ rv
@@ -235,7 +229,7 @@ func (m *Machine) doOpMul() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv * rv
@@ -249,7 +243,7 @@ func (m *Machine) doOpQuo() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv / rv
@@ -263,7 +257,7 @@ func (m *Machine) doOpRem() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv % rv
@@ -309,7 +303,7 @@ func (m *Machine) doOpBand() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv & rv
@@ -323,7 +317,7 @@ func (m *Machine) doOpBandn() {
 	rv := m.PopValue()
 	lv := m.PeekValue(1) // also result
 	if debug {
-		assertSameTypes(lv.T, rv.T)
+		assertAssignable(lv.T, rv.T)
 	}
 
 	// lv &^ rv

--- a/gnovm/pkg/gnolang/op_binary.go
+++ b/gnovm/pkg/gnolang/op_binary.go
@@ -331,11 +331,15 @@ func (m *Machine) doOpBandn() {
 func isEql(store Store, lv, rv *TypedValue) bool {
 	// If one is undefined, the other must be as well.
 	// Fields/items are set to defaultValue along the way.
+	// XXX check to see if IsUndefined() is needed. Why check interface nils?
 	lvu := lv.IsUndefined()
 	rvu := rv.IsUndefined()
 	if lvu {
 		return rvu
 	} else if rvu {
+		return false
+	}
+	if !isSameType(lv.T, rv.T) {
 		return false
 	}
 	if lnt, ok := lv.T.(*NativeType); ok {

--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -956,9 +956,6 @@ func (m *Machine) doOpSwitchClauseCase() {
 	cliv := m.PeekValue(3) // clause index (reuse)
 
 	// eval whether cv == tv.
-	if debug {
-		assertEqualityTypes(cv.T, tv.T)
-	}
 	match := isEql(m.Store, cv, tv)
 	if match {
 		// matched clause

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -194,8 +194,12 @@ func (m *Machine) doOpRef() {
 			nv.Value = rv2
 		}
 	}
+	elt := xv.TV.T
+	if elt == DataByteType {
+		elt = xv.TV.V.(DataByteValue).ElemType
+	}
 	m.PushValue(TypedValue{
-		T: m.Alloc.NewType(&PointerType{Elt: xv.TV.T}),
+		T: m.Alloc.NewType(&PointerType{Elt: elt}),
 		V: xv,
 	})
 }

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -877,7 +877,7 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 					} else if lnt, ok := lt.(*NativeType); ok {
 						if debug {
 							if !isShift {
-								assertSameTypes(lt, rt)
+								assertAssignable(lt, rt)
 							}
 						}
 						// If left and right are native type,

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2127,14 +2127,15 @@ func KindOf(t Type) Kind {
 // main type-assertion functions.
 
 // TODO: document what class of problems its for.
-// One of them can be nil, and this lets uninitialized primitives
-// and others serve as empty values.  See doOpAdd()
-// usage: if debug { assertSameTypes() }
-func assertSameTypes(lt, rt Type) {
-	if lt == nil && rt == nil {
-		// both are nil.
-	} else if lt == nil || rt == nil {
-		// one is nil.  see function comment.
+// LHS can be nil, and this assigning to interface variables.
+// usage: if debug { assertAssignable() }
+func assertAssignable(lt, rt Type) {
+	if isSameType(lt, rt) {
+		// both are nil/undefined or same type.
+	} else if lt == nil {
+		// LHS is undefined. see function comment.
+	} else if rt == nil {
+		panic("should not happen")
 	} else if lt.Kind() == rt.Kind() &&
 		isUntyped(lt) || isUntyped(rt) {
 		// one is untyped of same kind.
@@ -2144,8 +2145,6 @@ func assertSameTypes(lt, rt Type) {
 		// specifically for assignments.
 		// TODO: make another function
 		// and remove this case?
-	} else if lt.TypeID() == rt.TypeID() {
-		// non-nil types are identical.
 	} else {
 		debug.Errorf(
 			"incompatible operands in binary expression: %s and %s",
@@ -2155,30 +2154,10 @@ func assertSameTypes(lt, rt Type) {
 	}
 }
 
-// Like assertSameTypes(), but more relaxed, for == and !=.
-func assertEqualityTypes(lt, rt Type) {
-	if lt == nil && rt == nil {
-		// both are nil.
-	} else if lt == nil || rt == nil {
-		// one is nil.  see function comment.
-	} else if lt.Kind() == rt.Kind() &&
-		isUntyped(lt) || isUntyped(rt) {
-		// one is untyped of same kind.
-	} else if lt.Kind() == InterfaceKind &&
-		IsImplementedBy(lt, rt) {
-		// rt implements lt (and lt is nil interface).
-	} else if rt.Kind() == InterfaceKind &&
-		IsImplementedBy(rt, lt) {
-		// lt implements rt (and rt is nil interface).
-	} else if lt.TypeID() == rt.TypeID() {
-		// non-nil types are identical.
-	} else {
-		debug.Errorf(
-			"incompatible operands in binary (eql/neq) expression: %s and %s",
-			lt.String(),
-			rt.String(),
-		)
-	}
+func isSameType(lt, rt Type) bool {
+	return lt == nil && rt == nil || // both are nil/undefined
+		(lt != nil && rt != nil && // both are defined and equal.
+			lt.TypeID() == rt.TypeID())
 }
 
 // ----------------------------------------

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2156,8 +2156,8 @@ func assertAssignable(lt, rt Type) {
 
 func isSameType(lt, rt Type) bool {
 	return lt == nil && rt == nil || // both are nil/undefined
-		(lt != nil && rt != nil && // both are defined and equal.
-			lt.TypeID() == rt.TypeID())
+		(lt != nil && rt != nil) && // both are defined
+			(lt.TypeID() == rt.TypeID()) // and identical.
 }
 
 // ----------------------------------------


### PR DESCRIPTION
Alternative solution to #1426 

TODO: Move the below to test cases

```go
package main

import (
	"fmt"
	"reflect"
)

// implicit type conversion and equality
func main() {
	{ // case 1 with slices
		type X []byte
		var x interface{} = []byte("foo")
		var xx interface{} = X(x.([]byte))
		fmt.Println(reflect.TypeOf(x), x)  // []uint8 [102 111 111]
		fmt.Println(reflect.TypeOf(xx), x) // main.X [102 111 111]
		fmt.Println(x == xx)               // false
	}

	{ // case 2 with arrays
		type X [3]byte
		var x interface{} = [3]byte{102, 111, 111}
		var xx interface{} = X(x.([3]byte))
		fmt.Println(reflect.TypeOf(x), x)  // [3]uint8 [102 111 111]
		fmt.Println(reflect.TypeOf(xx), x) // main.X [102 111 111]
		fmt.Println(x == xx)               // false still.
	}

	{ // switch without conversion
		type X [3]byte
		var x interface{} = [3]byte{102, 111, 111}
		switch x {
		case [3]byte{102, 111, 111}:
			fmt.Println("ok") // ok
		case [3]byte{102, 111, 112}:
			panic("should not happen")
		default:
			panic("should not happen")
		}
	}

	{ // case 1 switch with conversion no match
		type X [3]byte
		var x interface{} = X([3]byte{102, 111, 111})
		switch x {
		case [3]byte{102, 111, 111}:
			panic("should not happen")
		case [3]byte{102, 111, 112}:
			panic("should not happen")
		default:
			fmt.Println("no match") // no match
		}
	}

	{ // case 2 switch with conversion match
		type X [3]byte
		var x interface{} = X([3]byte{102, 111, 111})
		switch x {
		case [3]byte{102, 111, 111}:
			panic("should not happen")
		case X([3]byte{102, 111, 111}):
			fmt.Println("ok") // ok
		case X([3]byte{102, 111, 112}):
			panic("should not happen")
		default:
			panic("should not happen")
		}
	}
}
```