### PR TITLE
docs: add new Prerequisites

### DIFF
--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,8 +15,12 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
-- **Check we have `export GOPATH="$HOME/go"` `PATH="$GOPATH/bin:$PATH"` 
-   in `.bashrc` or `.zshrc`**
+- **Check we have in `.bashrc` or `.zshrc`:
+
+     `export GOPATH="$HOME/go"` 
+
+     `PATH="$GOPATH/bin:$PATH"`    
+   
 
 ## 1. Cloning the repository
 

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,6 +15,8 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
+- **Check we have `export GOPATH="$HOME/go"` `PATH="$GOPATH/bin:$PATH"` 
+   in `.bashrc` or `.zshrc`**
 
 ## 1. Cloning the repository
 

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,7 +15,7 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
-- **Check we have in `.bashrc` or `.zshrc`:
+- **Check we have in `.bashrc` or `.zshrc` :**
 
      `export GOPATH="$HOME/go"` 
 

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,12 +15,13 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
-- **Check we have in `.bashrc` or `.zshrc` :**
+- **Check that you have in `.bashrc` or `.zshrc` the file at the end :**
 
      `export GOPATH="$HOME/go"` 
 
-     `PATH="$GOPATH/bin:$PATH"`    
-   
+     `PATH="$GOPATH/bin:$PATH"`  
+
+    **and if you don't have the commands, add this.**
 
 ## 1. Cloning the repository
 

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,13 +15,13 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
-- **Check that you have in `.bashrc` or `.zshrc` the file at the end :**
+- **Check that you have in `.bashrc` or `.zshrc` :**
 
      `export GOPATH="$HOME/go"` 
 
      `PATH="$GOPATH/bin:$PATH"`  
 
-    **and if you don't have the commands, add this.**
+    **and if you don't have the commands, add this in file at the end.**
 
 ## 1. Cloning the repository
 

--- a/docs/getting-started/local-setup.md
+++ b/docs/getting-started/local-setup.md
@@ -15,13 +15,13 @@ and validate that they are correctly configured to run on your machine.
 - **Git**
 - **`make` (for running Makefiles)**
 - **Go 19+**
-- **Check that you have in `.bashrc` or `.zshrc` :**
-
-     `export GOPATH="$HOME/go"` 
-
-     `PATH="$GOPATH/bin:$PATH"`  
-
-    **and if you don't have the commands, add this in file at the end.**
+- **Go Environment Setup**:
+  - Make sure `$GOPATH` is well-defined, and `$GOPATH/bin` is added to your `$PATH` variable.
+  - To do this, you can add the following line to your `.bashrc`, `.zshrc` or other config file:
+```
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$PATH
+```
 
 ## 1. Cloning the repository
 


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
I propose this change in the prerequisites of the [getting-started](https://docs.gno.land/getting-started/local-setup) because @kazai777  and I (mac apple silicon users) encountered a `command not found` with the given commands. And by checking with `echo $GOPATH`, the path was empty. We noticed that in the newer versions of Go, one must manually add the path.

However, thanks to @mous1985 , we saw that on Ubuntu, it was set automatically.

Warning -> this also needs to be verified on Windows.
<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
