### PR TITLE
docs: add private key of test address to ease Adena registering

### DIFF
--- a/docs/gno-tooling/cli/faucet/gnofaucet.md
+++ b/docs/gno-tooling/cli/faucet/gnofaucet.md
@@ -40,7 +40,7 @@ gnokey add test1 --recover
 
 > **Test Seed Phrase:** source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate
 > oppose farm nothing bullet exhibit title speed wink action roast
-
+> **Test Private key:** ea97b9fddb7e6bf6867090a7a819657047949fbb9466d617f940538efd888605
 ### **Step 2. Run `gnofaucet`**
 
 ```bash


### PR DESCRIPTION

<!-- please provide a detailed description of the changes made in this pull request. -->

## Updated the official documentation or not needed

Currently Adena wallet only allow one seedphrase. Using the Private Key you can register this address without removing yours.