### PR TITLE
feat: meaningful realm finalization panic messages

### DIFF
--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -135,7 +135,7 @@ func (rlm *Realm) DidUpdate(po, xo, co Object) {
 			panic("cannot attach a deleted object")
 		}
 		if po != nil && po.GetIsTransient() {
-			panic("should not happen")
+			panic("cannot attach to a transient object")
 		}
 		if po != nil && po.GetIsDeleted() {
 			panic("cannot attach to a deleted object")
@@ -186,18 +186,18 @@ func (rlm *Realm) MarkNewReal(oo Object) {
 		if pv, ok := oo.(*PackageValue); ok {
 			// packages should have no owner.
 			if pv.GetOwner() != nil {
-				panic("should not happen")
+				panic("cannot mark owned package as new real")
 			}
 			// packages should have ref-count 1.
 			if pv.GetRefCount() != 1 {
-				panic("should not happen")
+				panic("cannot mark non-singly referenced package as new real")
 			}
 		} else {
 			if oo.GetOwner() == nil {
-				panic("should not happen")
+				panic("cannot mark unowned object as new real")
 			}
 			if !oo.GetOwner().GetIsReal() {
-				panic("should not happen")
+				panic("cannot mark object as new real if owner is not real")
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (rlm *Realm) MarkNewReal(oo Object) {
 func (rlm *Realm) MarkDirty(oo Object) {
 	if debug {
 		if !oo.GetIsReal() && !oo.GetIsNewReal() {
-			panic("should not happen")
+			panic("cannot mark unreal object as dirty")
 		}
 	}
 	if oo.GetIsDirty() {
@@ -235,10 +235,10 @@ func (rlm *Realm) MarkDirty(oo Object) {
 func (rlm *Realm) MarkNewDeleted(oo Object) {
 	if debug {
 		if !oo.GetIsNewReal() && !oo.GetIsReal() {
-			panic("should not happen")
+			panic("cannot mark unreal object as new deleted")
 		}
 		if oo.GetIsDeleted() {
-			panic("should not happen")
+			panic("cannot mark deleted object as new deleted")
 		}
 	}
 	if oo.GetIsNewDeleted() {
@@ -255,13 +255,13 @@ func (rlm *Realm) MarkNewDeleted(oo Object) {
 func (rlm *Realm) MarkNewEscaped(oo Object) {
 	if debug {
 		if !oo.GetIsNewReal() && !oo.GetIsReal() {
-			panic("should not happen")
+			panic("cannot mark unreal object as new escaped")
 		}
 		if oo.GetIsDeleted() {
-			panic("should not happen")
+			panic("cannot mark deleted object as new escaped")
 		}
 		if oo.GetIsEscaped() {
-			panic("should not happen")
+			panic("cannot mark escaped object as new escaped")
 		}
 	}
 	if oo.GetIsNewEscaped() {
@@ -306,7 +306,7 @@ func (rlm *Realm) FinalizeRealmTransaction(readonly bool, store Store) {
 			rlm.created != nil ||
 			rlm.deleted != nil ||
 			rlm.escaped != nil {
-			panic("should not happen")
+			panic("realm should not have created, deleted, or escaped marks before beginning finalization")
 		}
 	}
 	// log realm boundaries in opslog.
@@ -349,7 +349,7 @@ func (rlm *Realm) processNewCreatedMarks(store Store) {
 	for _, oo := range rlm.newCreated {
 		if debug {
 			if oo.GetIsDirty() {
-				panic("should not happen")
+				panic("new created mark cannot be dirty")
 			}
 		}
 		if oo.GetRefCount() == 0 {
@@ -376,10 +376,10 @@ func (rlm *Realm) processNewCreatedMarks(store Store) {
 func (rlm *Realm) incRefCreatedDescendants(store Store, oo Object) {
 	if debug {
 		if oo.GetIsDirty() {
-			panic("should not happen")
+			panic("cannot increase reference of descendants of dirty objects")
 		}
 		if oo.GetRefCount() <= 0 {
-			panic("should not happen")
+			panic("cannot increase reference of descendants of unreferenced object")
 		}
 	}
 
@@ -400,7 +400,7 @@ func (rlm *Realm) incRefCreatedDescendants(store Store, oo Object) {
 		if _, ok := child.(*PackageValue); ok {
 			if debug {
 				if child.GetRefCount() < 1 {
-					panic("should not happen")
+					panic("cannot increase reference count of package descendant that is unreferenced")
 				}
 			}
 			// extern package values are skipped.
@@ -433,7 +433,7 @@ func (rlm *Realm) incRefCreatedDescendants(store Store, oo Object) {
 				rlm.MarkNewEscaped(child)
 			}
 		} else {
-			panic("should not happen")
+			panic("child reference count should be greater than zero after increasing")
 		}
 	}
 }
@@ -450,7 +450,7 @@ func (rlm *Realm) processNewDeletedMarks(store Store) {
 	for _, oo := range rlm.newDeleted {
 		if debug {
 			if oo.GetObjectID().IsZero() {
-				panic("should not happen")
+				panic("new deleted mark should have an object ID")
 			}
 		}
 		if oo.GetRefCount() > 0 {
@@ -467,10 +467,10 @@ func (rlm *Realm) processNewDeletedMarks(store Store) {
 func (rlm *Realm) decRefDeletedDescendants(store Store, oo Object) {
 	if debug {
 		if oo.GetObjectID().IsZero() {
-			panic("should not happen")
+			panic("cannot decrement references of deleted descendants of object with no object ID")
 		}
 		if oo.GetRefCount() != 0 {
-			panic("should not happen")
+			panic("cannot decrement references of deleted descendants of object with references")
 		}
 	}
 
@@ -498,7 +498,7 @@ func (rlm *Realm) decRefDeletedDescendants(store Store, oo Object) {
 		} else if rc > 0 {
 			// do nothing
 		} else {
-			panic("should not happen")
+			panic("deleted descendants should not have a reference count of less than zero")
 		}
 	}
 }
@@ -520,10 +520,10 @@ func (rlm *Realm) processNewEscapedMarks(store Store) {
 	for _, eo := range rlm.newEscaped {
 		if debug {
 			if !eo.GetIsNewEscaped() {
-				panic("should not happen")
+				panic("new escaped mark not marked as new escaped")
 			}
 			if eo.GetIsEscaped() {
-				panic("should not happen")
+				panic("new escaped mark already escaped")
 			}
 		}
 		if eo.GetRefCount() <= 1 {
@@ -554,7 +554,7 @@ func (rlm *Realm) processNewEscapedMarks(store Store) {
 					rlm.MarkDirty(po)
 				}
 				if eo.GetObjectID().IsZero() {
-					panic("should not happen")
+					panic("new escaped mark has no object ID")
 				}
 				// escaped has no owner.
 				eo.SetOwner(nil)
@@ -585,16 +585,16 @@ func (rlm *Realm) markDirtyAncestors(store Store) {
 			rc := oo.GetRefCount()
 			if debug {
 				if rc == 0 {
-					panic("should not happen")
+					panic("ancestor should have a non-zero reference count to be marked as dirty")
 				}
 			}
 			if rc > 1 {
 				if debug {
 					if !oo.GetIsEscaped() && !oo.GetIsNewEscaped() {
-						panic("should not happen")
+						panic("ancestor should cannot be escaped or new escaped to be marked as dirty")
 					}
 					if !oo.GetOwnerID().IsZero() {
-						panic("should not happen")
+						panic("ancestor's owner ID cannot be zero to be marked as dirty")
 					}
 				}
 				// object is escaped, so
@@ -667,18 +667,18 @@ func (rlm *Realm) saveUnsavedObjects(store Store) {
 func (rlm *Realm) saveUnsavedObjectRecursively(store Store, oo Object) {
 	if debug {
 		if !oo.GetIsNewReal() && !oo.GetIsDirty() {
-			panic("should not happen")
+			panic("cannot save new real or non-dirty objects")
 		}
 		// object id should have been assigned during processNewCreatedMarks.
 		if oo.GetObjectID().IsZero() {
-			panic("should not happen")
+			panic("cannot save object with no ID")
 		}
 		// deleted objects should not have gotten here.
 		if false ||
 			oo.GetRefCount() <= 0 ||
 			oo.GetIsNewDeleted() ||
 			oo.GetIsDeleted() {
-			panic("should not happen")
+			panic("cannot save deleted objects")
 		}
 	}
 	// first, save unsaved children.
@@ -695,7 +695,7 @@ func (rlm *Realm) saveUnsavedObjectRecursively(store Store, oo Object) {
 		// save created object.
 		if debug {
 			if oo.GetIsDirty() {
-				panic("should not happen")
+				panic("cannot save dirty new real object")
 			}
 		}
 		rlm.saveObject(store, oo)
@@ -704,13 +704,13 @@ func (rlm *Realm) saveUnsavedObjectRecursively(store Store, oo Object) {
 		// update existing object.
 		if debug {
 			if !oo.GetIsDirty() {
-				panic("should not happen")
+				panic("cannot save non-dirty existing object")
 			}
 			if !oo.GetIsReal() {
-				panic("should not happen")
+				panic("cannot save unreal existing object")
 			}
 			if oo.GetIsNewReal() {
-				panic("should not happen")
+				panic("cannot save new real existing object")
 			}
 		}
 		rlm.saveObject(store, oo)
@@ -767,17 +767,17 @@ func (rlm *Realm) clearMarks() {
 	if debug {
 		for _, oo := range rlm.newDeleted {
 			if oo.GetIsNewDeleted() {
-				panic("should not happen")
+				panic("cannot clear marks if new deleted exist")
 			}
 		}
 		for _, oo := range rlm.newCreated {
 			if oo.GetIsNewReal() {
-				panic("should not happen")
+				panic("cannot clear marks if new created exist")
 			}
 		}
 		for _, oo := range rlm.newEscaped {
 			if oo.GetIsNewEscaped() {
-				panic("should not happen")
+				panic("cannot clear marks if new escaped exist")
 			}
 		}
 	}
@@ -820,7 +820,7 @@ func getChildObjects(val Value, more []Value) []Value {
 	case BigdecValue:
 		return more
 	case DataByteValue:
-		panic("should not happen")
+		panic("cannot get children from data byte objects")
 	case PointerValue:
 		if cv.Base != nil {
 			more = getSelfOrChildObjects(cv.Base, more)
@@ -918,7 +918,7 @@ func getUnsavedChildObjects(val Value) []Object {
 				unsaved = append(unsaved, obj)
 			}
 		} else {
-			panic("should not happen")
+			panic("unsaved child is not an object")
 		}
 	}
 	return unsaved
@@ -967,7 +967,7 @@ func copyFieldsWithRefs(fields []FieldType) []FieldType {
 func copyTypeWithRefs(typ Type) Type {
 	switch ct := typ.(type) {
 	case nil:
-		panic("should not happen")
+		panic("cannot copy nil types")
 	case PrimitiveType:
 		return ct
 	case *PointerType:
@@ -975,7 +975,7 @@ func copyTypeWithRefs(typ Type) Type {
 			Elt: refOrCopyType(ct.Elt),
 		}
 	case FieldType:
-		panic("should not happen")
+		panic("cannot copy field types")
 	case *ArrayType:
 		return &ArrayType{
 			Len: ct.Len,
@@ -1026,7 +1026,7 @@ func copyTypeWithRefs(typ Type) Type {
 			Elt: refOrCopyType(ct.Elt),
 		}
 	case *NativeType:
-		panic("should not happen")
+		panic("cannot copy native types")
 	case blockType:
 		return blockType{}
 	case *tupleType:
@@ -1065,7 +1065,7 @@ func copyValueWithRefs(parent Object, val Value) Value {
 	case BigdecValue:
 		return cv
 	case DataByteValue:
-		panic("should not happen")
+		panic("cannot copy data byte value with references")
 	case PointerValue:
 		if cv.Base != nil {
 			return PointerValue{
@@ -1135,7 +1135,7 @@ func copyValueWithRefs(parent Object, val Value) Value {
 		// have NativePkg/Name) can't be persisted, and should not be able
 		// to get here anyway.
 		if cv.nativeBody != nil && cv.NativePkg == "" {
-			panic("should not happen")
+			panic("cannot copy function value with native body when there is no native package")
 		}
 		ft := copyTypeWithRefs(cv.Type)
 		return &FuncValue{
@@ -1228,7 +1228,7 @@ func fillType(store Store, typ Type) Type {
 		ct.Elt = fillType(store, ct.Elt)
 		return ct
 	case FieldType:
-		panic("should not happen")
+		panic("cannot fill field types")
 	case *ArrayType:
 		ct.Elt = fillType(store, ct.Elt)
 		return ct
@@ -1285,7 +1285,7 @@ func fillType(store Store, typ Type) Type {
 		ct.Elt = fillType(store, ct.Elt)
 		return ct
 	case *NativeType:
-		panic("should not happen")
+		panic("cannot fill native types")
 	case blockType:
 		return ct // nothing to do
 	case *tupleType:
@@ -1388,10 +1388,10 @@ func fillTypesOfValue(store Store, val Value) Value {
 
 func (rlm *Realm) nextObjectID() ObjectID {
 	if rlm == nil {
-		panic("should not happen")
+		panic("cannot get next object ID of nil realm")
 	}
 	if rlm.ID.IsZero() {
-		panic("should not happen")
+		panic("cannot get next object ID of realm without an ID")
 	}
 	rlm.Time++
 	nxtid := ObjectID{
@@ -1452,7 +1452,7 @@ func toRefValue(parent Object, val Value) RefValue {
 		} else if oo.GetIsEscaped() {
 			if debug {
 				if !oo.GetOwnerID().IsZero() {
-					panic("should not happen")
+					panic("cannot convert escaped object to ref value without an owner ID")
 				}
 			}
 			return RefValue{
@@ -1463,10 +1463,10 @@ func toRefValue(parent Object, val Value) RefValue {
 		} else {
 			if debug {
 				if oo.GetRefCount() > 1 {
-					panic("should not happen")
+					panic("unexpected references when converting to ref value")
 				}
 				if oo.GetHash().IsZero() {
-					panic("should not happen")
+					panic("hash missing when converting to ref value")
 				}
 			}
 			return RefValue{
@@ -1475,7 +1475,7 @@ func toRefValue(parent Object, val Value) RefValue {
 			}
 		}
 	} else {
-		panic("should not happen")
+		panic("unexpected error converting to ref value")
 	}
 }
 


### PR DESCRIPTION
This PR only modifies panic messages that occur during realm finalization.  It's currently harder than necessary to debug panics from realm finalization when there are 52 places they can happen, granted there are far less when the debug flag is off.  Please check for typos and contextual correctness.