### PR TITLE
docs: Update expired Discord link, and minor documentation fixes

### DIFF
--- a/docs/gno-infrastructure/validators/overview.md
+++ b/docs/gno-infrastructure/validators/overview.md
@@ -11,7 +11,7 @@ the [Gno Language](https://docs.gno.land/concepts/gno-language/) (Gno),
 [Tendermint2](https://docs.gno.land/concepts/tendermint2/) (TM2),
 and [GnoVM](https://docs.gno.land/concepts/gnovm/). Unlike
 existing [Proof of Stake](https://docs.cosmos.network/v0.46/modules/staking/) (PoS) blockchains in the Cosmos ecosystem,
-Gno.land runs on [Proof of Contribution](https://docs.gno.land/concepts/proof-of-contribution/) (PoC), a novel
+gno.land runs on [Proof of Contribution](https://docs.gno.land/concepts/proof-of-contribution/) (PoC), a novel
 reputation-based consensus mechanism that values expertise and alignment with the project. In PoC, validators are
 selected via governance based on their contribution to the project and technical proficiency. The voting power of the
 network is equally distributed across all validators to achieve a high nakamoto coefficient. A portion of all

--- a/docs/gno-infrastructure/validators/overview.md
+++ b/docs/gno-infrastructure/validators/overview.md
@@ -7,8 +7,8 @@ id: validators-overview
 ## Introduction
 
 Gno.land is a blockchain powered by the Gno tech stack, which consists of
-the [Gno Language](https://docs.gno.land/concepts/gno-language/) (
-Gno), [Tendermint2](https://docs.gno.land/concepts/tendermint2/) (TM2),
+the [Gno Language](https://docs.gno.land/concepts/gno-language/) (Gno),
+[Tendermint2](https://docs.gno.land/concepts/tendermint2/) (TM2),
 and [GnoVM](https://docs.gno.land/concepts/gnovm/). Unlike
 existing [Proof of Stake](https://docs.cosmos.network/v0.46/modules/staking/) (PoS) blockchains in the Cosmos ecosystem,
 Gno.land runs on [Proof of Contribution](https://docs.gno.land/concepts/proof-of-contribution/) (PoC), a novel

--- a/docs/gno-infrastructure/validators/overview.md
+++ b/docs/gno-infrastructure/validators/overview.md
@@ -79,7 +79,7 @@ Join the official gno.land community in various channels to receive the latest u
 communicate with other validators and contributors.
 
 - [Gno.land Blog](https://gno.land/r/gnoland/blog)
-- [Gno.land Discord](https://discord.gg/FqnzKsVj4B)
+- [Gno.land Discord](https://discord.gg/YFtMjWwUN7)
 - [Gno.land Twitter](https://x.com/_gnoland)
 
 :::info

--- a/docs/gno-infrastructure/validators/overview.md
+++ b/docs/gno-infrastructure/validators/overview.md
@@ -79,7 +79,7 @@ Join the official gno.land community in various channels to receive the latest u
 communicate with other validators and contributors.
 
 - [Gno.land Blog](https://gno.land/r/gnoland/blog)
-- [Gno.land Discord](https://discord.gg/w2MpVEunxr)
+- [Gno.land Discord](https://discord.gg/FqnzKsVj4B)
 - [Gno.land Twitter](https://x.com/_gnoland)
 
 :::info

--- a/docs/gno-infrastructure/validators/overview.md
+++ b/docs/gno-infrastructure/validators/overview.md
@@ -91,7 +91,7 @@ improve and complete the implementation are welcome.
 **Links to related efforts:**
 
 - Validator set injection through a Realm [[gnolang/gno #1823]](https://github.com/gnolang/gno/issues/1823)
-- Add Validator Set Realm / Package [[gnolang/gno #1824](https://github.com/gnolang/gno/issues/1824)
+- Add Validator Set Realm / Package [[gnolang/gno #1824]](https://github.com/gnolang/gno/issues/1824)
 - Add `/r/sys/vals` [[gnolang/gno #2130]](https://github.com/gnolang/gno/pull/2130)
 - Add valset injection through `r/sys/vals` [[gnolang/gno #2229]](https://github.com/gnolang/gno/pull/2229)
 


### PR DESCRIPTION
Update with Discord link that does not expire.  
Created via Discord channel menu -> Invite People -> Edit invite link -> Expire After: "Never" -> Generate a New Link

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
