### PR TITLE
fix(sdk/vm): coerce MsgRun pkgpath to `gno.land/r/$addr/run`

### DIFF
--- a/gno.land/pkg/gnoclient/client_txs.go
+++ b/gno.land/pkg/gnoclient/client_txs.go
@@ -144,7 +144,7 @@ func (c *Client) Run(cfg RunCfg) (*ctypes.ResultBroadcastTxCommit, error) {
 		return nil, errors.Wrap(err, "precompile and check")
 	}
 	memPkg.Name = "main"
-	memPkg.Path = "gno.land/r/" + caller.String() + "/run"
+	memPkg.Path = ""
 
 	// Construct message & transaction and marshal.
 	msg := vm.MsgRun{

--- a/gno.land/pkg/keyscli/run.go
+++ b/gno.land/pkg/keyscli/run.go
@@ -114,7 +114,8 @@ func execMakeRun(cfg *MakeRunCfg, args []string, cmdio commands.IO) error {
 		panic(err)
 	}
 	memPkg.Name = "main"
-	memPkg.Path = "gno.land/r/" + caller.String() + "/run"
+	// Set to empty; this will be automatically set by the VM keeper.
+	memPkg.Path = ""
 
 	// construct msg & tx and marshal.
 	msg := vm.MsgRun{

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -303,12 +303,10 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 	send := msg.Send
 	memPkg := msg.Package
 
-	// Force memPkg path to the reserved run path.
-	wantPath := "gno.land/r/" + caller.String() + "/run"
-	if path := memPkg.Path; path != "" && path != wantPath {
-		return "", ErrInvalidPkgPath(fmt.Sprintf("invalid pkgpath for MsgRun: %q", path))
-	}
-	memPkg.Path = wantPath
+	// coerce path to right one.
+	// the path in the message must be "" or the following path.
+	// this is already checked in MsgRun.ValidateBasic
+	memPkg.Path = "gno.land/r/" + msg.Caller.String() + "/run"
 
 	// Validate arguments.
 	callerAcc := vm.acck.GetAccount(ctx, caller)

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -131,7 +131,7 @@ func (vm *VMKeeper) getGnoStore(ctx sdk.Context) gno.Store {
 	}
 }
 
-var reReservedPath = regexp.MustCompile(`gno\.land/r/g[a-z0-9]+/run`)
+var reRunPath = regexp.MustCompile(`gno\.land/r/g[a-z0-9]+/run`)
 
 // AddPackage adds a package with given fileset.
 func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
@@ -156,7 +156,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) error {
 		return ErrInvalidPkgPath("package already exists: " + pkgPath)
 	}
 
-	if reReservedPath.MatchString(pkgPath) {
+	if reRunPath.MatchString(pkgPath) {
 		return ErrInvalidPkgPath("reserved package name: " + pkgPath)
 	}
 
@@ -302,6 +302,9 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 	store := vm.getGnoStore(ctx)
 	send := msg.Send
 	memPkg := msg.Package
+
+	// Force memPkg path to the reserved run path.
+	memPkg.Path = "gno.land/r/" + caller.String() + "/run"
 
 	// Validate arguments.
 	callerAcc := vm.acck.GetAccount(ctx, caller)

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -304,7 +304,11 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 	memPkg := msg.Package
 
 	// Force memPkg path to the reserved run path.
-	memPkg.Path = "gno.land/r/" + caller.String() + "/run"
+	wantPath := "gno.land/r/" + caller.String() + "/run"
+	if path := memPkg.Path; path != "" && path != wantPath {
+		return "", ErrInvalidPkgPath(fmt.Sprintf("invalid pkgpath for MsgRun: %q", path))
+	}
+	memPkg.Path = wantPath
 
 	// Validate arguments.
 	callerAcc := vm.acck.GetAccount(ctx, caller)

--- a/gno.land/pkg/sdk/vm/msgs.go
+++ b/gno.land/pkg/sdk/vm/msgs.go
@@ -163,7 +163,7 @@ func NewMsgRun(caller crypto.Address, send std.Coins, files []*std.MemFile) MsgR
 		Send:   send,
 		Package: &std.MemPackage{
 			Name:  "main",
-			Path:  "gno.land/r/" + caller.String() + "/run",
+			Path:  "", // auto set by the handler
 			Files: files,
 		},
 	}

--- a/gno.land/pkg/sdk/vm/msgs.go
+++ b/gno.land/pkg/sdk/vm/msgs.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"fmt"
 	"strings"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
@@ -179,9 +180,13 @@ func (msg MsgRun) ValidateBasic() error {
 	if msg.Caller.IsZero() {
 		return std.ErrInvalidAddress("missing caller address")
 	}
-	if msg.Package.Path == "" { // XXX
-		return ErrInvalidPkgPath("missing package path")
+
+	// Force memPkg path to the reserved run path.
+	wantPath := "gno.land/r/" + msg.Caller.String() + "/run"
+	if path := msg.Package.Path; path != "" && path != wantPath {
+		return ErrInvalidPkgPath(fmt.Sprintf("invalid pkgpath for MsgRun: %q", path))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is the path that is reserved, but right now the handler for MsgRun allows any path to be used. This PR enforces all run calls to happen here exclusively.