### PR TITLE
test(gnoclient): Fix a potential bug in the integration test

### DIFF
--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -53,7 +53,7 @@ func TestCallSingle_Integration(t *testing.T) {
 
 	// Execute call
 	res, err := client.Call(baseCfg, msg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := "(\"hi test argument\" string)\n\n"
 	got := string(res.DeliverTx.Data)
@@ -107,7 +107,7 @@ func TestCallMultiple_Integration(t *testing.T) {
 
 	// Execute call
 	res, err := client.Call(baseCfg, msg1, msg2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	got := string(res.DeliverTx.Data)
 	assert.Equal(t, expected, got)
@@ -149,12 +149,12 @@ func TestSendSingle_Integration(t *testing.T) {
 
 	// Execute send
 	res, err := client.Send(baseCfg, msg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", string(res.DeliverTx.Data))
 
 	// Get the new account balance
 	account, _, err := client.QueryAccount(toAddress)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := std.Coins{{"ugnot", int64(amount)}}
 	got := account.GetCoins()

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -53,11 +53,11 @@ func TestCallSingle_Integration(t *testing.T) {
 
 	// Execute call
 	res, err := client.Call(baseCfg, msg)
+	assert.NoError(t, err)
 
 	expected := "(\"hi test argument\" string)\n\n"
 	got := string(res.DeliverTx.Data)
 
-	assert.Nil(t, err)
 	assert.Equal(t, expected, got)
 }
 
@@ -107,9 +107,9 @@ func TestCallMultiple_Integration(t *testing.T) {
 
 	// Execute call
 	res, err := client.Call(baseCfg, msg1, msg2)
+	assert.NoError(t, err)
 
 	got := string(res.DeliverTx.Data)
-	assert.Nil(t, err)
 	assert.Equal(t, expected, got)
 }
 
@@ -149,12 +149,12 @@ func TestSendSingle_Integration(t *testing.T) {
 
 	// Execute send
 	res, err := client.Send(baseCfg, msg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "", string(res.DeliverTx.Data))
 
 	// Get the new account balance
 	account, _, err := client.QueryAccount(toAddress)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := std.Coins{{"ugnot", int64(amount)}}
 	got := account.GetCoins()
@@ -409,7 +409,7 @@ func Echo(str string) string {
 
 	// Execute AddPackage
 	_, err = client.AddPackage(baseCfg, msg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check for deployed file on the node
 	query, err := client.Query(QueryCfg{
@@ -501,7 +501,7 @@ func Hello(str string) string {
 
 	// Execute AddPackage
 	_, err = client.AddPackage(baseCfg, msg1, msg2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check Package #1
 	query, err := client.Query(QueryCfg{


### PR DESCRIPTION

![Screenshot from 2024-07-09 21-48-59](https://github.com/gnolang/gno/assets/167175638/a4429fb7-c277-4296-86fb-f55dfaa924ca)

I'm not sure about the root cause, but it seems like the test node isn't ready to handle the request call, so it returns an error. Using the result immediately without asserting that there's no error will cause this section to panic, leading to a CI that fails randomly

You can see https://github.com/gnolang/gno/actions/runs/9855164413/job/27209502761?pr=2518

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
