### PR TITLE
docs: add edit page link and info

### DIFF
--- a/misc/docusaurus/docusaurus.config.js
+++ b/misc/docusaurus/docusaurus.config.js
@@ -28,7 +28,7 @@ const config = {
       src: "https://sa.gno.services/latest.js",
       async: true,
       defer: true,
-    }
+    },
   ],
 
   presets: [
@@ -40,6 +40,8 @@ const config = {
           path: "../../docs",
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
+          showLastUpdateTime: true,
+          editUrl: ({ docPath }) => `https://github.com/gnolang/gno/edit/master/docs/${docPath}`,
         },
         blog: false,
         theme: {

--- a/misc/docusaurus/src/css/custom.css
+++ b/misc/docusaurus/src/css/custom.css
@@ -118,7 +118,8 @@ body nav[class*="navbarHidden"] {
   }
 }
 
-.theme-doc-markdown {
+.theme-doc-markdown,
+.theme-doc-footer {
   max-width: var(--content-max-w, 700px);
 }
 


### PR DESCRIPTION
Related to #1505,This PR aims to add the edit page option in order to link the source `md` file to docs page. So readers will be invited to edit the page to improve it. It also add the last update date, so readers can know if the page is up to date.
