### PR TITLE
feat: improve missing config error message

### DIFF
--- a/gno.land/cmd/gnoland/config.go
+++ b/gno.land/cmd/gnoland/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
 
-const tryConfigInit = "unable to load config; try running `gnoland config init`"
+const tryConfigInit = "unable to load config; try running `gnoland config init` or use the -lazy flag"
 
 type configCfg struct {
 	configPath string

--- a/gno.land/cmd/gnoland/config.go
+++ b/gno.land/cmd/gnoland/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
 
+const tryConfigInit = "unable to load config; try running `gnoland config init`"
+
 type configCfg struct {
 	configPath string
 }

--- a/gno.land/cmd/gnoland/config_get.go
+++ b/gno.land/cmd/gnoland/config_get.go
@@ -38,7 +38,7 @@ func execConfigGet(cfg *configCfg, io commands.IO, args []string) error {
 	// Load the config
 	loadedCfg, err := config.LoadConfigFile(cfg.configPath)
 	if err != nil {
-		return fmt.Errorf("unable to load config, %w", err)
+		return fmt.Errorf("%s, %w", tryConfigInit, err)
 	}
 
 	// Make sure the edit arguments are valid

--- a/gno.land/cmd/gnoland/config_get_test.go
+++ b/gno.land/cmd/gnoland/config_get_test.go
@@ -27,7 +27,7 @@ func TestConfig_Get_Invalid(t *testing.T) {
 
 	// Run the command
 	cmdErr := cmd.ParseAndRun(context.Background(), args)
-	assert.ErrorContains(t, cmdErr, "unable to load config")
+	assert.ErrorContains(t, cmdErr, tryConfigInit)
 }
 
 // testSetCase outlines the single test case for config get

--- a/gno.land/cmd/gnoland/config_set.go
+++ b/gno.land/cmd/gnoland/config_set.go
@@ -41,7 +41,7 @@ func execConfigEdit(cfg *configCfg, io commands.IO, args []string) error {
 	// Load the config
 	loadedCfg, err := config.LoadConfigFile(cfg.configPath)
 	if err != nil {
-		return fmt.Errorf("unable to load config, %w", err)
+		return fmt.Errorf("%s, %w", tryConfigInit, err)
 	}
 
 	// Make sure the edit arguments are valid

--- a/gno.land/cmd/gnoland/config_set_test.go
+++ b/gno.land/cmd/gnoland/config_set_test.go
@@ -91,7 +91,7 @@ func TestConfig_Set_Invalid(t *testing.T) {
 
 		// Run the command
 		cmdErr := cmd.ParseAndRun(context.Background(), args)
-		assert.ErrorContains(t, cmdErr, "unable to load config")
+		assert.ErrorContains(t, cmdErr, tryConfigInit)
 	})
 
 	t.Run("invalid config change", func(t *testing.T) {

--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -209,7 +209,7 @@ func execStart(ctx context.Context, c *startCfg, io commands.IO) error {
 	// Load the configuration
 	cfg, err := config.LoadConfig(nodeDir)
 	if err != nil {
-		return fmt.Errorf("unable to load config, %w", err)
+		return fmt.Errorf("%s, %w", tryConfigInit, err)
 	}
 
 	// Check if the genesis.json exists


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
If the config file can't be found when running `gnoland start`, then the error message should tell me how to fix this by running `gnoland config init`.
<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
