### PR TITLE
fix: fix noop logger reference

### DIFF
--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -54,7 +54,7 @@ func TestClient_Request(t *testing.T) {
 
 func TestClient_Run(t *testing.T) {
 	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
-	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNopLogger(), config)
+	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
 	defer node.Stop()
 
 	signer := newInMemorySigner(t, config.TMConfig.ChainID())


### PR DESCRIPTION
## Description

This PR fixes the `noop` log reference that was broken in https://github.com/gnolang/gno/pull/1574, after the #1302 PR was merged in earlier.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
