### PR TITLE
fix: register hljs plaintext language

### DIFF
--- a/gno.land/pkg/gnoweb/static/js/highlight.min.js
+++ b/gno.land/pkg/gnoweb/static/js/highlight.min.js
@@ -1,106 +1,331 @@
 /*!
-  Highlight.js v11.5.1 (git: b8f233c8e2)
-  (c) 2006-2022 Ivan Sagalaev and other contributors
+  Highlight.js v11.9.0 (git: b7ec4bfafc)
+  (c) 2006-2024 undefined and other contributors
   License: BSD-3-Clause
  */
-  var hljs=(function(){"use strict";var e={exports:{}};function t(e){return(e instanceof Map?(e.clear=e.delete=e.set=()=>{throw Error("map is read-only")}):e instanceof Set&&(e.add=e.clear=e.delete=()=>{throw Error("set is read-only")}),Object.freeze(e),Object.getOwnPropertyNames(e).forEach((n)=>{var i=e[n];"object"!=typeof i||Object.isFrozen(i)||t(i)}),e)}(e.exports=t),(e.exports.default=t);var n=e.exports;class i{constructor(e){void 0===e.data&&(e.data={}),(this.data=e.data),(this.isMatchIgnored=!1)}
-  ignoreMatch(){this.isMatchIgnored=!0}}
-  function r(e){return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")}
-  function s(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t];return(t.forEach((e)=>{for(const t in e)n[t]=e[t]}),n)}
-  const o=(e)=>!!e.kind;class a{constructor(e,t){(this.buffer=""),(this.classPrefix=t.classPrefix),e.walk(this)}
-  addText(e){this.buffer+=r(e)}
-  openNode(e){if(!o(e))return;let t=e.kind;(t=e.sublanguage?"language-"+t:((e,{prefix:t})=>{if(e.includes(".")){const n=e.split(".");return[`${t}${n.shift()}`,...n.map((e,t)=>`${e}${"_".repeat(t + 1)}`)].join(" ")}
-  return `${t}${e}`})(t,{prefix:this.classPrefix})),this.span(t)}
-  closeNode(e){o(e)&&(this.buffer+="</span>")}
-  value(){return this.buffer}
-  span(e){this.buffer+=`<span class="${e}">`}}
-  class c{constructor(){(this.rootNode={children:[],}),(this.stack=[this.rootNode])}
-  get top(){return this.stack[this.stack.length-1]}
-  get root(){return this.rootNode}
-  add(e){this.top.children.push(e)}
-  openNode(e){const t={kind:e,children:[]};this.add(t),this.stack.push(t)}
-  closeNode(){if(this.stack.length>1)return this.stack.pop();}
-  closeAllNodes(){for(;this.closeNode(););}
-  toJSON(){return JSON.stringify(this.rootNode,null,4)}
-  walk(e){return this.constructor._walk(e,this.rootNode)}
-  static _walk(e,t){return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),t.children.forEach((t)=>this._walk(e,t)),e.closeNode(t)),e}
-  static _collapse(e){"string"!=typeof e&&e.children&&(e.children.every((e)=>"string"==typeof e)?(e.children=[e.children.join("")]):e.children.forEach((e)=>{c._collapse(e)}))}}
-  class l extends c{constructor(e){super(),(this.options=e)}
-  addKeyword(e,t){""!==e&&(this.openNode(t),this.addText(e),this.closeNode())}
-  addText(e){""!==e&&this.add(e)}
-  addSublanguage(e,t){const n=e.root;(n.kind=t),(n.sublanguage=!0),this.add(n)}
-  toHTML(){return new a(this,this.options).value()}
-  finalize(){return!0}}
-  function g(e){return e?("string"==typeof e?e:e.source):null}
-  function d(e){return f("(?=",e,")")}
-  function u(e){return f("(?:",e,")*")}
-  function h(e){return f("(?:",e,")?")}
-  function f(...e){return e.map((e)=>g(e)).join("")}
-  function p(...e){const t=((e)=>{const t=e[e.length-1];return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}})(e);return"("+(t.capture?"":"?:")+e.map((e)=>g(e)).join("|")+")"}
-  function b(e){return RegExp(e.toString()+"|").exec("").length-1}
-  const m=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./;function E(e,{joinWith:t}){let n=0;return e.map((e)=>{n+=1;const t=n;let i=g(e),r="";for(;i.length>0;){const e=m.exec(i);if(!e){r+=i;break}(r+=i.substring(0,e.index)),(i=i.substring(e.index+e[0].length)),"\\"===e[0][0]&&e[1]?(r+="\\"+(Number(e[1])+t)):((r+=e[0]),"("===e[0]&&n++)}
-  return r}).map((e)=>`(${e})`).join(t)}
-  const x="[a-zA-Z]\\w*",w="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",_="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",k="\\b(0b[01]+)",v={begin:"\\\\[\\s\\S]",relevance:0,},O={scope:"string",begin:"'",end:"'",illegal:"\\n",contains:[v]},N={scope:"string",begin:'"',end:'"',illegal:"\\n",contains:[v]},M=(e,t,n={})=>{const i=s({scope:"comment",begin:e,end:t,contains:[]},n);i.contains.push({scope:"doctag",begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0});const r=p("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/);return i.contains.push({begin:f(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i},S=M("//","$"),R=M("/\\*","\\*/"),j=M("#","$");var A=Object.freeze({__proto__:null,MATCH_NOTHING_RE:/\b\B/,IDENT_RE:x,UNDERSCORE_IDENT_RE:w,NUMBER_RE:y,C_NUMBER_RE:_,BINARY_NUMBER_RE:k,RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",SHEBANG:(e={})=>{const t=/^#![ ]*\//;return(e.binary&&(e.begin=f(t,/.*\b/,e.binary,/\b.*/)),s({scope:"meta",begin:t,end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()},},e))},BACKSLASH_ESCAPE:v,APOS_STRING_MODE:O,QUOTE_STRING_MODE:N,PHRASAL_WORDS_MODE:{begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/,},COMMENT:M,C_LINE_COMMENT_MODE:S,C_BLOCK_COMMENT_MODE:R,HASH_COMMENT_MODE:j,NUMBER_MODE:{scope:"number",begin:y,relevance:0},C_NUMBER_MODE:{scope:"number",begin:_,relevance:0},BINARY_NUMBER_MODE:{scope:"number",begin:k,relevance:0},REGEXP_MODE:{begin:/(?=\/[^/\n]*\/)/,contains:[{scope:"regexp",begin:/\//,end:/\/[gimuy]*/,illegal:/\n/,contains:[v,{begin:/\[/,end:/\]/,relevance:0,contains:[v]}]}]},TITLE_MODE:{scope:"title",begin:x,relevance:0},UNDERSCORE_TITLE_MODE:{scope:"title",begin:w,relevance:0},METHOD_GUARD:{begin:"\\.\\s*[a-zA-Z_]\\w*",relevance:0,},END_SAME_AS_BEGIN:(e)=>Object.assign(e,{"on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{t.data._beginMatch!==e[1]&&t.ignoreMatch()},}),});function I(e,t){"."===e.input[e.index-1]&&t.ignoreMatch()}
-  function T(e,t){void 0!==e.className&&((e.scope=e.className),delete e.className)}
-  function L(e,t){t&&e.beginKeywords&&((e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)"),(e.__beforeBegin=I),(e.keywords=e.keywords||e.beginKeywords),delete e.beginKeywords,void 0===e.relevance&&(e.relevance=0))}
-  function B(e,t){Array.isArray(e.illegal)&&(e.illegal=p(...e.illegal))}
-  function D(e,t){if(e.match){if(e.begin||e.end)throw Error("begin & end are not supported with match");(e.begin=e.match),delete e.match}}
-  function H(e,t){void 0===e.relevance&&(e.relevance=1)}
-  const P=(e,t)=>{if(!e.beforeMatch)return;if(e.starts)throw Error("beforeMatch cannot be used with starts");const n=Object.assign({},e);Object.keys(e).forEach((t)=>{delete e[t]}),(e.keywords=n.keywords),(e.begin=f(n.beforeMatch,d(n.begin))),(e.starts={relevance:0,contains:[Object.assign(n,{endsParent:!0})],}),(e.relevance=0),delete n.beforeMatch},C=["of","and","for","in","not","or","if","then","parent","list","value"];function $(e,t,n="keyword"){const i=Object.create(null);return("string"==typeof e?r(n,e.split(" ")):Array.isArray(e)?r(n,e):Object.keys(e).forEach((n)=>{Object.assign(i,$(e[n],t,n))}),i);function r(e,n){t&&(n=n.map((e)=>e.toLowerCase())),n.forEach((t)=>{const n=t.split("|");i[n[0]]=[e,U(n[0],n[1])]})}}
-  function U(e,t){return t?Number(t):((e)=>C.includes(e.toLowerCase()))(e)?0:1}
-  const z={},K=(e)=>{console.error(e)},W=(e,...t)=>{console.log("WARN: "+e,...t)},X=(e,t)=>{z[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),(z[`${e}/${t}`]=!0))},G=Error();function Z(e,t,{key:n}){let i=0;const r=e[n],s={},o={};for(let e=1;e<=t.length;e++)(o[e+i]=r[e]),(s[e+i]=!0),(i+=b(t[e-1]));(e[n]=o),(e[n]._emit=s),(e[n]._multi=!0)}
-  function F(e){((e)=>{e.scope&&"object"==typeof e.scope&&null!==e.scope&&((e.beginScope=e.scope),delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={_wrap:e.beginScope,}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope}),((e)=>{if(Array.isArray(e.begin)){if(e.skip||e.excludeBegin||e.returnBegin)throw(K("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),G);if("object"!=typeof e.beginScope||null===e.beginScope)throw(K("beginScope must be object"),G);Z(e,e.begin,{key:"beginScope"}),(e.begin=E(e.begin,{joinWith:""}))}})(e),((e)=>{if(Array.isArray(e.end)){if(e.skip||e.excludeEnd||e.returnEnd)throw(K("skip, excludeEnd, returnEnd not compatible with endScope: {}"),G);if("object"!=typeof e.endScope||null===e.endScope)throw(K("endScope must be object"),G);Z(e,e.end,{key:"endScope"}),(e.end=E(e.end,{joinWith:""}))}})(e)}
-  function V(e){function t(t,n){return RegExp(g(t),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(n?"g":""))}
-  class n{constructor(){(this.matchIndexes={}),(this.regexes=[]),(this.matchAt=1),(this.position=0)}
-  addRule(e,t){(t.position=this.position++),(this.matchIndexes[this.matchAt]=t),this.regexes.push([t,e]),(this.matchAt+=b(e)+1)}
-  compile(){0===this.regexes.length&&(this.exec=()=>null);const e=this.regexes.map((e)=>e[1]);(this.matcherRe=t(E(e,{joinWith:"|"}),!0)),(this.lastIndex=0)}
-  exec(e){this.matcherRe.lastIndex=this.lastIndex;const t=this.matcherRe.exec(e);if(!t)return null;const n=t.findIndex((e,t)=>t>0&&void 0!==e),i=this.matchIndexes[n];return t.splice(0,n),Object.assign(t,i)}}
-  class i{constructor(){(this.rules=[]),(this.multiRegexes=[]),(this.count=0),(this.lastIndex=0),(this.regexIndex=0)}
-  getMatcher(e){if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n();return this.rules.slice(e).forEach(([e,n])=>t.addRule(e,n)),t.compile(),(this.multiRegexes[e]=t),t}
-  resumingScanAtSamePosition(){return 0!==this.regexIndex}
-  considerAll(){this.regexIndex=0}
-  addRule(e,t){this.rules.push([e,t]),"begin"===t.type&&this.count++}
-  exec(e){const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex;let n=t.exec(e);if(this.resumingScanAtSamePosition())
-  if(n&&n.index===this.lastIndex);else{const t=this.getMatcher(0);(t.lastIndex=this.lastIndex+1),(n=t.exec(e))}
-  return n&&((this.regexIndex+=n.position+1),this.regexIndex===this.count&&this.considerAll()),n}}
-  if((e.compilerExtensions||(e.compilerExtensions=[]),e.contains&&e.contains.includes("self")))
-  throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.");return((e.classNameAliases=s(e.classNameAliases||{})),(function n(r,o){const a=r;if(r.isCompiled)return a;[T,D,F,P].forEach((e)=>e(r,o)),e.compilerExtensions.forEach((e)=>e(r,o)),(r.__beforeBegin=null),[L,B,H].forEach((e)=>e(r,o)),(r.isCompiled=!0);let c=null;return("object"==typeof r.keywords&&r.keywords.$pattern&&((r.keywords=Object.assign({},r.keywords)),(c=r.keywords.$pattern),delete r.keywords.$pattern),(c=c||/\w+/),r.keywords&&(r.keywords=$(r.keywords,e.case_insensitive)),(a.keywordPatternRe=t(c,!0)),o&&(r.begin||(r.begin=/\B|\b/),(a.beginRe=t(a.begin)),r.end||r.endsWithParent||(r.end=/\B|\b/),r.end&&(a.endRe=t(a.end)),(a.terminatorEnd=g(a.end)||""),r.endsWithParent&&o.terminatorEnd&&(a.terminatorEnd+=(r.end?"|":"")+o.terminatorEnd)),r.illegal&&(a.illegalRe=t(r.illegal)),r.contains||(r.contains=[]),(r.contains=[].concat(...r.contains.map((e)=>((e)=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t)=>s(e,{variants:null,},t))),e.cachedVariants?e.cachedVariants:q(e)?s(e,{starts:e.starts?s(e.starts):null,}):Object.isFrozen(e)?s(e):e))("self"===e?r:e)))),r.contains.forEach((e)=>{n(e,a)}),r.starts&&n(r.starts,o),(a.matcher=((e)=>{const t=new i();return(e.contains.forEach((e)=>t.addRule(e.begin,{rule:e,type:"begin"})),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"}),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t)})(a)),a)})(e))}
-  function q(e){return!!e&&(e.endsWithParent||q(e.starts))}
-  class J extends Error{constructor(e,t){super(e),(this.name="HTMLInjectionError"),(this.html=t)}}
-  const Y=r,Q=s,ee=Symbol("nomatch");var te=((e)=>{const t=Object.create(null),r=Object.create(null),s=[];let o=!0;const a="Could not find the language '{}', did you forget to load/include a language module?",c={disableAutodetect:!0,name:"Plain text",contains:[],};let g={ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",cssSelector:"pre code",languages:null,__emitter:l,};function b(e){return g.noHighlightRe.test(e)}
-  function m(e,t,n){let i="",r="";"object"==typeof t?((i=e),(n=t.ignoreIllegals),(r=t.language)):(X("10.7.0","highlight(lang, code, ...args) has been deprecated."),X("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),(r=e),(i=t)),void 0===n&&(n=!0);const s={code:i,language:r};N("before:highlight",s);const o=s.result?s.result:E(s.language,s.code,n);return(o.code=s.code),N("after:highlight",o),o}
-  function E(e,n,r,s){const c=Object.create(null);function l(){if(!O.keywords)return void M.addText(S);let e=0;O.keywordPatternRe.lastIndex=0;let t=O.keywordPatternRe.exec(S),n="";for(;t;){n+=S.substring(e,t.index);const r=y.case_insensitive?t[0].toLowerCase():t[0],s=((i=r),O.keywords[i]);if(s){const[e,i]=s;if((M.addText(n),(n=""),(c[r]=(c[r]||0)+1),c[r]<=7&&(R+=i),e.startsWith("_")))n+=t[0];else{const n=y.classNameAliases[e]||e;M.addKeyword(t[0],n)}}else n+=t[0];(e=O.keywordPatternRe.lastIndex),(t=O.keywordPatternRe.exec(S))}
-  var i;(n+=S.substr(e)),M.addText(n)}
-  function d(){null!=O.subLanguage?(()=>{if(""===S)return;let e=null;if("string"==typeof O.subLanguage){if(!t[O.subLanguage])return void M.addText(S);(e=E(O.subLanguage,S,!0,N[O.subLanguage])),(N[O.subLanguage]=e._top)}else e=x(S,O.subLanguage.length?O.subLanguage:null);O.relevance>0&&(R+=e.relevance),M.addSublanguage(e._emitter,e.language)})():l(),(S="")}
-  function u(e,t){let n=1;const i=t.length-1;for(;n<=i;){if(!e._emit[n]){n++;continue}
-  const i=y.classNameAliases[e[n]]||e[n],r=t[n];i?M.addKeyword(r,i):((S=r),l(),(S="")),n++}}
-  function h(e,t){return(e.scope&&"string"==typeof e.scope&&M.openNode(y.classNameAliases[e.scope]||e.scope),e.beginScope&&(e.beginScope._wrap?(M.addKeyword(S,y.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),(S="")):e.beginScope._multi&&(u(e.beginScope,t),(S=""))),(O=Object.create(e,{parent:{value:O,},})),O)}
-  function f(e,t,n){let r=((e,t)=>{const n=e&&e.exec(t);return n&&0===n.index})(e.endRe,n);if(r){if(e["on:end"]){const n=new i(e);e["on:end"](t,n),n.isMatchIgnored&&(r=!1)}
-  if(r){for(;e.endsParent&&e.parent;)e=e.parent;return e}}
-  if(e.endsWithParent)return f(e.parent,t,n);}
-  function p(e){return 0===O.matcher.regexIndex?((S+=e[0]),1):((I=!0),0)}
-  function b(e){const t=e[0],i=n.substr(e.index),r=f(O,e,i);if(!r)return ee;const s=O;O.endScope&&O.endScope._wrap?(d(),M.addKeyword(t,O.endScope._wrap)):O.endScope&&O.endScope._multi?(d(),u(O.endScope,e)):s.skip?(S+=t):(s.returnEnd||s.excludeEnd||(S+=t),d(),s.excludeEnd&&(S=t));do{O.scope&&M.closeNode(),O.skip||O.subLanguage||(R+=O.relevance),(O=O.parent)}while(O!==r.parent);return r.starts&&h(r.starts,e),s.returnEnd?0:t.length}
-  let m={};function w(t,s){const a=s&&s[0];if(((S+=t),null==a))return d(),0;if("begin"===m.type&&"end"===s.type&&m.index===s.index&&""===a){if(((S+=n.slice(s.index,s.index+1)),!o)){const t=Error(`0 width match regex (${e})`);throw((t.languageName=e),(t.badRule=m.rule),t)}
-  return 1}
-  if(((m=s),"begin"===s.type))
-  return((e)=>{const t=e[0],n=e.rule,r=new i(n),s=[n.__beforeBegin,n["on:begin"]];for(const n of s)if(n&&(n(e,r),r.isMatchIgnored))return p(t);return n.skip?(S+=t):(n.excludeBegin&&(S+=t),d(),n.returnBegin||n.excludeBegin||(S=t)),h(n,e),n.returnBegin?0:t.length})(s);if("illegal"===s.type&&!r){const e=Error('Illegal lexeme "'+a+'" for mode "'+(O.scope||"<unnamed>")+'"');throw((e.mode=O),e)}
-  if("end"===s.type){const e=b(s);if(e!==ee)return e}
-  if("illegal"===s.type&&""===a)return 1;if(A>1e5&&A>3*s.index)throw Error("potential infinite loop, way more iterations than matches");return(S+=a),a.length}
-  const y=k(e);if(!y)throw(K(a.replace("{}",e)),Error('Unknown language: "'+e+'"'));const _=V(y);let v="",O=s||_;const N={},M=new g.__emitter(g);(()=>{const e=[];for(let t=O;t!==y;t=t.parent)t.scope&&e.unshift(t.scope);e.forEach((e)=>M.openNode(e))})();let S="",R=0,j=0,A=0,I=!1;try{for(O.matcher.considerAll();;){A++,I?(I=!1):O.matcher.considerAll(),(O.matcher.lastIndex=j);const e=O.matcher.exec(n);if(!e)break;const t=w(n.substring(j,e.index),e);j=e.index+t}
-  return(w(n.substr(j)),M.closeAllNodes(),M.finalize(),(v=M.toHTML()),{language:e,value:v,relevance:R,illegal:!1,_emitter:M,_top:O,})}catch(t){if(t.message&&t.message.includes("Illegal"))
-  return{language:e,value:Y(n),illegal:!0,relevance:0,_illegalBy:{message:t.message,index:j,context:n.slice(j-100,j+100),mode:t.mode,resultSoFar:v},_emitter:M};if(o)
-  return{language:e,value:Y(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:O,};throw t}}
-  function x(e,n){n=n||g.languages||Object.keys(t);const i=((e)=>{const t={value:Y(e),illegal:!1,relevance:0,_top:c,_emitter:new g.__emitter(g)};return t._emitter.addText(e),t})(e),r=n.filter(k).filter(O).map((t)=>E(t,e,!1));r.unshift(i);const s=r.sort((e,t)=>{if(e.relevance!==t.relevance)return t.relevance-e.relevance;if(e.language&&t.language){if(k(e.language).supersetOf===t.language)return 1;if(k(t.language).supersetOf===e.language)return-1}
-  return 0}),[o,a]=s,l=o;return(l.secondBest=a),l}
-  function w(e){let t=null;const n=((e)=>{let t=e.className+" ";t+=e.parentNode?e.parentNode.className:"";const n=g.languageDetectRe.exec(t);if(n){const t=k(n[1]);return t||(W(a.replace("{}",n[1])),W("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
-  return t.split(/\s+/).find((e)=>b(e)||k(e))})(e);if(b(n))return;if((N("before:highlightElement",{el:e,language:n}),e.children.length>0&&(g.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),console.warn("The element with unescaped HTML:"),console.warn(e)),g.throwUnescapedHTML)))
-  throw new J("One of your code blocks includes unescaped HTML.",e.innerHTML);t=e;const i=t.textContent,s=n?m(i,{language:n,ignoreIllegals:!0}):x(i);(e.innerHTML=s.value),((e,t,n)=>{const i=(t&&r[t])||n;e.classList.add("hljs"),e.classList.add("language-"+i)})(e,n,s.language),(e.result={language:s.language,re:s.relevance,relevance:s.relevance}),s.secondBest&&(e.secondBest={language:s.secondBest.language,relevance:s.secondBest.relevance,}),N("after:highlightElement",{el:e,result:s,text:i})}
-  let y=!1;function _(){"loading"!==document.readyState?document.querySelectorAll(g.cssSelector).forEach(w):(y=!0)}
-  function k(e){return(e=(e||"").toLowerCase()),t[e]||t[r[e]]}
-  function v(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e)=>{r[e.toLowerCase()]=t})}
-  function O(e){const t=k(e);return t&&!t.disableAutodetect}
-  function N(e,t){const n=e;s.forEach((e)=>{e[n]&&e[n](t)})}
-  "undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",()=>{y&&_()},!1),Object.assign(e,{highlight:m,highlightAuto:x,highlightAll:_,highlightElement:w,highlightBlock:(e)=>(X("10.7.0","highlightBlock will be removed entirely in v12.0"),X("10.7.0","Please use highlightElement now."),w(e)),configure:(e)=>{g=Q(g,e)},initHighlighting:()=>{_(),X("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},initHighlightingOnLoad:()=>{_(),X("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")},registerLanguage:(n,i)=>{let r=null;try{r=i(e)}catch(e){if((K("Language definition for '{}' could not be registered.".replace("{}",n)),!o))throw e;K(e),(r=c)}
-  r.name||(r.name=n),(t[n]=r),(r.rawDefinition=i.bind(null,e)),r.aliases&&v(r.aliases,{languageName:n,})},unregisterLanguage:(e)=>{delete t[e];for(const t of Object.keys(r))r[t]===e&&delete r[t]},listLanguages:()=>Object.keys(t),getLanguage:k,registerAliases:v,autoDetection:O,inherit:Q,addPlugin:(e)=>{((e)=>{e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=(t)=>{e["before:highlightBlock"](Object.assign({block:t.el},t))}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=(t)=>{e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),s.push(e)},}),(e.debugMode=()=>{o=!1}),(e.safeMode=()=>{o=!0}),(e.versionString="11.5.1"),(e.regex={concat:f,lookahead:d,either:p,optional:h,anyNumberOfTimes:u});for(const e in A)"object"==typeof A[e]&&n(A[e]);return Object.assign(e,A),e})({});return te})();"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);/*! `go` grammar compiled for Highlight.js 11.5.1 */
-  (()=>{var e=(()=>{"use strict";return(e)=>{const n={keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var",],type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune",],literal:["true","false","iota","nil"],built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"],};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1},e.C_NUMBER_MODE],},{begin:/:=/},{className:"function",beginKeywords:"func",end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}],},],}}})();hljs.registerLanguage("go",e)})();/*! `json` grammar compiled for Highlight.js 11.5.1 */
-  (()=>{var e=(()=>{"use strict";return(e)=>({name:"JSON",contains:[{className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,relevance:1.01,},{match:/[{}[\],:]/,className:"punctuation",relevance:0,},e.QUOTE_STRING_MODE,{beginKeywords:"true false null",},e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,],illegal:"\\S",})})();hljs.registerLanguage("json",e);hljs.registerLanguage("plaintext",e)})()
+  var hljs=function(){"use strict";function e(t){
+    return t instanceof Map?t.clear=t.delete=t.set=()=>{
+    throw Error("map is read-only")}:t instanceof Set&&(t.add=t.clear=t.delete=()=>{
+    throw Error("set is read-only")
+    }),Object.freeze(t),Object.getOwnPropertyNames(t).forEach((n=>{
+    const i=t[n],s=typeof i;"object"!==s&&"function"!==s||Object.isFrozen(i)||e(i)
+    })),t}class t{constructor(e){
+    void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+    ignoreMatch(){this.isMatchIgnored=!0}}function n(e){
+    return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+    }function i(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t]
+    ;return t.forEach((e=>{for(const t in e)n[t]=e[t]})),n}const s=e=>!!e.scope
+    ;class o{constructor(e,t){
+    this.buffer="",this.classPrefix=t.classPrefix,e.walk(this)}addText(e){
+    this.buffer+=n(e)}openNode(e){if(!s(e))return;const t=((e,{prefix:t})=>{
+    if(e.startsWith("language:"))return e.replace("language:","language-")
+    ;if(e.includes(".")){const n=e.split(".")
+    ;return[`${t}${n.shift()}`,...n.map(((e,t)=>`${e}${"_".repeat(t+1)}`))].join(" ")
+    }return`${t}${e}`})(e.scope,{prefix:this.classPrefix});this.span(t)}
+    closeNode(e){s(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+    this.buffer+=`<span class="${e}">`}}const r=(e={})=>{const t={children:[]}
+    ;return Object.assign(t,e),t};class a{constructor(){
+    this.rootNode=r(),this.stack=[this.rootNode]}get top(){
+    return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+    this.top.children.push(e)}openNode(e){const t=r({scope:e})
+    ;this.add(t),this.stack.push(t)}closeNode(){
+    if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+    for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+    walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,t){
+    return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),
+    t.children.forEach((t=>this._walk(e,t))),e.closeNode(t)),e}static _collapse(e){
+    "string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+    a._collapse(e)})))}}class c extends a{constructor(e){super(),this.options=e}
+    addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+    this.closeNode()}__addSublanguage(e,t){const n=e.root
+    ;t&&(n.scope="language:"+t),this.add(n)}toHTML(){
+    return new o(this,this.options).value()}finalize(){
+    return this.closeAllNodes(),!0}}function l(e){
+    return e?"string"==typeof e?e:e.source:null}function g(e){return h("(?=",e,")")}
+    function u(e){return h("(?:",e,")*")}function d(e){return h("(?:",e,")?")}
+    function h(...e){return e.map((e=>l(e))).join("")}function f(...e){const t=(e=>{
+    const t=e[e.length-1]
+    ;return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}
+    })(e);return"("+(t.capture?"":"?:")+e.map((e=>l(e))).join("|")+")"}
+    function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+    const b=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+    ;function m(e,{joinWith:t}){let n=0;return e.map((e=>{n+=1;const t=n
+    ;let i=l(e),s="";for(;i.length>0;){const e=b.exec(i);if(!e){s+=i;break}
+    s+=i.substring(0,e.index),
+    i=i.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?s+="\\"+(Number(e[1])+t):(s+=e[0],
+    "("===e[0]&&n++)}return s})).map((e=>`(${e})`)).join(t)}
+    const E="[a-zA-Z]\\w*",x="[a-zA-Z_]\\w*",w="\\b\\d+(\\.\\d+)?",y="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",_="\\b(0b[01]+)",O={
+    begin:"\\\\[\\s\\S]",relevance:0},v={scope:"string",begin:"'",end:"'",
+    illegal:"\\n",contains:[O]},k={scope:"string",begin:'"',end:'"',illegal:"\\n",
+    contains:[O]},N=(e,t,n={})=>{const s=i({scope:"comment",begin:e,end:t,
+    contains:[]},n);s.contains.push({scope:"doctag",
+    begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+    end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+    ;const o=f("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+    ;return s.contains.push({begin:h(/[ ]+/,"(",o,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),s
+    },S=N("//","$"),M=N("/\\*","\\*/"),R=N("#","$");var j=Object.freeze({
+    __proto__:null,APOS_STRING_MODE:v,BACKSLASH_ESCAPE:O,BINARY_NUMBER_MODE:{
+    scope:"number",begin:_,relevance:0},BINARY_NUMBER_RE:_,COMMENT:N,
+    C_BLOCK_COMMENT_MODE:M,C_LINE_COMMENT_MODE:S,C_NUMBER_MODE:{scope:"number",
+    begin:y,relevance:0},C_NUMBER_RE:y,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+    "on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{
+    t.data._beginMatch!==e[1]&&t.ignoreMatch()}}),HASH_COMMENT_MODE:R,IDENT_RE:E,
+    MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+x,relevance:0},
+    NUMBER_MODE:{scope:"number",begin:w,relevance:0},NUMBER_RE:w,
+    PHRASAL_WORDS_MODE:{
+    begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+    },QUOTE_STRING_MODE:k,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+    end:/\/[gimuy]*/,contains:[O,{begin:/\[/,end:/\]/,relevance:0,contains:[O]}]},
+    RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+    SHEBANG:(e={})=>{const t=/^#![ ]*\//
+    ;return e.binary&&(e.begin=h(t,/.*\b/,e.binary,/\b.*/)),i({scope:"meta",begin:t,
+    end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()}},e)},
+    TITLE_MODE:{scope:"title",begin:E,relevance:0},UNDERSCORE_IDENT_RE:x,
+    UNDERSCORE_TITLE_MODE:{scope:"title",begin:x,relevance:0}});function A(e,t){
+    "."===e.input[e.index-1]&&t.ignoreMatch()}function I(e,t){
+    void 0!==e.className&&(e.scope=e.className,delete e.className)}function T(e,t){
+    t&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+    e.__beforeBegin=A,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+    void 0===e.relevance&&(e.relevance=0))}function L(e,t){
+    Array.isArray(e.illegal)&&(e.illegal=f(...e.illegal))}function B(e,t){
+    if(e.match){
+    if(e.begin||e.end)throw Error("begin & end are not supported with match")
+    ;e.begin=e.match,delete e.match}}function P(e,t){
+    void 0===e.relevance&&(e.relevance=1)}const D=(e,t)=>{if(!e.beforeMatch)return
+    ;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+    ;const n=Object.assign({},e);Object.keys(e).forEach((t=>{delete e[t]
+    })),e.keywords=n.keywords,e.begin=h(n.beforeMatch,g(n.begin)),e.starts={
+    relevance:0,contains:[Object.assign(n,{endsParent:!0})]
+    },e.relevance=0,delete n.beforeMatch
+    },H=["of","and","for","in","not","or","if","then","parent","list","value"],C="keyword"
+    ;function $(e,t,n=C){const i=Object.create(null)
+    ;return"string"==typeof e?s(n,e.split(" ")):Array.isArray(e)?s(n,e):Object.keys(e).forEach((n=>{
+    Object.assign(i,$(e[n],t,n))})),i;function s(e,n){
+    t&&(n=n.map((e=>e.toLowerCase()))),n.forEach((t=>{const n=t.split("|")
+    ;i[n[0]]=[e,U(n[0],n[1])]}))}}function U(e,t){
+    return t?Number(t):(e=>H.includes(e.toLowerCase()))(e)?0:1}const z={},W=e=>{
+    console.error(e)},X=(e,...t)=>{console.log("WARN: "+e,...t)},G=(e,t)=>{
+    z[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),z[`${e}/${t}`]=!0)
+    },K=Error();function F(e,t,{key:n}){let i=0;const s=e[n],o={},r={}
+    ;for(let e=1;e<=t.length;e++)r[e+i]=s[e],o[e+i]=!0,i+=p(t[e-1])
+    ;e[n]=r,e[n]._emit=o,e[n]._multi=!0}function Z(e){(e=>{
+    e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+    delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+    _wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+    }),(e=>{if(Array.isArray(e.begin)){
+    if(e.skip||e.excludeBegin||e.returnBegin)throw W("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+    K
+    ;if("object"!=typeof e.beginScope||null===e.beginScope)throw W("beginScope must be object"),
+    K;F(e,e.begin,{key:"beginScope"}),e.begin=m(e.begin,{joinWith:""})}})(e),(e=>{
+    if(Array.isArray(e.end)){
+    if(e.skip||e.excludeEnd||e.returnEnd)throw W("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+    K
+    ;if("object"!=typeof e.endScope||null===e.endScope)throw W("endScope must be object"),
+    K;F(e,e.end,{key:"endScope"}),e.end=m(e.end,{joinWith:""})}})(e)}function V(e){
+    function t(t,n){
+    return RegExp(l(t),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(n?"g":""))
+    }class n{constructor(){
+    this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+    addRule(e,t){
+    t.position=this.position++,this.matchIndexes[this.matchAt]=t,this.regexes.push([t,e]),
+    this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+    ;const e=this.regexes.map((e=>e[1]));this.matcherRe=t(m(e,{joinWith:"|"
+    }),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+    ;const t=this.matcherRe.exec(e);if(!t)return null
+    ;const n=t.findIndex(((e,t)=>t>0&&void 0!==e)),i=this.matchIndexes[n]
+    ;return t.splice(0,n),Object.assign(t,i)}}class s{constructor(){
+    this.rules=[],this.multiRegexes=[],
+    this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+    if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n
+    ;return this.rules.slice(e).forEach((([e,n])=>t.addRule(e,n))),
+    t.compile(),this.multiRegexes[e]=t,t}resumingScanAtSamePosition(){
+    return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,t){
+    this.rules.push([e,t]),"begin"===t.type&&this.count++}exec(e){
+    const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex
+    ;let n=t.exec(e)
+    ;if(this.resumingScanAtSamePosition())if(n&&n.index===this.lastIndex);else{
+    const t=this.getMatcher(0);t.lastIndex=this.lastIndex+1,n=t.exec(e)}
+    return n&&(this.regexIndex+=n.position+1,
+    this.regexIndex===this.count&&this.considerAll()),n}}
+    if(e.compilerExtensions||(e.compilerExtensions=[]),
+    e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+    ;return e.classNameAliases=i(e.classNameAliases||{}),function n(o,r){const a=o
+    ;if(o.isCompiled)return a
+    ;[I,B,Z,D].forEach((e=>e(o,r))),e.compilerExtensions.forEach((e=>e(o,r))),
+    o.__beforeBegin=null,[T,L,P].forEach((e=>e(o,r))),o.isCompiled=!0;let c=null
+    ;return"object"==typeof o.keywords&&o.keywords.$pattern&&(o.keywords=Object.assign({},o.keywords),
+    c=o.keywords.$pattern,
+    delete o.keywords.$pattern),c=c||/\w+/,o.keywords&&(o.keywords=$(o.keywords,e.case_insensitive)),
+    a.keywordPatternRe=t(c,!0),
+    r&&(o.begin||(o.begin=/\B|\b/),a.beginRe=t(a.begin),o.end||o.endsWithParent||(o.end=/\B|\b/),
+    o.end&&(a.endRe=t(a.end)),
+    a.terminatorEnd=l(a.end)||"",o.endsWithParent&&r.terminatorEnd&&(a.terminatorEnd+=(o.end?"|":"")+r.terminatorEnd)),
+    o.illegal&&(a.illegalRe=t(o.illegal)),
+    o.contains||(o.contains=[]),o.contains=[].concat(...o.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t=>i(e,{
+    variants:null},t)))),e.cachedVariants?e.cachedVariants:q(e)?i(e,{
+    starts:e.starts?i(e.starts):null
+    }):Object.isFrozen(e)?i(e):e))("self"===e?o:e)))),o.contains.forEach((e=>{n(e,a)
+    })),o.starts&&n(o.starts,r),a.matcher=(e=>{const t=new s
+    ;return e.contains.forEach((e=>t.addRule(e.begin,{rule:e,type:"begin"
+    }))),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"
+    }),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t})(a),a}(e)}function q(e){
+    return!!e&&(e.endsWithParent||q(e.starts))}class J extends Error{
+    constructor(e,t){super(e),this.name="HTMLInjectionError",this.html=t}}
+    const Y=n,Q=i,ee=Symbol("nomatch"),te=n=>{
+    const i=Object.create(null),s=Object.create(null),o=[];let r=!0
+    ;const a="Could not find the language '{}', did you forget to load/include a language module?",l={
+    disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+    ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+    languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+    cssSelector:"pre code",languages:null,__emitter:c};function b(e){
+    return p.noHighlightRe.test(e)}function m(e,t,n){let i="",s=""
+    ;"object"==typeof t?(i=e,
+    n=t.ignoreIllegals,s=t.language):(G("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+    G("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+    s=e,i=t),void 0===n&&(n=!0);const o={code:i,language:s};N("before:highlight",o)
+    ;const r=o.result?o.result:E(o.language,o.code,n)
+    ;return r.code=o.code,N("after:highlight",r),r}function E(e,n,s,o){
+    const c=Object.create(null);function l(){if(!N.keywords)return void M.addText(R)
+    ;let e=0;N.keywordPatternRe.lastIndex=0;let t=N.keywordPatternRe.exec(R),n=""
+    ;for(;t;){n+=R.substring(e,t.index)
+    ;const s=_.case_insensitive?t[0].toLowerCase():t[0],o=(i=s,N.keywords[i]);if(o){
+    const[e,i]=o
+    ;if(M.addText(n),n="",c[s]=(c[s]||0)+1,c[s]<=7&&(j+=i),e.startsWith("_"))n+=t[0];else{
+    const n=_.classNameAliases[e]||e;u(t[0],n)}}else n+=t[0]
+    ;e=N.keywordPatternRe.lastIndex,t=N.keywordPatternRe.exec(R)}var i
+    ;n+=R.substring(e),M.addText(n)}function g(){null!=N.subLanguage?(()=>{
+    if(""===R)return;let e=null;if("string"==typeof N.subLanguage){
+    if(!i[N.subLanguage])return void M.addText(R)
+    ;e=E(N.subLanguage,R,!0,S[N.subLanguage]),S[N.subLanguage]=e._top
+    }else e=x(R,N.subLanguage.length?N.subLanguage:null)
+    ;N.relevance>0&&(j+=e.relevance),M.__addSublanguage(e._emitter,e.language)
+    })():l(),R=""}function u(e,t){
+    ""!==e&&(M.startScope(t),M.addText(e),M.endScope())}function d(e,t){let n=1
+    ;const i=t.length-1;for(;n<=i;){if(!e._emit[n]){n++;continue}
+    const i=_.classNameAliases[e[n]]||e[n],s=t[n];i?u(s,i):(R=s,l(),R=""),n++}}
+    function h(e,t){
+    return e.scope&&"string"==typeof e.scope&&M.openNode(_.classNameAliases[e.scope]||e.scope),
+    e.beginScope&&(e.beginScope._wrap?(u(R,_.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+    R=""):e.beginScope._multi&&(d(e.beginScope,t),R="")),N=Object.create(e,{parent:{
+    value:N}}),N}function f(e,n,i){let s=((e,t)=>{const n=e&&e.exec(t)
+    ;return n&&0===n.index})(e.endRe,i);if(s){if(e["on:end"]){const i=new t(e)
+    ;e["on:end"](n,i),i.isMatchIgnored&&(s=!1)}if(s){
+    for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+    if(e.endsWithParent)return f(e.parent,n,i)}function b(e){
+    return 0===N.matcher.regexIndex?(R+=e[0],1):(T=!0,0)}function m(e){
+    const t=e[0],i=n.substring(e.index),s=f(N,e,i);if(!s)return ee;const o=N
+    ;N.endScope&&N.endScope._wrap?(g(),
+    u(t,N.endScope._wrap)):N.endScope&&N.endScope._multi?(g(),
+    d(N.endScope,e)):o.skip?R+=t:(o.returnEnd||o.excludeEnd||(R+=t),
+    g(),o.excludeEnd&&(R=t));do{
+    N.scope&&M.closeNode(),N.skip||N.subLanguage||(j+=N.relevance),N=N.parent
+    }while(N!==s.parent);return s.starts&&h(s.starts,e),o.returnEnd?0:t.length}
+    let w={};function y(i,o){const a=o&&o[0];if(R+=i,null==a)return g(),0
+    ;if("begin"===w.type&&"end"===o.type&&w.index===o.index&&""===a){
+    if(R+=n.slice(o.index,o.index+1),!r){const t=Error(`0 width match regex (${e})`)
+    ;throw t.languageName=e,t.badRule=w.rule,t}return 1}
+    if(w=o,"begin"===o.type)return(e=>{
+    const n=e[0],i=e.rule,s=new t(i),o=[i.__beforeBegin,i["on:begin"]]
+    ;for(const t of o)if(t&&(t(e,s),s.isMatchIgnored))return b(n)
+    ;return i.skip?R+=n:(i.excludeBegin&&(R+=n),
+    g(),i.returnBegin||i.excludeBegin||(R=n)),h(i,e),i.returnBegin?0:n.length})(o)
+    ;if("illegal"===o.type&&!s){
+    const e=Error('Illegal lexeme "'+a+'" for mode "'+(N.scope||"<unnamed>")+'"')
+    ;throw e.mode=N,e}if("end"===o.type){const e=m(o);if(e!==ee)return e}
+    if("illegal"===o.type&&""===a)return 1
+    ;if(I>1e5&&I>3*o.index)throw Error("potential infinite loop, way more iterations than matches")
+    ;return R+=a,a.length}const _=O(e)
+    ;if(!_)throw W(a.replace("{}",e)),Error('Unknown language: "'+e+'"')
+    ;const v=V(_);let k="",N=o||v;const S={},M=new p.__emitter(p);(()=>{const e=[]
+    ;for(let t=N;t!==_;t=t.parent)t.scope&&e.unshift(t.scope)
+    ;e.forEach((e=>M.openNode(e)))})();let R="",j=0,A=0,I=0,T=!1;try{
+    if(_.__emitTokens)_.__emitTokens(n,M);else{for(N.matcher.considerAll();;){
+    I++,T?T=!1:N.matcher.considerAll(),N.matcher.lastIndex=A
+    ;const e=N.matcher.exec(n);if(!e)break;const t=y(n.substring(A,e.index),e)
+    ;A=e.index+t}y(n.substring(A))}return M.finalize(),k=M.toHTML(),{language:e,
+    value:k,relevance:j,illegal:!1,_emitter:M,_top:N}}catch(t){
+    if(t.message&&t.message.includes("Illegal"))return{language:e,value:Y(n),
+    illegal:!0,relevance:0,_illegalBy:{message:t.message,index:A,
+    context:n.slice(A-100,A+100),mode:t.mode,resultSoFar:k},_emitter:M};if(r)return{
+    language:e,value:Y(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:N}
+    ;throw t}}function x(e,t){t=t||p.languages||Object.keys(i);const n=(e=>{
+    const t={value:Y(e),illegal:!1,relevance:0,_top:l,_emitter:new p.__emitter(p)}
+    ;return t._emitter.addText(e),t})(e),s=t.filter(O).filter(k).map((t=>E(t,e,!1)))
+    ;s.unshift(n);const o=s.sort(((e,t)=>{
+    if(e.relevance!==t.relevance)return t.relevance-e.relevance
+    ;if(e.language&&t.language){if(O(e.language).supersetOf===t.language)return 1
+    ;if(O(t.language).supersetOf===e.language)return-1}return 0})),[r,a]=o,c=r
+    ;return c.secondBest=a,c}function w(e){let t=null;const n=(e=>{
+    let t=e.className+" ";t+=e.parentNode?e.parentNode.className:""
+    ;const n=p.languageDetectRe.exec(t);if(n){const t=O(n[1])
+    ;return t||(X(a.replace("{}",n[1])),
+    X("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
+    return t.split(/\s+/).find((e=>b(e)||O(e)))})(e);if(b(n))return
+    ;if(N("before:highlightElement",{el:e,language:n
+    }),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+    ;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+    console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+    console.warn("The element with unescaped HTML:"),
+    console.warn(e)),p.throwUnescapedHTML))throw new J("One of your code blocks includes unescaped HTML.",e.innerHTML)
+    ;t=e;const i=t.textContent,o=n?m(i,{language:n,ignoreIllegals:!0}):x(i)
+    ;e.innerHTML=o.value,e.dataset.highlighted="yes",((e,t,n)=>{const i=t&&s[t]||n
+    ;e.classList.add("hljs"),e.classList.add("language-"+i)
+    })(e,n,o.language),e.result={language:o.language,re:o.relevance,
+    relevance:o.relevance},o.secondBest&&(e.secondBest={
+    language:o.secondBest.language,relevance:o.secondBest.relevance
+    }),N("after:highlightElement",{el:e,result:o,text:i})}let y=!1;function _(){
+    "loading"!==document.readyState?document.querySelectorAll(p.cssSelector).forEach(w):y=!0
+    }function O(e){return e=(e||"").toLowerCase(),i[e]||i[s[e]]}
+    function v(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+    s[e.toLowerCase()]=t}))}function k(e){const t=O(e)
+    ;return t&&!t.disableAutodetect}function N(e,t){const n=e;o.forEach((e=>{
+    e[n]&&e[n](t)}))}
+    "undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
+    y&&_()}),!1),Object.assign(n,{highlight:m,highlightAuto:x,highlightAll:_,
+    highlightElement:w,
+    highlightBlock:e=>(G("10.7.0","highlightBlock will be removed entirely in v12.0"),
+    G("10.7.0","Please use highlightElement now."),w(e)),configure:e=>{p=Q(p,e)},
+    initHighlighting:()=>{
+    _(),G("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+    initHighlightingOnLoad:()=>{
+    _(),G("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+    },registerLanguage:(e,t)=>{let s=null;try{s=t(n)}catch(t){
+    if(W("Language definition for '{}' could not be registered.".replace("{}",e)),
+    !r)throw t;W(t),s=l}
+    s.name||(s.name=e),i[e]=s,s.rawDefinition=t.bind(null,n),s.aliases&&v(s.aliases,{
+    languageName:e})},unregisterLanguage:e=>{delete i[e]
+    ;for(const t of Object.keys(s))s[t]===e&&delete s[t]},
+    listLanguages:()=>Object.keys(i),getLanguage:O,registerAliases:v,
+    autoDetection:k,inherit:Q,addPlugin:e=>{(e=>{
+    e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=t=>{
+    e["before:highlightBlock"](Object.assign({block:t.el},t))
+    }),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=t=>{
+    e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),o.push(e)},
+    removePlugin:e=>{const t=o.indexOf(e);-1!==t&&o.splice(t,1)}}),n.debugMode=()=>{
+    r=!1},n.safeMode=()=>{r=!0},n.versionString="11.9.0",n.regex={concat:h,
+    lookahead:g,either:f,optional:d,anyNumberOfTimes:u}
+    ;for(const t in j)"object"==typeof j[t]&&e(j[t]);return Object.assign(n,j),n
+    },ne=te({});return ne.newInstance=()=>te({}),ne}()
+    ;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);/*! `go` grammar compiled for Highlight.js 11.9.0 */
+    (()=>{var e=(()=>{"use strict";return e=>{const n={
+    keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
+    type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
+    literal:["true","false","iota","nil"],
+    built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
+    };return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
+    contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
+    variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
+    className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1
+    },e.C_NUMBER_MODE]},{begin:/:=/},{className:"function",beginKeywords:"func",
+    end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",
+    begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}]}]}}})()
+    ;hljs.registerLanguage("go",e)})();/*! `json` grammar compiled for Highlight.js 11.9.0 */
+    (()=>{var e=(()=>{"use strict";return e=>{const a=["true","false","null"],n={
+    scope:"literal",beginKeywords:a.join(" ")};return{name:"JSON",keywords:{
+    literal:a},contains:[{className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+    relevance:1.01},{match:/[{}[\],:]/,className:"punctuation",relevance:0
+    },e.QUOTE_STRING_MODE,n,e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],
+    illegal:"\\S"}}})();hljs.registerLanguage("json",e)})();/*! `plaintext` grammar compiled for Highlight.js 11.9.0 */
+    (()=>{var t=(()=>{"use strict";return t=>({name:"Plain text",
+    aliases:["text","txt"],disableAutodetect:!0})})()
+    ;hljs.registerLanguage("plaintext",t)})();

--- a/gno.land/pkg/gnoweb/static/js/highlight.min.js
+++ b/gno.land/pkg/gnoweb/static/js/highlight.min.js
@@ -3,320 +3,104 @@
   (c) 2006-2022 Ivan Sagalaev and other contributors
   License: BSD-3-Clause
  */
-var hljs=function(){"use strict";var e={exports:{}};function t(e){
-return e instanceof Map?e.clear=e.delete=e.set=()=>{
-throw Error("map is read-only")}:e instanceof Set&&(e.add=e.clear=e.delete=()=>{
-throw Error("set is read-only")
-}),Object.freeze(e),Object.getOwnPropertyNames(e).forEach((n=>{var i=e[n]
-;"object"!=typeof i||Object.isFrozen(i)||t(i)})),e}
-e.exports=t,e.exports.default=t;var n=e.exports;class i{constructor(e){
-void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
-ignoreMatch(){this.isMatchIgnored=!0}}function r(e){
-return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
-}function s(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t]
-;return t.forEach((e=>{for(const t in e)n[t]=e[t]})),n}const o=e=>!!e.kind
-;class a{constructor(e,t){
-this.buffer="",this.classPrefix=t.classPrefix,e.walk(this)}addText(e){
-this.buffer+=r(e)}openNode(e){if(!o(e))return;let t=e.kind
-;t=e.sublanguage?"language-"+t:((e,{prefix:t})=>{if(e.includes(".")){
-const n=e.split(".")
-;return[`${t}${n.shift()}`,...n.map(((e,t)=>`${e}${"_".repeat(t+1)}`))].join(" ")
-}return`${t}${e}`})(t,{prefix:this.classPrefix}),this.span(t)}closeNode(e){
-o(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
-this.buffer+=`<span class="${e}">`}}class c{constructor(){this.rootNode={
-children:[]},this.stack=[this.rootNode]}get top(){
-return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
-this.top.children.push(e)}openNode(e){const t={kind:e,children:[]}
-;this.add(t),this.stack.push(t)}closeNode(){
-if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
-for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
-walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,t){
-return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),
-t.children.forEach((t=>this._walk(e,t))),e.closeNode(t)),e}static _collapse(e){
-"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
-c._collapse(e)})))}}class l extends c{constructor(e){super(),this.options=e}
-addKeyword(e,t){""!==e&&(this.openNode(t),this.addText(e),this.closeNode())}
-addText(e){""!==e&&this.add(e)}addSublanguage(e,t){const n=e.root
-;n.kind=t,n.sublanguage=!0,this.add(n)}toHTML(){
-return new a(this,this.options).value()}finalize(){return!0}}function g(e){
-return e?"string"==typeof e?e:e.source:null}function d(e){return f("(?=",e,")")}
-function u(e){return f("(?:",e,")*")}function h(e){return f("(?:",e,")?")}
-function f(...e){return e.map((e=>g(e))).join("")}function p(...e){const t=(e=>{
-const t=e[e.length-1]
-;return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}
-})(e);return"("+(t.capture?"":"?:")+e.map((e=>g(e))).join("|")+")"}
-function b(e){return RegExp(e.toString()+"|").exec("").length-1}
-const m=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
-;function E(e,{joinWith:t}){let n=0;return e.map((e=>{n+=1;const t=n
-;let i=g(e),r="";for(;i.length>0;){const e=m.exec(i);if(!e){r+=i;break}
-r+=i.substring(0,e.index),
-i=i.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?r+="\\"+(Number(e[1])+t):(r+=e[0],
-"("===e[0]&&n++)}return r})).map((e=>`(${e})`)).join(t)}
-const x="[a-zA-Z]\\w*",w="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",_="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",k="\\b(0b[01]+)",v={
-begin:"\\\\[\\s\\S]",relevance:0},O={scope:"string",begin:"'",end:"'",
-illegal:"\\n",contains:[v]},N={scope:"string",begin:'"',end:'"',illegal:"\\n",
-contains:[v]},M=(e,t,n={})=>{const i=s({scope:"comment",begin:e,end:t,
-contains:[]},n);i.contains.push({scope:"doctag",
-begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
-end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
-;const r=p("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
-;return i.contains.push({begin:f(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
-},S=M("//","$"),R=M("/\\*","\\*/"),j=M("#","$");var A=Object.freeze({
-__proto__:null,MATCH_NOTHING_RE:/\b\B/,IDENT_RE:x,UNDERSCORE_IDENT_RE:w,
-NUMBER_RE:y,C_NUMBER_RE:_,BINARY_NUMBER_RE:k,
-RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
-SHEBANG:(e={})=>{const t=/^#![ ]*\//
-;return e.binary&&(e.begin=f(t,/.*\b/,e.binary,/\b.*/)),s({scope:"meta",begin:t,
-end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()}},e)},
-BACKSLASH_ESCAPE:v,APOS_STRING_MODE:O,QUOTE_STRING_MODE:N,PHRASAL_WORDS_MODE:{
-begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
-},COMMENT:M,C_LINE_COMMENT_MODE:S,C_BLOCK_COMMENT_MODE:R,HASH_COMMENT_MODE:j,
-NUMBER_MODE:{scope:"number",begin:y,relevance:0},C_NUMBER_MODE:{scope:"number",
-begin:_,relevance:0},BINARY_NUMBER_MODE:{scope:"number",begin:k,relevance:0},
-REGEXP_MODE:{begin:/(?=\/[^/\n]*\/)/,contains:[{scope:"regexp",begin:/\//,
-end:/\/[gimuy]*/,illegal:/\n/,contains:[v,{begin:/\[/,end:/\]/,relevance:0,
-contains:[v]}]}]},TITLE_MODE:{scope:"title",begin:x,relevance:0},
-UNDERSCORE_TITLE_MODE:{scope:"title",begin:w,relevance:0},METHOD_GUARD:{
-begin:"\\.\\s*[a-zA-Z_]\\w*",relevance:0},END_SAME_AS_BEGIN:e=>Object.assign(e,{
-"on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{
-t.data._beginMatch!==e[1]&&t.ignoreMatch()}})});function I(e,t){
-"."===e.input[e.index-1]&&t.ignoreMatch()}function T(e,t){
-void 0!==e.className&&(e.scope=e.className,delete e.className)}function L(e,t){
-t&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
-e.__beforeBegin=I,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
-void 0===e.relevance&&(e.relevance=0))}function B(e,t){
-Array.isArray(e.illegal)&&(e.illegal=p(...e.illegal))}function D(e,t){
-if(e.match){
-if(e.begin||e.end)throw Error("begin & end are not supported with match")
-;e.begin=e.match,delete e.match}}function H(e,t){
-void 0===e.relevance&&(e.relevance=1)}const P=(e,t)=>{if(!e.beforeMatch)return
-;if(e.starts)throw Error("beforeMatch cannot be used with starts")
-;const n=Object.assign({},e);Object.keys(e).forEach((t=>{delete e[t]
-})),e.keywords=n.keywords,e.begin=f(n.beforeMatch,d(n.begin)),e.starts={
-relevance:0,contains:[Object.assign(n,{endsParent:!0})]
-},e.relevance=0,delete n.beforeMatch
-},C=["of","and","for","in","not","or","if","then","parent","list","value"]
-;function $(e,t,n="keyword"){const i=Object.create(null)
-;return"string"==typeof e?r(n,e.split(" ")):Array.isArray(e)?r(n,e):Object.keys(e).forEach((n=>{
-Object.assign(i,$(e[n],t,n))})),i;function r(e,n){
-t&&(n=n.map((e=>e.toLowerCase()))),n.forEach((t=>{const n=t.split("|")
-;i[n[0]]=[e,U(n[0],n[1])]}))}}function U(e,t){
-return t?Number(t):(e=>C.includes(e.toLowerCase()))(e)?0:1}const z={},K=e=>{
-console.error(e)},W=(e,...t)=>{console.log("WARN: "+e,...t)},X=(e,t)=>{
-z[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),z[`${e}/${t}`]=!0)
-},G=Error();function Z(e,t,{key:n}){let i=0;const r=e[n],s={},o={}
-;for(let e=1;e<=t.length;e++)o[e+i]=r[e],s[e+i]=!0,i+=b(t[e-1])
-;e[n]=o,e[n]._emit=s,e[n]._multi=!0}function F(e){(e=>{
-e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
-delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
-_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
-}),(e=>{if(Array.isArray(e.begin)){
-if(e.skip||e.excludeBegin||e.returnBegin)throw K("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
-G
-;if("object"!=typeof e.beginScope||null===e.beginScope)throw K("beginScope must be object"),
-G;Z(e,e.begin,{key:"beginScope"}),e.begin=E(e.begin,{joinWith:""})}})(e),(e=>{
-if(Array.isArray(e.end)){
-if(e.skip||e.excludeEnd||e.returnEnd)throw K("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
-G
-;if("object"!=typeof e.endScope||null===e.endScope)throw K("endScope must be object"),
-G;Z(e,e.end,{key:"endScope"}),e.end=E(e.end,{joinWith:""})}})(e)}function V(e){
-function t(t,n){
-return RegExp(g(t),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(n?"g":""))
-}class n{constructor(){
-this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
-addRule(e,t){
-t.position=this.position++,this.matchIndexes[this.matchAt]=t,this.regexes.push([t,e]),
-this.matchAt+=b(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
-;const e=this.regexes.map((e=>e[1]));this.matcherRe=t(E(e,{joinWith:"|"
-}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
-;const t=this.matcherRe.exec(e);if(!t)return null
-;const n=t.findIndex(((e,t)=>t>0&&void 0!==e)),i=this.matchIndexes[n]
-;return t.splice(0,n),Object.assign(t,i)}}class i{constructor(){
-this.rules=[],this.multiRegexes=[],
-this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
-if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n
-;return this.rules.slice(e).forEach((([e,n])=>t.addRule(e,n))),
-t.compile(),this.multiRegexes[e]=t,t}resumingScanAtSamePosition(){
-return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,t){
-this.rules.push([e,t]),"begin"===t.type&&this.count++}exec(e){
-const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex
-;let n=t.exec(e)
-;if(this.resumingScanAtSamePosition())if(n&&n.index===this.lastIndex);else{
-const t=this.getMatcher(0);t.lastIndex=this.lastIndex+1,n=t.exec(e)}
-return n&&(this.regexIndex+=n.position+1,
-this.regexIndex===this.count&&this.considerAll()),n}}
-if(e.compilerExtensions||(e.compilerExtensions=[]),
-e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
-;return e.classNameAliases=s(e.classNameAliases||{}),function n(r,o){const a=r
-;if(r.isCompiled)return a
-;[T,D,F,P].forEach((e=>e(r,o))),e.compilerExtensions.forEach((e=>e(r,o))),
-r.__beforeBegin=null,[L,B,H].forEach((e=>e(r,o))),r.isCompiled=!0;let c=null
-;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
-c=r.keywords.$pattern,
-delete r.keywords.$pattern),c=c||/\w+/,r.keywords&&(r.keywords=$(r.keywords,e.case_insensitive)),
-a.keywordPatternRe=t(c,!0),
-o&&(r.begin||(r.begin=/\B|\b/),a.beginRe=t(a.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
-r.end&&(a.endRe=t(a.end)),
-a.terminatorEnd=g(a.end)||"",r.endsWithParent&&o.terminatorEnd&&(a.terminatorEnd+=(r.end?"|":"")+o.terminatorEnd)),
-r.illegal&&(a.illegalRe=t(r.illegal)),
-r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t=>s(e,{
-variants:null},t)))),e.cachedVariants?e.cachedVariants:q(e)?s(e,{
-starts:e.starts?s(e.starts):null
-}):Object.isFrozen(e)?s(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{n(e,a)
-})),r.starts&&n(r.starts,o),a.matcher=(e=>{const t=new i
-;return e.contains.forEach((e=>t.addRule(e.begin,{rule:e,type:"begin"
-}))),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"
-}),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t})(a),a}(e)}function q(e){
-return!!e&&(e.endsWithParent||q(e.starts))}class J extends Error{
-constructor(e,t){super(e),this.name="HTMLInjectionError",this.html=t}}
-const Y=r,Q=s,ee=Symbol("nomatch");var te=(e=>{
-const t=Object.create(null),r=Object.create(null),s=[];let o=!0
-;const a="Could not find the language '{}', did you forget to load/include a language module?",c={
-disableAutodetect:!0,name:"Plain text",contains:[]};let g={
-ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
-languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
-cssSelector:"pre code",languages:null,__emitter:l};function b(e){
-return g.noHighlightRe.test(e)}function m(e,t,n){let i="",r=""
-;"object"==typeof t?(i=e,
-n=t.ignoreIllegals,r=t.language):(X("10.7.0","highlight(lang, code, ...args) has been deprecated."),
-X("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
-r=e,i=t),void 0===n&&(n=!0);const s={code:i,language:r};N("before:highlight",s)
-;const o=s.result?s.result:E(s.language,s.code,n)
-;return o.code=s.code,N("after:highlight",o),o}function E(e,n,r,s){
-const c=Object.create(null);function l(){if(!O.keywords)return void M.addText(S)
-;let e=0;O.keywordPatternRe.lastIndex=0;let t=O.keywordPatternRe.exec(S),n=""
-;for(;t;){n+=S.substring(e,t.index)
-;const r=y.case_insensitive?t[0].toLowerCase():t[0],s=(i=r,O.keywords[i]);if(s){
-const[e,i]=s
-;if(M.addText(n),n="",c[r]=(c[r]||0)+1,c[r]<=7&&(R+=i),e.startsWith("_"))n+=t[0];else{
-const n=y.classNameAliases[e]||e;M.addKeyword(t[0],n)}}else n+=t[0]
-;e=O.keywordPatternRe.lastIndex,t=O.keywordPatternRe.exec(S)}var i
-;n+=S.substr(e),M.addText(n)}function d(){null!=O.subLanguage?(()=>{
-if(""===S)return;let e=null;if("string"==typeof O.subLanguage){
-if(!t[O.subLanguage])return void M.addText(S)
-;e=E(O.subLanguage,S,!0,N[O.subLanguage]),N[O.subLanguage]=e._top
-}else e=x(S,O.subLanguage.length?O.subLanguage:null)
-;O.relevance>0&&(R+=e.relevance),M.addSublanguage(e._emitter,e.language)
-})():l(),S=""}function u(e,t){let n=1;const i=t.length-1;for(;n<=i;){
-if(!e._emit[n]){n++;continue}const i=y.classNameAliases[e[n]]||e[n],r=t[n]
-;i?M.addKeyword(r,i):(S=r,l(),S=""),n++}}function h(e,t){
-return e.scope&&"string"==typeof e.scope&&M.openNode(y.classNameAliases[e.scope]||e.scope),
-e.beginScope&&(e.beginScope._wrap?(M.addKeyword(S,y.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
-S=""):e.beginScope._multi&&(u(e.beginScope,t),S="")),O=Object.create(e,{parent:{
-value:O}}),O}function f(e,t,n){let r=((e,t)=>{const n=e&&e.exec(t)
-;return n&&0===n.index})(e.endRe,n);if(r){if(e["on:end"]){const n=new i(e)
-;e["on:end"](t,n),n.isMatchIgnored&&(r=!1)}if(r){
-for(;e.endsParent&&e.parent;)e=e.parent;return e}}
-if(e.endsWithParent)return f(e.parent,t,n)}function p(e){
-return 0===O.matcher.regexIndex?(S+=e[0],1):(I=!0,0)}function b(e){
-const t=e[0],i=n.substr(e.index),r=f(O,e,i);if(!r)return ee;const s=O
-;O.endScope&&O.endScope._wrap?(d(),
-M.addKeyword(t,O.endScope._wrap)):O.endScope&&O.endScope._multi?(d(),
-u(O.endScope,e)):s.skip?S+=t:(s.returnEnd||s.excludeEnd||(S+=t),
-d(),s.excludeEnd&&(S=t));do{
-O.scope&&M.closeNode(),O.skip||O.subLanguage||(R+=O.relevance),O=O.parent
-}while(O!==r.parent);return r.starts&&h(r.starts,e),s.returnEnd?0:t.length}
-let m={};function w(t,s){const a=s&&s[0];if(S+=t,null==a)return d(),0
-;if("begin"===m.type&&"end"===s.type&&m.index===s.index&&""===a){
-if(S+=n.slice(s.index,s.index+1),!o){const t=Error(`0 width match regex (${e})`)
-;throw t.languageName=e,t.badRule=m.rule,t}return 1}
-if(m=s,"begin"===s.type)return(e=>{
-const t=e[0],n=e.rule,r=new i(n),s=[n.__beforeBegin,n["on:begin"]]
-;for(const n of s)if(n&&(n(e,r),r.isMatchIgnored))return p(t)
-;return n.skip?S+=t:(n.excludeBegin&&(S+=t),
-d(),n.returnBegin||n.excludeBegin||(S=t)),h(n,e),n.returnBegin?0:t.length})(s)
-;if("illegal"===s.type&&!r){
-const e=Error('Illegal lexeme "'+a+'" for mode "'+(O.scope||"<unnamed>")+'"')
-;throw e.mode=O,e}if("end"===s.type){const e=b(s);if(e!==ee)return e}
-if("illegal"===s.type&&""===a)return 1
-;if(A>1e5&&A>3*s.index)throw Error("potential infinite loop, way more iterations than matches")
-;return S+=a,a.length}const y=k(e)
-;if(!y)throw K(a.replace("{}",e)),Error('Unknown language: "'+e+'"')
-;const _=V(y);let v="",O=s||_;const N={},M=new g.__emitter(g);(()=>{const e=[]
-;for(let t=O;t!==y;t=t.parent)t.scope&&e.unshift(t.scope)
-;e.forEach((e=>M.openNode(e)))})();let S="",R=0,j=0,A=0,I=!1;try{
-for(O.matcher.considerAll();;){
-A++,I?I=!1:O.matcher.considerAll(),O.matcher.lastIndex=j
-;const e=O.matcher.exec(n);if(!e)break;const t=w(n.substring(j,e.index),e)
-;j=e.index+t}return w(n.substr(j)),M.closeAllNodes(),M.finalize(),v=M.toHTML(),{
-language:e,value:v,relevance:R,illegal:!1,_emitter:M,_top:O}}catch(t){
-if(t.message&&t.message.includes("Illegal"))return{language:e,value:Y(n),
-illegal:!0,relevance:0,_illegalBy:{message:t.message,index:j,
-context:n.slice(j-100,j+100),mode:t.mode,resultSoFar:v},_emitter:M};if(o)return{
-language:e,value:Y(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:O}
-;throw t}}function x(e,n){n=n||g.languages||Object.keys(t);const i=(e=>{
-const t={value:Y(e),illegal:!1,relevance:0,_top:c,_emitter:new g.__emitter(g)}
-;return t._emitter.addText(e),t})(e),r=n.filter(k).filter(O).map((t=>E(t,e,!1)))
-;r.unshift(i);const s=r.sort(((e,t)=>{
-if(e.relevance!==t.relevance)return t.relevance-e.relevance
-;if(e.language&&t.language){if(k(e.language).supersetOf===t.language)return 1
-;if(k(t.language).supersetOf===e.language)return-1}return 0})),[o,a]=s,l=o
-;return l.secondBest=a,l}function w(e){let t=null;const n=(e=>{
-let t=e.className+" ";t+=e.parentNode?e.parentNode.className:""
-;const n=g.languageDetectRe.exec(t);if(n){const t=k(n[1])
-;return t||(W(a.replace("{}",n[1])),
-W("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
-return t.split(/\s+/).find((e=>b(e)||k(e)))})(e);if(b(n))return
-;if(N("before:highlightElement",{el:e,language:n
-}),e.children.length>0&&(g.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
-console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
-console.warn("The element with unescaped HTML:"),
-console.warn(e)),g.throwUnescapedHTML))throw new J("One of your code blocks includes unescaped HTML.",e.innerHTML)
-;t=e;const i=t.textContent,s=n?m(i,{language:n,ignoreIllegals:!0}):x(i)
-;e.innerHTML=s.value,((e,t,n)=>{const i=t&&r[t]||n
-;e.classList.add("hljs"),e.classList.add("language-"+i)
-})(e,n,s.language),e.result={language:s.language,re:s.relevance,
-relevance:s.relevance},s.secondBest&&(e.secondBest={
-language:s.secondBest.language,relevance:s.secondBest.relevance
-}),N("after:highlightElement",{el:e,result:s,text:i})}let y=!1;function _(){
-"loading"!==document.readyState?document.querySelectorAll(g.cssSelector).forEach(w):y=!0
-}function k(e){return e=(e||"").toLowerCase(),t[e]||t[r[e]]}
-function v(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
-r[e.toLowerCase()]=t}))}function O(e){const t=k(e)
-;return t&&!t.disableAutodetect}function N(e,t){const n=e;s.forEach((e=>{
-e[n]&&e[n](t)}))}
-"undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
-y&&_()}),!1),Object.assign(e,{highlight:m,highlightAuto:x,highlightAll:_,
-highlightElement:w,
-highlightBlock:e=>(X("10.7.0","highlightBlock will be removed entirely in v12.0"),
-X("10.7.0","Please use highlightElement now."),w(e)),configure:e=>{g=Q(g,e)},
-initHighlighting:()=>{
-_(),X("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
-initHighlightingOnLoad:()=>{
-_(),X("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
-},registerLanguage:(n,i)=>{let r=null;try{r=i(e)}catch(e){
-if(K("Language definition for '{}' could not be registered.".replace("{}",n)),
-!o)throw e;K(e),r=c}
-r.name||(r.name=n),t[n]=r,r.rawDefinition=i.bind(null,e),r.aliases&&v(r.aliases,{
-languageName:n})},unregisterLanguage:e=>{delete t[e]
-;for(const t of Object.keys(r))r[t]===e&&delete r[t]},
-listLanguages:()=>Object.keys(t),getLanguage:k,registerAliases:v,
-autoDetection:O,inherit:Q,addPlugin:e=>{(e=>{
-e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=t=>{
-e["before:highlightBlock"](Object.assign({block:t.el},t))
-}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=t=>{
-e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),s.push(e)}
-}),e.debugMode=()=>{o=!1},e.safeMode=()=>{o=!0
-},e.versionString="11.5.1",e.regex={concat:f,lookahead:d,either:p,optional:h,
-anyNumberOfTimes:u};for(const e in A)"object"==typeof A[e]&&n(A[e])
-;return Object.assign(e,A),e})({});return te}()
-;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);/*! `go` grammar compiled for Highlight.js 11.5.1 */
-(()=>{var e=(()=>{"use strict";return e=>{const n={
-keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
-type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
-literal:["true","false","iota","nil"],
-built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
-};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
-contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
-variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
-className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1
-},e.C_NUMBER_MODE]},{begin:/:=/},{className:"function",beginKeywords:"func",
-end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",
-begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}]}]}}})()
-;hljs.registerLanguage("go",e)})();/*! `json` grammar compiled for Highlight.js 11.5.1 */
-(()=>{var e=(()=>{"use strict";return e=>({name:"JSON",contains:[{
-className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,relevance:1.01},{
-match:/[{}[\],:]/,className:"punctuation",relevance:0},e.QUOTE_STRING_MODE,{
-beginKeywords:"true false null"
-},e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],illegal:"\\S"})
-})();hljs.registerLanguage("json",e)})();
+  var hljs=(function(){"use strict";var e={exports:{}};function t(e){return(e instanceof Map?(e.clear=e.delete=e.set=()=>{throw Error("map is read-only")}):e instanceof Set&&(e.add=e.clear=e.delete=()=>{throw Error("set is read-only")}),Object.freeze(e),Object.getOwnPropertyNames(e).forEach((n)=>{var i=e[n];"object"!=typeof i||Object.isFrozen(i)||t(i)}),e)}(e.exports=t),(e.exports.default=t);var n=e.exports;class i{constructor(e){void 0===e.data&&(e.data={}),(this.data=e.data),(this.isMatchIgnored=!1)}
+  ignoreMatch(){this.isMatchIgnored=!0}}
+  function r(e){return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")}
+  function s(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t];return(t.forEach((e)=>{for(const t in e)n[t]=e[t]}),n)}
+  const o=(e)=>!!e.kind;class a{constructor(e,t){(this.buffer=""),(this.classPrefix=t.classPrefix),e.walk(this)}
+  addText(e){this.buffer+=r(e)}
+  openNode(e){if(!o(e))return;let t=e.kind;(t=e.sublanguage?"language-"+t:((e,{prefix:t})=>{if(e.includes(".")){const n=e.split(".");return[`${t}${n.shift()}`,...n.map((e,t)=>`${e}${"_".repeat(t + 1)}`)].join(" ")}
+  return `${t}${e}`})(t,{prefix:this.classPrefix})),this.span(t)}
+  closeNode(e){o(e)&&(this.buffer+="</span>")}
+  value(){return this.buffer}
+  span(e){this.buffer+=`<span class="${e}">`}}
+  class c{constructor(){(this.rootNode={children:[],}),(this.stack=[this.rootNode])}
+  get top(){return this.stack[this.stack.length-1]}
+  get root(){return this.rootNode}
+  add(e){this.top.children.push(e)}
+  openNode(e){const t={kind:e,children:[]};this.add(t),this.stack.push(t)}
+  closeNode(){if(this.stack.length>1)return this.stack.pop();}
+  closeAllNodes(){for(;this.closeNode(););}
+  toJSON(){return JSON.stringify(this.rootNode,null,4)}
+  walk(e){return this.constructor._walk(e,this.rootNode)}
+  static _walk(e,t){return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),t.children.forEach((t)=>this._walk(e,t)),e.closeNode(t)),e}
+  static _collapse(e){"string"!=typeof e&&e.children&&(e.children.every((e)=>"string"==typeof e)?(e.children=[e.children.join("")]):e.children.forEach((e)=>{c._collapse(e)}))}}
+  class l extends c{constructor(e){super(),(this.options=e)}
+  addKeyword(e,t){""!==e&&(this.openNode(t),this.addText(e),this.closeNode())}
+  addText(e){""!==e&&this.add(e)}
+  addSublanguage(e,t){const n=e.root;(n.kind=t),(n.sublanguage=!0),this.add(n)}
+  toHTML(){return new a(this,this.options).value()}
+  finalize(){return!0}}
+  function g(e){return e?("string"==typeof e?e:e.source):null}
+  function d(e){return f("(?=",e,")")}
+  function u(e){return f("(?:",e,")*")}
+  function h(e){return f("(?:",e,")?")}
+  function f(...e){return e.map((e)=>g(e)).join("")}
+  function p(...e){const t=((e)=>{const t=e[e.length-1];return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}})(e);return"("+(t.capture?"":"?:")+e.map((e)=>g(e)).join("|")+")"}
+  function b(e){return RegExp(e.toString()+"|").exec("").length-1}
+  const m=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./;function E(e,{joinWith:t}){let n=0;return e.map((e)=>{n+=1;const t=n;let i=g(e),r="";for(;i.length>0;){const e=m.exec(i);if(!e){r+=i;break}(r+=i.substring(0,e.index)),(i=i.substring(e.index+e[0].length)),"\\"===e[0][0]&&e[1]?(r+="\\"+(Number(e[1])+t)):((r+=e[0]),"("===e[0]&&n++)}
+  return r}).map((e)=>`(${e})`).join(t)}
+  const x="[a-zA-Z]\\w*",w="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",_="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",k="\\b(0b[01]+)",v={begin:"\\\\[\\s\\S]",relevance:0,},O={scope:"string",begin:"'",end:"'",illegal:"\\n",contains:[v]},N={scope:"string",begin:'"',end:'"',illegal:"\\n",contains:[v]},M=(e,t,n={})=>{const i=s({scope:"comment",begin:e,end:t,contains:[]},n);i.contains.push({scope:"doctag",begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0});const r=p("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/);return i.contains.push({begin:f(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i},S=M("//","$"),R=M("/\\*","\\*/"),j=M("#","$");var A=Object.freeze({__proto__:null,MATCH_NOTHING_RE:/\b\B/,IDENT_RE:x,UNDERSCORE_IDENT_RE:w,NUMBER_RE:y,C_NUMBER_RE:_,BINARY_NUMBER_RE:k,RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",SHEBANG:(e={})=>{const t=/^#![ ]*\//;return(e.binary&&(e.begin=f(t,/.*\b/,e.binary,/\b.*/)),s({scope:"meta",begin:t,end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()},},e))},BACKSLASH_ESCAPE:v,APOS_STRING_MODE:O,QUOTE_STRING_MODE:N,PHRASAL_WORDS_MODE:{begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/,},COMMENT:M,C_LINE_COMMENT_MODE:S,C_BLOCK_COMMENT_MODE:R,HASH_COMMENT_MODE:j,NUMBER_MODE:{scope:"number",begin:y,relevance:0},C_NUMBER_MODE:{scope:"number",begin:_,relevance:0},BINARY_NUMBER_MODE:{scope:"number",begin:k,relevance:0},REGEXP_MODE:{begin:/(?=\/[^/\n]*\/)/,contains:[{scope:"regexp",begin:/\//,end:/\/[gimuy]*/,illegal:/\n/,contains:[v,{begin:/\[/,end:/\]/,relevance:0,contains:[v]}]}]},TITLE_MODE:{scope:"title",begin:x,relevance:0},UNDERSCORE_TITLE_MODE:{scope:"title",begin:w,relevance:0},METHOD_GUARD:{begin:"\\.\\s*[a-zA-Z_]\\w*",relevance:0,},END_SAME_AS_BEGIN:(e)=>Object.assign(e,{"on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{t.data._beginMatch!==e[1]&&t.ignoreMatch()},}),});function I(e,t){"."===e.input[e.index-1]&&t.ignoreMatch()}
+  function T(e,t){void 0!==e.className&&((e.scope=e.className),delete e.className)}
+  function L(e,t){t&&e.beginKeywords&&((e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)"),(e.__beforeBegin=I),(e.keywords=e.keywords||e.beginKeywords),delete e.beginKeywords,void 0===e.relevance&&(e.relevance=0))}
+  function B(e,t){Array.isArray(e.illegal)&&(e.illegal=p(...e.illegal))}
+  function D(e,t){if(e.match){if(e.begin||e.end)throw Error("begin & end are not supported with match");(e.begin=e.match),delete e.match}}
+  function H(e,t){void 0===e.relevance&&(e.relevance=1)}
+  const P=(e,t)=>{if(!e.beforeMatch)return;if(e.starts)throw Error("beforeMatch cannot be used with starts");const n=Object.assign({},e);Object.keys(e).forEach((t)=>{delete e[t]}),(e.keywords=n.keywords),(e.begin=f(n.beforeMatch,d(n.begin))),(e.starts={relevance:0,contains:[Object.assign(n,{endsParent:!0})],}),(e.relevance=0),delete n.beforeMatch},C=["of","and","for","in","not","or","if","then","parent","list","value"];function $(e,t,n="keyword"){const i=Object.create(null);return("string"==typeof e?r(n,e.split(" ")):Array.isArray(e)?r(n,e):Object.keys(e).forEach((n)=>{Object.assign(i,$(e[n],t,n))}),i);function r(e,n){t&&(n=n.map((e)=>e.toLowerCase())),n.forEach((t)=>{const n=t.split("|");i[n[0]]=[e,U(n[0],n[1])]})}}
+  function U(e,t){return t?Number(t):((e)=>C.includes(e.toLowerCase()))(e)?0:1}
+  const z={},K=(e)=>{console.error(e)},W=(e,...t)=>{console.log("WARN: "+e,...t)},X=(e,t)=>{z[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),(z[`${e}/${t}`]=!0))},G=Error();function Z(e,t,{key:n}){let i=0;const r=e[n],s={},o={};for(let e=1;e<=t.length;e++)(o[e+i]=r[e]),(s[e+i]=!0),(i+=b(t[e-1]));(e[n]=o),(e[n]._emit=s),(e[n]._multi=!0)}
+  function F(e){((e)=>{e.scope&&"object"==typeof e.scope&&null!==e.scope&&((e.beginScope=e.scope),delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={_wrap:e.beginScope,}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope}),((e)=>{if(Array.isArray(e.begin)){if(e.skip||e.excludeBegin||e.returnBegin)throw(K("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),G);if("object"!=typeof e.beginScope||null===e.beginScope)throw(K("beginScope must be object"),G);Z(e,e.begin,{key:"beginScope"}),(e.begin=E(e.begin,{joinWith:""}))}})(e),((e)=>{if(Array.isArray(e.end)){if(e.skip||e.excludeEnd||e.returnEnd)throw(K("skip, excludeEnd, returnEnd not compatible with endScope: {}"),G);if("object"!=typeof e.endScope||null===e.endScope)throw(K("endScope must be object"),G);Z(e,e.end,{key:"endScope"}),(e.end=E(e.end,{joinWith:""}))}})(e)}
+  function V(e){function t(t,n){return RegExp(g(t),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(n?"g":""))}
+  class n{constructor(){(this.matchIndexes={}),(this.regexes=[]),(this.matchAt=1),(this.position=0)}
+  addRule(e,t){(t.position=this.position++),(this.matchIndexes[this.matchAt]=t),this.regexes.push([t,e]),(this.matchAt+=b(e)+1)}
+  compile(){0===this.regexes.length&&(this.exec=()=>null);const e=this.regexes.map((e)=>e[1]);(this.matcherRe=t(E(e,{joinWith:"|"}),!0)),(this.lastIndex=0)}
+  exec(e){this.matcherRe.lastIndex=this.lastIndex;const t=this.matcherRe.exec(e);if(!t)return null;const n=t.findIndex((e,t)=>t>0&&void 0!==e),i=this.matchIndexes[n];return t.splice(0,n),Object.assign(t,i)}}
+  class i{constructor(){(this.rules=[]),(this.multiRegexes=[]),(this.count=0),(this.lastIndex=0),(this.regexIndex=0)}
+  getMatcher(e){if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n();return this.rules.slice(e).forEach(([e,n])=>t.addRule(e,n)),t.compile(),(this.multiRegexes[e]=t),t}
+  resumingScanAtSamePosition(){return 0!==this.regexIndex}
+  considerAll(){this.regexIndex=0}
+  addRule(e,t){this.rules.push([e,t]),"begin"===t.type&&this.count++}
+  exec(e){const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex;let n=t.exec(e);if(this.resumingScanAtSamePosition())
+  if(n&&n.index===this.lastIndex);else{const t=this.getMatcher(0);(t.lastIndex=this.lastIndex+1),(n=t.exec(e))}
+  return n&&((this.regexIndex+=n.position+1),this.regexIndex===this.count&&this.considerAll()),n}}
+  if((e.compilerExtensions||(e.compilerExtensions=[]),e.contains&&e.contains.includes("self")))
+  throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.");return((e.classNameAliases=s(e.classNameAliases||{})),(function n(r,o){const a=r;if(r.isCompiled)return a;[T,D,F,P].forEach((e)=>e(r,o)),e.compilerExtensions.forEach((e)=>e(r,o)),(r.__beforeBegin=null),[L,B,H].forEach((e)=>e(r,o)),(r.isCompiled=!0);let c=null;return("object"==typeof r.keywords&&r.keywords.$pattern&&((r.keywords=Object.assign({},r.keywords)),(c=r.keywords.$pattern),delete r.keywords.$pattern),(c=c||/\w+/),r.keywords&&(r.keywords=$(r.keywords,e.case_insensitive)),(a.keywordPatternRe=t(c,!0)),o&&(r.begin||(r.begin=/\B|\b/),(a.beginRe=t(a.begin)),r.end||r.endsWithParent||(r.end=/\B|\b/),r.end&&(a.endRe=t(a.end)),(a.terminatorEnd=g(a.end)||""),r.endsWithParent&&o.terminatorEnd&&(a.terminatorEnd+=(r.end?"|":"")+o.terminatorEnd)),r.illegal&&(a.illegalRe=t(r.illegal)),r.contains||(r.contains=[]),(r.contains=[].concat(...r.contains.map((e)=>((e)=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t)=>s(e,{variants:null,},t))),e.cachedVariants?e.cachedVariants:q(e)?s(e,{starts:e.starts?s(e.starts):null,}):Object.isFrozen(e)?s(e):e))("self"===e?r:e)))),r.contains.forEach((e)=>{n(e,a)}),r.starts&&n(r.starts,o),(a.matcher=((e)=>{const t=new i();return(e.contains.forEach((e)=>t.addRule(e.begin,{rule:e,type:"begin"})),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"}),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t)})(a)),a)})(e))}
+  function q(e){return!!e&&(e.endsWithParent||q(e.starts))}
+  class J extends Error{constructor(e,t){super(e),(this.name="HTMLInjectionError"),(this.html=t)}}
+  const Y=r,Q=s,ee=Symbol("nomatch");var te=((e)=>{const t=Object.create(null),r=Object.create(null),s=[];let o=!0;const a="Could not find the language '{}', did you forget to load/include a language module?",c={disableAutodetect:!0,name:"Plain text",contains:[],};let g={ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",cssSelector:"pre code",languages:null,__emitter:l,};function b(e){return g.noHighlightRe.test(e)}
+  function m(e,t,n){let i="",r="";"object"==typeof t?((i=e),(n=t.ignoreIllegals),(r=t.language)):(X("10.7.0","highlight(lang, code, ...args) has been deprecated."),X("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),(r=e),(i=t)),void 0===n&&(n=!0);const s={code:i,language:r};N("before:highlight",s);const o=s.result?s.result:E(s.language,s.code,n);return(o.code=s.code),N("after:highlight",o),o}
+  function E(e,n,r,s){const c=Object.create(null);function l(){if(!O.keywords)return void M.addText(S);let e=0;O.keywordPatternRe.lastIndex=0;let t=O.keywordPatternRe.exec(S),n="";for(;t;){n+=S.substring(e,t.index);const r=y.case_insensitive?t[0].toLowerCase():t[0],s=((i=r),O.keywords[i]);if(s){const[e,i]=s;if((M.addText(n),(n=""),(c[r]=(c[r]||0)+1),c[r]<=7&&(R+=i),e.startsWith("_")))n+=t[0];else{const n=y.classNameAliases[e]||e;M.addKeyword(t[0],n)}}else n+=t[0];(e=O.keywordPatternRe.lastIndex),(t=O.keywordPatternRe.exec(S))}
+  var i;(n+=S.substr(e)),M.addText(n)}
+  function d(){null!=O.subLanguage?(()=>{if(""===S)return;let e=null;if("string"==typeof O.subLanguage){if(!t[O.subLanguage])return void M.addText(S);(e=E(O.subLanguage,S,!0,N[O.subLanguage])),(N[O.subLanguage]=e._top)}else e=x(S,O.subLanguage.length?O.subLanguage:null);O.relevance>0&&(R+=e.relevance),M.addSublanguage(e._emitter,e.language)})():l(),(S="")}
+  function u(e,t){let n=1;const i=t.length-1;for(;n<=i;){if(!e._emit[n]){n++;continue}
+  const i=y.classNameAliases[e[n]]||e[n],r=t[n];i?M.addKeyword(r,i):((S=r),l(),(S="")),n++}}
+  function h(e,t){return(e.scope&&"string"==typeof e.scope&&M.openNode(y.classNameAliases[e.scope]||e.scope),e.beginScope&&(e.beginScope._wrap?(M.addKeyword(S,y.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),(S="")):e.beginScope._multi&&(u(e.beginScope,t),(S=""))),(O=Object.create(e,{parent:{value:O,},})),O)}
+  function f(e,t,n){let r=((e,t)=>{const n=e&&e.exec(t);return n&&0===n.index})(e.endRe,n);if(r){if(e["on:end"]){const n=new i(e);e["on:end"](t,n),n.isMatchIgnored&&(r=!1)}
+  if(r){for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+  if(e.endsWithParent)return f(e.parent,t,n);}
+  function p(e){return 0===O.matcher.regexIndex?((S+=e[0]),1):((I=!0),0)}
+  function b(e){const t=e[0],i=n.substr(e.index),r=f(O,e,i);if(!r)return ee;const s=O;O.endScope&&O.endScope._wrap?(d(),M.addKeyword(t,O.endScope._wrap)):O.endScope&&O.endScope._multi?(d(),u(O.endScope,e)):s.skip?(S+=t):(s.returnEnd||s.excludeEnd||(S+=t),d(),s.excludeEnd&&(S=t));do{O.scope&&M.closeNode(),O.skip||O.subLanguage||(R+=O.relevance),(O=O.parent)}while(O!==r.parent);return r.starts&&h(r.starts,e),s.returnEnd?0:t.length}
+  let m={};function w(t,s){const a=s&&s[0];if(((S+=t),null==a))return d(),0;if("begin"===m.type&&"end"===s.type&&m.index===s.index&&""===a){if(((S+=n.slice(s.index,s.index+1)),!o)){const t=Error(`0 width match regex (${e})`);throw((t.languageName=e),(t.badRule=m.rule),t)}
+  return 1}
+  if(((m=s),"begin"===s.type))
+  return((e)=>{const t=e[0],n=e.rule,r=new i(n),s=[n.__beforeBegin,n["on:begin"]];for(const n of s)if(n&&(n(e,r),r.isMatchIgnored))return p(t);return n.skip?(S+=t):(n.excludeBegin&&(S+=t),d(),n.returnBegin||n.excludeBegin||(S=t)),h(n,e),n.returnBegin?0:t.length})(s);if("illegal"===s.type&&!r){const e=Error('Illegal lexeme "'+a+'" for mode "'+(O.scope||"<unnamed>")+'"');throw((e.mode=O),e)}
+  if("end"===s.type){const e=b(s);if(e!==ee)return e}
+  if("illegal"===s.type&&""===a)return 1;if(A>1e5&&A>3*s.index)throw Error("potential infinite loop, way more iterations than matches");return(S+=a),a.length}
+  const y=k(e);if(!y)throw(K(a.replace("{}",e)),Error('Unknown language: "'+e+'"'));const _=V(y);let v="",O=s||_;const N={},M=new g.__emitter(g);(()=>{const e=[];for(let t=O;t!==y;t=t.parent)t.scope&&e.unshift(t.scope);e.forEach((e)=>M.openNode(e))})();let S="",R=0,j=0,A=0,I=!1;try{for(O.matcher.considerAll();;){A++,I?(I=!1):O.matcher.considerAll(),(O.matcher.lastIndex=j);const e=O.matcher.exec(n);if(!e)break;const t=w(n.substring(j,e.index),e);j=e.index+t}
+  return(w(n.substr(j)),M.closeAllNodes(),M.finalize(),(v=M.toHTML()),{language:e,value:v,relevance:R,illegal:!1,_emitter:M,_top:O,})}catch(t){if(t.message&&t.message.includes("Illegal"))
+  return{language:e,value:Y(n),illegal:!0,relevance:0,_illegalBy:{message:t.message,index:j,context:n.slice(j-100,j+100),mode:t.mode,resultSoFar:v},_emitter:M};if(o)
+  return{language:e,value:Y(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:O,};throw t}}
+  function x(e,n){n=n||g.languages||Object.keys(t);const i=((e)=>{const t={value:Y(e),illegal:!1,relevance:0,_top:c,_emitter:new g.__emitter(g)};return t._emitter.addText(e),t})(e),r=n.filter(k).filter(O).map((t)=>E(t,e,!1));r.unshift(i);const s=r.sort((e,t)=>{if(e.relevance!==t.relevance)return t.relevance-e.relevance;if(e.language&&t.language){if(k(e.language).supersetOf===t.language)return 1;if(k(t.language).supersetOf===e.language)return-1}
+  return 0}),[o,a]=s,l=o;return(l.secondBest=a),l}
+  function w(e){let t=null;const n=((e)=>{let t=e.className+" ";t+=e.parentNode?e.parentNode.className:"";const n=g.languageDetectRe.exec(t);if(n){const t=k(n[1]);return t||(W(a.replace("{}",n[1])),W("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
+  return t.split(/\s+/).find((e)=>b(e)||k(e))})(e);if(b(n))return;if((N("before:highlightElement",{el:e,language:n}),e.children.length>0&&(g.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),console.warn("The element with unescaped HTML:"),console.warn(e)),g.throwUnescapedHTML)))
+  throw new J("One of your code blocks includes unescaped HTML.",e.innerHTML);t=e;const i=t.textContent,s=n?m(i,{language:n,ignoreIllegals:!0}):x(i);(e.innerHTML=s.value),((e,t,n)=>{const i=(t&&r[t])||n;e.classList.add("hljs"),e.classList.add("language-"+i)})(e,n,s.language),(e.result={language:s.language,re:s.relevance,relevance:s.relevance}),s.secondBest&&(e.secondBest={language:s.secondBest.language,relevance:s.secondBest.relevance,}),N("after:highlightElement",{el:e,result:s,text:i})}
+  let y=!1;function _(){"loading"!==document.readyState?document.querySelectorAll(g.cssSelector).forEach(w):(y=!0)}
+  function k(e){return(e=(e||"").toLowerCase()),t[e]||t[r[e]]}
+  function v(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e)=>{r[e.toLowerCase()]=t})}
+  function O(e){const t=k(e);return t&&!t.disableAutodetect}
+  function N(e,t){const n=e;s.forEach((e)=>{e[n]&&e[n](t)})}
+  "undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",()=>{y&&_()},!1),Object.assign(e,{highlight:m,highlightAuto:x,highlightAll:_,highlightElement:w,highlightBlock:(e)=>(X("10.7.0","highlightBlock will be removed entirely in v12.0"),X("10.7.0","Please use highlightElement now."),w(e)),configure:(e)=>{g=Q(g,e)},initHighlighting:()=>{_(),X("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},initHighlightingOnLoad:()=>{_(),X("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")},registerLanguage:(n,i)=>{let r=null;try{r=i(e)}catch(e){if((K("Language definition for '{}' could not be registered.".replace("{}",n)),!o))throw e;K(e),(r=c)}
+  r.name||(r.name=n),(t[n]=r),(r.rawDefinition=i.bind(null,e)),r.aliases&&v(r.aliases,{languageName:n,})},unregisterLanguage:(e)=>{delete t[e];for(const t of Object.keys(r))r[t]===e&&delete r[t]},listLanguages:()=>Object.keys(t),getLanguage:k,registerAliases:v,autoDetection:O,inherit:Q,addPlugin:(e)=>{((e)=>{e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=(t)=>{e["before:highlightBlock"](Object.assign({block:t.el},t))}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=(t)=>{e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),s.push(e)},}),(e.debugMode=()=>{o=!1}),(e.safeMode=()=>{o=!0}),(e.versionString="11.5.1"),(e.regex={concat:f,lookahead:d,either:p,optional:h,anyNumberOfTimes:u});for(const e in A)"object"==typeof A[e]&&n(A[e]);return Object.assign(e,A),e})({});return te})();"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);/*! `go` grammar compiled for Highlight.js 11.5.1 */
+  (()=>{var e=(()=>{"use strict";return(e)=>{const n={keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var",],type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune",],literal:["true","false","iota","nil"],built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"],};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1},e.C_NUMBER_MODE],},{begin:/:=/},{className:"function",beginKeywords:"func",end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}],},],}}})();hljs.registerLanguage("go",e)})();/*! `json` grammar compiled for Highlight.js 11.5.1 */
+  (()=>{var e=(()=>{"use strict";return(e)=>({name:"JSON",contains:[{className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,relevance:1.01,},{match:/[{}[\],:]/,className:"punctuation",relevance:0,},e.QUOTE_STRING_MODE,{beginKeywords:"true false null",},e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,],illegal:"\\S",})})();hljs.registerLanguage("json",e);hljs.registerLanguage("plaintext",e)})()


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

This PR aims to fix the `md` rendering issue when `plaintext` is summon by marked.js / hljs. It just registers the `plaintext` module into `hljs` js lib.

Fixes: #2084


