### PR TITLE
fix: Pager added, improves  p/demo/ui improvements 

### DIFF
--- a/examples/gno.land/p/demo/ui/ui.gno
+++ b/examples/gno.land/p/demo/ui/ui.gno
@@ -220,9 +220,9 @@ func (l Link) String(dom DOM) string {
 		url = l.URL
 	}
 
-  if l.Title != "" {
+ /* if l.Title != "" {
     return "[" + l.Text + "]("+ url + ' "' + l.Title + '")'
-  }
+  } */
 
 	return "[" + l.Text + "](" + url + ")"
 }

--- a/examples/gno.land/p/demo/ui/ui.gno
+++ b/examples/gno.land/p/demo/ui/ui.gno
@@ -16,6 +16,8 @@ type DOM struct {
 	Header Element
 	Body   Element
 	Footer Element
+
+	Pager Pager
 }
 
 func (dom DOM) String() string {
@@ -61,6 +63,10 @@ func (dom DOM) String() string {
 		}
 	}
 
+	if pager := dom.Pager.String(dom); pager != "" {
+		output += pager + "\n"
+	}
+	
 	if classes != "" {
 		output += "</main>"
 	}
@@ -137,11 +143,65 @@ type Link struct {
 	Text string
 	Path string
 	URL  string
+  Title string
 }
 
 // TODO: image
 
 // TODO: pager
+type Pager struct {
+	CurrentPage int
+	TotalPages  int
+	PathPrefix  string
+}
+
+func (p Pager) String(dom DOM) string {
+	if p.TotalPages <= 1 {
+		return "" // No need for a pager if there's only one page
+	}
+
+	output := `<nav aria-label="Page navigation">` + "\n"
+	output += `<ul class="pagination">` + "\n"
+
+	
+	if p.CurrentPage > 1 {
+		prevPage := p.CurrentPage - 1
+		output += `<li class="page-item">` +
+			`<a class="page-link" href="` + p.generatePageLink(prevPage) + `" aria-label="Previous">` +
+			`<span aria-hidden="true">&laquo;</span>` +
+			`</a>` +
+			`</li>` + "\n"
+	}
+
+	
+	for i := 1; i <= p.TotalPages; i++ {
+		if i == p.CurrentPage {
+			output += `<li class="page-item active"><span class="page-link">` + strconv.Itoa(i) + `</span></li>` + "\n"
+		} else {
+			output += `<li class="page-item"><a class="page-link" href="` + p.generatePageLink(i) + `">` + strconv.Itoa(i) + `</a></li>` + "\n"
+		}
+	}
+
+	
+	if p.CurrentPage < p.TotalPages {
+		nextPage := p.CurrentPage + 1
+		output += `<li class="page-item">` +
+			`<a class="page-link" href="` + p.generatePageLink(nextPage) + `" aria-label="Next">` +
+			`<span aria-hidden="true">&raquo;</span>` +
+			`</a>` +
+			`</li>` + "\n"
+	}
+
+	output += `</ul>` + "\n"
+	output += `</nav>` + "\n"
+
+	return output
+}
+
+func (p Pager) generatePageLink(page int) string {
+	return p.PathPrefix + strconv.Itoa(page)
+}
+
 
 func (l Link) String(dom DOM) string {
 	url := ""
@@ -159,6 +219,10 @@ func (l Link) String(dom DOM) string {
 		}
 		url = l.URL
 	}
+
+  if l.Title != "" {
+    return "[" + l.Text + "]("+ url + ' "' + l.Title + '")'
+  }
 
 	return "[" + l.Text + "](" + url + ")"
 }

--- a/examples/gno.land/p/demo/ui/ui.gno
+++ b/examples/gno.land/p/demo/ui/ui.gno
@@ -66,7 +66,7 @@ func (dom DOM) String() string {
 	if pager := dom.Pager.String(dom); pager != "" {
 		output += pager + "\n"
 	}
-	
+
 	if classes != "" {
 		output += "</main>"
 	}
@@ -143,7 +143,7 @@ type Link struct {
 	Text string
 	Path string
 	URL  string
-  Title string
+  
 }
 
 // TODO: image
@@ -220,9 +220,7 @@ func (l Link) String(dom DOM) string {
 		url = l.URL
 	}
 
- /* if l.Title != "" {
-    return "[" + l.Text + "]("+ url + ' "' + l.Title + '")'
-  } */
+ 
 
 	return "[" + l.Text + "](" + url + ")"
 }

--- a/examples/gno.land/p/demo/ui/ui_test.gno
+++ b/examples/gno.land/p/demo/ui/ui_test.gno
@@ -1,1 +1,93 @@
 package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPagerSinglePage(t *testing.T) {
+	pager := Pager{
+		CurrentPage: 1,
+		TotalPages:  1,
+		PathPrefix:  "/articles/page/",
+	}
+
+	dom := DOM{Pager: pager}
+	result := dom.Pager.String(dom)
+
+	if result != "" {
+		t.Errorf("Expected no output for a single page, got %s", result)
+	}
+}
+
+func TestPagerMultiplePages(t *testing.T) {
+	pager := Pager{
+		CurrentPage: 2,
+		TotalPages:  5,
+		PathPrefix:  "/articles/page/",
+	}
+
+	dom := DOM{Pager: pager}
+	result := dom.Pager.String(dom)
+
+	// Verify the presence of the Previous link
+	expectedPrevLink := `/articles/page/1`
+	if !strings.Contains(result, expectedPrevLink) {
+		t.Errorf("Expected pager to contain link %s, got %s", expectedPrevLink, result)
+	}
+
+	// Verify the presence of the active page link (CurrentPage 2)
+	expectedActiveLink := `<li class="page-item active"><span class="page-link">2</span></li>`
+	if !strings.Contains(result, expectedActiveLink) {
+		t.Errorf("Expected pager to contain active link %s, got %s", expectedActiveLink, result)
+	}
+
+	// Verify the presence of the Next link
+	expectedNextLink := `/articles/page/3`
+	if !strings.Contains(result, expectedNextLink) {
+		t.Errorf("Expected pager to contain link %s, got %s", expectedNextLink, result)
+	}
+}
+
+
+func TestPagerFirstPage(t *testing.T) {
+	pager := Pager{
+		CurrentPage: 1,
+		TotalPages:  5,
+		PathPrefix:  "/articles/page/",
+	}
+
+	dom := DOM{Pager: pager}
+	result := dom.Pager.String(dom)
+
+	unexpected := `aria-label="Previous"`
+	if strings.Contains(result, unexpected) {
+		t.Errorf("Did not expect %s, got %s", unexpected, result)
+	}
+
+	expected := `<li class="page-item active"><span class="page-link">1</span></li>`
+	if !strings.Contains(result, expected) {
+		t.Errorf("Expected active link for first page, got %s", result)
+	}
+}
+
+func TestPagerLastPage(t *testing.T) {
+	pager := Pager{
+		CurrentPage: 5,
+		TotalPages:  5,
+		PathPrefix:  "/articles/page/",
+	}
+
+	dom := DOM{Pager: pager}
+	result := dom.Pager.String(dom)
+
+	unexpected := `aria-label="Next"`
+	if strings.Contains(result, unexpected) {
+		t.Errorf("Did not expect %s, got %s", unexpected, result)
+	}
+
+	expected := `<li class="page-item active"><span class="page-link">5</span></li>`
+	if !strings.Contains(result, expected) {
+		t.Errorf("Expected active link for last page, got %s", result)
+	}
+}


### PR DESCRIPTION
corresponds to #903  p/demo/ui improvements, pager added with unit tests

pager type struct defined to hold the page user is corrently on, total number of pages, and the prefix for the url used go generate pages.
the methods append the page number to the PathPredix to get complete URL for each page link.

several unit tests added to ui_test.gno:
TestPagerSinglePage
TestPagerMultiplePages
TestPagerFirstPage
TestPagerLastPage