### PR TITLE
fix(docs):  links in "Connecting from Go"

### DIFF
--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -102,7 +102,7 @@ A few things to note:
 - You can view keys in your local keybase by running `gnokey list`.  
 - You can get the password from a user input using the IO package.
 - `Signer` can also be initialized in-memory from a BIP39 mnemonic, using the 
-[`SignerFromBip39`](../reference/gnoclient/signer.md#func-signerfrombip39) function.
+[`SignerFromBip39`](https://gnolang.github.io/gno/github.com/gnolang/gno@v0.0.0/gno.land/pkg/gnoclient.html#SignerFromBip39) function.
 
 ## Initialize the RPC connection & Client
 
@@ -116,7 +116,7 @@ if err != nil {
 ```
 
 A list of Gno.land network endpoints & chain IDs can be found in the [Gno RPC 
-endpoints](../reference/rpc-endpoints.md#network-configurations) page. 
+endpoints](../reference/network-config.md) page. 
 
 With this, we can initialize the `gnoclient.Client` struct: 
 
@@ -267,7 +267,7 @@ fmt.Println(qevalRes)
 // (1000000 uint64)
 ```
 
-To see all functionality the `gnoclient` package provides, see the gnoclient
+To see all functionality the `gnoclient` package provides, see the `gnoclient`
 [reference page](../reference/gnoclient/gnoclient.md).
 
 ## Conclusion


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

This PR fixes broken links in the Connecting from Go how-to guide.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
