### PR TITLE
docs: Fix wrong indentation in concepts/packages

### DIFF
--- a/docs/concepts/packages.md
+++ b/docs/concepts/packages.md
@@ -41,12 +41,12 @@ The role of each function is as follows:
 
 Two types of contracts exist in`grc20`:
 
-1. `AdminToken`\
-   \- Implements the token factory with `Helper` functions.\
-   \- The underlying struct should not be exposed to users. However, it can be typecasted as UserToken using the `GRC20()` method.
-2. `UserToken`\
-   \- Implements the `IGRC20` interface.\
-   \- The underlying struct can be exposed to users. Created with the `GRC20()` method of `adminToken`.
+1. `AdminToken`
+   - Implements the token factory with `Helper` functions.
+   - The underlying struct should not be exposed to users. However, it can be typecasted as UserToken using the `GRC20()` method.
+2. `UserToken`
+   - Implements the `IGRC20` interface.
+   - The underlying struct can be exposed to users. Created with the `GRC20()` method of `adminToken`.
 
 ## `grc721`
 


### PR DESCRIPTION
Broken indentation in this documentation page fixed.

Before in https://docs.gno.land/concepts/packages/#grc20 :
![Screenshot from 2024-06-05 15-06-40](https://github.com/gnolang/gno/assets/49811529/ba2e7c22-402f-43cf-889a-c3cf1b0b285f)

After:
![Screenshot from 2024-06-05 15-07-03](https://github.com/gnolang/gno/assets/49811529/828713ec-f428-45a5-bc6e-371d3a090c16)

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
