### PR TITLE
chore(CODEOWNERS): add rules for gnovm/cmd/gno, gnovm/tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ gno.land/pkg/integration     @gfanton
 gnovm/                       @gnolang/tech-staff
 gnovm/stdlibs                @jaekwon @thehowl
 gnovm/tests                  @jaekwon @piux2 @thehowl @moul
-gnovm/cmd/gno                @moul @thehowl @gfanton
+gnovm/cmd/gno                @jaekwon @thehowl @harry-hov @moul
 gnovm/pkg/gnolang            @jaekwon @piux2 @thehowl @moul
 gnovm/pkg/doc                @thehowl
 gnovm/pkg/gnomod             @harry-hov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,8 @@ gno.land/pkg/integration     @gfanton
 # GnoVM/Gnolang.
 gnovm/                       @gnolang/tech-staff
 gnovm/stdlibs                @jaekwon @thehowl
+gnovm/tests                  @jaekwon @piux2 @thehowl @moul
+gnovm/cmd/gno                @moul @thehowl @gfanton
 gnovm/pkg/gnolang            @jaekwon @piux2 @thehowl @moul
 gnovm/pkg/doc                @thehowl
 gnovm/pkg/gnomod             @harry-hov


### PR DESCRIPTION
for tests, using same rules as `pkg/gnolang`, as they are tightly connected

for cmd/gno, I looked at the commit history; I put in @harry-hov has he has repeatedly also worked on the gno command CLI.