### PR TITLE
perf: WIP TV primitives

### DIFF
--- a/gnovm/pkg/gnolang/values_test.go
+++ b/gnovm/pkg/gnolang/values_test.go
@@ -1,0 +1,126 @@
+package gnolang
+
+import (
+	"math"
+	"testing"
+)
+
+func BenchmarkTVGetBool(b *testing.B) {
+	var tv TypedValue
+	tv.N[0] = 1
+	for i := 0; i < b.N; i++ {
+		tv.GetBool()
+	}
+}
+
+func BenchmarkTVGetBoolNew(b *testing.B) {
+	var tv TypedValue
+	tv.N[0] = 1
+	for i := 0; i < b.N; i++ {
+		tv.GetBoolNew()
+	}
+}
+
+func BenchmarkTVSetBool(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetBool(true)
+	}
+}
+
+func BenchmarkTVSetBoolNew(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetBoolNew(true)
+	}
+}
+
+func BenchmarkTVGetInt(b *testing.B) {
+	var tv TypedValue
+	tv.SetInt(math.MaxInt64)
+	for i := 0; i < b.N; i++ {
+		tv.GetInt()
+	}
+}
+
+func BenchmarkTVGetIntNew(b *testing.B) {
+	var tv TypedValue
+	tv.SetIntNew(math.MaxInt64)
+	for i := 0; i < b.N; i++ {
+		tv.GetIntNew()
+	}
+}
+
+func BenchmarkTVSetInt(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetInt(math.MaxInt64)
+	}
+}
+
+func BenchmarkTVSetIntNew(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetIntNew(math.MaxInt64)
+	}
+}
+
+func BenchmarkTVSetInt16(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetInt16(math.MaxInt16)
+	}
+}
+
+func BenchmarkTVSetInt16New(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetInt16New(math.MaxInt16)
+	}
+}
+
+func BenchmarkTVGetInt16(b *testing.B) {
+	var tv TypedValue
+	tv.SetInt16(math.MaxInt16)
+	for i := 0; i < b.N; i++ {
+		tv.GetInt16()
+	}
+}
+
+func BenchmarkTVGetInt16New(b *testing.B) {
+	var tv TypedValue
+	tv.SetInt16New(math.MaxInt16)
+	for i := 0; i < b.N; i++ {
+		tv.GetInt16New()
+	}
+}
+
+func BenchmarkTVSetFloat64(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetFloat64(math.MaxFloat64)
+	}
+}
+
+func BenchmarkTVSetFloat64New(b *testing.B) {
+	var tv TypedValue
+	for i := 0; i < b.N; i++ {
+		tv.SetFloat64New(math.MaxFloat64)
+	}
+}
+
+func BenchmarkTVGetFloat64(b *testing.B) {
+	var tv TypedValue
+	tv.SetFloat64(math.MaxFloat64)
+	for i := 0; i < b.N; i++ {
+		tv.GetFloat64()
+	}
+}
+
+func BenchmarkTVGetFloat64New(b *testing.B) {
+	var tv TypedValue
+	tv.SetFloat64New(math.MaxFloat64)
+	for i := 0; i < b.N; i++ {
+		tv.GetFloat64New()
+	}
+}


### PR DESCRIPTION
I noticed recently that many `TypedValue` instances that represent primitive types are set and get using the `unsafe.Pointer` function.  Curious as to this function's performance versus the more traditional methods, I wrote some new methods and benchmarked them agains the existing.  The new methods appear to be about six times more performant than the existing ones in most cases, and not statistically different in others.

Initial results:
```
go test -cpu 1,2,4,8 -benchmem -bench '^BenchmarkTV' -run=^$           
goos: darwin
goarch: amd64
pkg: github.com/gnolang/gno/gnovm/pkg/gnolang
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkTVGetBool              616270255                1.919 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetBool-2            623206738                1.859 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetBool-4            645019149                1.825 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetBool-8            628096153                1.897 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetBoolNew           1000000000               0.3015 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetBoolNew-2         1000000000               0.2997 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetBoolNew-4         1000000000               0.3026 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetBoolNew-8         1000000000               0.3009 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetBool              636429537                1.895 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetBool-2            612271684                1.983 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetBool-4            583097722                1.923 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetBool-8            608042474                1.949 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetBoolNew           1000000000               0.3109 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetBoolNew-2         1000000000               0.3116 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetBoolNew-4         1000000000               0.3101 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetBoolNew-8         1000000000               0.3080 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetInt               596222908                1.979 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt-2             565257805                2.024 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt-4             603462258                1.913 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt-8             623668717                1.896 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetIntNew            1000000000               0.3049 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetIntNew-2          1000000000               0.3035 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetIntNew-4          1000000000               0.3139 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetIntNew-8          1000000000               0.3006 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetInt               646375224                1.819 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt-2             639805758                1.817 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt-4             641337288                1.840 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt-8             636959119                1.836 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetIntNew            1000000000               0.3011 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetIntNew-2          1000000000               0.3017 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetIntNew-4          1000000000               0.2984 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetIntNew-8          1000000000               0.2909 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetInt16             606400609                1.887 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt16-2           603016816                1.914 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt16-4           623541004                1.875 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt16-8           612831452                1.910 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetInt16New          1000000000               0.2953 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetInt16New-2        1000000000               0.2925 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetInt16New-4        1000000000               0.2927 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetInt16New-8        1000000000               0.2919 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetInt16             616311234                1.839 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16-2           625753400                1.869 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16-4           646589143                1.897 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16-8           618113557                1.880 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16New          627622730                1.949 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16New-2        626688157                2.092 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16New-4        626905478                1.831 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetInt16New-8        618756903                1.860 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetFloat64           639282193                1.821 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetFloat64-2         631872494                1.868 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetFloat64-4         650367344                1.909 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetFloat64-8         610595700                2.442 ns/op           0 B/op          0 allocs/op
BenchmarkTVSetFloat64New        1000000000               0.3213 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetFloat64New-2      1000000000               0.3178 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetFloat64New-4      1000000000               0.3207 ns/op          0 B/op          0 allocs/op
BenchmarkTVSetFloat64New-8      1000000000               0.3222 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetFloat64           591416228                2.062 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetFloat64-2         564586014                2.109 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetFloat64-4         591356316                2.078 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetFloat64-8         577659637                2.043 ns/op           0 B/op          0 allocs/op
BenchmarkTVGetFloat64New        1000000000               0.3111 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetFloat64New-2      1000000000               0.3208 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetFloat64New-4      1000000000               0.3136 ns/op          0 B/op          0 allocs/op
BenchmarkTVGetFloat64New-8      1000000000               0.3093 ns/op          0 B/op          0 allocs/op
```

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
