### PR TITLE
fix(fmt): do not print a second line when printing file to stdout

### DIFF
--- a/gnovm/cmd/gno/fmt.go
+++ b/gnovm/cmd/gno/fmt.go
@@ -162,7 +162,7 @@ func fmtProcessSingleFile(cfg *fmtCfg, file string, processFile fmtProcessFileFu
 	}
 	if !cfg.write {
 		if !cfg.diff && !cfg.quiet {
-			io.Println(string(out))
+			io.Out().Write(out)
 		}
 		return true
 	}

--- a/gnovm/cmd/gno/testdata/gno_fmt/empty.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/empty.txtar
@@ -6,5 +6,4 @@ cmp stderr stderr.golden
 package hello
 -- stdout.golden.gno --
 package hello
-
 -- stderr.golden --

--- a/gnovm/cmd/gno/testdata/gno_fmt/import_cleaning.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/import_cleaning.txtar
@@ -26,5 +26,4 @@ var rand = &S{}
 package testdata
 
 var yes = rand.Val
-
 -- stderr.golden --

--- a/gnovm/cmd/gno/testdata/gno_fmt/include.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/include.txtar
@@ -27,5 +27,4 @@ package testdata
 import "gno.land/r/test/mypkg"
 
 var myVar = mypkg.HelloFromMyPkg()
-
 -- stderr.golden --

--- a/gnovm/cmd/gno/testdata/gno_fmt/multi_import.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/multi_import.txtar
@@ -92,5 +92,4 @@ func myBlog() *blog.Blog {
 
 	return &blog.Blog{}
 }
-
 -- stderr.golden --

--- a/gnovm/cmd/gno/testdata/gno_fmt/noimport_format.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/noimport_format.txtar
@@ -35,5 +35,4 @@ import (
 )
 
 var yes = rand.Val
-
 -- stderr.golden --

--- a/gnovm/cmd/gno/testdata/gno_fmt/shadow_import.txtar
+++ b/gnovm/cmd/gno/testdata/gno_fmt/shadow_import.txtar
@@ -49,5 +49,4 @@ import (
 func main() {
 	println("a", v1.Get("a"))
 }
-
 -- stderr.golden --


### PR DESCRIPTION
address #2633 

Avoid double printing newline when executing `gno fmt` without the `-w` (write) flag.