### PR TITLE
chore(gnoclient): Add Send support

### DIFF
--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -539,7 +539,7 @@ func TestClient_Send_Errors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-	        tc := tc
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -359,3 +359,192 @@ func TestClient_Call_Errors(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_Send_Errors(t *testing.T) {
+	t.Parallel()
+
+	toAddress, _ := crypto.AddressFromBech32("g14a0y9a64dugh3l7hneshdxr4w0rfkkww9ls35p")
+	testCases := []struct {
+		name          string
+		client        Client
+		cfg           BaseTxCfg
+		msgs          []MsgSend
+		expectedError error
+	}{
+		{
+			name: "Invalid Signer",
+			client: Client{
+				Signer:    nil,
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      100000,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrMissingSigner,
+		},
+		{
+			name: "Invalid RPCClient",
+			client: Client{
+				&mockSigner{},
+				nil,
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      100000,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrMissingRPCClient,
+		},
+		{
+			name: "Invalid Gas Fee",
+			client: Client{
+				Signer:    &mockSigner{},
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      100000,
+				GasFee:         "",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrInvalidGasFee,
+		},
+		{
+			name: "Negative Gas Wanted",
+			client: Client{
+				Signer:    &mockSigner{},
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      -1,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrInvalidGasWanted,
+		},
+		{
+			name: "0 Gas Wanted",
+			client: Client{
+				Signer:    &mockSigner{},
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      0,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrInvalidGasWanted,
+		},
+		{
+			name: "Invalid To Address",
+			client: Client{
+				Signer: &mockSigner{
+					info: func() keys.Info {
+						return &mockKeysInfo{
+							getAddress: func() crypto.Address {
+								adr, _ := crypto.AddressFromBech32("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+								return adr
+							},
+						}
+					},
+				},
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      100000,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: crypto.Address{},
+					Send:      "1ugnot",
+				},
+			},
+			expectedError: ErrInvalidToAddress,
+		},
+		{
+			name: "Invalid Send Coins",
+			client: Client{
+				Signer: &mockSigner{
+					info: func() keys.Info {
+						return &mockKeysInfo{
+							getAddress: func() crypto.Address {
+								adr, _ := crypto.AddressFromBech32("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+								return adr
+							},
+						}
+					},
+				},
+				RPCClient: &mockRPCClient{},
+			},
+			cfg: BaseTxCfg{
+				GasWanted:      100000,
+				GasFee:         "10000ugnot",
+				AccountNumber:  1,
+				SequenceNumber: 1,
+				Memo:           "Test memo",
+			},
+			msgs: []MsgSend{
+				{
+					ToAddress: toAddress,
+					Send:      "-1ugnot",
+				},
+			},
+			expectedError: ErrInvalidSendAmount,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := tc.client.Send(tc.cfg, tc.msgs...)
+			assert.Nil(t, res)
+			assert.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+}

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -539,6 +539,7 @@ func TestClient_Send_Errors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+	        tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gno.land/pkg/gnoclient/client_txs.go
+++ b/gno.land/pkg/gnoclient/client_txs.go
@@ -12,12 +12,14 @@ import (
 )
 
 var (
-	ErrEmptyPkgPath     = errors.New("empty pkg path")
-	ErrEmptyFuncName    = errors.New("empty function name")
-	ErrInvalidGasWanted = errors.New("invalid gas wanted")
-	ErrInvalidGasFee    = errors.New("invalid gas fee")
-	ErrMissingSigner    = errors.New("missing Signer")
-	ErrMissingRPCClient = errors.New("missing RPCClient")
+	ErrEmptyPkgPath      = errors.New("empty pkg path")
+	ErrEmptyFuncName     = errors.New("empty function name")
+	ErrInvalidGasWanted  = errors.New("invalid gas wanted")
+	ErrInvalidGasFee     = errors.New("invalid gas fee")
+	ErrMissingSigner     = errors.New("missing Signer")
+	ErrMissingRPCClient  = errors.New("missing RPCClient")
+	ErrInvalidToAddress  = errors.New("invalid send to address")
+	ErrInvalidSendAmount = errors.New("invalid send amount")
 )
 
 type BaseTxCfg struct {
@@ -132,6 +134,11 @@ func (c *Client) Send(cfg BaseTxCfg, msgs ...MsgSend) (*ctypes.ResultBroadcastTx
 	// Parse MsgSend slice
 	vmMsgs := make([]bank.MsgSend, 0, len(msgs))
 	for _, msg := range msgs {
+		// Validate MsgSend fields
+		if err := msg.validateMsgSend(); err != nil {
+			return nil, err
+		}
+
 		// Parse send coins
 		send, err := std.ParseCoins(msg.Send)
 		if err != nil {

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +105,109 @@ func TestClient_Call_Multiple_Integration(t *testing.T) {
 
 	got := string(res.DeliverTx.Data)
 	assert.Nil(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestClient_Send_Single_Integration(t *testing.T) {
+	// Set up in-memory node
+	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
+	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
+	defer node.Stop()
+
+	// Init Signer & RPCClient
+	signer := newInMemorySigner(t, "tendermint_test")
+	rpcClient := rpcclient.NewHTTP(remoteAddr, "/websocket")
+
+	// Setup Client
+	client := Client{
+		Signer:    signer,
+		RPCClient: rpcClient,
+	}
+
+	// Make Tx config
+	baseCfg := BaseTxCfg{
+		GasFee:         "10000ugnot",
+		GasWanted:      8000000,
+		AccountNumber:  0,
+		SequenceNumber: 0,
+		Memo:           "",
+	}
+
+	// Make Send config for a new address on the blockchain
+	toAddress, _ := crypto.AddressFromBech32("g14a0y9a64dugh3l7hneshdxr4w0rfkkww9ls35p")
+	amount := 10
+	msg := MsgSend{
+		ToAddress: toAddress,
+		Send:      std.Coin{"ugnot", int64(amount)}.String(),
+	}
+
+	// Execute send
+	res, err := client.Send(baseCfg, msg)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(res.DeliverTx.Data))
+
+	// Get the new account balance
+	account, _, err := client.QueryAccount(toAddress)
+	assert.Nil(t, err)
+
+	expected := std.Coins{{"ugnot", int64(amount)}}
+	got := account.GetCoins()
+
+	assert.Equal(t, expected, got)
+}
+
+func TestClient_Send_Multiple_Integration(t *testing.T) {
+	// Set up in-memory node
+	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
+	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
+	defer node.Stop()
+
+	// Init Signer & RPCClient
+	signer := newInMemorySigner(t, "tendermint_test")
+	rpcClient := rpcclient.NewHTTP(remoteAddr, "/websocket")
+
+	// Setup Client
+	client := Client{
+		Signer:    signer,
+		RPCClient: rpcClient,
+	}
+
+	// Make Tx config
+	baseCfg := BaseTxCfg{
+		GasFee:         "10000ugnot",
+		GasWanted:      8000000,
+		AccountNumber:  0,
+		SequenceNumber: 0,
+		Memo:           "",
+	}
+
+	// Make Msg configs
+	toAddress, _ := crypto.AddressFromBech32("g14a0y9a64dugh3l7hneshdxr4w0rfkkww9ls35p")
+	amount1 := 10
+	msg1 := MsgSend{
+		ToAddress: toAddress,
+		Send:      std.Coin{"ugnot", int64(amount1)}.String(),
+	}
+
+	// Same send, different argument
+	amount2 := 20
+	msg2 := MsgSend{
+		ToAddress: toAddress,
+		Send:      std.Coin{"ugnot", int64(amount2)}.String(),
+	}
+
+	// Execute send
+	res, err := client.Send(baseCfg, msg1, msg2)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(res.DeliverTx.Data))
+
+	// Get the new account balance
+	account, _, err := client.QueryAccount(toAddress)
+	assert.Nil(t, err)
+
+	expected := std.Coins{{"ugnot", int64(amount1 + amount2)}}
+	got := account.GetCoins()
+
 	assert.Equal(t, expected, got)
 }
 

--- a/gno.land/pkg/gnoclient/util.go
+++ b/gno.land/pkg/gnoclient/util.go
@@ -1,10 +1,12 @@
 package gnoclient
 
+import "github.com/gnolang/gno/tm2/pkg/std"
+
 func (cfg BaseTxCfg) validateBaseTxConfig() error {
-	if cfg.GasWanted < 0 {
+	if cfg.GasWanted <= 0 {
 		return ErrInvalidGasWanted
 	}
-	if cfg.GasFee < "" {
+	if cfg.GasFee == "" {
 		return ErrInvalidGasFee
 	}
 
@@ -17,6 +19,17 @@ func (msg MsgCall) validateMsgCall() error {
 	}
 	if msg.FuncName == "" {
 		return ErrEmptyFuncName
+	}
+	return nil
+}
+
+func (msg MsgSend) validateMsgSend() error {
+	if msg.ToAddress.IsZero() {
+		return ErrInvalidToAddress
+	}
+	_, err := std.ParseCoins(msg.Send)
+	if err != nil {
+		return ErrInvalidSendAmount
 	}
 	return nil
 }


### PR DESCRIPTION
gnoclient already supports MsgCall and MsgRun. This adds `Send` to support MsgSend.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
