### PR TITLE
feat(coverage): Add back coverage support for `txtar`

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -46,21 +46,32 @@ jobs:
             (set +x; echo 'txtar coverage results:')
             go tool covdata percent -i=$TXTARCOVERDIR
 
-            # Merge and print combined coverage results
-            go tool covdata merge -v 1 -i="$GOCOVERDIR,$TXTARCOVERDIR" -o $COVERDIR
-            (set +x; echo 'final coverage results:')
-            go tool covdata percent -i=$COVERDIR
-
             # Generate final coverage output
-            go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out || touch coverage.out
+            go tool covdata textfmt -v 1 -i=$GOCOVERDIR -o gocoverage.out
+            go tool covdata textfmt -v 1 -i=$TXTARCOVERDIR -o txtarcoverage.out
 
-        - name: Upload coverage to Codecov
+        - name: Upload go coverage to Codecov
+          working-directory:  ${{ inputs.modulepath }}
           uses: codecov/codecov-action@v4
           with:
-              token: ${{ secrets.codecov-token }}
-              verbose: true
-              fail_ci_if_error: true
-              flags: ${{ inputs.modulepath }}
+            disable_search: true
+            fail_ci_if_error: true
+            file: ./gocoverage.out
+            flags: ${{ inputs.modulepath }}
+            token: ${{ secrets.codecov-token }}
+            verbose: true
+
+        - name: Upload txtar coverage to Codecov
+          working-directory:  ${{ inputs.modulepath }}
+          uses: codecov/codecov-action@v4
+          with:
+            disable_search: true
+            fail_ci_if_error: true
+            file: ./txtarcoverage.out
+            flags: ${{ inputs.modulepath }}/txtar
+            token: ${{ secrets.codecov-token }}
+            verbose: true
+
     # TODO: We have to fix race conditions before running this job
     # test-with-race:
     #     runs-on: ubuntu-latest

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -43,6 +43,7 @@ jobs:
             # 1.23 regarding coverage, so we can use this as a workaround until
             # then.
             go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$GOCOVERDIR
+
             # Print results
             (set +x; echo 'go coverage results:')
             go tool covdata percent $filter -i=$GOCOVERDIR
@@ -60,17 +61,7 @@ jobs:
             file: ${{ inputs.modulepath }}/gocoverage.out
             flags: ${{ inputs.modulepath }}
             token: ${{ secrets.codecov-token }}
-            verbose: true
-
-        # - name: Upload txtar coverage to Codecov
-        #   uses: codecov/codecov-action@v4
-        #   with:
-        #     disable_search: true
-        #     fail_ci_if_error: true
-        #     file: ${{ inputs.modulepath }}/txtarcoverage.out
-        #     flags: ${{ inputs.modulepath }}
-        #     token: ${{ secrets.codecov-token }}
-        #     verbose: true
+            verbose: true # keep this enable as it help debugging when coverage fail randomly on the CI
 
     # TODO: We have to fix race conditions before running this job
     # test-with-race:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -51,23 +51,21 @@ jobs:
             go tool covdata textfmt -v 1 -i=$TXTARCOVERDIR -o txtarcoverage.out
 
         - name: Upload go coverage to Codecov
-          working-directory:  ${{ inputs.modulepath }}
           uses: codecov/codecov-action@v4
           with:
             disable_search: true
             fail_ci_if_error: true
-            file: ./gocoverage.out
+            file: ${{ inputs.modulepath }}/gocoverage.out
             flags: ${{ inputs.modulepath }}
             token: ${{ secrets.codecov-token }}
             verbose: true
 
         - name: Upload txtar coverage to Codecov
-          working-directory:  ${{ inputs.modulepath }}
           uses: codecov/codecov-action@v4
           with:
             disable_search: true
             fail_ci_if_error: true
-            file: ./txtarcoverage.out
+            file: ${{ inputs.modulepath }}/txtarcoverage.out
             flags: ${{ inputs.modulepath }}/txtar
             token: ${{ secrets.codecov-token }}
             verbose: true

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -35,7 +35,7 @@ jobs:
 
             mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
-            # filter by modulepath
+            # Craft a filter flag based on the module path to avoid expanding coverage on unrelated tags.
             export filter="-pkg=github.com/gnolang/gno/${{ inputs.modulepath }}/..."
 
             # XXX: Simplify coverage of txtar - the current setup is a bit
@@ -51,7 +51,6 @@ jobs:
 
             # Generate final coverage output
             go tool covdata textfmt -v 1 $filter -i=$GOCOVERDIR,$TXTARCOVERDIR -o gocoverage.out
-            # go tool covdata textfmt -v 1 $filter -i=$TXTARCOVERDIR -o txtarcoverage.out
 
         - name: Upload go coverage to Codecov
           uses: codecov/codecov-action@v4

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -35,6 +35,9 @@ jobs:
 
             mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
+            # filter by modulepath
+            export filter="-pkg=github.com/gnolang/gno/${{ inputs.modulepath }}/..."
+
             # XXX: Simplify coverage of txtar - the current setup is a bit
             # confusing and meticulous. There will be some improvements in Go
             # 1.23 regarding coverage, so we can use this as a workaround until
@@ -42,13 +45,13 @@ jobs:
             go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$GOCOVERDIR
             # Print results
             (set +x; echo 'go coverage results:')
-            go tool covdata percent -i=$GOCOVERDIR
+            go tool covdata percent $filter -i=$GOCOVERDIR
             (set +x; echo 'txtar coverage results:')
-            go tool covdata percent -i=$TXTARCOVERDIR
+            go tool covdata percent $filter -i=$TXTARCOVERDIR
 
             # Generate final coverage output
-            go tool covdata textfmt -v 1 -i=$GOCOVERDIR -o gocoverage.out
-            go tool covdata textfmt -v 1 -i=$TXTARCOVERDIR -o txtarcoverage.out
+            go tool covdata textfmt -v 1 $filter -i=$GOCOVERDIR,$TXTARCOVERDIR -o gocoverage.out
+            # go tool covdata textfmt -v 1 $filter -i=$TXTARCOVERDIR -o txtarcoverage.out
 
         - name: Upload go coverage to Codecov
           uses: codecov/codecov-action@v4
@@ -60,15 +63,15 @@ jobs:
             token: ${{ secrets.codecov-token }}
             verbose: true
 
-        - name: Upload txtar coverage to Codecov
-          uses: codecov/codecov-action@v4
-          with:
-            disable_search: true
-            fail_ci_if_error: true
-            file: ${{ inputs.modulepath }}/txtarcoverage.out
-            flags: ${{ inputs.modulepath }}/txtar
-            token: ${{ secrets.codecov-token }}
-            verbose: true
+        # - name: Upload txtar coverage to Codecov
+        #   uses: codecov/codecov-action@v4
+        #   with:
+        #     disable_search: true
+        #     fail_ci_if_error: true
+        #     file: ${{ inputs.modulepath }}/txtarcoverage.out
+        #     flags: ${{ inputs.modulepath }}
+        #     token: ${{ secrets.codecov-token }}
+        #     verbose: true
 
     # TODO: We have to fix race conditions before running this job
     # test-with-race:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -17,6 +17,8 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
+        env:
+          COVERAGE_DIR: "/tmp/coverage"
         steps:
         - name: Install Go
           uses: actions/setup-go@v5
@@ -25,8 +27,26 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v4
         - name: Go test
-          run: go test -coverprofile coverage.out -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./...
           working-directory:  ${{ inputs.modulepath }}
+          env:
+            COVERDIR: /tmp/coverdir
+          run: |
+            mkdir -p "$COVERDIR"
+
+            # XXX: simplify coverage of txtar - the current setup is a bit
+            # confusing and meticulous. There will be some improvements in Go
+            # 1.23 regarding coverage, so we can use this as a workaround until
+            # then.
+            TXTARCOVERDIR=$COVERDIR \
+              go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$COVERDIR
+
+            # print out coverage result
+            echo 'coverage results:'
+            go tool covdata percent -i=$COVERDIR
+
+            # generate coverage output
+            go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out
+
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v4
           with:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -17,8 +17,6 @@ on:
 jobs:
     test:
         runs-on: ubuntu-latest
-        env:
-          COVERAGE_DIR: "/tmp/coverage"
         steps:
         - name: Install Go
           uses: actions/setup-go@v5
@@ -33,7 +31,7 @@ jobs:
             GOCOVERDIR: /tmp/gocoverdir # go cover output
             COVERDIR: /tmp/coverdir # final output
           run: |
-            set -x # print command
+            set -x # print commands
 
             mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
@@ -54,8 +52,7 @@ jobs:
             go tool covdata percent -i=$COVERDIR
 
             # Generate final coverage output
-            touch coverage.out
-            go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out
+            go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out || touch coverage.out
 
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v4

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -33,6 +33,8 @@ jobs:
             GOCOVERDIR: /tmp/gocoverdir # go cover output
             COVERDIR: /tmp/coverdir # final output
           run: |
+            set -x # print command
+
             mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
             # XXX: Simplify coverage of txtar - the current setup is a bit
@@ -40,19 +42,19 @@ jobs:
             # 1.23 regarding coverage, so we can use this as a workaround until
             # then.
             go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$GOCOVERDIR
-
             # Print results
-            echo 'go coverage results:'
+            (set +x; echo 'go coverage results:')
             go tool covdata percent -i=$GOCOVERDIR
-            echo 'txtar coverage results:'
+            (set +x; echo 'txtar coverage results:')
             go tool covdata percent -i=$TXTARCOVERDIR
 
             # Merge and print combined coverage results
-            go tool covdata merge -v 1 -i="$GOCOVERAGE,$TXTARCOVERDIR" -o $COVERDIR
-            echo 'final coverage results:'
+            go tool covdata merge -v 1 -i="$GOCOVERDIR,$TXTARCOVERDIR" -o $COVERDIR
+            (set +x; echo 'final coverage results:')
             go tool covdata percent -i=$COVERDIR
 
             # Generate final coverage output
+            touch coverage.out
             go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out
 
         - name: Upload coverage to Codecov

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -29,22 +29,30 @@ jobs:
         - name: Go test
           working-directory:  ${{ inputs.modulepath }}
           env:
-            COVERDIR: /tmp/coverdir
+            TXTARCOVERDIR: /tmp/txtarcoverdir # txtar cover output
+            GOCOVERDIR: /tmp/gocoverdir # go cover output
+            COVERDIR: /tmp/coverdir # final output
           run: |
-            mkdir -p "$COVERDIR"
+            mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
-            # XXX: simplify coverage of txtar - the current setup is a bit
+            # XXX: Simplify coverage of txtar - the current setup is a bit
             # confusing and meticulous. There will be some improvements in Go
             # 1.23 regarding coverage, so we can use this as a workaround until
             # then.
-            TXTARCOVERDIR=$COVERDIR \
-              go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$COVERDIR
+            go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$GOCOVERDIR
 
-            # print out coverage result
-            echo 'coverage results:'
+            # Print results
+            echo 'go coverage results:'
+            go tool covdata percent -i=$GOCOVERDIR
+            echo 'txtar coverage results:'
+            go tool covdata percent -i=$TXTARCOVERDIR
+
+            # Merge and print combined coverage results
+            go tool covdata merge -v 1 -i="$GOCOVERAGE,$TXTARCOVERDIR" -o $COVERDIR
+            echo 'final coverage results:'
             go tool covdata percent -i=$COVERDIR
 
-            # generate coverage output
+            # Generate final coverage output
             go tool covdata textfmt -v 1 -i=$COVERDIR -o coverage.out
 
         - name: Upload coverage to Codecov


### PR DESCRIPTION
Add back coverage support for `txtar`, which was removed during the CI rework.
This only includes `txtar` test files from `gnovm` package (not those for gnoland, I will do that in another PR).
It adds approximately **5%** coverage, which is a non-negligible.


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
