### PR TITLE
docs: setting go env GOBIN

### DIFF
--- a/docs/getting-started/local-setup/installation.md
+++ b/docs/getting-started/local-setup/installation.md
@@ -20,6 +20,7 @@ to run on your machine.
 ```
 export GOPATH=$HOME/go
 export PATH=$GOPATH/bin:$PATH
+go env -w GOBIN=$GOPATH/bin
 ```
 
 ## 1. Cloning the repository


### PR DESCRIPTION
This PR adds a small go setup necessary on a brand new macOS and probably on Linux machine.

`make install` doesn't install `gno` correctly when `go env GOBIN` is not set.

- [ X ] Updated the official documentation or not needed

