### PR TITLE
refactor: use `stretchr/testify` throughout codebase

### DIFF
--- a/contribs/gnodev/go.mod
+++ b/contribs/gnodev/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/gotuna/gotuna v0.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
-	github.com/jaekwon/testify v1.6.1 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect

--- a/contribs/gnodev/go.sum
+++ b/contribs/gnodev/go.sum
@@ -98,8 +98,6 @@ github.com/gotuna/gotuna v0.6.0/go.mod h1:F/ecRt29ChB6Ycy1AFIBpBiMNK0j7Heq+gFbLW
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jaekwon/testify v1.6.1 h1:4AtAJcR9GzXN5W4DdY7ie74iCPiJV1JJUJL90t2ZUyw=
-github.com/jaekwon/testify v1.6.1/go.mod h1:Oun0RXIHI7osufabQ60i4Lqkj0GXLbqI1I7kgzBNm1U=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
@@ -157,7 +155,6 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/contribs/gnokeykc/go.mod
+++ b/contribs/gnokeykc/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
-	github.com/jaekwon/testify v1.6.1 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/ff/v3 v3.4.0 // indirect

--- a/contribs/gnokeykc/go.sum
+++ b/contribs/gnokeykc/go.sum
@@ -83,8 +83,6 @@ github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZH
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jaekwon/testify v1.6.1 h1:4AtAJcR9GzXN5W4DdY7ie74iCPiJV1JJUJL90t2ZUyw=
-github.com/jaekwon/testify v1.6.1/go.mod h1:Oun0RXIHI7osufabQ60i4Lqkj0GXLbqI1I7kgzBNm1U=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
@@ -127,7 +125,6 @@ github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/gno.land/pkg/gnoland/types_test.go
+++ b/gno.land/pkg/gnoland/types_test.go
@@ -8,8 +8,8 @@ import (
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBalance_Verify(t *testing.T) {

--- a/gno.land/pkg/integration/testing.go
+++ b/gno.land/pkg/integration/testing.go
@@ -3,9 +3,9 @@ package integration
 import (
 	"errors"
 
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
 	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This error is from testscript.Fatalf and is needed to correctly

--- a/gno.land/pkg/integration/testing_node.go
+++ b/gno.land/pkg/integration/testing_node.go
@@ -12,7 +12,7 @@ import (
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -94,7 +94,7 @@ func Echo(msg string) string {
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, res, `("echo:hello world" string)`)
+	assert.Equal(t, `("echo:hello world" string)`, res)
 	// t.Log("result:", res)
 }
 
@@ -147,7 +147,7 @@ func GetAdmin() string {
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.Error(t, err)
-	assert.Equal(t, res, "")
+	assert.Equal(t, "", res)
 	fmt.Println(err.Error())
 	assert.True(t, strings.Contains(err.Error(), "insufficient coins error"))
 }
@@ -237,7 +237,7 @@ func Echo(msg string) string {
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, res, `("echo:hello world" string)`)
+	assert.Equal(t, `("echo:hello world" string)`, res)
 }
 
 // Sending too much realm package coins fails.
@@ -335,7 +335,7 @@ func GetAdmin() string {
 	res, err := env.vmk.Call(ctx, msg2)
 	addrString := fmt.Sprintf("(\"%s\" string)", addr.String())
 	assert.NoError(t, err)
-	assert.Equal(t, res, addrString)
+	assert.Equal(t, addrString, res)
 }
 
 // Call Run without imports, without variables.
@@ -362,7 +362,7 @@ func main() {
 	msg2 := NewMsgRun(addr, coins, files)
 	res, err := env.vmk.Run(ctx, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, res, "hello world!\n")
+	assert.Equal(t, "hello world!\n", res)
 }
 
 // Call Run with stdlibs.
@@ -393,7 +393,7 @@ func main() {
 	res, err := env.vmk.Run(ctx, msg2)
 	assert.NoError(t, err)
 	expectedString := fmt.Sprintf("hello world! %s\n", addr.String())
-	assert.Equal(t, res, expectedString)
+	assert.Equal(t, expectedString, res)
 }
 
 func TestNumberOfArgsError(t *testing.T) {
@@ -430,9 +430,9 @@ func Echo(msg string) string {
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world", "extra arg"})
 	assert.PanicsWithValue(
 		t,
+		"wrong number of arguments in call to Echo: want 1 got 2",
 		func() {
 			env.vmk.Call(ctx, msg2)
 		},
-		"wrong number of arguments in call to Echo: want 1 got 2",
 	)
 }

--- a/gnovm/pkg/gnoenv/gnohome_test.go
+++ b/gnovm/pkg/gnoenv/gnohome_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHomeDir(t *testing.T) {

--- a/gnovm/pkg/gnoenv/gnoroot_test.go
+++ b/gnovm/pkg/gnoenv/gnoroot_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGuessGnoRootDir_WithSetGnoRoot(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGuessGnoRootDir_WithSetGnoRoot(t *testing.T) {
 	_GNOROOT = testPath
 	root, err := GuessRootDir()
 	require.NoError(t, err)
-	require.Equal(t, root, testPath)
+	require.Equal(t, testPath, root)
 }
 
 func TestGuessGnoRootDir_UsingCallerStack(t *testing.T) {
@@ -37,7 +37,7 @@ func TestGuessGnoRootDir_UsingCallerStack(t *testing.T) {
 	testPath, _ := filepath.Abs(filepath.Join(".", "..", "..", ".."))
 	root, err := GuessRootDir()
 	require.NoError(t, err)
-	require.Equal(t, root, testPath)
+	require.Equal(t, testPath, root)
 }
 
 func TestGuessGnoRootDir_Error(t *testing.T) {
@@ -61,7 +61,7 @@ func TestInferGnoRootFromGoMod(t *testing.T) {
 	t.Run("go is present", func(t *testing.T) {
 		root, err := inferRootFromGoMod()
 		require.NoError(t, err)
-		require.Equal(t, root, testPath)
+		require.Equal(t, testPath, root)
 	})
 
 	t.Run("go is not present", func(t *testing.T) {

--- a/gnovm/pkg/gnoenv/migration_test.go
+++ b/gnovm/pkg/gnoenv/migration_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFixOldDefaultGnoHome(t *testing.T) {

--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -13,8 +13,8 @@ import (
 	"unsafe"
 
 	// "github.com/davecgh/go-spew/spew"
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunInvalidLabels(t *testing.T) {
@@ -284,7 +284,7 @@ func TestDoOpEvalBaseConversion(t *testing.T) {
 		} else {
 			m.doOpEval()
 			v := m.PopValue()
-			assert.Equal(t, v.V.String(), tc.expect)
+			assert.Equal(t, tc.expect, v.V.String())
 		}
 	}
 }
@@ -314,7 +314,7 @@ func assertOutput(t *testing.T, input string, output string) {
 	n := MustParseFile("main.go", input)
 	m.RunFiles(n)
 	m.RunMain()
-	assert.Equal(t, string(buf.Bytes()), output)
+	assert.Equal(t, output, string(buf.Bytes()))
 	err := m.CheckEmpty()
 	assert.Nil(t, err)
 }
@@ -469,9 +469,9 @@ func TestModifyTypeAsserted(t *testing.T) {
 	x2.A = 2
 
 	// only x2 is changed.
-	assert.Equal(t, x.A, 1)
-	assert.Equal(t, v.(Struct1).A, 1)
-	assert.Equal(t, x2.A, 2)
+	assert.Equal(t, 1, x.A)
+	assert.Equal(t, 1, v.(Struct1).A)
+	assert.Equal(t, 2, x2.A)
 }
 
 type Interface1 interface {
@@ -668,7 +668,7 @@ func TestCallLHS(t *testing.T) {
 		return &x
 	}
 	*xptr() = 2
-	assert.Equal(t, x, 2)
+	assert.Equal(t, 2, x)
 }
 
 // XXX is there a way to test in Go as well as Gno?
@@ -684,6 +684,6 @@ func TestCallFieldLHS(t *testing.T) {
 	}
 	y := 0
 	xptr().X, y = 2, 3
-	assert.Equal(t, x.X, 2)
-	assert.Equal(t, y, 3)
+	assert.Equal(t, 2, x.X)
+	assert.Equal(t, 3, y)
 }

--- a/gnovm/pkg/gnolang/go2gno_test.go
+++ b/gnovm/pkg/gnolang/go2gno_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseForLoop(t *testing.T) {

--- a/gnovm/pkg/gnolang/gonative_test.go
+++ b/gnovm/pkg/gnolang/gonative_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/crypto"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // args is an even number of elements,
@@ -42,13 +42,13 @@ func TestGoNativeDefine(t *testing.T) {
 	rt := reflect.TypeOf(Foo{})
 	pkg.DefineGoNativeType(rt)
 	nt := pkg.GetValueRef(nil, Name("Foo")).GetType().(*NativeType)
-	assert.Equal(t, nt.Type, rt)
+	assert.Equal(t, rt, nt.Type)
 	path := pkg.GetPathForName(nil, Name("Foo"))
-	assert.Equal(t, path.Depth, uint8(1))
-	assert.Equal(t, path.Index, uint16(0))
+	assert.Equal(t, uint8(1), path.Depth)
+	assert.Equal(t, uint16(0), path.Index)
 	pv := pkg.NewPackage()
 	nt = pv.GetBlock(nil).GetPointerTo(nil, path).TV.GetType().(*NativeType)
-	assert.Equal(t, nt.Type, rt)
+	assert.Equal(t, rt, nt.Type)
 	store := gonativeTestStore(pkg, pv)
 
 	// Import above package and evaluate foo.Foo.
@@ -58,8 +58,8 @@ func TestGoNativeDefine(t *testing.T) {
 	})
 	m.RunDeclaration(ImportD("foo", "test.foo"))
 	tvs := m.Eval(Sel(Nx("foo"), "Foo"))
-	assert.Equal(t, len(tvs), 1)
-	assert.Equal(t, tvs[0].V.(TypeValue).Type, nt)
+	assert.Equal(t, 1, len(tvs))
+	assert.Equal(t, nt, tvs[0].V.(TypeValue).Type)
 }
 
 func TestGoNativeDefine2(t *testing.T) {
@@ -90,11 +90,11 @@ func main() {
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)
 	m.RunMain()
-	assert.Equal(t, string(out.Bytes()), `A: 1
+	assert.Equal(t, `A: 1
 B: 0
 C: 0
 D: 
-`)
+`, out.String())
 }
 
 func TestGoNativeDefine3(t *testing.T) {
@@ -129,11 +129,11 @@ func main() {
 	n := MustParseFile("main.go", c)
 	m.RunFiles(n)
 	m.RunMain()
-	assert.Equal(t, string(out.Bytes()), `A: 1
+	assert.Equal(t, `A: 1
 B: 0
 C: 0
 D: 
-`)
+`, out.String())
 }
 
 func TestCrypto(t *testing.T) {
@@ -142,6 +142,7 @@ func TestCrypto(t *testing.T) {
 	addr := crypto.Address{}
 	store := gonativeTestStore()
 	tv := Go2GnoValue(nilAllocator, store, reflect.ValueOf(addr))
-	assert.Equal(t, tv.String(),
-		`(array[0x0000000000000000000000000000000000000000] github.com/gnolang/gno/tm2/pkg/crypto.Address)`)
+	assert.Equal(t,
+		`(array[0x0000000000000000000000000000000000000000] github.com/gnolang/gno/tm2/pkg/crypto.Address)`,
+		tv.String())
 }

--- a/gnovm/pkg/gnolang/machine_test.go
+++ b/gnovm/pkg/gnolang/machine_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
 	"github.com/gnolang/gno/tm2/pkg/store/iavl"
 	stypes "github.com/gnolang/gno/tm2/pkg/store/types"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkCreateNewMachine(b *testing.B) {
@@ -53,6 +53,6 @@ func TestRunMemPackageWithOverrides_revertToOld(t *testing.T) {
 	// Check last value, assuming it is the result of Redecl.
 	v := m.Values[0]
 	assert.NotNil(t, v)
-	assert.Equal(t, v.T.Kind(), StringKind)
-	assert.Equal(t, v.V, StringValue("1"))
+	assert.Equal(t, StringKind, v.T.Kind())
+	assert.Equal(t, StringValue("1"), v.V)
 }

--- a/gnovm/pkg/gnolang/package_test.go
+++ b/gnovm/pkg/gnolang/package_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 )

--- a/gnovm/pkg/gnomod/preprocess_test.go
+++ b/gnovm/pkg/gnomod/preprocess_test.go
@@ -3,7 +3,7 @@ package gnomod
 import (
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 )
@@ -130,7 +130,7 @@ func TestRemoveRequireDups(t *testing.T) {
 			in := tc.in
 			removeRequireDups(&in)
 
-			assert.Equal(t, in, tc.expected)
+			assert.Equal(t, tc.expected, in)
 		})
 	}
 }
@@ -308,7 +308,7 @@ func TestRemoveReplaceDups(t *testing.T) {
 			in := tc.in
 			removeReplaceDups(&in)
 
-			assert.Equal(t, in, tc.expected)
+			assert.Equal(t, tc.expected, in)
 		})
 	}
 }

--- a/gnovm/pkg/transpiler/transpiler_test.go
+++ b/gnovm/pkg/transpiler/transpiler_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTranspile(t *testing.T) {
@@ -284,8 +284,8 @@ func foo() { _ = regexp.MatchString }
 			}
 			require.NoError(t, err)
 			expectedOutput := strings.TrimPrefix(c.expectedOutput, "\n")
-			assert.Equal(t, res.Translated, expectedOutput, "wrong output")
-			assert.Equal(t, res.Imports, c.expectedImports, "wrong imports")
+			assert.Equal(t, expectedOutput, res.Translated, "wrong output")
+			assert.Equal(t, c.expectedImports, res.Imports, "wrong imports")
 		})
 	}
 }
@@ -335,7 +335,7 @@ pkg/file.gno:60:20: ugly error`,
 		t.Run(tt.name, func(t *testing.T) {
 			err := parseGoBuildErrors(tt.output)
 
-			assert.Equal(t, err, tt.expectedError)
+			assert.Equal(t, tt.expectedError, err)
 		})
 	}
 }

--- a/gnovm/tests/package_test.go
+++ b/gnovm/tests/package_test.go
@@ -14,7 +14,7 @@ import (
 	// "go/build"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackages(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/gotuna/gotuna v0.6.0
-	github.com/jaekwon/testify v1.6.1
 	github.com/jmhodges/levigo v1.0.0
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/linxGnu/grocksdb v1.6.20

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,6 @@ github.com/gotuna/gotuna v0.6.0/go.mod h1:F/ecRt29ChB6Ycy1AFIBpBiMNK0j7Heq+gFbLW
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 h1:Wqo399gCIufwto+VfwCSvsnfGpF/w5E9CNxSwbpD6No=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jaekwon/testify v1.6.1 h1:4AtAJcR9GzXN5W4DdY7ie74iCPiJV1JJUJL90t2ZUyw=
-github.com/jaekwon/testify v1.6.1/go.mod h1:Oun0RXIHI7osufabQ60i4Lqkj0GXLbqI1I7kgzBNm1U=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
@@ -156,7 +154,6 @@ github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/misc/genstd/mapping_test.go
+++ b/misc/genstd/mapping_test.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testdataDir = "github.com/gnolang/gno/misc/genstd/testdata/"
@@ -64,18 +64,18 @@ func Test_linkFunctions(t *testing.T) {
 
 	for i, v := range mappings {
 		exp := str(i)
-		assert.Equal(t, v.GnoFunc, exp)
-		assert.Equal(t, v.GoFunc, exp)
-		assert.Equal(t, v.GnoImportPath, "std")
-		assert.Equal(t, v.GoImportPath, testdataDir+"linkFunctions/std")
+		assert.Equal(t, exp, v.GnoFunc)
+		assert.Equal(t, exp, v.GoFunc)
+		assert.Equal(t, "std", v.GnoImportPath)
+		assert.Equal(t, testdataDir+"linkFunctions/std", v.GoImportPath)
 
-		assert.Equal(t, v.MachineParam, i&machine != 0, "MachineParam should match expected value")
+		assert.Equal(t, i&machine != 0, v.MachineParam, "MachineParam should match expected value")
 		if i&param != 0 {
 			// require, otherwise the following would panic
 			require.Len(t, v.Params, 1)
 			p := v.Params[0]
-			assert.Equal(t, p.GnoType(), "int")
-			assert.Equal(t, p.GoQualifiedName(), "int")
+			assert.Equal(t, "int", p.GnoType())
+			assert.Equal(t, "int", p.GoQualifiedName())
 			assert.False(t, p.IsTypedValue)
 		} else {
 			assert.Len(t, v.Params, 0)
@@ -84,8 +84,8 @@ func Test_linkFunctions(t *testing.T) {
 			// require, otherwise the following would panic
 			require.Len(t, v.Results, 1)
 			p := v.Results[0]
-			assert.Equal(t, p.GnoType(), "int")
-			assert.Equal(t, p.GoQualifiedName(), "int")
+			assert.Equal(t, "int", p.GnoType())
+			assert.Equal(t, "int", p.GoQualifiedName())
 			assert.False(t, p.IsTypedValue)
 		} else {
 			assert.Len(t, v.Results, 0)
@@ -102,13 +102,13 @@ func Test_linkFunctions_unexp(t *testing.T) {
 	mappings := linkFunctions(pkgs)
 	require.Len(t, mappings, 2)
 
-	assert.Equal(t, mappings[0].MachineParam, false)
-	assert.Equal(t, mappings[0].GnoFunc, "t1")
-	assert.Equal(t, mappings[0].GoFunc, "X_t1")
+	assert.Equal(t, false, mappings[0].MachineParam)
+	assert.Equal(t, "t1", mappings[0].GnoFunc)
+	assert.Equal(t, "X_t1", mappings[0].GoFunc)
 
-	assert.Equal(t, mappings[1].MachineParam, true)
-	assert.Equal(t, mappings[1].GnoFunc, "t2")
-	assert.Equal(t, mappings[1].GoFunc, "X_t2")
+	assert.Equal(t, true, mappings[1].MachineParam)
+	assert.Equal(t, "t2", mappings[1].GnoFunc)
+	assert.Equal(t, "X_t2", mappings[1].GoFunc)
 }
 
 func Test_linkFunctions_TypedValue(t *testing.T) {
@@ -120,25 +120,25 @@ func Test_linkFunctions_TypedValue(t *testing.T) {
 	mappings := linkFunctions(pkgs)
 	require.Len(t, mappings, 3)
 
-	assert.Equal(t, mappings[0].MachineParam, false)
-	assert.Equal(t, mappings[0].GnoFunc, "TVParam")
-	assert.Equal(t, mappings[0].GoFunc, "TVParam")
+	assert.Equal(t, false, mappings[0].MachineParam)
+	assert.Equal(t, "TVParam", mappings[0].GnoFunc)
+	assert.Equal(t, "TVParam", mappings[0].GoFunc)
 	assert.Len(t, mappings[0].Results, 0)
 	_ = assert.Len(t, mappings[0].Params, 1) &&
-		assert.Equal(t, mappings[0].Params[0].IsTypedValue, true) &&
-		assert.Equal(t, mappings[0].Params[0].GnoType(), "struct{m1 map[string]interface{}}")
+		assert.Equal(t, true, mappings[0].Params[0].IsTypedValue) &&
+		assert.Equal(t, "struct{m1 map[string]interface{}}", mappings[0].Params[0].GnoType())
 
-	assert.Equal(t, mappings[1].MachineParam, false)
-	assert.Equal(t, mappings[1].GnoFunc, "TVResult")
-	assert.Equal(t, mappings[1].GoFunc, "TVResult")
+	assert.Equal(t, false, mappings[1].MachineParam)
+	assert.Equal(t, "TVResult", mappings[1].GnoFunc)
+	assert.Equal(t, "TVResult", mappings[1].GoFunc)
 	assert.Len(t, mappings[1].Params, 0)
 	_ = assert.Len(t, mappings[1].Results, 1) &&
-		assert.Equal(t, mappings[1].Results[0].IsTypedValue, true) &&
-		assert.Equal(t, mappings[1].Results[0].GnoType(), "interface{S() map[int]Banker}")
+		assert.Equal(t, true, mappings[1].Results[0].IsTypedValue) &&
+		assert.Equal(t, "interface{S() map[int]Banker}", mappings[1].Results[0].GnoType())
 
-	assert.Equal(t, mappings[2].MachineParam, true)
-	assert.Equal(t, mappings[2].GnoFunc, "TVFull")
-	assert.Equal(t, mappings[2].GoFunc, "TVFull")
+	assert.Equal(t, true, mappings[2].MachineParam)
+	assert.Equal(t, "TVFull", mappings[2].GnoFunc)
+	assert.Equal(t, "TVFull", mappings[2].GoFunc)
 	assert.Len(t, mappings[2].Params, 1)
 	assert.Len(t, mappings[2].Results, 1)
 }

--- a/misc/genstd/util_test.go
+++ b/misc/genstd/util_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_pkgNameFromPath(t *testing.T) {
@@ -25,7 +25,7 @@ func Test_pkgNameFromPath(t *testing.T) {
 	}
 	for i, tv := range tt {
 		t.Run(fmt.Sprintf("n%d", i+1), func(t *testing.T) {
-			assert.Equal(t, pkgNameFromPath(tv.input), tv.result)
+			assert.Equal(t, tv.result, pkgNameFromPath(tv.input))
 		})
 	}
 }

--- a/misc/logos/misc_test.go
+++ b/misc/logos/misc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/random"
-	require "github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 // Tests whether widthOf() and nextCharacter() do the same thing.
@@ -51,7 +51,7 @@ func TestStringWidthRandom(t *testing.T) {
 		} else {
 			require.True(t, 0 < width1, "got zero width for bytes %X", bz)
 		}
-		require.Equal(t, width2, width1,
+		require.Equal(t, width1, width2,
 			"want %d but got %d the slow way: %X",
 			width1, width2, bz)
 	}
@@ -71,7 +71,7 @@ func TestStringWidthDummy(t *testing.T) {
 	} else {
 		require.True(t, 0 < width1, "got zero width for bytes %X", bz)
 	}
-	require.Equal(t, width2, width1,
+	require.Equal(t, width1, width2,
 		"want %d but got %d the slow way: %X",
 		width1, width2, bz)
 }
@@ -84,8 +84,8 @@ func TestStringWidthDummy2(t *testing.T) {
 	bz := []byte("\U0001f1fa\U0001f1f8")
 	width1 := widthOf(string(bz))
 	width2 := widthOfSlow(string(bz))
-	require.Equal(t, width1, 1)
-	require.Equal(t, width2, width1,
+	require.Equal(t, 1, width1)
+	require.Equal(t, width1, width2,
 		"want %d but got %d the slow way: %X",
 		width1, width2, bz)
 }
@@ -142,22 +142,22 @@ func incBuffer(bz []byte) bool {
 func TestIncBuffer1(t *testing.T) {
 	bz := []byte{0x00}
 	for i := 0; i < (1<<(1*8))-1; i++ {
-		require.Equal(t, incBuffer(bz), true)
-		require.Equal(t, bz[0], byte(i+1))
+		require.Equal(t, true, incBuffer(bz))
+		require.Equal(t, byte(i+1), bz[0])
 	}
-	require.Equal(t, incBuffer(bz), false)
-	require.Equal(t, bz[0], byte(0x00))
+	require.Equal(t, false, incBuffer(bz))
+	require.Equal(t, byte(0x00), bz[0])
 }
 
 func TestIncBuffer2(t *testing.T) {
 	bz := []byte{0x00, 0x00}
 	for i := 0; i < (1<<(2*8))-1; i++ {
-		require.Equal(t, incBuffer(bz), true)
-		require.Equal(t, bz[0], byte(((i+1)>>0)%256))
-		require.Equal(t, bz[1], byte(((i+1)>>8)%256))
+		require.Equal(t, true, incBuffer(bz))
+		require.Equal(t, byte(((i+1)>>0)%256), bz[0])
+		require.Equal(t, byte(((i+1)>>8)%256), bz[1])
 	}
-	require.Equal(t, bz, []byte{0xFF, 0xFF})
-	require.Equal(t, incBuffer(bz), false)
-	require.Equal(t, bz[0], byte(0x00))
-	require.Equal(t, bz[1], byte(0x00))
+	require.Equal(t, []byte{0xFF, 0xFF}, bz)
+	require.Equal(t, false, incBuffer(bz))
+	require.Equal(t, byte(0x00), bz[0])
+	require.Equal(t, byte(0x00), bz[1])
 }

--- a/misc/logos/types_test.go
+++ b/misc/logos/types_test.go
@@ -3,14 +3,14 @@ package logos
 import (
 	"testing"
 
-	require "github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPage1(t *testing.T) {
 	page := NewPage("this is a new string", 40, false, nil)
 	require.NotNil(t, page)
 	size := page.Size
-	require.Equal(t, size, Size{Width: 20, Height: 1})
+	require.Equal(t, Size{Width: 20, Height: 1}, size)
 }
 
 func TestNewPage2(t *testing.T) {
@@ -22,13 +22,13 @@ func TestNewPage2(t *testing.T) {
 		this is a
 		new string
 	*/
-	require.Equal(t, size, Size{Width: 10, Height: 2})
-	require.Equal(t, page.Elems[0].GetCoord(), Coord{0, 0})
-	require.Equal(t, page.Elems[1].GetCoord(), Coord{5, 0})
-	require.Equal(t, page.Elems[2].GetCoord(), Coord{8, 0})
-	require.Equal(t, page.Elems[3].GetCoord(), Coord{0, 1})
-	require.Equal(t, page.Elems[4].GetCoord(), Coord{4, 1})
-	require.Equal(t, len(page.Elems), 5)
+	require.Equal(t, Size{Width: 10, Height: 2}, size)
+	require.Equal(t, Coord{0, 0}, page.Elems[0].GetCoord())
+	require.Equal(t, Coord{5, 0}, page.Elems[1].GetCoord())
+	require.Equal(t, Coord{8, 0}, page.Elems[2].GetCoord())
+	require.Equal(t, Coord{0, 1}, page.Elems[3].GetCoord())
+	require.Equal(t, Coord{4, 1}, page.Elems[4].GetCoord())
+	require.Equal(t, 5, len(page.Elems))
 }
 
 func TestNewPageSprint(t *testing.T) {
@@ -42,5 +42,5 @@ func TestNewPageSprint(t *testing.T) {
 	bpv := NewBufferedElemView(page, Size{})
 	bpv.Render()
 	out := bpv.Sprint()
-	require.Equal(t, out, "this is a \nnew string")
+	require.Equal(t, "this is a \nnew string", out)
 }

--- a/tm2/pkg/amino/genproto/bindings_test.go
+++ b/tm2/pkg/amino/genproto/bindings_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/amino/tests"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateProtoBindings(t *testing.T) {

--- a/tm2/pkg/amino/genproto/comments_test.go
+++ b/tm2/pkg/amino/genproto/comments_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // message comment
@@ -39,7 +39,7 @@ func TestComments(t *testing.T) {
 	p3c.ValidateBasic()
 	p3doc := p3c.GenerateProto3SchemaForTypes(pkg, pkg.ReflectTypes()...)
 	proto3Schema := p3doc.Print()
-	assert.Equal(t, proto3Schema, `syntax = "proto3";
+	assert.Equal(t, `syntax = "proto3";
 package amino_test;
 
 option go_package = "github.com/gnolang/gno/tm2/pkg/amino/genproto/pb";
@@ -57,5 +57,5 @@ message TestMessageName {
 message TestMessageName2 {
 	// another field comment
 	string field_name = 1 [json_name = "FieldName"];
-}`)
+}`, proto3Schema)
 }

--- a/tm2/pkg/amino/genproto/genproto_test.go
+++ b/tm2/pkg/amino/genproto/genproto_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	sm1 "github.com/gnolang/gno/tm2/pkg/amino/genproto/example/submodule"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBasic(t *testing.T) {
@@ -16,21 +16,21 @@ func TestBasic(t *testing.T) {
 	p3doc := P3Doc{PackageName: "test"}
 	obj := sm1.StructSM{}
 	p3message := p3c.GenerateProto3MessagePartial(&p3doc, reflect.TypeOf(obj))
-	assert.Equal(t, p3message.Print(), `message StructSM {
+	assert.Equal(t, `message StructSM {
 	sint64 field_a = 1 [json_name = "FieldA"];
 	string field_b = 2 [json_name = "FieldB"];
 	submodule2.StructSM2 field_c = 3 [json_name = "FieldC"];
 }
-`)
+`, p3message.Print())
 
-	assert.Equal(t, p3doc.Print(), `syntax = "proto3";
+	assert.Equal(t, `syntax = "proto3";
 package test;
 
 // imports
-import "github.com/gnolang/gno/tm2/pkg/amino/genproto/example/submodule2/submodule2.proto";`)
+import "github.com/gnolang/gno/tm2/pkg/amino/genproto/example/submodule2/submodule2.proto";`, p3doc.Print())
 
 	p3doc = p3c.GenerateProto3SchemaForTypes(sm1.Package, reflect.TypeOf(obj))
-	assert.Equal(t, p3doc.Print(), `syntax = "proto3";
+	assert.Equal(t, `syntax = "proto3";
 package submodule;
 
 option go_package = "github.com/gnolang/gno/tm2/pkg/amino/genproto/example/submodule/pb";
@@ -43,5 +43,5 @@ message StructSM {
 	sint64 field_a = 1 [json_name = "FieldA"];
 	string field_b = 2 [json_name = "FieldB"];
 	submodule2.StructSM2 field_c = 3 [json_name = "FieldC"];
-}`)
+}`, p3doc.Print())
 }

--- a/tm2/pkg/amino/genproto/types_test.go
+++ b/tm2/pkg/amino/genproto/types_test.go
@@ -3,7 +3,7 @@ package genproto
 import (
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrintP3Types(t *testing.T) {
@@ -41,7 +41,7 @@ func TestPrintP3Types(t *testing.T) {
 	}
 
 	proto3Schema := doc.Print()
-	assert.Equal(t, proto3Schema, `syntax = "proto3";
+	assert.Equal(t, `syntax = "proto3";
 
 // doc comment
 
@@ -56,5 +56,5 @@ message message_name {
 
 // message comment 2
 message message_name_2 {
-}`)
+}`, proto3Schema)
 }

--- a/tm2/pkg/amino/libs/press/press_test.go
+++ b/tm2/pkg/amino/libs/press/press_test.go
@@ -3,14 +3,14 @@ package press
 import (
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 
 	p := NewPress()
-	assert.Equal(t, p.Print(), "")
+	assert.Equal(t, "", p.Print())
 }
 
 func TestBasic(t *testing.T) {
@@ -20,7 +20,7 @@ func TestBasic(t *testing.T) {
 	p.P("this ")
 	p.P("is ")
 	p.P("a test")
-	assert.Equal(t, p.Print(), "this is a test")
+	assert.Equal(t, "this is a test", p.Print())
 }
 
 func TestBasicLn(t *testing.T) {
@@ -30,7 +30,7 @@ func TestBasicLn(t *testing.T) {
 	p.P("this ")
 	p.P("is ")
 	p.Pl("a test")
-	assert.Equal(t, p.Print(), "this is a test\n")
+	assert.Equal(t, "this is a test\n", p.Print())
 }
 
 func TestNewlineStr(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNewlineStr(t *testing.T) {
 	p.Pl("a test")
 	p.Pl("a test")
 	p.Pl("a test")
-	assert.Equal(t, p.Print(), "this is a test\r\na test\r\na test\r\n")
+	assert.Equal(t, "this is a test\r\na test\r\na test\r\n", p.Print())
 }
 
 func TestIndent(t *testing.T) {
@@ -54,10 +54,10 @@ func TestIndent(t *testing.T) {
 		p.Pl("second line")
 		p.Pl("third line")
 	}).P("}")
-	assert.Equal(t, p.Print(), `first line {
+	assert.Equal(t, `first line {
 	second line
 	third line
-}`)
+}`, p.Print())
 }
 
 func TestIndent2(t *testing.T) {
@@ -72,9 +72,9 @@ func TestIndent2(t *testing.T) {
 		// the indented lines terminate with newlineDelim before
 		// the next unindented line.
 	}).P("}")
-	assert.Equal(t, p.Print(), `first line {
+	assert.Equal(t, `first line {
 	second line
-}`)
+}`, p.Print())
 }
 
 func TestIndent3(t *testing.T) {
@@ -86,9 +86,9 @@ func TestIndent3(t *testing.T) {
 		p.P("second ")
 		p.Pl("line")
 	}).P("}")
-	assert.Equal(t, p.Print(), `first line {
+	assert.Equal(t, `first line {
 	second line
-}`)
+}`, p.Print())
 }
 
 func TestIndentLn(t *testing.T) {
@@ -100,11 +100,11 @@ func TestIndentLn(t *testing.T) {
 		p.Pl("second line")
 		p.Pl("third line")
 	}).Pl("}")
-	assert.Equal(t, p.Print(), `first line {
+	assert.Equal(t, `first line {
 	second line
 	third line
 }
-`)
+`, p.Print())
 }
 
 func TestNestedIndent(t *testing.T) {
@@ -120,11 +120,11 @@ func TestNestedIndent(t *testing.T) {
 			p.Pl("fifth line")
 		})
 	}).Pl("}")
-	assert.Equal(t, p.Print(), `first line {
+	assert.Equal(t, `first line {
 	second line
 	third line
 		fourth line
 		fifth line
 }
-`)
+`, p.Print())
 }

--- a/tm2/pkg/amino/pkg/pkg_test.go
+++ b/tm2/pkg/amino/pkg/pkg_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type Foo struct {
@@ -50,11 +50,11 @@ func TestFullNameForType(t *testing.T) {
 	gopkg := reflect.TypeOf(Foo{}).PkgPath()
 	pkg := NewPackage(gopkg, "some.path", "").WithTypes(Foo{})
 
-	assert.Equal(t, pkg.FullNameForType(reflect.TypeOf(Foo{})), "some.path.Foo")
+	assert.Equal(t, "some.path.Foo", pkg.FullNameForType(reflect.TypeOf(Foo{})))
 
 	typeURL := pkg.TypeURLForType(reflect.TypeOf(Foo{}))
 	assert.False(t, strings.Contains(typeURL[1:], "/"))
-	assert.Equal(t, string(typeURL[0]), "/")
+	assert.Equal(t, "/", string(typeURL[0]))
 }
 
 // If the struct wasn't registered, you can't get a name or type_url for it.

--- a/tm2/pkg/amino/reflect_test.go
+++ b/tm2/pkg/amino/reflect_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	fuzz "github.com/google/gofuzz"
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	proto "google.golang.org/protobuf/proto"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -140,7 +140,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 		require.NoError(t, err,
 			"failed to unmarshal bytes %X (%s): %v\nptr: %v\n",
 			bz, bz, err, spw(ptr))
-		require.Equal(t, ptr2, ptr,
+		require.Equal(t, ptr, ptr2,
 			"end to end failed.\nstart: %v\nend: %v\nbytes: %X\nstring(bytes): %s\n",
 			spw(ptr), spw(ptr2), bz, bz)
 
@@ -160,14 +160,14 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 			ptr3 := rv3.Interface()
 			err = ptr3.(amino.PBMessager).FromPBMessage(cdc, pbo)
 			require.NoError(t, err)
-			require.Equal(t, ptr3, ptr,
+			require.Equal(t, ptr, ptr3,
 				"end to end through pbo failed.\nstart(goo): %v\nend(goo): %v\nmid(pbo): %v\n",
 				spw(ptr), spw(ptr3), spw(pbo))
 
 			// Marshal pbo and check for equality of bz and b3. (go -> p3go -> bz vs go -> bz)
 			bz3, err := proto.Marshal(pbo)
 			require.NoError(t, err)
-			require.Equal(t, bz3, bz,
+			require.Equal(t, bz, bz3,
 				"pbo serialization check failed.\nbz(go): %X\nbz(pb-go): %X\nstart(goo): %v\nend(pbo): %v\n",
 				bz, bz3, spw(ptr), spw(pbo))
 
@@ -179,7 +179,7 @@ func _testCodec(t *testing.T, rt reflect.Type, codecType string) {
 			ptr4 := rv4.Interface()
 			err = ptr4.(amino.PBMessager).FromPBMessage(cdc, pbo2)
 			require.NoError(t, err)
-			require.Equal(t, ptr4, ptr,
+			require.Equal(t, ptr, ptr4,
 				"end to end through bytes and pbo failed.\nbz(go): %X\nstart(goo): %v\nend(goo): %v\nmid(pbo): %v\n",
 				bz, spw(ptr), spw(ptr3), spw(pbo))
 		}
@@ -210,7 +210,7 @@ func _testDeepCopy(t *testing.T, rt reflect.Type) {
 
 		ptr2 := amino.DeepCopy(ptr)
 
-		require.Equal(t, ptr2, ptr,
+		require.Equal(t, ptr, ptr2,
 			"end to end failed.\nstart: %v\nend: %v\nbytes: %X\nstring(bytes): %s\n",
 			spw(ptr), spw(ptr2))
 	}
@@ -237,13 +237,14 @@ func TestCodecMarshalPassesOnRegistered(t *testing.T) {
 
 	bz, err := cdc.Marshal(struct{ tests.Interface1 }{tests.Concrete1{}})
 	assert.NoError(t, err, "correctly registered")
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x0a --> field #1 Typ3ByteLength (anonymous struct)
 		//           0x12 --> length prefix (18 bytes)
 		//                 0x0a --> field #1 Typ3ByteLength (Any)
 		//                       0x10 --> length prefix (12 bytes)
 		//                             0x2f, ... 0x31 --> "/tests.Concrete1"
 		[]byte{0x0a, 0x12, 0x0a, 0x10, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x73, 0x2e, 0x43, 0x6f, 0x6e, 0x63, 0x72, 0x65, 0x74, 0x65, 0x31},
+		bz,
 		"bytes did not match")
 }
 
@@ -257,26 +258,28 @@ func TestCodecRegisterAndMarshalMultipleConcrete(t *testing.T) {
 	{ // test tests.Concrete1, no conflict.
 		bz, err := cdc.Marshal(struct{ tests.Interface1 }{tests.Concrete1{}})
 		assert.NoError(t, err, "correctly registered")
-		assert.Equal(t, bz,
+		assert.Equal(t,
 			//     0x0a --> field #1 Typ3ByteLength (anonymous struct)
 			//           0x12 --> length prefix (18 bytes)
 			//                 0x0a --> field #1 Typ3ByteLength (Any)
 			//                       0x10 --> length prefix (12 bytes)
 			//                             0x2f, ... 0x31 --> "/tests.Concrete1"
 			[]byte{0x0a, 0x12, 0x0a, 0x10, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x73, 0x2e, 0x43, 0x6f, 0x6e, 0x63, 0x72, 0x65, 0x74, 0x65, 0x31},
+			bz,
 			"bytes did not match")
 	}
 
 	{ // test tests.Concrete2, no conflict
 		bz, err := cdc.Marshal(struct{ tests.Interface1 }{tests.Concrete2{}})
 		assert.NoError(t, err, "correctly registered")
-		assert.Equal(t, bz,
+		assert.Equal(t,
 			//     0x0a --> field #1 Typ3ByteLength (anonymous struct)
 			//           0x12 --> length prefix (18 bytes)
 			//                 0x0a --> field #1 Typ3ByteLength (Any TypeURL)
 			//                       0x10 --> length prefix (12 bytes)
 			//                             0x2f, ... 0x31 --> "/tests.Concrete2"
 			[]byte{0x0a, 0x12, 0x0a, 0x10, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x73, 0x2e, 0x43, 0x6f, 0x6e, 0x63, 0x72, 0x65, 0x74, 0x65, 0x32},
+			bz,
 			"bytes did not match")
 	}
 }
@@ -293,7 +296,7 @@ func TestCodecRoundtripNonNilRegisteredTypeDef(t *testing.T) {
 
 	bz, err := cdc.Marshal(struct{ tests.Interface1 }{c3})
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x0a --> field #1 Typ3ByteLength (anonymous struct)
 		//           0x20 --> length prefix (32 bytes)
 		//                 0x0a --> field #1 Typ3ByteLength (Any TypeURL)
@@ -307,6 +310,7 @@ func TestCodecRoundtripNonNilRegisteredTypeDef(t *testing.T) {
 			//                     0x04 --> length prefix (4 bytes)
 			/**/ 0x12, 0x06, 0x0a, 0x04, 0x30, 0x31, 0x32, 0x33,
 		},
+		bz,
 		"ConcreteTypeDef incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -328,7 +332,7 @@ func TestCodecRoundtripNonNilRegisteredTypeDef(t *testing.T) {
 	// bz, err = cdc.Marshal(&i1c3)
 	bz, err = cdc.Marshal(anyc3)
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x0a --> field #1 Typ3ByteLength (Any TypeURL)
 		//           0x16 --> length prefix (22 bytes)
 		//                 0x2f, ... 0x33 --> "/tests.ConcreteTypeDef"
@@ -340,6 +344,7 @@ func TestCodecRoundtripNonNilRegisteredTypeDef(t *testing.T) {
 			//                     0x04 --> length prefix (4 bytes)
 			/**/ 0x12, 0x06, 0x0a, 0x04, 0x30, 0x31, 0x32, 0x33,
 		},
+		bz,
 		"ConcreteTypeDef incorrectly serialized")
 
 	// This time it should work.
@@ -365,7 +370,7 @@ func TestCodecRoundtripNonNilRegisteredWrappedValue(t *testing.T) {
 
 	bz, err := cdc.MarshalAny(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x0a --> field #1 Typ3ByteLength (Any TypeURL)
 		//           0x1b --> length prefix (27 bytes)
 		//                 0x2f, ... 0x33 --> "/tests.ConcreteWrappedBytes"
@@ -377,6 +382,7 @@ func TestCodecRoundtripNonNilRegisteredWrappedValue(t *testing.T) {
 			//                     0x04 --> length prefix (4 bytes)
 			/**/ 0x12, 0x06, 0x0a, 0x04, 0x30, 0x31, 0x32, 0x33,
 		},
+		bz,
 		"ConcreteWrappedBytes incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -416,8 +422,8 @@ func TestCodecJSONRoundtripNonNilRegisteredTypeDef(t *testing.T) {
 
 	bz, err := cdc.MarshalJSONAny(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, string(bz),
-		`{"@type":"/tests.ConcreteTypeDef","value":"MDEyMw=="}`,
+	assert.Equal(t,
+		`{"@type":"/tests.ConcreteTypeDef","value":"MDEyMw=="}`, string(bz),
 		"ConcreteTypeDef incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -438,7 +444,7 @@ func TestCodecRoundtripMarshalOnConcreteNonNilRegisteredTypeDef(t *testing.T) {
 
 	bz, err := cdc.MarshalAny(c3)
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x0a --> field #1 Typ3ByteLength (Any TypeURL)
 		//           0x16 --> length prefix (18 bytes)
 		//                 0x2f, ... 0x31 --> "/tests.ConcreteTypeDef"
@@ -450,6 +456,7 @@ func TestCodecRoundtripMarshalOnConcreteNonNilRegisteredTypeDef(t *testing.T) {
 			//                     0x04 --> length prefix (4 bytes)
 			/**/ 0x12, 0x06, 0x0a, 0x04, 0x30, 0x31, 0x32, 0x33,
 		},
+		bz,
 		"ConcreteTypeDef incorrectly serialized")
 
 	var i1 tests.Interface1
@@ -470,8 +477,8 @@ func TestCodecRoundtripUnmarshalOnConcreteNonNilRegisteredTypeDef(t *testing.T) 
 
 	bz, err := cdc.Marshal(c3a)
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
-		[]byte{0xa, 0x4, 0x30, 0x31, 0x32, 0x33},
+	assert.Equal(t,
+		[]byte{0xa, 0x4, 0x30, 0x31, 0x32, 0x33}, bz,
 		"ConcreteTypeDef incorrectly serialized")
 
 	var c3b tests.ConcreteTypeDef
@@ -494,7 +501,7 @@ func TestCodecBinaryStructFieldNilInterface(t *testing.T) {
 	err = cdc.UnmarshalSized(bz, i2)
 
 	assert.NoError(t, err)
-	require.Equal(t, i2, i1, "i1 and i2 should be the same after decoding")
+	require.Equal(t, i1, i2, "i1 and i2 should be the same after decoding")
 }
 
 // ----------------------------------------

--- a/tm2/pkg/amino/wellknown_test.go
+++ b/tm2/pkg/amino/wellknown_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/amino/tests"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAnyWellKnownNative(t *testing.T) {
@@ -20,7 +20,7 @@ func TestAnyWellKnownNative(t *testing.T) {
 
 	bz, err := cdc.Marshal(s1)
 	assert.Nil(t, err)
-	assert.Equal(t, bz,
+	assert.Equal(t,
 		//     0x1a --> field #3 Typ3ByteLength (F3)
 		//           0x2a --> length prefix (42 bytes)
 		//                 0x0a --> field #1 Typ3ByteLength (Any TypeURL)
@@ -41,6 +41,7 @@ func TestAnyWellKnownNative(t *testing.T) {
 			//                           0x2f, ... 0x65 --> "/google.protobuf.Int64Value"
 			/**/ 0x22, 0x1d, 0x0a, 0x1b, 0x2f, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x49, 0x6e, 0x74, 0x36, 0x34, 0x56, 0x61, 0x6c, 0x75, 0x65,
 		},
+		bz,
 		"InterfaceFieldsStruct incorrectly serialized")
 
 	var s2 tests.InterfaceFieldsStruct
@@ -51,5 +52,5 @@ func TestAnyWellKnownNative(t *testing.T) {
 		F3: string("dontcare"),
 		F4: int64(0), // ints get decoded as int64.
 	}
-	assert.Equal(t, s2, s3)
+	assert.Equal(t, s3, s2)
 }

--- a/tm2/pkg/bech32/bech32_test.go
+++ b/tm2/pkg/bech32/bech32_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/bech32"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeAndDecode(t *testing.T) {
@@ -49,7 +49,7 @@ func TestEncode(t *testing.T) {
 
 	p, err := bech32.Encode(pubkeyPrefix, bz)
 
-	assert.Equal(t, p, pubkeyBech32)
+	assert.Equal(t, pubkeyBech32, p)
 }
 
 func TestDecode(t *testing.T) {
@@ -58,7 +58,7 @@ func TestDecode(t *testing.T) {
 	hrp, b1, err := bech32.Decode(pubkeyBech32)
 
 	assert.NoError(t, err)
-	assert.Equal(t, hrp, pubkeyPrefix)
+	assert.Equal(t, pubkeyPrefix, hrp)
 
 	b2, err := hex.DecodeString(pubkeyBytes)
 

--- a/tm2/pkg/bft/rpc/lib/client/http_client_test.go
+++ b/tm2/pkg/bft/rpc/lib/client/http_client_test.go
@@ -3,7 +3,7 @@ package rpcclient
 import (
 	"testing"
 
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_parseRemoteAddr(t *testing.T) {
@@ -25,8 +25,8 @@ func Test_parseRemoteAddr(t *testing.T) {
 			_ = assert.NotNil(t, err) && assert.Contains(t, err.Error(), tc.errContains)
 		}
 		assert.NoError(t, err)
-		assert.Equal(t, n, tc.network)
-		assert.Equal(t, s, tc.s)
+		assert.Equal(t, tc.network, n)
+		assert.Equal(t, tc.s, s)
 	}
 }
 

--- a/tm2/pkg/db/common_test.go
+++ b/tm2/pkg/db/common_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/internal"
-	"github.com/jaekwon/testify/assert"
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ----------------------------------------

--- a/tm2/pkg/db/goleveldb/go_level_db_test.go
+++ b/tm2/pkg/db/goleveldb/go_level_db_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/internal"
-	"github.com/jaekwon/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )

--- a/tm2/pkg/iavl/benchmarks/bench_test.go
+++ b/tm2/pkg/iavl/benchmarks/bench_test.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/db"
 	_ "github.com/gnolang/gno/tm2/pkg/db/_all"

--- a/tm2/pkg/iavl/testutils_test.go
+++ b/tm2/pkg/iavl/testutils_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/db"

--- a/tm2/pkg/log/testing.go
+++ b/tm2/pkg/log/testing.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 // NewTestingLogger returns a new testing logger

--- a/tm2/pkg/service/service_test.go
+++ b/tm2/pkg/service/service_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaekwon/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 type testService struct {


### PR DESCRIPTION
Currently, we use 2 implementations of testify in our codebase - `jaekwon/testify` and `stretchr/testify`

To streamline our practices and minimize confusion, it's a good idea to opt for a single implementation.

After discussion, we all agreed on using `stretchr/testify` throughout our codebase. 

Closes #777 