### PR TITLE
fix: Give different names to nightly and master releases

### DIFF
--- a/.github/goreleaser-master.yaml
+++ b/.github/goreleaser-master.yaml
@@ -500,3 +500,4 @@ nightly:
   tag_name: master
   publish_release: true
   keep_single_release: true
+  name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}-master"

--- a/.github/goreleaser-nightly.yaml
+++ b/.github/goreleaser-nightly.yaml
@@ -499,3 +499,4 @@ nightly:
   tag_name: nightly
   publish_release: true
   keep_single_release: true
+  name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}-nightly"

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -494,8 +494,3 @@ release:
     You can find all docker images at:
 
     https://github.com/orgs/gnolang/packages?repo_name={{ .ProjectName }}
-
-nightly:
-  tag_name: nightly
-  publish_release: true
-  keep_single_release: true


### PR DESCRIPTION
Also removed nightly section from main goreleaser.yaml file

