### PR TITLE
fix(docs): some NewHTTP functions were not renamed

### DIFF
--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -109,7 +109,7 @@ A few things to note:
 You can initialize the RPC Client used to connect to the Gno.land network with
 the following line:
 ```go
-rpc := rpcclient.NewHTTP("<gno_chain_endpoint>")
+rpc := rpcclient.NewHTTPClient("<gno_chain_endpoint>")
 ```
 
 A list of Gno.land network endpoints & chain IDs can be found in the [Gno RPC 
@@ -138,7 +138,7 @@ func main() {
 	}
 
 	// Initialize the RPC client
-	rpc := rpcclient.NewHTTP("<gno.land_remote_endpoint>")
+	rpc := rpcclient.NewHTTPClient("<gno.land_remote_endpoint>")
 	
 	// Initialize the gnoclient
 	client := gnoclient.Client{


### PR DESCRIPTION
Some NewHTTP functions were not renamed to NewHTTPClient.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
