### PR TITLE
chore: In VMKeeper Call, panic with useful error message for wrong number of args

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -242,6 +242,11 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 	if cx.Varg {
 		panic("variadic calls not yet supported")
 	}
+	if len(msg.Args) < len(ft.Params) {
+		panic("not enough arguments in call to " + fnc)
+	} else if len(msg.Args) > len(ft.Params) {
+		panic("too many arguments in call to " + fnc)
+	}
 	for i, arg := range msg.Args {
 		argType := ft.Params[i].Type
 		atv := convertArgToGno(arg, argType)

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -395,3 +395,54 @@ func main() {
 	expectedString := fmt.Sprintf("hello world! %s\n", addr.String())
 	assert.Equal(t, res, expectedString)
 }
+
+func TestNumberOfArgsError(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	// Give "addr1" some gnots.
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+
+	// Create test package.
+	files := []*std.MemFile{
+		{
+			Name: "test.gno",
+			Body: `package test
+
+import "std"
+
+func Echo(msg string) string {
+	return "echo:"+msg
+}`,
+		},
+	}
+	pkgPath := "gno.land/r/test"
+	msg1 := NewMsgAddPackage(addr, pkgPath, files)
+	err := env.vmk.AddPackage(ctx, msg1)
+	assert.NoError(t, err)
+
+	// Call Echo function with not enough arguments.
+	coins := std.MustParseCoins("1ugnot")
+	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{})
+	assert.PanicsWithValue(
+		t,
+		func() {
+			env.vmk.Call(ctx, msg2)
+		},
+		"not enough arguments in call to Echo",
+	)
+
+	// Call Echo function with too many arguments.
+	msg3 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world", "extra arg"})
+	assert.PanicsWithValue(
+		t,
+		func() {
+			env.vmk.Call(ctx, msg3)
+		},
+		"too many arguments in call to Echo",
+	)
+}


### PR DESCRIPTION
If a realm function Call has too many arguments, VMKeeper Call panics with an uninformative index error message like "index out of range [1] with length 1" when it is [checking the arguments](https://github.com/gnolang/gno/blob/12b4b458e1b13d491a5797aa11b2002242f012bd/gno.land/pkg/sdk/vm/keeper.go#L244). This PR adds explicit checks for number of arguments with useful panic error messages like "not enough arguments in call to Echo" or "too many arguments in call to Echo" . (These are the same errors as the Go compiler.)

(I couldn't find an existing issue for this. If you already have other plans to improve this error message, then you can close this PR.)

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
