### PR TITLE
Revert "fix: hardcode max vm cycles in keeper"

### DIFF
--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -410,8 +410,9 @@ func newNodeConfig(tmc *tmcfg.Config, chainid string, appstate gnoland.GnoGenesi
 	}
 
 	return &gnoland.InMemoryNodeConfig{
-		PrivValidator: pv,
-		TMConfig:      tmc,
-		Genesis:       genesis,
+		PrivValidator:      pv,
+		TMConfig:           tmc,
+		Genesis:            genesis,
+		GenesisMaxVMCycles: 10_000_000,
 	}
 }

--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -36,6 +36,7 @@ type startCfg struct {
 	chainID               string
 	genesisRemote         string
 	dataDir               string
+	genesisMaxVMCycles    int64
 	config                string
 
 	txEventStoreType string
@@ -122,6 +123,13 @@ func (c *startCfg) RegisterFlags(fs *flag.FlagSet) {
 		"genesis-remote",
 		"localhost:26657",
 		"replacement for '%%REMOTE%%' in genesis",
+	)
+
+	fs.Int64Var(
+		&c.genesisMaxVMCycles,
+		"genesis-max-vm-cycles",
+		10_000_000,
+		"set maximum allowed vm cycles per operation. Zero means no limit.",
 	)
 
 	fs.StringVar(
@@ -246,7 +254,7 @@ func execStart(c *startCfg, io commands.IO) error {
 	cfg.TxEventStore = txEventStoreCfg
 
 	// Create application and node.
-	gnoApp, err := gnoland.NewApp(dataDir, c.skipFailingGenesisTxs, logger)
+	gnoApp, err := gnoland.NewApp(dataDir, c.skipFailingGenesisTxs, logger, c.genesisMaxVMCycles)
 	if err != nil {
 		return fmt.Errorf("error in creating new app: %w", err)
 	}

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -31,6 +31,7 @@ type AppOptions struct {
 	GnoRootDir            string
 	SkipFailingGenesisTxs bool
 	Logger                *slog.Logger
+	MaxCycles             int64
 }
 
 func NewAppOptions() *AppOptions {
@@ -77,7 +78,7 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 
 	// XXX: Embed this ?
 	stdlibsDir := filepath.Join(cfg.GnoRootDir, "gnovm", "stdlibs")
-	vmKpr := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, stdlibsDir)
+	vmKpr := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, stdlibsDir, cfg.MaxCycles)
 
 	// Set InitChainer
 	baseApp.SetInitChainer(InitChainer(baseApp, acctKpr, bankKpr, cfg.SkipFailingGenesisTxs))
@@ -122,7 +123,7 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 }
 
 // NewApp creates the GnoLand application.
-func NewApp(dataRootDir string, skipFailingGenesisTxs bool, logger *slog.Logger) (abci.Application, error) {
+func NewApp(dataRootDir string, skipFailingGenesisTxs bool, logger *slog.Logger, maxCycles int64) (abci.Application, error) {
 	var err error
 
 	cfg := NewAppOptions()

--- a/gno.land/pkg/gnoland/node_inmemory.go
+++ b/gno.land/pkg/gnoland/node_inmemory.go
@@ -25,6 +25,7 @@ type InMemoryNodeConfig struct {
 	Genesis               *bft.GenesisDoc
 	TMConfig              *tmcfg.Config
 	SkipFailingGenesisTxs bool
+	GenesisMaxVMCycles    int64
 }
 
 // NewMockedPrivValidator generate a new key
@@ -78,9 +79,10 @@ func NewDefaultInMemoryNodeConfig(rootdir string) *InMemoryNodeConfig {
 	}
 
 	return &InMemoryNodeConfig{
-		PrivValidator: pv,
-		TMConfig:      tm,
-		Genesis:       genesis,
+		PrivValidator:      pv,
+		TMConfig:           tm,
+		Genesis:            genesis,
+		GenesisMaxVMCycles: 10_000_000,
 	}
 }
 
@@ -113,6 +115,7 @@ func NewInMemoryNode(logger *slog.Logger, cfg *InMemoryNodeConfig) (*node.Node, 
 		Logger:                logger,
 		GnoRootDir:            cfg.TMConfig.RootDir,
 		SkipFailingGenesisTxs: cfg.SkipFailingGenesisTxs,
+		MaxCycles:             cfg.GenesisMaxVMCycles,
 		DB:                    memdb.NewMemDB(),
 	})
 	if err != nil {

--- a/gno.land/pkg/sdk/vm/common_test.go
+++ b/gno.land/pkg/sdk/vm/common_test.go
@@ -39,7 +39,7 @@ func setupTestEnv() testEnv {
 	acck := authm.NewAccountKeeper(iavlCapKey, std.ProtoBaseAccount)
 	bank := bankm.NewBankKeeper(acck)
 	stdlibsDir := filepath.Join("..", "..", "..", "..", "gnovm", "stdlibs")
-	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir)
+	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, stdlibsDir, 10_000_000)
 
 	vmk.Initialize(ms.MultiCacheWrap())
 

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -22,11 +22,6 @@ import (
 const (
 	maxAllocTx    = 500 * 1000 * 1000
 	maxAllocQuery = 1500 * 1000 * 1000 // higher limit for queries
-
-	// maxVMCycles is the maximum number of cycles allowed while executing a single VM
-	// message. Ideally this should not be needed, as execution should halt when out of
-	// gas. The worst case scenario is that this value is used as a fallback.
-	maxVMCycles = 10_000_000
 )
 
 // vm.VMKeeperI defines a module interface that supports Gno
@@ -60,6 +55,7 @@ func NewVMKeeper(
 	acck auth.AccountKeeper,
 	bank bank.BankKeeper,
 	stdlibsDir string,
+	maxCycles int64,
 ) *VMKeeper {
 	// TODO: create an Options struct to avoid too many constructor parameters
 	vmk := &VMKeeper{
@@ -68,7 +64,7 @@ func NewVMKeeper(
 		acck:       acck,
 		bank:       bank,
 		stdlibsDir: stdlibsDir,
-		maxCycles:  maxVMCycles,
+		maxCycles:  maxCycles,
 	}
 	return vmk
 }


### PR DESCRIPTION
Reverts gnolang/gno#1807

This PR is causing problems in some realms because the maximum limit is too low.

