### PR TITLE
fix(cmd/gno): correctly filter filetests in `listNonTestFiles`

### DIFF
--- a/gnovm/cmd/gno/run.go
+++ b/gnovm/cmd/gno/run.go
@@ -144,7 +144,7 @@ func listNonTestFiles(dir string) ([]string, error) {
 		n := f.Name()
 		if isGnoFile(f) &&
 			!strings.HasSuffix(n, "_test.gno") &&
-			!strings.HasPrefix(n, "_filetest.gno") {
+			!strings.HasSuffix(n, "_filetest.gno") {
 			fn = append(fn, filepath.Join(dir, n))
 		}
 	}


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

`s/HasPrefix/HasSuffix`

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
