### PR TITLE
feat: issue warning when gno test package can't be resolved

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gnolang/gno/gnovm/tests"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/tm2/pkg/random"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
 )
@@ -316,7 +317,9 @@ func gnoTestPkg(
 		} else {
 			gnoPkgPath = pkgPathFromRootDir(pkgPath, rootDir)
 			if gnoPkgPath == "" {
-				return errors.New("unable to read package path from gno.mod or gno root directory; try creating a gno.mod file")
+				// unable to read pkgPath from gno.mod, generate a random realm path
+				io.ErrPrintfln("--- WARNING: unable to read package path from gno.mod or gno root directory; try creating a gno.mod file")
+				gnoPkgPath = transpiler.GnoRealmPkgsPrefixBefore + random.RandStr(8)
 			}
 		}
 		memPkg := gno.ReadMemPackage(pkgPath, gnoPkgPath)

--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gnolang/gno/gnovm/tests"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/errors"
-	"github.com/gnolang/gno/tm2/pkg/random"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
 )
@@ -317,8 +316,7 @@ func gnoTestPkg(
 		} else {
 			gnoPkgPath = pkgPathFromRootDir(pkgPath, rootDir)
 			if gnoPkgPath == "" {
-				// unable to read pkgPath from gno.mod, generate a random realm path
-				gnoPkgPath = transpiler.GnoRealmPkgsPrefixBefore + random.RandStr(8)
+				return errors.New("unable to read package path from gno.mod or gno root directory; try creating a gno.mod file")
 			}
 		}
 		memPkg := gno.ReadMemPackage(pkgPath, gnoPkgPath)


### PR DESCRIPTION
Pretty straightforward one line change.  If `gno test` fails to find a gno.mod field or package path in gno root, the result will be a panic with the message `panic: unexpected unreal object`, which makes it pretty difficult to figure out what must be done to correct the issue.  The warning gives a solution on how to fix this.