### PR TITLE
feat(gnoweb): Docs link to `gnokey list` with specific anchor

### DIFF
--- a/gno.land/pkg/gnoweb/views/realm_help.html
+++ b/gno.land/pkg/gnoweb/views/realm_help.html
@@ -17,7 +17,7 @@
         <br />
         These are the realm's exposed functions ("public smart contracts").<br />
         <br />
-        My address: <input id="my_address" placeholder="ADDRESS" width="40" /> (see <a href="https://docs.gno.land/gno-tooling/cli/gno-tooling-gnokey" target="_blank">`gnokey list`</a>)<br />
+        My address: <input id="my_address" placeholder="ADDRESS" width="40" /> (see <a href="https://docs.gno.land/gno-tooling/cli/gno-tooling-gnokey/#list-all-known-keys" target="_blank">`gnokey list`</a>)<br />
         <br />
         <br />
         {{ template "func_specs" . }}


### PR DESCRIPTION
In the realm help UI of `gnoweb`, a link to the documentation of `gnokey list` is provided, but it's only redirecting to the page and not the specific `list` explanation.

Fixed it by adding the corresponding anchor to the link.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
