### PR TITLE
refactor: use `jaekwon/testify` throughout codebase

### DIFF
--- a/gno.land/cmd/genesis/balances_export_test.go
+++ b/gno.land/cmd/genesis/balances_export_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // getDummyBalances generates dummy balance lines

--- a/gno.land/cmd/genesis/balances_remove_test.go
+++ b/gno.land/cmd/genesis/balances_remove_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
-	"github.com/stretchr/testify/assert"
+	"github.com/jaekwon/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/gno.land/cmd/genesis/generate_test.go
+++ b/gno.land/cmd/genesis/generate_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/jaekwon/testify/assert"
+	"github.com/jaekwon/testify/require"
 )
 
 func TestGenesis_Generate(t *testing.T) {

--- a/gno.land/cmd/genesis/txs_add_test.go
+++ b/gno.land/cmd/genesis/txs_add_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // generateDummyTxs generates dummy transactions

--- a/gno.land/cmd/genesis/txs_export_test.go
+++ b/gno.land/cmd/genesis/txs_export_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenesis_Txs_Export(t *testing.T) {

--- a/gno.land/cmd/genesis/txs_remove_test.go
+++ b/gno.land/cmd/genesis/txs_remove_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenesis_Txs_Remove(t *testing.T) {

--- a/gno.land/cmd/genesis/validator_add_test.go
+++ b/gno.land/cmd/genesis/validator_add_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 	"github.com/gnolang/gno/tm2/pkg/crypto/secp256k1"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // getDummyKey generates a random public key,

--- a/gno.land/cmd/genesis/validator_remove_test.go
+++ b/gno.land/cmd/genesis/validator_remove_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGenesis_Validator_Remove(t *testing.T) {

--- a/gno.land/cmd/genesis/verify_test.go
+++ b/gno.land/cmd/genesis/verify_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/crypto/mock"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
-	"github.com/stretchr/testify/require"
+	"github.com/jaekwon/testify/require"
 )
 
 func TestGenesis_Verify(t *testing.T) {

--- a/gno.land/cmd/gnofaucet/throttle_test.go
+++ b/gno.land/cmd/gnofaucet/throttle_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIPThrottler_RegisterNewRequest(t *testing.T) {

--- a/gno.land/cmd/gnoland/config_get_test.go
+++ b/gno.land/cmd/gnoland/config_get_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/bft/config"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Get_Invalid(t *testing.T) {

--- a/gno.land/cmd/gnoland/config_init_test.go
+++ b/gno.land/cmd/gnoland/config_init_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/bft/config"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Init(t *testing.T) {

--- a/gno.land/cmd/gnoland/config_set_test.go
+++ b/gno.land/cmd/gnoland/config_set_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/state/eventstore/file"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // initializeTestConfig initializes a default configuration

--- a/gno.land/cmd/gnoland/secrets_common_test.go
+++ b/gno.land/cmd/gnoland/secrets_common_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/p2p"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCommon_SaveReadData(t *testing.T) {

--- a/gno.land/cmd/gnoland/secrets_get_test.go
+++ b/gno.land/cmd/gnoland/secrets_get_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/privval"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/p2p"
+	"github.com/jaekwon/testify/require"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSecrets_Get_All(t *testing.T) {

--- a/gno.land/cmd/gnoland/start_test.go
+++ b/gno.land/cmd/gnoland/start_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
-	"github.com/stretchr/testify/require"
+	"github.com/jaekwon/testify/require"
 )
 
 func TestStartInitialize(t *testing.T) {

--- a/tm2/pkg/sdk/bank/handler_test.go
+++ b/tm2/pkg/sdk/bank/handler_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/jaekwon/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"

--- a/tm2/pkg/strings/string_test.go
+++ b/tm2/pkg/strings/string_test.go
@@ -3,9 +3,8 @@ package strings
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/jaekwon/testify/assert"
+	"github.com/jaekwon/testify/require"
 )
 
 func TestStringInSlice(t *testing.T) {
@@ -60,7 +59,7 @@ func TestStringSliceEqual(t *testing.T) {
 		{[]string{"two", "words!"}, []string{"only 1 word"}, false},
 	}
 	for i, tt := range tests {
-		require.Equal(t, tt.want, StringSliceEqual(tt.a, tt.b),
+		require.Equal(t, StringSliceEqual(tt.a, tt.b), tt.want,
 			"StringSliceEqual failed on test %d", i)
 	}
 }

--- a/tm2/pkg/timer/throttle_timer_test.go
+++ b/tm2/pkg/timer/throttle_timer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	asrt "github.com/stretchr/testify/assert"
+	"github.com/jaekwon/testify/assert"
 )
 
 type thCounter struct {
@@ -35,45 +35,43 @@ func (c *thCounter) Read() {
 	}
 }
 
-func TestThrottle(test *testing.T) {
-	test.Parallel()
-
-	assert := asrt.New(test)
+func TestThrottle(t *testing.T) {
+	t.Parallel()
 
 	ms := 100
 	delay := time.Duration(ms) * time.Millisecond
 	longwait := time.Duration(2) * delay
-	t := NewThrottleTimer("foo", delay)
+	timer := NewThrottleTimer("foo", delay)
 
 	// start at 0
-	c := &thCounter{input: t.Ch}
-	assert.Equal(0, c.Count())
+	c := &thCounter{input: timer.Ch}
+	assert.Equal(t, c.Count(), 0)
 	go c.Read()
 
 	// waiting does nothing
 	time.Sleep(longwait)
-	assert.Equal(0, c.Count())
+	assert.Equal(t, c.Count(), 0)
 
 	// send one event adds one
-	t.Set()
+	timer.Set()
 	time.Sleep(longwait)
-	assert.Equal(1, c.Count())
+	assert.Equal(t, c.Count(), 1)
 
 	// send a burst adds one
 	for i := 0; i < 5; i++ {
-		t.Set()
+		timer.Set()
 	}
 	time.Sleep(longwait)
-	assert.Equal(2, c.Count())
+	assert.Equal(t, c.Count(), 2)
 
 	// send 14, over 2 delay sections, adds 3
 	short := time.Duration(ms/5) * time.Millisecond
 	for i := 0; i < 14; i++ {
-		t.Set()
+		timer.Set()
 		time.Sleep(short)
 	}
 	time.Sleep(longwait)
-	assert.Equal(5, c.Count())
+	assert.Equal(t, c.Count(), 5)
 
-	close(t.Ch)
+	close(timer.Ch)
 }


### PR DESCRIPTION
Currently, we use 2 implementations of testify in our codebase - `jaekwon/testify` and `stretchr/testify`

To streamline our practices and minimize confusion, it's a good idea to opt for a single implementation. Given our preference for jaekwon/testify (see: https://github.com/gnolang/gno/issues/777#issuecomment-1632014195), this PR is an attempt to replace `stretchr/testify` with `jaekwon/testify`.

--

Update: After discussion, we all agreed on using `stretchr/testify` throughout our codebase. Superseded by #1931.