### PR TITLE
fix(gnovm): handle non call expression valuedecl values

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2189,13 +2189,16 @@ func Preprocess(store Store, ctx BlockNode, n Node) Node {
 					}
 
 					if rLen := len(tuple.Elts); rLen != numNames {
-						rhsExprString := valueExpr.String()
-						if cx, ok := valueExpr.(*CallExpr); ok {
-							rhsExprString = cx.Func.String()
-						}
-
-						panic(fmt.Sprintf("assignment mismatch: %d variable(s) but %s returns %d value(s)", numNames, rhsExprString, rLen))
+						panic(
+							fmt.Sprintf(
+								"assignment mismatch: %d variable(s) but %s returns %d value(s)",
+								numNames,
+								valueExpr.String(),
+								rLen,
+							),
+						)
 					}
+
 					if n.Type != nil {
 						// only a single type can be specified.
 						nt := evalStaticType(store, last, n.Type)

--- a/gnovm/tests/files/var20.gno
+++ b/gnovm/tests/files/var20.gno
@@ -9,4 +9,4 @@ func main() {
 }
 
 // Error:
-// main/files/var20.gno:8:6: assignment mismatch: 3 variable(s) but r<VPBlock(3,0)> returns 1 value(s)
+// main/files/var20.gno:8:6: assignment mismatch: 3 variable(s) but r<VPBlock(3,0)>() returns 1 value(s)

--- a/gnovm/tests/files/vardecl.gno
+++ b/gnovm/tests/files/vardecl.gno
@@ -1,0 +1,23 @@
+package main
+
+func main() {
+	var i interface{} = 1
+	a, ok := i.(int)
+	println(a, ok)
+
+	b, c := doSomething()
+	println(b, c)
+
+	m := map[string]int{"a": 1, "b": 2}
+	d, okk := m["d"]
+	println(d, okk)
+}
+
+func doSomething() (int, string) {
+	return 4, "hi"
+}
+
+// Output:
+// 1 true
+// 4 hi
+// 0 false

--- a/gnovm/tests/files/vardecl.gno
+++ b/gnovm/tests/files/vardecl.gno
@@ -2,14 +2,14 @@ package main
 
 func main() {
 	var i interface{} = 1
-	a, ok := i.(int)
+	var a, ok = i.(int)
 	println(a, ok)
 
-	b, c := doSomething()
+	var b, c = doSomething()
 	println(b, c)
 
 	m := map[string]int{"a": 1, "b": 2}
-	d, okk := m["d"]
+	var d, okk = m["d"]
 	println(d, okk)
 }
 


### PR DESCRIPTION
Closes #2636.

With a value declaration like `var a, b = ...`, we currently only support a call expression on the RHS. This PR supports type assertion and index expressions as well.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
