### PR TITLE
fix(stdlibs/net/url): avoid using `fmt`

### DIFF
--- a/gnovm/stdlibs/net/url/url.gno
+++ b/gnovm/stdlibs/net/url/url.gno
@@ -12,7 +12,6 @@ package url
 
 import (
 	"errors"
-	"fmt"
 	"path"
 	"sort"
 	"strconv"
@@ -27,7 +26,7 @@ type Error struct {
 }
 
 func (e *Error) Unwrap() error { return e.Err }
-func (e *Error) Error() string { return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err) }
+func (e *Error) Error() string { return e.Op + " \"" + e.URL + "\": " + e.Err.Error() } // "%s %q: %s"
 
 func (e *Error) Timeout() bool {
 	t, ok := e.Err.(interface {
@@ -623,7 +622,7 @@ func parseHost(host string) (string, error) {
 		}
 		colonPort := host[i+1:]
 		if !validOptionalPort(colonPort) {
-			return "", fmt.Errorf("invalid port %q after host", colonPort)
+			return "", errors.New("invalid port \"" + colonPort + "\" after host")
 		}
 
 		// RFC 6874 defines that %25 (%-encoded percent) introduces
@@ -651,7 +650,7 @@ func parseHost(host string) (string, error) {
 	} else if i := strings.LastIndex(host, ":"); i != -1 {
 		colonPort := host[i:]
 		if !validOptionalPort(colonPort) {
-			return "", fmt.Errorf("invalid port %q after host", colonPort)
+			return "", errors.New("invalid port \"" + colonPort + "\" after host")
 		}
 	}
 
@@ -934,7 +933,7 @@ func parseQuery(m Values, query string) (err error) {
 		var key string
 		key, query, _ = strings.Cut(query, "&")
 		if strings.Contains(key, ";") {
-			err = fmt.Errorf("invalid semicolon separator in query")
+			err = errors.New("invalid semicolon separator in query")
 			continue
 		}
 		if key == "" {


### PR DESCRIPTION
If a package/realm imports `net/url`, e.g,
```
# load tmp.gno file located in $WORK directory as gno.land/r/tmp
loadpkg gno.land/r/tmp $WORK

## start a new node
gnoland start

-- tmp.gno --
package tmp

import _ "net/url"
```

it fails with error message: 
```
panic: recovered: net/url/url.gno:6: unknown import path fmt
```
because `net/url` imports `fmt` which is not part of stdlibs.

---

PS: These types of errors should be detected when stdlibs are loaded on chain and CI should also be able to detect them.