### PR TITLE
chore: demonstrate PrevRealm init() bug in `gno test` runs

### DIFF
--- a/examples/gno.land/r/demo/teritori/callee/gno.mod
+++ b/examples/gno.land/r/demo/teritori/callee/gno.mod
@@ -1,0 +1,1 @@
+module callee

--- a/examples/gno.land/r/demo/teritori/callee/gno.mod
+++ b/examples/gno.land/r/demo/teritori/callee/gno.mod
@@ -1,1 +1,1 @@
-module callee
+module gno.land/r/demo/teritori/callee

--- a/examples/gno.land/r/demo/teritori/callee/main.gno
+++ b/examples/gno.land/r/demo/teritori/callee/main.gno
@@ -1,21 +1,23 @@
 package callee
 
 import (
-    "std"
+	"std"
 )
 
-var caller string
-var callerAddr std.Address
+var (
+	caller     string
+	callerAddr std.Address
+)
 
 func SetCaller() {
-    caller = std.PrevRealm().PkgPath()
+	caller = std.PrevRealm().PkgPath()
 	callerAddr = std.PrevRealm().Addr()
 }
 
 func GetCaller() string {
-    return caller
+	return caller
 }
 
 func GetCallerAddress() std.Address {
-    return callerAddr
+	return callerAddr
 }

--- a/examples/gno.land/r/demo/teritori/callee/main.gno
+++ b/examples/gno.land/r/demo/teritori/callee/main.gno
@@ -1,0 +1,21 @@
+package callee
+
+import (
+    "std"
+)
+
+var caller string
+var callerAddr std.Address
+
+func SetCaller() {
+    caller = std.PrevRealm().PkgPath()
+	callerAddr = std.PrevRealm().Addr()
+}
+
+func GetCaller() string {
+    return caller
+}
+
+func GetCallerAddress() std.Address {
+    return callerAddr
+}

--- a/examples/gno.land/r/demo/teritori/caller/caller_test.gno
+++ b/examples/gno.land/r/demo/teritori/caller/caller_test.gno
@@ -1,0 +1,22 @@
+package caller
+
+import (
+	"testing"
+	"gno.land/r/demo/teritori/callee"
+)
+
+func TestInitPkgPath(t *testing.T) {
+	caller := callee.GetCaller()
+	expected := "gno.land/r/demo/teritori/caller"
+	if caller != expected {
+		t.Errorf("caller should be '%s', but got '%s'", expected, caller)
+	}
+}
+
+func TestInitAddr(t *testing.T) {
+	caller := callee.GetCallerAddress()
+	expected := "g1r2h3mkm8ky54w60vphvk8q7uk36uyum9gsqyj3"
+	if caller != expected {
+		t.Errorf("caller address should be '%s', but got '%s'", expected, caller)
+	}
+}

--- a/examples/gno.land/r/demo/teritori/caller/caller_test.gno
+++ b/examples/gno.land/r/demo/teritori/caller/caller_test.gno
@@ -2,6 +2,7 @@ package caller
 
 import (
 	"testing"
+
 	"gno.land/r/demo/teritori/callee"
 )
 

--- a/examples/gno.land/r/demo/teritori/caller/gno.mod
+++ b/examples/gno.land/r/demo/teritori/caller/gno.mod
@@ -1,3 +1,3 @@
-module caller
+module gno.land/r/demo/teritori/caller
 
 require gno.land/r/demo/teritori/callee v0.0.0-latest

--- a/examples/gno.land/r/demo/teritori/caller/gno.mod
+++ b/examples/gno.land/r/demo/teritori/caller/gno.mod
@@ -1,0 +1,3 @@
+module caller
+
+require gno.land/r/demo/teritori/callee v0.0.0-latest

--- a/examples/gno.land/r/demo/teritori/caller/main.gno
+++ b/examples/gno.land/r/demo/teritori/caller/main.gno
@@ -1,9 +1,9 @@
 package caller
 
 import (
-    "gno.land/r/demo/teritori/callee"
+	"gno.land/r/demo/teritori/callee"
 )
 
 func init() {
-    callee.SetCaller()
+	callee.SetCaller()
 }

--- a/examples/gno.land/r/demo/teritori/caller/main.gno
+++ b/examples/gno.land/r/demo/teritori/caller/main.gno
@@ -1,0 +1,9 @@
+package caller
+
+import (
+    "gno.land/r/demo/teritori/callee"
+)
+
+func init() {
+    callee.SetCaller()
+}

--- a/gno.land/cmd/gnoland/testdata/issue-prevrealm-init.txtar
+++ b/gno.land/cmd/gnoland/testdata/issue-prevrealm-init.txtar
@@ -1,0 +1,47 @@
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK/callee -pkgpath gno.land/r/demo/callee -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+
+gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/demo/caller -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+
+gnokey maketx call -pkgpath 'gno.land/r/demo/callee' -func 'GetCaller' -gas-fee 1000000ugnot -gas-wanted 2000000 -send '' -broadcast -chainid='tendermint_test' test1
+stdout 'OK!'
+stdout '"gno.land/r/demo/caller"'
+
+gnokey maketx call -pkgpath 'gno.land/r/demo/callee' -func 'GetCallerAddr' -gas-fee 1000000ugnot -gas-wanted 2000000 -send '' -broadcast -chainid='tendermint_test' test1
+stdout 'OK!'
+stdout '"g1r2h3mkm8ky54w60vphvk8q7uk36uyum9gsqyj3"'
+
+-- caller/main.gno --
+package caller
+
+import (
+    "gno.land/r/demo/callee"
+)
+
+func init() {
+    callee.SetCaller()
+}
+
+-- callee/main.gno --
+package callee
+
+import (
+    "std"
+)
+
+var caller string
+var callerAddr std.Address
+
+func SetCaller() {
+    caller = std.PrevRealm().PkgPath()
+    callerAddr = std.PrevRealm().Addr()
+}
+
+func GetCaller() string {
+    return caller
+}
+
+func GetCallerAddr() std.Address {
+    return callerAddr
+}


### PR DESCRIPTION
This demonstrate a PrevRealm bug only present in the gnotest environment

The txtar test added is passing but the gnotest version seem to have an EOA as PrevRealm where it should be `gno.land/r/demo/teritori/caller`

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
