### PR TITLE
chore: simplify staging

### DIFF
--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -9,7 +9,7 @@ id: network-config
 | Portal Loop | https://rpc.gno.land:443          | `portal-loop` |
 | Test4       | https://rpc.test4.gno.land:443    | `test4`       |
 | Test3       | https://rpc.test3.gno.land:443    | `test3`       |
-| Staging     | http://rpc.staging.gno.land:36657 | `staging`     |
+| Staging     | https://rpc.staging.gno.land:443  | `staging`     |
 
 ### WebSocket endpoints
 All networks follow the same pattern for websocket connections: 

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   gnoland:
     image: ghcr.io/gnolang/gno/gnoland:master
-    restart: on-failure
+    restart: unless-stopped
     entrypoint: /entrypoint.sh
     working_dir: /gnoroot
     environment:
@@ -75,6 +75,7 @@ services:
 
   gnofaucet:
     image: ghcr.io/gnolang/gno/gnofaucet-slim
+    restart: unless-stopped
     command:
       - "serve"
       - "--listen-address=0.0.0.0:5050"
@@ -100,6 +101,7 @@ services:
 
   watchtower:
     image: containrrr/watchtower
+    restart: unless-stopped
     command: --interval 30 --http-api-metrics --label-enable
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -29,8 +29,9 @@ services:
       - ./letsencrypt:/letsencrypt
 
   gnoland:
-    image: ghcr.io/gnolang/gno
+    image: ghcr.io/gnolang/gno/gnoland
     restart: on-failure
+    working_dir: /gnoroot
     command: /entrypoint.sh
     environment:
       CHAIN_ID: staging

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -1,9 +1,10 @@
 
 services:
   traefik:
-    image: "traefik:v2.10"
+    image: "traefik:v2.11"
     restart: unless-stopped
     command:
+      - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
@@ -60,7 +61,7 @@ services:
       - gnoweb
       - --bind=0.0.0.0:8888
       - --remote=http://traefik:26657
-      - --faucet-url=https://faucet-api.staging.gnoteam.com
+      - --faucet-url=https://faucet-api.staging.gno.land
       - --captcha-site=$CAPTCHA_SITE_KEY
       - --with-analytics
       - --help-chainid=staging

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -1,130 +1,108 @@
-version: "2"
+
+version: "3"
 
 services:
-  gnoland:
-    container_name: gnoland
-    build: ../../..
-    environment:
-      - VIRTUAL_HOST=rpc.staging.gno.land
-      - VIRTUAL_PORT=26657
-      - LETSENCRYPT_HOST=rpc.staging.gno.land
-      - LOG_LEVEL=4
-    working_dir: /opt/gno/src/gno.land
+  traefik:
+    image: "traefik:v2.10"
+    restart: unless-stopped
     command:
-      - gnoland
-      - start
-      - --skip-failing-genesis-txs
-      - --chainid=staging
-      - --genesis-remote=staging.gno.land:26657
-    volumes:
-      - "./data/gnoland:/opt/gno/src/gno.land/gnoland-data"
-    ports:
-      - 26656:26656
-      - 26657:26657
-    restart: on-failure
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "10"
-        max-size: "100m"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.rpc.address=:26657"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+      - "--entryPoints.web.forwardedHeaders.insecure"
+      - "--entrypoints.traefik.address=:8080"
+      - "--entrypoints.websecure.address=:443"
 
-  gnoweb:
-    container_name: gnoweb
-    build: ../../..
-    command:
-      - gnoweb
-      - --bind=0.0.0.0:80
-      - --remote=gnoland:26657
-      - --captcha-site=$RECAPTCHA_SITE_KEY
-      - --faucet-url=https://faucet-staging.gno.land/
-      - --help-chainid=staging
-      - --help-remote=staging.gno.land:26657
-      - --with-analytics
-    volumes:
-      - "./overlay:/overlay:ro"
-    links:
-      - gnoland
-    environment:
-      - VIRTUAL_HOST=staging.gno.land
-      - LETSENCRYPT_HOST=staging.gno.land
-      # from .env
-      - RECAPTCHA_SITE_KEY
-    restart: on-failure
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "10"
-        max-size: "100m"
-
-  gnofaucet:
-    container_name: gnofaucet
-    build: ../../..
-    command: sh -xc "
-        date &&
-        mkdir -p /.gno &&
-        expect -c \"set timeout -1; spawn gnokey add --home /.gno/ --recover faucet; expect \\\"Enter a passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Repeat the passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Enter your bip39 mnemonic\\\"; send \\\"$FAUCET_WORDS\\r\\\"; expect eof\" &&
-        while true; do
-          expect -c \"set timeout -1; spawn gnofaucet serve --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:26657 --chain-id staging --home /.gno/ faucet; expect \\\"Enter password\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
-          sleep 5;
-        done
-      "
-    links:
-      - gnoland
-    environment:
-      - VIRTUAL_HOST=faucet-staging.gno.land
-      - VIRTUAL_PORT=5050
-      - LETSENCRYPT_HOST=faucet-staging.gno.land
-      # from .env
-      - RECAPTCHA_SECRET_KEY
-      - FAUCET_WORDS
-      - GNOKEY_PASS
-    ports:
-      - 5050
-    restart: on-failure
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "10"
-        max-size: "100m"
-
-  nginx-proxy:
-    image: nginxproxy/nginx-proxy
-    container_name: nginx-proxy
+      - "--certificatesresolvers.le.acme.tlschallenge=true"
+      - "--certificatesresolvers.le.acme.email=dev@gno.land"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
     ports:
       - "80:80"
       - "443:443"
+      - "26657:26657"
     volumes:
-      - conf:/etc/nginx/conf.d
-      - vhost:/etc/nginx/vhost.d
-      - html:/usr/share/nginx/html
-      - certs:/etc/nginx/certs:ro
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "10"
-        max-size: "100m"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - ./letsencrypt:/letsencrypt
 
-  acme-companion:
-    image: nginxproxy/acme-companion
-    container_name: nginx-proxy-acme
+  gnoland:
+    image: ghcr.io/gnolang/gno
+    restart: on-failure
+    command: /entrypoint.sh
     environment:
-      - DEFAULT_EMAIL=noreply@gno.land
-    volumes_from:
-      - nginx-proxy
+      CHAIN_ID: staging
+      MONIKER: gno-staging
     volumes:
-      - certs:/etc/nginx/certs:rw
-      - acme:/etc/acme.sh
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "10"
-        max-size: "100m"
+      - ./gnoland.entrypoint.sh:/entrypoint.sh
+    ports:
+      - 26656:26656
+      - 36657:26657
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+      traefik.enable: "true"
+      traefik.http.routers.gnoland.entrypoints: "web,websecure"
+      traefik.http.routers.gnoland.rule: "Host(`rpc.staging.gno.land`)"
+      traefik.http.routers.gnoland.service: gnoland-rpc
+      traefik.http.routers.gnoland.tls: "true"
+      traefik.http.routers.gnoland.tls.certresolver: "le"
+      traefik.http.routers.gnoland-rpc.entrypoints: "rpc"
+      traefik.http.routers.gnoland-rpc.rule: "Host(`rpc.staging.gno.land`)"
+      traefik.http.routers.gnoland-rpc.service: gnoland-rpc
+      traefik.http.services.gnoland-rpc.loadbalancer.server.port: 26657
 
-volumes:
-  conf:
-  vhost:
-  html:
-  certs:
-  acme:
+  gnoweb:
+    image: ghcr.io/gnolang/gno/gnoweb-slim
+    restart: unless-stopped
+    env_file: ".env"
+    entrypoint:
+      - gnoweb
+      - --bind=0.0.0.0:8888
+      - --remote=traefik:26657
+      - --faucet-url=https://faucet-api.staging.gnoteam.com
+      - --captcha-site=$CAPTCHA_SITE_KEY
+      - --with-analytics
+      - --help-chainid=staging
+      - --help-remote=https://rpc.gno.land:443
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+      traefik.enable: "true"
+      traefik.http.routers.gnoweb.entrypoints: "web,websecure"
+      traefik.http.routers.gnoweb.rule: "Host(`staging.gno.land`)"
+      traefik.http.routers.gnoweb.tls: "true"
+      traefik.http.routers.gnoweb.tls.certresolver: "le"
+
+  gnofaucet:
+    image: ghcr.io/gnolang/gno/gnofaucet-slim
+    command:
+      - "serve"
+      - "--listen-address=0.0.0.0:5050"
+      - "--chain-id=staging"
+      - "--is-behind-proxy=true"
+      - "--mnemonic=${FAUCET_MNEMONIC}"
+      - "--num-accounts=1"
+      - "--remote=http://traefik:26657"
+      - "--captcha-secret=${CAPTCHA_SECRET_KEY}"
+    env_file: ".env"
+    # environment:
+    # from .env
+    # - RECAPTCHA_SECRET_KEY
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+      traefik.enable: "true"
+      traefik.http.routers.gnofaucet-api.entrypoints: "websecure"
+      traefik.http.routers.gnofaucet-api.rule: "Host(`faucet-api.staging.gno.land`) || Host(`faucet-api.staging.gnoteam.com`)"
+      traefik.http.routers.gnofaucet-api.tls: "true"
+      traefik.http.routers.gnofaucet-api.tls.certresolver: "le"
+      traefik.http.middlewares.gnofaucet-ratelimit.ratelimit.average: "6"
+      traefik.http.middlewares.gnofaucet-ratelimit.ratelimit.period: "1m"
+
+  watchtower:
+    image: containrrr/watchtower
+    command: --interval 30 --http-api-metrics --label-enable
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      WATCHTOWER_HTTP_API_TOKEN: "mytoken"

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -1,4 +1,4 @@
-
+name: "staging-gno-land"
 services:
   traefik:
     image: "traefik:v2.11"
@@ -105,3 +105,20 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       WATCHTOWER_HTTP_API_TOKEN: "mytoken"
+
+  restarter:
+    image: docker:cli
+    restart: unless-stopped
+    entrypoint: [ "/bin/sh", "-c" ]
+    working_dir: "/app"
+    volumes:
+      - ".:/app"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    command:
+      - |
+        while true; do
+          if [ "$$(date +'%H:%M')" = '22:00' ]; then
+            docker compose restart gnoland
+          fi
+          sleep 60
+        done

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -37,9 +37,8 @@ services:
       MONIKER: gno-staging
     volumes:
       - ./gnoland.entrypoint.sh:/entrypoint.sh
-    ports:
-      - 26656:26656
-      - 36657:26657
+    #ports:
+    #  - 26656:26656
     labels:
       com.centurylinklabs.watchtower.enable: "true"
       traefik.enable: "true"

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       traefik.http.routers.gnoland.tls: "true"
       traefik.http.routers.gnoland.tls.certresolver: "le"
       traefik.http.routers.gnoland-rpc.entrypoints: "rpc"
-      traefik.http.routers.gnoland-rpc.rule: "Host(`rpc.staging.gno.land`)"
+      traefik.http.routers.gnoland-rpc.rule: "PathPrefix(`/`)"
       traefik.http.routers.gnoland-rpc.service: gnoland-rpc
       traefik.http.services.gnoland-rpc.loadbalancer.server.port: 26657
 
@@ -60,7 +60,7 @@ services:
     entrypoint:
       - gnoweb
       - --bind=0.0.0.0:8888
-      - --remote=traefik:26657
+      - --remote=http://traefik:26657
       - --faucet-url=https://faucet-api.staging.gnoteam.com
       - --captcha-site=$CAPTCHA_SITE_KEY
       - --with-analytics

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - --captcha-site=$CAPTCHA_SITE_KEY
       - --with-analytics
       - --help-chainid=staging
-      - --help-remote=https://rpc.gno.land:443
+      - --help-remote=https://rpc.staging.gno.land:443
     labels:
       com.centurylinklabs.watchtower.enable: "true"
       traefik.enable: "true"

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -1,6 +1,4 @@
 
-version: "3"
-
 services:
   traefik:
     image: "traefik:v2.10"
@@ -29,10 +27,10 @@ services:
       - ./letsencrypt:/letsencrypt
 
   gnoland:
-    image: ghcr.io/gnolang/gno/gnoland
+    image: ghcr.io/gnolang/gno/gnoland:master
     restart: on-failure
+    entrypoint: /entrypoint.sh
     working_dir: /gnoroot
-    command: /entrypoint.sh
     environment:
       CHAIN_ID: staging
       MONIKER: gno-staging
@@ -55,7 +53,7 @@ services:
       traefik.http.services.gnoland-rpc.loadbalancer.server.port: 26657
 
   gnoweb:
-    image: ghcr.io/gnolang/gno/gnoweb-slim
+    image: ghcr.io/gnolang/gno/gnoweb:master
     restart: unless-stopped
     env_file: ".env"
     entrypoint:

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -6,13 +6,14 @@ RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
 
 CHAIN_ID=${CHAIN_ID:-"dev"}
 
-/gnoland start \
+gnoland secret init
+gnoland config int
+
+gnoland config set moniker "${MONIKER}"
+gnoland config set rpc.laddr "${RPC_LADDR}"
+gnoland config set p2p.laddr "${P2P_LADDR}"
+
+exec gnoland start \
+    --skip-failing-genesis-txs \
     --chainid="${CHAIN_ID}" \
-    --skip-start=true \
-    --skip-failing-genesis-txs
-
-sed -i "s#^moniker = \".*\"#moniker = \"${MONIKER}\"#" ./gnoland-data/config/config.toml
-sed -i "s#laddr = \".*:26656\"#laddr = \"${P2P_LADDR}\"#" ./gnoland-data/config/config.toml
-sed -i "s#laddr = \".*:26657\"#laddr = \"${RPC_LADDR}\"#" ./gnoland-data/config/config.toml
-
-exec /gnoland start --skip-failing-genesis-txs
+    --lazy

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+MONIKER=${MONIKER:-"gnode"}
+P2P_LADDR=${P2P_LADDR:-"tcp://0.0.0.0:26656"}
+RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
+
+CHAIN_ID=${CHAIN_ID:-"dev"}
+
+gnoland start \
+    --chainid="${CHAIN_ID}" \
+    --skip-start=true \
+    --skip-failing-genesis-txs
+
+sed -i "s#^moniker = \".*\"#moniker = \"${MONIKER}\"#" ./gnoland-data/config/config.toml
+sed -i "s#laddr = \".*:26656\"#laddr = \"${P2P_LADDR}\"#" ./gnoland-data/config/config.toml
+sed -i "s#laddr = \".*:26657\"#laddr = \"${RPC_LADDR}\"#" ./gnoland-data/config/config.toml
+
+exec gnoland start --skip-failing-genesis-txs

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -6,7 +6,7 @@ MONIKER=${MONIKER:-"gnode"}
 P2P_LADDR=${P2P_LADDR:-"tcp://0.0.0.0:26656"}
 RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
 
-CHAIN_ID=${CHAIN_ID:-"dev"}
+CHAIN_ID=${CHAIN_ID:-"staging"}
 
 gnoland config  init
 gnoland secrets init

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -8,6 +8,8 @@ RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
 
 CHAIN_ID=${CHAIN_ID:-"staging"}
 
+rm -rfv ./gnoland-data genesis.json
+
 gnoland config  init
 gnoland secrets init
 

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env sh
 
+set -ex
+
 MONIKER=${MONIKER:-"gnode"}
 P2P_LADDR=${P2P_LADDR:-"tcp://0.0.0.0:26656"}
 RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
 
 CHAIN_ID=${CHAIN_ID:-"dev"}
 
-gnoland secret init
-gnoland config int
+gnoland config  init
+gnoland secrets init
 
 gnoland config set moniker "${MONIKER}"
 gnoland config set rpc.laddr "${RPC_LADDR}"

--- a/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
+++ b/misc/deployments/staging.gno.land/gnoland.entrypoint.sh
@@ -6,7 +6,7 @@ RPC_LADDR=${RPC_LADDR:-"tcp://0.0.0.0:26657"}
 
 CHAIN_ID=${CHAIN_ID:-"dev"}
 
-gnoland start \
+/gnoland start \
     --chainid="${CHAIN_ID}" \
     --skip-start=true \
     --skip-failing-genesis-txs
@@ -15,4 +15,4 @@ sed -i "s#^moniker = \".*\"#moniker = \"${MONIKER}\"#" ./gnoland-data/config/con
 sed -i "s#laddr = \".*:26656\"#laddr = \"${P2P_LADDR}\"#" ./gnoland-data/config/config.toml
 sed -i "s#laddr = \".*:26657\"#laddr = \"${RPC_LADDR}\"#" ./gnoland-data/config/config.toml
 
-exec gnoland start --skip-failing-genesis-txs
+exec /gnoland start --skip-failing-genesis-txs


### PR DESCRIPTION
This simplify the staging servers system.

It's using the docker image: [watchtower](https://github.com/containrrr/watchtower) to automatically pull-update new gno versions.

It's currently deployed on the server: we now have

- https://rpc.staging.gno.land
- http://rpc.staging.gno.land:26657
- http://rpc.staging.gno.land:36657 (to be compliant with previous version)

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
