### PR TITLE
fix(blog): add edit check

### DIFF
--- a/examples/gno.land/p/demo/blog/blog.gno
+++ b/examples/gno.land/p/demo/blog/blog.gno
@@ -67,7 +67,7 @@ func (b Blog) RenderPost(res *mux.ResponseWriter, req *mux.Request) {
 	}
 	p := post.(*Post)
 
-    res.Write("<main class='gno-tmpl-page'>" + "\n\n")
+	res.Write("<main class='gno-tmpl-page'>" + "\n\n")
 
 	res.Write("# " + p.Title + "\n\n")
 	res.Write(p.Body + "\n\n")
@@ -88,7 +88,7 @@ func (b Blog) RenderPost(res *mux.ResponseWriter, req *mux.Request) {
 	})
 
 	res.Write("</details>\n")
-    res.Write("</main>")
+	res.Write("</main>")
 
 }
 
@@ -159,10 +159,10 @@ func (b *Blog) NewPost(publisher std.Address, slug, title, body, pubDate string,
 		CreatedAt: parsedTime,
 	}
 
-	return b.prepareAndSetPost(post)
+	return b.prepareAndSetPost(post, false)
 }
 
-func (b *Blog) prepareAndSetPost(post *Post) error {
+func (b *Blog) prepareAndSetPost(post *Post, edit bool) error {
 	post.Title = strings.TrimSpace(post.Title)
 	post.Body = strings.TrimSpace(post.Body)
 
@@ -182,13 +182,15 @@ func (b *Blog) prepareAndSetPost(post *Post) error {
 	trimmedTitleKey := getTitleKey(post.Title)
 	pubDateKey := getPublishedKey(post.CreatedAt)
 
-	// Cannot have two posts with same title key
-	if _, found := b.PostsAlphabetical.Get(trimmedTitleKey); found {
-		return ErrPostTitleExists
-	}
-	// Cannot have two posts with *exact* same timestamp
-	if _, found := b.PostsPublished.Get(pubDateKey); found {
-		return ErrPostPubDateExists
+	if !edit {
+		// Cannot have two posts with same title key
+		if _, found := b.PostsAlphabetical.Get(trimmedTitleKey); found {
+			return ErrPostTitleExists
+		}
+		// Cannot have two posts with *exact* same timestamp
+		if _, found := b.PostsPublished.Get(pubDateKey); found {
+			return ErrPostPubDateExists
+		}
 	}
 
 	// Store post under keys
@@ -249,7 +251,7 @@ func (p *Post) Update(title, body, publicationDate string, authors, tags []strin
 	}
 
 	p.CreatedAt = parsedTime
-	return p.Blog.prepareAndSetPost(p)
+	return p.Blog.prepareAndSetPost(p, true)
 }
 
 func (p *Post) AddComment(author std.Address, comment string) error {

--- a/examples/gno.land/r/gnoland/blog/gnoblog_test.gno
+++ b/examples/gno.land/r/gnoland/blog/gnoblog_test.gno
@@ -135,11 +135,14 @@ Published by g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq to Gnoland's Blog
 
 	// edit post.
 	{
-		ModEditPost("slug2", "title2++", "body2++", "2009-11-10T23:00:00Z", "manfred", "tag1,tag4")
+		oldTitle := "title2"
+		oldDate := "2022-05-20T13:17:23Z"
+
+		ModEditPost("slug2", oldTitle, "body2++", oldDate, "manfred", "tag1,tag4")
 		got := Render("p/slug2")
 		expected := `<main class='gno-tmpl-page'>
 
-# title2++
+# title2
 
 body2++
 
@@ -147,7 +150,7 @@ body2++
 
 Tags: [#tag1](/r/gnoland/blog:t/tag1) [#tag4](/r/gnoland/blog:t/tag4)
 
-Written by manfred on 10 Nov 2009
+Written by manfred on 20 May 2022
 
 Published by g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq to Gnoland's Blog
 
@@ -170,6 +173,14 @@ Published by g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq to Gnoland's Blog
 </main>
 	`
 		assertMDEquals(t, got, expected)
+
+		home := Render("")
+
+		if strings.Count(home, oldTitle) != 1 {
+			t.Errorf("post not edited properly")
+		}
+		// Edits work everything except title, slug, and publicationDate
+		// Edits to the above will cause duplication on the blog home page
 	}
 
 	{ // Test remove functionality


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

This PR provides a hotfix to the edit functionality in the blog package. This is not the best solution, but due to the urgency of the requests, a we cannot wait for a full refactor of the code, and there are still issues with [AVL & GnoVM](https://github.com/gnolang/gno/issues/2266) that are blocking the other proper workaround on this.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
