### PR TITLE
fix(gnovm): revert to storing frames in the machine as values instead of pointers

### DIFF
--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -28,7 +28,7 @@ func setupMachine(b *testing.B, numValues, numStmts, numExprs, numBlocks, numFra
 		Exprs:      make([]Expr, numExprs),
 		Stmts:      make([]Stmt, numStmts),
 		Blocks:     make([]*Block, numBlocks),
-		Frames:     make([]*Frame, numFrames),
+		Frames:     make([]Frame, numFrames),
 		Exceptions: make([]Exception, numExceptions),
 	}
 	return m

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -1002,11 +1002,11 @@ func UverseNode() *PackageNode {
 
 			// If the frame the exception occurred in is not popped, it's possible that
 			// the exception is still in scope and can be recovered.
-			if !exception.Frame.Popped {
+			if !exception.FramePopped {
 				// If the frame is not the current frame, the exception is not in scope; return nil.
 				// This retrieves the second most recent call frame because the first most recent
 				// is the call to recover itself.
-				if frame := m.LastCallFrame(2); frame == nil || (frame != nil && frame != exception.Frame) {
+				if frameIdx := m.LastCallFrameIdx(2); frameIdx == -1 || frameIdx != exception.FrameIndex {
 					m.PushValue(TypedValue{})
 					return
 				}

--- a/gnovm/stdlibs/std/native_test.go
+++ b/gnovm/stdlibs/std/native_test.go
@@ -15,8 +15,8 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 		ctx  = ExecContext{
 			OrigCaller: user,
 		}
-		msgCallFrame = &gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "main"}}
-		msgRunFrame  = &gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/g1337/run"}}
+		msgCallFrame = gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "main"}}
+		msgRunFrame  = gno.Frame{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/g1337/run"}}
 	)
 	tests := []struct {
 		name                 string
@@ -29,7 +29,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "no frames",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames:  []*gno.Frame{},
+				Frames:  []gno.Frame{},
 			},
 			expectedAddr:         user,
 			expectedPkgPath:      "",
@@ -39,7 +39,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one frame w/o LastPackage",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					{LastPackage: nil},
 				},
 			},
@@ -51,7 +51,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one package frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/p/xxx"}},
 				},
 			},
@@ -63,7 +63,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one realm frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/xxx"}},
 				},
 			},
@@ -75,7 +75,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one msgCall frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgCallFrame,
 				},
 			},
@@ -87,7 +87,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one msgRun frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgRunFrame,
 				},
 			},
@@ -99,7 +99,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one package frame and one msgCall frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgCallFrame,
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/p/xxx"}},
 				},
@@ -112,7 +112,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one realm frame and one msgCall frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgCallFrame,
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/xxx"}},
 				},
@@ -125,7 +125,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one package frame and one msgRun frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgRunFrame,
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/p/xxx"}},
 				},
@@ -138,7 +138,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "one realm frame and one msgRun frame",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					msgRunFrame,
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/xxx"}},
 				},
@@ -151,7 +151,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "multiple frames with one realm",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/p/xxx"}},
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/p/xxx"}},
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/xxx"}},
@@ -165,7 +165,7 @@ func TestPrevRealmIsOrigin(t *testing.T) {
 			name: "multiple frames with multiple realms",
 			machine: &gno.Machine{
 				Context: ctx,
-				Frames: []*gno.Frame{
+				Frames: []gno.Frame{
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/zzz"}},
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/zzz"}},
 					{LastPackage: &gno.PackageValue{PkgPath: "gno.land/r/yyy"}},

--- a/gnovm/tests/stdlibs/std/std.go
+++ b/gnovm/tests/stdlibs/std/std.go
@@ -122,7 +122,7 @@ func X_testSetRealm(m *gno.Machine, addr, pkgPath string) {
 	for i := m.NumFrames() - 3; i >= 0; i-- {
 		// Must be a frame from calling a function.
 		if fr := m.Frames[i]; fr.Func != nil {
-			frame = fr
+			frame = &fr
 			break
 		}
 	}
@@ -147,7 +147,7 @@ func X_getRealm(m *gno.Machine, height int) (address string, pkgPath string) {
 
 	for i := m.NumFrames() - 1; i >= 0; i-- {
 		fr := m.Frames[i]
-		override, overridden := ctx.RealmFrames[m.Frames[max(i-1, 0)]]
+		override, overridden := ctx.RealmFrames[&m.Frames[max(i-1, 0)]]
 		if !overridden &&
 			(fr.LastPackage == nil || !fr.LastPackage.IsRealm()) {
 			continue


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
