### PR TITLE
feat(stdlibs/errors): support `Is` function

### DIFF
--- a/gnovm/pkg/gnolang/gonative_test.go
+++ b/gnovm/pkg/gnolang/gonative_test.go
@@ -145,3 +145,58 @@ func TestCrypto(t *testing.T) {
 	assert.Equal(t, tv.String(),
 		`(array[0x0000000000000000000000000000000000000000] github.com/gnolang/gno/tm2/pkg/crypto.Address)`)
 }
+
+func TestCollectInterfaceMethods(t *testing.T) {
+	ift := &InterfaceType{
+		Methods: []FieldType{
+			{
+				Name: "Foo",
+				Type: &FuncType{
+					Params: nil,
+					Results: nil,
+				},
+			},
+			{
+				Name: "Bar",
+				Type: &FuncType{
+					Params: []FieldType{
+						{Type: IntType},
+						{Type: StringType},
+					},
+					Results: []FieldType{
+						{Type: BoolType},
+					},
+				},
+			},
+		},
+	}
+
+	methods := collectInterfaceMethods(ift)
+
+	if len(methods) != 2 {
+		t.Fatalf("expected 1 method, got %d", len(methods))
+	}
+
+	// check method names
+	if methods[0].Name != "Foo" {
+		t.Fatalf("expected method name Bar, got %s", methods[0].Name)
+	}
+	if methods[1].Name != "Bar" {
+		t.Fatalf("expected method name Foo, got %s", methods[1].Name)
+	}
+
+	// check method types
+	if methods[0].Type.NumIn() != 0 {
+		t.Fatalf("expected 0 input arguments, got %d", methods[0].Type.NumIn())
+	}
+	if methods[0].Type.NumOut() != 0 {
+		t.Fatalf("expected 0 output arguments, got %d", methods[0].Type.NumOut())
+	}
+
+	if methods[1].Type.NumIn() != 2 {
+		t.Fatalf("expected 2 input arguments, got %d", methods[1].Type.NumIn())
+	}
+	if methods[1].Type.NumOut() != 1 {
+		t.Fatalf("expected 1 output arguments, got %d", methods[1].Type.NumOut())
+	}
+}

--- a/gnovm/stdlibs/errors/errors.gno
+++ b/gnovm/stdlibs/errors/errors.gno
@@ -67,3 +67,72 @@ type errorString struct {
 func (e *errorString) Error() string {
 	return e.s
 }
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+//
+// An error type might provide an Is method so it can be treated as equivalent
+// to an existing error. For example, if MyError defines
+//
+//	func (m MyError) Is(target error) bool { return target == os.ErrExist }
+//
+// then Is(MyError{}, os.ErrExist) returns true. See syscall.Errno.Is for
+// an example in the standard library.
+//
+// This implementation also compares the error strings for equality if both err and target
+// are of type *errorString. This is different from the standard library's errors package.
+//
+// Example:
+//
+//	if errors.Is(err, fs.ErrExist) {
+//	    ...
+//	}
+func Is(err, target error) bool {
+	if target == nil {
+		return err == target
+	}
+
+	if err == nil {
+		return false
+	}
+
+	for {
+		if err == target {
+			return true
+		}
+
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+
+		if x, ok := err.(*errorString); ok {
+			if t, ok := target.(*errorString); ok && x.s == t.s {
+				return true
+			}
+		}
+
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	u, ok := err.(interface {
+		Unwrap() error
+	})
+
+	if !ok {
+		return nil
+	}
+
+	return u.Unwrap()
+}

--- a/gnovm/stdlibs/errors/errors.gno
+++ b/gnovm/stdlibs/errors/errors.gno
@@ -93,12 +93,8 @@ func (e *errorString) Error() string {
 //	    ...
 //	}
 func Is(err, target error) bool {
-	if target == nil {
+        if target == nil || err == nil {
 		return err == target
-	}
-
-	if err == nil {
-		return false
 	}
 
 	for {

--- a/gnovm/stdlibs/errors/errors_test.gno
+++ b/gnovm/stdlibs/errors/errors_test.gno
@@ -51,3 +51,60 @@ func ExampleNew_errorf() {
 	}
 	// Output: user "bimmler" (id 17) not found
 }
+
+type customError struct {
+	msg string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}
+
+func (e *customError) Is(target error) bool {
+	t, ok := target.(*customError)
+	if !ok {
+		return false
+	}
+	return e.msg == t.msg
+}
+
+func TestIs(t *testing.T) {
+	testCases := []struct {
+		err    error
+		target error
+		want   bool
+	}{
+		{nil, nil, true},
+		{errors.New("test"), nil, false},
+		{&customError{msg: "custom"}, &customError{msg: "custom"}, true},
+		{&customError{msg: "custom"}, &customError{msg: "other"}, false},
+		{&customError{msg: "custom"}, errors.New("custom"), false},
+		{errors.New("custom"), &customError{msg: "custom"}, false},
+		{errors.New("custom"), errors.New("custom"), true},
+		{&wrappedError{err: errors.New("wrapped")}, errors.New("wrapped"), true},
+		{&wrappedError{err: &customError{msg: "custom"}}, &customError{msg: "custom"}, true},
+		{&wrappedError{err: errors.New("wrapped")}, errors.New("other"), false},
+		{&wrappedError{err: &customError{msg: "custom"}}, &customError{msg: "other"}, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test Case %d", i+1), func(t *testing.T) {
+			got := errors.Is(tc.err, tc.target)
+			if got != tc.want {
+				t.Errorf("Is(%v, %v) = %v, want %v", tc.err, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+type wrappedError struct {
+	err error
+}
+
+func (e *wrappedError) Error() string {
+	return "wrapped error: " + e.err.Error()
+}
+
+func (e *wrappedError) Unwrap() error {
+	return e.err
+}


### PR DESCRIPTION
# Description

Added the `Is` function to the `errors` package.

- Implemented it based on the `errorString` type
- Checks if the error type and message are the same
- Uses `Unwrap` method to traverse the error chain to find an error that matches the target error.

## Relative Issue

#486  // Failed to implement `As` function due to the technical issue. maybe later