### PR TITLE
chore: add r/demo/echo

### DIFF
--- a/examples/gno.land/r/demo/echo/echo.gno
+++ b/examples/gno.land/r/demo/echo/echo.gno
@@ -2,8 +2,9 @@ package echo
 
 /*
  * This realm echoes the `path` argument it received.
- * Can be used as a simple endpoint to e.g. test
- * forbidden characters and/or pentesting.
+ * Can be used by developers as a simple endpoint to test
+ * forbidden characters, for pentesting or simply to
+ * test it works.
  *
  * See also r/demo/print (to print various thing like user address)
  */

--- a/examples/gno.land/r/demo/echo/echo.gno
+++ b/examples/gno.land/r/demo/echo/echo.gno
@@ -1,0 +1,12 @@
+package echo
+
+/*
+ * This realm echoes the `path` argument it received.
+ * Can be used as a simple endpoint to e.g. test
+ * forbidden characters and/or pentesting.
+ *
+ * See also r/demo/print (to print various thing like user address)
+ */
+func Render(path string) string {
+	return path
+}

--- a/examples/gno.land/r/demo/echo/echo_test.gno
+++ b/examples/gno.land/r/demo/echo/echo_test.gno
@@ -1,0 +1,14 @@
+package echo
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	if Render("aa") != "aa" {
+		t.Fail()
+	}
+	if Render("") != "" {
+		t.Fail()
+	}
+}

--- a/examples/gno.land/r/demo/echo/gno.mod
+++ b/examples/gno.land/r/demo/echo/gno.mod
@@ -1,0 +1,1 @@
+module echo

--- a/examples/gno.land/r/demo/echo/gno.mod
+++ b/examples/gno.land/r/demo/echo/gno.mod
@@ -1,1 +1,1 @@
-module echo
+module gno.land/r/demo/echo


### PR DESCRIPTION
This realm echoes the `path` argument it received.              
Can be used as a simple endpoint to e.g. test                   
forbidden characters and/or pentesting.                         
                                                                
Also planning to PR r/demo/print (to print various thing like user address)
