### PR TITLE
fix(gnoweb): Cursor pointer when hovering over dark mode theme

### DIFF
--- a/gno.land/pkg/gnoweb/static/css/app.css
+++ b/gno.land/pkg/gnoweb/static/css/app.css
@@ -119,6 +119,7 @@ html[data-theme="dark"] {
 .logo-hat {fill: var(--logo-hat, #ffffff); }
 
 #theme-toggle {
+  cursor: pointer;
   display: inline-block;
   padding: 0;
   color: var(--header-forground, #ffffff);


### PR DESCRIPTION
Made the cursor `pointer` when hovering over the light/dark theme toggle button

![image](https://github.com/gnolang/gno/assets/68433935/0b63b779-b4b5-4b0b-adf1-a269d5e2a5d0)

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
