### PR TITLE
fix(testdata): wrong expectation at gnoweb_airgapped.txtar

### DIFF
--- a/gno.land/cmd/gnoland/testdata/gnoweb_airgapped.txtar
+++ b/gno.land/cmd/gnoland/testdata/gnoweb_airgapped.txtar
@@ -28,7 +28,7 @@ height: 0
 data: {
   "BaseAccount": {
     "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-    "coins": "9999997000000ugnot",
+    "coins": "[0-9]*ugnot",
     "public_key": null,
     "account_number": "0",
     "sequence": "0"

--- a/gno.land/cmd/gnoland/testdata/gnoweb_airgapped.txtar
+++ b/gno.land/cmd/gnoland/testdata/gnoweb_airgapped.txtar
@@ -28,7 +28,7 @@ height: 0
 data: {
   "BaseAccount": {
     "address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-    "coins": "9999999000000ugnot",
+    "coins": "9999997000000ugnot",
     "public_key": null,
     "account_number": "0",
     "sequence": "0"


### PR DESCRIPTION
This caused a CI failure on the latest commit on the master branch : https://github.com/gnolang/gno/actions/runs/9925367874/job/27417714921

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
