### PR TITLE
feat(cmd/gno): perform type checking when calling linter

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,7 +23,7 @@ test:
 
 .PHONY: lint
 lint:
-	go run ../gnovm/cmd/gno lint $(OFFICIAL_PACKAGES)
+	go run ../gnovm/cmd/gno lint --verbose $(OFFICIAL_PACKAGES)
 
 .PHONY: test.sync
 test.sync:

--- a/examples/gno.land/r/demo/art/gnoface/gno.mod
+++ b/examples/gno.land/r/demo/art/gnoface/gno.mod
@@ -1,3 +1,5 @@
+// Draft
+
 module gno.land/r/demo/art/gnoface
 
 require (

--- a/gnovm/cmd/gno/lint_test.go
+++ b/gnovm/cmd/gno/lint_test.go
@@ -9,7 +9,7 @@ func TestLintApp(t *testing.T) {
 			errShouldBe: "flag: help requested",
 		}, {
 			args:                []string{"lint", "--set-exit-status=0", "../../tests/integ/run-main/"},
-			stderrShouldContain: "./../../tests/integ/run-main: missing 'gno.mod' file (code=1).",
+			stderrShouldContain: "./../../tests/integ/run-main: gno.mod file not found in current or any parent directory (code=1).",
 		}, {
 			args:                []string{"lint", "--set-exit-status=0", "../../tests/integ/undefined-variable-test/undefined_variables_test.gno"},
 			stderrShouldContain: "undefined_variables_test.gno:6: name toto not declared (code=2)",
@@ -18,20 +18,24 @@ func TestLintApp(t *testing.T) {
 			stderrShouldContain: "main.gno:4: name fmt not declared (code=2).",
 		}, {
 			args:                []string{"lint", "--set-exit-status=0", "../../tests/integ/run-main/"},
-			stderrShouldContain: "./../../tests/integ/run-main: missing 'gno.mod' file (code=1).",
+			stderrShouldContain: "./../../tests/integ/run-main: gno.mod file not found in current or any parent directory (code=1).",
 		}, {
 			args: []string{"lint", "--set-exit-status=0", "../../tests/integ/minimalist-gnomod/"},
 			// TODO: raise an error because there is a gno.mod, but no .gno files
 		}, {
 			args: []string{"lint", "--set-exit-status=0", "../../tests/integ/invalid-module-name/"},
 			// TODO: raise an error because gno.mod is invalid
+		}, {
+			args:                []string{"lint", "--set-exit-status=0", "../../tests/integ/invalid-gno-file/"},
+			stderrShouldContain: "../../tests/integ/invalid-gno-file/invalid.gno:1: expected 'package', found packag (code=2).",
+		}, {
+			args:                []string{"lint", "--set-exit-status=0", "../../tests/integ/typecheck-missing-return/"},
+			stderrShouldContain: "../../tests/integ/typecheck-missing-return/main.gno:5:1: missing return (code=4).",
 		},
 
 		// TODO: 'gno mod' is valid?
-		// TODO: is gno source valid?
 		// TODO: are dependencies valid?
 		// TODO: is gno source using unsafe/discouraged features?
-		// TODO: consider making `gno transpile; go lint *gen.go`
 		// TODO: check for imports of native libs from non _test.gno files
 	}
 	testMainCaseRun(t, tc)

--- a/gnovm/pkg/gnolang/go2gno.go
+++ b/gnovm/pkg/gnolang/go2gno.go
@@ -37,7 +37,9 @@ import (
 	"go/token"
 	"go/types"
 	"os"
+	"path"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -490,6 +492,18 @@ type MemPackageGetter interface {
 //
 // The syntax checking is performed entirely using Go's go/types package.
 func TypeCheckMemPackage(mempkg *std.MemPackage, getter MemPackageGetter) error {
+	return typeCheckMemPackage(mempkg, getter, false)
+}
+
+// TypeCheckMemPackageTest performs the same type checks as [TypeCheckMemPackage],
+// but allows re-declarations.
+//
+// Note: like TypeCheckMemPackage, this function ignores tests and filetests.
+func TypeCheckMemPackageTest(mempkg *std.MemPackage, getter MemPackageGetter) error {
+	return typeCheckMemPackage(mempkg, getter, true)
+}
+
+func typeCheckMemPackage(mempkg *std.MemPackage, getter MemPackageGetter, testing bool) error {
 	var errs error
 	imp := &gnoImporter{
 		getter: getter,
@@ -499,6 +513,7 @@ func TypeCheckMemPackage(mempkg *std.MemPackage, getter MemPackageGetter) error 
 				errs = multierr.Append(errs, err)
 			},
 		},
+		testing: testing,
 	}
 	imp.cfg.Importer = imp
 
@@ -520,6 +535,9 @@ type gnoImporter struct {
 	getter MemPackageGetter
 	cache  map[string]gnoImporterResult
 	cfg    *types.Config
+
+	// if true, allows re-definitions
+	testing bool
 }
 
 // Unused, but satisfies the Importer interface.
@@ -549,20 +567,37 @@ func (g *gnoImporter) ImportFrom(path, _ string, _ types.ImportMode) (*types.Pac
 }
 
 func (g *gnoImporter) parseCheckMemPackage(mpkg *std.MemPackage) (*types.Package, error) {
+	// This map is used to allow for function re-definitions, which are allowed
+	// in Gno (testing context) but not in Go.
+	// This map links each function identifier with a closure to remove its
+	// associated declaration.
+	var delFunc map[string]func()
+	if g.testing {
+		delFunc = make(map[string]func())
+	}
+
 	fset := token.NewFileSet()
 	files := make([]*ast.File, 0, len(mpkg.Files))
 	var errs error
 	for _, file := range mpkg.Files {
+		// Ignore non-gno files.
+		// TODO: support filetest type checking. (should probably handle as each its
+		// own separate pkg, which should also be typechecked)
 		if !strings.HasSuffix(file.Name, ".gno") ||
-			endsWith(file.Name, []string{"_test.gno", "_filetest.gno"}) {
-			continue // skip spurious file.
+			strings.HasSuffix(file.Name, "_test.gno") ||
+			strings.HasSuffix(file.Name, "_filetest.gno") {
+			continue
 		}
 
 		const parseOpts = parser.ParseComments | parser.DeclarationErrors | parser.SkipObjectResolution
-		f, err := parser.ParseFile(fset, file.Name, file.Body, parseOpts)
+		f, err := parser.ParseFile(fset, path.Join(mpkg.Path, file.Name), file.Body, parseOpts)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
+		}
+
+		if delFunc != nil {
+			deleteOldIdents(delFunc, f)
 		}
 
 		files = append(files, f)
@@ -572,6 +607,25 @@ func (g *gnoImporter) parseCheckMemPackage(mpkg *std.MemPackage) (*types.Package
 	}
 
 	return g.cfg.Check(mpkg.Path, fset, files, nil)
+}
+
+func deleteOldIdents(idents map[string]func(), f *ast.File) {
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv != nil { // ignore methods
+			continue
+		}
+		del := idents[fd.Name.Name]
+		if del != nil {
+			del()
+		}
+		decl := decl
+		idents[fd.Name.Name] = func() {
+			// NOTE: cannot use the index as a file may contain multiple decls to be removed,
+			// so removing one would make all "later" indexes wrong.
+			f.Decls = slices.DeleteFunc(f.Decls, func(d ast.Decl) bool { return decl == d })
+		}
+	}
 }
 
 //----------------------------------------

--- a/gnovm/tests/integ/typecheck-missing-return/gno.mod
+++ b/gnovm/tests/integ/typecheck-missing-return/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/integ/valid

--- a/gnovm/tests/integ/typecheck-missing-return/main.gno
+++ b/gnovm/tests/integ/typecheck-missing-return/main.gno
@@ -1,0 +1,5 @@
+package valid
+
+func Hello() int {
+	// no return
+}


### PR DESCRIPTION
Depends on (in order):

1. #1700 
2. #1702 

This PR uses the type checker added in #1702 to perform Gno type checking when calling `gno lint`. Additionally, it adds validation of gno.mod indirectly (the parsed gno mod is used to determine if a package is a draft, and if so skip type checking).

Because `gno lint` uses the TestStore, the resulting `MemPackage`s may contain redefinitions, for overwriting standard libraries like `AssertOriginCall`. I changed the type checker to filter out the redefinitions before they reach the Go type checker.

Further improvements, which can be done after this:

- Add shims for gonative special libraries (`fmt`, `os`...)
  - This will allow us to fully type check also tests and filetests
- Make the type checking on-chain (#1702) also typecheck tests
  - as a consequence of the above.