### PR TITLE
fix: make install colors not always shown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install: install.gnokey install.gno install.gnodev
 .PHONY: install.gnokey
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
+	# \033[0;32m ... \033[0m is ansi for green text.
 	@echo -e "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
 .PHONY: install.gno
 install.gno:

--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,15 @@ install: install.gnokey install.gno install.gnodev
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
 	# \033[0;32m ... \033[0m is ansi for green text.
-	@echo -e "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
+	@printf "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m\n"
 .PHONY: install.gno
 install.gno:
 	$(MAKE) --no-print-directory -C ./gnovm	install
-	@echo -e "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m"
+	@printf "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m\n"
 .PHONY: install.gnodev
 install.gnodev:
 	$(MAKE) --no-print-directory -C ./contribs install.gnodev
-	@echo -e "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m"
+	@printf "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m\n"
 
 # old aliases
 .PHONY: install_gnokey

--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,15 @@ install: install.gnokey install.gno install.gnodev
 .PHONY: install.gnokey
 install.gnokey:
 	$(MAKE) --no-print-directory -C ./gno.land	install.gnokey
-	# \033[0;32m ... \033[0m is ansi for green text.
-	@echo "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
+	@echo -e "\033[0;32m[+] 'gnokey' has been installed. Read more in ./gno.land/\033[0m"
 .PHONY: install.gno
 install.gno:
 	$(MAKE) --no-print-directory -C ./gnovm	install
-	@echo "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m"
+	@echo -e "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m"
 .PHONY: install.gnodev
 install.gnodev:
 	$(MAKE) --no-print-directory -C ./contribs install.gnodev
-	@echo "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m"
+	@echo -e "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m"
 
 # old aliases
 .PHONY: install_gnokey


### PR DESCRIPTION
In my terminals (konsole, kmscon, kmscon+tmux), colors won't show without -e in
`echo -e "\033[0;32m blabla \033[0m"`.

The -e option enables interpretation of backslash escapes in the string, which
 allows the color code `\033[0;32m` to work. With -e it should be more widely
 supported across different platforms and shell environments.

```
$ help echo
echo: echo [-neE] [arg ...]
    Write arguments to the standard output.

    Display the ARGs, separated by a single space character and followed by a
    newline, on the standard output.

    Options:
      -n        do not append a newline
      -e        enable interpretation of the following backslash escapes
      -E        explicitly suppress interpretation of backslash escapes

    `echo' interprets the following backslash-escaped characters:
      \a        alert (bell)
      \b        backspace
      \c        suppress further output
      \e        escape character
      \E        escape character
      \f        form feed
      \n        new line
      \r        carriage return
      \t        horizontal tab
      \v        vertical tab
      \\        backslash
      \0nnn     the character whose ASCII code is NNN (octal).  NNN can be
                0 to 3 octal digits
```

An alternative is to directly input the escape character, or to use printf: `printf "\033[0;32mHello\033[0m\n"`.

@leohhhh does it still work on your machine with `echo -e`? (what terminal are you using btw?)
