### PR TITLE
fix(gnovm): Correct file test issue in zream12

### DIFF
--- a/gnovm/tests/files/zrealm12.gno
+++ b/gnovm/tests/files/zrealm12.gno
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"gno.land/r/demo/tests"
 	"std"
 )
 

--- a/gnovm/tests/files/zrealm12.gno
+++ b/gnovm/tests/files/zrealm12.gno
@@ -24,3 +24,6 @@ func main() {
 		panic("should not happen")
 	}
 }
+
+// Output:
+// second's child


### PR DESCRIPTION
This file(zrealm12.gno) causes a panic that isn't caught(as it's missing import), making the test invalid. 
This PR addresses the issue.