### PR TITLE
fix: bad module naming in gov package

### DIFF
--- a/examples/gno.land/p/gov/proposal/gno.mod
+++ b/examples/gno.land/p/gov/proposal/gno.mod
@@ -1,1 +1,1 @@
-module proposal
+module gno.land/p/gov/proposal

--- a/examples/gno.land/r/gnoland/valopers/gno.mod
+++ b/examples/gno.land/r/gnoland/valopers/gno.mod
@@ -1,4 +1,4 @@
-module valopers
+module gno.land/r/gnoland/valopers
 
 require (
 	gno.land/p/demo/ownable v0.0.0-latest

--- a/examples/gno.land/r/gov/dao/gno.mod
+++ b/examples/gno.land/r/gov/dao/gno.mod
@@ -1,3 +1,3 @@
-module govdao
+module gno.land/r/gov/dao
 
 require gno.land/p/gov/proposal v0.0.0-latest

--- a/examples/gno.land/r/gov/proposals/prop1/gno.mod
+++ b/examples/gno.land/r/gov/proposals/prop1/gno.mod
@@ -1,4 +1,4 @@
-module prop1
+module gno.land/r/gov/proposals/prop1
 
 require (
 	gno.land/r/gov/dao v0.0.0-latest


### PR DESCRIPTION
This PR addresses the issue of poor module naming introduced in the recent merge #1945.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
