### PR TITLE
chore(gnovm, tm2): changed `reflect.PtrTo` to `reflect.PointerTo`

### DIFF
--- a/gnovm/pkg/gnolang/gonative.go
+++ b/gnovm/pkg/gnolang/gonative.go
@@ -129,7 +129,7 @@ func (ds *defaultStore) Go2GnoType(rt reflect.Type) (t Type) {
 					// for methods with ptr receivers,
 					// whereas gno methods are all
 					// declared on the *DeclaredType.
-					prt = reflect.PtrTo(rt)
+					prt = reflect.PointerTo(rt)
 				}
 				nm := prt.NumMethod()
 				mtvs = make([]TypedValue, nm)
@@ -825,7 +825,7 @@ func gno2GoType(t Type) reflect.Type {
 		}
 	case *PointerType:
 		et := gno2GoType(ct.Elem())
-		return reflect.PtrTo(et)
+		return reflect.PointerTo(et)
 	case *ArrayType:
 		ne := ct.Len
 		et := gno2GoType(ct.Elem())

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -163,7 +163,7 @@ func (m *Machine) doOpStar() {
 		t := xv.GetType()
 		var pt Type
 		if nt, ok := t.(*NativeType); ok {
-			pt = &NativeType{Type: reflect.PtrTo(nt.Type)}
+			pt = &NativeType{Type: reflect.PointerTo(nt.Type)}
 		} else {
 			pt = &PointerType{Elt: t}
 		}

--- a/gnovm/pkg/gnolang/op_types.go
+++ b/gnovm/pkg/gnolang/op_types.go
@@ -405,7 +405,7 @@ func (m *Machine) doOpStaticTypeOf() {
 						"VPNative access on pointer to non-native value %v", pt.Elt))
 				}
 				dxt = &NativeType{
-					Type: reflect.PtrTo(net.Type),
+					Type: reflect.PointerTo(net.Type),
 				}
 			}
 			// switch on type and maybe match field.
@@ -431,10 +431,10 @@ func (m *Machine) doOpStaticTypeOf() {
 					return
 				}
 				// make rt ptr.
-				rt = reflect.PtrTo(rt)
+				rt = reflect.PointerTo(rt)
 			} else {
 				// make rt ptr.
-				rt = reflect.PtrTo(rt)
+				rt = reflect.PointerTo(rt)
 			}
 			// match method.
 			rmt, ok := rt.MethodByName(string(x.Sel))

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2453,7 +2453,7 @@ func checkType(xt Type, dt Type, autoNative bool) {
 						nidt.String()))
 				}
 				// if xt has native base, do the naive native.
-				if reflect.PtrTo(nxt.Type).AssignableTo(nidt) {
+				if reflect.PointerTo(nxt.Type).AssignableTo(nidt) {
 					return // ok
 				} else {
 					panic(fmt.Sprintf(
@@ -2478,7 +2478,7 @@ func checkType(xt Type, dt Type, autoNative bool) {
 		//nolint:misspell
 		if enxt, ok := pxt.Elt.(*NativeType); ok {
 			xt = &NativeType{
-				Type: reflect.PtrTo(enxt.Type),
+				Type: reflect.PointerTo(enxt.Type),
 			}
 		}
 	}
@@ -2486,7 +2486,7 @@ func checkType(xt Type, dt Type, autoNative bool) {
 		// *gonative{x} is gonative{*x}
 		if endt, ok := pdt.Elt.(*NativeType); ok {
 			dt = &NativeType{
-				Type: reflect.PtrTo(endt.Type),
+				Type: reflect.PointerTo(endt.Type),
 			}
 		}
 	}

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -696,7 +696,7 @@ func (pt *PointerType) FindEmbeddedFieldType(callerPath string, n Name, m map[Ty
 		}
 	case *NativeType:
 		npt := &NativeType{
-			Type: reflect.PtrTo(cet.Type),
+			Type: reflect.PointerTo(cet.Type),
 		}
 		return npt.FindEmbeddedFieldType(n, m)
 	default:

--- a/tm2/pkg/amino/codec.go
+++ b/tm2/pkg/amino/codec.go
@@ -594,7 +594,7 @@ func (cdc *Codec) newTypeInfoUnregisteredWLocked(rt reflect.Type) *TypeInfo {
 	cdc.typeInfos[rt] = info
 
 	info.Type = rt
-	info.PtrToType = reflect.PtrTo(rt)
+	info.PtrToType = reflect.PointerTo(rt)
 	info.ZeroValue = reflect.Zero(rt)
 	var isAminoMarshaler bool
 	var reprType reflect.Type
@@ -602,7 +602,7 @@ func (cdc *Codec) newTypeInfoUnregisteredWLocked(rt reflect.Type) *TypeInfo {
 		isAminoMarshaler = true
 		reprType = marshalAminoReprType(rm)
 	}
-	if rm, ok := reflect.PtrTo(rt).MethodByName("UnmarshalAmino"); ok {
+	if rm, ok := reflect.PointerTo(rt).MethodByName("UnmarshalAmino"); ok {
 		if !isAminoMarshaler {
 			panic("Must implement both (o).MarshalAmino and (*o).UnmarshalAmino")
 		}


### PR DESCRIPTION
# Description

The `reflect.PtrTo` function has been deprecated, so I changed this method to `reflect.PointerTo`. These two functions have exactly the same behavior.

ref: https://pkg.go.dev/reflect#PtrTo
