### PR TITLE
fix: convert compatible types

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2435,7 +2435,10 @@ func checkOrConvertType(store Store, last BlockNode, x *Expr, t Type, autoNative
 		if t != nil {
 			checkType(xt, t, autoNative)
 		}
-		if isUntyped(xt) || xt.TypeID() != t.TypeID() {
+
+		// If untyped or xt and t are compatible types, convert x to an expression that
+		// yields type t.
+		if isUntyped(xt) || (t != nil && xt.TypeID() != t.TypeID()) {
 			if t == nil {
 				t = defaultTypeOf(xt)
 			}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2438,7 +2438,7 @@ func checkOrConvertType(store Store, last BlockNode, x *Expr, t Type, autoNative
 
 		// If untyped or xt and t are compatible types, convert x to an expression that
 		// yields type t.
-		if isUntyped(xt) || (t != nil && xt.TypeID() != t.TypeID() && !isNative(t)) {
+		if isUntyped(xt) || (t != nil && xt.TypeID() != t.TypeID() && !isNative(t) && !isNative(xt)) {
 			if t == nil {
 				t = defaultTypeOf(xt)
 			}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2435,7 +2435,7 @@ func checkOrConvertType(store Store, last BlockNode, x *Expr, t Type, autoNative
 		if t != nil {
 			checkType(xt, t, autoNative)
 		}
-		if isUntyped(xt) {
+		if isUntyped(xt) || xt.TypeID() != t.TypeID() {
 			if t == nil {
 				t = defaultTypeOf(xt)
 			}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2438,7 +2438,7 @@ func checkOrConvertType(store Store, last BlockNode, x *Expr, t Type, autoNative
 
 		// If untyped or xt and t are compatible types, convert x to an expression that
 		// yields type t.
-		if isUntyped(xt) || (t != nil && xt.TypeID() != t.TypeID()) {
+		if isUntyped(xt) || (t != nil && xt.TypeID() != t.TypeID() && !isNative(t)) {
 			if t == nil {
 				t = defaultTypeOf(xt)
 			}

--- a/gnovm/tests/files/type40.gno
+++ b/gnovm/tests/files/type40.gno
@@ -1,0 +1,20 @@
+package main
+
+type Set map[string]struct{}
+
+func NewSet(items ...string) Set {
+	return map[string]struct{}{}
+}
+
+func (s Set) Has(key string) bool {
+	_, ok := s[key]
+	return ok
+}
+
+func main() {
+	s := NewSet()
+	println(s.Has("a"))
+}
+
+// Output:
+// false


### PR DESCRIPTION
Closes #2006.

This PR ensures that the types returned or assigned are converted the the type that is expected.

I don't 100% understand the reason for excluding native and uverse types from being considered for conversion.  If anyone has an example that would break this, please include it in a comment.
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
