### PR TITLE
feat: add support for dynamic user addresses in txtar tests

### DIFF
--- a/gno.land/pkg/integration/doc.go
+++ b/gno.land/pkg/integration/doc.go
@@ -21,6 +21,12 @@
 //   - Creates a new user in the default keybase directory.
 //   - Must be run before `gnoland start`.
 //
+// 4. `withuser`:
+//   - usage is `withuser <username> gnokey`.
+//   - username should be registered username, either prepopulated or added via the adduser command.
+//   - using the placeholder USERADDRESS in the command will be replaced with the user's address.
+//   - example `withuser test8 gnokey maketx call ... -func Render -args 'USERADDRESS' ... `
+//
 // Logging:
 //
 // Gnoland logs aren't forwarded to stdout to avoid overwhelming the tests with too much

--- a/gno.land/pkg/integration/doc.go
+++ b/gno.land/pkg/integration/doc.go
@@ -23,7 +23,7 @@
 //
 // 4. `withuser`:
 //   - usage is `withuser <username> gnokey`.
-//   - username should be registered username, either prepopulated or added via the adduser command.
+//   - username should be a username registered via the `adduser“ command.
 //   - using the placeholder USERADDRESS in the command will be replaced with the user's address.
 //   - example `withuser test8 gnokey maketx call ... -func Render -args 'USERADDRESS' ... `
 //

--- a/gno.land/pkg/integration/testdata/adduser.txtar
+++ b/gno.land/pkg/integration/testdata/adduser.txtar
@@ -3,14 +3,14 @@ adduser test8
 ## start a new node
 gnoland start
 
-## add bar.gno package located in $WORK directory as gno.land/r/foobar/bar
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test8
+## add bar.gno package located in $WORK directory as gno.land/r/bar
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/bar -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test8
 
 ## execute Render
-gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test8 $WORK/script/script.gno
+withuser test8 gnokey maketx call -pkgpath gno.land/r/bar -func Render -args 'USERADDRESS' -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test8
 
 ## compare render
-stdout 'main: --- hello from foo ---'
+stdout 'hello from'
 stdout 'OK!'
 stdout 'GAS WANTED: 200000'
 stdout 'GAS USED: '
@@ -19,16 +19,9 @@ stdout 'GAS USED: '
 ! adduser test5
 stderr '"adduser" error: adduser must be used before starting node'
 
--- bar/bar.gno --
+-- bar.gno --
 package bar
 
 func Render(path string) string {
- 	return "hello from foo"
-}
-
--- script/script.gno --
-package main
-import "gno.land/r/foobar/bar"
-func main() {
-	println("main: ---", bar.Render(""), "---")
+ 	return "hello from " + path
 }


### PR DESCRIPTION
This feature makes it possible to reference addresses of users that were dynamically added using the `adduser` command. The modified `adduser.txtar` file contains an example of this and the modified doc file contains instructions how to use it.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
