### PR TITLE
docs: add LongHelp to `gno bug`, remove \n from `gnodev` LongHelp

### DIFF
--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -84,9 +84,7 @@ func main() {
 			Name:       "gnodev",
 			ShortUsage: "gnodev [flags] [path ...]",
 			ShortHelp:  "runs an in-memory node and gno.land web server for development purposes.",
-			LongHelp: `The gnodev command starts an in-memory node and a gno.land web interface
-primarily for realm package development. It automatically loads the 'examples' directory and any
-additional specified paths.`,
+			LongHelp:   `The gnodev command starts an in-memory node and a gno.land web interface primarily for realm package development. It automatically loads the 'examples' directory and any additional specified paths.`,
 		},
 		cfg,
 		func(_ context.Context, args []string) error {

--- a/gnovm/cmd/gno/bug.go
+++ b/gnovm/cmd/gno/bug.go
@@ -61,6 +61,17 @@ func newBugCmd(io commands.IO) *commands.Command {
 			Name:       "bug",
 			ShortUsage: "bug",
 			ShortHelp:  "Start a bug report",
+			LongHelp: `opens https://github.com/gnolang/gno/issues in a browser. 
+
+The new issue body is prefilled for you with the following information:
+
+- Go version (example: go1.22.2)
+- OS and CPU architecture (example: linux/amd64)
+- Gno commit hash causing the issue (example: f24690e7ebf325bffcfaf9e328c3df8e6b21e50c)
+
+The rest of the report consists of markdown sections such as ### Steps to reproduce
+that you can edit.
+`,
 		},
 		cfg,
 		func(_ context.Context, args []string) error {
@@ -74,7 +85,7 @@ func (c *bugCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.skipBrowser,
 		"skip-browser",
 		false,
-		"do not open the browser",
+		"output a prefilled issue template on the cli instead",
 	)
 }
 


### PR DESCRIPTION
Added a LongDesc to `gno bug help`.

For gnodev -h think the help body should be on one long line to let it
flow naturally depending on the terminal's width.
