### PR TITLE
chore(docs): fix example rpcclient.NewHTTPClient returning variables

### DIFF
--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -109,8 +109,7 @@ A few things to note:
 You can initialize the RPC Client used to connect to the Gno.land network with
 the following line:
 ```go
-rpc, err := rpcclient.NewHTTPClient("gno.land/health")
-
+rpc, err := rpcclient.NewHTTPClient("<gno.land_remote_endpoint>")
 if err != nil {
     panic(err)
 }
@@ -143,7 +142,10 @@ func main() {
 	}
 
 	// Initialize the RPC client
-	rpc := rpcclient.NewHTTPClient("<gno.land_remote_endpoint>")
+	rpc, err := rpcclient.NewHTTPClient("<gno.land_remote_endpoint>")
+	if err != nil {
+		panic(err)
+	}
 	
 	// Initialize the gnoclient
 	client := gnoclient.Client{

--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -109,7 +109,11 @@ A few things to note:
 You can initialize the RPC Client used to connect to the Gno.land network with
 the following line:
 ```go
-rpc := rpcclient.NewHTTPClient("<gno_chain_endpoint>")
+rpc, err := rpcclient.NewHTTPClient("gno.land/health")
+
+if err != nil {
+    panic(err)
+}
 ```
 
 A list of Gno.land network endpoints & chain IDs can be found in the [Gno RPC 
@@ -157,6 +161,13 @@ We can now communicate with the Gno.land chain. Let's explore some of the functi
 To send transactions to the chain, we need to know the account number (ID) and 
 sequence (nonce). We can get this information by querying the chain with the
 `QueryAccount` function:
+
+```go
+import (
+    ...
+    crypto "github.com/gnolang/gno/tm2/pkg/crypto"
+)
+```
 
 ```go
 // Convert Gno address string to `crypto.Address`

--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -167,7 +167,7 @@ sequence (nonce). We can get this information by querying the chain with the
 ```go
 import (
     ...
-    crypto "github.com/gnolang/gno/tm2/pkg/crypto"
+    "github.com/gnolang/gno/tm2/pkg/crypto"
 )
 ```
 


### PR DESCRIPTION
In the [how to connect a Go app to Gno.land](https://docs.gno.land/how-to-guides/connect-from-go) tutorial I got an error when I tried to run this line:

```go
rpc := rpcclient.NewHTTPClient("<gno_chain_endpoint>")
```

It seems that NewHTTPClient returns 2 values
```go
func NewHTTPClient(rpcURL string) (*RPCClient, error);
``` 
and in the example we assign only one variable.

I updated the examples with:
```go
rpc, err := rpcclient.NewHTTPClient("<gno.land_remote_endpoint>")
if err != nil {
    panic(err)
}
```

There is also a step where `crypto.AddressFromBech32` is used but I didn't found when the `crypto` was imported so I also added it in the doc:

```go
import (
    ...
    crypto "github.com/gnolang/gno/tm2/pkg/crypto"
)
```