### PR TITLE
chore: In gnodev, include gnoweb flags

### DIFF
--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gnolang/gno/contribs/gnodev/pkg/emitter"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/rawterm"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/watcher"
-	"github.com/gnolang/gno/gno.land/pkg/gnoweb"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -39,7 +38,6 @@ var (
 
 type devCfg struct {
 	// Listeners
-	webListenerAddr          string
 	nodeRPCListenerAddr      string
 	nodeP2PListenerAddr      string
 	nodeProxyAppListenerAddr string
@@ -52,6 +50,10 @@ type devCfg struct {
 	balancesFile    string
 	txsFile         string
 
+	// Web Configuration
+	webListenerAddr     string
+	webRemoteHelperAddr string
+
 	// Node Configuration
 	minimal    bool
 	verbose    bool
@@ -60,7 +62,6 @@ type devCfg struct {
 	maxGas     int64
 	chainId    string
 	serverMode bool
-	webConfig  gnoweb.Config
 }
 
 var defaultDevOptions = &devCfg{
@@ -79,9 +80,7 @@ var defaultDevOptions = &devCfg{
 }
 
 func main() {
-	cfg := &devCfg{
-		webConfig: gnoweb.NewDefaultConfig(),
-	}
+	cfg := &devCfg{}
 
 	stdio := commands.NewDefaultIO()
 	cmd := commands.NewCommand(
@@ -116,15 +115,15 @@ func (c *devCfg) RegisterFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(
 		&c.webListenerAddr,
-		"web-bind",
+		"web-listener",
 		defaultDevOptions.webListenerAddr,
-		"web server listening address",
+		"web server listener address",
 	)
 
 	fs.StringVar(
-		&c.webConfig.HelpRemote,
+		&c.webRemoteHelperAddr,
 		"web-help-remote",
-		"",
+		defaultDevOptions.webRemoteHelperAddr,
 		"web server help page's remote addr (default to <node-rpc-listener>)",
 	)
 

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gnolang/gno/contribs/gnodev/pkg/emitter"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/rawterm"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/watcher"
+	"github.com/gnolang/gno/gno.land/pkg/gnoweb"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -52,14 +53,14 @@ type devCfg struct {
 	txsFile         string
 
 	// Node Configuration
-	minimal       bool
-	verbose       bool
-	noWatch       bool
-	noReplay      bool
-	maxGas        int64
-	chainId       string
-	serverMode    bool
-	webHelpRemote string
+	minimal    bool
+	verbose    bool
+	noWatch    bool
+	noReplay   bool
+	maxGas     int64
+	chainId    string
+	serverMode bool
+	webConfig  gnoweb.Config
 }
 
 var defaultDevOptions = &devCfg{
@@ -78,7 +79,9 @@ var defaultDevOptions = &devCfg{
 }
 
 func main() {
-	cfg := &devCfg{}
+	cfg := &devCfg{
+		webConfig: gnoweb.NewDefaultConfig(),
+	}
 
 	stdio := commands.NewDefaultIO()
 	cmd := commands.NewCommand(
@@ -113,16 +116,16 @@ func (c *devCfg) RegisterFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(
 		&c.webListenerAddr,
-		"web-listener",
+		"web-bind",
 		defaultDevOptions.webListenerAddr,
 		"web server listening address",
 	)
 
 	fs.StringVar(
-		&c.webHelpRemote,
+		&c.webConfig.HelpRemote,
 		"web-help-remote",
-		defaultDevOptions.nodeRPCListenerAddr,
-		"web server help page's remote addr",
+		"",
+		"web server help page's remote addr (default to <node-rpc-listener>)",
 	)
 
 	fs.StringVar(

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -52,13 +52,14 @@ type devCfg struct {
 	txsFile         string
 
 	// Node Configuration
-	minimal    bool
-	verbose    bool
-	noWatch    bool
-	noReplay   bool
-	maxGas     int64
-	chainId    string
-	serverMode bool
+	minimal       bool
+	verbose       bool
+	noWatch       bool
+	noReplay      bool
+	maxGas        int64
+	chainId       string
+	serverMode    bool
+	webHelpRemote string
 }
 
 var defaultDevOptions = &devCfg{
@@ -115,6 +116,13 @@ func (c *devCfg) RegisterFlags(fs *flag.FlagSet) {
 		"web-listener",
 		defaultDevOptions.webListenerAddr,
 		"web server listening address",
+	)
+
+	fs.StringVar(
+		&c.webHelpRemote,
+		"web-help-remote",
+		defaultDevOptions.nodeRPCListenerAddr,
+		"web server help page's remote addr",
 	)
 
 	fs.StringVar(

--- a/contribs/gnodev/cmd/gnodev/setup_web.go
+++ b/contribs/gnodev/cmd/gnodev/setup_web.go
@@ -10,12 +10,17 @@ import (
 
 // setupGnowebServer initializes and starts the Gnoweb server.
 func setupGnoWebServer(logger *slog.Logger, cfg *devCfg, dnode *gnodev.Node) http.Handler {
-	cfg.webConfig.RemoteAddr = dnode.GetRemoteAddress()
-	if cfg.webConfig.HelpRemote == "" {
-		cfg.webConfig.HelpRemote = dnode.GetRemoteAddress()
-	}
-	cfg.webConfig.HelpChainID = cfg.chainId
+	webConfig := gnoweb.NewDefaultConfig()
 
-	app := gnoweb.MakeApp(logger, cfg.webConfig)
+	webConfig.HelpChainID = cfg.chainId
+	webConfig.RemoteAddr = dnode.GetRemoteAddress()
+	webConfig.HelpRemote = cfg.webRemoteHelperAddr
+
+	// If `HelpRemote` is empty default it to `RemoteAddr`
+	if webConfig.HelpRemote == "" {
+		webConfig.HelpRemote = webConfig.RemoteAddr
+	}
+
+	app := gnoweb.MakeApp(logger, webConfig)
 	return app.Router
 }

--- a/contribs/gnodev/cmd/gnodev/setup_web.go
+++ b/contribs/gnodev/cmd/gnodev/setup_web.go
@@ -12,7 +12,11 @@ import (
 func setupGnoWebServer(logger *slog.Logger, cfg *devCfg, dnode *gnodev.Node) http.Handler {
 	webConfig := gnoweb.NewDefaultConfig()
 	webConfig.RemoteAddr = dnode.GetRemoteAddress()
-	webConfig.HelpRemote = dnode.GetRemoteAddress()
+	if cfg.webHelpRemote != "" {
+		webConfig.HelpRemote = cfg.webHelpRemote
+	} else {
+		webConfig.HelpRemote = dnode.GetRemoteAddress()
+	}
 	webConfig.HelpChainID = cfg.chainId
 
 	app := gnoweb.MakeApp(logger, webConfig)

--- a/contribs/gnodev/cmd/gnodev/setup_web.go
+++ b/contribs/gnodev/cmd/gnodev/setup_web.go
@@ -10,15 +10,12 @@ import (
 
 // setupGnowebServer initializes and starts the Gnoweb server.
 func setupGnoWebServer(logger *slog.Logger, cfg *devCfg, dnode *gnodev.Node) http.Handler {
-	webConfig := gnoweb.NewDefaultConfig()
-	webConfig.RemoteAddr = dnode.GetRemoteAddress()
-	if cfg.webHelpRemote != "" {
-		webConfig.HelpRemote = cfg.webHelpRemote
-	} else {
-		webConfig.HelpRemote = dnode.GetRemoteAddress()
+	cfg.webConfig.RemoteAddr = dnode.GetRemoteAddress()
+	if cfg.webConfig.HelpRemote == "" {
+		cfg.webConfig.HelpRemote = dnode.GetRemoteAddress()
 	}
-	webConfig.HelpChainID = cfg.chainId
+	cfg.webConfig.HelpChainID = cfg.chainId
 
-	app := gnoweb.MakeApp(logger, webConfig)
+	app := gnoweb.MakeApp(logger, cfg.webConfig)
 	return app.Router
 }

--- a/docs/gno-tooling/cli/gnodev.md
+++ b/docs/gno-tooling/cli/gnodev.md
@@ -135,5 +135,5 @@ While `gnodev` is running, the following shortcuts are available:
 | --root              | gno root directory                                         |
 | --server-mode       | disable interaction, and adjust logging for server use.    |
 | --verbose           | enable verbose output for development                      |
-| --web-listener      | web server listening address                               |
+| --web-bind          | web server listening address                               |
 | --web-help-remote   | web server help page's remote addr                         |

--- a/docs/gno-tooling/cli/gnodev.md
+++ b/docs/gno-tooling/cli/gnodev.md
@@ -120,20 +120,20 @@ While `gnodev` is running, the following shortcuts are available:
 
 ### Options
 
-| Flag                | Effect                                                     |
-|---------------------|------------------------------------------------------------|
-| --minimal           | Start `gnodev` without loading the examples folder.        |
-| --no-watch          | Disable hot reload.                                        |
-| --add-account       | Pre-add account(s) in the form `<bech32>[=<amount>]`       |
-| --balances-file     | Load a balance for the user(s) from a balance file.        |
-| --chain-id          | Set node ChainID                                           |
-| --deploy-key        | Default key name or Bech32 address for uploading packages. |
-| --home              | Set the path to load user's Keybase.                       |
-| --max-gas           | Set the maximum gas per block                              |
-| --no-replay         | Do not replay previous transactions upon reload            |
-| --node-rpc-listener | listening address for GnoLand RPC node                     |
-| --root              | gno root directory                                         |
-| --server-mode       | disable interaction, and adjust logging for server use.    |
-| --verbose           | enable verbose output for development                      |
-| --web-bind          | web server listening address                               |
-| --web-help-remote   | web server help page's remote addr                         |
+| Flag                | Effect                                                              |
+|---------------------|---------------------------------------------------------------------|
+| --minimal           | Start `gnodev` without loading the examples folder.                 |
+| --no-watch          | Disable hot reload.                                                 |
+| --add-account       | Pre-add account(s) in the form `<bech32>[=<amount>]`                |
+| --balances-file     | Load a balance for the user(s) from a balance file.                 |
+| --chain-id          | Set node ChainID                                                    |
+| --deploy-key        | Default key name or Bech32 address for uploading packages.          |
+| --home              | Set the path to load user's Keybase.                                |
+| --max-gas           | Set the maximum gas per block                                       |
+| --no-replay         | Do not replay previous transactions upon reload                     |
+| --node-rpc-listener | listening address for GnoLand RPC node                              |
+| --root              | gno root directory                                                  |
+| --server-mode       | disable interaction, and adjust logging for server use.             |
+| --verbose           | enable verbose output for development                               |
+| --web-listener      | web server listening address                                        |
+| --web-help-remote   | web server help page's remote addr - default to <node-rpc-listener> |

--- a/docs/gno-tooling/cli/gnodev.md
+++ b/docs/gno-tooling/cli/gnodev.md
@@ -136,3 +136,4 @@ While `gnodev` is running, the following shortcuts are available:
 | --server-mode       | disable interaction, and adjust logging for server use.    |
 | --verbose           | enable verbose output for development                      |
 | --web-listener      | web server listening address                               |
+| --web-help-remote   | web server help page's remote addr                         |


### PR DESCRIPTION
gnodev starts gnoweb which can show a [help page](https://gno.berty.io/r/berty/social?help) with the gnokey command for each function. The help for the gnokey command includes `-remote` which is the same as the gnodev listening address. But the gnokey command is meant to be used from a different computer, and the address which gnodev listens on can be different than the address to connect from outside. (In our use case, gnodev runs in a docker container behind a reverse proxy.)

The gnoweb command already has an option `-help-remote` which is used on the help page. When gnodev [starts gnoweb](https://github.com/gnolang/gno/blob/ccc6d5b789bbb6a267135b05047db8b85adc74c7/contribs/gnodev/cmd/gnodev/setup_web.go#L15), it gives its own listening address. This PR adds a gnodev command line option `-web-help-remote` . If supplied, this overrides and is used when starting gnoweb.