### PR TITLE
fix(tm2/gnovm): multi-msg overwrites previous event(s)

### DIFF
--- a/examples/gno.land/r/demo/event/event.gno
+++ b/examples/gno.land/r/demo/event/event.gno
@@ -1,0 +1,9 @@
+package event
+
+import (
+	"std"
+)
+
+func Emit(value string) {
+	std.Emit("TAG", "key", value)
+}

--- a/examples/gno.land/r/demo/event/gno.mod
+++ b/examples/gno.land/r/demo/event/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/demo/event

--- a/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
@@ -1,18 +1,31 @@
 # load the package from $WORK directory
 loadpkg gno.land/r/demo/simple_event $WORK/event
 
+# start a new node
+gnoland start
+
+## test1 account should be available on default
+gnokey query auth/accounts/${USER_ADDR_test1}
+stdout 'height: 0'
+stdout 'data: {'
+stdout '  "BaseAccount": {'
+stdout '    "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",'
+stdout '    "coins": "[0-9]*ugnot",' # dynamic
+stdout '    "public_key": null,'
+stdout '    "account_number": "0",'
+stdout '    "sequence": "0"'
+stdout '  }'
+stdout '}'
+! stderr '.+' # empty
+
+
 ## sign
 gnokey sign -tx-path $WORK/multi/multi_msg.tx -chainid=tendermint_test -account-number 0 -account-sequence 0 test1
 stdout 'Tx successfully signed and saved to '
 
-
-# start a new node
-gnoland start
-
-
 ## broadcast
 gnokey broadcast $WORK/multi/multi_msg.tx -quiet=false
-stdout OK!
+
 
 -- event/simple_event.gno --
 package simple_event

--- a/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
@@ -1,0 +1,43 @@
+# load the package from $WORK directory
+loadpkg gno.land/r/demo/simple_event $WORK/event
+
+# start a new node
+gnoland start
+
+## test1 account should be available on default
+gnokey query auth/accounts/${USER_ADDR_test1}
+stdout 'height: 0'
+stdout 'data: {'
+stdout '  "BaseAccount": {'
+stdout '    "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",'
+stdout '    "coins": "[0-9]*ugnot",' # dynamic
+stdout '    "public_key": null,'
+stdout '    "account_number": "0",'
+stdout '    "sequence": "0"'
+stdout '  }'
+stdout '}'
+! stderr '.+' # empty
+
+
+## sign
+gnokey sign -tx-path $WORK/multi/multi_msg.tx -chainid=tendermint_test -account-number 0 -account-sequence 0 test1
+stdout 'Tx successfully signed and saved to '
+
+## broadcast
+gnokey broadcast $WORK/multi/multi_msg.tx -quiet=false
+## not stdout ??
+
+-- event/simple_event.gno --
+package simple_event
+
+import (
+	"std"
+)
+
+func Event(value string) {
+    std.Emit("TAG", "KEY", value)
+}
+
+-- multi/multi_msg.tx --
+{"msg":[{"@type":"/vm.m_call","caller":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5","send":"","pkg_path":"gno.land/r/demo/simple_event","func":"Event","args":["value11"]},{"@type":"/vm.m_call","caller":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5","send":"","pkg_path":"gno.land/r/demo/simple_event","func":"Event","args":["value22"]}],"fee":{"gas_wanted":"2000000","gas_fee":"1000000ugnot"},"signatures":null,"memo":""}
+

--- a/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_multi_msg.txtar
@@ -1,31 +1,18 @@
 # load the package from $WORK directory
 loadpkg gno.land/r/demo/simple_event $WORK/event
 
-# start a new node
-gnoland start
-
-## test1 account should be available on default
-gnokey query auth/accounts/${USER_ADDR_test1}
-stdout 'height: 0'
-stdout 'data: {'
-stdout '  "BaseAccount": {'
-stdout '    "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",'
-stdout '    "coins": "[0-9]*ugnot",' # dynamic
-stdout '    "public_key": null,'
-stdout '    "account_number": "0",'
-stdout '    "sequence": "0"'
-stdout '  }'
-stdout '}'
-! stderr '.+' # empty
-
-
 ## sign
 gnokey sign -tx-path $WORK/multi/multi_msg.tx -chainid=tendermint_test -account-number 0 -account-sequence 0 test1
 stdout 'Tx successfully signed and saved to '
 
+
+# start a new node
+gnoland start
+
+
 ## broadcast
 gnokey broadcast $WORK/multi/multi_msg.tx -quiet=false
-## not stdout ??
+stdout OK!
 
 -- event/simple_event.gno --
 package simple_event

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -164,6 +164,12 @@ func TestCallMultipleEvent_Integration(t *testing.T) {
 	blockRes, err := client.BlockResult(res.Height)
 	assert.Nil(t, err)
 
+	// only one tx in the block
+	assert.Len(t, blockRes.Results.DeliverTxs, 1)
+
+	// only two event in the tx
+	assert.Len(t, blockRes.Results.DeliverTxs[0].Events, 2)
+
 	// XXX: better comparison ?
 	event0 := fmt.Sprintf("%v", blockRes.Results.DeliverTxs[0].Events[0])
 	assert.Equal(t, event0, "{TAG gno.land/r/demo/event Emit [{key first_value}]}")
@@ -264,12 +270,12 @@ func TestSendMultiple_Integration(t *testing.T) {
 
 	// Execute send
 	res, err := client.Send(baseCfg, msg1, msg2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "", string(res.DeliverTx.Data))
 
 	// Get the new account balance
 	account, _, err := client.QueryAccount(toAddress)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := std.Coins{{"ugnot", int64(amount1 + amount2)}}
 	got := account.GetCoins()

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -1,7 +1,6 @@
 package gnoclient
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gnolang/gno/gnovm/pkg/gnolang"
@@ -112,70 +111,6 @@ func TestCallMultiple_Integration(t *testing.T) {
 	got := string(res.DeliverTx.Data)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, got)
-}
-
-func TestCallMultipleEvent_Integration(t *testing.T) {
-	// Set up in-memory node
-	config, _ := integration.TestingNodeConfig(t, gnoenv.RootDir())
-	node, remoteAddr := integration.TestingInMemoryNode(t, log.NewNoopLogger(), config)
-	defer node.Stop()
-
-	// Init Signer & RPCClient
-	signer := newInMemorySigner(t, "tendermint_test")
-	rpcClient, err := rpcclient.NewHTTPClient(remoteAddr)
-	require.NoError(t, err)
-
-	// Setup Client
-	client := Client{
-		Signer:    signer,
-		RPCClient: rpcClient,
-	}
-
-	// Make Tx config
-	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
-		GasWanted:      8000000,
-		AccountNumber:  0,
-		SequenceNumber: 0,
-		Memo:           "",
-	}
-
-	// Make Msg configs
-	msg1 := MsgCall{
-		PkgPath:  "gno.land/r/demo/event",
-		FuncName: "Emit",
-		Args:     []string{"first_value"},
-		Send:     "",
-	}
-
-	// Same call, different argument
-	msg2 := MsgCall{
-		PkgPath:  "gno.land/r/demo/event",
-		FuncName: "Emit",
-		Args:     []string{"second_value"},
-		Send:     "",
-	}
-
-	// Execute call
-	res, err := client.Call(baseCfg, msg1, msg2)
-	assert.Nil(t, err)
-
-	// check response from block_results to get event
-	blockRes, err := client.BlockResult(res.Height)
-	assert.Nil(t, err)
-
-	// only one tx in the block
-	assert.Len(t, blockRes.Results.DeliverTxs, 1)
-
-	// only two event in the tx
-	assert.Len(t, blockRes.Results.DeliverTxs[0].Events, 2)
-
-	// XXX: better comparison ?
-	event0 := fmt.Sprintf("%v", blockRes.Results.DeliverTxs[0].Events[0])
-	assert.Equal(t, event0, "{TAG gno.land/r/demo/event Emit [{key first_value}]}")
-
-	event1 := fmt.Sprintf("%v", blockRes.Results.DeliverTxs[0].Events[1])
-	assert.Equal(t, event1, "{TAG gno.land/r/demo/event Emit [{key second_value}]}")
 }
 
 func TestSendSingle_Integration(t *testing.T) {

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -170,7 +170,6 @@ func TestCallMultipleEvent_Integration(t *testing.T) {
 
 	event1 := fmt.Sprintf("%v", blockRes.Results.DeliverTxs[0].Events[1])
 	assert.Equal(t, event1, "{TAG gno.land/r/demo/event Emit [{key second_value}]}")
-
 }
 
 func TestSendSingle_Integration(t *testing.T) {

--- a/gnovm/stdlibs/stdshim/stdshim.gno
+++ b/gnovm/stdlibs/stdshim/stdshim.gno
@@ -79,3 +79,7 @@ func DecodeBech32(addr Address) (prefix string, bytes [20]byte, ok bool) {
 func DerivePkgAddr(pkgPath string) (addr Address) {
 	panic(shimWarn)
 }
+
+func Emit(tag, key, value string) {
+	panic(shimWarn)
+}

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -652,11 +652,9 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 		// Each message result's Data must be length prefixed in order to separate
 		// each result.
 		data = append(data, msgResult.Data...)
-		events = append(events, msgResult.Events...)
-		defer func() {
-			events = append(events, ctx.EventLogger().Events()...)
-			result.Events = events
-		}()
+		events = append(events, ctx.EventLogger().Events()...)
+		result.Events = events
+
 		// TODO append msgevent from ctx. XXX XXX
 
 		// stop execution and return on first failed message

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -624,6 +624,8 @@ func (app *BaseApp) getContextForTx(mode RunTxMode, txBytes []byte) (ctx Context
 
 // / runMsgs iterates through all the messages and executes them.
 func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Result) {
+	ctx = ctx.WithEventLogger(NewEventLogger())
+
 	msgLogs := make([]string, 0, len(msgs))
 
 	data := make([]byte, 0, len(msgs))
@@ -641,20 +643,17 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 		}
 
 		var msgResult Result
-		ctx = ctx.WithEventLogger(NewEventLogger())
 
 		// run the message!
 		// skip actual execution for CheckTx mode
 		if mode != RunTxModeCheck {
-			msgResult = handler.Process(ctx, msg)
+			msgResult = handler.Process(ctx, msg) // ctx event logger being updated in handler
 		}
 
 		// Each message result's Data must be length prefixed in order to separate
 		// each result.
 		data = append(data, msgResult.Data...)
 		events = append(events, msgResult.Events...)
-		events = append(events, ctx.EventLogger().Events()...)
-		result.Events = events
 
 		// stop execution and return on first failed message
 		if !msgResult.IsOK() {
@@ -669,12 +668,13 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 			fmt.Sprintf("msg:%d,success:%v,log:%s,events:%v",
 				i, true, msgResult.Log, events))
 	}
+	events = append(events, ctx.EventLogger().Events()...)
 
 	result.Error = ABCIError(err)
 	result.Data = data
+	result.Events = events
 	result.Log = strings.Join(msgLogs, "\n")
 	result.GasUsed = ctx.GasMeter().GasConsumed()
-	result.Events = events
 	return result
 }
 

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -652,10 +652,9 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 		// Each message result's Data must be length prefixed in order to separate
 		// each result.
 		data = append(data, msgResult.Data...)
+		events = append(events, msgResult.Events...)
 		events = append(events, ctx.EventLogger().Events()...)
 		result.Events = events
-
-		// TODO append msgevent from ctx. XXX XXX
 
 		// stop execution and return on first failed message
 		if !msgResult.IsOK() {


### PR DESCRIPTION
Closes #2028 

root cause: `defer` was used inside of loop that handles multi-msg. It was causing vm to use only last appended event value 

---
## AS-IS
```json
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "height": "43",
    "results": {
      "deliver_tx": [
        {
          "ResponseBase": {
            "Error": null,
            "Data": null,
            "Events": [
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event",
                "type": "other",
                "func": "Other",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              },
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event",
                "type": "other",
                "func": "Other",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              }
            ],
            "Log": "msg:0,success:true,log:,events:[]\nmsg:1,success:true,log:,events:[]",
            "Info": ""
          },
          "GasWanted": "2000000",
          "GasUsed": "270168"
        }
      ],
      "end_block": {
        "ResponseBase": {
          "Error": null,
          "Data": null,
          "Events": null,
          "Log": "",
          "Info": ""
        },
        "ValidatorUpdates": null,
        "ConsensusParams": null,
        "Events": null
      },
      "begin_block": {
        "ResponseBase": {
          "Error": null,
          "Data": null,
          "Events": null,
          "Log": "",
          "Info": ""
        }
      }
    }
  }
}
```
---

## TO-BE (in this PR)
```json
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "height": "6",
    "results": {
      "deliver_tx": [
        {
          "ResponseBase": {
            "Error": null,
            "Data": null,
            "Events": [
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event2",
                "type": "t",
                "func": "inner",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              },
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event2",
                "type": "t",
                "func": "Hello",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              },
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event",
                "type": "t",
                "func": "inner",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              },
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event",
                "type": "t",
                "func": "Hello",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              },
              {
                "@type": "/tm.gnoEvent",
                "pkg_path": "gno.land/r/demo/event",
                "type": "other",
                "func": "Other",
                "attrs": [
                  {
                    "key": "k",
                    "value": "v"
                  }
                ]
              }
            ],
            "Log": "msg:0,success:true,log:,events:[{gno.land/r/demo/event2 t inner [{k v}] \u003cnil\u003e} {gno.land/r/demo/event2 t Hello [{k v}] \u003cnil\u003e} {gno.land/r/demo/event t inner [{k v}] \u003cnil\u003e} {gno.land/r/demo/event t Hello [{k v}] \u003cnil\u003e}]\nmsg:1,success:true,log:,events:[{gno.land/r/demo/event2 t inner [{k v}] \u003cnil\u003e} {gno.land/r/demo/event2 t Hello [{k v}] \u003cnil\u003e} {gno.land/r/demo/event t inner [{k v}] \u003cnil\u003e} {gno.land/r/demo/event t Hello [{k v}] \u003cnil\u003e} {gno.land/r/demo/event other Other [{k v}] \u003cnil\u003e}]",
            "Info": ""
          },
          "GasWanted": "2000000",
          "GasUsed": "270168"
        }
      ],
      "end_block": {
        "ResponseBase": {
          "Error": null,
          "Data": null,
          "Events": null,
          "Log": "",
          "Info": ""
        },
        "ValidatorUpdates": null,
        "ConsensusParams": null,
        "Events": null
      },
      "begin_block": {
        "ResponseBase": {
          "Error": null,
          "Data": null,
          "Events": null,
          "Log": "",
          "Info": ""
        }
      }
    }
  }
}
```

FYI, unable to provide any test cases(unit test, integration test or txtar) due to lack of multi-msg testing.

---




<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
