### PR TITLE
feat(sdk/vm): support return values from main in msgrun

### DIFF
--- a/gno.land/cmd/gnoland/testdata/run.txtar
+++ b/gno.land/cmd/gnoland/testdata/run.txtar
@@ -8,7 +8,7 @@ gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 1
 gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1 $WORK/script/script.gno
 
 ## compare render
-stdout 'main: --- hello from foo ---'
+stdout '("main: --- hello from foo ---" string)'
 stdout 'OK!'
 stdout 'GAS WANTED: 200000'
 stdout 'GAS USED: '
@@ -23,6 +23,6 @@ func Render(path string) string {
 -- script/script.gno --
 package main
 import "gno.land/r/foobar/bar"
-func main() {
-	println("main: ---", bar.Render(""), "---")
+func main() string {
+	return "main: --- " + bar.Render("") + " ---"
 }

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -68,17 +68,20 @@ func TestClient_Run(t *testing.T) {
 
 import (
 	"std"
+	"strings"
 
 	"gno.land/p/demo/ufmt"
 	"gno.land/r/demo/tests"
 )
 
-func main() {
-	println(ufmt.Sprintf("- before: %d", tests.Counter()))
+func main() string {
+	var buf strings.Builder
+	buf.WriteString(ufmt.Sprintf("- before: %d\n", tests.Counter()))
 	for i := 0; i < 10; i++ {
 		tests.IncCounter()
 	}
-	println(ufmt.Sprintf("- after: %d", tests.Counter()))
+	buf.WriteString(ufmt.Sprintf("- after: %d\n", tests.Counter()))
+	return buf.String()
 }`
 	memPkg := &std.MemPackage{
 		Files: []*std.MemFile{
@@ -96,5 +99,5 @@ func main() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.NotEmpty(t, res.DeliverTx.Data)
-	require.Equal(t, string(res.DeliverTx.Data), "- before: 0\n- after: 10\n")
+	require.Contains(t, string(res.DeliverTx.Data), `"- before: 0\n- after: 10\n"`)
 }

--- a/gno.land/pkg/integration/testdata/adduser.txtar
+++ b/gno.land/pkg/integration/testdata/adduser.txtar
@@ -29,6 +29,6 @@ func Render(path string) string {
 -- script/script.gno --
 package main
 import "gno.land/r/foobar/bar"
-func main() {
-	println("main: ---", bar.Render(""), "---")
+func main() string {
+	return "main: --- " + bar.Render("") + " ---"
 }

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -352,8 +352,8 @@ func TestVMKeeperRunSimple(t *testing.T) {
 		{"script.gno", `
 package main
 
-func main() {
-	println("hello world!")
+func main() string {
+	return "hello world!"
 }
 `},
 	}
@@ -362,7 +362,7 @@ func main() {
 	msg2 := NewMsgRun(addr, coins, files)
 	res, err := env.vmk.Run(ctx, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, res, "hello world!\n")
+	assert.Contains(t, res, `"hello world!" string`)
 }
 
 // Call Run with stdlibs.
@@ -381,9 +381,9 @@ package main
 
 import "std"
 
-func main() {
+func main() string {
 	addr := std.GetOrigCaller()
-	println("hello world!", addr)
+	return "hello world! " + addr.String()
 }
 `},
 	}
@@ -392,6 +392,6 @@ func main() {
 	msg2 := NewMsgRun(addr, coins, files)
 	res, err := env.vmk.Run(ctx, msg2)
 	assert.NoError(t, err)
-	expectedString := fmt.Sprintf("hello world! %s\n", addr.String())
-	assert.Equal(t, res, expectedString)
+	expectedString := fmt.Sprintf("hello world! %s", addr.String())
+	assert.Contains(t, res, expectedString)
 }


### PR DESCRIPTION
Something I wondered about what we could do with MsgRun. I saw that in the current implementation, the output that is returned to the user is the output of calls to the "Output", ie. `println`. I don't think we should support this OR endorse any usage of `println` as a stable function in production code; hence this PR.

This PR adds support for adding return values to the `main()` function in `MsgRun`. It substitutes the current way to get data back from a `MsgRun` call -- `println` -- to using return values, as we do for `MsgCall`. This creates an inconsistency with the "model" of inspiration for `MsgRun` -- ie. `gno run` -- but I think it is the right call.

Let's discuss!