### PR TITLE
chore: `s/use/loadpkg` and `s/example/examples`

### DIFF
--- a/contribs/gnodev/README.md
+++ b/contribs/gnodev/README.md
@@ -21,8 +21,8 @@ the following combinations:
 - **Ctrl+R**: Reset the current node state.
 - **Ctrl+C**: Exit `gnodev`.
 
-### Example Folder Loading
-The **example** package folder is loaded automatically. If working within this folder, you don't have to specify any additional paths to `gnodev`. Use `--minimal` to prevent this.
+### Loading 'examples'
+The **examples** directory is loaded automatically. If working within this folder, you don't have to specify any additional paths to `gnodev`. Use `--minimal` to prevent this.
 
 ### Installation
 Run `make install` to install `gnodev`.

--- a/contribs/gnodev/main.go
+++ b/contribs/gnodev/main.go
@@ -52,7 +52,7 @@ func main() {
 			ShortUsage: "gnodev [flags] [path ...]",
 			ShortHelp:  "Runs an in-memory node and gno.land web server for development purposes.",
 			LongHelp: `The gnodev command starts an in-memory node and a gno.land web interface
-primarily for realm package development. It automatically loads the example folder and any
+primarily for realm package development. It automatically loads the 'examples' directory and any
 additional specified paths.`,
 		},
 		cfg,
@@ -75,7 +75,7 @@ func (c *devCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.minimal,
 		"minimal",
 		defaultDevOptions.verbose,
-		"do not load example folder packages",
+		"do not load packages from examples directory",
 	)
 
 	fs.BoolVar(

--- a/gno.land/pkg/integration/doc.go
+++ b/gno.land/pkg/integration/doc.go
@@ -23,16 +23,16 @@
 //
 // 4. `loadpkg`:
 //   - Must be run before `gnoland start`.
-//   - Loads a specific package from the example folder or from the working ($WORK) directory.
+//   - Loads a specific package from the 'examples' directory or from the working ($WORK) directory.
 //   - Can be used to load a single package or all packages within a directory.
 //   - If the target package has a `gno.mod`, all its dependencies (and their respective
 //     dependencies) will also be loaded.
 //   - The command takes either one or two arguments. The first argument is the name of the package(s),
 //     and the second (optional) argument is the path to the package(s).
 //     Examples:
-//     -- # Load a package from the example packages directory:
+//     -- # Load a package from the 'examples' directory:
 //     -- loadpkg gno.land/p/demo/ufmt
-//     -- # Load a package `./bar` from the current testscript's working directory with the name `gno.land/r/foobar/bar`:
+//     -- # Load a package `./bar` from the testscript's working directory with the name `gno.land/r/foobar/bar`:
 //     -- loadpkg gno.land/r/foobar/bar $WORK/bar
 //   - If the path is not prefixed with the working directory, it is assumed to be relative to the
 //     examples directory.

--- a/gno.land/pkg/integration/testdata/import.txtar
+++ b/gno.land/pkg/integration/testdata/import.txtar
@@ -1,4 +1,4 @@
-# test that the example packages directory is loaded and usable.
+# test that the packages from examples directory are importable and usable.
 loadpkg gno.land/p/demo/ufmt
 loadpkg $WORK
 

--- a/gno.land/pkg/integration/testdata/loadpkg_example.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_example.txtar
@@ -1,4 +1,4 @@
-# load a package from the example packages directory.
+# load a package from the 'examples' directory.
 loadpkg gno.land/p/demo/ufmt
 
 ## start a new node

--- a/gno.land/pkg/integration/testdata/loadpkg_example_and_work.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_example_and_work.txtar
@@ -1,4 +1,4 @@
-# load a package from the example packages directory.
+# load a package from the 'examples' and $WORK directory.
 loadpkg gno.land/p/demo/ufmt
 loadpkg gno.land/r/importtest $WORK
 

--- a/gno.land/pkg/integration/testdata/loadpkg_work.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_work.txtar
@@ -1,3 +1,4 @@
+# load a package from $WORK directory.
 loadpkg gno.land/r/foobar/bar $WORK/bar
 
 ## start a new node

--- a/gno.land/pkg/integration/testing_integration.go
+++ b/gno.land/pkg/integration/testing_integration.go
@@ -125,7 +125,7 @@ func setupGnolandTestScript(t *testing.T, txtarDir string) testscript.Params {
 			}
 
 			// Track new user balances added via the `adduser`
-			// command and packages added with the `use` commnand.
+			// command and packages added with the `loadpkg` command.
 			// This genesis will be use when node is started.
 			genesis := &gnoland.GnoGenesisState{
 				Balances: LoadDefaultGenesisBalanceFile(t, gnoRootDir),
@@ -279,7 +279,7 @@ func setupGnolandTestScript(t *testing.T, txtarDir string) testscript.Params {
 				genesis := ts.Value(envKeyGenesis).(*gnoland.GnoGenesisState)
 				genesis.Balances = append(genesis.Balances, balance)
 			},
-			// `loadpkg` load a specific package from the example folder or from the working directory
+			// `loadpkg` load a specific package from the 'examples' or working directory
 			"loadpkg": func(ts *testscript.TestScript, neg bool, args []string) {
 				// special dirs
 				workDir := ts.Getenv("WORK")
@@ -300,7 +300,7 @@ func setupGnolandTestScript(t *testing.T, txtarDir string) testscript.Params {
 					ts.Fatalf("`loadpkg`: too many arguments specified")
 				}
 
-				// If `all` is specified, fully load example folder.
+				// If `all` is specified, fully load 'examples' directory.
 				// NOTE: In 99% of cases, this is not needed, and
 				// packages should be loaded individually.
 				if path == "all" {


### PR DESCRIPTION
- Removed an occurrence of `use` (leftover from #1598) 
- Found some references of "example" directory. We don't have anything called `example`. It's `examples`(with `s`). Fixed it.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
