### PR TITLE
docs: add missing doc link to docs/reference/gnoclient

### DIFF
--- a/gno.land/pkg/gnoclient/README.md
+++ b/gno.land/pkg/gnoclient/README.md
@@ -3,7 +3,7 @@
 The Gno.land Go client is a dedicated library for interacting seamlessly with the Gno.land RPC API.
 This library simplifies the process of querying or sending transactions to the Gno.land RPC API and interpreting the responses.
 
-Documentation may be found at ../../../docs/reference/gnoclient
+Documentation may be found at [gnoclient](../../../docs/reference/gnoclient).
 
 ## Installation
 

--- a/gno.land/pkg/gnoclient/README.md
+++ b/gno.land/pkg/gnoclient/README.md
@@ -3,6 +3,8 @@
 The Gno.land Go client is a dedicated library for interacting seamlessly with the Gno.land RPC API.
 This library simplifies the process of querying or sending transactions to the Gno.land RPC API and interpreting the responses.
 
+Documentation may be found at ../../../docs/reference/gnoclient
+
 ## Installation
 
 Integrate this library into your Go project with the following command:
@@ -17,6 +19,3 @@ The roadmap for the Gno.land Go client includes:
 - **Integration:** Begin incorporating this library within various components such as `gno.land/cmd/*` and other external clients, including `gnoblog-client`, the Discord community faucet bot, and [GnoMobile](https://github.com/gnolang/gnomobile).
 - **Enhancements:** Once the generic client establishes a robust foundation, we aim to utilize code generation for contracts. This will streamline the creation of type-safe, contract-specific clients.
 
-## Usage
-
-TODO: Documentation for usage is currently in development and will be available soon.


### PR DESCRIPTION
Replaced the announcement of upcoming documentation by a link.

Including a link to the github version is more commonplace.
But relative links inside the same repo can work even locally.
So I don't know, let's see if relative is ok.
