### PR TITLE
chore(gnodev): show link to docs upon 'h' key

### DIFF
--- a/contribs/gnodev/README.md
+++ b/contribs/gnodev/README.md
@@ -2,6 +2,8 @@
 
 `gnodev` is designed to be a robust and user-friendly tool in your realm package development journey, streamlining your workflow and enhancing productivity.
 
+We will only give a quick overview below. You may find the official documentation at [docs/gno-tooling/gnodev.md](../../docs/gno-tooling/cli/gnodev.md).
+
 ### Synopsis
 **gnodev** [**-minimal**] [**-no-watch**] [**PKG_PATH ...**]
 

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -310,10 +310,13 @@ func execDev(cfg *devCfg, args []string, io commands.IO) (err error) {
 }
 
 var helper string = `
+For more in-depth documentation, visit the GNO Tooling CLI documentation: 
+https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev
+
 A           Accounts - Display known accounts and balances
-H           Help - Also https://github.com/gnolang/gno/blob/master/docs/gno-tooling/cli/gnodev.md
-R           Reload - Reload all packages to take change into account.
-Ctrl+R      Reset - Reset application state.
+H           Help - Display this message
+R           Reload - Reload all packages to take change into account
+Ctrl+R      Reset - Reset application state
 Ctrl+C      Exit - Exit the application
 `
 

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -309,8 +309,7 @@ func execDev(cfg *devCfg, args []string, io commands.IO) (err error) {
 	return runEventLoop(ctx, logger, book, rt, devNode, watcher)
 }
 
-var helper string = `
-For more in-depth documentation, visit the GNO Tooling CLI documentation: 
+var helper string = `For more in-depth documentation, visit the GNO Tooling CLI documentation: 
 https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev
 
 A           Accounts - Display known accounts and balances

--- a/contribs/gnodev/cmd/gnodev/main.go
+++ b/contribs/gnodev/cmd/gnodev/main.go
@@ -311,7 +311,7 @@ func execDev(cfg *devCfg, args []string, io commands.IO) (err error) {
 
 var helper string = `
 A           Accounts - Display known accounts and balances
-H           Help - Display this message
+H           Help - Also https://github.com/gnolang/gno/blob/master/docs/gno-tooling/cli/gnodev.md
 R           Reload - Reload all packages to take change into account.
 Ctrl+R      Reset - Reset application state.
 Ctrl+C      Exit - Exit the application


### PR DESCRIPTION
I propose we have "h" commandin gnodev mention a link to the full help of gnodev. This is a possible implementation.

Tried a few variants, this one seems simple enough:

![ksnip_20240704-134249](https://github.com/gnolang/gno/assets/350354/f97bf22a-1028-45ad-a1b3-3f80b8b3d68f)

@gfanton feel free to suggest changes :)