### PR TITLE
chore: tm2 telemetry add prefixes and service instance name

### DIFF
--- a/tm2/pkg/telemetry/config/config.go
+++ b/tm2/pkg/telemetry/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"os"
 )
 
 var errEndpointNotSet = errors.New("telemetry exporter endpoint not set")
@@ -11,15 +12,21 @@ type Config struct {
 	MetricsEnabled   bool   `toml:"enabled"`
 	MeterName        string `toml:"meter_name"`
 	ServiceName      string `toml:"service_name"`
+	ServiceInstance  string `toml:"service_instance"`
 	ExporterEndpoint string `toml:"exporter_endpoint" comment:"the endpoint to export metrics to, like a local OpenTelemetry collector"`
 }
 
 // DefaultTelemetryConfig is the default configuration used for the node
 func DefaultTelemetryConfig() *Config {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "gno-node"
+	}
 	return &Config{
 		MetricsEnabled:   false,
 		MeterName:        "gno.land",
 		ServiceName:      "gno.land",
+		ServiceInstance:  hostname,
 		ExporterEndpoint: "",
 	}
 }

--- a/tm2/pkg/telemetry/metrics/metrics.go
+++ b/tm2/pkg/telemetry/metrics/metrics.go
@@ -152,8 +152,9 @@ func Init(config config.Config) error {
 			resource.NewWithAttributes(
 				semconv.SchemaURL,
 				semconv.ServiceNameKey.String(config.ServiceName),
+				// TODO: Get git tag / commit version
 				semconv.ServiceVersionKey.String("1.0.0"),
-				semconv.ServiceInstanceIDKey.String("gno-node-1"),
+				semconv.ServiceInstanceIDKey.String(config.ServiceInstance),
 			),
 		),
 	)

--- a/tm2/pkg/telemetry/metrics/metrics.go
+++ b/tm2/pkg/telemetry/metrics/metrics.go
@@ -16,30 +16,30 @@ import (
 )
 
 const (
-	broadcastTxTimerKey = "broadcast_tx_hist"
-	buildBlockTimerKey  = "build_block_hist"
+	broadcastTxTimerKey = "tm2_broadcast_tx_hist"
+	buildBlockTimerKey  = "tm2_build_block_hist"
 
-	inboundPeersKey  = "inbound_peers_hist"
-	outboundPeersKey = "outbound_peers_hist"
-	dialingPeersKey  = "dialing_peers_hist"
+	inboundPeersKey  = "tm2_inbound_peers_hist"
+	outboundPeersKey = "tm2_outbound_peers_hist"
+	dialingPeersKey  = "tm2_dialing_peers_hist"
 
-	numMempoolTxsKey = "num_mempool_txs_hist"
-	numCachedTxsKey  = "num_cached_txs_hist"
+	numMempoolTxsKey = "tm2_num_mempool_txs_hist"
+	numCachedTxsKey  = "tm2_num_cached_txs_hist"
 
-	vmQueryCallsKey  = "vm_query_calls_counter"
-	vmQueryErrorsKey = "vm_query_errors_counter"
-	vmGasUsedKey     = "vm_gas_used_hist"
-	vmCPUCyclesKey   = "vm_cpu_cycles_hist"
-	vmExecMsgKey     = "vm_exec_msg_hist"
+	vmQueryCallsKey  = "gno_vm_query_calls_counter"
+	vmQueryErrorsKey = "gno_vm_query_errors_counter"
+	vmGasUsedKey     = "gno_vm_gas_used_hist"
+	vmCPUCyclesKey   = "gno_vm_cpu_cycles_hist"
+	vmExecMsgKey     = "gno_vm_exec_msg_hist"
 
-	validatorCountKey       = "validator_count_hist"
-	validatorVotingPowerKey = "validator_vp_hist"
-	blockIntervalKey        = "block_interval_hist"
-	blockTxsKey             = "block_txs_hist"
-	blockSizeKey            = "block_size_hist"
+	validatorCountKey       = "gno_validator_count_hist"
+	validatorVotingPowerKey = "gno_validator_vp_hist"
+	blockIntervalKey        = "tm2_block_interval_hist"
+	blockTxsKey             = "tm2_block_txs_hist"
+	blockSizeKey            = "tm2_block_size_hist"
 
-	httpRequestTimeKey = "http_request_time_hist"
-	wsRequestTimeKey   = "ws_request_time_hist"
+	httpRequestTimeKey = "tm2_http_request_time_hist"
+	wsRequestTimeKey   = "tm2_ws_request_time_hist"
 )
 
 var (


### PR DESCRIPTION
This PR add 2 simple modifications to the telemetry package:

- Add prefixes to all exported names, since they're all catched up in prometheus, it's a monitoring norm to have them all prefixed. It's simpler to created dashboards and check what's exposed.
I used `tm2` and `gno` as prefixes depending on what i believed it was linked, if i made a mistake, don't hesitate to tell me :)

- The service instance was forced to `gno-node-1`, since we have multiple instance nodes now, it's better to have the possiblity to set it.


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
