### PR TITLE
docs: add disclaimer that `maketx call` is a state-changing call

### DIFF
--- a/docs/gno-tooling/cli/gnokey.md
+++ b/docs/gno-tooling/cli/gnokey.md
@@ -207,7 +207,7 @@ gnokey maketx call \
     > unsigned.tx
 ```
 
-:::info `call` is a state-changing message  
+:::warn `call` is a state-changing message  
 
 All exported functions, including `Render()`, can be called in two main ways:
 `call` and [`query vm/qeval`](#query).

--- a/docs/gno-tooling/cli/gnokey.md
+++ b/docs/gno-tooling/cli/gnokey.md
@@ -190,7 +190,7 @@ gnokey maketx addpkg \
 
 ### `call`
 
-This subcommand lets you call a public function.
+This subcommand lets you call any exported function.
 
 ```bash
 # Register
@@ -206,6 +206,20 @@ gnokey maketx call \
     {ADDRESS} \
     > unsigned.tx
 ```
+
+:::info `call` is a state-changing message  
+
+All exported functions, including `Render()`, can be called in two main ways:
+`call` and [`query vm/qeval`](#query).
+
+With `call`, any state change that happened in the function being called will be
+applied and persisted in on the blockchain, and the gas used for this call will
+be subtracted from the caller balance. 
+
+As opposed to this, an ABCI query, such as `vm/qeval` will not persist state 
+changes and does not cost gas, only evaluating the expression in read-only mode.
+
+:::
 
 #### **SignBroadcast Options**
 


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

After discussions in #1523, we decided to add a disclaimer to `maketx call` which will let people know that a `call` to `Render()` will appliy state changes.

Closes: #1523 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
