### PR TITLE
docs: update getting-started with `gno test`

### DIFF
--- a/docs/how-to-guides/testing-gno.md
+++ b/docs/how-to-guides/testing-gno.md
@@ -145,7 +145,7 @@ Simply point it to the location containing our testing source code, and the test
 For example, we can run the following command from the `counter-app/r/counter` directory:
 
 ```bash
-gno test -verbose -root-dir /Users/zmilos/Work/gno .
+gno test -verbose .
 ```
 
 Let's look into the different parts of this command:


### PR DESCRIPTION
`gno test -verbose -root-dir /Users/zmilos/Work/gno .` --> will not work, It needs to be changed to `gno test -verbose .` so that it works for anyone.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
