### PR TITLE
fix(doc): add a missing rpcclient import

### DIFF
--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -123,6 +123,7 @@ package main
 import (
 	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 )
 
 func main() {


### PR DESCRIPTION
This PR adds an import of `rpcclient` that was missing in the doc.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
