### PR TITLE
fix(makefile): `gnodev` with `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install.gno:
 	@printf "\033[0;32m[+] 'gno' has been installed. Read more in ./gnovm/\033[0m\n"
 .PHONY: install.gnodev
 install.gnodev:
-	$(MAKE) --no-print-directory -C ./contribs install.gnodev
+	$(MAKE) --no-print-directory -C ./contribs/gnodev install
 	@printf "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m\n"
 
 # old aliases


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

In this PR the Makefile for `contribs/` was changed, so running `make install` in the root Makefile will not install `gnodev` properly. I've fixed the path to get back to the original, intended functionality.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
