### PR TITLE
feat(package) `/p/demo/mux` support query strings

### DIFF
--- a/examples/gno.land/p/demo/mux/query.gno
+++ b/examples/gno.land/p/demo/mux/query.gno
@@ -1,0 +1,51 @@
+package mux
+
+import "strings"
+
+type UrlQuery map[string][]string
+
+/*
+	URL() returns a full map of key-listValue from request
+	to get a list of params by key, use: req.URL()["key"]
+	to get single param by key, use: req.URL().Get("key")
+*/
+func (r *Request) URL() UrlQuery {
+	urlQueries := UrlQuery{}
+	reqParts := strings.Split(r.Path, "/")
+	for i := 0; i < len(reqParts); i++ {
+		rFullPath := reqParts[i]
+		switch {
+		// find the starting of query string
+		case strings.Contains(rFullPath, "?"):
+			{
+				index := strings.Index(rFullPath, "?")
+				// get the query path and the query string
+				// the rQueryPath may be used for handler for handling request path
+				// rQueryPath := rFullPath[:index]
+				queryString := rFullPath[index+1:]
+				params := strings.Split(queryString, "&")
+				for _, param := range params {
+					// find key - value of query params, then append to the UrlQuery
+					kv := strings.Split(param, "=")
+					if len(kv) == 2 {
+						urlQueries[kv[0]] = append(urlQueries[kv[0]], kv[1])
+					}
+				}
+			}
+		default:
+			// continue
+		}
+	}
+	return urlQueries
+}
+
+// get the query by key
+// if there is more than one query, returns the very first param
+func (qs UrlQuery) Get(key string) string {
+	listMatching, ok := qs[key]
+	if ok {
+		return listMatching[0]
+	} else {
+		return ""
+	}
+}

--- a/examples/gno.land/p/demo/mux/query.gno
+++ b/examples/gno.land/p/demo/mux/query.gno
@@ -5,11 +5,11 @@ import "strings"
 type UrlQuery map[string][]string
 
 /*
-	URL() returns a full map of key-listValue from request
-	to get a list of params by key, use: req.URL()["key"]
-	to get single param by key, use: req.URL().Get("key")
+	Query() returns a full map of key-listValue from request
+	to get a list of params by key, use: req.Query()["key"]
+	to get single param by key, use: req.Query().Get("key")
 */
-func (r *Request) URL() UrlQuery {
+func (r *Request) Query() UrlQuery {
 	urlQueries := UrlQuery{}
 	reqParts := strings.Split(r.Path, "/")
 	for i := 0; i < len(reqParts); i++ {

--- a/examples/gno.land/p/demo/mux/query_test.gno
+++ b/examples/gno.land/p/demo/mux/query_test.gno
@@ -13,9 +13,10 @@ func TestQuery_Get(t *testing.T) {
 		expectedOutput string
 	}{
 		// get by key
-		{"get_by_key_normal", "users/?name=testname&age=12", "name", "testname"},
-		{"get_same_query", "users/user?name=name1&name=name2", "name", "name1"},
-		{"get_by_key_unprocesspath", "users/unprocesspath?user=thinhnx&age=12", "user", "thinhnx"},
+		{"Get_query_key", "api/v1/?name=testname&age=12", "name", "testname"},
+		{"Get_query_repeat", "api/v1/user?name=name1&name=name2&name=name3", "name", "name1"},
+		{"Get_query_with_pre_path", "api/v1/unprocesspath?user=thinhnx&age=12", "user", "thinhnx"},
+		{"Get_query_empty", "api/v1/?name=testname&age=12", "loc", ""},
 	}
 
 	for _, tt := range cases {
@@ -25,7 +26,7 @@ func TestQuery_Get(t *testing.T) {
 				HandlerPath: "",
 				Path:        tt.reqPath,
 			}
-			output := req.URL().Get(tt.key)
+			output := req.Query().Get(tt.key)
 			if output != tt.expectedOutput {
 				t.Errorf("Expected %q, but got %q", tt.expectedOutput, output)
 			}
@@ -34,7 +35,7 @@ func TestQuery_Get(t *testing.T) {
 }
 
 
-func TestQuery_List(t *testing.T) {
+func TestQuery_QueryList(t *testing.T) {
 	cases := []struct {
 		name           string
 		reqPath        string
@@ -42,7 +43,10 @@ func TestQuery_List(t *testing.T) {
 		expectedOutput []string
 	}{
 		// get all queries
-		{"get_the_queries", "users/user?name=testname&age=12&name=thinhnx", "name", []string{"testname", "thinhnx"}},
+		{"get_name_list", "api/v1/user?name=name0&age=12&name=name1&age=30", "name", []string{"name0", "name1"}},
+		{"get_age_list", "api/v1/user?name=name0&age=12&name=name1&age=30", "age", []string{"12", "30"}},
+		{"get_loc_list", "api/v1/user?name=name0&age=12&name=name1&age=30&loc=HN", "loc", []string{"HN"}},
+		{"get_empty_list", "api/v1/user?name=name0&age=12&name=name1&age=30&loc=HN", "addr", []string{}},
 	}
 
 	for _, tt := range cases {
@@ -52,11 +56,13 @@ func TestQuery_List(t *testing.T) {
 				HandlerPath: "",
 				Path:        tt.reqPath,
 			}
-			output := req.URL()[tt.key]
+			// simple check for length of expected and output list
+			output := req.Query()[tt.key]
 			if len(output) != len(tt.expectedOutput) {
 				t.Errorf("Expected %q, but got %q", tt.expectedOutput, output)
 			}
-			listOutput := req.URL()[tt.key]
+			// check the corresponding elements
+			listOutput := req.Query()[tt.key]
 			for i, ttExpt := range tt.expectedOutput {
 				if ttExpt != listOutput[i] {
 					t.Errorf("Expected %q, but got %q", ttExpt, listOutput[i])

--- a/examples/gno.land/p/demo/mux/query_test.gno
+++ b/examples/gno.land/p/demo/mux/query_test.gno
@@ -1,0 +1,67 @@
+package mux
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestQuery_Get(t *testing.T) {
+	cases := []struct {
+		name           string
+		reqPath        string
+		key            string
+		expectedOutput string
+	}{
+		// get by key
+		{"get_by_key_normal", "users/?name=testname&age=12", "name", "testname"},
+		{"get_same_query", "users/user?name=name1&name=name2", "name", "name1"},
+		{"get_by_key_unprocesspath", "users/unprocesspath?user=thinhnx&age=12", "user", "thinhnx"},
+	}
+
+	for _, tt := range cases {
+		name := fmt.Sprintf("%s-%s", tt.name, tt.reqPath)
+		t.Run(name, func(t *testing.T) {
+			req := &Request{
+				HandlerPath: "",
+				Path:        tt.reqPath,
+			}
+			output := req.URL().Get(tt.key)
+			if output != tt.expectedOutput {
+				t.Errorf("Expected %q, but got %q", tt.expectedOutput, output)
+			}
+		})
+	}
+}
+
+
+func TestQuery_List(t *testing.T) {
+	cases := []struct {
+		name           string
+		reqPath        string
+		key            string
+		expectedOutput []string
+	}{
+		// get all queries
+		{"get_the_queries", "users/user?name=testname&age=12&name=thinhnx", "name", []string{"testname", "thinhnx"}},
+	}
+
+	for _, tt := range cases {
+		name := fmt.Sprintf("%s-%s", tt.name, tt.reqPath)
+		t.Run(name, func(t *testing.T) {
+			req := &Request{
+				HandlerPath: "",
+				Path:        tt.reqPath,
+			}
+			output := req.URL()[tt.key]
+			if len(output) != len(tt.expectedOutput) {
+				t.Errorf("Expected %q, but got %q", tt.expectedOutput, output)
+			}
+			listOutput := req.URL()[tt.key]
+			for i, ttExpt := range tt.expectedOutput {
+				if ttExpt != listOutput[i] {
+					t.Errorf("Expected %q, but got %q", ttExpt, listOutput[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>

### This PR aims to support `mux` package for querying with strings.

### Usage:
```
request.Query(): Get  map of keys and list of values from params
request.Query()["key"]: Get list of values corresponding to the key
request.Query().Get("key"): Get the very first value of the key.
```