### PR TITLE
chore: fixate `golangci-lint` CI version to `1.59`

### DIFF
--- a/.github/workflows/lint_template.yml
+++ b/.github/workflows/lint_template.yml
@@ -1,12 +1,12 @@
 on:
   workflow_call:
-      inputs:
-          modulepath:
-            required: true
-            type: string
-          go-version:
-            required: true
-            type: string
+    inputs:
+      modulepath:
+        required: true
+        type: string
+      go-version:
+        required: true
+        type: string
 
 
 jobs:
@@ -25,3 +25,4 @@ jobs:
           working-directory: ${{ inputs.modulepath }}
           args:
             --config=${{ github.workspace }}/.github/golangci.yml
+          version: v1.59 # sync with misc/devdeps


### PR DESCRIPTION
## Description

This PR fixates the `golangci-lint` CI version to `1.59`, since this is the version we utilize for `misc/devdeps` that powers the `make lint` directive.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
