### PR TITLE
fix(stdlibs/io): handle potential overflow in `NewSectionReader`

### DIFF
--- a/gnovm/stdlibs/io/io.gno
+++ b/gnovm/stdlibs/io/io.gno
@@ -488,7 +488,7 @@ func NewSectionReader(r ReaderAt, off int64, n int64) *SectionReader {
 		// Assume we can read up to an offset of `1<<63 - 1` bytes in this case.
 		remaining = maxInt64
 	}
-	return &SectionReader{r, off, off, off + n}
+	return &SectionReader{r, off, off, remaining}
 }
 
 // SectionReader implements Read, Seek, and ReadAt on a section


### PR DESCRIPTION
`NewSectionReader` sets `remaining` to `maxInt64` (i.e `1<<63 - 1`) in case of overflow, but it remained unused.

`SectionReader.limit` is always set to `n+off`. Utilize `remaining` to handle overflow.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
