### PR TITLE
fix(gnoweb): fixed broken URL link

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -17,7 +17,7 @@
         <br />
         These are the realm's exposed functions ("public smart contracts").<br />
         <br />
-        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://docs.gno.land/getting-started/working-with-key-pairs">`gnokey list`</a>)<br />
+        My address: <input id="my_address" value="ADDRESS" width="40" /> (see <a href="https://docs.gno.land/gno-tooling/cli/gno-tooling-gnokey" target="_blank">`gnokey list`</a>)<br />
         <br />
         <br />
         {{ template "func_specs" . }}


### PR DESCRIPTION
Fixed broken URL link.

<img width="884" alt="Screenshot 2024-03-25 at 21 14 43" src="https://github.com/gnolang/gno/assets/689440/aa70ea14-b38a-4487-8e0f-51966e1b1a95">
