### PR TITLE
chore(examples): rm inexistent dir in `make lint` targets; use `make` in ci

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -73,13 +73,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
-      - run: go install -v ./gnovm/cmd/gno
       # testing official directories, basically examples/ minus examples/.../x/.
-      - run: go run ./gnovm/cmd/gno lint -v ./examples/gno.land/p
-      - run: go run ./gnovm/cmd/gno lint -v ./examples/gno.land/r/demo
-      - run: go run ./gnovm/cmd/gno lint -v ./examples/gno.land/r/gnoland
-      - run: go run ./gnovm/cmd/gno lint -v ./examples/gno.land/r/sys
-      # - run: go run ./gnovm/cmd/gno lint -v ./examples/gno.land/r/gov
+      - run: make lint -C ./examples
       # TODO: consider running lint on every other directories, maybe in "warning" mode?
     # TODO: track coverage
   mod-tidy:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,7 +27,6 @@ OFFICIAL_PACKAGES = ./gno.land/p
 OFFICIAL_PACKAGES += ./gno.land/r/demo
 OFFICIAL_PACKAGES += ./gno.land/r/gnoland
 OFFICIAL_PACKAGES += ./gno.land/r/sys
-OFFICIAL_PACKAGES += ./gno.land/r/gov
 
 ########################################
 # Dev tools


### PR DESCRIPTION
Currently `cd examples && make lint` fails because `gno.land/r/gov` does not exists. This PR removes `gno.land/r/gov` from the targets and refactor the CI to run the make rule

## Before
```
❯ cd examples && make lint
go run ../gnovm/cmd/gno lint ./gno.land/p ./gno.land/r/demo ./gno.land/r/gnoland ./gno.land/r/sys ./gno.land/r/gov
list packages from args: invalid file or package path: stat ./gno.land/r/gov: no such file or directory
exit status 1
make: *** [lint] Error 1
```

## After
```
❯ cd examples && make lint
go run ../gnovm/cmd/gno lint ./gno.land/p ./gno.land/r/demo ./gno.land/r/gnoland ./gno.land/r/sys
```

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
