### PR TITLE
docs(guides/grc20): Fix playground link with correct code

### DIFF
--- a/docs/how-to-guides/creating-grc20.md
+++ b/docs/how-to-guides/creating-grc20.md
@@ -219,7 +219,7 @@ func Render(path string) string {
 Calling the `Render` method returns a general render of the GRC20 realm, or
 if given a specific address, the user's `balance` as a formatted string.
 
-You can view the full code on [this Playground link](https://play.gno.land/p/km7Ja6WDQoL).
+You can view the full code on [this Playground link](https://play.gno.land/p/RB_yIz9bAoB).
 If you want to deploy it, do so on the [Portal Loop](../concepts/portal-loop.md).
 
 ## Conclusion


### PR DESCRIPTION
Following [this guide](https://docs.gno.land/how-to-guides/creating-grc20), I noticed that the code in the given playground link at the end was incorrect:

Previous link and code of the `TransferFrom` function:
https://play.gno.land/p/km7Ja6WDQoL
```go
func TransferFrom(sender, recipient std.Address, amount uint64) {
	caller := std.PrevRealm().Addr()

	if amount <= 0 {
		panic("transfer amount must be greater than zero")
	}

	if err := mytoken.TransferFrom(caller, from, to, amount); err != nil {
		panic(err)
	}
}
```
The problem is `mytoken.TransferFrom(caller, from, to, amount)`, where `from` and `to` are not defined

New link and code (that matches the one given in the guide):
https://play.gno.land/p/RB_yIz9bAoB
```go
func TransferFrom(sender, recipient std.Address, amount uint64) {
    caller := std.PrevRealm().Addr()

    if amount <= 0 {
        panic("transfer amount must be greater than zero")
    }

    if err := mytoken.TransferFrom(caller, sender, recipient, amount); err != nil {
        panic(err)
    }
}
```

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
