### PR TITLE
test: add regression integ test for gnolang/gnochess#97

### DIFF
--- a/gno.land/cmd/gnoland/testdata/issue-gnochess-97.txtar
+++ b/gno.land/cmd/gnoland/testdata/issue-gnochess-97.txtar
@@ -1,0 +1,41 @@
+# test for https://github.com/gnolang/gnochess/issues/97
+
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/bug97 -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 1000000ugnot -gas-wanted 2000000 -send '' -broadcast -chainid='tendermint_test' test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall2' -gas-fee 1000000ugnot -gas-wanted 2000000 -send '' -broadcast -chainid='tendermint_test' test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 1000000ugnot -gas-wanted 2000000 -send '' -broadcast -chainid='tendermint_test' test1
+stdout 'OK!'
+
+-- bug97.gno --
+package bug97
+
+var x = [3]int{1, 2, 3}
+
+func newX() [3]int { return x}
+
+type S struct {
+	Arr [3]int
+}
+
+func NewS() S {
+	return S{Arr: x}
+}
+
+var s S
+
+func RealmCall1() {
+	s = NewS()
+}
+
+func RealmCall2()  {
+	arr2 := s.Arr
+	arr2[0] = 8
+	s = S{Arr: arr2}
+}


### PR DESCRIPTION
From #1172, pushed to current codebase.