### PR TITLE
chore: In doc setting-up-a-new-chain, resetting the chain also, delete genesis.json

### DIFF
--- a/docs/gno-infrastructure/validators/setting-up-a-new-chain.md
+++ b/docs/gno-infrastructure/validators/setting-up-a-new-chain.md
@@ -93,7 +93,7 @@ Let's break down the most important default settings:
 :::info Resetting the chain
 
 As mentioned, the working directory for the node is located in `data-dir`. To reset the chain, you need
-to delete this directory and start the node up again. If you are using the default node configuration, you can run
+to delete this directory and `genesis.json`, then start the node up again. If you are using the default node configuration, you can run
 `make fclean` from the `gno.land` sub-folder to delete the `gnoland-data` working directory.
 
 :::


### PR DESCRIPTION
In the docs for setting up a new chain, section "Resetting the chain", it's also necessary to delete `genesis.json`. This is the same as [`make fclean`](https://github.com/gnolang/gno/blob/ee69fbd6baaa318d1504789df59ec961e1f5075b/gno.land/Makefile#L52). 