### PR TITLE
docs(gno-js): Add provider instantiation docs

### DIFF
--- a/docs/reference/gno-js-client/gno-provider.md
+++ b/docs/reference/gno-js-client/gno-provider.md
@@ -7,6 +7,38 @@ id: gno-js-provider
 The `Gno Provider` is an extension on the `tm2-js-client` `Provider`,
 outlined [here](../tm2-js-client/Provider/provider.md). Both JSON-RPC and WS providers are included with the package.
 
+## Instantiation
+
+### new GnoWSProvider
+
+Creates a new instance of the Gno WebSocket Provider, based on [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md)
+
+#### Parameters
+
+Same as [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md)
+
+#### Usage
+
+```ts
+new GnoWSProvider('ws://staging.gno.land:26657/ws');
+// provider with WS connection is created
+```
+
+### new GnoJSONRPCProvider
+
+Creates a new instance of the Gno JSON-RPC Provider, based on [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md)
+
+#### Parameters
+
+Same as [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md)
+
+#### Usage
+
+```ts
+new GnoJSONRPCProvider('http://staging.gno.land:36657');
+// provider is created
+```
+
 ## Realm Methods
 
 ### getRenderOutput

--- a/docs/reference/gno-js-client/gno-provider.md
+++ b/docs/reference/gno-js-client/gno-provider.md
@@ -11,11 +11,11 @@ outlined [here](../tm2-js-client/Provider/provider.md). Both JSON-RPC and WS pro
 
 ### new GnoWSProvider
 
-Creates a new instance of the Gno WebSocket Provider, based on [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md)
+Creates a new instance of the Gno WebSocket Provider, based on [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md).
 
 #### Parameters
 
-Same as [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md)
+Same as [`tm2-js-client` `WSProvider`](../tm2-js-client/Provider/ws-provider.md).
 
 #### Usage
 
@@ -26,11 +26,11 @@ new GnoWSProvider('ws://staging.gno.land:26657/ws');
 
 ### new GnoJSONRPCProvider
 
-Creates a new instance of the Gno JSON-RPC Provider, based on [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md)
+Creates a new instance of the Gno JSON-RPC Provider, based on [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md).
 
 #### Parameters
 
-Same as [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md)
+Same as [`tm2-js-client` `JSONRPCProvider`](../tm2-js-client/Provider/json-rpc-provider.md).
 
 #### Usage
 


### PR DESCRIPTION
While using `gno-js` and reading the [related docs](https://docs.gno.land/reference/gno-js-client/gno-js-provider), I saw the message saying that it's based on `tm2-js-client` with related link.
This is useful to understand how it works and see the available methods from the base Provider classes, but doesn't inform the developer about how he should instantiate a provider with `gno-js-client`, the name of the providers isn't mentioned anywhere and I had to guess it (or use my IDE autocomplete) and look at other projects using it to find out.

This PR adds a small section to the documentation page with explicit instantiation examples to fix this (without repeating too much info, parameters for example are linked to `tm2-js-client`, but could be extended in the future and documented here).

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
