### PR TITLE
fix(tm2): rpc status validator power

### DIFF
--- a/tm2/pkg/bft/rpc/core/status.go
+++ b/tm2/pkg/bft/rpc/core/status.go
@@ -125,7 +125,7 @@ func validatorAtHeight(h int64) *types.Validator {
 	lastBlockHeight, vals := consensusState.GetValidators()
 	if lastBlockHeight == h {
 		for _, val := range vals {
-			if val.Address != privValAddress {
+			if val.Address == privValAddress {
 				return val
 			}
 		}


### PR DESCRIPTION
Error discovered working on https://github.com/gnolang/gno/issues/2430

On `/status` all node are showed with `voting_power=1`

![image](https://github.com/gnolang/gno/assets/8089712/09b3bd4c-3060-4681-a7a1-82c425734d8e)

This fixes it :) 