### PR TITLE
feat: allow disabling consensus WAL

### DIFF
--- a/gno.land/pkg/integration/testing_node.go
+++ b/gno.land/pkg/integration/testing_node.go
@@ -147,6 +147,7 @@ func DefaultTestingTMConfig(gnoroot string) *tmcfg.Config {
 	const defaultListner = "tcp://127.0.0.1:0"
 
 	tmconfig := tmcfg.TestConfig().SetRootDir(gnoroot)
+	tmconfig.Consensus.WALDisabled = true
 	tmconfig.Consensus.CreateEmptyBlocks = true
 	tmconfig.Consensus.CreateEmptyBlocksInterval = time.Duration(0)
 	tmconfig.RPC.ListenAddress = defaultListner

--- a/tm2/pkg/bft/consensus/config/config.go
+++ b/tm2/pkg/bft/consensus/config/config.go
@@ -18,7 +18,7 @@ const (
 type ConsensusConfig struct {
 	RootDir     string `toml:"home"`
 	WALPath     string `toml:"wal_file"`
-	WALDisabled bool
+	WALDisabled bool   `toml:"-"`
 	walFile     string // overrides WalPath if set
 
 	TimeoutPropose        time.Duration `toml:"timeout_propose"`

--- a/tm2/pkg/bft/consensus/config/config.go
+++ b/tm2/pkg/bft/consensus/config/config.go
@@ -20,6 +20,8 @@ type ConsensusConfig struct {
 	WalPath string `toml:"wal_file"`
 	walFile string // overrides WalPath if set
 
+	WALDisabled bool `toml:"wal_disabled" comment:"Disable the write-ahead log"`
+
 	TimeoutPropose        time.Duration `toml:"timeout_propose"`
 	TimeoutProposeDelta   time.Duration `toml:"timeout_propose_delta"`
 	TimeoutPrevote        time.Duration `toml:"timeout_prevote"`

--- a/tm2/pkg/bft/consensus/config/config.go
+++ b/tm2/pkg/bft/consensus/config/config.go
@@ -16,11 +16,10 @@ const (
 // ConsensusConfig defines the configuration for the Tendermint consensus service,
 // including timeouts and details about the WAL and the block structure.
 type ConsensusConfig struct {
-	RootDir string `toml:"home"`
-	WalPath string `toml:"wal_file"`
-	walFile string // overrides WalPath if set
-
-	WALDisabled bool `toml:"wal_disabled" comment:"Disable the write-ahead log"`
+	RootDir     string `toml:"home"`
+	WALPath     string `toml:"wal_file"`
+	WALDisabled bool
+	walFile     string // overrides WalPath if set
 
 	TimeoutPropose        time.Duration `toml:"timeout_propose"`
 	TimeoutProposeDelta   time.Duration `toml:"timeout_propose_delta"`
@@ -45,7 +44,7 @@ type ConsensusConfig struct {
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {
 	return &ConsensusConfig{
-		WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
+		WALPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
 		TimeoutPropose:              3000 * time.Millisecond,
 		TimeoutProposeDelta:         500 * time.Millisecond,
 		TimeoutPrevote:              1000 * time.Millisecond,
@@ -113,7 +112,7 @@ func (cfg *ConsensusConfig) WalFile() string {
 	if cfg.walFile != "" {
 		return cfg.walFile
 	}
-	return join(cfg.RootDir, cfg.WalPath)
+	return join(cfg.RootDir, cfg.WALPath)
 }
 
 // SetWalFile sets the path to the write-ahead log file

--- a/tm2/pkg/bft/consensus/state.go
+++ b/tm2/pkg/bft/consensus/state.go
@@ -122,6 +122,7 @@ type ConsensusState struct {
 	// a Write-Ahead Log ensures we can recover from any kind of crash
 	// and helps us avoid signing conflicting votes
 	wal          walm.WAL
+	walDisabled  bool
 	replayMode   bool // so we don't log signing errors during replay
 	doWALCatchup bool // determines if we even try to do the catchup
 
@@ -162,6 +163,7 @@ func NewConsensusState(
 		doWALCatchup:     true,
 		evsw:             events.NewEventSwitch(),
 		wal:              walm.NopWAL{},
+		walDisabled:      config.WALDisabled,
 	}
 	// set function defaults (may be overwritten before calling Start)
 	cs.decideProposal = cs.defaultDecideProposal
@@ -294,7 +296,7 @@ func (cs *ConsensusState) OnStart() error {
 
 	// we may set the WAL in testing before calling Start,
 	// so only OpenWAL if its still the walm.NopWAL
-	if _, ok := cs.wal.(walm.NopWAL); ok {
+	if _, ok := cs.wal.(walm.NopWAL); ok && !cs.walDisabled {
 		walFile := cs.config.WalFile()
 		wal, err := cs.OpenWAL(walFile)
 		if err != nil {


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
This allows for the consensus state's WAL to be disabled.  This is desirable for testing against a running node when we don't care about the WAL -- it avoids potential permissions issues by not writing anything to disk.  This allows for our integration testing package to be imported and used outside of the gno repository.
<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
