### PR TITLE
feat(keys/client): prompt user for key name when not provided by user

### DIFF
--- a/tm2/pkg/crypto/keys/client/export.go
+++ b/tm2/pkg/crypto/keys/client/export.go
@@ -63,7 +63,16 @@ func (c *ExportCfg) RegisterFlags(fs *flag.FlagSet) {
 func execExport(cfg *ExportCfg, io commands.IO) error {
 	// check keyname
 	if cfg.NameOrBech32 == "" {
-		return errors.New("key to be exported shouldn't be empty")
+		inputName, err := io.GetString(
+			"WARNING: --key is required, please provide a value here:",
+		)
+		if err != nil {
+			return err
+		}
+		if inputName == "" {
+			return errors.New("key to be exported shouldn't be empty")
+		}
+		cfg.NameOrBech32 = inputName
 	}
 
 	// Create a new instance of the key-base

--- a/tm2/pkg/crypto/keys/client/import.go
+++ b/tm2/pkg/crypto/keys/client/import.go
@@ -63,7 +63,16 @@ func (c *ImportCfg) RegisterFlags(fs *flag.FlagSet) {
 func execImport(cfg *ImportCfg, io commands.IO) error {
 	// check keyname
 	if cfg.KeyName == "" {
-		return errors.New("name shouldn't be empty")
+		inputName, err := io.GetString(
+			"WARNING: --name is required, please provide a value here:",
+		)
+		if err != nil {
+			return err
+		}
+		if inputName == "" {
+			return errors.New("name shouldn't be empty")
+		}
+		cfg.KeyName = inputName
 	}
 
 	// Create a new instance of the key-base

--- a/tm2/pkg/crypto/keys/client/import_test.go
+++ b/tm2/pkg/crypto/keys/client/import_test.go
@@ -62,7 +62,8 @@ func TestImport_ImportKey(t *testing.T) {
 			},
 			strings.NewReader(
 				fmt.Sprintf(
-					"%s\n%s\n%s\n",
+					"%s\n%s\n%s\n%s\n",
+					importKeyName,
 					password, // decrypt
 					password, // key-base encrypt
 					password, // key-base encrypt confirm
@@ -76,7 +77,8 @@ func TestImport_ImportKey(t *testing.T) {
 			},
 			strings.NewReader(
 				fmt.Sprintf(
-					"%s\n%s\n",
+					"%s\n%s\n%s\n",
+					importKeyName,
 					password, // key-base encrypt
 					password, // key-base encrypt confirm
 				),
@@ -134,7 +136,7 @@ func TestImport_ImportKey(t *testing.T) {
 						kbHome: kbHome,
 						// Change the import key name so the existing one (in the key-base)
 						// doesn't get overwritten
-						keyName: importKeyName,
+						keyName: "",
 						unsafe:  testCase.baseOpts.unsafe,
 					},
 					armorPath: outputFile.Name(),
@@ -163,7 +165,7 @@ func TestImport_ImportKeyWithEmptyName(t *testing.T) {
 				keyName: "",
 			},
 		},
-		nil,
+		strings.NewReader("\n"),
 	)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "name shouldn't be empty")


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
Refer to #1492 [comment](https://github.com/gnolang/gno/pull/1492#pullrequestreview-1821800095)

> it would be cool to prompt the user for the key name if it's not specified (not in this PR).


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
