### PR TITLE
chore(make): disable cgo, reorganise makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,31 @@ help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | grep -v 'install_' | cut -d: -f1 | sort | sed 's/^/  /'
 
-rundep=go run -modfile misc/devdeps/go.mod
+# command to run dependency utilities, like goimports.
+rundep=go run -modfile ../misc/devdeps/go.mod
 
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+# NOTE: these are not very useful in this makefile, but they serve as
+# documentation for sub-makefiles.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+# when running `make tidy`, use it to check that the go.mods are up-to-date.
+VERIFY_MOD_SUMS ?= false
+
+########################################
+# Dev tools
 .PHONY: install
 install: install.gnokey install.gno
 	@if ! command -v gnodev > /dev/null; then \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help:
 	@cat Makefile | grep '^[a-z][^:]*:' | grep -v 'install_' | cut -d: -f1 | sort | sed 's/^/  /'
 
 # command to run dependency utilities, like goimports.
-rundep=go run -modfile ../misc/devdeps/go.mod
+rundep=go run -modfile misc/devdeps/go.mod
 
 ########################################
 # Environment variables

--- a/contribs/Makefile
+++ b/contribs/Makefile
@@ -3,6 +3,27 @@ help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
+# command to run dependency utilities, like goimports.
+rundep=go run -modfile ../misc/devdeps/go.mod
+
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+
+########################################
+# Dev tools
 .PHONY: install
 install: install.gnomd install.gnodev
 
@@ -18,7 +39,6 @@ clean:
 rundep=go run -modfile ../misc/devdeps/go.mod
 
 .PHONY: fmt
-GOFMT_FLAGS ?= -w
 fmt:
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) .
 
@@ -33,8 +53,6 @@ tidy:
 
 ########################################
 # Test suite
-GOTEST_FLAGS ?= -v -p 1 -timeout=30m
-
 .PHONY: test
 test:
 	@echo "nothing to do."

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,14 +1,35 @@
-# Official packages: more reliable and tested modules, distinct from the experimentation area.
-OFFICIAL_PACKAGES = ./gno.land/p
-OFFICIAL_PACKAGES += ./gno.land/r/demo
-OFFICIAL_PACKAGES += ./gno.land/r/gnoland
-OFFICIAL_PACKAGES += ./gno.land/r/system
-
 .PHONY: help
 help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
+# command to run dependency utilities, like goimports.
+rundep=go run -modfile ../misc/devdeps/go.mod
+
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+
+# Official packages (non-overridable): more reliable and tested modules, distinct from the experimentation area.
+OFFICIAL_PACKAGES = ./gno.land/p
+OFFICIAL_PACKAGES += ./gno.land/r/demo
+OFFICIAL_PACKAGES += ./gno.land/r/gnoland
+OFFICIAL_PACKAGES += ./gno.land/r/system
+
+########################################
+# Dev tools
 .PHONY: transpile
 transpile:
 	go run ../gnovm/cmd/gno transpile --verbose .

--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -3,13 +3,27 @@ help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
+# command to run dependency utilities, like goimports.
 rundep=go run -modfile ../misc/devdeps/go.mod
 
-gnoland.start:
-	@#TODO: remove this makefile directive in a few weeks.
-	@echo "DEPRECATED: use 'start.gnoland' instead of 'gnoland.start'"
-	go run ./cmd/gnoland start
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
 
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+
+########################################
+# Dev tools
 .PHONY: start.gnoland
 start.gnoland:; go run ./cmd/gnoland start
 
@@ -23,10 +37,10 @@ build.gnoland:;    go build -o build/gnoland   ./cmd/gnoland
 build.gnoweb:;     go build -o build/gnoweb    ./cmd/gnoweb
 build.gnofaucet:;  go build -o build/gnofaucet ./cmd/gnofaucet
 build.gnokey:;     go build -o build/gnokey    ./cmd/gnokey
-build.genesis:;  go build -o build/genesis  ./cmd/genesis
+build.genesis:;    go build -o build/genesis  ./cmd/genesis
 
-run.gnoland:;  go run ./cmd/gnoland start
-run.gnoweb:;  go run ./cmd/gnoweb
+run.gnoland:;      go run ./cmd/gnoland start
+run.gnoweb:;       go run ./cmd/gnoweb
 
 .PHONY: install
 install: install.gnoland install.gnoweb install.gnofaucet install.gnokey install.genesis
@@ -35,7 +49,7 @@ install.gnoland:;    go install ./cmd/gnoland
 install.gnoweb:;     go install ./cmd/gnoweb
 install.gnofaucet:;  go install ./cmd/gnofaucet
 install.gnokey:;     go install ./cmd/gnokey
-install.genesis:;  go install ./cmd/genesis
+install.genesis:;    go install ./cmd/genesis
 
 .PHONY: fclean
 fclean: clean
@@ -50,12 +64,10 @@ lint:
 	$(rundep) github.com/golangci/golangci-lint/cmd/golangci-lint run --config ../.github/golangci.yml ./...
 
 .PHONY: fmt
-GOFMT_FLAGS ?= -w
 fmt:
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) .
 
 .PHONY: imports
-GOIMPORTS_FLAGS ?= -w
 imports:
 	$(rundep) golang.org/x/tools/cmd/goimports $(GOIMPORTS_FLAGS) .
 
@@ -64,12 +76,8 @@ imports:
 .PHONY: test
 test: _test.gnoland _test.gnoweb _test.gnokey _test.pkgs
 
-GOTEST_FLAGS ?= -v -p 1 -timeout=30m
-
 _test.gnoland:;      go test $(GOTEST_FLAGS) ./cmd/gnoland
 _test.gnoweb:;       go test $(GOTEST_FLAGS) ./cmd/gnoweb
 _test.gnokey:;       go test $(GOTEST_FLAGS) ./cmd/gnokey
 _test.pkgs:;         go test $(GOTEST_FLAGS) ./pkg/...
 _test.pkgs.sync:;    UPDATE_SCRIPTS=true go test $(GOTEST_FLAGS) ./pkg/...
-
-

--- a/gnovm/Makefile
+++ b/gnovm/Makefile
@@ -1,15 +1,35 @@
-GNOROOT_DIR ?= $(abspath $(lastword $(MAKEFILE_LIST))/../../)
-
 .PHONY: help
 help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
+# command to run dependency utilities, like goimports.
 rundep=go run -modfile ../misc/devdeps/go.mod
 
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+# used to set the default GNOROOT. This helps on local development, as it sets
+# up GNOROOT to the supposed path of the Gno repository clone.
+GNOROOT_DIR ?= $(abspath $(lastword $(MAKEFILE_LIST))/../../)
 # We can't use '-trimpath' yet as amino use absolute path from call stack
 # to find some directory: see #1236
-GOBUILD_FLAGS := -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=$(GNOROOT_DIR)"
+GOBUILD_FLAGS ?= -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=$(GNOROOT_DIR)"
+
+########################################
+# Dev tools
 .PHONY: build
 build:
 	go build $(GOBUILD_FLAGS) -o build/gno ./cmd/gno
@@ -29,13 +49,11 @@ lint:
 	$(rundep) github.com/golangci/golangci-lint/cmd/golangci-lint run --config ../.github/golangci.yml ./...
 
 .PHONY: fmt
-GOFMT_FLAGS ?= -w
 fmt:
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) .
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) `find stdlibs -name "*.gno"`
 
 .PHONY: imports
-GOIMPORTS_FLAGS ?= -w
 imports:
 	$(rundep) golang.org/x/tools/cmd/goimports $(GOIMPORTS_FLAGS) .
 
@@ -43,8 +61,6 @@ imports:
 # Test suite
 .PHONY: test
 test: _test.cmd _test.pkg _test.gnolang
-
-GOTEST_FLAGS ?= -v -p 1 -timeout=30m
 
 .PHONY: _test.cmd
 _test.cmd:

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -3,7 +3,26 @@ help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
-rundep=go run -modfile ./devdeps/go.mod
+# command to run dependency utilities, like goimports.
+rundep=go run -modfile ../misc/devdeps/go.mod
+
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+# when running `make tidy`, use it to check that the go.mods are up-to-date.
+VERIFY_MOD_SUMS ?= false
 
 ########################################
 # Dev tools
@@ -12,7 +31,6 @@ lint:
 	$(rundep) github.com/golangci/golangci-lint/cmd/golangci-lint run --config ../.github/golangci.yml ./...
 
 .PHONY: fmt
-GOFMT_FLAGS ?= -w
 fmt:
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) .
 
@@ -21,14 +39,11 @@ fmt:
 .PHONY: test
 test: _test.genstd
 
-GOTEST_FLAGS ?= -v -p 1 -timeout=30m
-
 .PHONY: _test.genstd
 _test.genstd:
 	go test ./genstd/... $(GOTEST_FLAGS)
 
 .PHONY: tidy
-VERIFY_MOD_SUMS ?= false
 tidy:
 	# Give execute permissions
 	chmod +x ./mod_tidy.sh

--- a/tm2/Makefile
+++ b/tm2/Makefile
@@ -3,8 +3,27 @@ help:
 	@echo "Available make commands:"
 	@cat Makefile | grep '^[a-z][^:]*:' | cut -d: -f1 | sort | sed 's/^/  /'
 
+# command to run dependency utilities, like goimports.
 rundep=go run -modfile ../misc/devdeps/go.mod
 
+########################################
+# Environment variables
+# You can overwrite any of the following by passing a different value on the
+# command line, ie. `CGO_ENABLED=1 make test`.
+
+# disable cgo by default. cgo requires some additional dependencies in some
+# cases, and is not strictly required by any tm2 code.
+CGO_ENABLED ?= 0
+export CGO_ENABLED
+# flags for `make fmt`. -w will write the result to the destination files.
+GOFMT_FLAGS ?= -w
+# flags for `make imports`.
+GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
+# test suite flags.
+GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+
+########################################
+# Dev tools
 .PHONY: build
 _build.tools: _build.aminoscan _build.goscan _build.logjack _build.iaviewer
 
@@ -13,21 +32,15 @@ _build.goscan:;     go build -o build/goscan     ./pkg/amino/cmd/goscan
 _build.logjack:;    go build -o build/logjack    ./pkg/autofile/cmd
 _build.iaviewer:;   go build -o build/iaviewer   ./pkg/iavl/cmd/iaviewer
 
-.PHONY: install
-install:
-#	go install ./cmd/...
-
 .PHONY: clean
 clean:
 	rm -rf ./build/
 
 .PHONY: fmt
-GOFMT_FLAGS ?= -w
 fmt:
 	$(rundep) mvdan.cc/gofumpt $(GOFMT_FLAGS) .
 
 .PHONY: imports
-GOIMPORTS_FLAGS ?= -w
 imports:
 	$(rundep) golang.org/x/tools/cmd/goimports $(GOIMPORTS_FLAGS) .
 
@@ -46,12 +59,9 @@ _test.flappy:
 	TEST_STABILITY=flappy $(rundep) moul.io/testman test -test.v -timeout=20m -retry=10 -run ^TestFlappy \
 		./pkg/bft/consensus ./pkg/bft/blockchain ./pkg/bft/mempool ./pkg/p2p ./pkg/bft/privval
 
-GOTEST_FLAGS ?= -v -p 1 -timeout=30m
 _test.pkg.others:;  go test $(GOTEST_FLAGS) `go list ./pkg/... | grep -Ev 'pkg/(amino|bft|db|iavl/benchmarks)(/|$$)'`
 _test.pkg.amino:;   go test $(GOTEST_FLAGS) ./pkg/amino/...
 _test.pkg.bft:;     go test $(GOTEST_FLAGS) ./pkg/bft/...
 
-CGO_ENABLED ?= 0
 _test.pkg.db:
-	@[ -z "$$CGO_ENABLED" ] && echo 'Disabling cgo for database tests. Use CGO_ENABLED=1 to enable it if you have the correct libs' || true
 	CGO_ENABLED=$(CGO_ENABLED) go test $(GOTEST_FLAGS) ./pkg/db/... ./pkg/iavl/benchmarks/...

--- a/tm2/pkg/bft/state/state_test.go
+++ b/tm2/pkg/bft/state/state_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
-	_ "github.com/gnolang/gno/tm2/pkg/db/_all"
+	_ "github.com/gnolang/gno/tm2/pkg/db/_tags"
+	_ "github.com/gnolang/gno/tm2/pkg/db/goleveldb"
+	_ "github.com/gnolang/gno/tm2/pkg/db/memdb"
 	"github.com/gnolang/gno/tm2/pkg/random"
 )
 


### PR DESCRIPTION
This PR sets `CGO_ENABLED=0` in all top-level makefiles. This comes as a consequence of a rare occurrence where [bft is actually failing for a valid reason](https://github.com/gnolang/gno/actions/runs/8111419409/job/22170651604). This is the relevant part of the logs:

```
2024-03-01T12:36:50.7818357Z ok  	github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/types	0.004s	coverage: 33.3% of statements
2024-03-01T12:36:50.7853384Z 	github.com/gnolang/gno/tm2/pkg/bft/rpc/test		coverage: 0.0% of statements
2024-03-01T12:36:51.5524659Z # github.com/jmhodges/levigo
2024-03-01T12:36:51.5556601Z ##[error]../../../../go/pkg/mod/github.com/jmhodges/levigo@v1.0.0/batch.go:4:11: fatal error: leveldb/c.h: No such file or directory
2024-03-01T12:36:51.5567246Z     4 | // #include "leveldb/c.h"
2024-03-01T12:36:51.5567886Z       |           ^~~~~~~~~~~~~
2024-03-01T12:36:51.5568424Z compilation terminated.
2024-03-01T12:36:59.3179828Z FAIL	github.com/gnolang/gno/tm2/pkg/bft/state [build failed]
```

This is likely a consequence of https://github.com/gnolang/gno/pull/1602. I've additionally made it so that `bft/state` doesn't require any database it doesn't need in its tests, but personally I have been repeatedly bitten by finding out CGO was enabled and compiling in unexpected places (including the Go stdlib) that I think it makes sense to keep it disabled by default in our makefiles.

This PR tackles that, and takes the chance to re-organise the overall structure of makefiles to document prominently the available variables that can be changed.