### PR TITLE
fix(gnovm): remove sort from gonative packages

### DIFF
--- a/gnovm/tests/imports.go
+++ b/gnovm/tests/imports.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -331,11 +330,6 @@ func TestStore(rootDir, filesPath string, stdin io.Reader, stdout, stderr io.Wri
 			case "math/big":
 				pkg := gno.NewPackageNode("big", pkgPath, nil)
 				pkg.DefineGoNativeValue("NewInt", big.NewInt)
-				return pkg, pkg.NewPackage()
-			case "sort":
-				pkg := gno.NewPackageNode("sort", pkgPath, nil)
-				pkg.DefineGoNativeValue("Strings", sort.Strings)
-				// pkg.DefineGoNativeValue("Sort", sort.Sort)
 				return pkg, pkg.NewPackage()
 			case "flag":
 				pkg := gno.NewPackageNode("flag", pkgPath, nil)


### PR DESCRIPTION
Fixes #2139.

Removing `sort` from the list of native packages allows tests to use the full-Gno `sort` implementation, which has support for `sort.Sort` and will not cause the panic mentioned by @leohhhn.