### PR TITLE
fix: `urequire` module path

### DIFF
--- a/examples/gno.land/p/demo/urequire/gno.mod
+++ b/examples/gno.land/p/demo/urequire/gno.mod
@@ -1,3 +1,3 @@
-module urequire
+module gno.land/p/demo/urequire
 
 require gno.land/p/demo/uassert v0.0.0-latest


### PR DESCRIPTION
## Description

This PR includes a hotfix for the `urequire` gno.mod to have a proper module path, introduced in #928 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
