### PR TITLE
docs(vim-lsp): handle precompile->transpile rename in gnols

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ if (executable('gnols'))
         \ 'workspace_config': {
         \   'root' : '/path/to/gno_repo',
         \	'gno'  : '/path/to/gno_bin',
-        \   'precompileOnSave' : v:true,
+        \   'transpileOnSave' : v:true,
         \   'buildOnSave'      : v:false,
         \ },
         \ 'languageId': {server_info->'gno'},


### PR DESCRIPTION
Related to #1681

Gnols has been updated to reflect the command rename `precompile` to `transpile`. The configuration options have been renamed accordingly. Related commit: https://github.com/tbruyelle/gnols/commit/2328330a58e8ce2a217b5d39cd20c1bbfe8c9055

Marked as draft similarly to https://github.com/gnolang/gno/pull/1382#issuecomment-1825604140, until we decide what to do with gnols repository reference.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
