### PR TITLE
feat: add the ability to add packages to genesis transactions

### DIFF
--- a/examples/gno.land/p/demo/blog/blog.gno
+++ b/examples/gno.land/p/demo/blog/blog.gno
@@ -89,7 +89,6 @@ func (b Blog) RenderPost(res *mux.ResponseWriter, req *mux.Request) {
 
 	res.Write("</details>\n")
 	res.Write("</main>")
-
 }
 
 func (b Blog) RenderTag(res *mux.ResponseWriter, req *mux.Request) {

--- a/examples/gno.land/r/gnoland/events/events.gno
+++ b/examples/gno.land/r/gnoland/events/events.gno
@@ -78,7 +78,8 @@ func upcomingEvents() ui.Element {
 <div class="column">
 
 </div><!-- end column-->
-</div><!-- end columns-3-->`)}
+</div><!-- end columns-3-->`),
+	}
 }
 
 func pastEvents() ui.Element {
@@ -211,5 +212,6 @@ func pastEvents() ui.Element {
 [Watch the talk](https://www.youtube.com/watch?v=hCLErPgnavI)
 
 </div><!-- end column-->
-</div><!-- end columns-3-->`)}
+</div><!-- end columns-3-->`),
+	}
 }

--- a/gno.land/cmd/gnoland/genesis_txs.go
+++ b/gno.land/cmd/gnoland/genesis_txs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
@@ -12,6 +13,8 @@ import (
 type txsCfg struct {
 	commonCfg
 }
+
+var errInvalidGenesisStateType = errors.New("invalid genesis state type")
 
 // newTxsCmd creates the genesis txs subcommand
 func newTxsCmd(io commands.IO) *commands.Command {
@@ -48,7 +51,11 @@ func appendGenesisTxs(genesis *types.GenesisDoc, txs []std.Tx) error {
 		genesis.AppState = gnoland.GnoGenesisState{}
 	}
 
-	state := genesis.AppState.(gnoland.GnoGenesisState)
+	// Make sure the app state is the Gno genesis state
+	state, ok := genesis.AppState.(gnoland.GnoGenesisState)
+	if !ok {
+		return errInvalidGenesisStateType
+	}
 
 	// Left merge the transactions
 	fileTxStore := txStore(txs)

--- a/gno.land/cmd/gnoland/genesis_txs_add.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add.go
@@ -1,149 +1,26 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/gnolang/gno/gno.land/pkg/gnoland"
-	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
-	"github.com/gnolang/gno/tm2/pkg/crypto"
-	"github.com/gnolang/gno/tm2/pkg/std"
-)
-
-var (
-	errInvalidTxsPath     = errors.New("invalid transactions path")
-	errInvalidTxsFile     = errors.New("unable to open transactions file")
-	errNoTxsFileSpecified = errors.New("no txs file specified")
-)
-
-var (
-	genesisDeployAddress = crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // test1
-	genesisDeployFee     = std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
 )
 
 // newTxsAddCmd creates the genesis txs add subcommand
 func newTxsAddCmd(txsCfg *txsCfg, io commands.IO) *commands.Command {
-	return commands.NewCommand(
+	cmd := commands.NewCommand(
 		commands.Metadata{
 			Name:       "add",
-			ShortUsage: "txs add <tx-path ...>",
-			ShortHelp:  "imports transactions into the genesis.json",
-			LongHelp:   "Imports the transactions from a given transactions sheet, or package directory, to the genesis.json",
+			ShortUsage: "txs add <subcommand> [flags] [<arg>...]",
+			ShortHelp:  "adds transactions into the genesis.json",
+			LongHelp:   "Adds initial transactions to the genesis.json",
 		},
 		commands.NewEmptyConfig(),
-		func(ctx context.Context, args []string) error {
-			return execTxsAdd(ctx, txsCfg, io, args)
-		},
-	)
-}
-
-func execTxsAdd(
-	ctx context.Context,
-	cfg *txsCfg,
-	io commands.IO,
-	args []string,
-) error {
-	// Load the genesis
-	genesis, loadErr := types.GenesisDocFromFile(cfg.genesisPath)
-	if loadErr != nil {
-		return fmt.Errorf("unable to load genesis, %w", loadErr)
-	}
-
-	// Open the transactions files
-	if len(args) == 0 {
-		return errNoTxsFileSpecified
-	}
-
-	parsedTxs := make([]std.Tx, 0)
-	for _, argPath := range args {
-		// Grab the absolute path
-		path, err := filepath.Abs(argPath)
-		if err != nil {
-			return fmt.Errorf("unable to get absolute path %s, %w", path, err)
-		}
-
-		// Grab the file info
-		fileInfo, err := os.Stat(path)
-		if err != nil {
-			return fmt.Errorf("%w %s, %w", errInvalidTxsPath, path, err)
-		}
-
-		var txs []std.Tx
-
-		if fileInfo.IsDir() {
-			// Generate transactions from the packages
-			txs, err = loadTxFromDir(path)
-		} else {
-			// Load the transactions from the transaction sheet
-			txs, err = loadTxFromFile(ctx, path)
-		}
-
-		if err != nil {
-			return fmt.Errorf("unable to load transactions, %w", err)
-		}
-
-		parsedTxs = append(parsedTxs, txs...)
-	}
-
-	// Initialize the app state if it's not present
-	if genesis.AppState == nil {
-		genesis.AppState = gnoland.GnoGenesisState{}
-	}
-
-	state := genesis.AppState.(gnoland.GnoGenesisState)
-
-	// Left merge the transactions
-	fileTxStore := txStore(parsedTxs)
-	genesisTxStore := txStore(state.Txs)
-
-	// The genesis transactions have preference with the order
-	// in the genesis.json
-	if err := genesisTxStore.leftMerge(fileTxStore); err != nil {
-		return err
-	}
-
-	// Save the state
-	state.Txs = genesisTxStore
-	genesis.AppState = state
-
-	// Save the updated genesis
-	if err := genesis.SaveAs(cfg.genesisPath); err != nil {
-		return fmt.Errorf("unable to save genesis.json, %w", err)
-	}
-
-	io.Printfln(
-		"Saved %d transactions to genesis.json",
-		len(parsedTxs),
+		commands.HelpExec,
 	)
 
-	return nil
-}
+	cmd.AddSubCommands(
+		newTxsAddSheetCmd(txsCfg, io),
+		newTxsAddPackagesCmd(txsCfg, io),
+	)
 
-// loadTxFromFile loads the transactions from a transaction sheet
-func loadTxFromFile(ctx context.Context, path string) ([]std.Tx, error) {
-	file, loadErr := os.Open(path)
-	if loadErr != nil {
-		return nil, fmt.Errorf("%w, %w", errInvalidTxsFile, loadErr)
-	}
-
-	txs, err := std.ParseTxs(ctx, file)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read file, %w", err)
-	}
-
-	return txs, nil
-}
-
-// loadTxFromDir loads the transactions from the given packages directory, recursively
-func loadTxFromDir(path string) ([]std.Tx, error) {
-	txs, err := gnoland.LoadPackagesFromDir(path, genesisDeployAddress, genesisDeployFee)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load txs from directory, %w", err)
-	}
-
-	return txs, nil
+	return cmd
 }

--- a/gno.land/cmd/gnoland/genesis_txs_add_packages.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_packages.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+var errInvalidPackageDir = errors.New("invalid package directory")
+
+var (
+	genesisDeployAddress = crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // test1
+	genesisDeployFee     = std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
+)
+
+// newTxsAddPackagesCmd creates the genesis txs add packages subcommand
+func newTxsAddPackagesCmd(txsCfg *txsCfg, io commands.IO) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "packages",
+			ShortUsage: "txs add packages <package-path ...>",
+			ShortHelp:  "imports transactions from the given packages into the genesis.json",
+			LongHelp:   "Imports the transactions from a given package directory recursively to the genesis.json",
+		},
+		commands.NewEmptyConfig(),
+		func(_ context.Context, args []string) error {
+			return execTxsAddPackages(txsCfg, io, args)
+		},
+	)
+}
+
+func execTxsAddPackages(
+	cfg *txsCfg,
+	io commands.IO,
+	args []string,
+) error {
+	// Load the genesis
+	genesis, loadErr := types.GenesisDocFromFile(cfg.genesisPath)
+	if loadErr != nil {
+		return fmt.Errorf("unable to load genesis, %w", loadErr)
+	}
+
+	// Make sure the package dir is set
+	if len(args) == 0 {
+		return errInvalidPackageDir
+	}
+
+	parsedTxs := make([]std.Tx, 0)
+	for _, path := range args {
+		// Generate transactions from the packages (recursively)
+		txs, err := gnoland.LoadPackagesFromDir(path, genesisDeployAddress, genesisDeployFee)
+		if err != nil {
+			return fmt.Errorf("unable to load txs from directory, %w", err)
+		}
+
+		parsedTxs = append(parsedTxs, txs...)
+	}
+
+	// Save the txs to the genesis.json
+	if err := appendGenesisTxs(genesis, parsedTxs); err != nil {
+		return fmt.Errorf("unable to append genesis transactions, %w", err)
+	}
+
+	// Save the updated genesis
+	if err := genesis.SaveAs(cfg.genesisPath); err != nil {
+		return fmt.Errorf("unable to save genesis.json, %w", err)
+	}
+
+	io.Printfln(
+		"Saved %d transactions to genesis.json",
+		len(parsedTxs),
+	)
+
+	return nil
+}

--- a/gno.land/cmd/gnoland/genesis_txs_add_packages_test.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_packages_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	vmm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesis_Txs_Add_Packages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid genesis file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"genesis",
+			"txs",
+			"add",
+			"packages",
+			"--genesis-path",
+			"dummy-path",
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errUnableToLoadGenesis.Error())
+	})
+
+	t.Run("invalid package dir", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"genesis",
+			"txs",
+			"add",
+			"packages",
+			"--genesis-path",
+			tempGenesis.Name(),
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorContains(t, cmdErr, errInvalidPackageDir.Error())
+	})
+
+	t.Run("valid package", func(t *testing.T) {
+		t.Parallel()
+
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := getDefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		// Prepare the package
+		var (
+			packagePath = "gno.land/p/demo/cuttlas"
+			dir         = t.TempDir()
+		)
+
+		createFile := func(path, data string) {
+			file, err := os.Create(path)
+			require.NoError(t, err)
+
+			_, err = file.WriteString(data)
+			require.NoError(t, err)
+		}
+
+		// Create the gno.mod file
+		createFile(
+			filepath.Join(dir, "gno.mod"),
+			fmt.Sprintf("module %s\n", packagePath),
+		)
+
+		// Create a simple main.gno
+		createFile(
+			filepath.Join(dir, "main.gno"),
+			"package cuttlas\n\nfunc Example() string {\nreturn \"Manos arriba!\"\n}",
+		)
+
+		// Create the command
+		cmd := newRootCmd(commands.NewTestIO())
+		args := []string{
+			"genesis",
+			"txs",
+			"add",
+			"packages",
+			"--genesis-path",
+			tempGenesis.Name(),
+			dir,
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		require.NoError(t, cmdErr)
+
+		// Validate the transactions were written down
+		updatedGenesis, err := types.GenesisDocFromFile(tempGenesis.Name())
+		require.NoError(t, err)
+		require.NotNil(t, updatedGenesis.AppState)
+
+		// Fetch the state
+		state := updatedGenesis.AppState.(gnoland.GnoGenesisState)
+
+		require.Equal(t, 1, len(state.Txs))
+		require.Equal(t, 1, len(state.Txs[0].Msgs))
+
+		msgAddPkg, ok := state.Txs[0].Msgs[0].(vmm.MsgAddPackage)
+		require.True(t, ok)
+
+		assert.Equal(t, packagePath, msgAddPkg.Package.Path)
+	})
+}

--- a/gno.land/cmd/gnoland/genesis_txs_add_sheet.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_sheet.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+var (
+	errInvalidTxsFile     = errors.New("unable to open transactions file")
+	errNoTxsFileSpecified = errors.New("no txs file specified")
+)
+
+// newTxsAddSheetCmd creates the genesis txs add sheet subcommand
+func newTxsAddSheetCmd(txsCfg *txsCfg, io commands.IO) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "sheet",
+			ShortUsage: "txs add sheet <tx-path ...>",
+			ShortHelp:  "imports transactions into the genesis.json",
+			LongHelp:   "Imports the transactions from a given transactions sheet to the genesis.json",
+		},
+		commands.NewEmptyConfig(),
+		func(ctx context.Context, args []string) error {
+			return execTxsAddSheet(ctx, txsCfg, io, args)
+		},
+	)
+}
+
+func execTxsAddSheet(
+	ctx context.Context,
+	cfg *txsCfg,
+	io commands.IO,
+	args []string,
+) error {
+	// Load the genesis
+	genesis, loadErr := types.GenesisDocFromFile(cfg.genesisPath)
+	if loadErr != nil {
+		return fmt.Errorf("unable to load genesis, %w", loadErr)
+	}
+
+	// Open the transactions files
+	if len(args) == 0 {
+		return errNoTxsFileSpecified
+	}
+
+	parsedTxs := make([]std.Tx, 0)
+	for _, file := range args {
+		file, loadErr := os.Open(file)
+		if loadErr != nil {
+			return fmt.Errorf("%w, %w", errInvalidTxsFile, loadErr)
+		}
+
+		txs, err := std.ParseTxs(ctx, file)
+		if err != nil {
+			return fmt.Errorf("unable to read file, %w", err)
+		}
+
+		parsedTxs = append(parsedTxs, txs...)
+	}
+
+	// Save the txs to the genesis.json
+	if err := appendGenesisTxs(genesis, parsedTxs); err != nil {
+		return fmt.Errorf("unable to append genesis transactions, %w", err)
+	}
+
+	// Save the updated genesis
+	if err := genesis.SaveAs(cfg.genesisPath); err != nil {
+		return fmt.Errorf("unable to save genesis.json, %w", err)
+	}
+
+	io.Printfln(
+		"Saved %d transactions to genesis.json",
+		len(parsedTxs),
+	)
+
+	return nil
+}

--- a/gno.land/cmd/gnoland/genesis_txs_add_sheet.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_sheet.go
@@ -20,9 +20,9 @@ var (
 func newTxsAddSheetCmd(txsCfg *txsCfg, io commands.IO) *commands.Command {
 	return commands.NewCommand(
 		commands.Metadata{
-			Name:       "sheet",
-			ShortUsage: "txs add sheet <tx-path ...>",
-			ShortHelp:  "imports transactions into the genesis.json",
+			Name:       "sheets",
+			ShortUsage: "txs add sheets <sheet-path ...>",
+			ShortHelp:  "imports transactions from the given sheets into the genesis.json",
 			LongHelp:   "Imports the transactions from a given transactions sheet to the genesis.json",
 		},
 		commands.NewEmptyConfig(),

--- a/gno.land/cmd/gnoland/genesis_txs_add_sheet_test.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_sheet_test.go
@@ -62,7 +62,7 @@ func encodeDummyTxs(t *testing.T, txs []std.Tx) []string {
 	return encodedTxs
 }
 
-func TestGenesis_Txs_Add_Sheet(t *testing.T) {
+func TestGenesis_Txs_Add_Sheets(t *testing.T) {
 	t.Parallel()
 
 	t.Run("invalid genesis file", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			"dummy-path",
 		}
@@ -99,7 +99,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			tempGenesis.Name(),
 			"dummy-tx-file",
@@ -125,7 +125,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			tempGenesis.Name(),
 		}
@@ -150,7 +150,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			tempGenesis.Name(),
 			tempGenesis.Name(), // invalid txs file
@@ -191,7 +191,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			tempGenesis.Name(),
 			txsFile.Name(),
@@ -251,7 +251,7 @@ func TestGenesis_Txs_Add_Sheet(t *testing.T) {
 			"genesis",
 			"txs",
 			"add",
-			"sheet",
+			"sheets",
 			"--genesis-path",
 			tempGenesis.Name(),
 			txsFile.Name(),

--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	osm "github.com/gnolang/gno/tm2/pkg/os"
-	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/telemetry"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -401,9 +400,7 @@ func generateGenesisFile(genesisFile string, pk crypto.PubKey, c *startCfg) erro
 
 	// Load examples folder
 	examplesDir := filepath.Join(c.gnoRootDir, "examples")
-	test1 := crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
-	defaultFee := std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
-	pkgsTxs, err := gnoland.LoadPackagesFromDir(examplesDir, test1, defaultFee, nil)
+	pkgsTxs, err := gnoland.LoadPackagesFromDir(examplesDir, genesisDeployAddress, genesisDeployFee)
 	if err != nil {
 		return fmt.Errorf("unable to load examples folder: %w", err)
 	}

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -86,7 +86,7 @@ func LoadGenesisTxsFile(path string, chainID string, genesisRemote string) ([]st
 
 // LoadPackagesFromDir loads gno packages from a directory.
 // It creates and returns a list of transactions based on these packages.
-func LoadPackagesFromDir(dir string, creator bft.Address, fee std.Fee, deposit std.Coins) ([]std.Tx, error) {
+func LoadPackagesFromDir(dir string, creator bft.Address, fee std.Fee) ([]std.Tx, error) {
 	// list all packages from target path
 	pkgs, err := gnomod.ListPkgs(dir)
 	if err != nil {
@@ -103,7 +103,7 @@ func LoadPackagesFromDir(dir string, creator bft.Address, fee std.Fee, deposit s
 	nonDraftPkgs := sortedPkgs.GetNonDraftPkgs()
 	txs := []std.Tx{}
 	for _, pkg := range nonDraftPkgs {
-		tx, err := LoadPackage(pkg, creator, fee, deposit)
+		tx, err := LoadPackage(pkg, creator, fee, nil)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load package %q: %w", pkg.Dir, err)
 		}

--- a/gno.land/pkg/integration/testing_node.go
+++ b/gno.land/pkg/integration/testing_node.go
@@ -115,7 +115,7 @@ func LoadDefaultPackages(t TestingTS, creator bft.Address, gnoroot string) []std
 	examplesDir := filepath.Join(gnoroot, "examples")
 
 	defaultFee := std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
-	txs, err := gnoland.LoadPackagesFromDir(examplesDir, creator, defaultFee, nil)
+	txs, err := gnoland.LoadPackagesFromDir(examplesDir, creator, defaultFee)
 	require.NoError(t, err)
 
 	return txs


### PR DESCRIPTION
## Description

This PR introduces the ability to specify a package directory that will recursively be added (deployed) to the `genesis.json`, utilizing the existing `gnoland genesis txs add` command.

It also separates out the logic from `gnoland genesis txs add` into:
- `gnoland genesis txs add sheets` for individual tx sheet files (ex. from tx-archive output)
- `gnoland genesis txs add packages` for recursively adding packages (ex. `examples`)

![sample](https://github.com/gnolang/gno/assets/16712663/e88b363f-2911-454e-8002-46ee4cbecde6)

Related:
- #1952 
- #1988

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
