### PR TITLE
feat: repl against remote node

### DIFF
--- a/gnovm/cmd/gno/repl.go
+++ b/gnovm/cmd/gno/repl.go
@@ -10,15 +10,21 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	"github.com/gnolang/gno/gnovm/pkg/repl"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
 type replCfg struct {
 	rootDir        string
 	initialCommand string
 	skipUsage      bool
+
+	remoteAddr string // FIXME: embed keyscli struct directly
 }
 
 func newReplCmd() *commands.Command {
@@ -58,6 +64,13 @@ func (c *replCfg) RegisterFlags(fs *flag.FlagSet) {
 		false,
 		"do not print usage",
 	)
+
+	fs.StringVar(
+		&c.remoteAddr,
+		"remote",
+		"",
+		"Remote RPC Endpoint (gnokey). If empty, use a local gno.Machine.",
+	)
 }
 
 func execRepl(cfg *replCfg, args []string) error {
@@ -88,7 +101,7 @@ func runRepl(cfg *replCfg) error {
 	r := repl.NewRepl()
 
 	if cfg.initialCommand != "" {
-		handleInput(r, cfg.initialCommand)
+		handleInput(cfg, r, cfg.initialCommand)
 	}
 
 	fmt.Fprint(os.Stdout, "gno> ")
@@ -116,7 +129,7 @@ func runRepl(cfg *replCfg) error {
 			continue
 		}
 
-		if err := handleInput(r, line); err != nil {
+		if err := handleInput(cfg, r, line); err != nil {
 			var goScanError scanner.ErrorList
 			if errors.As(err, &goScanError) {
 				// We assune that a Go scanner error indicates an incomplete Go statement.
@@ -137,7 +150,7 @@ func runRepl(cfg *replCfg) error {
 }
 
 // handleInput executes specific "/" commands, or evaluates input as Gno source code.
-func handleInput(r *repl.Repl, input string) error {
+func handleInput(cfg *replCfg, r *repl.Repl, input string) error {
 	switch strings.TrimSpace(input) {
 	case "/reset":
 		r.Reset()
@@ -148,11 +161,71 @@ func handleInput(r *repl.Repl, input string) error {
 	case "":
 		// Avoid to increase the repl execution counter if no input.
 	default:
-		out, err := r.Process(input)
-		if err != nil {
-			return err
+		_, err := r.Process(input)
+		_ = err // XXX: we don't care about errors, we just want repl to parse
+		// XXX: refactor (tmp code)
+		if cfg.remoteAddr != "" { // remote mode (gnokey)
+			rpcClient, err := rpcclient.NewHTTPClient(cfg.remoteAddr)
+			if err != nil {
+				panic(err)
+			}
+			kb, err := keys.NewKeyBaseFromDir("/Users/moul/Library/Application Support/gno")
+			if err != nil {
+				panic(err)
+			}
+			signer := gnoclient.SignerFromKeybase{
+				Keybase:  kb,
+				Account:  "moul",
+				Password: os.Getenv("GNOKEY_PWD"),
+				ChainID:  "portal-loop",
+			}
+			client := gnoclient.Client{
+				Signer:    signer,
+				RPCClient: rpcClient,
+			}
+			runCfg := gnoclient.BaseTxCfg{
+				GasWanted: 10000000,
+				GasFee:    "1ugnot",
+			}
+			/*
+							body := fmt.Sprintf(`package main
+				func main() {
+				%s
+							   }`, r.Src())*/
+			body := fmt.Sprintf(`package main
+import "gno.land/r/manfred/home"
+import "gno.land/r/demo/users"
+func main() {
+	_ = home.Render
+	_ = users.Render
+	%s
+}
+`, input)
+			// println("src", body)
+			msg := gnoclient.MsgRun{
+				Package: &std.MemPackage{
+					Name: "repl",
+					Path: "gno.land/r/myself/repl",
+					Files: []*std.MemFile{
+						{
+							Name: "stdin.gno",
+							Body: body,
+						},
+					},
+				},
+			}
+			res, err := client.Run(runCfg, msg)
+			if err != nil {
+				fmt.Println("error", err)
+			}
+			fmt.Println(string(res.DeliverTx.Data))
+		} else { // local mode (gno.Machine)
+			out, err := r.Process(input)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, out)
 		}
-		fmt.Fprintln(os.Stdout, out)
 	}
 	return nil
 }

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -138,6 +138,21 @@ func NewRepl(opts ...ReplOption) *Repl {
 	return r
 }
 
+// XXX: improve this
+func (r *Repl) Parse(input string) (out string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered from panic: %q", r)
+		}
+	}()
+	r.state.id++
+
+	_, declErr := r.parseDeclaration(input)
+	_, expErr := r.parseExpression(input)
+
+	return "", fmt.Errorf("error parsing code:\n\t- as expression: %w\n\t- as declarations: %w", expErr, declErr)
+}
+
 // Process accepts any valid Gno source code and executes it if it
 // is an expression, or stores it for later use if they are declarations.
 // If the provided input is not valid Gno source code, an error is returned.

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -138,6 +138,8 @@ func NewRepl(opts ...ReplOption) *Repl {
 	return r
 }
 
+// Process accepts any valid Gno source code and executes it if it
+// is an expression, or stores it for later use if they are declarations.
 // If the provided input is not valid Gno source code, an error is returned.
 // If the execution on the VM is not successful, the panic is recovered and
 // returned as an error.

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -138,23 +138,6 @@ func NewRepl(opts ...ReplOption) *Repl {
 	return r
 }
 
-// XXX: improve this
-func (r *Repl) Parse(input string) (out string, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("recovered from panic: %q", r)
-		}
-	}()
-	r.state.id++
-
-	_, declErr := r.parseDeclaration(input)
-	_, expErr := r.parseExpression(input)
-
-	return "", fmt.Errorf("error parsing code:\n\t- as expression: %w\n\t- as declarations: %w", expErr, declErr)
-}
-
-// Process accepts any valid Gno source code and executes it if it
-// is an expression, or stores it for later use if they are declarations.
 // If the provided input is not valid Gno source code, an error is returned.
 // If the execution on the VM is not successful, the panic is recovered and
 // returned as an error.


### PR DESCRIPTION
Proof of Concept: REPL using `maketx run` (remote) instead of `gno.Machine` (local).

This example demonstrates a POC where the REPL executes `maketx run` instead of running against an in-memory local `gno.Machine`. While the implementation is quick and (very) dirty, it shows the potential to unify the REPL experience for local testing, remote querying, and remote transactions.

To achieve this, the repl package should be refactored to handle the majority of the parsing and verification logic locally. By default, the REPL should use `maketx query q_eval`, and only fall back to `maketx run` when the transaction needs to update the remote state by paying gas fees.

The REPL should download remote sources locally, implement auto-completion, and use readline.

<div>
    <a href="https://www.loom.com/share/2966caa7c3594c748f5c1004f687bcdb">
      <p>Arc - 19 June 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/2966caa7c3594c748f5c1004f687bcdb">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2966caa7c3594c748f5c1004f687bcdb-with-play.gif">
    </a>
  </div>