### PR TITLE
chore: time-simple.txtar

### DIFF
--- a/gno.land/cmd/gnoland/testdata/time-simple.txtar
+++ b/gno.land/cmd/gnoland/testdata/time-simple.txtar
@@ -1,0 +1,18 @@
+# Originally, the addpkg failed due to changes in PR https://github.com/gnolang/gno/pull/1702 .
+# This bug was fixed with https://github.com/gnolang/gno/pull/2105 .
+
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/time_simple -gas-fee 1ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+
+-- time_simple.gno --
+package time_simple
+
+import (
+	"time"
+)
+
+func GetUnixTime() int64 {
+	return time.Now().Unix()
+}


### PR DESCRIPTION
This PR adds a simple regression test for a bug that was introduced in https://github.com/gnolang/gno/pull/1702 and fixed in https://github.com/gnolang/gno/pull/2105 .