### PR TITLE
refactor: compile all regexes at init

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -131,9 +131,7 @@ func (vm *VMKeeper) getGnoStore(ctx sdk.Context) gno.Store {
 	}
 }
 
-const (
-	reReservedPath = `gno\.land/r/g[a-z0-9]+/run`
-)
+var reReservedPath = regexp.MustCompile(`gno\.land/r/g[a-z0-9]+/run`)
 
 // AddPackage adds a package with given fileset.
 func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
@@ -158,7 +156,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
 		return ErrInvalidPkgPath("package already exists: " + pkgPath)
 	}
 
-	if ok, _ := regexp.MatchString(reReservedPath, pkgPath); ok {
+	if reReservedPath.MatchString(pkgPath) {
 		return ErrInvalidPkgPath("reserved package name: " + pkgPath)
 	}
 

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -2076,11 +2076,12 @@ const (
 	ATTR_INJECTED     GnoAttribute = "ATTR_INJECTED"
 )
 
+var rePkgName = regexp.MustCompile(`^[a-z][a-z0-9_]+$`)
+
 // TODO: consider length restrictions.
 // If this function is changed, ReadMemPackage's documentation should be updated accordingly.
 func validatePkgName(name string) {
-	if nameOK, _ := regexp.MatchString(
-		`^[a-z][a-z0-9_]+$`, name); !nameOK {
+	if !rePkgName.MatchString(name) {
 		panic(fmt.Sprintf("cannot create package with invalid name %q", name))
 	}
 }

--- a/gnovm/pkg/gnolang/op_eval.go
+++ b/gnovm/pkg/gnolang/op_eval.go
@@ -12,6 +12,11 @@ import (
 	"github.com/cockroachdb/apd/v3"
 )
 
+var (
+	reFloat    = regexp.MustCompile(`^[0-9\.]+([eE][\-\+]?[0-9]+)?$`)
+	reHexFloat = regexp.MustCompile(`^0[xX][0-9a-fA-F\.]+([pP][\-\+]?[0-9a-fA-F]+)?$`)
+)
+
 func (m *Machine) doOpEval() {
 	x := m.PeekExpr(1)
 	if debug {
@@ -81,7 +86,7 @@ func (m *Machine) doOpEval() {
 		case FLOAT:
 			x.Value = strings.ReplaceAll(x.Value, "_", "")
 
-			if matched, _ := regexp.MatchString(`^[0-9\.]+([eE][\-\+]?[0-9]+)?$`, x.Value); matched {
+			if reFloat.MatchString(x.Value) {
 				value := x.Value
 				bd, c, err := apd.NewFromString(value)
 				if err != nil {
@@ -99,7 +104,7 @@ func (m *Machine) doOpEval() {
 					V: BigdecValue{V: bd},
 				})
 				return
-			} else if matched, _ := regexp.MatchString(`^0[xX][0-9a-fA-F\.]+([pP][\-\+]?[0-9a-fA-F]+)?$`, x.Value); matched {
+			} else if reHexFloat.MatchString(x.Value) {
 				originalInput := x.Value
 				value := x.Value[2:]
 				var hexString string

--- a/gnovm/pkg/gnomod/read.go
+++ b/gnovm/pkg/gnomod/read.go
@@ -796,6 +796,8 @@ func parseReplace(filename string, line *modfile.Line, verb string, args []strin
 	}, nil
 }
 
+var reDeprecation = regexp.MustCompile(`(?s)(?:^|\n\n)Deprecated: *(.*?)(?:$|\n\n)`)
+
 // parseDeprecation extracts the text of comments on a "module" directive and
 // extracts a deprecation message from that.
 //
@@ -806,8 +808,7 @@ func parseReplace(filename string, line *modfile.Line, verb string, args []strin
 // parseDeprecation returns the message from the first.
 func parseDeprecation(block *modfile.LineBlock, line *modfile.Line) string {
 	text := parseDirectiveComment(block, line)
-	rx := regexp.MustCompile(`(?s)(?:^|\n\n)Deprecated: *(.*?)(?:$|\n\n)`)
-	m := rx.FindStringSubmatch(text)
+	m := reDeprecation.FindStringSubmatch(text)
 	if m == nil {
 		return ""
 	}

--- a/tm2/pkg/amino/pkg/pkg.go
+++ b/tm2/pkg/amino/pkg/pkg.go
@@ -382,30 +382,25 @@ func GetCallersDirname() string {
 	return dirName
 }
 
+const (
+	reDomain    = `[[:alnum:]-_]+[[:alnum:]-_.]+\.[a-zA-Z]{2,4}`
+	reGoPkgPart = `[[:alpha:]-_]+`
+	reR3PkgPart = `[[:alpha:]_]+`
+)
+
 var (
-	RE_DOMAIN     = `[[:alnum:]-_]+[[:alnum:]-_.]+\.[a-zA-Z]{2,4}`
-	RE_GOPKG_PART = `[[:alpha:]-_]+`
-	RE_GOPKG      = fmt.Sprintf(`(?:%v|%v)(?:/%v)*`, RE_DOMAIN, RE_GOPKG_PART, RE_GOPKG_PART)
-	RE_P3PKG_PART = `[[:alpha:]_]+`
-	RE_P3PKG      = fmt.Sprintf(`%v(?:\.:%v)*`, RE_P3PKG_PART, RE_P3PKG_PART)
+	reGoPkg = regexp.MustCompile(fmt.Sprintf(`(?:%v|%v)(?:/%v)*`, reDomain, reGoPkgPart, reGoPkgPart))
+	reR3Pkg = regexp.MustCompile(fmt.Sprintf(`%v(?:\.:%v)*`, reR3PkgPart, reR3PkgPart))
 )
 
 func assertValidGoPkgPath(gopkgPath string) {
-	matched, err := regexp.Match(RE_GOPKG, []byte(gopkgPath))
-	if err != nil {
-		panic(err)
-	}
-	if !matched {
+	if !reGoPkg.Match([]byte(gopkgPath)) {
 		panic(fmt.Sprintf("not a valid go package path: %v", gopkgPath))
 	}
 }
 
 func assertValidP3PkgName(p3pkgName string) {
-	matched, err := regexp.Match(RE_P3PKG, []byte(p3pkgName))
-	if err != nil {
-		panic(err)
-	}
-	if !matched {
+	if !reR3Pkg.Match([]byte(p3pkgName)) {
 		panic(fmt.Sprintf("not a valid proto3 package path: %v", p3pkgName))
 	}
 }

--- a/tm2/pkg/autofile/group.go
+++ b/tm2/pkg/autofile/group.go
@@ -347,6 +347,8 @@ func (g *Group) ReadGroupInfo() GroupInfo {
 	return g.readGroupInfo()
 }
 
+var indexedFilePattern = regexp.MustCompile(`^.+\.([0-9]{3,})$`)
+
 // Index includes the head.
 // CONTRACT: caller should have called g.mtx.Lock
 func (g *Group) readGroupInfo() GroupInfo {
@@ -375,7 +377,6 @@ func (g *Group) readGroupInfo() GroupInfo {
 		} else if strings.HasPrefix(fileInfo.Name(), headBase) {
 			fileSize := fileInfo.Size()
 			totalSize += fileSize
-			indexedFilePattern := regexp.MustCompile(`^.+\.([0-9]{3,})$`)
 			submatch := indexedFilePattern.FindSubmatch([]byte(fileInfo.Name()))
 			if len(submatch) != 0 {
 				// Matches

--- a/tm2/pkg/bft/rpc/lib/server/handlers.go
+++ b/tm2/pkg/bft/rpc/lib/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -357,6 +358,8 @@ func nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, error, bool
 		return _nonJSONStringToArg(rt, arg)
 	}
 }
+
+var reInt = regexp.MustCompile(`^-?[0-9]+$`)
 
 // NOTE: rt.Kind() isn't a pointer.
 func _nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, error, bool) {

--- a/tm2/pkg/bft/rpc/lib/server/handlers.go
+++ b/tm2/pkg/bft/rpc/lib/server/handlers.go
@@ -360,7 +360,7 @@ func nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, error, bool
 
 // NOTE: rt.Kind() isn't a pointer.
 func _nonJSONStringToArg(rt reflect.Type, arg string) (reflect.Value, error, bool) {
-	isIntString := RE_INT.Match([]byte(arg))
+	isIntString := reInt.Match([]byte(arg))
 	isQuotedString := strings.HasPrefix(arg, `"`) && strings.HasSuffix(arg, `"`)
 	isHexString := strings.HasPrefix(strings.ToLower(arg), "0x")
 

--- a/tm2/pkg/bft/rpc/lib/server/http_params.go
+++ b/tm2/pkg/bft/rpc/lib/server/http_params.go
@@ -15,13 +15,13 @@ var (
 	dotAtom = atom + `(?:\.` + atom + `)*`
 	domain  = `[A-Z0-9.-]+\.[A-Z]{2,4}`
 
-	RE_INT     = regexp.MustCompile(`^-?[0-9]+$`)
-	RE_HEX     = regexp.MustCompile(`^(?i)[a-f0-9]+$`)
-	RE_EMAIL   = regexp.MustCompile(`^(?i)(` + dotAtom + `)@(` + dotAtom + `)$`)
-	RE_ADDRESS = regexp.MustCompile(`^(?i)[a-z0-9]{25,34}$`)
-	RE_HOST    = regexp.MustCompile(`^(?i)(` + domain + `)$`)
+	reInt     = regexp.MustCompile(`^-?[0-9]+$`)
+	reHex     = regexp.MustCompile(`^(?i)[a-f0-9]+$`)
+	reEmail   = regexp.MustCompile(`^(?i)(` + dotAtom + `)@(` + dotAtom + `)$`)
+	reAddress = regexp.MustCompile(`^(?i)[a-z0-9]{25,34}$`)
+	reHost    = regexp.MustCompile(`^(?i)(` + domain + `)$`)
 
-	// RE_ID12       = regexp.MustCompile(`^[a-zA-Z0-9]{12}$`)
+	// reID12       = regexp.MustCompile(`^[a-zA-Z0-9]{12}$`)
 )
 
 func GetParam(r *http.Request, param string) string {

--- a/tm2/pkg/bft/rpc/lib/server/http_params.go
+++ b/tm2/pkg/bft/rpc/lib/server/http_params.go
@@ -9,21 +9,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/errors"
 )
 
-var (
-	// Parts of regular expressions
-	atom    = "[A-Z0-9!#$%&'*+\\-/=?^_`{|}~]+"
-	dotAtom = atom + `(?:\.` + atom + `)*`
-	domain  = `[A-Z0-9.-]+\.[A-Z]{2,4}`
-
-	reInt     = regexp.MustCompile(`^-?[0-9]+$`)
-	reHex     = regexp.MustCompile(`^(?i)[a-f0-9]+$`)
-	reEmail   = regexp.MustCompile(`^(?i)(` + dotAtom + `)@(` + dotAtom + `)$`)
-	reAddress = regexp.MustCompile(`^(?i)[a-z0-9]{25,34}$`)
-	reHost    = regexp.MustCompile(`^(?i)(` + domain + `)$`)
-
-	// reID12       = regexp.MustCompile(`^[a-zA-Z0-9]{12}$`)
-)
-
 func GetParam(r *http.Request, param string) string {
 	s := r.URL.Query().Get(param)
 	if s == "" {

--- a/tm2/pkg/std/memfile.go
+++ b/tm2/pkg/std/memfile.go
@@ -42,8 +42,6 @@ const rePathPart = `[a-z][a-z0-9_]*`
 
 var (
 	rePkgName      = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
-	rePkgPath      = regexp.MustCompile(`gno\.land/p(?:/` + rePathPart + `)+`)
-	reRlmPath      = regexp.MustCompile(`gno\.land/r(?:/` + rePathPart + `)+`)
 	rePkgOrRlmPath = regexp.MustCompile(`gno\.land/(?:p|r)(?:/` + rePathPart + `)+`)
 	reFileName     = regexp.MustCompile(`^[a-zA-Z0-9_]*\.[a-z0-9_\.]*$`)
 )

--- a/tm2/pkg/std/memfile.go
+++ b/tm2/pkg/std/memfile.go
@@ -38,32 +38,29 @@ func (mempkg *MemPackage) IsEmpty() bool {
 	return len(mempkg.Files) == 0
 }
 
-const (
-	reDomainPart   = `gno\.land`
-	rePathPart     = `[a-z][a-z0-9_]*`
-	rePkgName      = `^[a-z][a-z0-9_]*$`
-	rePkgPath      = reDomainPart + `/p/` + rePathPart + `(/` + rePathPart + `)*`
-	reRlmPath      = reDomainPart + `/r/` + rePathPart + `(/` + rePathPart + `)*`
-	rePkgOrRlmPath = `^(` + rePkgPath + `|` + reRlmPath + `)$`
-	reFileName     = `^[a-zA-Z0-9_]*\.[a-z0-9_\.]*$`
+const rePathPart = `[a-z][a-z0-9_]*`
+
+var (
+	rePkgName      = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	rePkgPath      = regexp.MustCompile(`gno\.land/p(?:/` + rePathPart + `)+`)
+	reRlmPath      = regexp.MustCompile(`gno\.land/r(?:/` + rePathPart + `)+`)
+	rePkgOrRlmPath = regexp.MustCompile(`gno\.land/(?:p|r)(?:/` + rePathPart + `)+`)
+	reFileName     = regexp.MustCompile(`^[a-zA-Z0-9_]*\.[a-z0-9_\.]*$`)
 )
 
 // path must not contain any dots after the first domain component.
 // file names must contain dots.
 // NOTE: this is to prevent conflicts with nested paths.
 func (mempkg *MemPackage) Validate() error {
-	ok, _ := regexp.MatchString(rePkgName, mempkg.Name)
-	if !ok {
+	if !rePkgName.MatchString(mempkg.Name) {
 		return errors.New(fmt.Sprintf("invalid package name %q", mempkg.Name))
 	}
-	ok, _ = regexp.MatchString(rePkgOrRlmPath, mempkg.Path)
-	if !ok {
+	if !rePkgOrRlmPath.MatchString(mempkg.Path) {
 		return errors.New(fmt.Sprintf("invalid package/realm path %q", mempkg.Path))
 	}
 	fnames := map[string]struct{}{}
 	for _, memfile := range mempkg.Files {
-		ok, _ := regexp.MatchString(reFileName, memfile.Name)
-		if !ok {
+		if !reFileName.MatchString(memfile.Name) {
 			return errors.New(fmt.Sprintf("invalid file name %q", memfile.Name))
 		}
 		if _, exists := fnames[memfile.Name]; exists {


### PR DESCRIPTION
This PR changes all regexes (except for some in test files) in the code to make them compile at init.

This, aside from giving a slight performance optimisation by skipping the compile stage on execution, allows also to ensure that the regexes themselves are correct by panicking at program start-up if they are not. (before this PR, in almost every instance where we used `regexp.MatchString` or similar, we did not check the error).