### PR TITLE
feat(gnovm): `gno test` now has gas used information

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -207,7 +207,7 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 			io.ErrPrintfln("FAIL")
 			testErrCount++
 		} else {
-			io.ErrPrintfln("ok      %s \ttotal gas used: %s", pkg.Dir, strconv.Itoa(int(gasUsed)))
+			io.ErrPrintfln("ok      %s \ttotal gas used: %d", pkg.Dir, gasUsed)
 		}
 	}
 	if testErrCount > 0 || buildErrCount > 0 {
@@ -384,7 +384,7 @@ func gnoTestPkg(
 			}
 
 			if verbose {
-				io.ErrPrintfln("--- PASS: %s (%s) with GasUsed: %v", testName, dstr, gasUsedInThisPeriod)
+				io.ErrPrintfln("--- PASS: %s (%s) with GasUsed: %d", testName, dstr, gasUsedInThisPeriod)
 			}
 			// XXX: add per-test metrics
 		}

--- a/gnovm/stdlibs/testing/testing.gno
+++ b/gnovm/stdlibs/testing/testing.gno
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	// gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	// "github.com/gnolang/gno/tm2/pkg/store"
 )
 
 // ----------------------------------------
@@ -326,7 +328,9 @@ func tRunner(t *T, fn testingFunc, verbose bool) {
 	if !t.shouldRun(t.name) {
 		return
 	}
-
+	// m := gno.NewMachine("", nil)
+	// m.GasMeter = store.NewGasMeter(10000 * 1000 * 1000)
+	// gasStart := 0
 	start := unixNano()
 
 	defer func() {
@@ -341,7 +345,7 @@ func tRunner(t *T, fn testingFunc, verbose bool) {
 
 		dur := unixNano() - start
 		t.dur = formatDur(dur)
-
+		// gasUsed := m.GasMeter.GasConsumed()
 		if t.verbose {
 			switch {
 			case t.Failed():
@@ -349,7 +353,7 @@ func tRunner(t *T, fn testingFunc, verbose bool) {
 			case t.skipped:
 				fmt.Fprintf(os.Stderr, "--- SKIP: %s (%s)\n", t.name, t.dur)
 			case t.verbose:
-				fmt.Fprintf(os.Stderr, "--- PASS: %s (%s)\n", t.name, t.dur)
+				fmt.Fprintf(os.Stderr, "--- PASS: %s \n", t.name)
 			}
 		}
 	}()

--- a/gnovm/tests/file_test.go
+++ b/gnovm/tests/file_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"flag"
+	"fmt"
 	"io/fs"
 	"os"
 	"path"
@@ -137,8 +138,9 @@ func runFileTest(t *testing.T, path string, opts ...RunFileTestOption) {
 		logger = t.Log
 	}
 	rootDir := filepath.Join("..", "..")
-	err := RunFileTest(rootDir, path, append(opts, WithLoggerFunc(logger))...)
+	_, err := RunFileTest(rootDir, path, append(opts, WithLoggerFunc(logger))...)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
+	// fmt.Printf("GasUsed runFileTest: %v\n", gasUsed)
 }


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>

### Why we have this PR?
After discussion in #2467 and #2149 that the `gno test` now has gas used information instead of execution time.
### Target:
- [x] `gno test` has `total gas used` information
- [x] `gno test` has `gas used` for each xxx_filetest.gno

I will `add realm storage diff size` #2468 in another PR.

- <img width="1672" alt="image" src="https://github.com/gnolang/gno/assets/168700277/5386e201-188e-4df2-a1d1-cb58c1b1553e">



- <img width="1672" alt="image" src="https://github.com/gnolang/gno/assets/168700277/a9e04a60-ee69-409b-bd17-5bc3b01292ab">
