### PR TITLE
fix: a breakpoint in a loop body was working only once.

### DIFF
--- a/gnovm/pkg/gnolang/debugger.go
+++ b/gnovm/pkg/gnolang/debugger.go
@@ -146,6 +146,7 @@ loop:
 			os.Exit(0)
 		}
 	}
+	m.Debugger.prevLoc = m.Debugger.loc
 	debugUpdateLocation(m)
 
 	// Keep track of exact locations when performing calls.

--- a/gnovm/pkg/gnolang/debugger_test.go
+++ b/gnovm/pkg/gnolang/debugger_test.go
@@ -83,7 +83,7 @@ func TestDebug(t *testing.T) {
 		{in: "help b\n", out: "Set a breakpoint."},
 		{in: "help zzz\n", out: "command not available"},
 		{in: "list " + debugTarget + ":1\n", out: "1: // This is a sample target"},
-		{in: "l 55\n", out: "42: }"},
+		{in: "l 55\n", out: "46: }"},
 		{in: "l xxx:0\n", out: "xxx: no such file or directory"},
 		{in: "l :xxx\n", out: `"xxx": invalid syntax`},
 		{in: brk, out: "Breakpoint 0 at main "},
@@ -131,6 +131,7 @@ func TestDebug(t *testing.T) {
 		{in: "b 37\nc\np b\n", out: "(3 int)"},
 		{in: "b 27\nc\np b\n", out: `("!zero" string)`},
 		{in: "b 22\nc\np t.A[3]\n", out: "Command failed: slice index out of bounds: 3 (len=3)"},
+		{in: "b 43\nc\nc\np i\nd\n", out: "(1 int)"},
 	})
 
 	runDebugTest(t, "../../tests/files/a1.gno", []dtest{

--- a/gnovm/tests/integ/debugger/sample.gno
+++ b/gnovm/tests/integ/debugger/sample.gno
@@ -38,5 +38,9 @@ func main() {
 	}
 	t := T{A: []int{1, 2, 3} }
 	println(t.get(1))
-	println("bye")
+	x := 0
+	for i := 0; i < 5; i++ {
+		x = i
+	}
+	println("bye", x)
 }


### PR DESCRIPTION
A breakpoint in a loop body was working only the first time, and was ignored the next times, letting 'continue' to skip over it.

This is fixed by updating the debugger previous code location state variable at each VM cycle, instead of just when used by 'step'.

This also corrects similar variants, like breakpoints working only once in recursive function calls.

Thank you @jaekwon for raising the issue and discussing the solution.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [*] Added new tests, or not needed, or not feasible
- [*] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [*] Updated the official documentation or not needed
- [*] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
