### PR TITLE
fix(gnovm): incorrect `Emit` signature in stdshim

### DIFF
--- a/gnovm/stdlibs/stdshim/stdshim.gno
+++ b/gnovm/stdlibs/stdshim/stdshim.gno
@@ -80,6 +80,6 @@ func DerivePkgAddr(pkgPath string) (addr Address) {
 	panic(shimWarn)
 }
 
-func Emit(tag, key, value string) {
+func Emit(typ string, attrs ...string) {
 	panic(shimWarn)
 }


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

Cherry-picked from [here](https://github.com/gnolang/gno/pull/2130/commits/4c2101214db1c039609e6296d28f7ce5925c318e). Fixes the `Emit` function where it fails in specific cases. 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
