### PR TITLE
feat: sync gc

### DIFF
--- a/gnovm/pkg/gnolang/alloc.go
+++ b/gnovm/pkg/gnolang/alloc.go
@@ -311,8 +311,8 @@ func (alloc *Allocator) NewStructFields(fields int) []TypedValue {
 	ffs := make([]TypedValue, fields)
 
 	if alloc != nil {
-		runtime.SetFinalizer(ffs, func(ffs *StructValue) {
-			atomic.AddInt64(&alloc.bytes, allocStructField*-int64(fields))
+		runtime.SetFinalizer(&ffs, func(ffs *[]TypedValue) {
+			atomic.AddInt64(&alloc.bytes, allocStructField*-int64(len(*ffs)))
 			fmt.Printf("deleted fields: current bytes used %+v\n", atomic.LoadInt64(&alloc.bytes))
 		})
 	}


### PR DESCRIPTION
Use the `runtime.SetFinalizer` api to decrease the counter in the VM allocator when garbage is collected.
This is to address [this](https://github.com/gnolang/gno/issues/266)