### PR TITLE
[ops] Full revision of Goreleaser tasks

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,4 +1,10 @@
 project_name: gno
+version: 2
+
+env:
+  - TAG_VERSION={{ if index .Env "TAG_VERSION"  }}{{ .Env.TAG_VERSION }}{{ else }}latest{{ end }}
+  # supported in next versions -> https://github.com/goreleaser/goreleaser/issues/5059
+  # - TAG_VERSION="{{ envOrDefault "TAG_VERSION" "latest" }}"
 
 before:
   hooks:
@@ -65,6 +71,22 @@ builds:
     goarm:
       - 6
       - 7
+  - id: gnofaucet
+    dir: ./contribs/gnofaucet
+    binary: gnofaucet
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
+
 gomod:
   proxy: true
 
@@ -99,7 +121,7 @@ dockers:
     goarch: amd64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ghcr.io/gnolang/{{ .ProjectName }}:latest-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
       - "--target=gno"
       - "--platform=linux/amd64"
@@ -119,7 +141,7 @@ dockers:
     goarch: arm64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-      - "ghcr.io/gnolang/{{ .ProjectName }}:latest-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-arm64v8"
     build_flag_templates:
       - "--target=gno"
       - "--platform=linux/arm64/v8"
@@ -140,7 +162,7 @@ dockers:
     goarm: 6
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-armv6"
-      - "ghcr.io/gnolang/{{ .ProjectName }}:latest-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-armv6"
     build_flag_templates:
       - "--target=gno"
       - "--platform=linux/arm/v6"
@@ -161,7 +183,7 @@ dockers:
     goarm: 7
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-armv7"
-      - "ghcr.io/gnolang/{{ .ProjectName }}:latest-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-armv7"
     build_flag_templates:
       - "--target=gno"
       - "--platform=linux/arm/v7"
@@ -183,7 +205,7 @@ dockers:
     goarch: amd64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-amd64"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
       - "--target=gnoland"
       - "--platform=linux/amd64"
@@ -204,7 +226,7 @@ dockers:
     goarch: arm64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-arm64v8"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-arm64v8"
     build_flag_templates:
       - "--target=gnoland"
       - "--platform=linux/arm64/v8"
@@ -226,7 +248,7 @@ dockers:
     goarm: 6
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-armv6"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-armv6"
     build_flag_templates:
       - "--target=gnoland"
       - "--platform=linux/arm/v6"
@@ -248,7 +270,7 @@ dockers:
     goarm: 7
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-armv7"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-armv7"
     build_flag_templates:
       - "--target=gnoland"
       - "--platform=linux/arm/v7"
@@ -270,7 +292,7 @@ dockers:
     goarch: amd64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-amd64"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
       - "--target=gnokey"
       - "--platform=linux/amd64"
@@ -286,7 +308,7 @@ dockers:
     goarch: arm64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-arm64v8"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-arm64v8"
     build_flag_templates:
       - "--target=gnokey"
       - "--platform=linux/arm64/v8"
@@ -303,7 +325,7 @@ dockers:
     goarm: 6
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-armv6"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-armv6"
     build_flag_templates:
       - "--target=gnokey"
       - "--platform=linux/arm/v6"
@@ -320,7 +342,7 @@ dockers:
     goarm: 7
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-armv7"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-armv7"
     build_flag_templates:
       - "--target=gnokey"
       - "--platform=linux/arm/v7"
@@ -338,7 +360,7 @@ dockers:
     goarch: amd64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-amd64"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
       - "--target=gnoweb"
       - "--platform=linux/amd64"
@@ -354,7 +376,7 @@ dockers:
     goarch: arm64
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-arm64v8"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-arm64v8"
     build_flag_templates:
       - "--target=gnoweb"
       - "--platform=linux/arm64/v8"
@@ -371,7 +393,7 @@ dockers:
     goarm: 6
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-armv6"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-armv6"
     build_flag_templates:
       - "--target=gnoweb"
       - "--platform=linux/arm/v6"
@@ -388,7 +410,7 @@ dockers:
     goarm: 7
     image_templates:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-armv7"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-armv7"
     build_flag_templates:
       - "--target=gnoweb"
       - "--platform=linux/arm/v7"
@@ -398,6 +420,74 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
       - gnoweb
+
+  # gnofaucet
+  - use: buildx
+    dockerfile: Dockerfile.release
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-amd64"
+    build_flag_templates:
+      - "--target=gnofaucet"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnofaucet"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    ids:
+      - gnofaucet
+  - use: buildx
+    dockerfile: Dockerfile.release
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-arm64v8"
+    build_flag_templates:
+      - "--target=gnofaucet"
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnofaucet"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    ids:
+      - gnofaucet
+  - use: buildx
+    dockerfile: Dockerfile.release
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv6"
+    build_flag_templates:
+      - "--target=gnofaucet"
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnofaucet"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    ids:
+      - gnofaucet
+  - use: buildx
+    dockerfile: Dockerfile.release
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv7"
+    build_flag_templates:
+      - "--target=gnofaucet"
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnofaucet"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    ids:
+      - gnofaucet
 
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/
@@ -409,12 +499,12 @@ docker_manifests:
       - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-arm64v8
       - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-armv6
       - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Version }}-armv7
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}:latest
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}:latest-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}:latest-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}:latest-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}:latest-armv7
+      - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}:{{ .Env.TAG_VERSION }}-armv7
 
   # gnoland
   - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}
@@ -423,12 +513,12 @@ docker_manifests:
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-arm64v8
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-armv6
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Version }}-armv7
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:latest-armv7
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoland:{{ .Env.TAG_VERSION }}-armv7
 
   # gnokey
   - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}
@@ -437,13 +527,13 @@ docker_manifests:
       - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-arm64v8
       - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-armv6
       - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Version }}-armv7
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:latest-armv7
-
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnokey:{{ .Env.TAG_VERSION }}-armv7
+ 
   # gnoweb
   - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}
     image_templates:
@@ -451,12 +541,26 @@ docker_manifests:
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-arm64v8
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-armv6
       - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Version }}-armv7
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:latest-armv7
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnoweb:{{ .Env.TAG_VERSION }}-armv7
+
+  # gnofaucet
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}
+    image_templates:
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Version }}-armv7
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}
+    image_templates:
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv7
 
 docker_signs:
   - cmd: cosign
@@ -487,6 +591,8 @@ release:
   draft: true
   replace_existing_draft: true
   prerelease: auto
+  # make_latest: {{ if .IsNightly }}true{{ else }}false{{ end }}
+  # make_latest: {{ if eq .Env.TAG_VERSION "master" }}false{{ else }}true{{ end }}
   mode: append
   footer: |
     ### Container Images
@@ -494,3 +600,10 @@ release:
     You can find all docker images at:
 
     https://github.com/orgs/gnolang/packages?repo_name={{ .ProjectName }}
+
+# Only valid for nightly build
+nightly:
+  tag_name: nightly
+  publish_release: true
+  keep_single_release: true
+  name_template: "{{ incpatch .Version }}-{{ .ShortCommit }}-{{ .Env.TAG_VERSION }}"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: v1.26.2-pro
-          args: release --clean --nightly --config ./.github/goreleaser-nightly.yaml
+          version: ~> v2
+          args: release --clean --nightly --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          TAG_VERSION: nightly

--- a/.github/workflows/releaser-master.yml
+++ b/.github/workflows/releaser-master.yml
@@ -39,8 +39,9 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: v1.26.2-pro
-          args: release --clean --nightly --config ./.github/goreleaser-master.yaml
+          version: ~> v2 # v1.26.2-pro
+          args: release --clean --skip publish --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          TAG_VERSION: master

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: v1.26.2-pro
+          version: ~> v2
           args: release --clean --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -35,6 +35,13 @@ COPY       ./gnoweb /usr/bin/gnoweb
 EXPOSE      8888
 ENTRYPOINT [ "/usr/bin/gnoweb" ]
 
+#
+## ghcr.io/gnolang/gno/gnofaucet
+FROM base as gnofaucet
+
+COPY       ./gnofaucet /usr/bin/gnofaucet
+EXPOSE     5050
+ENTRYPOINT [ "/usr/bin/gnofaucet" ]
 
 #
 ## ghcr.io/gnolang/gno


### PR DESCRIPTION
This PR has different purposes:
* adding Gnofaucet to Goreleaser task (closes #2557)
* moving Goreleaser from v 1.26 to v 2.1
* reducing the verbosity of tasks by merging the different release types (latest, nightly, master) into a single goreleaser file
  * adding a fallbacked env variable called `TAG_VERSION`, which label the various docker images
  * adding the `nightly` subtask, which is ignored for latest releases
  * skipping publish for master release (NOTE: this part is the one TBC, because `master` release is using nightly too, but the variable `tag_name` unfortunately cannot be templated, let's see if it can make sense or if there is another workaround) 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
