### PR TITLE
chore: add `nightly` flag for `master` releases

### DIFF
--- a/.github/goreleaser-master.yaml
+++ b/.github/goreleaser-master.yaml
@@ -495,8 +495,3 @@ release:
     You can find all docker images at:
 
     https://github.com/orgs/gnolang/packages?repo_name={{ .ProjectName }}
-
-nightly:
-  tag_name: master
-  publish_release: true
-  keep_single_release: true

--- a/.github/goreleaser-master.yaml
+++ b/.github/goreleaser-master.yaml
@@ -495,3 +495,8 @@ release:
     You can find all docker images at:
 
     https://github.com/orgs/gnolang/packages?repo_name={{ .ProjectName }}
+
+nightly:
+  tag_name: master
+  publish_release: true
+  keep_single_release: true

--- a/.github/workflows/releaser-master.yml
+++ b/.github/workflows/releaser-master.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
-          args: release --clean --config ./.github/goreleaser-master.yaml
+          args: release --clean --nightly --config ./.github/goreleaser-master.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
## Description

This PR adds the `nightly` flag from the Goreleaser workflow on `master` pushes:
https://github.com/gnolang/gno/actions/runs/9273867067/job/25514896531

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
