### PR TITLE
feat: bump max faucet drip amount

### DIFF
--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -116,7 +116,7 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&c.maxSendAmount,
 		"max-send-amount",
-		"1000000ugnot",
+		"5000000ugnot",
 		"the static max send amount (native currency)",
 	)
 

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -116,7 +116,7 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&c.maxSendAmount,
 		"max-send-amount",
-		"5000000ugnot",
+		"10000000ugnot",
 		"the static max send amount (native currency)",
 	)
 


### PR DESCRIPTION
## Description

This PR bumps the max faucet drip amount from `1gnot` to `10gnot`, to accommodate the desired [Faucet Hub](https://faucet.gnoteam.com) functionality (drip amounts in range `1gnot`, `5gnot`, `10gnot`).

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
