### PR TITLE
docs(gno-js): Remove wrong param in getFileContent

### DIFF
--- a/docs/reference/gno-js-client/gno-provider.md
+++ b/docs/reference/gno-js-client/gno-provider.md
@@ -116,7 +116,7 @@ Returns **Promise<string\>**
 #### Usage
 
 ```ts
-await provider.getFileContent('gno.land/r/demo/foo20', 'TotalSupply()')
+await provider.getFileContent('gno.land/r/demo/foo20')
 /*
 foo20.gno
 foo20_test.gno


### PR DESCRIPTION
The example is using a wrong argument (probably copy pasted from the previous one above) that doesn't match the function signature (2nd param is an optional `height`

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
