### PR TITLE
test(gnovm): print unexpected error in filetests

### DIFF
--- a/gnovm/tests/file.go
+++ b/gnovm/tests/file.go
@@ -139,12 +139,10 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 					fmt.Printf("OUTPUT:\n%s\n", stdout.String())
 					pnc = r
 					err := strings.TrimSpace(fmt.Sprintf("%v", pnc))
-					fmt.Printf("ERROR:\n%s\n", err)
 					// print stack if unexpected error.
-					if errWanted == "" {
-						rtdb.PrintStack()
-					}
-					if !strings.Contains(err, errWanted) {
+					if errWanted == "" ||
+						!strings.Contains(err, errWanted) {
+						fmt.Printf("ERROR:\n%s\n", err)
 						// error didn't match: print stack
 						// NOTE: will fail testcase later.
 						rtdb.PrintStack()

--- a/gnovm/tests/file.go
+++ b/gnovm/tests/file.go
@@ -136,13 +136,14 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 			defer func() {
 				if r := recover(); r != nil {
 					// print output.
-					fmt.Println("OUTPUT:\n", stdout.String())
-					// print stack if unexpected error.
+					fmt.Printf("OUTPUT:\n%s\n", stdout.String())
 					pnc = r
+					err := strings.TrimSpace(fmt.Sprintf("%v", pnc))
+					fmt.Printf("ERROR:\n%s\n", err)
+					// print stack if unexpected error.
 					if errWanted == "" {
 						rtdb.PrintStack()
 					}
-					err := strings.TrimSpace(fmt.Sprintf("%v", pnc))
 					if !strings.Contains(err, errWanted) {
 						// error didn't match: print stack
 						// NOTE: will fail testcase later.


### PR DESCRIPTION
If an error occurred in a filetest, this was not printed unless a specific `// Error:` directive was added. This adds printing for errors anytime that it doesn't match the expected value in the directive.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
