### PR TITLE
fix: typo in portal-loop.md

### DIFF
--- a/docs/concepts/portal-loop.md
+++ b/docs/concepts/portal-loop.md
@@ -8,7 +8,7 @@ Portal Loop is an always-up-to-date staging testnet that allows for using
 the latest version of Gno, Gno.land, and TM2. By utilizing the power of Docker
 & the [tx-archive](https://github.com/gnolang/tx-archive) tool, the Portal Loop can run the latest code from the 
 master branch on the [Gno monorepo](https://github.com/gnolang/gno), 
-while preserving most/all the previous the transaction data. 
+while preserving most/all of the previous transaction data. 
 
 The Portal Loop allows for quick iteration on the latest version of Gno - without
 having to make a hard/soft fork. 


### PR DESCRIPTION
Just a documentation typo fixed. It's not much, but it's honest work.