### PR TITLE
fix(test3): RunMemPackage on p/leon/avl to restore types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.21.x", "1.22.x"]
         goarch: ["amd64"]
         goos: ["linux"]
         program: ["genproto", "gnofaucet", "gnokey", "gnoland", "gnotxport", "goscan", "gnodev", "gnoweb"]

--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.21.x", "1.22.x"]
         tags:
           - cleveldb
           - memdb

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.21.x", "1.22.x"]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.18.x", "1.19.x"]
+        goversion: ["1.21.x", "1.22.x"]
         args:
           - test.go1
           - test.go2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM        golang:1.19 AS build
+FROM        golang:1.21 AS build
 RUN         mkdir -p /opt/gno/src /opt/build
 WORKDIR     /opt/build
 ADD         go.mod go.sum /opt/build/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnolang/gno
 
-go 1.18
+go 1.21
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c


### PR DESCRIPTION
```
		// XXX(morgan): test3 specific, there is a bug with the transactions and
		// the way test3 runs.
		// The theory is as follows:
		//     Take a look at defaultStore.SetType
		//     When p/leon/avl was called, a type with the same TypeID was found in the cache, but it was different than the ones passed, so the function returned
		//     But the type was never in the store
		//     The reason this can happen is that up until this recent commit
		//     https://github.com/gnolang/gno/commit/8afb1a42e138014a3025ef4817aff67b6f4f7ded
		//     The store caches were shared with all child stores, even the ones that are eventually rolled back (due to, like, a failing transaction)
		//     So, in the running node, in a first addpkg, the type was saved in the cache, but then there was a bug in the code so the transaction failed
		//     The type is now in cacheTypes, but not in the database
		//     Afterwards, it was re-uploaded. SetType is called, it detects an existing type in cacheType, but the types are different; so SetType returns without storing it in the database
```