### PR TITLE
chore(stdlibs/std): use appropriate variable names for regex

### DIFF
--- a/gnovm/stdlibs/std/banker.go
+++ b/gnovm/stdlibs/std/banker.go
@@ -34,9 +34,7 @@ const (
 )
 
 // regexp for denom format
-const denomRegex = "[a-z][a-z0-9]{2,15}"
-
-var reg = regexp.MustCompile(denomRegex)
+var reDenom = regexp.MustCompile("[a-z][a-z0-9]{2,15}")
 
 func X_bankerGetCoins(m *gno.Machine, bt uint8, addr string) (denoms []string, amounts []int64) {
 	coins := m.Context.(ExecContext).Banker.GetCoins(crypto.Bech32Address(addr))
@@ -96,9 +94,9 @@ func X_bankerIssueCoin(m *gno.Machine, bt uint8, addr string, denom string, amou
 	// gno checks for bt == RealmIssue
 
 	// check origin denom format
-	matched := reg.MatchString(denom)
+	matched := reDenom.MatchString(denom)
 	if !matched {
-		m.Panic(typedString("invalid denom format to issue coin, must be " + denomRegex))
+		m.Panic(typedString("invalid denom format to issue coin, must be " + reDenom.String()))
 		return
 	}
 
@@ -112,9 +110,9 @@ func X_bankerIssueCoin(m *gno.Machine, bt uint8, addr string, denom string, amou
 func X_bankerRemoveCoin(m *gno.Machine, bt uint8, addr string, denom string, amount int64) {
 	// gno checks for bt == RealmIssue
 
-	matched := reg.MatchString(denom)
+	matched := reDenom.MatchString(denom)
 	if !matched {
-		m.Panic(typedString("invalid denom format to remove coin, must be " + denomRegex))
+		m.Panic(typedString("invalid denom format to remove coin, must be " + reDenom.String()))
 		return
 	}
 


### PR DESCRIPTION
Introduced in #875, but only managed to review after it was merged

(cc/ @r3v4s)