### PR TITLE
fix(memeland): sort by newest instead of by oldest

### DIFF
--- a/examples/gno.land/p/demo/memeland/memeland.gno
+++ b/examples/gno.land/p/demo/memeland/memeland.gno
@@ -118,7 +118,7 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 		dateSorter := PostSorter{
 			Posts: filteredPosts,
 			LessF: func(i, j int) bool {
-				return filteredPosts[i].Timestamp.Before(filteredPosts[j].Timestamp)
+				return filteredPosts[i].Timestamp.After(filteredPosts[j].Timestamp)
 			},
 		}
 		sort.Sort(dateSorter)

--- a/examples/gno.land/p/demo/memeland/memeland_test.gno
+++ b/examples/gno.land/p/demo/memeland/memeland_test.gno
@@ -110,7 +110,7 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 
 	// Check if ordering is correct, sort by created date
 	for i := 0; i < len(memeData)-2; i++ {
-		if strings.Index(jsonStr, memeData[i]) > strings.Index(jsonStr, memeData[i+1]) {
+		if strings.Index(jsonStr, memeData[i]) < strings.Index(jsonStr, memeData[i+1]) {
 			t.Errorf("Expected %s to be before %s, but was at %d, and %d", memeData[i], memeData[i+1], i, i+1)
 		}
 	}
@@ -148,7 +148,7 @@ func TestGetPostsInRangeByUpvote(t *testing.T) {
 		afterLatest.Unix(),    // end at latest post
 		1,                     // first page
 		2,                     // all memes on the page
-		"UPVOTE",              // sort by upvote
+		"UPVOTES",             // sort by upvote
 	)
 
 	if jsonStr == "" {


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

This PR introduces a small fix to the way Memeland sorts memes.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
