### PR TITLE
fix(gno.land/Makefile): lazily start gnoland node

### DIFF
--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -25,7 +25,7 @@ GOTEST_FLAGS ?= -v -p 1 -timeout=30m
 ########################################
 # Dev tools
 .PHONY: start.gnoland
-start.gnoland:; go run ./cmd/gnoland start
+start.gnoland:; go run ./cmd/gnoland start -lazy
 
 .PHONY: start.gnoweb
 start.gnoweb:; go run ./cmd/gnoweb


### PR DESCRIPTION
`start.gnoland` fails as it requires `config`, `genesis`,... to be created manually in order to start the node. 

Since this is for development purpose. Let's run `gnoland start` with `-lazy` flag.