### PR TITLE
feat(gnovm): add /debug command in REPL

### DIFF
--- a/gnovm/cmd/gno/repl.go
+++ b/gnovm/cmd/gno/repl.go
@@ -74,6 +74,7 @@ func execRepl(cfg *replCfg, args []string) error {
 //   gno> import "gno.land/p/demo/avl"     // import the p/demo/avl package
 //   gno> func a() string { return "a" }   // declare a new function named a
 //   gno> /src                             // print current generated source
+//   gno> /debug                           // activate the GnoVM debugger
 //   gno> /editor                          // enter in multi-line mode, end with ';'
 //   gno> /reset                           // remove all previously inserted code
 //   gno> println(a())                     // print the result of calling a()
@@ -141,6 +142,8 @@ func handleInput(r *repl.Repl, input string) error {
 	switch strings.TrimSpace(input) {
 	case "/reset":
 		r.Reset()
+	case "/debug":
+		r.Debug()
 	case "/src":
 		fmt.Fprintln(os.Stdout, r.Src())
 	case "/exit":

--- a/gnovm/pkg/gnolang/debugger.go
+++ b/gnovm/pkg/gnolang/debugger.go
@@ -43,14 +43,29 @@ type Debugger struct {
 	out     io.Writer      // debugger output, defaults to Stdout
 	scanner *bufio.Scanner // to parse input per line
 
-	state       DebugState // current state of debugger
-	lastCmd     string     // last debugger command
-	lastArg     string     // last debugger command arguments
-	loc         Location   // source location of the current machine instruction
-	prevLoc     Location   // source location of the previous machine instruction
-	breakpoints []Location // list of breakpoints set by user, as source locations
-	call        []Location // for function tracking, ideally should be provided by machine frame
-	frameLevel  int        // frame level of the current machine instruction
+	state       DebugState          // current state of debugger
+	lastCmd     string              // last debugger command
+	lastArg     string              // last debugger command arguments
+	loc         Location            // source location of the current machine instruction
+	prevLoc     Location            // source location of the previous machine instruction
+	breakpoints []Location          // list of breakpoints set by user, as source locations
+	call        []Location          // for function tracking, ideally should be provided by machine frame
+	frameLevel  int                 // frame level of the current machine instruction
+	getSrc      func(string) string // helper to access source from repl or others
+}
+
+// Enable makes the debugger d active, using in as input reader, out as output writer and f as a source helper.
+func (d *Debugger) Enable(in io.Reader, out io.Writer, f func(string) string) {
+	d.in = in
+	d.out = out
+	d.enabled = true
+	d.state = DebugAtInit
+	d.getSrc = f
+}
+
+// Disable makes the debugger d inactive.
+func (d *Debugger) Disable() {
+	d.enabled = false
 }
 
 type debugCommand struct {
@@ -470,7 +485,13 @@ func debugList(m *Machine, arg string) (err error) {
 	}
 	src, err := fileContent(m.Store, loc.PkgPath, loc.File)
 	if err != nil {
-		return err
+		// Use optional getSrc helper as fallback to get source.
+		if m.Debugger.getSrc != nil {
+			src = m.Debugger.getSrc(loc.File)
+		}
+		if src == "" {
+			return err
+		}
 	}
 	lines, offset := linesAround(src, loc.Line, 10)
 	for i, l := range lines {


### PR DESCRIPTION
![gno-repl-dbg](https://github.com/gnolang/gno/assets/5792239/1bab47bc-42b3-4378-b99d-58f4a22b43c6)

The REPL /debug command activates the gnovm debugger on the next evaluation, allowing interactive debugging of interactive sessions.

One interest of this feature is the capability to run the debugger at no other cost also from the Gno playground.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [*] Added new tests, or not needed, or not feasible
- [*] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [*] Updated the official documentation or not needed
- [*] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [*] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
