### PR TITLE
ci: fix backwards incompatible change

### DIFF
--- a/tm2/pkg/crypto/secp256k1/secp256k1_nocgo.go
+++ b/tm2/pkg/crypto/secp256k1/secp256k1_nocgo.go
@@ -15,10 +15,7 @@ import (
 func (privKey PrivKeySecp256k1) Sign(msg []byte) ([]byte, error) {
 	priv, _ := btcec.PrivKeyFromBytes(privKey[:])
 
-	sig, err := ecdsa.SignCompact(priv, crypto.Sha256(msg), false) // ref uncompressed pubkey
-	if err != nil {
-		return nil, err
-	}
+	sig := ecdsa.SignCompact(priv, crypto.Sha256(msg), false) // ref uncompressed pubkey
 
 	// remove compact sig recovery code byte at the beginning
 	return sig[1:], nil


### PR DESCRIPTION
https://github.com/gnolang/gno/pull/2612 for some reason only had two checks. Hopefully this has changed with the latest changes to CI.