### PR TITLE
feat: add r/demo/bar20 example

### DIFF
--- a/examples/gno.land/r/demo/bar20/bar20.gno
+++ b/examples/gno.land/r/demo/bar20/bar20.gno
@@ -1,0 +1,46 @@
+// Package bar20 is similar to foo20 but exposes a safe-object that can be used
+// by `maketx run`, another contract importing foo20, and in the future when
+// we'll support `maketx call Token.XXX`.
+package bar20
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/p/demo/grc/grc20"
+	"gno.land/p/demo/ufmt"
+)
+
+var (
+	banker *grc20.AdminToken // private banker.
+	Token  grc20.IGRC20      // public safe-object.
+)
+
+func init() {
+	banker = grc20.NewAdminToken("Bar", "BAR", 4)
+	Token = banker.GRC20()
+}
+
+func Faucet() string {
+	caller := std.PrevRealm().Addr()
+	if err := banker.Mint(caller, 1_000_000); err != nil {
+		return "error: " + err.Error()
+	}
+	return "OK"
+}
+
+func Render(path string) string {
+	parts := strings.Split(path, "/")
+	c := len(parts)
+
+	switch {
+	case path == "":
+		return banker.RenderHome() // XXX: should be Token.RenderHome()
+	case c == 2 && parts[0] == "balance":
+		owner := std.Address(parts[1])
+		balance, _ := Token.BalanceOf(owner)
+		return ufmt.Sprintf("%d\n", balance)
+	default:
+		return "404\n"
+	}
+}

--- a/examples/gno.land/r/demo/bar20/bar20_test.gno
+++ b/examples/gno.land/r/demo/bar20/bar20_test.gno
@@ -1,0 +1,29 @@
+package bar20
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/testutils"
+)
+
+func TestPackage(t *testing.T) {
+	alice := testutils.TestAddress("alice")
+	std.TestSetRealm(std.NewUserRealm(alice))
+
+	balance, _ := Token.BalanceOf(alice)
+	expected := uint64(0)
+	if balance != expected {
+		t.Errorf("balance should be %d, got %d", expected, balance)
+	}
+
+	if ret := Faucet(); ret != "OK" {
+		t.Errorf("faucet should work, got %s", ret)
+	}
+
+	balance, _ = Token.BalanceOf(alice)
+	expected = uint64(1_000_000)
+	if balance != expected {
+		t.Errorf("balance should be %d, got %d", expected, balance)
+	}
+}

--- a/examples/gno.land/r/demo/bar20/bar20_test.gno
+++ b/examples/gno.land/r/demo/bar20/bar20_test.gno
@@ -10,6 +10,7 @@ import (
 func TestPackage(t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	std.TestSetRealm(std.NewUserRealm(alice))
+	std.TestSetOrigCaller(alice) // XXX: should not need this
 
 	balance, _ := Token.BalanceOf(alice)
 	expected := uint64(0)
@@ -17,8 +18,9 @@ func TestPackage(t *testing.T) {
 		t.Errorf("balance should be %d, got %d", expected, balance)
 	}
 
-	if ret := Faucet(); ret != "OK" {
-		t.Errorf("faucet should work, got %s", ret)
+	ret := Faucet()
+	if ret != "OK" {
+		t.Errorf("faucet should be OK, got %s", ret)
 	}
 
 	balance, _ = Token.BalanceOf(alice)

--- a/examples/gno.land/r/demo/bar20/gno.mod
+++ b/examples/gno.land/r/demo/bar20/gno.mod
@@ -1,0 +1,7 @@
+module bar20
+
+require (
+	gno.land/p/demo/grc/grc20 v0.0.0-latest
+	gno.land/p/demo/testutils v0.0.0-latest
+	gno.land/p/demo/ufmt v0.0.0-latest
+)


### PR DESCRIPTION
```go
// Package bar20 is similar to foo20 but exposes a safe-object that can be used
// by `maketx run`, another contract importing foo20, and in the future when
// we'll support `maketx call Token.XXX`.
```

This package currently has limited functionality, but it should become more useful in the future.

I'm using it to demonstrate the rationale for having two implementations in the `grc20` package - one with a banker, and one with a safe object.

Related with #2314 