### PR TITLE
chore(docs): fix broken link in tm2/pkg/amino/README.md

### DIFF
--- a/tm2/pkg/amino/README.md
+++ b/tm2/pkg/amino/README.md
@@ -45,8 +45,7 @@ This is experimental and subject to change.
 
 ## Amino in the Wild
 
-* Amino:binary spec in [Tendermint](
-https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/encoding.md)
+* Amino:binary spec in [Tendermint](https://github.com/tendermint/tendermint/blob/main/spec/core/encoding.md)
 
 
 # Amino Spec


### PR DESCRIPTION
This is a broken link:

https://github.com/gnolang/gno/blob/3f5a6ad90600fef16a04675d79e4ef8f0e19bf4d/tm2/pkg/amino/README.md?plain=1#L46-L50

PR replaces it with the updated link.

<details><summary>Details</summary>
<p>
File was move there:
 https://github.com/tendermint/tendermint/blob/main/spec/blockchain/encoding.md

which says it's been moved there:
 https://github.com/tendermint/tendermint/blob/main/spec/core/encoding.md

</p>
</details> 

---
For the future, since we have a version in the monorepo and gnolang/tendermint2, where is the best place to post PR?

Because gnolang/tendermint2 of course has the same issue (https://github.com/gnolang/tendermint2/blob/master/pkgs/amino/README.md)
