### PR TITLE
feat(gnovm):  Implement conversion of Gno interface types with methods to Go types

### DIFF
--- a/gnovm/pkg/gnolang/gonative_test.go
+++ b/gnovm/pkg/gnolang/gonative_test.go
@@ -146,3 +146,203 @@ func TestCrypto(t *testing.T) {
 		`(array[0x0000000000000000000000000000000000000000] github.com/gnolang/gno/tm2/pkg/crypto.Address)`,
 		tv.String())
 }
+
+func TestCollectInterfaceMethods(t *testing.T) {
+	ift := &InterfaceType{
+		Methods: []FieldType{
+			{
+				Name: "Foo",
+				Type: &FuncType{
+					Params:  nil,
+					Results: nil,
+				},
+			},
+			{
+				Name: "Bar",
+				Type: &FuncType{
+					Params: []FieldType{
+						{Type: IntType},
+						{Type: StringType},
+					},
+					Results: []FieldType{
+						{Type: BoolType},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		expectparamNums  int
+		expectResultNums int
+	}{
+		{
+			name:             "Foo",
+			expectparamNums:  0,
+			expectResultNums: 0,
+		},
+		{
+			name:             "Bar",
+			expectparamNums:  2,
+			expectResultNums: 1,
+		},
+	}
+
+	methods, err := collectInterfaceMethods(ift)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(methods) != 2 {
+		t.Fatalf("expected 1 method, got %d", len(methods))
+	}
+
+	for i, tt := range tests {
+		if methods[i].Name != tt.name {
+			t.Fatalf("expected method name %s, got %s", tt.name, methods[i].Name)
+		}
+
+		if methods[i].Type.NumIn() != tt.expectparamNums {
+			t.Fatalf("expected %d input arguments, got %d", tt.expectparamNums, methods[i].Type.NumIn())
+		}
+
+		if methods[i].Type.NumOut() != tt.expectResultNums {
+			t.Fatalf("expected %d output arguments, got %d", tt.expectResultNums, methods[i].Type.NumOut())
+		}
+	}
+}
+
+func TestGno2GoType_Interface(t *testing.T) {
+	emptyInterfaceType := &InterfaceType{
+		Methods: []FieldType{},
+	}
+
+	result := gno2GoType(emptyInterfaceType)
+	expectedType := createEmptyInterfaceType()
+
+	if result != expectedType {
+		t.Errorf("expected empty interface type, but got: %v", result)
+	}
+
+	// test interface with methods
+	interfaceType := &InterfaceType{
+		Methods: []FieldType{
+			{
+				Name: "Method1",
+				Type: &FuncType{
+					Params:  nil,
+					Results: nil,
+				},
+			},
+			{
+				Name: "Method2",
+				Type: &FuncType{
+					Params: []FieldType{
+						{Type: IntType},
+						{Type: StringType},
+					},
+					Results: []FieldType{
+						{Type: BoolType},
+					},
+				},
+			},
+		},
+	}
+
+	// test nil interface type
+	result = gno2GoType(interfaceType)
+	expectedNumMethods := 2
+	if result.NumField() != expectedNumMethods {
+		t.Errorf("expected %d methods, but got %d", expectedNumMethods, result.NumMethod())
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic for nil  InterfaceType, but got none")
+		}
+	}()
+	gno2GoType(nil)
+}
+
+func TestGno2GoTypeMatches_InterfaceType(t *testing.T) {
+	emptyInterfaceType := &InterfaceType{}
+	nonEmptyInterfaceType := &InterfaceType{
+		Methods: []FieldType{
+			{
+				Name: "Method1",
+				Type: &FuncType{
+					Params:  nil,
+					Results: nil,
+				},
+			},
+			{
+				Name: "Method2",
+				Type: &FuncType{
+					Params: []FieldType{
+						{Type: IntType},
+					},
+					Results: []FieldType{
+						{Type: StringType},
+					},
+				},
+			},
+		},
+	}
+
+	// generate Go interface type
+	type nonEmptyGoInterface interface {
+		Method1()
+		Method2(int) string
+	}
+
+	tests := []struct {
+		name      string
+		gnoIF     Type
+		goIF      reflect.Type
+		expectFit bool
+	}{
+		{
+			name:      "empty interface",
+			gnoIF:     emptyInterfaceType,
+			goIF:      reflect.TypeOf((*interface{})(nil)).Elem(),
+			expectFit: true,
+		},
+		{
+			name:      "non-empty interface",
+			gnoIF:     nonEmptyInterfaceType,
+			goIF:      reflect.TypeOf((*nonEmptyGoInterface)(nil)).Elem(),
+			expectFit: true,
+		},
+		{
+			name:  "method count mismatch",
+			gnoIF: emptyInterfaceType,
+			goIF:  reflect.TypeOf((*nonEmptyGoInterface)(nil)).Elem(),
+		},
+		{
+			name:  "mismatched method parameter type",
+			gnoIF: nonEmptyInterfaceType,
+			goIF: reflect.TypeOf((*interface {
+				Method1()
+				Method2(string) string
+			})(nil)).Elem(),
+		},
+		{
+			name:  "mismatched method return value",
+			gnoIF: nonEmptyInterfaceType,
+			goIF: reflect.TypeOf((*interface {
+				Method1()
+				Method2(int) int
+			})(nil)).Elem(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fit := gno2GoTypeMatches(tt.gnoIF, tt.goIF)
+			if fit != tt.expectFit {
+				t.Errorf("expected fit %v, but got %v", tt.expectFit, fit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Implements the functionality to convert Gno interface types with methods to Go types.

## Main changes

1. Modified the `gno2GoType` function:
   - For instances with methods, use the `collectInterfaceMethods` function to collect method information and convert to a struct type to represents each methods.
2. Implemented the rest `InterfaceType` part in the `gno2GoTypeMatches` function:
   - Compare the informations (e.g., identifer, params type, number of methods) of Gno interface and Go interface to determine if they match.

Related to #1929 