### PR TITLE
chore(examples): `make clean` uses `gno clean`

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -52,7 +52,7 @@ test.sync:
 
 .PHONY: clean
 clean:
-	find . \( -name "*.gno.gen.go" -or -name ".*.gno.gen_test.go" \) -delete
+	find . -name "gno.mod" -execdir go run github.com/gnolang/gno/gnovm/cmd/gno clean -x \;
 
 .PHONY: fmt
 GOFMT_FLAGS ?= -w


### PR DESCRIPTION
Previously, the `make clean` target relied on manual deletion using a `find` command to remove files matching patterns `*.gno.gen.go` and `.*.gno.gen_test.go`.

Replaced it with `gno clean` to have consistent experience, if decided to have diff kind of generated files in future. 

--

Status: Draft; as this makes `make clean` comparatively slow as it uses `go run` not compiled `gno` binary.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
