### PR TITLE
docs: add testnets concepts & reference pages

### DIFF
--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -46,7 +46,7 @@ check out the [Portal Loop concept page](./portal-loop.md).
 Staging is a testnet that is reset once every 60 minutes.
 
 - **Persistence of state:**
-    - State is fully discarded
+  - State is fully discarded
 - **Timeliness of code:**
   - With every reset, the latest commit of the Gno tech stack is applied, including
   the demo packages and realms

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -55,8 +55,6 @@ Staging is a testnet that is reset once every 60 minutes.
 - **Versioning strategy**:
   - Staging is reset every 60 minutes to match the latest monorepo commit
 
-View the staging network configuration [here]. // add rpc config
-
 ## Test4 (upcoming)
 Test4 (name subject to change) is an upcoming, permanent, multi-node testnet. 
 To follow test4 progress, view the test4 milestone
@@ -67,7 +65,7 @@ Once it is complete, it will have the following properties:
   - State is fully persisted unless there are breaking changes in a new release,
 where persistence partly depends on implementing a migration strategy
 - **Timeliness of code:**
-  - 
+  - ?
 - **Intended purpose**
   - Running a full node, testing validator coordination, deploying stable Gno 
 dApps, creating tools that require persisted state & transaction history

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -111,8 +111,4 @@ Release commit: [652dc7a](https://github.com/gnolang/gno/commit/652dc7a3a62ee043
 The first Gno testnet. Find archive data [here](https://github.com/gnolang/tx-exports/tree/main/test1.gno.land).
 
 Launch date: May 6th 2022  
-Release commit: [797c7a1](https://github.com/gnolang/gno/commit/797c7a132d65534df373c63b837cf94b7831ac6e) 
-
-
-
-
+Release commit: [797c7a1](https://github.com/gnolang/gno/commit/797c7a132d65534df373c63b837cf94b7831ac6e)

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -21,7 +21,6 @@ Gno.land testnets are categorized by 4 main points:
 Below you can find a breakdown of each existing testnet by these categories.
 
 ## Portal Loop
-
 Portal Loop is an always up-to-date rolling testnet. It is meant to be used as 
 a nightly build of the Gno tech stack. The home page of gno.land is the `gnoweb`
 render of the Portal Loop testnet. 
@@ -44,7 +43,6 @@ check out the [Portal Loop concept page](./portal-loop.md).
 View the Portal Loop network configuration [here]. // add rpc config 
 
 ## Staging
-
 Staging is a testnet that is reset once every 60 minutes.
 
 - **Persistence of state:**
@@ -61,7 +59,6 @@ Staging is a testnet that is reset once every 60 minutes.
 View the staging network configuration [here]. // add rpc config
 
 ## Test4 (upcoming)
-
 Test4 (name subject to change) is an upcoming, permanent, multi-node testnet. 
 To follow test4 progress, view the test4 milestone
 [here](https://github.com/gnolang/gno/milestone/4).
@@ -77,7 +74,7 @@ where persistence partly depends on implementing a migration strategy
 dApps, creating tools that require persisted state & transaction history
 - **Versioning strategy**:
   - Test4 will be the first testnet to be release-based, following releases of
-the Gno tech stack
+the Gno tech stack. 
 
 View the staging network configuration [here]. // add rpc config
 

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -1,0 +1,63 @@
+---
+id: testnets
+---
+
+# Gno.land Testnets
+
+This page documents all Gno.land testnets, what their properties are, and how
+they are meant to be used. For testnet configuration, visit the 
+[reference section](../reference/testnets.md).
+
+Gno.land testnets are categorized by 3 main points:
+- Persistence of state
+- Timeliness of on-chain code
+- Intended purpose
+
+Below you can find a breakdown of each existing testnet by these categories.
+
+## Portal Loop
+
+Portal Loop is an always up-to-date rolling testnet. It is meant to be used as 
+a nightly build of the Gno tech stack. The home page of gno.land is the `gnoweb`
+render of the Portal Loop testnet. 
+
+- Persistence of state:
+  - State is kept on a best-effort basis 
+  - Transactions that are affected by breaking changes will be discarded
+- Timeliness of on-chain code:
+  - Packages & realms which are available in the `examples/` folder on the [Gno
+monorepo](https://github.com/gnolang/gno) exist on the Portal Loop in matching 
+state - they are refreshed with every new commit to the `master` branch.
+- Intended purpose
+  - Giving access the latest version of Gno for fast development & demoing
+
+For more information on how the Portal Loop works, and how you can best utilize it, 
+check out the [concept page](./portal-loop.md).
+
+View the Portal Loop network configuration [here]. // add rpc config 
+
+## Staging
+
+Staging is a testnet that is reset about every hour.
+
+- Persistence of state:
+    - State is fully discarded
+- Timeliness of on-chain code:
+    - With every reset, the latest commit of the Gno tech stack is applied 
+- Intended purpose
+    - Demoing, single-use code in a staging environment, testing automation which
+uploads code to the chain, etc.
+
+View the staging network configuration [here]. // add rpc config
+
+## Test4 (upcoming)
+
+Test4 (name subject to change) is an upcoming, permanent, multi-node testnet. To follow test4 progress,
+view the test4 milestone [here](https://github.com/gnolang/gno/milestone/4).
+
+## TestX
+
+These testnets are deprecated and currently serve as archives of previous progress.
+
+
+## Test3 (archive)

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -84,7 +84,8 @@ most packages, such as the AVL package, are outdated.
 - **Persistence of state:**
   - State is fully preserved
 - **Timeliness of code:**
-  - Test3 is at commit XYZ, and it can contain new on-chain code
+  - Test3 is at commit [1ca2d97](https://github.com/gnolang/gno/commit/1ca2d973817b174b5b06eb9da011e1fcd2cca575)
+of Gno, and it can contain new on-chain code
 - **Intended purpose**
   - Running a full node, building an indexer, showing demos, persisting history  
 - **Versioning strategy**:

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -66,7 +66,7 @@ Once it is complete, it will have the following properties:
   - State is fully persisted unless there are breaking changes in a new release,
 where persistence partly depends on implementing a migration strategy
 - **Timeliness of code:**
-  - ?
+  - Versioning mechanisms for packages & realms will be implemented for test4
 - **Intended purpose**
   - Running a full node, testing validator coordination, deploying stable Gno 
 dApps, creating tools that require persisted state & transaction history

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -96,14 +96,21 @@ available code by browsing the [test3 homepage](https://test3.gno.land/).
 Test3 is a single-node testnet, ran by the Gno core team. There is no plan to 
 upgrade test3 to a multi-node testnet. 
 
-### Test2 (archive)
-// add launch date?
+Launch date: November 4th 2022  
+Release commit: [1ca2d97](https://github.com/gnolang/gno/commit/1ca2d973817b174b5b06eb9da011e1fcd2cca575)
 
+### Test2 (archive)
 The second Gno testnet. Find archive data [here](https://github.com/gnolang/tx-exports/tree/main/test2.gno.land).
 
-### Test1 (archive)
-// add launch date?
+Launch date: July 10th 2022  
+Release commit: [652dc7a](https://github.com/gnolang/gno/commit/652dc7a3a62ee0438093d598d123a8c357bf2499) 
 
+### Test1 (archive)
 The first Gno testnet. Find archive data [here](https://github.com/gnolang/tx-exports/tree/main/test1.gno.land).
+
+Launch date: May 6th 2022  
+Release commit: [797c7a1](https://github.com/gnolang/gno/commit/797c7a132d65534df373c63b837cf94b7831ac6e) 
+
+
 
 

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -2,16 +2,21 @@
 id: testnets
 ---
 
-# Gno.land Testnets
+# Gno Testnets
 
 This page documents all Gno.land testnets, what their properties are, and how
 they are meant to be used. For testnet configuration, visit the 
 [reference section](../reference/testnets.md).
 
-Gno.land testnets are categorized by 3 main points:
-- Persistence of state
-- Timeliness of on-chain code
-- Intended purpose
+Gno.land testnets are categorized by 4 main points:
+- **Persistence of state**
+  - Is the state and transaction history persisted?
+- **Timeliness of code**
+  - How up-to-date are Gno language features and demo packages & realms?
+- **Intended purpose**
+  - When should this testnet be used?
+- **Versioning strategy**
+  - How is this testnet versioned?
 
 Below you can find a breakdown of each existing testnet by these categories.
 
@@ -21,43 +26,93 @@ Portal Loop is an always up-to-date rolling testnet. It is meant to be used as
 a nightly build of the Gno tech stack. The home page of gno.land is the `gnoweb`
 render of the Portal Loop testnet. 
 
-- Persistence of state:
+- **Persistence of state:**
   - State is kept on a best-effort basis 
   - Transactions that are affected by breaking changes will be discarded
-- Timeliness of on-chain code:
+- **Timeliness of code:**
   - Packages & realms which are available in the `examples/` folder on the [Gno
 monorepo](https://github.com/gnolang/gno) exist on the Portal Loop in matching 
 state - they are refreshed with every new commit to the `master` branch.
-- Intended purpose
-  - Giving access the latest version of Gno for fast development & demoing
+- **Intended purpose**
+  - Providing access the latest version of Gno for fast development & demoing
+- **Versioning strategy**:
+  - Portal Loop infrastructure is managed within the `misc/loop` folder
 
-For more information on how the Portal Loop works, and how you can best utilize it, 
-check out the [concept page](./portal-loop.md).
+For more information on the Portal Loop, and how it can be best utilized, 
+check out the [Portal Loop concept page](./portal-loop.md).
 
 View the Portal Loop network configuration [here]. // add rpc config 
 
 ## Staging
 
-Staging is a testnet that is reset about every hour.
+Staging is a testnet that is reset once every 60 minutes.
 
-- Persistence of state:
+- **Persistence of state:**
     - State is fully discarded
-- Timeliness of on-chain code:
-    - With every reset, the latest commit of the Gno tech stack is applied 
-- Intended purpose
-    - Demoing, single-use code in a staging environment, testing automation which
-uploads code to the chain, etc.
+- **Timeliness of code:**
+  - With every reset, the latest commit of the Gno tech stack is applied, including
+  the demo packages and realms
+- **Intended purpose**
+  - Demoing, single-use code in a staging environment, testing automation which
+  uploads code to the chain, etc.
+- **Versioning strategy**:
+  - Staging is reset every 60 minutes to match the latest monorepo commit
 
 View the staging network configuration [here]. // add rpc config
 
 ## Test4 (upcoming)
 
-Test4 (name subject to change) is an upcoming, permanent, multi-node testnet. To follow test4 progress,
-view the test4 milestone [here](https://github.com/gnolang/gno/milestone/4).
+Test4 (name subject to change) is an upcoming, permanent, multi-node testnet. 
+To follow test4 progress, view the test4 milestone
+[here](https://github.com/gnolang/gno/milestone/4).
+Once it is complete, it will have the following properties:
+
+- **Persistence of state:**
+  - State is fully persisted unless there are breaking changes in a new release,
+where persistence partly depends on implementing a migration strategy
+- **Timeliness of code:**
+  - 
+- **Intended purpose**
+  - Running a full node, testing validator coordination, deploying stable Gno 
+dApps, creating tools that require persisted state & transaction history
+- **Versioning strategy**:
+  - Test4 will be the first testnet to be release-based, following releases of
+the Gno tech stack
+
+View the staging network configuration [here]. // add rpc config
 
 ## TestX
-
 These testnets are deprecated and currently serve as archives of previous progress.
 
+### Test3
+Test3 is the most recent persistent Gno testnet. It is still being used, but 
+most packages, such as the AVL package, are outdated.
 
-## Test3 (archive)
+- **Persistence of state:**
+  - State is fully preserved
+- **Timeliness of code:**
+  - Test3 is at commit XYZ, and it can contain new on-chain code
+- **Intended purpose**
+  - Running a full node, building an indexer, showing demos, persisting history  
+- **Versioning strategy**:
+  - There is no versioning strategy for test3. It will stay the way it is, until
+the team chooses to shut it down.
+
+Since Gno.land is designed with open-source in mind, anyone can see currently 
+available code by browsing the [test3 homepage](https://test3.gno.land/). 
+
+Test3 is a single-node testnet, ran by the Gno core team. There is no plan to 
+upgrade test3 to a multi-node testnet. View the staging network
+configuration [here]. // add rpc config
+
+### Test2 (archive)
+// add launch date?
+
+The second Gno testnet. Find archive data [here](https://github.com/gnolang/tx-exports/tree/main/test2.gno.land).
+
+### Test1 (archive)
+// add launch date?
+
+The first Gno testnet. Find archive data [here](https://github.com/gnolang/tx-exports/tree/main/test1.gno.land).
+
+

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -6,7 +6,7 @@ id: testnets
 
 This page documents all Gno.land testnets, what their properties are, and how
 they are meant to be used. For testnet configuration, visit the 
-[reference section](../reference/testnets.md).
+[reference section](../reference/network-config).
 
 Gno.land testnets are categorized by 4 main points:
 - **Persistence of state**
@@ -22,8 +22,8 @@ Below you can find a breakdown of each existing testnet by these categories.
 
 ## Portal Loop
 Portal Loop is an always up-to-date rolling testnet. It is meant to be used as 
-a nightly build of the Gno tech stack. The home page of gno.land is the `gnoweb`
-render of the Portal Loop testnet. 
+a nightly build of the Gno tech stack. The home page of [gno.land](https://gno.land)
+is the `gnoweb` render of the Portal Loop testnet. 
 
 - **Persistence of state:**
   - State is kept on a best-effort basis 
@@ -35,12 +35,11 @@ state - they are refreshed with every new commit to the `master` branch.
 - **Intended purpose**
   - Providing access the latest version of Gno for fast development & demoing
 - **Versioning strategy**:
-  - Portal Loop infrastructure is managed within the `misc/loop` folder
+  - Portal Loop infrastructure is managed within the `misc/loop` folder in the 
+monorepo
 
 For more information on the Portal Loop, and how it can be best utilized, 
 check out the [Portal Loop concept page](./portal-loop.md).
-
-View the Portal Loop network configuration [here]. // add rpc config 
 
 ## Staging
 Staging is a testnet that is reset once every 60 minutes.
@@ -74,9 +73,7 @@ where persistence partly depends on implementing a migration strategy
 dApps, creating tools that require persisted state & transaction history
 - **Versioning strategy**:
   - Test4 will be the first testnet to be release-based, following releases of
-the Gno tech stack. 
-
-View the staging network configuration [here]. // add rpc config
+the Gno tech stack.
 
 ## TestX
 These testnets are deprecated and currently serve as archives of previous progress.
@@ -99,8 +96,7 @@ Since Gno.land is designed with open-source in mind, anyone can see currently
 available code by browsing the [test3 homepage](https://test3.gno.land/). 
 
 Test3 is a single-node testnet, ran by the Gno core team. There is no plan to 
-upgrade test3 to a multi-node testnet. View the staging network
-configuration [here]. // add rpc config
+upgrade test3 to a multi-node testnet. 
 
 ### Test2 (archive)
 // add launch date?

--- a/docs/concepts/testnets.md
+++ b/docs/concepts/testnets.md
@@ -35,7 +35,8 @@ state - they are refreshed with every new commit to the `master` branch.
 - **Intended purpose**
   - Providing access the latest version of Gno for fast development & demoing
 - **Versioning strategy**:
-  - Portal Loop infrastructure is managed within the `misc/loop` folder in the 
+  - Portal Loop infrastructure is managed within the
+[`misc/loop`](https://github.com/gnolang/gno/tree/master/misc/loop) folder in the 
 monorepo
 
 For more information on the Portal Loop, and how it can be best utilized, 

--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -18,5 +18,5 @@ id: network-config
 All networks follow the same pattern for websocket connections: 
 
 ```shell
-ws://<rpc-endpoint:port>/ws
+wss://<rpc-endpoint:port>/websocket
 ```

--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -4,8 +4,6 @@ id: network-config
 
 # Network configurations
 
-
-
 | Network     | RPC Endpoint                       | Chain ID      | 
 |-------------|------------------------------------|---------------|
 | Portal Loop | https://rpc.gno.land:443           | `portal-loop` |

--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -10,11 +10,8 @@ id: network-config
 | Testnet 4   | upcoming                           | upcoming      |
 | Testnet 3   | https://rpc.test3.gno.land:443     | `test3`       |
 | Staging     | https://rpc.staging.gno.land:36657 | `test3`       |
-| Local       | http://127.0.0.1:26657             | `dev`         |
-
 
 ### WebSocket endpoints
-
 All networks follow the same pattern for websocket connections: 
 
 ```shell

--- a/docs/reference/rpc-endpoints.md
+++ b/docs/reference/rpc-endpoints.md
@@ -4,7 +4,7 @@ id: rpc-endpoints
 
 # Gno RPC Endpoints
 
-For network configurations, view the [network configuration page](testnets.md).
+For network configurations, view the [network configuration page](./network-config.md).
 ## Common Parameters
 
 #### Response

--- a/docs/reference/rpc-endpoints.md
+++ b/docs/reference/rpc-endpoints.md
@@ -4,19 +4,7 @@ id: rpc-endpoints
 
 # Gno RPC Endpoints
 
-## Network Configurations
-
-This is a list of Gno.land networks. Use the information below to configure wallets and Web3 middleware providers to the appropriate RPC Server Address and Chain ID to connect to the correct Gno network.
-
-Note: The below endpoints may produce errors on dialing if the ports are not provided (eg, `:443`).
-
-| Network     | RPC Server Addr.               | Chain ID      |
-| ----------- | ------------------------------ | ------------- |
-| Portal Loop | https://rpc.gno.land:443       | `portal-loop` |
-| Testnet 3   | https://rpc.test3.gno.land:443 | `test3`       |
-| Staging     | http://staging.gno.land:36657  | `test3`       |
-| Local       | http://127.0.0.1:26657         | `dev`         |
-
+For network configurations, view the [network configuration page](testnets.md).
 ## Common Parameters
 
 #### Response

--- a/docs/reference/testnets.md
+++ b/docs/reference/testnets.md
@@ -1,0 +1,19 @@
+---
+id: network-config
+---
+
+# Network configurations
+
+This is a list of Gno.land networks. Use the information below to configure 
+wallets and Web3 middleware providers to the appropriate RPC Server Address
+and Chain ID to connect to the correct Gno network.
+
+Note: The below endpoints may produce errors on dialing if the ports are not 
+provided (eg, `:443`).
+
+| Network     | RPC Server Addr.               | Chain ID      |
+| ----------- | ------------------------------ | ------------- |
+| Portal Loop | https://rpc.gno.land:443       | `portal-loop` |
+| Testnet 3   | https://rpc.test3.gno.land:443 | `test3`       |
+| Staging     | http://staging.gno.land:36657  | `test3`       |
+| Local       | http://127.0.0.1:26657         | `dev`         |

--- a/docs/reference/testnets.md
+++ b/docs/reference/testnets.md
@@ -4,16 +4,21 @@ id: network-config
 
 # Network configurations
 
-This is a list of Gno.land networks. Use the information below to configure 
-wallets and Web3 middleware providers to the appropriate RPC Server Address
-and Chain ID to connect to the correct Gno network.
 
-Note: The below endpoints may produce errors on dialing if the ports are not 
-provided (eg, `:443`).
 
-| Network     | RPC Server Addr.               | Chain ID      |
-| ----------- | ------------------------------ | ------------- |
-| Portal Loop | https://rpc.gno.land:443       | `portal-loop` |
-| Testnet 3   | https://rpc.test3.gno.land:443 | `test3`       |
-| Staging     | http://staging.gno.land:36657  | `test3`       |
-| Local       | http://127.0.0.1:26657         | `dev`         |
+| Network     | RPC Endpoint                       | Chain ID      | 
+|-------------|------------------------------------|---------------|
+| Portal Loop | https://rpc.gno.land:443           | `portal-loop` |
+| Testnet 4   | upcoming                           | upcoming      |
+| Testnet 3   | https://rpc.test3.gno.land:443     | `test3`       |
+| Staging     | https://rpc.staging.gno.land:36657 | `test3`       |
+| Local       | http://127.0.0.1:26657             | `dev`         |
+
+
+### WebSocket endpoints
+
+All networks follow the same pattern for websocket connections: 
+
+```shell
+ws://<rpc-endpoint:port>/ws
+```

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -93,6 +93,7 @@ const sidebars = {
             link: {type: 'doc', id: 'reference/reference'},
             items: [
                 'reference/rpc-endpoints',
+                'reference/network-config',
                 {
                     type: 'category',
                     label: 'Standard Libraries',

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -58,6 +58,7 @@ const sidebars = {
                 },
                 'concepts/gnovm',
                 'concepts/gno-language',
+                'concepts/testnets',
                 'concepts/effective-gno',
                 'concepts/proof-of-contribution',
                 'concepts/tendermint2',


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

Closes: #1791 & #1822

This PR adds concept & reference pages for Gno testnets. It details out what each testnet is meant for, what its versioning strategy is, and how it handles state & tx history persistence. 

I am missing some information - 
- Since test4 will be versioned based on Gno releases, will this also include new code in the `examples/` folder? How will this work? cc @zivkovicmilos 
- ~Please comment below if you know the release dates of test1, test2, & test3 - and possibly the version (gh commit) of their binaries.~ found tags thanks to @r3v4s on the repo.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
