### PR TITLE
feat: Embed genesis files.

### DIFF
--- a/gno.land/genesis/embed.go
+++ b/gno.land/genesis/embed.go
@@ -1,0 +1,9 @@
+package genesis
+
+import _ "embed"
+
+//go:embed genesis_balances.txt
+var DefaultGenesisBalances []byte
+
+//go:embed genesis_txs.jsonl
+var DefaultGenesisTxs []byte

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -20,11 +20,16 @@ import (
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) ([]Balance, error) {
 	var content []byte
+	var err error
 	if path == "" {
 		slog.Warn("genesis file not specified, using embedded defaults")
 		content = genesis.DefaultGenesisBalances
 	} else {
-		content = osm.MustReadFile(path)
+		content, err = osm.ReadFile(path)
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	// each balance is in the form: g1xxxxxxxxxxxxxxxx=100000ugnot
@@ -71,11 +76,16 @@ func LoadGenesisBalancesFile(path string) ([]Balance, error) {
 // XXX: Improve the way we generate and load this file
 func LoadGenesisTxsFile(path string, chainID string, genesisRemote string) ([]std.Tx, error) {
 	var txsBz []byte
+	var err error
 	if path == "" {
 		slog.Warn("genesis transactions file not specified, using embedded defaults")
 		txsBz = genesis.DefaultGenesisTxs
 	} else {
-		txsBz = osm.MustReadFile(path)
+		txsBz, err = osm.ReadFile(path)
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	txsLines := strings.Split(string(txsBz), "\n")

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -3,8 +3,10 @@ package gnoland
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
+	"github.com/gnolang/gno/gno.land/genesis"
 	vmm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/pkg/gnomod"
@@ -17,8 +19,15 @@ import (
 
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) ([]Balance, error) {
+	var content []byte
+	if path == "" {
+		slog.Warn("genesis file not specified, using embedded defaults")
+		content = genesis.DefaultGenesisBalances
+	} else {
+		content = osm.MustReadFile(path)
+	}
+
 	// each balance is in the form: g1xxxxxxxxxxxxxxxx=100000ugnot
-	content := osm.MustReadFile(path)
 	lines := strings.Split(string(content), "\n")
 
 	balances := make([]Balance, 0, len(lines))
@@ -61,9 +70,17 @@ func LoadGenesisBalancesFile(path string) ([]Balance, error) {
 // LoadGenesisTxsFile loads genesis transactions from the provided file path.
 // XXX: Improve the way we generate and load this file
 func LoadGenesisTxsFile(path string, chainID string, genesisRemote string) ([]std.Tx, error) {
-	txs := []std.Tx{}
-	txsBz := osm.MustReadFile(path)
+	var txsBz []byte
+	if path == "" {
+		slog.Warn("genesis transactions file not specified, using embedded defaults")
+		txsBz = genesis.DefaultGenesisTxs
+	} else {
+		txsBz = osm.MustReadFile(path)
+	}
+
 	txsLines := strings.Split(string(txsBz), "\n")
+
+	txs := []std.Tx{}
 	for _, txLine := range txsLines {
 		if txLine == "" {
 			continue // Skip empty line.

--- a/gno.land/pkg/gnoland/genesis_test.go
+++ b/gno.land/pkg/gnoland/genesis_test.go
@@ -1,0 +1,25 @@
+package gnoland
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalances(t *testing.T) {
+	b, err := LoadGenesisBalancesFile("")
+	require.NoError(t, err)
+	require.Len(t, b, 56)
+
+	_, err = LoadGenesisBalancesFile("DOES_NOT_EXIST")
+	require.Error(t, err)
+}
+
+func TestTransactions(t *testing.T) {
+	b, err := LoadGenesisTxsFile("", "id", "remote")
+	require.NoError(t, err)
+	require.Len(t, b, 17)
+
+	_, err = LoadGenesisTxsFile("DOES_NOT_EXIST", "id", "remote")
+	require.Error(t, err)
+}

--- a/gno.land/pkg/integration/testing_node.go
+++ b/gno.land/pkg/integration/testing_node.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	tmcfg "github.com/gnolang/gno/tm2/pkg/bft/config"
@@ -12,7 +14,6 @@ import (
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -123,9 +124,7 @@ func LoadDefaultPackages(t TestingTS, creator bft.Address, gnoroot string) []std
 
 // LoadDefaultGenesisBalanceFile loads the default genesis balance file for testing.
 func LoadDefaultGenesisBalanceFile(t TestingTS, gnoroot string) []gnoland.Balance {
-	balanceFile := filepath.Join(gnoroot, "gno.land", "genesis", "genesis_balances.txt")
-
-	genesisBalances, err := gnoland.LoadGenesisBalancesFile(balanceFile)
+	genesisBalances, err := gnoland.LoadGenesisBalancesFile("")
 	require.NoError(t, err)
 
 	return genesisBalances


### PR DESCRIPTION
Proposal for embedding initial genesis data inside the gnoland binary instead of need them on the filesystem in the gnoroot folder.

It will simplify docker images and in general install and execution process.

When a gnoland node is started and no genesis files are specified, we will log a warning per genesis file indicating to the user that we are loading defaults.

Related with #2091 

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
