### PR TITLE
feat: use 0.0.0.0 as the default listening address for RPC and gnoweb

### DIFF
--- a/docs/getting-started/setting-up-a-local-chain.md
+++ b/docs/getting-started/setting-up-a-local-chain.md
@@ -71,7 +71,7 @@ gnoland start --chainid NewChainID
 ```
 
 We can verify the chain ID has been changed, by fetching the status of the node and seeing the
-associated chain ID. By default, the node exposes the JSON-RPC API on `http://127.0.0.1:26657`:
+associated chain ID. By default, the node exposes the JSON-RPC API on `http://0.0.0.0:26657`[^1]:
 
 ```bash
 curl -H "Content-type: application/json" -d '{
@@ -140,3 +140,7 @@ Following this pattern, potential entries into the genesis balances file would l
 g1qpymzwx4l4cy6cerdyajp9ksvjsf20rk5y9rtt=10000000000ugnot
 g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq=10000000000ugnot
 ```
+
+[^1]: The address `0.0.0.0` means that the node can be accessed by any IPv4 address,
+  including any loopback address like `127.0.0.1`, a private network address like
+  `192.168.0.X`, or a public IP address.

--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -36,7 +36,7 @@ func runMain(args []string) error {
 	fs.StringVar(&cfg.HelpChainID, "help-chainid", cfg.HelpChainID, "help page's chainid")
 	fs.StringVar(&cfg.HelpRemote, "help-remote", cfg.HelpRemote, "help page's remote addr")
 	fs.BoolVar(&cfg.WithAnalytics, "with-analytics", cfg.WithAnalytics, "enable privacy-first analytics")
-	fs.StringVar(&bindAddress, "bind", "127.0.0.1:8888", "server listening address")
+	fs.StringVar(&bindAddress, "bind", ":8888", "server listening address")
 
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/tm2/pkg/bft/rpc/config/config.go
+++ b/tm2/pkg/bft/rpc/config/config.go
@@ -88,7 +88,7 @@ type RPCConfig struct {
 // DefaultRPCConfig returns a default configuration for the RPC server
 func DefaultRPCConfig() *RPCConfig {
 	return &RPCConfig{
-		ListenAddress:          "tcp://127.0.0.1:26657",
+		ListenAddress:          "tcp://0.0.0.0:26657",
 		CORSAllowedOrigins:     []string{"*"},
 		CORSAllowedMethods:     []string{http.MethodHead, http.MethodGet, http.MethodPost, http.MethodOptions},
 		CORSAllowedHeaders:     []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time"},


### PR DESCRIPTION
Decided to create this PR after discussing with @zivkovicmilos.

This PR changes the default listening address for the RPC node and gnoweb to be 0.0.0.0 instead of 127.0.0.1. This entails that when starting up a gno.land node or a gnoweb server, it is accessible from any IP address (on the specified port). This includes local loopback addresses like 127.0.0.1, private network addresses like 192.0.0.X, public addresses if the machine has one and the ports are not firewalled, as well as giving the ability to expose the services in docker without having to juggle flags or configuration files.

> **Milos:** What do you think about changing the default IP to 0.0.0.0?
In the code itself, always
>
> **Morgan:** that is an option and my first thought
but I think there could be security concerns
ie. the RPC node could be an attack vector a validator might not want to expose by default, so it makes sense to expose it only with an opt-in
>
>**Milos:** I have never in my life seen a production blockchain node directly exposed to the internet
>without something like nginx in front of it
>There are entire layers of issues that don't have to be solved node-level
>The protocol can't cover everything, and it shouldn't
> I'd 100% back having the default listen address 0.0.0.0
>There is no argument against it really, because the node won't ever be "naked" on the internet

This PR attempts to improve the developer experience of using the two services "by default", with the risk of exposing the RPC endpoints out-of-the-box which could be undesirable for some production environments. However, as Milos has stated, and I agree, any validator who wants to launch a production-grade node

1. without having a firewall already set up on their system
2. without checking through the configuration and defaults for the gnoland node
3.  without putting a reverse-proxy like nginx, caddy, $what_have_you 
4. expecting that this does not expose the RPC endpoint by default
 
 ... is probably insane.

cc/ @albttx

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
