### PR TITLE
fix(gnovm): Fix panic when calling `len()` on pointer array

### DIFF
--- a/gnovm/pkg/gnolang/uverse_test.go
+++ b/gnovm/pkg/gnolang/uverse_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 )
 
-type printlnTestCases struct {
+type uverseTestCases struct {
 	name     string
 	code     string
 	expected string
 }
 
 func TestIssue1337PrintNilSliceAsUndefined(t *testing.T) {
-	test := []printlnTestCases{
+	test := []uverseTestCases{
 		{
 			name: "print empty slice",
 			code: `package test
@@ -156,5 +156,56 @@ func TestIssue1337PrintNilSliceAsUndefined(t *testing.T) {
 			m.RunMain()
 			assertOutput(t, tc.code, tc.expected)
 		})
+	}
+}
+
+func TestIssue2707PointerSliceAsParamInLen(t *testing.T) {
+	tests := []uverseTestCases{
+		{
+			name: "pointer slice as param in len",
+			code: `
+package test
+
+func main() {
+	exp := [...]string{"HELLO"}
+	x := len(&exp)
+	println(x)
+}
+			`,
+			expected: "1\n",
+		},
+		{
+			name: "len of array",
+			code: `
+package test
+
+func main() {
+	exp := [...]string{"HELLO", "WORLD"}
+	println(len(exp))
+}
+			`,
+			expected: "2\n",
+		},
+		{
+			name: "len of pointer to array",
+			code: `
+package test
+
+func main() {
+	exp := [...]int{1, 2, 3, 4, 5}
+	ptr := &exp
+	println(len(ptr))
+}
+			`,
+			expected: "5\n",
+		},
+	}
+
+	for _, tc := range tests {
+		m := NewMachine("test", nil)
+		n := MustParseFile("main.go", tc.code)
+		m.RunFiles(n)
+		m.RunMain()
+		assertOutput(t, tc.code, tc.expected)
 	}
 }

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -2149,6 +2149,11 @@ func (tv *TypedValue) GetLength() int {
 		return cv.GetLength()
 	case *NativeValue:
 		return cv.Value.Len()
+	case PointerValue:
+		if av, ok := cv.TV.V.(*ArrayValue); ok {
+			return av.GetLength()
+		}
+		panic(fmt.Sprintf("unexpected pointer value for len(): %s", tv.T.String()))
 	default:
 		panic(fmt.Sprintf("unexpected type for len(): %s",
 			tv.T.String()))

--- a/gnovm/tests/files/len1.gno
+++ b/gnovm/tests/files/len1.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	exp := [...]string{"HELLO"}
+	x := len(&exp)
+	println(x)
+}
+
+// Output:
+// 1


### PR DESCRIPTION
# Description

Closes 2707

The `GetLength()` method in `TypedValue` has been updated to handle pointer type.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
