### PR TITLE
fix: correctly validate package/realm path

### DIFF
--- a/tm2/pkg/std/memfile_test.go
+++ b/tm2/pkg/std/memfile_test.go
@@ -51,3 +51,29 @@ func TestMemPackage_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestRePkgOrRlmPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc, in string
+		expected bool
+	}{
+		{"Valid p", "gno.land/p/path/path", true},
+		{"Valid r", "gno.land/r/path/path", true},
+		{"Invalid x", "gno.land/x/path/path", false},
+		{"Special Character 1", "gno.land/p/p@th/abc/def", false},   // fails
+		{"Special Character 2", "gno.land/p/p&th/abc/def", false},   // fails
+		{"Special Character 3", "gno.land/p/p&%$#h/abc/def", false}, // fails
+		{"Leading Number", "gno.land/p/1Path/abc/def", false},
+		{"Uppercase Letters", "gno.land/p/PaTh/abc/def", false},
+		{"Empty Path Part", "gno.land/p/path//def", false},     // fails
+		{"Trailing Slash", "gno.land/p/path/abc/def/", false},  // fails
+		{"Extra Slash(s)", "gno.land/p/path///abc/def", false}, // fails
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := rePkgOrRlmPath.MatchString(tc.in)
+			assert.Equal(t, res, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
The regex pattern used for package/realm path validation seems incorrect. Commit ceab4a4ca090efa5579b5539e56baad2523b0c62 demonstrates that.

TODO: fix

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
