### PR TITLE
feat: `gnodev` in root `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,15 @@ install: install.gnokey install.gno install.gnodev
 .PHONY: install.gnokey
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
-	@echo "[+] 'gnokey' is installed. more info in ./gno.land/."
+	@echo "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
 .PHONY: install.gno
 install.gno:
 	$(MAKE) --no-print-directory -C ./gnovm	install
-	@echo "[+] 'gno' is installed. more info in ./gnovm/."
+	@echo "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m"
 .PHONY: install.gnodev
 install.gnodev:
 	$(MAKE) --no-print-directory -C ./contribs install.gnodev
-	@echo "[+] 'gnodev' is installed."
+	@echo "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m"
 
 # old aliases
 .PHONY: install_gnokey

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install: install.gnokey install.gno install.gnodev
 .PHONY: install.gnokey
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
+	# \033[0;32m ... \033[0m is ansi for green text.
 	@echo "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
 .PHONY: install.gno
 install.gno:

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,7 @@ VERIFY_MOD_SUMS ?= false
 ########################################
 # Dev tools
 .PHONY: install
-install: install.gnokey install.gno
-	@if ! command -v gnodev > /dev/null; then \
-		echo ------------------------------; \
-		echo "For local realm development, gnodev is recommended: https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev"; \
-		echo "You can install it by calling 'make install.gnodev'"; \
-	fi
+install: install.gnokey install.gno install.gnodev
 
 # shortcuts to frequently used commands from sub-components.
 .PHONY: install.gnokey


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

As discussed with @moul, this PR adds `gnodev` to the root Makefile command `make install`. With this, users who are just getting started can simply run `make install` and have a fully working local environment set up, with only one command. 

I also made the output of the command a bit more readable with some color:
<img width="930" alt="Screenshot 2024-04-16 at 13 31 52" src="https://github.com/gnolang/gno/assets/33522493/176c7e0c-529d-4015-9f54-ca2f053dc9ea">

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
