### PR TITLE
fix: replace `fmt` with `ufmt` in realm examples (docs)

### DIFF
--- a/docs/assets/how-to-guides/simple-contract/counter.gno
+++ b/docs/assets/how-to-guides/simple-contract/counter.gno
@@ -1,6 +1,8 @@
 package counter
 
-import "fmt"
+import (
+	"gno.land/p/demo/ufmt"
+)
 
 var count int
 
@@ -13,5 +15,5 @@ func Decrement() {
 }
 
 func Render(_ string) string {
-	return fmt.Sprintf("Count: %d", count)
+	return ufmt.Sprintf("Count: %d", count)
 }

--- a/docs/assets/how-to-guides/testing-gno/counter-1.gno
+++ b/docs/assets/how-to-guides/testing-gno/counter-1.gno
@@ -2,7 +2,9 @@
 
 package counter
 
-import "fmt"
+import (
+	"gno.land/p/demo/ufmt"
+)
 
 var count int
 
@@ -15,5 +17,5 @@ func Decrement() {
 }
 
 func Render(_ string) string {
-	return fmt.Sprintf("Count: %d", count)
+	return ufmt.Sprintf("Count: %d", count)
 }

--- a/docs/how-to-guides/simple-contract.md
+++ b/docs/how-to-guides/simple-contract.md
@@ -91,7 +91,9 @@ We can finally write out the logic of the _Counter_ Smart Contract in `counter.g
 ```go
 package counter
 
-import "fmt"
+import (
+	"gno.land/p/demo/ufmt"
+)
 
 var count int
 
@@ -104,7 +106,7 @@ func Decrement() {
 }
 
 func Render(_ string) string {
-	return fmt.Sprintf("Count: %d", count)
+	return ufmt.Sprintf("Count: %d", count)
 }
 ```
 

--- a/docs/how-to-guides/testing-gno.md
+++ b/docs/how-to-guides/testing-gno.md
@@ -26,7 +26,9 @@ the [How to write a simple Gno Smart Contract (Realm)](simple-contract.md) guide
 
 package counter
 
-import "fmt"
+import (
+	"gno.land/p/demo/ufmt"
+)
 
 var count int
 
@@ -39,7 +41,7 @@ func Decrement() {
 }
 
 func Render(_ string) string {
-	return fmt.Sprintf("Count: %d", count)
+	return ufmt.Sprintf("Count: %d", count)
 }
 ```
 


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

In select places within the documentation, we still import `fmt` despite this not being fully supported. This PR replaces `fmt` usage in those select cases with `ufmt`.

Closes: #1547 

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
