### PR TITLE
chore(make): provide install.gnodev in root makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,24 @@ help:
 rundep=go run -modfile misc/devdeps/go.mod
 
 .PHONY: install
-install: install_gnokey install_gno
+install: install.gnokey install.gno
+	@echo "Installing gnokey & gno command."
+	@echo "For local realm development, gnodev is recommended: https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev"
+	@echo "You can install it by calling 'make install.gnodev'"
 
 # shortcuts to frequently used commands from sub-components.
-install_gnokey:
+install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
 	@echo "[+] 'gnokey' is installed. more info in ./gno.land/."
-install_gno:
+install.gno:
 	$(MAKE) --no-print-directory -C ./gnovm	install
 	@echo "[+] 'gno' is installed. more info in ./gnovm/."
+install.gnodev:
+	$(MAKE) --no-print-directory -C ./contribs install.gnodev
+	@echo "[+] 'gnodev' is installed."
+# old aliases
+install_gnokey: install.gnokey
+install_gno: install.gno
 
 .PHONY: test
 test: test.components test.docker

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,32 @@
 .PHONY: help
 help:
 	@echo "Available make commands:"
-	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
+	@cat Makefile | grep '^[a-z][^:]*:' | grep -v 'install_' | cut -d: -f1 | sort | sed 's/^/  /'
 
 rundep=go run -modfile misc/devdeps/go.mod
 
 .PHONY: install
 install: install.gnokey install.gno
-	@echo "Installing gnokey & gno command."
-	@echo "For local realm development, gnodev is recommended: https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev"
-	@echo "You can install it by calling 'make install.gnodev'"
+	@if ! command -v gnodev > /dev/null; then \
+		echo ------------------------------; \
+		echo "For local realm development, gnodev is recommended: https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev"; \
+		echo "You can install it by calling 'make install.gnodev'"; \
+	fi
 
 # shortcuts to frequently used commands from sub-components.
+.PHONY: install.gnokey
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
 	@echo "[+] 'gnokey' is installed. more info in ./gno.land/."
+.PHONY: install.gno
 install.gno:
 	$(MAKE) --no-print-directory -C ./gnovm	install
 	@echo "[+] 'gno' is installed. more info in ./gnovm/."
+.PHONY: install.gnodev
 install.gnodev:
 	$(MAKE) --no-print-directory -C ./contribs install.gnodev
 	@echo "[+] 'gnodev' is installed."
+
 # old aliases
 install_gnokey: install.gnokey
 install_gno: install.gno

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ install.gnodev:
 	@echo "[+] 'gnodev' is installed."
 
 # old aliases
+.PHONY: install_gnokey
 install_gnokey: install.gnokey
+.PHONY: install_gno
 install_gno: install.gno
 
 .PHONY: test


### PR DESCRIPTION
cc/ @leohhhn 

Since from what I understood we're going to direct users to install `gnodev` as part of getting started, let's add it as a command in the top level Makefile?

I also took the chance to make everything [PHONY](https://makefiletutorial.com/#phony).