### PR TITLE
chore(cmd/gno): remove dead/dormant flags from `repl`

### DIFF
--- a/docs/gno-tooling/cli/gno.md
+++ b/docs/gno-tooling/cli/gno.md
@@ -53,5 +53,4 @@ gno {SUB_COMMAND}
 
 | Name       | Type    | Description                                                        |
 | ---------- | ------- | ------------------------------------------------------------------ |
-| `verbose`  | Boolean | Displays extended information.                                     |
 | `root-dir` | String  | Clones location of github.com/gnolang/gno (gno tries to guess it). |

--- a/gnovm/cmd/gno/repl.go
+++ b/gnovm/cmd/gno/repl.go
@@ -38,7 +38,6 @@ func newReplCmd() *commands.Command {
 }
 
 func (c *replCfg) RegisterFlags(fs *flag.FlagSet) {
-
 	fs.StringVar(
 		&c.rootDir,
 		"root-dir",

--- a/gnovm/cmd/gno/repl.go
+++ b/gnovm/cmd/gno/repl.go
@@ -16,9 +16,7 @@ import (
 )
 
 type replCfg struct {
-	verbose        bool
 	rootDir        string
-	initialImports string
 	initialCommand string
 	skipUsage      bool
 }
@@ -40,25 +38,12 @@ func newReplCmd() *commands.Command {
 }
 
 func (c *replCfg) RegisterFlags(fs *flag.FlagSet) {
-	fs.BoolVar(
-		&c.verbose,
-		"verbose",
-		false,
-		"verbose output when running",
-	)
 
 	fs.StringVar(
 		&c.rootDir,
 		"root-dir",
 		"",
 		"clone location of github.com/gnolang/gno (gno tries to guess it)",
-	)
-
-	fs.StringVar(
-		&c.initialImports,
-		"imports",
-		"gno.land/p/demo/avl,gno.land/p/demo/ufmt",
-		"initial imports, separated by a comma",
 	)
 
 	fs.StringVar(


### PR DESCRIPTION
Removed `-verbose` and `-imports` flags from the `gno repl` command as they were not functional.

Reducing clutter ✨ 