### PR TITLE
fix: In r/demo/profile fieldHandler, use url.QueryEscape(value)

### DIFF
--- a/examples/gno.land/r/demo/profile/render.gno
+++ b/examples/gno.land/r/demo/profile/render.gno
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"bytes"
+	"net/url"
 	"std"
 
 	"gno.land/p/demo/mux"
@@ -83,7 +84,7 @@ func fieldHandler(res *mux.ResponseWriter, req *mux.Request) {
 
 	if _, ok := stringFields[field]; ok {
 		value = ufmt.Sprintf("%s", GetStringField(address, field, "n/a"))
-		editLink = ufmt.Sprintf(SetStringFieldURL+"&addr=%s&value=%s", field, addr, value)
+		editLink = ufmt.Sprintf(SetStringFieldURL+"&addr=%s&value=%s", field, addr, url.QueryEscape(value))
 	} else if _, ok := intFields[field]; ok {
 		value = ufmt.Sprintf("%d", GetIntField(address, field, 0))
 		editLink = ufmt.Sprintf(SetIntFieldURL+"&addr=%s&value=%s", field, addr, value)


### PR DESCRIPTION
In r/demo/profile, if the Bio field is "My bio", then the web render for `r/demo/profile:f/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5/Bio` shows:
```
Bio: My bio [Edit](/r/demo/profile?help&__func=SetStringField&field=Bio&addr=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5&value=My bio)
```

The `[Edit]` link doesn't display properly because of the space in "My bio". This PR updates fieldHandler to use `url.QueryEscape`. With this fix the web render is as expected with the correct `[Edit]` link:
```
Bio: My bio Edit
```