### PR TITLE
chore(gnoweb): link header "start" button to docs: Getting Started

### DIFF
--- a/gno.land/pkg/gnoweb/views/funcs.html
+++ b/gno.land/pkg/gnoweb/views/funcs.html
@@ -13,7 +13,7 @@
         <ul>
           <li><a href="/about">About</a></li>
           <li><a href="/blog">Blog</a></li>
-          <li><a href="/start">Start</a></li>
+          <li><a href="https://docs.gno.land/getting-started">Start</a></li>
           <li><a href="/testnets">Testnets</a></li>
           <li><a href="/gor">Game of Realms</a></li>
         </ul>


### PR DESCRIPTION
## Description

This PR changes the navbar button "start" on the gno.land home page to lead to the Getting Started page in the docs.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
