### PR TITLE
fix: remove gnofaucet leftover from gno.land Make

### DIFF
--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -31,11 +31,10 @@ start.gnoland:; go run ./cmd/gnoland start
 start.gnoweb:; go run ./cmd/gnoweb
 
 .PHONY: build
-build: build.gnoland build.gnokey build.gnoweb build.gnofaucet build.genesis
+build: build.gnoland build.gnokey build.gnoweb build.genesis
 
 build.gnoland:;    go build -o build/gnoland   ./cmd/gnoland
 build.gnoweb:;     go build -o build/gnoweb    ./cmd/gnoweb
-build.gnofaucet:;  go build -o build/gnofaucet ./cmd/gnofaucet
 build.gnokey:;     go build -o build/gnokey    ./cmd/gnokey
 build.genesis:;    go build -o build/genesis  ./cmd/genesis
 


### PR DESCRIPTION
## Description

This PR removes the `build.gnofaucet` directive from the `gno.land` Makefile

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
