### PR TITLE
docs: add index pages

### DIFF
--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -1,0 +1,8 @@
+---
+id: concepts
+---
+
+# Concepts
+
+Welcome to the Concepts section for Gno. This section outlines the most important
+concepts related to Gno & Gno.land.

--- a/docs/concepts/concepts.md
+++ b/docs/concepts/concepts.md
@@ -4,5 +4,5 @@ id: concepts
 
 # Concepts
 
-Welcome to the Concepts section for Gno. This section outlines the most important
+Welcome to the **Concepts** section for Gno. This section outlines the most important
 concepts related to Gno & Gno.land.

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -4,6 +4,5 @@ id: getting-started
 
 # Getting started
 
-Welcome to the Getting Started section for Gno. This section outlines two ways to
-get started writing Gno code: by using the Gno Playground inside your browser,
-or by setting up a local development environment.
+Welcome to the Getting Started section for Gno. This section outlines how to
+get started with Gno by setting up a local development environment, get funds, etc.

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,0 +1,9 @@
+---
+id: getting-started
+---
+
+# Getting started
+
+Welcome to the Getting Started section for Gno. This section outlines two ways to
+get started writing Gno code: by using the Gno Playground inside your browser,
+or by setting up a local development environment.

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -4,5 +4,5 @@ id: getting-started
 
 # Getting started
 
-Welcome to the Getting Started section for Gno. This section outlines how to
+Welcome to the **Getting Started** section for Gno. This section outlines how to
 get started with Gno by setting up a local development environment, get funds, etc.

--- a/docs/gno-tooling/gno-tooling.md
+++ b/docs/gno-tooling/gno-tooling.md
@@ -1,0 +1,8 @@
+---
+id: gno-tooling
+---
+
+# Gno Tooling
+
+Welcome to the Gno Tooling section for Gno. This section outlines programs & tools
+that are commonly used when developing applications with Gno.

--- a/docs/gno-tooling/gno-tooling.md
+++ b/docs/gno-tooling/gno-tooling.md
@@ -4,5 +4,5 @@ id: gno-tooling
 
 # Gno Tooling
 
-Welcome to the Gno Tooling section for Gno. This section outlines programs & tools
+Welcome to the **Gno Tooling** section for Gno. This section outlines programs & tools
 that are commonly used when developing applications with Gno.

--- a/docs/how-to-guides/how-to-guides.md
+++ b/docs/how-to-guides/how-to-guides.md
@@ -1,0 +1,9 @@
+---
+id: how-to-guides
+---
+
+# How-to Guides
+
+Welcome to the How-to Guides section for Gno. This section outlines how to
+complete specific tasks related to Gno, such as writing a realm & package, deploying
+code to the chain, creating a GRC20 or GRC721 token, etc.

--- a/docs/how-to-guides/how-to-guides.md
+++ b/docs/how-to-guides/how-to-guides.md
@@ -4,6 +4,6 @@ id: how-to-guides
 
 # How-to Guides
 
-Welcome to the How-to Guides section for Gno. This section outlines how to
+Welcome to the **How-to Guides** section for Gno. This section outlines how to
 complete specific tasks related to Gno, such as writing a realm & package, deploying
 code to the chain, creating a GRC20 or GRC721 token, etc.

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -1,0 +1,8 @@
+---
+id: reference
+---
+
+# Concepts
+
+Welcome to the Reference section for Gno. This section outlines common APIs, 
+network configurations, client usages, etc.

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -2,7 +2,7 @@
 id: reference
 ---
 
-# Concepts
+# Reference
 
-Welcome to the Reference section for Gno. This section outlines common APIs, 
+Welcome to the **Reference** section for Gno. This section outlines common APIs, 
 network configurations, client usages, etc.

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -7,6 +7,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'Getting Started',
+            link: {type: 'doc', id: 'getting-started/getting-started'},
             items: [
                 'getting-started/local-setup',
                 'getting-started/working-with-key-pairs',

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -26,6 +26,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'How-to Guides',
+            link: {type: 'doc', id: 'how-to-guides/how-to-guides'},
             items: [
                 'how-to-guides/simple-contract',
                 'how-to-guides/simple-library',
@@ -40,6 +41,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'Concepts',
+            link: {type: 'doc', id: 'concepts/concepts'},
             items: [
                 'concepts/realms',
                 'concepts/packages',

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -69,6 +69,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'Gno Tooling',
+            link: {type: 'doc', id: 'gno-tooling/gno-tooling'},
             items: [
                 'gno-tooling/cli/gno-tooling-gno',
                 'gno-tooling/cli/gno-tooling-gnokey',
@@ -80,6 +81,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'Reference',
+            link: {type: 'doc', id: 'reference/reference'},
             items: [
                 'reference/rpc-endpoints',
                 {


### PR DESCRIPTION
## Description

This PR adds basic index pages to the documentation.

This way, `docs.gno.land/<insert section id here>` works properly. Ie, [docs.gno.land/getting-started](https://docs.gno.land/getting-started) will properly redirect to the start of the section. 

Closes: #1694 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x]  Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
