### PR TITLE
fix(docker): fix docker action by adding build target

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [gnoland, gnoland-slim, gnokey-slim, gno-slim, gnofaucet-slim, gnoweb-slim]
+        target: [gnoland-slim, gnokey-slim, gno-slim, gnofaucet-slim, gnoweb-slim]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -77,6 +77,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.target }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ matrix.target }}:latest


### PR DESCRIPTION
In the previous PR #1912, the target was not specified, causing slim images to build the first layer of the Dockerfile. This PR updates the docker action to correctly pass the `target` argument.

Signed-off-by: gfanton <8671905+gfanton@users.noreply.github.com><!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
