### PR TITLE
fix(sdk/vm): re-load iavl store from backup if empty

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -123,6 +123,7 @@ func uncachedPackageLoad(
 		for ; iter.Valid(); iter.Next() {
 			baseStore.Set(append(iavlBackupPrefix, iter.Key()...), iter.Value())
 		}
+		iter.Close()
 
 		logger.Debug("Standard libraries initialized",
 			"elapsed", time.Since(start))


### PR DESCRIPTION
This is a hack; during initialization, the iavlStore is backed up to the baseStore, and it is then recovered in Initialize if the iavlStore is found to be empty (but there's supposed to be packages inside).

This is a hotfix for test4 non-validator nodes.

It still requires to start up the non-validator node once, with the new changes applied, with a fresh db