### PR TITLE
chore(examples): prefer Go and Gno for respective language names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Likewise, if you have an idea on how to improve this guide, go for it as well.
 
 ### Environment
 
-The gno repository is primarily based on Golang (Go) and Gnolang (Gno).
+The gno repository is primarily based on Go (Golang) and Gno.
 
 The primary tech stack for working on the repository:
 
@@ -63,7 +63,7 @@ It is recommended to work on a Unix environment, as most of the tooling is built
 for Windows / Linux / macOS).
 
 For Gno, there is no specific tooling that needs to be installed, that’s not already provided with the repo itself.
-You can utilize the `gno` command to facilitate Gnolang support when writing Smart Contracts in Gno, by installing it
+You can utilize the `gno` command to facilitate Gno support when writing Smart Contracts in Gno, by installing it
 with `make install_gno`.
 
 If you are working on Go source code on this repository, `pkg.go.dev` will not
@@ -149,16 +149,16 @@ if (executable('gnols'))
 else
 	echomsg 'gnols binary not found: LSP disabled for Gno files'
 endif
-	
+
 function! s:on_lsp_buffer_enabled() abort
     " Autocompletion
     setlocal omnifunc=lsp#complete
     " Format on save
     autocmd BufWritePre <buffer> LspDocumentFormatSync
     " Some optional mappings
-    nmap <buffer> <leader>i <Plug>(lsp-hover) 
+    nmap <buffer> <leader>i <Plug>(lsp-hover)
     " Following mappings are not supported yet by gnols
-    " nmap <buffer> gd <plug>(lsp-definition)     
+    " nmap <buffer> gd <plug>(lsp-definition)
     " nmap <buffer> <leader>rr <plug>(lsp-rename)
 endfunction
 augroup lsp_install

--- a/examples/gno.land/r/gnoland/home/home.gno
+++ b/examples/gno.land/r/gnoland/home/home.gno
@@ -73,7 +73,7 @@ func upcomingEvents(limit int) ui.Element {
 
 func introSection() ui.Element {
 	return ui.Element{
-		ui.H3("An interpretation of the Golang (Go) programming language for advanced developers and intrepid pioneers to build succinct, composable smart contracts for social coordination."),
+		ui.H3("An interpretation of the Go (Golang) programming language for advanced developers and intrepid pioneers to build succinct, composable smart contracts for social coordination."),
 		ui.Paragraph("If you’re concerned about information censorship and want to contribute to the #GnoWorldOrder, follow our socials to find out how."),
 		ui.Paragraph("Gno.land is in building mode. If you want to help lay the foundations of a fairer and freer world through innovative ideas and exceptional code, join us today."),
 	}
@@ -220,12 +220,12 @@ func discoverLinks() ui.Element {
 
 <div class="column">
 
-### Build with Gnolang
+### Build with Gno
 
 - [Gno dev with CLI (soon)](#)
 - [Explore the Universe](/ecosystem)
 - [Test in the browser (soon)](#)
-- [About the Gnolang Language](/gnolang)
+- [About the Gno Language](/gnolang)
 - [Docs/ Tutorials](https://github.com/gnolang)
 - [Gno by example](https://gno-by-example.com/)
 - [Getting started video (soon)](#)

--- a/examples/gno.land/r/gnoland/home/home_filetest.gno
+++ b/examples/gno.land/r/gnoland/home/home_filetest.gno
@@ -9,7 +9,7 @@ func main() {
 // Output:
 // # Welcome to Gno.land
 //
-// ### An interpretation of the Golang (Go) programming language for advanced developers and intrepid pioneers to build succinct, composable smart contracts for social coordination.
+// ### An interpretation of the Go (Golang) programming language for advanced developers and intrepid pioneers to build succinct, composable smart contracts for social coordination.
 //
 //
 // If you’re concerned about information censorship and want to contribute to the #GnoWorldOrder, follow our socials to find out how.
@@ -124,12 +124,12 @@ func main() {
 //
 // <div class="column">
 //
-// ### Build with Gnolang
+// ### Build with Gno
 //
 // - [Gno dev with CLI (soon)](#)
 // - [Explore the Universe](/ecosystem)
 // - [Test in the browser (soon)](#)
-// - [About the Gnolang Language](/gnolang)
+// - [About the Gno Language](/gnolang)
 // - [Docs/ Tutorials](https://github.com/gnolang)
 // - [Gno by example](https://gno-by-example.com/)
 // - [Getting started video (soon)](#)

--- a/examples/gno.land/r/gnoland/pages/page_about.gno
+++ b/examples/gno.land/r/gnoland/pages/page_about.gno
@@ -2,19 +2,19 @@ package gnopages
 
 func init() {
 	path := "about"
-	title := "Gno.land Is A Platform To Write Smart Contracts In Gnolang (Gno)"
-	// XXX: description := "On Gno.land, developers write smart contracts and other blockchain apps using Gnolang (Gno) without learning a language that’s exclusive to a single ecosystem."
+	title := "Gno.land Is A Platform To Write Smart Contracts In Gno"
+	// XXX: description := "On Gno.land, developers write smart contracts and other blockchain apps using Gno without learning a language that’s exclusive to a single ecosystem."
 	body := `# About Gno.land
 
-Gno.land is a platform to write smart contracts in Gnolang (Gno).
-Using an interpreted version of the general-purpose programming language Golang (Go), developers can write smart contracts and other blockchain apps without having to learn a language that’s exclusive to a single ecosystem.
+Gno.land is a platform to write smart contracts in Gno.
+Using an interpreted version of the general-purpose programming language Go (Golang), developers can write smart contracts and other blockchain apps without having to learn a language that’s exclusive to a single ecosystem.
 Web2 developers can easily contribute to web3 and start building a more transparent, accountable world.
 
 The Gno transaction token, GNOT, and the contributor memberships power the platform, which runs on a variation of Proof of Stake.
 Proof of Contribution rewards contributors from technical and non-technical backgrounds, fairly and for life with GNOT.
 This consensus mechanism also achieves higher security with fewer validators, optimizing resources for a greener, more sustainable, and enduring blockchain ecosystem.
 
-Any blockchain using Gnolang achieves succinctness, composability, expressivity, and completeness not found in any other smart contract platform.
+Any blockchain using Gno achieves succinctness, composability, expressivity, and completeness not found in any other smart contract platform.
 By observing a minimal structure, the design can endure over time and challenge the regime of information censorship we’re living in today.`
 	_ = b.NewPost("", path, title, body, nil)
 }

--- a/examples/gno.land/r/gnoland/pages/page_gnolang.gno
+++ b/examples/gno.land/r/gnoland/pages/page_gnolang.gno
@@ -3,11 +3,11 @@ package gnopages
 func init() {
 	var (
 		path  = "gnolang"
-		title = "Gnolang (Gno) Is a Complete Language for Blockchain"
+		title = "Gno Is a Complete Language for Blockchain"
 		// XXX: description = "Gnolang (Gno) is an interpretation of the popular Golang (Go) language for blockchain created by Tendermint and Cosmos founder Jae Kwon."
-		body = `# About the Gnolang, the Gno Language
+		body = `# About the Gno, the Language for Gno.land
 
-[Gnolang](https://github.com/gnolang/gno/blob/master/LICENSE.md) (Gno) is an interpretation of the widely-used Golang (Go) programming language for blockchain created by Cosmos co-founder Jae Kwon in 2022 to mark a new era in smart contracting. Gno is ~99% identical to Go, so Go programmers can start coding in Gno right away, with a minimal learning curve. For example, Gno comes with blockchain-specific standard libraries, but any code that doesn’t use blockchain-specific logic can run in Go with minimal processing. Libraries that don’t make sense in the blockchain context, such as network or operating-system access, are not available in Gno. Otherwise, Gno loads and uses many standard libraries that power Go, so most of the parsing of the source code is the same.
+[Gno](https://github.com/gnolang/gno/blob/master/LICENSE.md) is an interpretation of the widely-used Go (Golang) programming language for blockchain created by Cosmos co-founder Jae Kwon in 2022 to mark a new era in smart contracting. Gno is ~99% identical to Go, so Go programmers can start coding in Gno right away, with a minimal learning curve. For example, Gno comes with blockchain-specific standard libraries, but any code that doesn’t use blockchain-specific logic can run in Go with minimal processing. Libraries that don’t make sense in the blockchain context, such as network or operating-system access, are not available in Gno. Otherwise, Gno loads and uses many standard libraries that power Go, so most of the parsing of the source code is the same.
 
 Under the hood, the Gno code is parsed into an abstract syntax tree (AST) and the AST itself is used in the interpreter, rather than bytecode as in many virtual machines such as Java, Python, or Wasm. This makes even the GnoVM accessible to any Go programmer. The novel design of the intuitive GnoVM interpreter allows Gno to freeze and resume the program by persisting and loading the entire memory state. Gno is deterministic, auto-persisted, and auto-Merkle-ized, allowing (smart contract) programs to be succinct, as the programmer doesn’t have to serialize and deserialize objects to persist them into a database (unlike programming applications with the Cosmos SDK).
 

--- a/examples/gno.land/r/gnoland/pages/pages_test.gno
+++ b/examples/gno.land/r/gnoland/pages/pages_test.gno
@@ -33,7 +33,7 @@ func TestAbout(t *testing.T) {
 	got := Render("p/about")
 	expectedSubtrings := []string{
 		"# About Gno.land",
-		"Gno.land is a platform to write smart contracts in Gnolang (Gno).",
+		"Gno.land is a platform to write smart contracts in Gno.",
 	}
 	for _, substring := range expectedSubtrings {
 		if !strings.Contains(got, substring) {


### PR DESCRIPTION
More on my crusade for right terminology and avoid dooming us to have "gnolang" as the official language name.

See-also #1548 