### PR TITLE
chore(.github): dependabot group for all GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       interval: "daily"
     labels:
       - "github_actions"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   # Maintain dependencies for top level Go modules
   - package-ecosystem: gomod


### PR DESCRIPTION
Continuing the work in #1553, this adds a dependabot group to update all GH actions together.