### PR TITLE
add redirect temporarily from /gophercon24 to docs.gno.land

### DIFF
--- a/gno.land/pkg/gnoweb/gnoweb.go
+++ b/gno.land/pkg/gnoweb/gnoweb.go
@@ -103,6 +103,7 @@ func MakeApp(logger *slog.Logger, cfg Config) gotuna.App {
 		"/grants":                  "/partners",
 		"/language":                "/gnolang",
 		"/getting-started":         "/start",
+		"/gophercon24":             "https://docs.gno.land",
 	}
 	for from, to := range redirects {
 		app.Router.Handle(from, handlerRedirect(logger, app, &cfg, to))


### PR DESCRIPTION
This should change and become a full page by Gophercon EU, or at least US.