### PR TITLE
fix(tm2): Fix request_id mismatch at http client

### DIFF
--- a/tm2/pkg/bft/rpc/lib/client/http/client.go
+++ b/tm2/pkg/bft/rpc/lib/client/http/client.go
@@ -18,6 +18,9 @@ const (
 	protoHTTP  = "http"
 	protoHTTPS = "https"
 	protoTCP   = "tcp"
+
+	portHTTP  = "80"
+	portHTTPS = "443"
 )
 
 var (
@@ -230,9 +233,9 @@ func parseRemoteAddr(remoteAddr string) (string, string) {
 	if !strings.Contains(address, ":") {
 		switch protocol {
 		case protoHTTPS:
-			address += ":443"
+			address += ":" + portHTTPS
 		case protoHTTP, protoTCP:
-			address += ":80"
+			address += ":" + portHTTP
 		default: // noop
 		}
 	}

--- a/tm2/pkg/bft/rpc/lib/client/http/client.go
+++ b/tm2/pkg/bft/rpc/lib/client/http/client.go
@@ -57,7 +57,7 @@ func (c *Client) SendRequest(ctx context.Context, request types.RPCRequest) (*ty
 	}
 
 	// Make sure the ID matches
-	if response.ID != response.ID {
+	if request.ID != response.ID {
 		return nil, ErrRequestResponseIDMismatch
 	}
 

--- a/tm2/pkg/bft/rpc/lib/client/http/client_test.go
+++ b/tm2/pkg/bft/rpc/lib/client/http/client_test.go
@@ -108,53 +108,101 @@ func createTestServer(
 func TestClient_SendRequest(t *testing.T) {
 	t.Parallel()
 
-	var (
-		request = types.RPCRequest{
-			JSONRPC: "2.0",
-			ID:      types.JSONRPCStringID("id"),
-		}
+	t.Run("valid request, response", func(t *testing.T) {
+		t.Parallel()
 
-		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, http.MethodPost, r.Method)
-			require.Equal(t, "application/json", r.Header.Get("content-type"))
-
-			// Parse the message
-			var req types.RPCRequest
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			require.Equal(t, request.ID.String(), req.ID.String())
-
-			// Send an empty response back
-			response := types.RPCResponse{
+		var (
+			request = types.RPCRequest{
 				JSONRPC: "2.0",
-				ID:      req.ID,
+				ID:      types.JSONRPCStringID("id"),
 			}
 
-			// Marshal the response
-			marshalledResponse, err := json.Marshal(response)
-			require.NoError(t, err)
+			handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "application/json", r.Header.Get("content-type"))
 
-			_, err = w.Write(marshalledResponse)
-			require.NoError(t, err)
-		})
+				// Parse the message
+				var req types.RPCRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				require.Equal(t, request.ID.String(), req.ID.String())
 
-		server = createTestServer(t, handler)
-	)
+				// Send an empty response back
+				response := types.RPCResponse{
+					JSONRPC: "2.0",
+					ID:      req.ID,
+				}
 
-	// Create the client
-	c, err := NewClient(server.URL)
-	require.NoError(t, err)
+				// Marshal the response
+				marshalledResponse, err := json.Marshal(response)
+				require.NoError(t, err)
 
-	ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancelFn()
+				_, err = w.Write(marshalledResponse)
+				require.NoError(t, err)
+			})
 
-	// Send the request
-	resp, err := c.SendRequest(ctx, request)
-	require.NoError(t, err)
+			server = createTestServer(t, handler)
+		)
 
-	assert.Equal(t, request.ID, resp.ID)
-	assert.Equal(t, request.JSONRPC, resp.JSONRPC)
-	assert.Nil(t, resp.Result)
-	assert.Nil(t, resp.Error)
+		// Create the client
+		c, err := NewClient(server.URL)
+		require.NoError(t, err)
+
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancelFn()
+
+		// Send the request
+		resp, err := c.SendRequest(ctx, request)
+		require.NoError(t, err)
+
+		assert.Equal(t, request.ID, resp.ID)
+		assert.Equal(t, request.JSONRPC, resp.JSONRPC)
+		assert.Nil(t, resp.Result)
+		assert.Nil(t, resp.Error)
+	})
+
+	t.Run("response ID mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			request = types.RPCRequest{
+				JSONRPC: "2.0",
+				ID:      types.JSONRPCStringID("id"),
+			}
+
+			handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "application/json", r.Header.Get("content-type"))
+
+				// Send an empty response back,
+				// with an invalid ID
+				response := types.RPCResponse{
+					JSONRPC: "2.0",
+					ID:      types.JSONRPCStringID("totally random ID"),
+				}
+
+				// Marshal the response
+				marshalledResponse, err := json.Marshal(response)
+				require.NoError(t, err)
+
+				_, err = w.Write(marshalledResponse)
+				require.NoError(t, err)
+			})
+
+			server = createTestServer(t, handler)
+		)
+
+		// Create the client
+		c, err := NewClient(server.URL)
+		require.NoError(t, err)
+
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancelFn()
+
+		// Send the request
+		resp, err := c.SendRequest(ctx, request)
+		assert.Nil(t, resp)
+		assert.ErrorIs(t, err, ErrRequestResponseIDMismatch)
+	})
 }
 
 func TestClient_SendBatchRequest(t *testing.T) {


### PR DESCRIPTION
It seems this check is not working as intended

The failing CI seems to be an existing issue not caused by these changes

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
