### PR TITLE
WIP: inject closure-calls for loop externs in closures

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1460,6 +1460,7 @@ type BlockNode interface {
 	GetParentNode(Store) BlockNode
 	GetPathForName(Store, Name) ValuePath
 	GetExternPathForName(Store, Name) ValuePath
+	GetBlockNodeForPath(ValuePath) BlockNode
 	GetIsConst(Store, Name) bool
 	GetLocalIndex(Name) (uint16, bool)
 	GetValueRef(Store, Name) *TypedValue
@@ -1640,6 +1641,21 @@ func (sb *StaticBlock) GetExternPathForName(store Store, n Name) ValuePath {
 	path := parent.GetPathForName(store, n)
 	path.Depth += 1
 	return path
+}
+
+// Get the containing block node for node with path relative to this containing block.
+func (sb *StaticBlock) GetBlockNodeForPath(store Store, path ValuePath) BlockNode {
+	if path.Type != VPBlock {
+		panic("expected block type value path but got something else")
+	}
+
+	// NOTE: path.Depth == 1 means it's in bn.
+	var bn BlockNode = sb.GetSource(store)
+	for i := 1; i < path.Depth; i++ {
+		bn = bn.GetParentNode(store)
+	}
+
+	return bn
 }
 
 // Returns whether a name defined here in in ancestry is a const.

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1460,7 +1460,7 @@ type BlockNode interface {
 	GetParentNode(Store) BlockNode
 	GetPathForName(Store, Name) ValuePath
 	GetExternPathForName(Store, Name) ValuePath
-	GetBlockNodeForPath(ValuePath) BlockNode
+	GetBlockNodeForPath(Store, ValuePath) BlockNode
 	GetIsConst(Store, Name) bool
 	GetLocalIndex(Name) (uint16, bool)
 	GetValueRef(Store, Name) *TypedValue
@@ -1651,7 +1651,7 @@ func (sb *StaticBlock) GetBlockNodeForPath(store Store, path ValuePath) BlockNod
 
 	// NOTE: path.Depth == 1 means it's in bn.
 	var bn BlockNode = sb.GetSource(store)
-	for i := 1; i < path.Depth; i++ {
+	for i := 1; i < int(path.Depth); i++ {
 		bn = bn.GetParentNode(store)
 	}
 

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1636,7 +1636,7 @@ func (sb *StaticBlock) GetExternPathForName(store Store, n Name) ValuePath {
 	if n == "_" {
 		return NewValuePathBlock(0, 0, "_")
 	}
-	parent := n.GetParentNode(store)
+	parent := sb.GetParentNode(store)
 	path := parent.GetPathForName(store, n)
 	path.Depth += 1
 	return path

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -617,6 +617,16 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 					// elide composite lit element (nested) composite types.
 					elideCompositeElements(clx, clt)
 				}
+				switch n.(type) {
+				// TRANS_LEAVE (deferred)---------
+				// NOTE: DO NOT USE TRANS_SKIP WITHIN BLOCK
+				// NODES, AS TRANS_LEAVE WILL BE SKIPPED; OR
+				// POP BLOCK YOURSELF.
+				case BlockNode:
+					// Pop block.
+					stack = stack[:len(stack)-1]
+					last = stack[len(stack)-1]
+				}
 			}()
 
 			// The main TRANS_LEAVE switch.
@@ -783,6 +793,7 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 					// nothing to transform
 					return n, TRANS_CONTINUE
 				}
+				panic("!!! ITS HAPPENING (insert ron paul jazz hands) !!!")
 				// Finally, do the transform.
 				// The inner closure loop externs will be
 				// modified to have a path depth of 2 (or more)
@@ -2032,17 +2043,10 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 				n.Type = constType(n.Type, dst)
 			}
 			// end type switch statement
+			// END TRANS_LEAVE -----------------------
 
-			// TRANS_LEAVE -----------------------
-			// finalization.
-			if _, ok := n.(BlockNode); ok {
-				// Pop block.
-				stack = stack[:len(stack)-1]
-				last = stack[len(stack)-1]
-				return n, TRANS_CONTINUE
-			} else {
-				return n, TRANS_CONTINUE
-			}
+			// Convenience return in case not already returned.
+			return n, TRANS_CONTINUE
 		}
 
 		panic(fmt.Sprintf(


### PR DESCRIPTION
This is an alternative implementation to #1768 and #1585 for #1135. 
This should be much more performant overall, as loop externs are rare. 

- [ ] as pointed out by Maxwell, this would also need to work with GOTO implicit loops. Should be doable, but another approach would be to disallow this edge case (probably very rare).

UPDATE: noticed that "TestSearchEfficiency" is affected but the runtime is not because the closure is called synchronously. 