### PR TITLE
chore(tm2/pkg/std): add failing regexp in MemPackage.Validate's errors

### DIFF
--- a/tm2/pkg/std/memfile.go
+++ b/tm2/pkg/std/memfile.go
@@ -51,15 +51,15 @@ var (
 // NOTE: this is to prevent conflicts with nested paths.
 func (mempkg *MemPackage) Validate() error {
 	if !rePkgName.MatchString(mempkg.Name) {
-		return errors.New(fmt.Sprintf("invalid package name %q", mempkg.Name))
+		return errors.New(fmt.Sprintf("invalid package name %q, failed to match %q", mempkg.Name, rePkgName))
 	}
 	if !rePkgOrRlmPath.MatchString(mempkg.Path) {
-		return errors.New(fmt.Sprintf("invalid package/realm path %q", mempkg.Path))
+		return errors.New(fmt.Sprintf("invalid package/realm path %q, failed to match %q", mempkg.Path, rePkgOrRlmPath))
 	}
 	fnames := map[string]struct{}{}
 	for _, memfile := range mempkg.Files {
 		if !reFileName.MatchString(memfile.Name) {
-			return errors.New(fmt.Sprintf("invalid file name %q", memfile.Name))
+			return errors.New(fmt.Sprintf("invalid file name %q, failed to match %q", memfile.Name, reFileName))
 		}
 		if _, exists := fnames[memfile.Name]; exists {
 			return errors.New(fmt.Sprintf("duplicate file name %q", memfile.Name))


### PR DESCRIPTION
This helps a cli user to know what went wrong directly (otherwise, he has to look at gno/tm2/pkg/std/memfile.go).
Since the cli user is a technical one, it makes no sense to not show this.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
