### PR TITLE
test(bug): In TestKeyManagement, test GetByAddress after replacing a key with the same name

### DIFF
--- a/tm2/pkg/crypto/keys/keybase_test.go
+++ b/tm2/pkg/crypto/keys/keybase_test.go
@@ -111,6 +111,21 @@ func TestKeyManagement(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keyS))
 
+	// Lookup by original i2 address
+	infoByAddress, err := cstore.GetByAddress(i2.GetAddress())
+	require.NoError(t, err)
+	// GetByAddress should return Info with the corresponding public key
+	require.Equal(t, infoByAddress.GetPubKey(), i2.GetPubKey())
+	// Replace n2 with a new address
+	mn2New := `fancy assault crane note start invite ladder ordinary gold amateur check cousin text mercy speak chuckle wine raw chief isolate swallow cushion wrist piece`
+	_, err = cstore.CreateAccount(n2, mn2New, bip39Passphrase, p2, 0, 0)
+	require.NoError(t, err)
+	// Lookup again by the original i2 address
+	infoByAddress2, err := cstore.GetByAddress(i2.GetAddress())
+	require.NoError(t, err)
+	// As before, GetByAddress should return Info with the corresponding public key
+	require.Equal(t, infoByAddress2.GetPubKey(), i2.GetPubKey())
+
 	// addr cache gets nuked - and test skip flag
 	err = cstore.Delete(n2, "", true)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR demonstrates a bug. `TestKeyManagement` creates a key named "n2" with `Info` "i2". This PR adds `GetByAddress` and confirms that the public key in the retrieved `Info` matches the original public key. So good so far. Then the test calls `CreateAccount` to replace the entry for the same name with a new key (address). It calls `GetByAddress` with the original address, which successfully returns `Info`.

Expected: The public key in the `Info` should correspond to the address that it is fetched by.
Actual: The test fails because the public key doesn't match. (The "lookup by address" entry maps to the name "n2" but now that name entry has new `Info`.

To run the test:
```
cd gno/tm2/pkg/crypto/keys
go test .
```

Discussion: `CreateAccount` is allowed to replace the entry for a name with new `Info` (new address), but it leaves the existing "lookup by address" entry untouched. This creates the possibility of `GetByAddress` returning a public key which doesn't correspond to that address. This can cause problems with attempting to use the key, expecting it to match the address. A possible solution: When replacing a name entry with new `Info`, remove the "lookup by address" entry for the existing address. `GetByAddress` with the old address should fail.