### PR TITLE
docs: Remove slash from test4 endpoint

### DIFF
--- a/docs/reference/network-config.md
+++ b/docs/reference/network-config.md
@@ -7,7 +7,7 @@ id: network-config
 | Network     | RPC Endpoint                      | Chain ID      | 
 |-------------|-----------------------------------|---------------|
 | Portal Loop | https://rpc.gno.land:443          | `portal-loop` |
-| Test4       | https://rpc.test4.gno.land:443/   | `test4`       |
+| Test4       | https://rpc.test4.gno.land:443    | `test4`       |
 | Test3       | https://rpc.test3.gno.land:443    | `test3`       |
 | Staging     | http://rpc.staging.gno.land:36657 | `staging`     |
 


### PR DESCRIPTION
The trailing slash at the end of the test4 endpoint seems redundant. I suggest removing it for consistency

https://github.com/gnolang/gno/blob/master/docs/reference/network-config.md?plain=1#L1-L19

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
