### PR TITLE
feat: add adena wallet in-app faucet account

### DIFF
--- a/gno.land/genesis/genesis_balances.txt
+++ b/gno.land/genesis/genesis_balances.txt
@@ -13,6 +13,7 @@ g1f4v282mwyhu29afke4vq5r2xzcm6z3ftnugcnv=1000000000000ugnot # faucet0 (jae)
 g127jydsh6cms3lrtdenydxsckh23a8d6emqcvfa=1000000000000ugnot # faucet1 (moul)
 g1q6jrp203fq0239pv38sdq3y3urvd6vt5azacpv=1000000000000ugnot # faucet2 (devx)
 g13d7jc32adhc39erm5me38w5v7ej7lpvlnqjk73=1000000000000ugnot # faucet3 (devx)
+g18l9us6trqaljw39j94wzf5ftxmd9qqkvrxghd2=1000000000000ugnot # faucet4 (adena)
 
 # Contributors premine & GitHub requests (closed).
 g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq=10000000000ugnot # @moul


### PR DESCRIPTION
Adena Wallet will add an In-App Faucet in the following version, which requires a dedicated faucet account.

The Faucet will support 2 of the official Gno.land Testnets.

Details of the feature including our policies, the user flow, and a UI preview can be found here: [[New Feature] In-app Faucet #454](https://github.com/onbloc/adena-wallet/issues/454)

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
