### PR TITLE
docs: gno CLI tool sub commands

### DIFF
--- a/docs/gno-tooling/cli/gno.md
+++ b/docs/gno-tooling/cli/gno.md
@@ -25,9 +25,9 @@ To print a comprehensive list of `gno` commands and a brief description of each 
 | `run`              | Runs the specified `.gno` file(s).         | `gno run [flags] <file> [<file>...]`             |
 | `transpile`        | Transpiles a `.gno` file to a `.go` file.  | `gno transpile [flags] <package> [<package>...]` |
 | `repl`             | Starts a GnoVM REPL.                       | `gno repl`                                       |
-| `doc`              | Get documentation for the specified package or symbol (type, function, method, or variable/constant). |
-| `env`              | Prints Gno environment information.        |
-| `bug`              | Starts a bug report.                       |
+| `doc`              | Get documentation for the specified package or symbol (type, function, method, or variable/constant). | `gno doc <package/symbol>` |
+| `env`              | Prints Gno environment information.        | `gno env`                                        |
+| `bug`              | Starts a bug report in GitHub.             | `gno bug`                                        |
 
 ### `mod`
 

--- a/docs/gno-tooling/cli/gno.md
+++ b/docs/gno-tooling/cli/gno.md
@@ -8,44 +8,63 @@ id: gno-tooling-gno
 
 ## Run `gno` Commands
 
-The following command will run `gno`.
+The following command will run `gno`, modified by the sub command.
 
 ```bash
 gno {SUB_COMMAND}
 ```
+To print a comprehensive list of `gno` commands and a brief description of each command, use the command `gno`.
 
-**Subcommands**
+**Sub Commands**
 
-| Name         | Description                                |
-| ------------ | ------------------------------------------ |
-| `test`       | Tests a gno package.                       |
-| `transpile`  | Transpiles a `.gno` file to a `.go` file. |
-| `repl`       | Starts a GnoVM REPL.                       |
+| Sub Command        | Description                                | Usage                                            |
+| ------------------ | ------------------------------------------ | ------------------------------------------------ |
+| `mod`              | Manage gno.mod.                            | `gno mod <sub_command>`                          |
+| `test`             | Runs the tests for the specified packages. | `gno test [flags] <package> [<package>...]`      |
+| `lint`             | Runs the linter for the specified packages.| `gno lint [flags] <package> [<package>...]`      |
+| `run`              | Runs the specified `.gno` file(s).         | `gno run [flags] <file> [<file>...]`             |
+| `transpile`        | Transpiles a `.gno` file to a `.go` file.  | `gno transpile [flags] <package> [<package>...]` |
+| `repl`             | Starts a GnoVM REPL.                       | `gno repl`                                       |
+| `doc`              | Get documentation for the specified package or symbol (type, function, method, or variable/constant). |
+| `env`              | Prints Gno environment information.        |
+| `bug`              | Starts a bug report.                       |
+
+### `mod`
+
+#### **Sub Commands**
+
+| Name         | Description                                                        |
+| ------------ | ------------------------------------------------------------------ |
+| `download`   | Downloads modules to local cache.                                  |
+| `init`       | Initialize `gno.mod` file in current directory.                    |
+| `tidy`       | Add missing modules and remove unused modules.                     |
+| `why`        | Explains why modules are needed.                                   |
 
 ### `test`
 
-#### **Options**
+#### **Flags**
 
 | Name         | Type          | Description                                                        |
 | ------------ | ------------- | ------------------------------------------------------------------ |
-| `v`          | Boolean       | Displays verbose output.                                     |
+| `v`          | Boolean       | Displays verbose output.                                           |
 | `root-dir`   | String        | Clones location of github.com/gnolang/gno (gno tries to guess it). |
 | `run`        | String        | Test name filtering pattern.                                       |
 | `timeout`    | time.Duration | The maximum execution time in ns.                                  |
-| `transpile`  | Boolean       | Transpiles a `.gno` file to a `.go` file before testing.          |
+| `transpile`  | Boolean       | Transpiles a `.gno` file to a `.go` file before testing.           |
 
 ### `transpile`
 
-#### **Options**
+#### **Flags**
 
-| Name        | Type    | Description                                                     |
-| ----------- | ------- | --------------------------------------------------------------- |
-| `v`         | Boolean | Displays verbose output.                                  |
-| `skip-fmt`  | Boolean | Skips the syntax checking of generated `.go` files.             |
-| `gobuild`   | Boolean | Run `go build` on generated `.go` files, ignoring test files.   |
-| `go-binary` | String  | The go binary to use for building (default: `go`).              |
-| `gofmt`     | String  | The gofmt binary to use for syntax checking (default: `gofmt`). |
-| `output`    | String  | The output directory (default: `.`).                            |
+| Name              | Type    | Description                                                       |
+| ----------------- | ------- | ----------------------------------------------------------------- |
+| `go-binary`       | String  | The go binary to use for building (default: `go`).                |
+| `go-fmt-binary`   | String  | The `gofmt` binary to use for syntax checking (default: `gofmt`). |
+| `gobuild`         | Boolean | Run `go build` on generated `.go` files, ignoring test files.     |     
+| `output`          | String  | The output directory (default: `.`).                              |
+| `skip-fmt`        | Boolean | Skips the syntax checking of generated `.go` files.               |
+| `skip-imports`    | Boolean | Do not transpile imports recursively.                             |
+| `v`               | Boolean | Displays verbose output.                                          |
 
 ### `repl`
 


### PR DESCRIPTION
This PR adds sub commands missing from the`gno` CLI tool documentation. I kept the verbiage in as close alignment with my terminal output to keep consistency. 

Comprehensive changes:
* Add missing sub commands from `gno` CLI tool documentation
* Add usage column to Sub Commands table
* Add `mod` sub commands
* Rename `test` and `transpile` “Options” to “Flags” to clarify input in usage
* Add instruction for users to obtain a comprehensive list of `gno` commands

Note that the `clean` command appears on the `gno` command output in my terminal. However, when I run the command, I get `not a gno module: gno.mod file not found in current or any parent directory`. Has the `clean` command been removed or renamed?

For now, I have not included the `clean` command in documentation, as I cannot verify that it exists through testing. 

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [X] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
