### PR TITLE
feat(p/ufmt): add ufmt.Errorf

### DIFF
--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -3,11 +3,7 @@
 // (hence the name µfmt - micro fmt).
 package ufmt
 
-import (
-	"bytes"
-	"io"
-	"strconv"
-)
+import "strconv"
 
 // Sprintf offers similar functionality to Go's fmt.Sprintf, or the sprintf
 // equivalent available in many languages, including C/C++.

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -3,7 +3,11 @@
 // (hence the name µfmt - micro fmt).
 package ufmt
 
-import "strconv"
+import (
+	"bytes"
+	"io"
+	"strconv"
+)
 
 // Sprintf offers similar functionality to Go's fmt.Sprintf, or the sprintf
 // equivalent available in many languages, including C/C++.
@@ -95,4 +99,36 @@ func Sprintf(format string, args ...interface{}) string {
 		panic("too many arguments to ufmt.Sprintf")
 	}
 	return buf
+}
+
+// errMsg implements the error interface.
+type errMsg struct {
+	msg string
+}
+
+// Error defines the requirements of the error interface.
+// It functions similarly to Go's errors.New()
+func (e *errMsg) Error() string {
+	return e.msg
+}
+
+// Errorf is a function that mirrors the functionality of fmt.Errorf.
+//
+// It takes a format string and arguments to create a formatted string,
+// then sets this string as the 'msg' field of an errMsg struct and returns a pointer to this struct.
+//
+// This function operates in a similar manner to Go's fmt.Errorf,
+// providing a way to create formatted error messages.
+//
+// The currently formatted verbs are the following:
+//
+//	%s: places a string value directly.
+//	    If the value implements the interface interface{ String() string },
+//	    the String() method is called to retrieve the value.
+//	%d: formats an integer value using package "strconv".
+//	    Currently supports only uint, uint64, int, int64.
+//	%t: formats a boolean value to "true" or "false".
+//	%%: outputs a literal %. Does not consume an argument.
+func Errorf(format string, args ...interface{}) error {
+	return &errMsg{Sprintf(format, args...)}
 }

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -1,7 +1,7 @@
 package ufmt
 
 import (
-	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -35,7 +35,7 @@ func TestSprintf(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		name := Sprintf(tc.format, tc.values...)
+		name := fmt.Sprintf(tc.format, tc.values...)
 		t.Run(name, func(t *testing.T) {
 			got := Sprintf(tc.format, tc.values...)
 			if got != tc.expectedOutput {

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -1,7 +1,7 @@
 package ufmt
 
 import (
-	"fmt"
+	"bytes"
 	"testing"
 )
 
@@ -35,11 +35,60 @@ func TestSprintf(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		name := fmt.Sprintf(tc.format, tc.values...)
+		name := Sprintf(tc.format, tc.values...)
 		t.Run(name, func(t *testing.T) {
 			got := Sprintf(tc.format, tc.values...)
 			if got != tc.expectedOutput {
 				t.Errorf("got %q, want %q.", got, tc.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		args     []interface{}
+		expected string
+	}{
+		{
+			name:     "simple string",
+			format:   "error: %s",
+			args:     []interface{}{"something went wrong"},
+			expected: "error: something went wrong",
+		},
+		{
+			name:     "integer value",
+			format:   "value: %d",
+			args:     []interface{}{42},
+			expected: "value: 42",
+		},
+		{
+			name:     "boolean value",
+			format:   "success: %t",
+			args:     []interface{}{true},
+			expected: "success: true",
+		},
+		{
+			name:     "multiple values",
+			format:   "error %d: %s (success=%t)",
+			args:     []interface{}{123, "failure occurred", false},
+			expected: "error 123: failure occurred (success=false)",
+		},
+		{
+			name:     "literal percent",
+			format:   "literal %%",
+			args:     []interface{}{},
+			expected: "literal %",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Errorf(tt.format, tt.args...)
+			if err.Error() != tt.expected {
+				t.Errorf("Errorf(%q, %v) = %q, expected %q", tt.format, tt.args, err.Error(), tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

Added the `Errorf` function to `ufmt` based on `ufmt.Sprintf`. 

Previously, formatting errors involved a method like using `errors.New(ufmt.Sprintf(XXX))`, but this approach is not only cumbersome but also, as using `Errorf` is recommended in Go, I have newly incorporated it.

## Usage

### Simple Error

This example demonstrates the process of using `Errorf` to format and print error messages.

```go
package main

import (
	"gno.land/p/demo/ufmt"
)

func foo() error {
	return fmt.Errorf("an error occurred in simpleFunction")
}

func main() {
	if err := foo(); err != nil {
             println("Error:", err)
	}
}
```

### With Panic

Using panic is the recommended practice in [effective gno](<https://docs.gno.land/concepts/effective-gno/#embrace-panic>), In this example, format the error and then output the error message with `panic`.

```go
package main

import (
	"gno.land/p/demo/ufmt"
)


func foo() {
	msg := ufmt.Errorf("error: %s", "something went wrong")
	panic(msg)
}
```