### PR TITLE
test(stdlibs/std): use real MsgRun pkgpath in TestPrevRealmIsOrigin

### DIFF
--- a/gnovm/stdlibs/std/native_test.go
+++ b/gnovm/stdlibs/std/native_test.go
@@ -16,7 +16,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			OrigCaller: user,
 		}
 		msgCallFrame = &gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "main"}}
-		msgRunFrame  = &gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/user-realm"}}
+		msgRunFrame  = &gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/g1337/run"}}
 	)
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
This PR fixes the current failing CI on master.

The test case was incorrect, as it was using a MsgRun frame which wasn't matching what a MsgRun frame would look like (and thus give a corresponding result, when calling PrevRealm):

https://github.com/gnolang/gno/blob/ac3a802e7dd8a2ac47a1c119f5614e76e96e643a/gnovm/pkg/gnolang/realm.go#L1521-L1529

This PR makes the "test frame" respect the regex, making the test case correct again.