### PR TITLE
docs: s/Gnolang/Gno, s/Golang/Go

### DIFF
--- a/docs/concepts/gno-language.md
+++ b/docs/concepts/gno-language.md
@@ -4,7 +4,7 @@ id: gno-language
 
 # The Gno Language
 
-Gno (Gno) is an interpretation of the widely-used Go (Go) programming language for blockchain created by Cosmos
+Gno (Gnolang) is an interpretation of the widely-used Go (Golang) programming language for blockchain created by Cosmos
 co-founder Jae Kwon in 2021 to mark a new era in smart contracting. Gno is almost identical to Go, so Go developers can
 quickly start using it, with minimal effort. For example, Gno comes with blockchain-specific standard libraries, but any
 code that doesn’t use blockchain-specific logic can run in Go with minimal processing. Libraries that could lead to

--- a/docs/concepts/gno-language.md
+++ b/docs/concepts/gno-language.md
@@ -4,7 +4,7 @@ id: gno-language
 
 # The Gno Language
 
-Gno (Gnolang) is an interpretation of the widely-used Go (Golang) programming language for blockchain created by Cosmos
+Gno (Gno) is an interpretation of the widely-used Go (Go) programming language for blockchain created by Cosmos
 co-founder Jae Kwon in 2021 to mark a new era in smart contracting. Gno is almost identical to Go, so Go developers can
 quickly start using it, with minimal effort. For example, Gno comes with blockchain-specific standard libraries, but any
 code that doesn’t use blockchain-specific logic can run in Go with minimal processing. Libraries that could lead to

--- a/docs/concepts/gno-test.md
+++ b/docs/concepts/gno-test.md
@@ -13,7 +13,7 @@ While the first method is recommended for its accuracy and similarity to the act
 
 This section will teach you how to use the second method.
 
-Writing test cases in Gnolang is similar to that of Golang, with general rules as the following:
+Writing test cases in Gno is similar to that of Go, with general rules as the following:
 
 * Test file naming conventions must be adhered to (ex: `xxx_test.gno`).
 * Test functions must start with `Test`.

--- a/docs/concepts/gnovm.md
+++ b/docs/concepts/gnovm.md
@@ -4,7 +4,7 @@ id: gnovm
 
 # GnoVM
 
-GnoVM is a virtual machine that interprets Gnolang, a custom version of Golang optimized for blockchains, featuring automatic state management, full determinism, and idiomatic Go.
+GnoVM is a virtual machine that interprets Gno, a custom version of Go optimized for blockchains, featuring automatic state management, full determinism, and idiomatic Go.
 It works with Tendermint2 and enables smarter, more modular, and transparent appchains with embedded smart-contracts.
 It can be adapted for use in TendermintCore, forks, and non-Cosmos blockchains.
 
@@ -24,4 +24,4 @@ This enables non-web3 developers to contribute without requiring an understandin
 
 Install [`gno`](../getting-started/local-setup.md) and refer to the [`examples`](https://github.com/gnolang/gno/tree/master/examples) folder to start developing contracts.
 
-Check the [Makefile](https://github.com/gnolang/gno/blob/master/gnovm/Makefile) to enhance GnoVM, Gnolang, and stdlibs.
+Check the [Makefile](https://github.com/gnolang/gno/blob/master/gnovm/Makefile) to enhance GnoVM, Gno, and stdlibs.

--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -10,15 +10,15 @@ The full list of pre-deployed available packages can be found under the [demo pa
 
 ## `avl`
 
-In Golang, the classic key/value data type is represented by the `map` construct. However, while Gnolang also supports the use of `map`, it is not a viable option as it lacks determinism due to its non-sequential nature.
+In Go, the classic key/value data type is represented by the `map` construct. However, while Gno also supports the use of `map`, it is not a viable option as it lacks determinism due to its non-sequential nature.
  
-To address this issue, Gnolang implements the [AVL Tree](https://en.wikipedia.org/wiki/AVL\_tree) (Adelson-Velsky-Landis Tree) as a solution. The AVL Tree is a self-balancing binary search tree.
+To address this issue, Gno implements the [AVL Tree](https://en.wikipedia.org/wiki/AVL\_tree) (Adelson-Velsky-Landis Tree) as a solution. The AVL Tree is a self-balancing binary search tree.
 
 The `avl` package comprises a set of functions that can manipulate the leaves and nodes of the AVL Tree.
 
 ## `grc20`
 
-Gnolang includes an implementation of the `erc20` fungible token standard referred to as `grc20`. The interfaces of `grc20` are as follows:
+Gno includes an implementation of the `erc20` fungible token standard referred to as `grc20`. The interfaces of `grc20` are as follows:
 
 [embedmd]:# (../assets/explanation/packages/pkg-1.gno go)
 ```go
@@ -50,7 +50,7 @@ Two types of contracts exist in`grc20`:
 
 ## `grc721`
 
-Gnolang includes an implementation of the `erc721` non-fungible token standard referred to as `grc721`. The interfaces of `grc721` are as follows:
+Gno includes an implementation of the `erc721` non-fungible token standard referred to as `grc721`. The interfaces of `grc721` are as follows:
 
 [embedmd]:# (../assets/explanation/packages/pkg-2.gno go)
 ```go

--- a/docs/concepts/realms.md
+++ b/docs/concepts/realms.md
@@ -5,7 +5,7 @@ id: realms
 # Realms
 
 A realm refers to a specific instance of a smart contract that can be written
-in [Gnolang](./gno-language.md). The potentials of realms are endless - you can create virtually any
+in [Gno](./gno-language.md). The potentials of realms are endless - you can create virtually any
 application in your mind with built-in composability,
 transparency, and censorship resistance. Here are some ideas of what you can build with realms:
 
@@ -27,7 +27,7 @@ transparency, and censorship resistance. Here are some ideas of what you can bui
 
 #### [**Realms**](https://github.com/gnolang/gno/tree/master/examples/gno.land/r)
 
-* Smart contracts in Gnolang.
+* Smart contracts in Gno.
 * Realms are stateful.
 * Realms can own assets (tokens).
 * The default import path is `gno.land/r/~~~`.

--- a/docs/concepts/standard-library/overview.md
+++ b/docs/concepts/standard-library/overview.md
@@ -5,7 +5,7 @@ id: overview
 # Overview
 
 Gno comes with a set of standard libraries which are included to ease development and provide extended functionality to the language. These include:
-- standard libraries as we know them in classic Golang, i.e. `encoding/binary`, `strings`, `testing`, etc.
+- standard libraries as we know them in classic Go, i.e. `encoding/binary`, `strings`, `testing`, etc.
 - a special `std` package, which contains types, interfaces, and APIs created to handle blockchain-related functionality.
 
 

--- a/docs/how-to-guides/creating-grc20.md
+++ b/docs/how-to-guides/creating-grc20.md
@@ -6,7 +6,7 @@ id: creating-grc20
 
 ## Overview
 
-This guide shows you how to write a simple _GRC20_ Smart Contract, or rather a [Realm](../concepts/realms.md), in [Gno (Gnolang)](../concepts/gno-language.md). For actually deploying the Realm, please see the [deployment](deploy.md) guide.
+This guide shows you how to write a simple _GRC20_ Smart Contract, or rather a [Realm](../concepts/realms.md), in [Gno (Gno)](../concepts/gno-language.md). For actually deploying the Realm, please see the [deployment](deploy.md) guide.
 
 Our _GRC20_ Realm will have the following functionality:
 

--- a/docs/how-to-guides/creating-grc721.md
+++ b/docs/how-to-guides/creating-grc721.md
@@ -7,7 +7,7 @@ id: creating-grc721
 ## Overview
 
 This guide shows you how to write a simple _GRC721_ Smart Contract, or rather a [Realm](../concepts/realms.md),
-in [Gno (Gnolang)](../concepts/gno-language.md). For actually deploying the Realm, please see
+in [Gno (Gno)](../concepts/gno-language.md). For actually deploying the Realm, please see
 the [deployment](deploy.md) guide.
 
 Our _GRC721_ Realm will have the following functionality:

--- a/docs/how-to-guides/porting-solidity-to-gno.md
+++ b/docs/how-to-guides/porting-solidity-to-gno.md
@@ -2,12 +2,12 @@
 id: port-solidity-to-gno
 ---
 
-# Port a Solidity Contract to a Gnolang Realm
+# Port a Solidity Contract to a Gno Realm
 
 
 ## Overview
 
-This guide shows you how to port a Solidity contract `Simple Auction` to a Gnolang Realm `auction.gno` with test cases (Test Driven Development (TDD) approach).
+This guide shows you how to port a Solidity contract `Simple Auction` to a Gno Realm `auction.gno` with test cases (Test Driven Development (TDD) approach).
 
 You can check the Solidity contract in this [link](https://docs.soliditylang.org/en/latest/solidity-by-example.html#simple-open-auction), and here's the code for porting.
 
@@ -166,7 +166,7 @@ The contract consists of:
 * Initialization by a constructor
 * Three functions
 
-Let's dive into the details of the role of each function, and learn how to port each function into Gnolang with test cases.
+Let's dive into the details of the role of each function, and learn how to port each function into Gno with test cases.
 
 When writing a test case, the following conditions are often used to determine whether the function has been properly executed:
 
@@ -176,7 +176,7 @@ When writing a test case, the following conditions are often used to determine w
 
 Below is a test case helper that will help implement each condition.
 
-### Gnolang - Testcase Helper
+### Gno - Testcase Helper
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-1.gno go)
 ```go
@@ -281,7 +281,7 @@ constructor(
 * `mapping(address => uint) pendingReturns;` : Bidder's address and amount to be returned (in case of the highest bid changes).
 * `bool ended;` : Whether the auction is closed.
 
-### Variable init - Gnolang
+### Variable init - Gno
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-3.gno go)
 ```go
@@ -344,7 +344,7 @@ function bid() external payable {
 * Prepare data to return the bid amount to the existing highest bidder in case of the highest bid is increased.
 * Update variables with the top bidder & top bid amount.
 
-### bid() - Gnolang
+### bid() - Gno
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-5.gno go)
 ```go
@@ -380,7 +380,7 @@ func Bid() {
 }
 ```
 
-### bid() - Gnolang Testcase
+### bid() - Gno Testcase
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-6.gno go)
 ```go
@@ -460,7 +460,7 @@ function withdraw() external returns (bool) {
 * When called, determine if there's a bid amount to be returned to the address.
 * (If there's an amount to be returned) Before returning, set the previously recorded amount to `0` and return the actual amount.
 
-### withdraw() - Gnolang
+### withdraw() - Gno
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-8.gno go)
 ```go
@@ -483,7 +483,7 @@ func Withdraw() {
 
 ###
 
-### withdraw() - Gnolang Testcase
+### withdraw() - Gno Testcase
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-9.gno go)
 ```go
@@ -548,7 +548,7 @@ function auctionEnd() external {
   * (If not ended) End the auction.
   * (If not ended) Send the highest bid amount to the recipient.
 
-### auctionEnd() - Gnolang
+### auctionEnd() - Gno
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-11.gno go)
 ```go
@@ -571,7 +571,7 @@ func AuctionEnd() {
 }
 ```
 
-### auctionEnd() - Gnolang Testcase
+### auctionEnd() - Gno Testcase
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-12.gno go)
 ```go
@@ -598,7 +598,7 @@ func TestAuctionEnd(t *testing.T) {
 ## Precautions for Running Test Cases
 
 * Each test function should be executed separately one by one, to return all passes without any errors.
-* Same as Golang, Gnolang doesn't support `setup()` & `teardown()` functions. So running two or more test functions simultaneously can result in tainted data.
+* Same as Go, Gno doesn't support `setup()` & `teardown()` functions. So running two or more test functions simultaneously can result in tainted data.
 * If you want to do the whole test at once, make it into a single function as below:
 
 [embedmd]:# (../assets/how-to-guides/porting-solidity-to-gno/porting-13.gno go)

--- a/docs/how-to-guides/simple-contract.md
+++ b/docs/how-to-guides/simple-contract.md
@@ -7,7 +7,7 @@ id: simple-contract
 ## Overview
 
 This guide shows you how to write a simple _Counter_ Smart Contract, or rather a [Realm](../concepts/realms.md),
-in [Gno (Gnolang)](../concepts/gno-language.md). For actually deploying the Realm, please see
+in [Gno (Gno)](../concepts/gno-language.md). For actually deploying the Realm, please see
 the [deployment](deploy.md) guide.
 
 Our _Counter_ Realm will have the following functionality:
@@ -21,7 +21,7 @@ Our _Counter_ Realm will have the following functionality:
 - **Text editor**
 
 :::info Editor support
-The Gno language is based on Golang, but it does not have all the bells and whistles in major text editors like Go.
+The Gno language is based on Go, but it does not have all the bells and whistles in major text editors like Go.
 Advanced language features like IntelliSense are still in the works.
 
 Currently, we officially have language support
@@ -80,7 +80,7 @@ touch counter.gno
 ```
 
 :::info Gno file extension
-All Gno (Gnolang) source code has the file extension `.gno`.
+All Gno (Gno) source code has the file extension `.gno`.
 
 This file extension is required for existing gno tools and processes to work.
 :::

--- a/docs/how-to-guides/simple-contract.md
+++ b/docs/how-to-guides/simple-contract.md
@@ -7,7 +7,7 @@ id: simple-contract
 ## Overview
 
 This guide shows you how to write a simple _Counter_ Smart Contract, or rather a [Realm](../concepts/realms.md),
-in [Gno (Gno)](../concepts/gno-language.md). For actually deploying the Realm, please see
+in [Gno (Gnolang)](../concepts/gno-language.md). For actually deploying the Realm, please see
 the [deployment](deploy.md) guide.
 
 Our _Counter_ Realm will have the following functionality:
@@ -80,7 +80,7 @@ touch counter.gno
 ```
 
 :::info Gno file extension
-All Gno (Gno) source code has the file extension `.gno`.
+All Gno (Gnolang) source code has the file extension `.gno`.
 
 This file extension is required for existing gno tools and processes to work.
 :::

--- a/docs/how-to-guides/simple-library.md
+++ b/docs/how-to-guides/simple-library.md
@@ -6,7 +6,7 @@ id: simple-library
 
 ## Overview
 
-This guide shows you how to write a simple library (Package) in Gnolang, which can be used by other Packages and Realms.
+This guide shows you how to write a simple library (Package) in Gno, which can be used by other Packages and Realms.
 Packages are _stateless_, meaning they do not hold state like regular Realms (Smart Contracts). To learn more about the
 intricacies of Packages, please see the [Packages reference](../concepts/packages.md).
 
@@ -18,7 +18,7 @@ We will define a set list of tapas, and define a method that randomly selects a 
 - **Text editor**
 
 :::info Editor support
-The Gno language is based on Golang, but it does not have all the bells and whistles in major text editors like Go.
+The Gno language is based on Go, but it does not have all the bells and whistles in major text editors like Go.
 Advanced language features like IntelliSense are still in the works.
 
 Currently, we officially have language support

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 id: overview
 slug: /
 description: "Gno.land is a Layer 1 blockchain platform that enables the execution of Smart Contracts using an interpreted
-version of the Go programming language called Gnolang."
+version of the Go programming language called Gno."
 ---
 
 # Overview
@@ -10,13 +10,13 @@ version of the Go programming language called Gnolang."
 ## What is Gno.land?
 
 Gno.land is a Layer 1 blockchain platform that enables the execution of Smart Contracts using an interpreted
-version of the Go programming language called Gnolang (Gno for short).
+version of the Go programming language called Gno (Gno for short).
 
 ### Key Features and Technology
 
-1. **Interpreted Gnolang**: Gno.land utilizes the Gnolang programming language, which is based on Go. It is executed
+1. **Interpreted Gno**: Gno.land utilizes the Gno programming language, which is based on Go. It is executed
    through a specialized virtual machine called the GnoVM, purpose-built for blockchain development with built-in
-   determinism and a modified standard library. While Gnolang
+   determinism and a modified standard library. While Gno
    shares similarities with Go in terms of syntax, it currently lacks go routine support. However, this feature is
    planned for future development, ensuring deterministic GnoVM executions.
 2. **Consensus Protocol - Tendermint2**: Gno.land achieves consensus between blockchain nodes using the Tendermint2
@@ -42,7 +42,7 @@ In comparison to Ethereum, Gno.land offers distinct advantages:
    precompiled into bytecode, leading to less transparency as bytecode is stored on the blockchain, not the
    human-readable source code.
 
-2. **General-Purpose Language**: Gno.land's Gnolang is a general-purpose language, similar to Go, extending its
+2. **General-Purpose Language**: Gno.land's Gno is a general-purpose language, similar to Go, extending its
    usability beyond the context of blockchain. In contrast, Solidity is designed specifically for Smart Contracts on the
    Ethereum platform.
 

--- a/docs/reference/standard-library/overview.md
+++ b/docs/reference/standard-library/overview.md
@@ -6,7 +6,7 @@ id: overview
 
 This section serves as a reference to the standard libraries available in Gno.
 
-Gno is designed to offer features similar to those in Golang. Therefore, this documentation
+Gno is designed to offer features similar to those in Go. Therefore, this documentation
 does not include in-depth references for libraries that have identical implementation details
-as those in Golang. If a standard library differs in any way from its usage or implementation in Golang,
+as those in Go. If a standard library differs in any way from its usage or implementation in Go,
 it will be documented in this section.

--- a/docs/tasks/001_describe_in_your_words.md
+++ b/docs/tasks/001_describe_in_your_words.md
@@ -1,3 +1,0 @@
-Describe in your words, on your favorite medium, why you are interested in gno.land and gnolang.
-
-Reply here with a URL link to your written piece as a comment, for rewards.


### PR DESCRIPTION
They're Gno and Go. The "lang" part should be used only for disambiguation. Same as we don't call C "Clang", Java "Javalang" and so on.

Arguably, we could drop "gnolang" completely outside maybe of internal usage in the code, as contrary to Go, "Gno" is not a common verb in the english language.