### PR TITLE
fix: refactor nightly workflow to use goreleaser pro

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -479,3 +479,7 @@ release:
 
     https://github.com/orgs/gnolang/packages?repo_name={{ .ProjectName }}
 
+nightly:
+  tag_name: nightly
+  publish_release: true
+  keep_single_release: true

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -5,46 +5,41 @@ on:
     - cron:  '0 0 * * 2-6'
   workflow_dispatch:
 
+permissions:
+  contents: write # needed to write releases
+  id-token: write # needed for keyless signing
+  packages: write # needed for ghcr access
+
 jobs:
-  trigger-nightly:
-    name: Push tag for nightly build
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - name: 'Push new tag'
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          # A previous release was created using a lightweight tag
-          # git describe by default includes only annotated tags
-          # git describe --tags includes lightweight tags as well
-          DESCRIBE=`git tag -l --sort=-v:refname | grep -v nightly | head -n 1`
-          MAJOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[1]}'`
-          MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
-          MINOR_VERSION="$((${MINOR_VERSION} + 1))"
-          TAG="${MAJOR_VERSION}.${MINOR_VERSION}.0-nightly.$(date +'%Y%m%d')"
-          git tag -a $TAG -m "$TAG: nightly build"
-          git push origin $TAG
-      - name: 'Clean up nightly releases'
-        uses: dev-drprasad/delete-older-releases@v0.3.3
+      - uses: actions/setup-go@v5
         with:
-          keep_latest: 5
-          delete_tags: true
-          delete_tag_pattern: nightly
+          go-version: "1.22.x"
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3.5.0
+      - uses: anchore/sbom-action/download-syft@v0.15.10
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --clean --nightly --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Delete nightly containers older than a week'
-        uses: snok/container-retention-policy@v2.1.2
-        with:
-          image-names: gnolang/gno*
-          cut-off: 1 week ago UTC
-          account-type: org
-          org-name: gnolang
-          keep-at-least: 5
-          token: ${{ secrets.GITHUB_TOKEN }}
-          filter-tags: '*-nightly*'
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
Workflows are not triggered if the change was generated by a workflow to avoid loop workflow executions. Changing that to directly trigger a nightly using goreleaser pro.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
