### PR TITLE
chore: In r/demo/boards public API, change AssertOriginCall() to PrevRealm().IsUser()

### DIFF
--- a/examples/gno.land/r/demo/boards/public.gno
+++ b/examples/gno.land/r/demo/boards/public.gno
@@ -17,7 +17,9 @@ func GetBoardIDFromName(name string) (BoardID, bool) {
 }
 
 func CreateBoard(name string) BoardID {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	bid := incGetBoardID()
 	caller := std.GetOrigCaller()
 	if usernameOf(caller) == "" {
@@ -41,7 +43,9 @@ func checkAnonFee() bool {
 }
 
 func CreateThread(bid BoardID, title string, body string) PostID {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	caller := std.GetOrigCaller()
 	if usernameOf(caller) == "" {
 		if !checkAnonFee() {
@@ -57,7 +61,9 @@ func CreateThread(bid BoardID, title string, body string) PostID {
 }
 
 func CreateReply(bid BoardID, threadid, postid PostID, body string) PostID {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	caller := std.GetOrigCaller()
 	if usernameOf(caller) == "" {
 		if !checkAnonFee() {
@@ -85,7 +91,9 @@ func CreateReply(bid BoardID, threadid, postid PostID, body string) PostID {
 // If dstBoard is private, does not ping back.
 // If board specified by bid is private, panics.
 func CreateRepost(bid BoardID, postid PostID, title string, body string, dstBoardID BoardID) PostID {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	caller := std.GetOrigCaller()
 	if usernameOf(caller) == "" {
 		// TODO: allow with gDefaultAnonFee payment.
@@ -113,7 +121,9 @@ func CreateRepost(bid BoardID, postid PostID, title string, body string, dstBoar
 }
 
 func DeletePost(bid BoardID, threadid, postid PostID, reason string) {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	caller := std.GetOrigCaller()
 	board := getBoard(bid)
 	if board == nil {
@@ -143,7 +153,9 @@ func DeletePost(bid BoardID, threadid, postid PostID, reason string) {
 }
 
 func EditPost(bid BoardID, threadid, postid PostID, title, body string) {
-	std.AssertOriginCall()
+	if !std.PrevRealm().IsUser() {
+		panic("invalid non-user call")
+	}
 	caller := std.GetOrigCaller()
 	board := getBoard(bid)
 	if board == nil {

--- a/examples/gno.land/r/demo/boards/public.gno
+++ b/examples/gno.land/r/demo/boards/public.gno
@@ -17,7 +17,7 @@ func GetBoardIDFromName(name string) (BoardID, bool) {
 }
 
 func CreateBoard(name string) BoardID {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	bid := incGetBoardID()
@@ -43,7 +43,7 @@ func checkAnonFee() bool {
 }
 
 func CreateThread(bid BoardID, title string, body string) PostID {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	caller := std.GetOrigCaller()
@@ -61,7 +61,7 @@ func CreateThread(bid BoardID, title string, body string) PostID {
 }
 
 func CreateReply(bid BoardID, threadid, postid PostID, body string) PostID {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	caller := std.GetOrigCaller()
@@ -91,7 +91,7 @@ func CreateReply(bid BoardID, threadid, postid PostID, body string) PostID {
 // If dstBoard is private, does not ping back.
 // If board specified by bid is private, panics.
 func CreateRepost(bid BoardID, postid PostID, title string, body string, dstBoardID BoardID) PostID {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	caller := std.GetOrigCaller()
@@ -121,7 +121,7 @@ func CreateRepost(bid BoardID, postid PostID, title string, body string, dstBoar
 }
 
 func DeletePost(bid BoardID, threadid, postid PostID, reason string) {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	caller := std.GetOrigCaller()
@@ -153,7 +153,7 @@ func DeletePost(bid BoardID, threadid, postid PostID, reason string) {
 }
 
 func EditPost(bid BoardID, threadid, postid PostID, title, body string) {
-	if !std.PrevRealm().IsUser() {
+	if !(std.IsOriginCall() || std.PrevRealm().IsUser()) {
 		panic("invalid non-user call")
 	}
 	caller := std.GetOrigCaller()


### PR DESCRIPTION
In r/demo/boards, `std.AssertOriginCall()` blocks calling the API from another realm. But it also prevents using MsgRun for testing as we do in PR #1583. Therefore, we change to check `std.PrevRealm().IsUser()`. This still blocks another realm from calling the code, but allows being [called by MsgRun](https://github.com/gnolang/gno/blob/d7f12167eff72cd4a12e9e8b8aaa30dc241bfb6c/misc/stress-test/stress-test-many-posts/main.go#L148-L156) where a user keypair sends the transaction.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
</details>
