### PR TITLE
fix: use docker buildx on ci to support multiple arch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,69 +14,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-push:
+  build-main:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build main Docker image
-        env:
-          owner: ${{ github.repository_owner }}
-          reponame: ${{ github.event.repository.name }}
-        run: |
-          docker build -t ghcr.io/${owner}/${reponame} .
-          docker tag ghcr.io/${owner}/${reponame}:latest ghcr.io/${owner}/${reponame}:${GITHUB_SHA::8}
+      - name: Get commit SHA
+        id: commit
+        run: echo "sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
-      - name: Build slim Docker images
-        env:
-          owner: ${{ github.repository_owner }}
-          reponame: ${{ github.event.repository.name }}
-        run: |
-          docker build --target=gnoland-slim   -t ghcr.io/${owner}/${reponame}/gnoland-slim   .
-          docker build --target=gnokey-slim    -t ghcr.io/${owner}/${reponame}/gnokey-slim    .
-          docker build --target=gno-slim       -t ghcr.io/${owner}/${reponame}/gno-slim       .
-          docker build --target=gnofaucet-slim -t ghcr.io/${owner}/${reponame}/gnofaucet-slim .
-          docker build --target=gnoweb-slim    -t ghcr.io/${owner}/${reponame}/gnoweb-slim    .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-          docker tag ghcr.io/${owner}/${reponame}/gnoland-slim:latest   ghcr.io/${owner}/${reponame}/gnoland-slim:${GITHUB_SHA::8}
-          docker tag ghcr.io/${owner}/${reponame}/gnokey-slim:latest    ghcr.io/${owner}/${reponame}/gnokey-slim:${GITHUB_SHA::8}
-          docker tag ghcr.io/${owner}/${reponame}/gno-slim:latest       ghcr.io/${owner}/${reponame}/gno-slim:${GITHUB_SHA::8}
-          docker tag ghcr.io/${owner}/${reponame}/gnofaucet-slim:latest ghcr.io/${owner}/${reponame}/gnofaucet-slim:${GITHUB_SHA::8}
-          docker tag ghcr.io/${owner}/${reponame}/gnoweb-slim:latest    ghcr.io/${owner}/${reponame}/gnoweb-slim:${GITHUB_SHA::8}
-
-      - name: List docker images
-        run: |
-          docker images | grep ghcr
-
-      - name: Log in to GitHub Container Registry
-        if: (github.event_name != 'pull_request')
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
+        if: (github.event_name != 'pull_request')
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.commit.outputs.sha }}
 
-      - name: Publish images
+  build-slim:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [gnoland, gnoland-slim, gnokey-slim, gno-slim, gnofaucet-slim, gnoweb-slim]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get commit SHA
+        id: commit
+        run: echo "sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         if: (github.event_name != 'pull_request')
-        env:
-          owner: ${{ github.repository_owner }}
-          reponame: ${{ github.event.repository.name }}
-        run: |
-            docker push ghcr.io/${owner}/${reponame}:latest
-            docker push ghcr.io/${owner}/${reponame}:${GITHUB_SHA::8}
-
-            docker push ghcr.io/${owner}/${reponame}/gnoland-slim:latest
-            docker push ghcr.io/${owner}/${reponame}/gnoland-slim:${GITHUB_SHA::8}
-
-            docker push ghcr.io/${owner}/${reponame}/gnokey-slim:latest
-            docker push ghcr.io/${owner}/${reponame}/gnokey-slim:${GITHUB_SHA::8}
-
-            docker push ghcr.io/${owner}/${reponame}/gno-slim:latest
-            docker push ghcr.io/${owner}/${reponame}/gno-slim:${GITHUB_SHA::8}
-
-            docker push ghcr.io/${owner}/${reponame}/gnofaucet-slim:latest
-            docker push ghcr.io/${owner}/${reponame}/gnofaucet-slim:${GITHUB_SHA::8}
-
-            docker push ghcr.io/${owner}/${reponame}/gnoweb-slim:latest
-            docker push ghcr.io/${owner}/${reponame}/gnoweb-slim:${GITHUB_SHA::8}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ matrix.target }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ matrix.target }}:${{ steps.commit.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR     /opt/build
 ADD         go.mod go.sum ./
 RUN         go mod download
 ADD         . ./
+ENV         CGO_ENABLED=0
 RUN         go build -o ./build/gnoland   ./gno.land/cmd/gnoland
 RUN         go build -o ./build/gnokey    ./gno.land/cmd/gnokey
 RUN         go build -o ./build/gnofaucet ./gno.land/cmd/gnofaucet

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR     /opt/build
 ADD         go.mod go.sum ./
 RUN         go mod download
 ADD         . ./
-ENV         CGO_ENABLED=0
 RUN         go build -o ./build/gnoland   ./gno.land/cmd/gnoland
 RUN         go build -o ./build/gnokey    ./gno.land/cmd/gnokey
 RUN         go build -o ./build/gnofaucet ./gno.land/cmd/gnofaucet


### PR DESCRIPTION
Cleanup and upgrade CI docker build jobs to use Docker Buildx for multi-architecture support

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
