### PR TITLE
fix: wugnot-to-respect-p_users

### DIFF
--- a/examples/gno.land/r/demo/wugnot/gno.mod
+++ b/examples/gno.land/r/demo/wugnot/gno.mod
@@ -3,4 +3,6 @@ module gno.land/r/demo/wugnot
 require (
 	gno.land/p/demo/grc/grc20 v0.0.0-latest
 	gno.land/p/demo/ufmt v0.0.0-latest
+	gno.land/p/demo/users v0.0.0-latest
+	gno.land/r/demo/users v0.0.0-latest
 )

--- a/examples/gno.land/r/demo/wugnot/wugnot.gno
+++ b/examples/gno.land/r/demo/wugnot/wugnot.gno
@@ -6,6 +6,10 @@ import (
 
 	"gno.land/p/demo/grc/grc20"
 	"gno.land/p/demo/ufmt"
+
+	"gno.land/r/demo/users"
+
+	pusers "gno.land/p/demo/users"
 )
 
 var (
@@ -82,16 +86,16 @@ func TotalSupply() uint64 {
 	return wugnot.TotalSupply()
 }
 
-func BalanceOf(owner std.Address) uint64 {
-	balance, err := wugnot.BalanceOf(owner)
+func BalanceOf(owner pusers.AddressOrName) uint64 {
+	balance, err := wugnot.BalanceOf(users.Resolve(owner))
 	if err != nil {
 		panic(err)
 	}
 	return balance
 }
 
-func Allowance(owner, spender std.Address) uint64 {
-	allowance, err := wugnot.Allowance(owner, spender)
+func Allowance(owner, spender pusers.AddressOrName) uint64 {
+	allowance, err := wugnot.Allowance(users.Resolve(owner), users.Resolve(spender))
 	if err != nil {
 		panic(err)
 	}
@@ -101,25 +105,25 @@ func Allowance(owner, spender std.Address) uint64 {
 // setters.
 //
 
-func Transfer(to std.Address, amount uint64) {
+func Transfer(to pusers.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	err := wugnot.Transfer(caller, to, amount)
+	err := wugnot.Transfer(caller, users.Resolve(to), amount)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func Approve(spender std.Address, amount uint64) {
+func Approve(spender pusers.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	err := wugnot.Approve(caller, spender, amount)
+	err := wugnot.Approve(caller, users.Resolve(spender), amount)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func TransferFrom(from, to std.Address, amount uint64) {
+func TransferFrom(from, to pusers.AddressOrName, amount uint64) {
 	caller := std.PrevRealm().Addr()
-	err := wugnot.TransferFrom(caller, from, to, amount)
+	err := wugnot.TransferFrom(caller, users.Resolve(from), users.Resolve(to), amount)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/gno.land/r/demo/wugnot/z0_filetest.gno
+++ b/examples/gno.land/r/demo/wugnot/z0_filetest.gno
@@ -37,7 +37,7 @@ func main() {
 
 func printBalances() {
 	printSingleBalance := func(name string, addr std.Address) {
-		wugnotBal := wugnot.BalanceOf(addr)
+		wugnotBal := wugnot.BalanceOf(pusers.AddressOrName(addr))
 		std.TestSetOrigCaller(addr)
 		abanker := std.GetBanker(std.BankerTypeOrigSend)
 		acoins := abanker.GetCoins(addr).AmountOf("ugnot")

--- a/examples/gno.land/r/demo/wugnot/z0_filetest.gno
+++ b/examples/gno.land/r/demo/wugnot/z0_filetest.gno
@@ -7,6 +7,8 @@ import (
 
 	"gno.land/p/demo/testutils"
 	"gno.land/r/demo/wugnot"
+
+	pusers "gno.land/p/demo/users"
 )
 
 var (

--- a/gno.land/cmd/gnoland/testdata/issue-1786.txtar
+++ b/gno.land/cmd/gnoland/testdata/issue-1786.txtar
@@ -48,6 +48,7 @@ import (
 	"gno.land/r/demo/wugnot"
 
 	"gno.land/p/demo/ufmt"
+	pusers "gno.land/p/demo/users"
 )
 
 func ProxyWrap() {
@@ -65,17 +66,17 @@ func ProxyWrap() {
 	wugnot.Deposit() // `proxywugnot` has ugnot
 
 	// SEND WUGNOT: PROXY_WUGNOT -> USER
-	wugnot.Transfer(std.GetOrigCaller(), ugnotSent)
+	wugnot.Transfer(pusers.AddressOrName(std.GetOrigCaller()), ugnotSent)
 }
 
 func ProxyUnwrap(wugnotAmount uint64) {
 	if wugnotAmount == 0 {
 		return
 	}
-	userOldWugnot := wugnot.BalanceOf(std.GetOrigCaller())
+	userOldWugnot := wugnot.BalanceOf(pusers.AddressOrName(std.GetOrigCaller()))
 
 	// SEND WUGNOT: USER -> PROXY_WUGNOT
-	wugnot.TransferFrom(std.GetOrigCaller(), std.CurrentRealm().Addr(), wugnotAmount)
+	wugnot.TransferFrom(pusers.AddressOrName(std.GetOrigCaller()), pusers.AddressOrName(std.CurrentRealm().Addr()), wugnotAmount)
 
 	// UNWRAP IT
 	wugnot.Withdraw(wugnotAmount)


### PR DESCRIPTION
### !!! BREAKING CHANGE: data type for `wugnot` public function's parameter has been changed

Just like `foo20` respects a new `p/demo/users`, fix `wugnot` to respect it too.

Related https://github.com/gnolang/gno/pull/1433 by @harry-hov 

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
