### PR TITLE
chore(gnovm): replace previous `PeekStmt` to `PeekStmt1`

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -1451,17 +1451,7 @@ func (m *Machine) ForcePopOp() {
 }
 
 // Offset starts at 1.
-// DEPRECATED use PeekStmt1() instead.
-func (m *Machine) PeekStmt(offset int) Stmt {
-	if debug {
-		if offset != 1 {
-			panic("should not happen")
-		}
-	}
-	return m.Stmts[len(m.Stmts)-offset]
-}
-
-func (m *Machine) PeekStmt1() Stmt {
+func (m *Machine) PeekStmt() Stmt {
 	numStmts := len(m.Stmts)
 	s := m.Stmts[numStmts-1]
 	if bs, ok := s.(*bodyStmt); ok {
@@ -1779,7 +1769,7 @@ func (m *Machine) PeekFrameAndContinueFor() {
 	m.Exprs = m.Exprs[:fr.NumExprs]
 	m.Stmts = m.Stmts[:fr.NumStmts+1]
 	m.Blocks = m.Blocks[:fr.NumBlocks+1]
-	ls := m.PeekStmt(1).(*bodyStmt)
+	ls := m.PeekStmt().(*bodyStmt)
 	ls.NextBodyIndex = ls.BodyLen
 }
 
@@ -1790,7 +1780,7 @@ func (m *Machine) PeekFrameAndContinueRange() {
 	m.Exprs = m.Exprs[:fr.NumExprs]
 	m.Stmts = m.Stmts[:fr.NumStmts+1]
 	m.Blocks = m.Blocks[:fr.NumBlocks+1]
-	ls := m.PeekStmt(1).(*bodyStmt)
+	ls := m.PeekStmt().(*bodyStmt)
 	ls.NextBodyIndex = ls.BodyLen
 }
 

--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -51,7 +51,7 @@ SelectStmt ->
 // operation is that the value of the expression is pushed onto the stack.
 
 func (m *Machine) doOpExec(op Op) {
-	s := m.PeekStmt(1) // TODO: PeekStmt1()?
+	s := m.PeekStmt()
 	if debug {
 		debug.Printf("PEEK STMT: %v\n", s)
 		debug.Printf("%v\n", m)
@@ -906,7 +906,7 @@ func (m *Machine) doOpTypeSwitch() {
 }
 
 func (m *Machine) doOpSwitchClause() {
-	ss := m.PeekStmt1().(*SwitchStmt)
+	ss := m.PeekStmt().(*SwitchStmt)
 	// tv := m.PeekValue(1) // switch tag value
 	// caiv := m.PeekValue(2) // switch clause case index (reuse)
 	cliv := m.PeekValue(3) // switch clause index (reuse)
@@ -983,7 +983,7 @@ func (m *Machine) doOpSwitchClauseCase() {
 		m.PushStmt(b.GetBodyStmt())
 	} else {
 		// try next case or clause.
-		ss := m.PeekStmt1().(*SwitchStmt) // peek switch stmt
+		ss := m.PeekStmt().(*SwitchStmt) // peek switch stmt
 		clidx := cliv.GetInt()
 		cl := ss.Clauses[clidx]
 		caidx := caiv.GetInt()


### PR DESCRIPTION
## Description

`PeekStmt` is deprecated. So, I updated the code to use `PeekStmt1` and renamed it accordingly.