### PR TITLE
fix(docs): broken links

### DIFF
--- a/docs/how-to-guides/simple-library.md
+++ b/docs/how-to-guides/simple-library.md
@@ -141,7 +141,7 @@ There are a few things happening here, so let's dissect them:
 
 - We defined the logic of our library into a package called `tapas`.
 - The package imports `std`, which
-is the [Gno standard library](../concepts/standard-library/overview.md)
+is the [Gno standard library](../concepts/stdlibs/stdlibs.md)
 - We use the imported package inside of `GetTapaSuggestion` to generate a
 random index value for a tapa
 

--- a/docs/how-to-guides/testing-gno.md
+++ b/docs/how-to-guides/testing-gno.md
@@ -177,7 +177,7 @@ Luckily, the Gno standard library provides ample support for functionality such 
 time, such as the request caller address, or the calling package address.
 
 You can learn more about these methods, that are importable using the `std` import declaration,
-in the [Standard Library](../concepts/stdlibs/overview.md) reference section.
+in the [Standard Library](../concepts/stdlibs/stdlibs.md) reference section.
 
 ## Conclusion
 

--- a/misc/docusaurus/sidebars.js
+++ b/misc/docusaurus/sidebars.js
@@ -11,7 +11,7 @@ const sidebars = {
             items: [
                 'getting-started/playground-start',
                 {
-                 type: "category",
+                 type: 'category',
                  label: 'Local Setup',
                     items: [
                         'getting-started/local-setup/local-setup',


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

This PR fixes two broken links in the docs. Docusaurus build works as shown below:
![Screenshot 2024-04-10 at 20 33 24](https://github.com/gnolang/gno/assets/33522493/727b1265-c6fe-4439-9f0b-cc5b608a0882)

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
