### PR TITLE
chore: add a ugnot constant

### DIFF
--- a/contribs/gnodev/cmd/gnodev/accounts.go
+++ b/contribs/gnodev/cmd/gnodev/accounts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gnolang/gno/contribs/gnodev/pkg/address"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/dev"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -50,7 +51,7 @@ func (va varPremineAccounts) String() string {
 
 func generateBalances(bk *address.Book, cfg *devCfg) (gnoland.Balances, error) {
 	bls := gnoland.NewBalances()
-	premineBalance := std.Coins{std.NewCoin("ugnot", 10e12)}
+	premineBalance := std.Coins{std.NewCoin(ugnot.Denom, 10e12)}
 
 	entries := bk.List()
 

--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gnolang/gno/contribs/gnodev/pkg/emitter"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnomod"
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -52,7 +53,7 @@ func DefaultNodeConfig(rootdir string) *NodeConfig {
 	balances := []gnoland.Balance{
 		{
 			Address: defaultDeployer,
-			Amount:  std.Coins{std.NewCoin("ugnot", 10e12)},
+			Amount:  std.Coins{std.NewCoin(ugnot.Denom, 10e12)},
 		},
 	}
 
@@ -87,7 +88,7 @@ type Node struct {
 	currentStateIndex   int
 }
 
-var DefaultFee = std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
+var DefaultFee = std.NewFee(50000, std.MustParseCoin(ugnot.ValueString(1000000)))
 
 func NewDevNode(ctx context.Context, cfg *NodeConfig) (*Node, error) {
 	mpkgs, err := NewPackagesMap(cfg.PackagesPathList)

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
 	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
@@ -246,8 +247,8 @@ func testingCallRealm(t *testing.T, node *Node, msgs ...gnoclient.MsgCall) (*cor
 	}
 
 	txcfg := gnoclient.BaseTxCfg{
-		GasFee:    "1000000ugnot", // Gas fee
-		GasWanted: 2_000_000,      // Gas wanted
+		GasFee:    ugnot.ValueString(1000000), // Gas fee
+		GasWanted: 2_000_000,                  // Gas wanted
 	}
 
 	return cli.Call(txcfg, msgs...)

--- a/contribs/gnodev/pkg/dev/packages_test.go
+++ b/contribs/gnodev/pkg/dev/packages_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/contribs/gnodev/pkg/address"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
@@ -26,33 +27,60 @@ func TestResolvePackagePathQuery(t *testing.T) {
 		ExpectedPackagePath PackagePath
 		ShouldFail          bool
 	}{
-		{".", PackagePath{
+		{
 			Path: ".",
-		}, false},
-		{"/simple/path", PackagePath{
+			ExpectedPackagePath: PackagePath{
+				Path: ".",
+			},
+		},
+		{
 			Path: "/simple/path",
-		}, false},
-		{"/ambiguo/u//s/path///", PackagePath{
-			Path: "/ambiguo/u/s/path",
-		}, false},
-		{"/path/with/creator?creator=testAccount", PackagePath{
-			Path:    "/path/with/creator",
-			Creator: testingAddress,
-		}, false},
-		{"/path/with/deposit?deposit=100ugnot", PackagePath{
-			Path:    "/path/with/deposit",
-			Deposit: std.MustParseCoins("100ugnot"),
-		}, false},
-		{".?creator=g1hr3dl82qdy84a5h3dmckh0suc7zgwm5rnns6na&deposit=100ugnot", PackagePath{
-			Path:    ".",
-			Creator: testingAddress,
-			Deposit: std.MustParseCoins("100ugnot"),
-		}, false},
+			ExpectedPackagePath: PackagePath{
+				Path: "/simple/path",
+			},
+		},
+		{
+			Path: "/ambiguo/u//s/path///",
+			ExpectedPackagePath: PackagePath{
+				Path: "/ambiguo/u/s/path",
+			},
+		},
+		{
+			Path: "/path/with/creator?creator=testAccount",
+			ExpectedPackagePath: PackagePath{
+				Path:    "/path/with/creator",
+				Creator: testingAddress,
+			},
+		},
+		{
+			Path: "/path/with/deposit?deposit=" + ugnot.ValueString(100),
+			ExpectedPackagePath: PackagePath{
+				Path:    "/path/with/deposit",
+				Deposit: std.MustParseCoins(ugnot.ValueString(100)),
+			},
+		},
+		{
+			Path: ".?creator=g1hr3dl82qdy84a5h3dmckh0suc7zgwm5rnns6na&deposit=" + ugnot.ValueString(100),
+			ExpectedPackagePath: PackagePath{
+				Path:    ".",
+				Creator: testingAddress,
+				Deposit: std.MustParseCoins(ugnot.ValueString(100)),
+			},
+		},
 
 		// errors cases
-		{"/invalid/account?creator=UnknownAccount", PackagePath{}, true},
-		{"/invalid/address?creator=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", PackagePath{}, true},
-		{"/invalid/deposit?deposit=abcd", PackagePath{}, true},
+		{
+			Path:       "/invalid/account?creator=UnknownAccount",
+			ShouldFail: true,
+		},
+		{
+			Path:       "/invalid/address?creator=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			ShouldFail: true,
+		},
+		{
+			Path:       "/invalid/deposit?deposit=abcd",
+			ShouldFail: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -12,6 +12,7 @@ import (
 	tm2Client "github.com/gnolang/faucet/client/http"
 	"github.com/gnolang/faucet/config"
 	"github.com/gnolang/faucet/estimate/static"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/errors"
@@ -20,7 +21,7 @@ import (
 )
 
 const (
-	defaultGasFee        = "1000000ugnot"
+	defaultGasFee        = "1000000" + ugnot.Denom
 	defaultGasWanted     = "100000"
 	defaultRemote        = "http://127.0.0.1:26657"
 	defaultListenAddress = "127.0.0.1:5050"
@@ -116,7 +117,7 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&c.maxSendAmount,
 		"max-send-amount",
-		"10000000ugnot",
+		ugnot.ValueString(10000000),
 		"the static max send amount (native currency)",
 	)
 

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -12,7 +12,6 @@ import (
 	tm2Client "github.com/gnolang/faucet/client/http"
 	"github.com/gnolang/faucet/config"
 	"github.com/gnolang/faucet/estimate/static"
-	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/errors"
@@ -21,7 +20,7 @@ import (
 )
 
 const (
-	defaultGasFee        = "1000000" + ugnot.Denom
+	defaultGasFee        = "1000000ugnot"
 	defaultGasWanted     = "100000"
 	defaultRemote        = "http://127.0.0.1:26657"
 	defaultListenAddress = "127.0.0.1:5050"
@@ -117,7 +116,7 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(
 		&c.maxSendAmount,
 		"max-send-amount",
-		ugnot.ValueString(10000000),
+		"10000000ugnot",
 		"the static max send amount (native currency)",
 	)
 

--- a/gno.land/cmd/gnoland/genesis_balances_add.go
+++ b/gno.land/cmd/gnoland/genesis_balances_add.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -57,13 +58,13 @@ func (c *balancesAddCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.balanceSheet,
 		"balance-sheet",
 		"",
-		"the path to the balance file containing addresses in the format <address>=<amount>ugnot",
+		"the path to the balance file containing addresses in the format <address>=<amount>"+ugnot.Denom,
 	)
 
 	fs.Var(
 		&c.singleEntries,
 		"single",
-		"the direct balance addition in the format <address>=<amount>ugnot",
+		"the direct balance addition in the format <address>=<amount>"+ugnot.Denom,
 	)
 
 	fs.StringVar(
@@ -167,7 +168,7 @@ func execBalancesAdd(ctx context.Context, cfg *balancesAddCfg, io commands.IO) e
 	io.Println()
 
 	for address, balance := range finalBalances {
-		io.Printfln("%s:%dugnot", address.String(), balance)
+		io.Printfln("%s:%d%s", address.String(), balance, ugnot.Denom)
 	}
 
 	return nil
@@ -208,7 +209,7 @@ func getBalancesFromTransactions(
 			}
 
 			feeAmount := std.NewCoins(tx.Fee.GasFee)
-			if feeAmount.AmountOf("ugnot") <= 0 {
+			if feeAmount.AmountOf(ugnot.Denom) <= 0 {
 				io.ErrPrintfln(
 					"invalid gas fee amount encountered: %q",
 					tx.Fee.GasFee.String(),
@@ -223,7 +224,7 @@ func getBalancesFromTransactions(
 				msgSend := msg.(bank.MsgSend)
 
 				sendAmount := msgSend.Amount
-				if sendAmount.AmountOf("ugnot") <= 0 {
+				if sendAmount.AmountOf(ugnot.Denom) <= 0 {
 					io.ErrPrintfln(
 						"invalid send amount encountered: %s",
 						msgSend.Amount.String(),
@@ -248,7 +249,7 @@ func getBalancesFromTransactions(
 				if from.IsAllLT(sendAmount) || from.IsAllLT(feeAmount) {
 					// Account cannot cover send amount / fee
 					// (see message above)
-					from = std.NewCoins(std.NewCoin("ugnot", 0))
+					from = std.NewCoins(std.NewCoin(ugnot.Denom, 0))
 				}
 
 				if from.IsAllGT(sendAmount) {

--- a/gno.land/cmd/gnoland/genesis_balances_add_test.go
+++ b/gno.land/cmd/gnoland/genesis_balances_add_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -100,16 +101,16 @@ func TestGenesis_Balances_Add(t *testing.T) {
 			tempGenesis.Name(),
 		}
 
-		amount := std.NewCoins(std.NewCoin("ugnot", 10))
+		amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 		for _, dummyKey := range dummyKeys {
 			args = append(args, "--single")
 			args = append(
 				args,
 				fmt.Sprintf(
-					"%s=%dugnot",
+					"%s=%s",
 					dummyKey.Address().String(),
-					amount.AmountOf("ugnot"),
+					ugnot.ValueString(amount.AmountOf(ugnot.Denom)),
 				),
 			)
 		}
@@ -158,7 +159,7 @@ func TestGenesis_Balances_Add(t *testing.T) {
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
 
 		dummyKeys := getDummyKeys(t, 10)
-		amount := std.NewCoins(std.NewCoin("ugnot", 10))
+		amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 		balances := make([]string, len(dummyKeys))
 
@@ -167,9 +168,9 @@ func TestGenesis_Balances_Add(t *testing.T) {
 
 		for index, key := range dummyKeys {
 			balances[index] = fmt.Sprintf(
-				"%s=%dugnot",
+				"%s=%s",
 				key.Address().String(),
-				amount.AmountOf("ugnot"),
+				ugnot.ValueString(amount.AmountOf(ugnot.Denom)),
 			)
 		}
 
@@ -237,9 +238,9 @@ func TestGenesis_Balances_Add(t *testing.T) {
 
 		var (
 			dummyKeys   = getDummyKeys(t, 10)
-			amount      = std.NewCoins(std.NewCoin("ugnot", 10))
-			amountCoins = std.NewCoins(std.NewCoin("ugnot", 10))
-			gasFee      = std.NewCoin("ugnot", 1000000)
+			amount      = std.NewCoins(std.NewCoin(ugnot.Denom, 10))
+			amountCoins = std.NewCoins(std.NewCoin(ugnot.Denom, 10))
+			gasFee      = std.NewCoin(ugnot.Denom, 1000000)
 			txs         = make([]std.Tx, 0)
 		)
 
@@ -316,7 +317,7 @@ func TestGenesis_Balances_Add(t *testing.T) {
 				if index == 0 {
 					// the first address should
 					// have a balance of 0
-					checkAmount = std.NewCoins(std.NewCoin("ugnot", 0))
+					checkAmount = std.NewCoins(std.NewCoin(ugnot.Denom, 0))
 				}
 
 				if dummyKey.Address().String() == balance.Address.String() {
@@ -347,7 +348,7 @@ func TestGenesis_Balances_Add(t *testing.T) {
 			Balances: []gnoland.Balance{
 				{
 					Address: dummyKeys[0].Address(),
-					Amount:  std.NewCoins(std.NewCoin("ugnot", 100)),
+					Amount:  std.NewCoins(std.NewCoin(ugnot.Denom, 100)),
 				},
 			},
 		}
@@ -364,16 +365,16 @@ func TestGenesis_Balances_Add(t *testing.T) {
 			tempGenesis.Name(),
 		}
 
-		amount := std.NewCoins(std.NewCoin("ugnot", 10))
+		amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 		for _, dummyKey := range dummyKeys {
 			args = append(args, "--single")
 			args = append(
 				args,
 				fmt.Sprintf(
-					"%s=%dugnot",
+					"%s=%s",
 					dummyKey.Address().String(),
-					amount.AmountOf("ugnot"),
+					ugnot.ValueString(amount.AmountOf(ugnot.Denom)),
 				),
 			)
 		}
@@ -421,9 +422,9 @@ func TestBalances_GetBalancesFromTransactions(t *testing.T) {
 
 		var (
 			dummyKeys   = getDummyKeys(t, 10)
-			amount      = std.NewCoins(std.NewCoin("ugnot", 10))
-			amountCoins = std.NewCoins(std.NewCoin("ugnot", 10))
-			gasFee      = std.NewCoin("ugnot", 1000000)
+			amount      = std.NewCoins(std.NewCoin(ugnot.Denom, 10))
+			amountCoins = std.NewCoins(std.NewCoin(ugnot.Denom, 10))
+			gasFee      = std.NewCoin(ugnot.Denom, 1000000)
 			txs         = make([]std.Tx, 0)
 		)
 
@@ -479,7 +480,7 @@ func TestBalances_GetBalancesFromTransactions(t *testing.T) {
 
 		var (
 			dummyKeys   = getDummyKeys(t, 10)
-			amountCoins = std.NewCoins(std.NewCoin("ugnot", 10))
+			amountCoins = std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 			gasFee      = std.NewCoin("gnos", 1) // invalid fee
 			txs         = make([]std.Tx, 0)
 		)
@@ -532,7 +533,7 @@ func TestBalances_GetBalancesFromTransactions(t *testing.T) {
 		var (
 			dummyKeys   = getDummyKeys(t, 10)
 			amountCoins = std.NewCoins(std.NewCoin("gnogno", 10)) // invalid send amount
-			gasFee      = std.NewCoin("ugnot", 1)
+			gasFee      = std.NewCoin(ugnot.Denom, 1)
 			txs         = make([]std.Tx, 0)
 		)
 

--- a/gno.land/cmd/gnoland/genesis_balances_export_test.go
+++ b/gno.land/cmd/gnoland/genesis_balances_export_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
@@ -18,7 +19,7 @@ func getDummyBalances(t *testing.T, count int) []gnoland.Balance {
 	t.Helper()
 
 	dummyKeys := getDummyKeys(t, count)
-	amount := std.NewCoins(std.NewCoin("ugnot", 10))
+	amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 	balances := make([]gnoland.Balance, len(dummyKeys))
 

--- a/gno.land/cmd/gnoland/genesis_balances_remove_test.go
+++ b/gno.land/cmd/gnoland/genesis_balances_remove_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -75,7 +76,7 @@ func TestGenesis_Balances_Remove(t *testing.T) {
 			Balances: []gnoland.Balance{
 				{
 					Address: dummyKey.Address(),
-					Amount:  std.NewCoins(std.NewCoin("ugnot", 100)),
+					Amount:  std.NewCoins(std.NewCoin(ugnot.Denom, 100)),
 				},
 			},
 		}

--- a/gno.land/cmd/gnoland/genesis_txs_add_packages.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_packages.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
@@ -16,7 +17,7 @@ var errInvalidPackageDir = errors.New("invalid package directory")
 
 var (
 	genesisDeployAddress = crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // test1
-	genesisDeployFee     = std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
+	genesisDeployFee     = std.NewFee(50000, std.MustParseCoin(ugnot.ValueString(1000000)))
 )
 
 // newTxsAddPackagesCmd creates the genesis txs add packages subcommand

--- a/gno.land/cmd/gnoland/genesis_txs_add_sheet_test.go
+++ b/gno.land/cmd/gnoland/genesis_txs_add_sheet_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -30,12 +31,12 @@ func generateDummyTxs(t *testing.T, count int) []std.Tx {
 				bank.MsgSend{
 					FromAddress: crypto.Address{byte(i)},
 					ToAddress:   crypto.Address{byte((i + 1) % count)},
-					Amount:      std.NewCoins(std.NewCoin("ugnot", 1)),
+					Amount:      std.NewCoins(std.NewCoin(ugnot.Denom, 1)),
 				},
 			},
 			Fee: std.Fee{
 				GasWanted: 1,
-				GasFee:    std.NewCoin("ugnot", 1000000),
+				GasFee:    std.NewCoin(ugnot.Denom, 1000000),
 			},
 			Memo: fmt.Sprintf("tx %d", i),
 		}

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
@@ -13,6 +14,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
+
+var testGasFee = ugnot.ValueString(10000)
 
 func TestRender(t *testing.T) {
 	t.Parallel()
@@ -88,7 +91,7 @@ func TestCallSingle(t *testing.T) {
 
 	cfg := BaseTxCfg{
 		GasWanted:      100000,
-		GasFee:         "10000ugnot",
+		GasFee:         testGasFee,
 		AccountNumber:  1,
 		SequenceNumber: 1,
 		Memo:           "Test memo",
@@ -99,7 +102,7 @@ func TestCallSingle(t *testing.T) {
 			PkgPath:  "gno.land/r/demo/deep/very/deep",
 			FuncName: "Render",
 			Args:     []string{""},
-			Send:     "100ugnot",
+			Send:     ugnot.ValueString(100),
 		},
 	}
 
@@ -147,7 +150,7 @@ func TestCallMultiple(t *testing.T) {
 
 	cfg := BaseTxCfg{
 		GasWanted:      100000,
-		GasFee:         "10000ugnot",
+		GasFee:         testGasFee,
 		AccountNumber:  1,
 		SequenceNumber: 1,
 		Memo:           "Test memo",
@@ -158,13 +161,13 @@ func TestCallMultiple(t *testing.T) {
 			PkgPath:  "gno.land/r/demo/deep/very/deep",
 			FuncName: "Render",
 			Args:     []string{""},
-			Send:     "100ugnot",
+			Send:     ugnot.ValueString(100),
 		},
 		{
 			PkgPath:  "gno.land/r/demo/wugnot",
 			FuncName: "Deposit",
 			Args:     []string{""},
-			Send:     "1000ugnot",
+			Send:     ugnot.ValueString(1000),
 		},
 		{
 			PkgPath:  "gno.land/r/demo/tamagotchi",
@@ -197,7 +200,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -220,7 +223,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -264,7 +267,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      -1,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -287,7 +290,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      0,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -310,7 +313,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -333,7 +336,7 @@ func TestCallErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -381,7 +384,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -389,7 +392,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrMissingSigner,
@@ -402,7 +405,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -410,7 +413,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrMissingRPCClient,
@@ -431,7 +434,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrInvalidGasFee,
@@ -444,7 +447,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      -1,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -452,7 +455,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrInvalidGasWanted,
@@ -465,7 +468,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      0,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -473,7 +476,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrInvalidGasWanted,
@@ -495,7 +498,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -503,7 +506,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: crypto.Address{},
-					Send:      "1ugnot",
+					Send:      ugnot.ValueString(1),
 				},
 			},
 			expectedError: ErrInvalidToAddress,
@@ -525,7 +528,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -533,7 +536,7 @@ func TestClient_Send_Errors(t *testing.T) {
 			msgs: []MsgSend{
 				{
 					ToAddress: toAddress,
-					Send:      "-1ugnot",
+					Send:      ugnot.ValueString(-1),
 				},
 			},
 			expectedError: ErrInvalidSendAmount,
@@ -586,7 +589,7 @@ func TestRunSingle(t *testing.T) {
 
 	cfg := BaseTxCfg{
 		GasWanted:      100000,
-		GasFee:         "10000ugnot",
+		GasFee:         testGasFee,
 		AccountNumber:  1,
 		SequenceNumber: 1,
 		Memo:           "Test memo",
@@ -653,7 +656,7 @@ func TestRunMultiple(t *testing.T) {
 
 	cfg := BaseTxCfg{
 		GasWanted:      100000,
-		GasFee:         "10000ugnot",
+		GasFee:         testGasFee,
 		AccountNumber:  1,
 		SequenceNumber: 1,
 		Memo:           "Test memo",
@@ -717,7 +720,7 @@ func TestRunErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -747,7 +750,7 @@ func TestRunErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -793,7 +796,7 @@ func TestRunErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      -1,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -823,7 +826,7 @@ func TestRunErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      0,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -862,7 +865,7 @@ func TestRunErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -908,7 +911,7 @@ func TestAddPackageErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -938,7 +941,7 @@ func TestAddPackageErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -984,7 +987,7 @@ func TestAddPackageErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      -1,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -1014,7 +1017,7 @@ func TestAddPackageErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      0,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",
@@ -1053,7 +1056,7 @@ func TestAddPackageErrors(t *testing.T) {
 			},
 			cfg: BaseTxCfg{
 				GasWanted:      100000,
-				GasFee:         "10000ugnot",
+				GasFee:         testGasFee,
 				AccountNumber:  1,
 				SequenceNumber: 1,
 				Memo:           "Test memo",

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/std"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
@@ -36,7 +37,7 @@ func TestCallSingle_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -80,7 +81,7 @@ func TestCallMultiple_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -132,7 +133,7 @@ func TestSendSingle_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -144,7 +145,7 @@ func TestSendSingle_Integration(t *testing.T) {
 	amount := 10
 	msg := MsgSend{
 		ToAddress: toAddress,
-		Send:      std.Coin{"ugnot", int64(amount)}.String(),
+		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount)}.String(),
 	}
 
 	// Execute send
@@ -156,7 +157,7 @@ func TestSendSingle_Integration(t *testing.T) {
 	account, _, err := client.QueryAccount(toAddress)
 	require.NoError(t, err)
 
-	expected := std.Coins{{"ugnot", int64(amount)}}
+	expected := std.Coins{{Denom: ugnot.Denom, Amount: int64(amount)}}
 	got := account.GetCoins()
 
 	assert.Equal(t, expected, got)
@@ -181,7 +182,7 @@ func TestSendMultiple_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -193,14 +194,14 @@ func TestSendMultiple_Integration(t *testing.T) {
 	amount1 := 10
 	msg1 := MsgSend{
 		ToAddress: toAddress,
-		Send:      std.Coin{"ugnot", int64(amount1)}.String(),
+		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount1)}.String(),
 	}
 
 	// Same send, different argument
 	amount2 := 20
 	msg2 := MsgSend{
 		ToAddress: toAddress,
-		Send:      std.Coin{"ugnot", int64(amount2)}.String(),
+		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount2)}.String(),
 	}
 
 	// Execute send
@@ -212,7 +213,7 @@ func TestSendMultiple_Integration(t *testing.T) {
 	account, _, err := client.QueryAccount(toAddress)
 	assert.NoError(t, err)
 
-	expected := std.Coins{{"ugnot", int64(amount1 + amount2)}}
+	expected := std.Coins{{Denom: ugnot.Denom, Amount: int64(amount1 + amount2)}}
 	got := account.GetCoins()
 
 	assert.Equal(t, expected, got)
@@ -237,7 +238,7 @@ func TestRunSingle_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -295,7 +296,7 @@ func TestRunMultiple_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -375,7 +376,7 @@ func TestAddPackageSingle_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
@@ -390,7 +391,7 @@ func Echo(str string) string {
 
 	fileName := "echo.gno"
 	deploymentPath := "gno.land/p/demo/integration/test/echo"
-	deposit := "100ugnot"
+	deposit := ugnot.ValueString(100)
 
 	// Make Msg config
 	msg := MsgAddPackage{
@@ -444,14 +445,14 @@ func TestAddPackageMultiple_Integration(t *testing.T) {
 
 	// Make Tx config
 	baseCfg := BaseTxCfg{
-		GasFee:         "10000ugnot",
+		GasFee:         ugnot.ValueString(10000),
 		GasWanted:      8000000,
 		AccountNumber:  0,
 		SequenceNumber: 0,
 		Memo:           "",
 	}
 
-	deposit := "100ugnot"
+	deposit := ugnot.ValueString(100)
 	deploymentPath1 := "gno.land/p/demo/integration/test/echo"
 
 	body1 := `package echo

--- a/gno.land/pkg/gnoclient/signer.go
+++ b/gno.land/pkg/gnoclient/signer.go
@@ -3,6 +3,7 @@ package gnoclient
 import (
 	"fmt"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/errors"
@@ -47,7 +48,7 @@ func (s SignerFromKeybase) Validate() error {
 	signCfg := SignCfg{
 		UnsignedTX: std.Tx{
 			Msgs: []std.Msg{msg},
-			Fee:  std.NewFee(0, std.NewCoin("ugnot", 1000000)),
+			Fee:  std.NewFee(0, std.NewCoin(ugnot.Denom, 1000000)),
 		},
 	}
 	if _, err = s.Sign(signCfg); err != nil {

--- a/gno.land/pkg/gnoland/balance_test.go
+++ b/gno.land/pkg/gnoland/balance_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
@@ -78,7 +79,7 @@ func TestBalance_Parse(t *testing.T) {
 func TestBalance_AminoUnmarshalJSON(t *testing.T) {
 	expected := Balance{
 		Address: crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-		Amount:  std.MustParseCoins("100ugnot"),
+		Amount:  std.MustParseCoins(ugnot.ValueString(100)),
 	}
 	value := fmt.Sprintf("[%q]", expected.String())
 
@@ -95,7 +96,7 @@ func TestBalance_AminoUnmarshalJSON(t *testing.T) {
 func TestBalance_AminoMarshalJSON(t *testing.T) {
 	expected := Balance{
 		Address: crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-		Amount:  std.MustParseCoins("100ugnot"),
+		Amount:  std.MustParseCoins(ugnot.ValueString(100)),
 	}
 	expectedJSON := fmt.Sprintf("[%q]", expected.String())
 
@@ -112,15 +113,15 @@ func TestBalances_GetBalancesFromEntries(t *testing.T) {
 
 		// Generate dummy keys
 		dummyKeys := getDummyKeys(t, 2)
-		amount := std.NewCoins(std.NewCoin("ugnot", 10))
+		amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 		entries := make([]string, len(dummyKeys))
 
 		for index, key := range dummyKeys {
 			entries[index] = fmt.Sprintf(
-				"%s=%dugnot",
+				"%s=%s",
 				key.Address().String(),
-				amount.AmountOf("ugnot"),
+				ugnot.ValueString(amount.AmountOf(ugnot.Denom)),
 			)
 		}
 
@@ -150,7 +151,7 @@ func TestBalances_GetBalancesFromEntries(t *testing.T) {
 		t.Parallel()
 
 		balances := []string{
-			"dummyaddress=10ugnot",
+			"dummyaddress=" + ugnot.ValueString(10),
 		}
 
 		balanceMap, err := GetBalancesFromEntries(balances...)
@@ -165,9 +166,10 @@ func TestBalances_GetBalancesFromEntries(t *testing.T) {
 
 		balances := []string{
 			fmt.Sprintf(
-				"%s=%sugnot",
+				"%s=%s%s",
 				dummyKey.Address().String(),
 				strconv.FormatUint(math.MaxUint64, 10),
+				ugnot.Denom,
 			),
 		}
 
@@ -185,15 +187,15 @@ func TestBalances_GetBalancesFromSheet(t *testing.T) {
 
 		// Generate dummy keys
 		dummyKeys := getDummyKeys(t, 2)
-		amount := std.NewCoins(std.NewCoin("ugnot", 10))
+		amount := std.NewCoins(std.NewCoin(ugnot.Denom, 10))
 
 		balances := make([]string, len(dummyKeys))
 
 		for index, key := range dummyKeys {
 			balances[index] = fmt.Sprintf(
-				"%s=%dugnot",
+				"%s=%s",
 				key.Address().String(),
-				amount.AmountOf("ugnot"),
+				ugnot.ValueString(amount.AmountOf(ugnot.Denom)),
 			)
 		}
 
@@ -215,9 +217,10 @@ func TestBalances_GetBalancesFromSheet(t *testing.T) {
 
 		balances := []string{
 			fmt.Sprintf(
-				"%s=%sugnot",
+				"%s=%s%s",
 				dummyKey.Address().String(),
 				strconv.FormatUint(math.MaxUint64, 10),
+				ugnot.Denom,
 			),
 		}
 

--- a/gno.land/pkg/gnoland/ugnot/denom.go
+++ b/gno.land/pkg/gnoland/ugnot/denom.go
@@ -1,0 +1,11 @@
+package ugnot
+
+import "strconv"
+
+// Denom is the denomination for ugnot, gno.land's native token.
+const Denom = "ugnot"
+
+// ValueString converts `value` to a string, appends "ugnot", and returns it.
+func ValueString(value int64) string {
+	return strconv.FormatInt(value, 10) + Denom
+}

--- a/gno.land/pkg/integration/testing_integration.go
+++ b/gno.land/pkg/integration/testing_integration.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/keyscli"
 	"github.com/gnolang/gno/gno.land/pkg/log"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
@@ -172,7 +173,7 @@ func setupGnolandTestScript(t *testing.T, txtarDir string) testscript.Params {
 					// get packages
 					pkgs := ts.Value(envKeyPkgsLoader).(*pkgsLoader)                // grab logger
 					creator := crypto.MustAddressFromString(DefaultAccount_Address) // test1
-					defaultFee := std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
+					defaultFee := std.NewFee(50000, std.MustParseCoin(ugnot.ValueString(1000000)))
 					pkgsTxs, err := pkgs.LoadPackages(creator, defaultFee, nil)
 					if err != nil {
 						ts.Fatalf("unable to load packages txs: %s", err)
@@ -562,7 +563,7 @@ func createAccount(env envSetter, kb keys.Keybase, accountName string) (gnoland.
 
 	return gnoland.Balance{
 		Address: address,
-		Amount:  std.Coins{std.NewCoin("ugnot", 10e6)},
+		Amount:  std.Coins{std.NewCoin(ugnot.Denom, 10e6)},
 	}, nil
 }
 
@@ -586,7 +587,7 @@ func createAccountFrom(env envSetter, kb keys.Keybase, accountName, mnemonic str
 
 	return gnoland.Balance{
 		Address: address,
-		Amount:  std.Coins{std.NewCoin("ugnot", 10e6)},
+		Amount:  std.Coins{std.NewCoin(ugnot.Denom, 10e6)},
 	}, nil
 }
 

--- a/gno.land/pkg/integration/testing_node.go
+++ b/gno.land/pkg/integration/testing_node.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	tmcfg "github.com/gnolang/gno/tm2/pkg/bft/config"
 	"github.com/gnolang/gno/tm2/pkg/bft/node"
@@ -102,7 +103,7 @@ func DefaultTestingGenesisConfig(t TestingTS, gnoroot string, self crypto.PubKey
 			Balances: []gnoland.Balance{
 				{
 					Address: crypto.MustAddressFromString(DefaultAccount_Address),
-					Amount:  std.MustParseCoins("10000000000000ugnot"),
+					Amount:  std.MustParseCoins(ugnot.ValueString(10000000000000)),
 				},
 			},
 			Txs: []std.Tx{},
@@ -114,7 +115,7 @@ func DefaultTestingGenesisConfig(t TestingTS, gnoroot string, self crypto.PubKey
 func LoadDefaultPackages(t TestingTS, creator bft.Address, gnoroot string) []std.Tx {
 	examplesDir := filepath.Join(gnoroot, "examples")
 
-	defaultFee := std.NewFee(50000, std.MustParseCoin("1000000ugnot"))
+	defaultFee := std.NewFee(50000, std.MustParseCoin(ugnot.ValueString(1000000)))
 	txs, err := gnoland.LoadPackagesFromDir(examplesDir, creator, defaultFee)
 	require.NoError(t, err)
 

--- a/gno.land/pkg/sdk/vm/gas_test.go
+++ b/gno.land/pkg/sdk/vm/gas_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"testing"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
@@ -140,7 +141,7 @@ func setupAddPkg(success bool) (sdk.Context, sdk.Tx, vmHandler) {
 	addr := crypto.AddressFromPreimage([]byte("test1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(ugnot.ValueString(10000000)))
 	// success message
 	var files []*std.MemFile
 	if success {
@@ -172,7 +173,7 @@ func Echo() UnknowType {
 	// create messages and a transaction
 	msg := NewMsgAddPackage(addr, pkgPath, files)
 	msgs := []std.Msg{msg}
-	fee := std.NewFee(500000, std.MustParseCoin("1ugnot"))
+	fee := std.NewFee(500000, std.MustParseCoin(ugnot.ValueString(1)))
 	tx := std.NewTx(msgs, fee, []std.Signature{}, "")
 
 	return ctx, tx, vmHandler

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
+
+var coinsString = ugnot.ValueString(10000000)
 
 func TestVMKeeperAddPackage(t *testing.T) {
 	env := setupTestEnv()
@@ -23,8 +26,8 @@ func TestVMKeeperAddPackage(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -68,8 +71,8 @@ func TestVMKeeperOrigSend1(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -96,7 +99,7 @@ func Echo(msg string) string {
 	assert.NoError(t, err)
 
 	// Run Echo function.
-	coins := std.MustParseCoins("10000000ugnot")
+	coins := std.MustParseCoins(coinsString)
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.NoError(t, err)
@@ -113,8 +116,8 @@ func TestVMKeeperOrigSend2(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -149,7 +152,7 @@ func GetAdmin() string {
 	assert.NoError(t, err)
 
 	// Run Echo function.
-	coins := std.MustParseCoins("11000000ugnot")
+	coins := std.MustParseCoins(ugnot.ValueString(11000000))
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.Error(t, err)
@@ -167,8 +170,8 @@ func TestVMKeeperOrigSend3(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -195,7 +198,7 @@ func Echo(msg string) string {
 	assert.NoError(t, err)
 
 	// Run Echo function.
-	coins := std.MustParseCoins("9000000ugnot")
+	coins := std.MustParseCoins(ugnot.ValueString(9000000))
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	// XXX change this into an error and make sure error message is descriptive.
 	_, err = env.vmk.Call(ctx, msg2)
@@ -211,8 +214,8 @@ func TestVMKeeperRealmSend1(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -239,7 +242,7 @@ func Echo(msg string) string {
 	assert.NoError(t, err)
 
 	// Run Echo function.
-	coins := std.MustParseCoins("10000000ugnot")
+	coins := std.MustParseCoins(coinsString)
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.NoError(t, err)
@@ -255,8 +258,8 @@ func TestVMKeeperRealmSend2(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -283,7 +286,7 @@ func Echo(msg string) string {
 	assert.NoError(t, err)
 
 	// Run Echo function.
-	coins := std.MustParseCoins("9000000ugnot")
+	coins := std.MustParseCoins(ugnot.ValueString(9000000))
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world"})
 	// XXX change this into an error and make sure error message is descriptive.
 	_, err = env.vmk.Call(ctx, msg2)
@@ -299,8 +302,8 @@ func TestVMKeeperOrigCallerInit(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -422,8 +425,8 @@ func TestNumberOfArgsError(t *testing.T) {
 	addr := crypto.AddressFromPreimage([]byte("addr1"))
 	acc := env.acck.NewAccountWithAddress(ctx, addr)
 	env.acck.SetAccount(ctx, acc)
-	env.bank.SetCoins(ctx, addr, std.MustParseCoins("10000000ugnot"))
-	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins("10000000ugnot")))
+	env.bank.SetCoins(ctx, addr, std.MustParseCoins(coinsString))
+	assert.True(t, env.bank.GetCoins(ctx, addr).IsEqual(std.MustParseCoins(coinsString)))
 
 	// Create test package.
 	files := []*std.MemFile{
@@ -442,7 +445,7 @@ func Echo(msg string) string {
 	assert.NoError(t, err)
 
 	// Call Echo function with wrong number of arguments
-	coins := std.MustParseCoins("1ugnot")
+	coins := std.MustParseCoins(ugnot.ValueString(1))
 	msg2 := NewMsgCall(addr, coins, pkgPath, "Echo", []string{"hello world", "extra arg"})
 	assert.PanicsWithValue(
 		t,

--- a/gnovm/tests/file.go
+++ b/gnovm/tests/file.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/stdlibs"
 	teststd "github.com/gnolang/gno/gnovm/tests/stdlibs/std"
@@ -53,7 +54,7 @@ func TestContext(pkgPath string, send std.Coins) *teststd.TestExecContext {
 	pkgAddr := gno.DerivePkgAddr(pkgPath) // the addr of the pkgPath called.
 	caller := gno.DerivePkgAddr("user1.gno")
 
-	pkgCoins := std.MustParseCoins("200000000ugnot").Add(send) // >= send.
+	pkgCoins := std.MustParseCoins(ugnot.ValueString(200000000)).Add(send) // >= send.
 	banker := newTestBanker(pkgAddr.Bech32(), pkgCoins)
 	ctx := stdlibs.ExecContext{
 		ChainID:       "dev",

--- a/misc/autocounterd/cmd/cmd_start.go
+++ b/misc/autocounterd/cmd/cmd_start.go
@@ -84,7 +84,7 @@ func execStart(cfg *startCfg, args []string, io commands.IO) error {
 		res, err := client.Call(gnoclient.CallCfg{
 			PkgPath:   cfg.realmPath,
 			FuncName:  "Incr",
-			GasFee:    ugnot.ValueString(10000000),
+			GasFee:    "10000000ugnot",
 			GasWanted: 800000,
 			Args:      nil,
 		})

--- a/misc/autocounterd/cmd/cmd_start.go
+++ b/misc/autocounterd/cmd/cmd_start.go
@@ -84,7 +84,7 @@ func execStart(cfg *startCfg, args []string, io commands.IO) error {
 		res, err := client.Call(gnoclient.CallCfg{
 			PkgPath:   cfg.realmPath,
 			FuncName:  "Incr",
-			GasFee:    "10000000ugnot",
+			GasFee:    ugnot.ValueString(10000000),
 			GasWanted: 800000,
 			Args:      nil,
 		})

--- a/misc/docker-integration/integration_test.go
+++ b/misc/docker-integration/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -55,7 +56,10 @@ func runSuite(t *testing.T, tempdir string) {
 	var acc gnoland.GnoAccount
 	dockerExec_gnokeyQuery(t, "auth/accounts/"+test1Addr, &acc)
 	require.Equal(t, test1Addr, acc.Address.String(), "test1 account not found")
-	minCoins := std.MustParseCoins("9990000000000ugnot") // This value is chosen arbitrarily and may not be optimal. Feel free to update it to a more suitable amount
+
+	// This value is chosen arbitrarily and may not be optimal.
+	// Feel free to update it to a more suitable amount.
+	minCoins := std.MustParseCoins(ugnot.ValueString(9990000000000))
 	require.True(t, acc.Coins.IsAllGTE(minCoins),
 		"test1 account coins expected at least %s, got %s", minCoins, acc.Coins)
 


### PR DESCRIPTION
Was starting to work on GNOT token locking and noticed we had no `ugnot` constant in our codebase.  This PR adds a ugnot constant and replaces ugnot literals in most places.
