### PR TITLE
ci: use action to validate dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-HEY!! NOT VALID YAML
 version: 2
 updates:
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+HEY!! NOT VALID YAML
 version: 2
 updates:
 

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,0 +1,19 @@
+name: dependabot validate
+
+on:
+  pull_request:
+    paths:
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependabot-validate.yml'
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: marocchino/validate-dependabot@v2
+        id: validate
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always()
+        with:
+          header: validate-dependabot
+          message: ${{ steps.validate.outputs.markdown }}

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -11,9 +11,3 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: marocchino/validate-dependabot@v2
-        id: validate
-      - uses: marocchino/sticky-pull-request-comment@v2
-        if: always()
-        with:
-          header: validate-dependabot
-          message: ${{ steps.validate.outputs.markdown }}


### PR DESCRIPTION
following [this comment](https://github.com/gnolang/gno/pull/1628#issuecomment-1924795401) from @kristovatlas 

This action seems to only validate the JSON schema. For full validation, it's on GitHub to provide this -- tracked in this issue: https://github.com/dependabot/dependabot-core/issues/4605