### PR TITLE
fix(docs): update blog link

### DIFF
--- a/misc/docusaurus/docusaurus.config.js
+++ b/misc/docusaurus/docusaurus.config.js
@@ -82,7 +82,7 @@ const config = {
           {
             position: "left",
             label: "Blog",
-            to: "https://test3.gno.land/r/gnoland/blog",
+            to: "https://gno.land/r/gnoland/blog",
           },
           {
             href: "https://github.com/gnolang/gno",


### PR DESCRIPTION
## Description

This PR fixes the Blog link from the navbar. It was outdated, pointing to test3 - now it points to the Portal Loop blog.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
