### PR TITLE
fix(gnoland): fix: wrong help message for balances add

### DIFF
--- a/gno.land/cmd/gnoland/genesis_balances_add.go
+++ b/gno.land/cmd/gnoland/genesis_balances_add.go
@@ -43,7 +43,7 @@ func newBalancesAddCmd(rootCfg *balancesCfg, io commands.IO) *commands.Command {
 		commands.Metadata{
 			Name:       "add",
 			ShortUsage: "balances add [flags]",
-			ShortHelp:  "adds the balance information",
+			ShortHelp:  "adds balances to the genesis.json",
 		},
 		cfg,
 		func(ctx context.Context, _ []string) error {

--- a/gno.land/cmd/gnoland/genesis_balances_add.go
+++ b/gno.land/cmd/gnoland/genesis_balances_add.go
@@ -43,7 +43,7 @@ func newBalancesAddCmd(rootCfg *balancesCfg, io commands.IO) *commands.Command {
 		commands.Metadata{
 			Name:       "add",
 			ShortUsage: "balances add [flags]",
-			ShortHelp:  "adds a new validator to the genesis.json",
+			ShortHelp:  "adds the balance information",
 		},
 		cfg,
 		func(ctx context.Context, _ []string) error {


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

command is `balances add`, but help message was for `validator add`

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
