### PR TITLE
fix(docs/getting-started): `s/genesis_txs.txt/genesis_balances.txt`

### DIFF
--- a/docs/getting-started/setting-up-a-local-chain.md
+++ b/docs/getting-started/setting-up-a-local-chain.md
@@ -40,7 +40,7 @@ Let's break down the most important default settings:
 - `config` - the custom node configuration file
   for more details on utilizing this file
 - `genesis-balances-file` - the initial premine balances file, which contains initial native currency allocations for
-  the chain. By default, the genesis balances file is located in `gno.land/genesis/genesis_txs.txt`, this is also the
+  the chain. By default, the genesis balances file is located in `gno.land/genesis/genesis_balances.txt`, this is also the
   reason why we need to navigate to the `gno.land` sub-folder to run the command with default settings
 - `root-dir` - the working directory for the node configuration and node data (state DB)
 


### PR DESCRIPTION
Correct typo in file reference from `genesis_txs.txt` to `genesis_balances.txt` in documentation.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
