### PR TITLE
feat(telemetry): set otel service instance key id

### DIFF
--- a/tm2/pkg/telemetry/config/config.go
+++ b/tm2/pkg/telemetry/config/config.go
@@ -8,19 +8,21 @@ var errEndpointNotSet = errors.New("telemetry exporter endpoint not set")
 
 // Config is the configuration struct for the tm2 telemetry package
 type Config struct {
-	MetricsEnabled   bool   `json:"enabled" toml:"enabled"`
-	MeterName        string `json:"meter_name" toml:"meter_name"`
-	ServiceName      string `json:"service_name" toml:"service_name"`
-	ExporterEndpoint string `json:"exporter_endpoint" toml:"exporter_endpoint" comment:"the endpoint to export metrics to, like a local OpenTelemetry collector"`
+	MetricsEnabled    bool   `json:"enabled" toml:"enabled"`
+	MeterName         string `json:"meter_name" toml:"meter_name"`
+	ServiceName       string `json:"service_name" toml:"service_name"`
+	ServiceInstanceID string `json:"service_instance_id" toml:"service_instance_id" comment:"the ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service)"`
+	ExporterEndpoint  string `json:"exporter_endpoint" toml:"exporter_endpoint" comment:"the endpoint to export metrics to, like a local OpenTelemetry collector"`
 }
 
 // DefaultTelemetryConfig is the default configuration used for the node
 func DefaultTelemetryConfig() *Config {
 	return &Config{
-		MetricsEnabled:   false,
-		MeterName:        "gno.land",
-		ServiceName:      "gno.land",
-		ExporterEndpoint: "",
+		MetricsEnabled:    false,
+		MeterName:         "gno.land",
+		ServiceName:       "gno.land",
+		ServiceInstanceID: "gno-node-1",
+		ExporterEndpoint:  "",
 	}
 }
 

--- a/tm2/pkg/telemetry/metrics/metrics.go
+++ b/tm2/pkg/telemetry/metrics/metrics.go
@@ -153,7 +153,7 @@ func Init(config config.Config) error {
 				semconv.SchemaURL,
 				semconv.ServiceNameKey.String(config.ServiceName),
 				semconv.ServiceVersionKey.String("1.0.0"),
-				semconv.ServiceInstanceIDKey.String("gno-node-1"),
+				semconv.ServiceInstanceIDKey.String(config.ServiceInstanceID),
 			),
 		),
 	)


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

At the moment the OpenTelemetry `ServiceInstanceKeyID` is hardcoded. In the case of running multiple nodes (see the upcoming case of test4 multinode), we would want to distinguish the different instances. The `ServiceInstanceKeyID` is meant for that https://github.com/open-telemetry/opentelemetry-go/blob/5661ff0ded32cf1b83f1147dae96ca403c198504/semconv/v1.12.0/resource.go#L941

![2024-06-25_13-48](https://github.com/gnolang/gno/assets/5463218/3f1ae21a-5f7f-42cc-9e98-e743317fd123)


<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
