### PR TITLE
chore(docs): bump minimum version to go 1.21

### DIFF
--- a/docs/getting-started/local-setup/installation.md
+++ b/docs/getting-started/local-setup/installation.md
@@ -13,7 +13,7 @@ to run on your machine.
 ## Prerequisites
 - **Git**
 - **`make` (for running Makefiles)**
-- **Go 1.19+**
+- **Go 1.21+**
 - **Go Environment Setup**:
   - Make sure `$GOPATH` is well-defined, and `$GOPATH/bin` is added to your `$PATH` variable.
   - To do this, you can add the following line to your `.bashrc`, `.zshrc` or other config file:


### PR DESCRIPTION
@leohhhn this should be kept in sync with the go version in go.mod

if we want to have something which we don't need to update, we can say simply that "we support the latest 2 Go [major versions](https://go.dev/doc/devel/release)"