### PR TITLE
fix(docs): Update `GetOrigPkgAddr` reference

### DIFF
--- a/docs/reference/standard-library/std/chain.md
+++ b/docs/reference/standard-library/std/chain.md
@@ -92,7 +92,7 @@ caller := std.GetOrigSend()
 ```go
 func GetOrigPkgAddr() string
 ```
-Returns the `pkgpath` of the current Realm or Package.
+Returns the address of the first (entry point) realm/package in a sequence of realm/package calls.
 
 #### Usage
 ```go


### PR DESCRIPTION
## Description

This PR fixes the wrong reference for `std.GetOrigPkgAddr()`.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
