### PR TITLE
chore: replace all occurence of port 3665{6,7,8} to 2665{6,7,8}

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,7 +37,7 @@ ports:
 
   - name: "gnoland RPC"
     description: "the RPC server, managed by tendermint2"
-    port: 36657
+    port: 26657
     onOpen: notify
 
 github:

--- a/Dockerfile.gnoland.release
+++ b/Dockerfile.gnoland.release
@@ -8,6 +8,6 @@ COPY ./gno.land/genesis/genesis_txs.jsonl /gnoroot/gno.land/genesis/genesis_txs.
 
 ENV GNOROOT="/gnoroot/"
 
-EXPOSE 26657 26657
+EXPOSE 26656 26657
 ENTRYPOINT [ "/gnoland" ]
 CMD [ "" ]

--- a/Dockerfile.gnoland.release
+++ b/Dockerfile.gnoland.release
@@ -8,6 +8,6 @@ COPY ./gno.land/genesis/genesis_txs.jsonl /gnoroot/gno.land/genesis/genesis_txs.
 
 ENV GNOROOT="/gnoroot/"
 
-EXPOSE 26657 36657
+EXPOSE 26657 26657
 ENTRYPOINT [ "/gnoland" ]
 CMD [ "" ]

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -64,7 +64,7 @@ var defaultDevOptions = &devCfg{
 	chainId:             "dev",
 	maxGas:              10_000_000_000,
 	webListenerAddr:     "127.0.0.1:8888",
-	nodeRPCListenerAddr: "127.0.0.1:36657",
+	nodeRPCListenerAddr: "127.0.0.1:26657",
 	deployKey:           DefaultDeployerAddress.String(),
 	home:                gnoenv.HomeDir(),
 	root:                gnoenv.RootDir(),

--- a/docs/how-to-guides/interact-with-gnoland.md
+++ b/docs/how-to-guides/interact-with-gnoland.md
@@ -29,7 +29,7 @@ gnokey maketx call \
     -gas-fee="1ugnot" \
     -gas-wanted="5000000" \
     -broadcast="true" \
-    -remote="staging.gno.land:36657" \
+    -remote="staging.gno.land:26657" \
     -chainid="test3" \
     -pkgpath="gno.land/r/demo/users" \
     -func="Register" \
@@ -48,13 +48,13 @@ gnokey maketx call \
 
 ```bash
 # Get account information
-gnokey query -remote="staging.gno.land:36657" "auth/accounts/{address}"
+gnokey query -remote="staging.gno.land:26657" "auth/accounts/{address}"
 
 # Get account balance
-gnokey query -remote="staging.gno.land:36657" "bank/balances/{address}"
+gnokey query -remote="staging.gno.land:26657" "bank/balances/{address}"
 
 # Get /r/demo/boards user information
-gnokey query -remote="staging.gno.land:36657" -data "gno.land/r/demo/users
+gnokey query -remote="staging.gno.land:26657" -data "gno.land/r/demo/users
 my_account" "vm/qrender"
 ```
 
@@ -68,7 +68,7 @@ gnokey maketx send \
     -gas-fee="1ugnot" \
     -gas-wanted="5000000" \
     -broadcast="true" \
-    -remote="staging.gno.land:36657" \
+    -remote="staging.gno.land:26657" \
     -chainid="test3" \
     -to="{address}" \ # g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
     -send="{amount}{denom}" \ # 1234ugnot
@@ -85,7 +85,7 @@ gnokey maketx call \
     -gas-fee="1ugnot" \
     -gas-wanted="5000000" \
     -broadcast="true" \
-    -remote "staging.gno.land:36657" \
+    -remote "staging.gno.land:26657" \
     -chainid="test3" \
     -pkgpath="gno.land/r/demo/boards" \
     -func="CreateBoard" \

--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -9,7 +9,7 @@ id: network-config
 | Portal Loop | https://rpc.gno.land:443           | `portal-loop` |
 | Testnet 4   | upcoming                           | upcoming      |
 | Testnet 3   | https://rpc.test3.gno.land:443     | `test3`       |
-| Staging     | https://rpc.staging.gno.land:36657 | `test3`       |
+| Staging     | https://rpc.staging.gno.land:26657 | `test3`       |
 
 ### WebSocket endpoints
 All networks follow the same pattern for websocket connections: 

--- a/docs/reference/tm2-js-client/Provider/json-rpc-provider.md
+++ b/docs/reference/tm2-js-client/Provider/json-rpc-provider.md
@@ -17,6 +17,6 @@ Creates a new instance of the JSON-RPC Provider
 #### Usage
 
 ```ts
-new JSONRPCProvider('http://staging.gno.land:36657');
+new JSONRPCProvider('http://staging.gno.land:26657');
 // provider is created
 ```

--- a/docs/reference/tm2-js-client/Provider/ws-provider.md
+++ b/docs/reference/tm2-js-client/Provider/ws-provider.md
@@ -18,7 +18,7 @@ Creates a new instance of the WebSocket Provider
 #### Usage
 
 ```ts
-new WSProvider('ws://staging.gno.land:36657/ws');
+new WSProvider('ws://staging.gno.land:26657/ws');
 // provider with WS connection is created
 ```
 
@@ -30,7 +30,7 @@ with the WS provider
 #### Usage
 
 ```ts
-const wsProvider = new WSProvider('ws://staging.gno.land:36657/ws');
+const wsProvider = new WSProvider('ws://staging.gno.land:26657/ws');
 
 wsProvider.closeConnection();
 // WS connection is now closed
@@ -52,7 +52,7 @@ Returns **Promise<RPCResponse<Result\>>**
 ```ts
 const request: RPCRequest = // ...
 
-const wsProvider = new WSProvider('ws://staging.gno.land:36657/ws');
+const wsProvider = new WSProvider('ws://staging.gno.land:26657/ws');
 
 wsProvider.sendRequest<Result>(request);
 // request is sent over the open WS connection
@@ -73,7 +73,7 @@ Returns **Result**
 ```ts
 const response: RPCResponse = // ...
 
-const wsProvider = new WSProvider('ws://staging.gno.land:36657/ws');
+const wsProvider = new WSProvider('ws://staging.gno.land:26657/ws');
 
 wsProvider.parseResponse<Result>(response);
 // response is parsed
@@ -88,7 +88,7 @@ Returns **Promise<null\>**
 #### Usage
 
 ```ts
-const wsProvider = new WSProvider('ws://staging.gno.land:36657/ws');
+const wsProvider = new WSProvider('ws://staging.gno.land:26657/ws');
 
 await wsProvider.waitForOpenConnection()
 // status of the connection is: CONNECTED

--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -8,7 +8,7 @@ name ["gno.land/r/demo/boards"](https://gno.land/r/demo/boards/)
 ## Build `gnokey`, create your account, and interact with Gno.
 
 NOTE: Where you see `-remote localhost:26657` here, that flag can be replaced
-with `-remote test3.gno.land:36657` if you have $GNOT on the testnet.
+with `-remote test3.gno.land:26657` if you have $GNOT on the testnet.
 (To use the testnet, also replace `-chainid dev` with `-chainid test3` .)
 
 ### Build `gnokey` (and other tools).

--- a/gnovm/cmd/gno/mod.go
+++ b/gnovm/cmd/gno/mod.go
@@ -128,7 +128,7 @@ func (c *modDownloadCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&c.remote,
 		"remote",
-		"test3.gno.land:36657",
+		"test3.gno.land:26657",
 		"remote for fetching gno modules",
 	)
 

--- a/gnovm/pkg/gnomod/file_test.go
+++ b/gnovm/pkg/gnomod/file_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/mod/module"
 )
 
-const testRemote string = "test3.gno.land:36657"
+const testRemote string = "test3.gno.land:26657"
 
 func TestFetchDeps(t *testing.T) {
 	for _, tc := range []struct {

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build: ../../..
     environment:
       - VIRTUAL_HOST=rpc.staging.gno.land
-      - VIRTUAL_PORT=36657
+      - VIRTUAL_PORT=26657
       - LETSENCRYPT_HOST=rpc.staging.gno.land
       - LOG_LEVEL=4
     working_dir: /opt/gno/src/gno.land
@@ -15,12 +15,12 @@ services:
       - start
       - --skip-failing-genesis-txs
       - --chainid=staging
-      - --genesis-remote=staging.gno.land:36657
+      - --genesis-remote=staging.gno.land:26657
     volumes:
       - "./data/gnoland:/opt/gno/src/gno.land/gnoland-data"
     ports:
       - 36656:36656
-      - 36657:36657
+      - 26657:26657
     restart: on-failure
     logging:
       driver: "json-file"
@@ -34,11 +34,11 @@ services:
     command:
       - gnoweb
       - --bind=0.0.0.0:80
-      - --remote=gnoland:36657
+      - --remote=gnoland:26657
       - --captcha-site=$RECAPTCHA_SITE_KEY
       - --faucet-url=https://faucet-staging.gno.land/
       - --help-chainid=staging
-      - --help-remote=staging.gno.land:36657
+      - --help-remote=staging.gno.land:26657
       - --with-analytics
     volumes:
       - "./overlay:/overlay:ro"
@@ -64,7 +64,7 @@ services:
         mkdir -p /.gno &&
         expect -c \"set timeout -1; spawn gnokey add --home /.gno/ --recover faucet; expect \\\"Enter a passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Repeat the passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Enter your bip39 mnemonic\\\"; send \\\"$FAUCET_WORDS\\r\\\"; expect eof\" &&
         while true; do
-          expect -c \"set timeout -1; spawn gnofaucet serve --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:36657 --chain-id staging --home /.gno/ faucet; expect \\\"Enter password\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
+          expect -c \"set timeout -1; spawn gnofaucet serve --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:26657 --chain-id staging --home /.gno/ faucet; expect \\\"Enter password\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
           sleep 5;
         done
       "

--- a/misc/deployments/staging.gno.land/docker-compose.yml
+++ b/misc/deployments/staging.gno.land/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - "./data/gnoland:/opt/gno/src/gno.land/gnoland-data"
     ports:
-      - 36656:36656
+      - 26656:26656
       - 26657:26657
     restart: on-failure
     logging:

--- a/misc/deployments/staging.gno.land/overlay/config.toml
+++ b/misc/deployments/staging.gno.land/overlay/config.toml
@@ -139,7 +139,7 @@ tls_key_file = ""
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:36656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Address to advertise to peers for them to dial
 # If empty, will use the same port as the laddr,

--- a/misc/deployments/staging.gno.land/overlay/config.toml
+++ b/misc/deployments/staging.gno.land/overlay/config.toml
@@ -72,7 +72,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:36657"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support

--- a/misc/deployments/test2.gno.land/Makefile
+++ b/misc/deployments/test2.gno.land/Makefile
@@ -25,9 +25,9 @@ build:
 
 gnotxport:
 	#docker build -t gno ../..
-	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport export --remote test2.gno.land:36657
+	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport export --remote test2.gno.land:26657
 	tail -n 1 txexport.log
 	wc -l txexport.log
 
 gnotximport:
-	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport import --remote test2.gno.land:36657
+	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport import --remote test2.gno.land:26657

--- a/misc/deployments/test2.gno.land/docker-compose.yml
+++ b/misc/deployments/test2.gno.land/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - LOG_LEVEL=4
       - VIRTUAL_HOST=rpc.test2.gno.land
-      - VIRTUAL_PORT=36657
+      - VIRTUAL_PORT=26657
       - LETSENCRYPT_HOST=rpc.test2.gno.land
     command:
       - gnoland
@@ -16,7 +16,7 @@ services:
       - --chainid
       - test2
       - --genesis-remote
-      - test2.gno.land:36657
+      - test2.gno.land:26657
       - --genesis-balances-file
       - /overlay/balances.txt
     volumes:
@@ -24,7 +24,7 @@ services:
       - "./overlay:/overlay:ro"
     ports:
       - 36656:36656
-      - 36657:36657
+      - 26657:26657
     restart: on-failure
     logging:
       driver: "json-file"
@@ -40,7 +40,7 @@ services:
       - --bind
       - 0.0.0.0:80
       - --remote
-      - gnoland:36657
+      - gnoland:26657
       - --captcha-site
       - $RECAPTCHA_SITE_KEY
       - --faucet-url
@@ -48,7 +48,7 @@ services:
       - --help-chainid
       - test2
       - --help-remote
-      - test2.gno.land:36657
+      - test2.gno.land:26657
       - --home-content
       - /overlay/HOME.md
     volumes:
@@ -75,7 +75,7 @@ services:
         mkdir -p /.gno &&
         expect -c \"set timeout -1; spawn gnokey add faucet --home /.gno/ --recover; expect \\\"Enter a passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Repeat the passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Enter your bip39 mnemonic\\\"; send \\\"$FAUCET_WORDS\\r\\\"; expect eof\" &&
         while true; do
-          expect -c \"set timeout -1; spawn gnofaucet serve faucet --is-behind-proxy --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:36657 --chain-id test2 --home /.gno/; expect \\\"Enter password.\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
+          expect -c \"set timeout -1; spawn gnofaucet serve faucet --is-behind-proxy --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:26657 --chain-id test2 --home /.gno/; expect \\\"Enter password.\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
           sleep 5;
         done
       "

--- a/misc/deployments/test2.gno.land/docker-compose.yml
+++ b/misc/deployments/test2.gno.land/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "./data/gnoland:/opt/gno/src/testdir"
       - "./overlay:/overlay:ro"
     ports:
-      - 36656:36656
+      - 26656:26656
       - 26657:26657
     restart: on-failure
     logging:

--- a/misc/deployments/test2.gno.land/overlay/config.toml
+++ b/misc/deployments/test2.gno.land/overlay/config.toml
@@ -139,7 +139,7 @@ tls_key_file = ""
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:36656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Address to advertise to peers for them to dial
 # If empty, will use the same port as the laddr,

--- a/misc/deployments/test2.gno.land/overlay/config.toml
+++ b/misc/deployments/test2.gno.land/overlay/config.toml
@@ -72,7 +72,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:36657"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support

--- a/misc/deployments/test3.gno.land/Makefile
+++ b/misc/deployments/test3.gno.land/Makefile
@@ -28,9 +28,9 @@ build:
 
 gnotxport:
 	#docker build -t gno ../..
-	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport export --remote test3.gno.land:36657
+	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport export --remote test3.gno.land:26657
 	tail -n 1 txexport.log
 	wc -l txexport.log
 
 gnotximport:
-	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport import --remote test3.gno.land:36657
+	docker run -v "$(PWD):$(PWD)" -w "$(PWD)" gno gnotxport import --remote test3.gno.land:26657

--- a/misc/deployments/test3.gno.land/docker-compose.yml
+++ b/misc/deployments/test3.gno.land/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - LOG_LEVEL=4
       - VIRTUAL_HOST=rpc.test3.gno.land
-      - VIRTUAL_PORT=36657
+      - VIRTUAL_PORT=26657
       - LETSENCRYPT_HOST=rpc.test3.gno.land
     command:
       - gnoland
@@ -16,7 +16,7 @@ services:
       - --chainid
       - test3
       - --genesis-remote
-      - test3.gno.land:36657
+      - test3.gno.land:26657
       - --genesis-balances-file
       - /overlay/balances.txt
       - --genesis-txs-file
@@ -26,7 +26,7 @@ services:
       - "./overlay:/overlay:ro"
     ports:
       - 36656:36656
-      - 36657:36657
+      - 26657:26657
     restart: on-failure
     logging:
       driver: "json-file"
@@ -42,7 +42,7 @@ services:
       - --bind
       - 0.0.0.0:80
       - --remote
-      - gnoland:36657
+      - gnoland:26657
       - --captcha-site
       - $RECAPTCHA_SITE_KEY
       - --faucet-url
@@ -50,7 +50,7 @@ services:
       - --help-chainid
       - test3
       - --help-remote
-      - test3.gno.land:36657
+      - test3.gno.land:26657
       - --home-content
       - /overlay/HOME.md
     volumes:
@@ -77,7 +77,7 @@ services:
         mkdir -p /.gno &&
         expect -c \"set timeout -1; spawn gnokey add faucet --home /.gno/ --recover; expect \\\"Enter a passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Repeat the passphrase\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect \\\"Enter your bip39 mnemonic\\\"; send \\\"$FAUCET_WORDS\\r\\\"; expect eof\" &&
         while true; do
-          expect -c \"set timeout -1; spawn gnofaucet serve faucet --is-behind-proxy --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:36657 --chain-id test3 --home /.gno/; expect \\\"Enter password.\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
+          expect -c \"set timeout -1; spawn gnofaucet serve faucet --is-behind-proxy --send 50000000ugnot --captcha-secret \\\"$RECAPTCHA_SECRET_KEY\\\" --remote gnoland:26657 --chain-id test3 --home /.gno/; expect \\\"Enter password.\\\"; send \\\"$GNOKEY_PASS\\r\\\"; expect eof\";
           sleep 5;
         done
       "

--- a/misc/deployments/test3.gno.land/docker-compose.yml
+++ b/misc/deployments/test3.gno.land/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     ports:
       - 26656:26656
       - 26657:26657
+      - 36657:26657
     restart: on-failure
     logging:
       driver: "json-file"

--- a/misc/deployments/test3.gno.land/docker-compose.yml
+++ b/misc/deployments/test3.gno.land/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - "./data/gnoland:/opt/gno/src/testdir"
       - "./overlay:/overlay:ro"
     ports:
-      - 36656:36656
+      - 26656:26656
       - 26657:26657
     restart: on-failure
     logging:

--- a/misc/deployments/test3.gno.land/overlay/config.toml
+++ b/misc/deployments/test3.gno.land/overlay/config.toml
@@ -139,7 +139,7 @@ tls_key_file = ""
 [p2p]
 
 # Address to listen for incoming connections
-laddr = "tcp://0.0.0.0:36656"
+laddr = "tcp://0.0.0.0:26656"
 
 # Address to advertise to peers for them to dial
 # If empty, will use the same port as the laddr,

--- a/misc/deployments/test3.gno.land/overlay/config.toml
+++ b/misc/deployments/test3.gno.land/overlay/config.toml
@@ -72,7 +72,7 @@ filter_peers = false
 [rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "tcp://0.0.0.0:36657"
+laddr = "tcp://0.0.0.0:26657"
 
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support

--- a/tm2/pkg/bft/rpc/config/config.go
+++ b/tm2/pkg/bft/rpc/config/config.go
@@ -112,7 +112,7 @@ func DefaultRPCConfig() *RPCConfig {
 func TestRPCConfig() *RPCConfig {
 	cfg := DefaultRPCConfig()
 	cfg.ListenAddress = "tcp://0.0.0.0:26657"
-	cfg.GRPCListenAddress = "tcp://0.0.0.0:36658"
+	cfg.GRPCListenAddress = "tcp://0.0.0.0:26658"
 	cfg.Unsafe = true
 	return cfg
 }

--- a/tm2/pkg/bft/rpc/config/config.go
+++ b/tm2/pkg/bft/rpc/config/config.go
@@ -111,7 +111,7 @@ func DefaultRPCConfig() *RPCConfig {
 // TestRPCConfig returns a configuration for testing the RPC server
 func TestRPCConfig() *RPCConfig {
 	cfg := DefaultRPCConfig()
-	cfg.ListenAddress = "tcp://0.0.0.0:36657"
+	cfg.ListenAddress = "tcp://0.0.0.0:26657"
 	cfg.GRPCListenAddress = "tcp://0.0.0.0:36658"
 	cfg.Unsafe = true
 	return cfg

--- a/tm2/pkg/p2p/config/config.go
+++ b/tm2/pkg/p2p/config/config.go
@@ -107,7 +107,7 @@ func DefaultP2PConfig() *P2PConfig {
 // TestP2PConfig returns a configuration for testing the peer-to-peer layer
 func TestP2PConfig() *P2PConfig {
 	cfg := DefaultP2PConfig()
-	cfg.ListenAddress = "tcp://0.0.0.0:36656"
+	cfg.ListenAddress = "tcp://0.0.0.0:26656"
 	cfg.FlushThrottleTimeout = 10 * time.Millisecond
 	cfg.AllowDuplicateIP = true
 	return cfg


### PR DESCRIPTION
```
s/36657/26657/g
```

I believe the port 36657 come because there was multiple testnet on the same server, so the port have been put to 36657.

`tendermint` default port is `266*` and i believe we should keep everything conform to it.

I let test3 compatible with 26657 AND 36657 for legacy purpose

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
