### PR TITLE
fix: top sort var/const globals

### DIFF
--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -125,21 +125,22 @@ func TestRunLoopyMain(t *testing.T) {
 package test
 
 func main() {
-	//println(a)
-	//println(b)
-	//println(c)
+	println(a)
+	println(b)
+	println(c)
+	println(d)
 
-	b()
+	//b()
 }
 
 //var a, b, c = 1, a + 1, b + 1
 
-var b = func(){println(123)}
+//var b = func(){println(a)}
 //var c = a
 //var a = "123"
 
-//var a, b, c = 1, a + d, 3
-//var d = a
+var a, b, c = 1, a + d, 3
+var d = a
 `
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)

--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -121,14 +121,26 @@ func TestRunLoopyMain(t *testing.T) {
 	t.Parallel()
 
 	m := NewMachine("test", nil)
-	c := `package test
+	c := `
+package test
+
 func main() {
-	for i:=0; i<1000; i++ {
-		if i == -1 {
-			return
-		}
-	}
-}`
+	//println(a)
+	//println(b)
+	//println(c)
+
+	b()
+}
+
+//var a, b, c = 1, a + 1, b + 1
+
+var b = func(){println(123)}
+//var c = a
+//var a = "123"
+
+//var a, b, c = 1, a + d, 3
+//var d = a
+`
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)
 	m.RunMain()

--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -121,27 +121,14 @@ func TestRunLoopyMain(t *testing.T) {
 	t.Parallel()
 
 	m := NewMachine("test", nil)
-	c := `
-package test
-
+	c := `package test
 func main() {
-	println(a)
-	println(b)
-	println(c)
-	println(d)
-
-	//b()
-}
-
-//var a, b, c = 1, a + 1, b + 1
-
-//var b = func(){println(a)}
-//var c = a
-//var a = "123"
-
-var a, b, c = 1, a + d, 3
-var d = a
-`
+	for i:=0; i<1000; i++ {
+		if i == -1 {
+			return
+		}
+	}
+}`
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)
 	m.RunMain()

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1658,7 +1658,7 @@ func (sb *StaticBlock) GetIsConst(store Store, n Name) bool {
 			sb = bp.GetStaticBlock()
 			bp = bp.GetParentNode(store)
 		} else {
-			panic(fmt.Sprintf("GetIsConst: name %s not declared", n))
+			panic(fmt.Sprintf("name %s not declared", n))
 		}
 	}
 }
@@ -1691,7 +1691,7 @@ func (sb *StaticBlock) GetStaticTypeOf(store Store, n Name) Type {
 			tv := Uverse().GetValueAt(store, path)
 			return tv.T
 		} else {
-			panic(fmt.Sprintf("GetStaticTypeOf: name %s not declared", n))
+			panic(fmt.Sprintf("name %s not declared", n))
 		}
 	}
 }

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -158,6 +158,23 @@ type Attributes struct {
 	data  map[interface{}]interface{} // not persisted
 }
 
+func (attr *Attributes) Copy() Attributes {
+	if attr == nil {
+		return Attributes{}
+	}
+
+	data := make(map[interface{}]interface{})
+	for k, v := range attr.data {
+		data[k] = v
+	}
+
+	return Attributes{
+		Line:  attr.Line,
+		Label: attr.Label,
+		data:  data,
+	}
+}
+
 func (attr *Attributes) GetLine() int {
 	return attr.Line
 }

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1614,7 +1614,7 @@ func (sb *StaticBlock) GetPathForName(store Store, n Name) ValuePath {
 			bp = bp.GetParentNode(store)
 			gen++
 			if 0xff < gen {
-				panic("value path depth overflow")
+				panic("GetPathForName: value path depth overflow")
 			}
 		}
 	}
@@ -1641,7 +1641,7 @@ func (sb *StaticBlock) GetIsConst(store Store, n Name) bool {
 			sb = bp.GetStaticBlock()
 			bp = bp.GetParentNode(store)
 		} else {
-			panic(fmt.Sprintf("name %s not declared", n))
+			panic(fmt.Sprintf("GetIsConst: name %s not declared", n))
 		}
 	}
 }
@@ -1674,7 +1674,7 @@ func (sb *StaticBlock) GetStaticTypeOf(store Store, n Name) Type {
 			tv := Uverse().GetValueAt(store, path)
 			return tv.T
 		} else {
-			panic(fmt.Sprintf("name %s not declared", n))
+			panic(fmt.Sprintf("GetStaticTypeOf: name %s not declared", n))
 		}
 	}
 }

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -13,7 +13,6 @@ import (
 // Anything predefined or preprocessed here get skipped during the Preprocess
 // phase.
 func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
-	// First, initialize all file nodes and connect to package node.
 	for _, fn := range fset.Files {
 		decls, err := sortValueDeps(store, fn.Decls)
 		if err != nil {
@@ -21,7 +20,10 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 		}
 
 		fn.Decls = decls
+	}
 
+	// First, initialize all file nodes and connect to package node.
+	for _, fn := range fset.Files {
 		SetNodeLocations(pn.PkgPath, string(fn.Name), fn)
 		fn.InitStaticBlock(fn, pn)
 	}
@@ -37,11 +39,7 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 			d := fn.Decls[i]
 			switch d.(type) {
 			case *ImportDecl:
-				if d.GetAttribute(ATTR_PREDEFINED) == true {
-					// skip declarations already predefined
-					// (e.g. through recursion for a
-					// dependent)
-				} else {
+				if d.GetAttribute(ATTR_PREDEFINED) != true {
 					// recursively predefine dependencies.
 					d2, _ := predefineNow(store, fn, d)
 					fn.Decls[i] = d2
@@ -49,17 +47,14 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 			}
 		}
 	}
+
 	// Predefine all type decls decls.
 	for _, fn := range fset.Files {
 		for i := 0; i < len(fn.Decls); i++ {
 			d := fn.Decls[i]
 			switch d.(type) {
 			case *TypeDecl:
-				if d.GetAttribute(ATTR_PREDEFINED) == true {
-					// skip declarations already predefined
-					// (e.g. through recursion for a
-					// dependent)
-				} else {
+				if d.GetAttribute(ATTR_PREDEFINED) != true {
 					// recursively predefine dependencies.
 					d2, _ := predefineNow(store, fn, d)
 					fn.Decls[i] = d2
@@ -73,11 +68,7 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 			d := fn.Decls[i]
 			switch d.(type) {
 			case *FuncDecl:
-				if d.GetAttribute(ATTR_PREDEFINED) == true {
-					// skip declarations already predefined
-					// (e.g. through recursion for a
-					// dependent)
-				} else {
+				if d.GetAttribute(ATTR_PREDEFINED) != true {
 					// recursively predefine dependencies.
 					d2, _ := predefineNow(store, fn, d)
 					fn.Decls[i] = d2
@@ -91,10 +82,7 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 	for _, fn := range fset.Files {
 		for i := 0; i < len(fn.Decls); i++ {
 			d := fn.Decls[i]
-			if d.GetAttribute(ATTR_PREDEFINED) == true {
-				// skip declarations already predefined (e.g.
-				// through recursion for a dependent)
-			} else {
+			if d.GetAttribute(ATTR_PREDEFINED) != true {
 				// recursively predefine dependencies.
 				d2, _ := predefineNow(store, fn, d)
 				fn.Decls[i] = d2

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -15,9 +15,17 @@ import (
 func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 	// First, initialize all file nodes and connect to package node.
 	for _, fn := range fset.Files {
+		decls, err := sortValueDeps(store, fn.Decls)
+		if err != nil {
+			panic(err)
+		}
+
+		fn.Decls = decls
+
 		SetNodeLocations(pn.PkgPath, string(fn.Name), fn)
 		fn.InitStaticBlock(fn, pn)
 	}
+
 	// NOTE: much of what follows is duplicated for a single *FileNode
 	// in the main Preprocess translation function.  Keep synced.
 
@@ -81,13 +89,6 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 	// Finally, predefine other decls and
 	// preprocess ValueDecls..
 	for _, fn := range fset.Files {
-		decls, err := sortValueDeps(store, fn.Decls)
-		if err != nil {
-			panic(err)
-		}
-
-		fn.Decls = decls
-
 		for i := 0; i < len(fn.Decls); i++ {
 			d := fn.Decls[i]
 			if d.GetAttribute(ATTR_PREDEFINED) == true {

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -77,9 +77,18 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 			}
 		}
 	}
+
 	// Finally, predefine other decls and
 	// preprocess ValueDecls..
 	for _, fn := range fset.Files {
+		decls, err := sortValueDeps(store, fn.Decls)
+
+		if err != nil {
+			panic(err)
+		}
+
+		fn.Decls = decls
+
 		for i := 0; i < len(fn.Decls); i++ {
 			d := fn.Decls[i]
 			if d.GetAttribute(ATTR_PREDEFINED) == true {

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -14,7 +14,7 @@ import (
 // phase.
 func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 	for _, fn := range fset.Files {
-		decls, err := sortValueDeps(store, fn.Decls)
+		decls, err := sortValueDeps(fn.Decls)
 		if err != nil {
 			panic(err)
 		}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -82,7 +82,6 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 	// preprocess ValueDecls..
 	for _, fn := range fset.Files {
 		decls, err := sortValueDeps(store, fn.Decls)
-
 		if err != nil {
 			panic(err)
 		}

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -65,7 +65,7 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		}
 
 		if dd == nil {
-			panic("should not happen")
+			continue
 		}
 
 		sorted = append(sorted, dd)

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -54,7 +54,7 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 			for i, nameExpr := range vd.NameExprs {
 				if len(vd.Values) > i && string(nameExpr.Name) == node {
 					dd = &ValueDecl{
-						Attributes: vd.Attributes,
+						Attributes: vd.Attributes.Copy(),
 						NameExprs:  []NameExpr{nameExpr},
 						Type:       vd.Type,
 						Values:     []Expr{vd.Values[i]},

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -8,11 +8,14 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		vertices: make([]string, 0),
 	}
 
+	otherDecls := make(Decls, 0)
+
 	for i := 0; i < len(decls); i++ {
 		d := decls[i]
 		vd, ok := d.(*ValueDecl)
 
 		if !ok {
+			otherDecls = append(otherDecls, d)
 			continue
 		}
 
@@ -43,7 +46,6 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 			vd, ok := decl.(*ValueDecl)
 
 			if !ok {
-				sorted = append(sorted, decl)
 				continue
 			}
 
@@ -69,7 +71,9 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 
 	slices.Reverse(sorted)
 
-	return sorted, nil
+	otherDecls = append(otherDecls, sorted...)
+
+	return otherDecls, nil
 }
 
 func addDepFromExpr(dg *Graph, fromNode string, expr Expr) {

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -52,13 +52,17 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 			}
 
 			for i, nameExpr := range vd.NameExprs {
-				if len(vd.Values) > i && string(nameExpr.Name) == node {
-					dd = &ValueDecl{
-						Attributes: vd.Attributes.Copy(),
-						NameExprs:  []NameExpr{nameExpr},
-						Type:       vd.Type,
-						Values:     []Expr{vd.Values[i]},
-						Const:      vd.Const,
+				if string(nameExpr.Name) == node {
+					if len(vd.Values) > i {
+						dd = &ValueDecl{
+							Attributes: vd.Attributes.Copy(),
+							NameExprs:  []NameExpr{nameExpr},
+							Type:       vd.Type,
+							Values:     []Expr{vd.Values[i]},
+							Const:      vd.Const,
+						}
+					} else {
+						dd = vd
 					}
 				}
 			}

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -137,6 +137,41 @@ func addDepFromExprStmt(dg *Graph, fromNode string, stmt Stmt) {
 	switch e := stmt.(type) {
 	case *ExprStmt:
 		addDepFromExpr(dg, fromNode, e.X)
+	case *IfStmt:
+		addDepFromExprStmt(dg, fromNode, e.Init)
+		addDepFromExpr(dg, fromNode, e.Cond)
+
+		for _, stm := range e.Then.Body {
+			addDepFromExprStmt(dg, fromNode, stm)
+		}
+		for _, stm := range e.Else.Body {
+			addDepFromExprStmt(dg, fromNode, stm)
+		}
+	case *ReturnStmt:
+		for _, stm := range e.Results {
+			addDepFromExpr(dg, fromNode, stm)
+		}
+	case *AssignStmt:
+		for _, stm := range e.Rhs {
+			addDepFromExpr(dg, fromNode, stm)
+		}
+	case *SwitchStmt:
+		addDepFromExpr(dg, fromNode, e.X)
+		for _, clause := range e.Clauses {
+			addDepFromExpr(dg, fromNode, clause.bodyStmt.Cond)
+			for _, s := range clause.bodyStmt.Body {
+				addDepFromExprStmt(dg, fromNode, s)
+			}
+		}
+	case *ForStmt:
+		addDepFromExpr(dg, fromNode, e.Cond)
+		for _, s := range e.bodyStmt.Body {
+			addDepFromExprStmt(dg, fromNode, s)
+		}
+	case *BlockStmt:
+		for _, s := range e.Block.bodyStmt.Body {
+			addDepFromExprStmt(dg, fromNode, s)
+		}
 	}
 }
 

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -1,0 +1,139 @@
+package gnolang
+
+import "slices"
+
+func sortValueDeps(store Store, decls Decls) (Decls, error) {
+	graph := &Graph{
+		edges:    make(map[string][]string),
+		vertices: make([]string, 0),
+	}
+
+	for i := 0; i < len(decls); i++ {
+		d := decls[i]
+		vd, ok := d.(*ValueDecl)
+
+		if !ok || d.GetAttribute(ATTR_PREDEFINED) == true {
+			continue
+		}
+
+		for j := 0; j < len(vd.NameExprs); j++ {
+			graph.addVertex(string(vd.NameExprs[j].Name))
+		}
+	}
+
+	for i := 0; i < len(decls); i++ {
+		d := decls[i]
+		vd, ok := d.(*ValueDecl)
+
+		if !ok || d.GetAttribute(ATTR_PREDEFINED) == true {
+			continue
+		}
+
+		for j := 0; j < len(vd.NameExprs); j++ {
+			addDepFromExpr(graph, string(vd.NameExprs[j].Name), vd.Values[j])
+		}
+	}
+
+	sorted := make(Decls, 0)
+
+	for _, node := range graph.topologicalSort() {
+		var dd Decl
+
+		for _, decl := range decls {
+			vd, ok := decl.(*ValueDecl)
+
+			if !ok || vd.GetAttribute(ATTR_PREDEFINED) == true {
+				continue
+			}
+
+			for i, nameExpr := range vd.NameExprs {
+				if string(nameExpr.Name) == node {
+					dd = &ValueDecl{
+						Attributes: vd.Attributes,
+						NameExprs:  []NameExpr{nameExpr},
+						Type:       vd.Type,
+						Values:     []Expr{vd.Values[i]},
+						Const:      vd.Const,
+					}
+				}
+			}
+		}
+
+		if dd == nil {
+			panic("should not happen")
+		}
+
+		sorted = append(sorted, dd)
+	}
+
+	slices.Reverse(sorted)
+
+	return sorted, nil
+}
+
+func addDepFromExpr(dg *Graph, fromNode string, expr Expr) {
+	switch e := expr.(type) {
+	case *FuncLitExpr:
+		for _, stmt := range e.Body {
+			addDepFromExprStmt(dg, fromNode, stmt)
+		}
+	case *CallExpr:
+		addDepFromExpr(dg, fromNode, e.Func)
+
+		for _, arg := range e.Args {
+			addDepFromExpr(dg, fromNode, arg)
+		}
+	case *NameExpr:
+		if isUverseName(e.Name) {
+			break
+		}
+
+		toNode := string(e.Name)
+		dg.addEdge(fromNode, toNode)
+	}
+}
+
+func addDepFromExprStmt(dg *Graph, fromNode string, stmt Stmt) {
+	switch e := stmt.(type) {
+	case *ExprStmt:
+		addDepFromExpr(dg, fromNode, e.X)
+	}
+}
+
+type Graph struct {
+	edges    map[string][]string
+	vertices []string
+}
+
+func (g *Graph) addEdge(u, v string) {
+	g.edges[u] = append(g.edges[u], v)
+}
+
+func (g *Graph) addVertex(v string) {
+	g.vertices = append(g.vertices, v)
+}
+
+func (g *Graph) topologicalSortUtil(v string, visited map[string]bool, stack *[]string) {
+	visited[v] = true
+
+	for _, u := range g.edges[v] {
+		if !visited[u] {
+			g.topologicalSortUtil(u, visited, stack)
+		}
+	}
+
+	*stack = append([]string{v}, *stack...)
+}
+
+func (g *Graph) topologicalSort() []string {
+	stack := make([]string, 0)
+	visited := make(map[string]bool)
+
+	for _, v := range g.vertices {
+		if !visited[v] {
+			g.topologicalSortUtil(v, visited, &stack)
+		}
+	}
+
+	return stack
+}

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -9,7 +9,7 @@ import (
 // sortValueDeps creates a new topologically sorted
 // decl slice ready for processing in order
 func sortValueDeps(decls Decls) (Decls, error) {
-	graph := &Graph{
+	graph := &graph{
 		edges:    make(map[string][]string),
 		vertices: make([]string, 0),
 	}
@@ -111,7 +111,7 @@ func sortValueDeps(decls Decls) (Decls, error) {
 	return otherDecls, nil
 }
 
-func addDepFromExpr(dg *Graph, fromNode string, expr Expr) {
+func addDepFromExpr(dg *graph, fromNode string, expr Expr) {
 	switch e := expr.(type) {
 	case *FuncLitExpr:
 		for _, stmt := range e.Body {
@@ -133,7 +133,7 @@ func addDepFromExpr(dg *Graph, fromNode string, expr Expr) {
 	}
 }
 
-func addDepFromExprStmt(dg *Graph, fromNode string, stmt Stmt) {
+func addDepFromExprStmt(dg *graph, fromNode string, stmt Stmt) {
 	switch e := stmt.(type) {
 	case *ExprStmt:
 		addDepFromExpr(dg, fromNode, e.X)
@@ -175,20 +175,20 @@ func addDepFromExprStmt(dg *Graph, fromNode string, stmt Stmt) {
 	}
 }
 
-type Graph struct {
+type graph struct {
 	edges    map[string][]string
 	vertices []string
 }
 
-func (g *Graph) addEdge(u, v string) {
+func (g *graph) addEdge(u, v string) {
 	g.edges[u] = append(g.edges[u], v)
 }
 
-func (g *Graph) addVertex(v string) {
+func (g *graph) addVertex(v string) {
 	g.vertices = append(g.vertices, v)
 }
 
-func (g *Graph) topologicalSortUtil(v string, visited map[string]bool, stack *[]string) {
+func (g *graph) topologicalSortUtil(v string, visited map[string]bool, stack *[]string) {
 	visited[v] = true
 
 	for _, u := range g.edges[v] {
@@ -200,7 +200,7 @@ func (g *Graph) topologicalSortUtil(v string, visited map[string]bool, stack *[]
 	*stack = append([]string{v}, *stack...)
 }
 
-func (g *Graph) topologicalSort() []string {
+func (g *graph) topologicalSort() []string {
 	stack := make([]string, 0)
 	visited := make(map[string]bool)
 

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -33,7 +33,9 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		}
 
 		for j := 0; j < len(vd.NameExprs); j++ {
-			addDepFromExpr(graph, string(vd.NameExprs[j].Name), vd.Values[j])
+			if len(vd.Values) > j {
+				addDepFromExpr(graph, string(vd.NameExprs[j].Name), vd.Values[j])
+			}
 		}
 	}
 
@@ -50,7 +52,7 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 			}
 
 			for i, nameExpr := range vd.NameExprs {
-				if string(nameExpr.Name) == node {
+				if len(vd.Values) > i && string(nameExpr.Name) == node {
 					dd = &ValueDecl{
 						Attributes: vd.Attributes,
 						NameExprs:  []NameExpr{nameExpr},

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -225,7 +225,7 @@ func processCompound(node string, vd *ValueDecl, decl Decl) Decl {
 	names := strings.Split(node, ", ")
 
 	if len(names) != len(vd.NameExprs) {
-		panic("1should not happen")
+		panic("should not happen")
 	}
 
 	equal := true

--- a/gnovm/pkg/gnolang/value_decl_dep_graph.go
+++ b/gnovm/pkg/gnolang/value_decl_dep_graph.go
@@ -12,7 +12,7 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		d := decls[i]
 		vd, ok := d.(*ValueDecl)
 
-		if !ok || d.GetAttribute(ATTR_PREDEFINED) == true {
+		if !ok {
 			continue
 		}
 
@@ -25,7 +25,7 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		d := decls[i]
 		vd, ok := d.(*ValueDecl)
 
-		if !ok || d.GetAttribute(ATTR_PREDEFINED) == true {
+		if !ok {
 			continue
 		}
 
@@ -42,7 +42,8 @@ func sortValueDeps(store Store, decls Decls) (Decls, error) {
 		for _, decl := range decls {
 			vd, ok := decl.(*ValueDecl)
 
-			if !ok || vd.GetAttribute(ATTR_PREDEFINED) == true {
+			if !ok {
+				sorted = append(sorted, decl)
 				continue
 			}
 

--- a/gnovm/tests/files/var18.gno
+++ b/gnovm/tests/files/var18.gno
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	println(a)
+	println(b)
+}
+
+func r2() (int, int) { return 1, 2 }
+
+var a, b int = r2()
+
+// Output:
+// 1
+// 2

--- a/gnovm/tests/files/var19.gno
+++ b/gnovm/tests/files/var19.gno
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	println(a)
+	println(b)
+	println(c)
+}
+
+var a, b, c = 1, a + 1, b + 1
+
+// Output:
+// 1
+// 2
+// 3

--- a/gnovm/tests/files/var20.gno
+++ b/gnovm/tests/files/var20.gno
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	println(a)
+	println(b)
+	println(c)
+	println(d)
+}
+
+var a, b, c = 1, a + d, 3
+var d = a
+
+// Output:
+// 1
+// 2
+// 3
+// 1

--- a/gnovm/tests/files/var21.gno
+++ b/gnovm/tests/files/var21.gno
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	myDep = "123"
+	myVar()
+}
+
+func hello(s string) {}
+
+var myVar = func() { hello(myDep) }
+
+var myDep string
+
+// Output:
+// 123

--- a/gnovm/tests/files/var21.gno
+++ b/gnovm/tests/files/var21.gno
@@ -5,7 +5,9 @@ func main() {
 	myVar()
 }
 
-func hello(s string) {}
+func hello(s string) {
+	println(s)
+}
 
 var myVar = func() { hello(myDep) }
 


### PR DESCRIPTION
This PR fixes [this](https://github.com/gnolang/gno/issues/1849) and [this](https://github.com/gnolang/gno/issues/1463).

Before preprocessing, a dependency graph is created and edges between the nodes which represent the relationship between global `var` and `const` declarations.
Then, a new slice of declarations is created that is topologically sorted.
This enables the rest of the preprocessing code to work the way it is now.

Small scale refactoring is included by removing unnecessary else statements in `PredefineFileSet`.