### PR TITLE
chore(website): fix js console error (fix #2564)

### DIFF
--- a/gno.land/pkg/gnoweb/views/funcs.html
+++ b/gno.land/pkg/gnoweb/views/funcs.html
@@ -160,6 +160,7 @@
 <script type="text/javascript" src="/static/js/renderer.js"></script>
 <script type="text/javascript">
   function main() {
+    if (document.getElementById("source") == null) return;
     const parsed = parseContent(document.getElementById("source").innerHTML);
     const DOM = {
       home: document.getElementById("home"),


### PR DESCRIPTION
fixes #2564

In javascript, main() always runs checks to DOMPurify the element of id "source",
but that element is only included for pages showing realm renderings, meaning
modified code used to output an error in the javascript console.
