### PR TITLE
fix(docs): wrong `GetOrigCaller` usage reference

### DIFF
--- a/docs/reference/stdlibs/std/chain.md
+++ b/docs/reference/stdlibs/std/chain.md
@@ -85,7 +85,7 @@ Returns the original signer of the transaction.
 
 #### Usage
 ```go
-caller := std.GetOrigSend()
+caller := std.GetOrigCaller()
 ```
 ---
 


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

Small fix for the docs.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
