### PR TITLE
fix: add missing args field to `gnoclient` Call

### DIFF
--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -168,7 +168,7 @@ func TestClient_CallMultiple(t *testing.T) {
 		{
 			PkgPath:  "gno.land/r/demo/tamagotchi",
 			FuncName: "Feed",
-			Args:     []string{},
+			Args:     []string{""},
 			Send:     "",
 		},
 	}

--- a/gno.land/pkg/gnoclient/client_txs.go
+++ b/gno.land/pkg/gnoclient/client_txs.go
@@ -78,6 +78,7 @@ func (c *Client) Call(cfg BaseTxCfg, msgs ...MsgCall) (*ctypes.ResultBroadcastTx
 			Caller:  c.Signer.Info().GetAddress(),
 			PkgPath: msg.PkgPath,
 			Func:    msg.FuncName,
+			Args:    msg.Args,
 			Send:    send,
 		})
 	}

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -1,0 +1,125 @@
+package gnoclient
+
+import (
+	"github.com/gnolang/gno/gno.land/pkg/integration"
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClient_Call_Single_Integration(t *testing.T) {
+	// Set up in-memory node
+	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
+	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
+	defer node.Stop()
+
+	// Init Signer & RPCClient
+	signer := newInMemorySigner(t, "tendermint_test")
+	rpcClient := rpcclient.NewHTTP(remoteAddr, "/websocket")
+
+	// Setup Client
+	client := Client{
+		Signer:    signer,
+		RPCClient: rpcClient,
+	}
+
+	// Make Tx config
+	baseCfg := BaseTxCfg{
+		GasFee:         "10000ugnot",
+		GasWanted:      8000000,
+		AccountNumber:  0,
+		SequenceNumber: 0,
+		Memo:           "",
+	}
+
+	// Make Msg config
+	msg := MsgCall{
+		PkgPath:  "gno.land/r/demo/deep/very/deep",
+		FuncName: "Render",
+		Args:     []string{"test argument"},
+		Send:     "",
+	}
+
+	// Execute call
+	res, err := client.Call(baseCfg, msg)
+
+	expected := "(\"hi test argument\" string)"
+	got := string(res.DeliverTx.Data)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+
+}
+
+func TestClient_Call_Multiple_Integration(t *testing.T) {
+	// Set up in-memory node
+	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
+	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
+	defer node.Stop()
+
+	// Init Signer & RPCClient
+	signer := newInMemorySigner(t, "tendermint_test")
+	rpcClient := rpcclient.NewHTTP(remoteAddr, "/websocket")
+
+	// Setup Client
+	client := Client{
+		Signer:    signer,
+		RPCClient: rpcClient,
+	}
+
+	// Make Tx config
+	baseCfg := BaseTxCfg{
+		GasFee:         "10000ugnot",
+		GasWanted:      8000000,
+		AccountNumber:  0,
+		SequenceNumber: 0,
+		Memo:           "",
+	}
+
+	// Make Msg configs
+	msg1 := MsgCall{
+		PkgPath:  "gno.land/r/demo/deep/very/deep",
+		FuncName: "Render",
+		Args:     []string{""},
+		Send:     "",
+	}
+
+	msg2 := MsgCall{
+		PkgPath:  "gno.land/r/demo/deep/very/deep",
+		FuncName: "Render",
+		Args:     []string{"test argument"},
+		Send:     "",
+	}
+
+	expected := "(\"it works!\" string)(\"hi test argument\" string)"
+
+	// Execute call
+	res, err := client.Call(baseCfg, msg1, msg2)
+
+	got := string(res.DeliverTx.Data)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+
+}
+
+func newInMemorySigner(t *testing.T, chainid string) *SignerFromKeybase {
+	t.Helper()
+
+	mnemonic := integration.DefaultAccount_Seed
+	name := integration.DefaultAccount_Name
+
+	kb := keys.NewInMemory()
+	_, err := kb.CreateAccount(name, mnemonic, "", "", uint32(0), uint32(0))
+	require.NoError(t, err)
+
+	return &SignerFromKeybase{
+		Keybase:  kb,      // Stores keys in memory or on disk
+		Account:  name,    // Account name or bech32 format
+		Password: "",      // Password for encryption
+		ChainID:  chainid, // Chain ID for transaction signing
+	}
+}

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -1,6 +1,8 @@
 package gnoclient
 
 import (
+	"testing"
+
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
@@ -8,7 +10,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestClient_Call_Single_Integration(t *testing.T) {

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -107,6 +107,8 @@ func TestClient_Call_Multiple_Integration(t *testing.T) {
 
 }
 
+// todo add more integration tests.
+
 func newInMemorySigner(t *testing.T, chainid string) *SignerFromKeybase {
 	t.Helper()
 

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -52,7 +52,6 @@ func TestClient_Call_Single_Integration(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, got)
-
 }
 
 func TestClient_Call_Multiple_Integration(t *testing.T) {

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -88,6 +88,7 @@ func TestClient_Call_Multiple_Integration(t *testing.T) {
 		Send:     "",
 	}
 
+	// Same call, different argument
 	msg2 := MsgCall{
 		PkgPath:  "gno.land/r/demo/deep/very/deep",
 		FuncName: "Render",

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -104,7 +104,6 @@ func TestClient_Call_Multiple_Integration(t *testing.T) {
 	got := string(res.DeliverTx.Data)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, got)
-
 }
 
 // todo add more integration tests.


### PR DESCRIPTION
## Description

This PR fixes the Gnoclient Call function that left out the MsgCall arguments when parsing, and introduces integration tests to test this.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
