### PR TITLE
chore: fix rpc consensus_state height_vote_set

### DIFF
--- a/tm2/pkg/bft/rpc/lib/types/types.go
+++ b/tm2/pkg/bft/rpc/lib/types/types.go
@@ -194,7 +194,7 @@ func NewRPCSuccessResponse(id JSONRPCID, res any) RPCResponse {
 
 	if res != nil {
 		var js []byte
-		js, err := amino.MarshalJSON(res)
+		js, err := json.Marshal(res)
 		if err != nil {
 			return RPCInternalError(id, errors.Wrap(err, "Error marshalling response"))
 		}


### PR DESCRIPTION
It seems there is an error on amino parsing `RoundStateSimple.Votes`

Before

```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "round_state": {
      "height/round/step": "810255/0/1",
      "start_time": "2024-08-14T10:48:40.822715298Z",
      "proposal_block_hash": null,
      "locked_block_hash": null,
      "valid_block_hash": null,
      "height_vote_set": {}
    }
  }
}
```

After
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "round_state": {
      "height/round/step": "87/0/4",
      "start_time": "2024-08-14T10:46:41.086066222Z",
      "proposal_block_hash": "RzxP5+qPE3m2TmSIPToKlXZSQrsbPpZaVDHBipWceTs=",
      "locked_block_hash": null,
      "valid_block_hash": null,
      "height_vote_set": [
        {
          "round": "0",
          "prevotes": [
            "Vote{0:0E33DB6910E5 87/00/1(Prevote) 473C4FE7EA8F D1B277E50809 @ 2024-08-14T10:46:41.115790322Z}",
            "Vote{1:102A3FB16690 87/00/1(Prevote) 473C4FE7EA8F 05871AA71823 @ 2024-08-14T10:46:41.010870819Z}",
            "nil-Vote"
          ],
          "prevotes_bit_array": "BA{3:xx_} 2/3 = 0.67",
          "precommits": [
            "nil-Vote",
            "nil-Vote",
            "nil-Vote"
          ],
          "precommits_bit_array": "BA{3:___} 0/3 = 0.00"
        },
        {
          "round": "1",
          "prevotes": [
            "nil-Vote",
            "nil-Vote",
            "nil-Vote"
          ],
          "prevotes_bit_array": "BA{3:___} 0/3 = 0.00",
          "precommits": [
            "nil-Vote",
            "nil-Vote",
            "nil-Vote"
          ],
          "precommits_bit_array": "BA{3:___} 0/3 = 0.00"
        }
      ]
    }
  }
```

After the fix, i realized that tendermint1 latest version is using json too on this field

https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/rpc/jsonrpc/types/types.go#L187-L200
