### PR TITLE
fix(contribs): revert back to `make <action>.<program>` syntax instead of the opposite

### DIFF
--- a/contribs/Makefile
+++ b/contribs/Makefile
@@ -31,27 +31,27 @@ install:
 	@echo 'To install a tool, go to the subdirectory, then run `make install`.'
 	@echo 'To do a full installation, run `make install_all`.'
 
-install_all: $(addsuffix .install,$(programs))
-%.install:
-	@echo "[+] make -C $(basename $@) install"
-	$(MAKE) --no-print-directory -C $(basename $@) install
+install_all: $(addprefix install.,$(programs))
+install.%:
+	@echo "[+] make -C $(subst install.,,$@) install"
+	$(MAKE) --no-print-directory -C $(subst install.,,$@) install
 .PHONY: install_all
 
 ########################################
 # Test suite
-test: $(addsuffix .test,$(programs))
-%.test:
-	@echo "[+] make -C $(basename $@) install"
-	$(MAKE) --no-print-directory -C $(basename $@) test
-.PHONY: test 
+test: $(addprefix test.,$(programs))
+test.%:
+	@echo "[+] make -C $(subst test.,,$@) install"
+	$(MAKE) --no-print-directory -C $(subst test.,,$@) test
+.PHONY: test
 
 ########################################
 # Lint
 .PHONY: lint
-lint: $(addsuffix .lint,$(programs))
-%.lint:
-	@echo "[+] make -C $(basename $@) install"
-	$(MAKE) --no-print-directory -C $(basename $@) lint
+lint: $(addprefix lint.,$(programs))
+lint.%:
+	@echo "[+] make -C $(subst lint.,,$@) install"
+	$(MAKE) --no-print-directory -C $(subst lint.,,$@) lint
 
 ########################################
 # Dev tools


### PR DESCRIPTION
Please, can we take a bit of care when modifying the syntaxes of our makefile commands?

They may not break code, but they break documentation and user flows. We can add a CI check as well; I see this for another PR as this is a hotfix. (Currently, running `make install` / `make install.gnodev` in the top-level directory doesn't work; because @moul inverted these in #1945). This is still not a substitute for a bit of good ol' attention in recognising when something is user-facing and thus should be changed with a bit more care and reason.

Note, I'm NOT saying that we should not change things, as we are before any 1.0 so we should change anything that makes sense; but it is a good practice that when changing a flag, command, etc., to do a global search for the old syntax to see examples where old documentation or untested code is broken.