### PR TITLE
docs: Move Effective Gno, reorg Concepts ordering

### DIFF
--- a/docs/concepts/effective-gno.md
+++ b/docs/concepts/effective-gno.md
@@ -1,5 +1,5 @@
 ---
-id: 'effective-gno'
+id: effective-gno
 ---
 
 # Effective Gno
@@ -82,7 +82,7 @@ Go developers "Don't panic.", in Gno, we actually embrace `panic`.
 
 Panic in Gno is not just for critical errors or programming mistakes as it is in
 Go. Instead, it's used as a control flow mechanism to stop the execution of a
-[realm](../concepts/realms.md) when something goes wrong. This could be due to an invalid input, a
+[realm](realms.md) when something goes wrong. This could be due to an invalid input, a
 failed precondition, or any other situation where it's not possible or desirable
 to continue executing the contract.
 

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -34,7 +34,6 @@ const sidebars = {
                 'how-to-guides/creating-grc20',
                 'how-to-guides/creating-grc721',
                 'how-to-guides/connect-wallet-dapp',
-                'how-to-guides/effective-gno',
             ],
         },
         {
@@ -53,10 +52,11 @@ const sidebars = {
                         'concepts/standard-library/gnopher-hole-stdlib',
                     ]
                 },
-                'concepts/tendermint2',
                 'concepts/gnovm',
-                'concepts/proof-of-contribution',
                 'concepts/gno-language',
+                'concepts/effective-gno',
+                'concepts/proof-of-contribution',
+                'concepts/tendermint2',
                 'concepts/gno-modules',
                 'concepts/gno-test',
                 'concepts/from-go-to-gno',


### PR DESCRIPTION
## Description

This PR moves the `Effective Gno` page from How-to's, to Concepts, and also reorders the Concepts section in the sidebar. 

To follow the Diataxis framework more closely, `Effective Gno` should be in the Concepts ([Explanation](https://diataxis.fr/explanation/)) section.

Also, I removed the quotation marks from the ID to match the rest of docs content.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
