### PR TITLE
fix: attempt to fix dependabot mod tidy

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -11,6 +11,8 @@ jobs:
   tidy_go_mods:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,6 +38,8 @@ jobs:
 
       - name: Commit changes, if any
         uses: stefanzweifel/git-auto-commit-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           skip_dirty_check: false # Enable dirty check, and skip unnecessary committing
           commit_message: "Run 'go mod tidy' via GitHub Actions"


### PR DESCRIPTION
## Description

This PR aims to fix failing Dependabot mod tidy workflows, since Dependabot doesn't have push permissions on the repo.

Error that's looking to be fixed:
<img width="1156" alt="Screenshot 2024-01-18 at 15 19 20" src="https://github.com/gnolang/gno/assets/16712663/83129d6e-ddfa-4a17-818c-0fb7156b16e5">



<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
