### PR TITLE
chore: gnoclient: Require Caller in Msg. Remove syntax sugar Msgs

### DIFF
--- a/contribs/gnodev/pkg/dev/node_state_test.go
+++ b/contribs/gnodev/pkg/dev/node_state_test.go
@@ -8,8 +8,8 @@ import (
 
 	emitter "github.com/gnolang/gno/contribs/gnodev/internal/mock"
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
-	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -87,10 +87,10 @@ func TestSaveCurrentState(t *testing.T) {
 	require.NoError(t, err)
 
 	// Send a new tx
-	msg := gnoclient.MsgCall{
-		PkgPath:  testCounterRealm,
-		FuncName: "Inc",
-		Args:     []string{"10"},
+	msg := vm.MsgCall{
+		PkgPath: testCounterRealm,
+		Func:    "Inc",
+		Args:    []string{"10"},
 	}
 
 	res, err := testingCallRealm(t, node, msg)
@@ -169,10 +169,10 @@ func Render(_ string) string { return strconv.Itoa(value) }
 	for i := 0; i < inc; i++ {
 		t.Logf("call %d", i)
 		// Craft `Inc` msg
-		msg := gnoclient.MsgCall{
-			PkgPath:  testCounterRealm,
-			FuncName: "Inc",
-			Args:     []string{"1"},
+		msg := vm.MsgCall{
+			PkgPath: testCounterRealm,
+			Func:    "Inc",
+			Args:    []string{"1"},
 		}
 
 		res, err := testingCallRealm(t, node, msg)

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
@@ -190,11 +191,11 @@ func Render(_ string) string { return str }
 	require.Equal(t, render, "foo")
 
 	// Call `UpdateStr` to update `str` value with "bar"
-	msg := gnoclient.MsgCall{
-		PkgPath:  "gno.land/r/dev/foo",
-		FuncName: "UpdateStr",
-		Args:     []string{"bar"},
-		Send:     "",
+	msg := vm.MsgCall{
+		PkgPath: "gno.land/r/dev/foo",
+		Func:    "UpdateStr",
+		Args:    []string{"bar"},
+		Send:    nil,
 	}
 	res, err := testingCallRealm(t, node, msg)
 	require.NoError(t, err)
@@ -237,7 +238,7 @@ func testingRenderRealm(t *testing.T, node *Node, rlmpath string) (string, error
 	return render, err
 }
 
-func testingCallRealm(t *testing.T, node *Node, msgs ...gnoclient.MsgCall) (*core_types.ResultBroadcastTxCommit, error) {
+func testingCallRealm(t *testing.T, node *Node, msgs ...vm.MsgCall) (*core_types.ResultBroadcastTxCommit, error) {
 	t.Helper()
 
 	signer := newInMemorySigner(t, node.Config().ChainID())
@@ -251,7 +252,15 @@ func testingCallRealm(t *testing.T, node *Node, msgs ...gnoclient.MsgCall) (*cor
 		GasWanted: 2_000_000,                  // Gas wanted
 	}
 
-	return cli.Call(txcfg, msgs...)
+	// Set Caller in the msgs
+	caller, err := signer.Info()
+	require.NoError(t, err)
+	vmMsgs := make([]vm.MsgCall, 0, len(msgs))
+	for _, msg := range msgs {
+		vmMsgs = append(vmMsgs, vm.NewMsgCall(caller.GetAddress(), msg.Send, msg.PkgPath, msg.Func, msg.Args))
+	}
+
+	return cli.Call(txcfg, vmMsgs...)
 }
 
 func generateTestingPackage(t *testing.T, nameFile ...string) PackagePath {

--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -233,7 +233,7 @@ import (
 
 ```go
 msg := vm.MsgCall{
-    Caller:  accountRes.GetAddress(),                                 // address of the caller (signer)
+    Caller:  addr,                                                    // address of the caller (signer)
     PkgPath: "gno.land/r/demo/wugnot",                                // wrapped ugnot realm path
     Func:    "Deposit",                                               // function to call
     Args:    nil,                                                     // arguments in string format

--- a/docs/how-to-guides/connecting-from-go.md
+++ b/docs/how-to-guides/connecting-from-go.md
@@ -223,11 +223,21 @@ message type. We will use the wrapped ugnot realm for this example, wrapping
 `1000000ugnot` (1 $GNOT) for demonstration purposes.
 
 ```go
-msg := gnoclient.MsgCall{
-    PkgPath:  "gno.land/r/demo/wugnot", // wrapped ugnot realm path
-    FuncName: "Deposit",                // function to call
-    Args:     nil,                      // arguments in string format
-    Send:     "1000000ugnot",           // coins to send along with transaction
+import (
+    ...
+	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+```
+
+```go
+msg := vm.MsgCall{
+    Caller:  accountRes.GetAddress(),                                 // address of the caller (signer)
+    PkgPath: "gno.land/r/demo/wugnot",                                // wrapped ugnot realm path
+    Func:    "Deposit",                                               // function to call
+    Args:    nil,                                                     // arguments in string format
+    Send:    std.Coins{{Denom: ugnot.Denom, Amount: int64(1000000)}}, // coins to send along with transaction
 }
 ```
 

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -205,7 +205,7 @@ func TestCallErrors(t *testing.T) {
 		client        Client
 		cfg           BaseTxCfg
 		msgs          []vm.MsgCall
-		expectedError error
+		expectedError string
 	}{
 		{
 			name: "Invalid Signer",
@@ -223,13 +223,13 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "RandomName",
 					Send:    nil,
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrMissingSigner,
+			expectedError: ErrMissingSigner.Error(),
 		},
 		{
 			name: "Invalid RPCClient",
@@ -247,13 +247,13 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "RandomName",
 					Send:    nil,
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrMissingRPCClient,
+			expectedError: ErrMissingRPCClient.Error(),
 		},
 		{
 			name: "Invalid Gas Fee",
@@ -271,11 +271,11 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "RandomName",
 				},
 			},
-			expectedError: ErrInvalidGasFee,
+			expectedError: ErrInvalidGasFee.Error(),
 		},
 		{
 			name: "Negative Gas Wanted",
@@ -293,13 +293,13 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "RandomName",
 					Send:    nil,
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "0 Gas Wanted",
@@ -317,13 +317,13 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "RandomName",
 					Send:    nil,
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "Invalid PkgPath",
@@ -347,7 +347,7 @@ func TestCallErrors(t *testing.T) {
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrEmptyPkgPath,
+			expectedError: vm.InvalidPkgPathError{}.Error(),
 		},
 		{
 			name: "Invalid FuncName",
@@ -365,13 +365,13 @@ func TestCallErrors(t *testing.T) {
 			msgs: []vm.MsgCall{
 				{
 					Caller:  mockAddress,
-					PkgPath: "random/path",
+					PkgPath: "gno.land/r/random/path",
 					Func:    "",
 					Send:    nil,
 					Args:    []string{},
 				},
 			},
-			expectedError: ErrEmptyFuncName,
+			expectedError: vm.InvalidExprError{}.Error(),
 		},
 	}
 
@@ -382,7 +382,7 @@ func TestCallErrors(t *testing.T) {
 
 			res, err := tc.client.Call(tc.cfg, tc.msgs...)
 			assert.Nil(t, res)
-			assert.ErrorIs(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
 }
@@ -399,7 +399,7 @@ func TestClient_Send_Errors(t *testing.T) {
 		client        Client
 		cfg           BaseTxCfg
 		msgs          []bank.MsgSend
-		expectedError error
+		expectedError string
 	}{
 		{
 			name: "Invalid Signer",
@@ -421,7 +421,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrMissingSigner,
+			expectedError: ErrMissingSigner.Error(),
 		},
 		{
 			name: "Invalid RPCClient",
@@ -443,7 +443,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrMissingRPCClient,
+			expectedError: ErrMissingRPCClient.Error(),
 		},
 		{
 			name: "Invalid Gas Fee",
@@ -465,7 +465,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrInvalidGasFee,
+			expectedError: ErrInvalidGasFee.Error(),
 		},
 		{
 			name: "Negative Gas Wanted",
@@ -487,7 +487,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "0 Gas Wanted",
@@ -509,7 +509,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "Invalid To Address",
@@ -540,7 +540,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(1)}},
 				},
 			},
-			expectedError: ErrInvalidToAddress,
+			expectedError: std.InvalidAddressError{}.Error(),
 		},
 		{
 			name: "Invalid Send Coins",
@@ -571,7 +571,7 @@ func TestClient_Send_Errors(t *testing.T) {
 					Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(-1)}},
 				},
 			},
-			expectedError: ErrInvalidSendAmount,
+			expectedError: std.InvalidCoinsError{}.Error(),
 		},
 	}
 
@@ -582,7 +582,7 @@ func TestClient_Send_Errors(t *testing.T) {
 
 			res, err := tc.client.Send(tc.cfg, tc.msgs...)
 			assert.Nil(t, res)
-			assert.ErrorIs(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
 }
@@ -754,7 +754,7 @@ func TestRunErrors(t *testing.T) {
 		client        Client
 		cfg           BaseTxCfg
 		msgs          []vm.MsgRun
-		expectedError error
+		expectedError string
 	}{
 		{
 			name: "Invalid Signer",
@@ -785,7 +785,7 @@ func TestRunErrors(t *testing.T) {
 					Send: nil,
 				},
 			},
-			expectedError: ErrMissingSigner,
+			expectedError: ErrMissingSigner.Error(),
 		},
 		{
 			name: "Invalid RPCClient",
@@ -801,7 +801,7 @@ func TestRunErrors(t *testing.T) {
 				Memo:           "Test memo",
 			},
 			msgs:          []vm.MsgRun{},
-			expectedError: ErrMissingRPCClient,
+			expectedError: ErrMissingRPCClient.Error(),
 		},
 		{
 			name: "Invalid Gas Fee",
@@ -832,7 +832,7 @@ func TestRunErrors(t *testing.T) {
 					Send: nil,
 				},
 			},
-			expectedError: ErrInvalidGasFee,
+			expectedError: ErrInvalidGasFee.Error(),
 		},
 		{
 			name: "Negative Gas Wanted",
@@ -863,7 +863,7 @@ func TestRunErrors(t *testing.T) {
 					Send: nil,
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "0 Gas Wanted",
@@ -894,7 +894,7 @@ func TestRunErrors(t *testing.T) {
 					Send: nil,
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "Invalid Empty Package",
@@ -921,11 +921,11 @@ func TestRunErrors(t *testing.T) {
 			msgs: []vm.MsgRun{
 				{
 					Caller:  mockAddress,
-					Package: nil,
+					Package: &std.MemPackage{Name: "", Path: " "},
 					Send:    nil,
 				},
 			},
-			expectedError: ErrEmptyPackage,
+			expectedError: vm.InvalidPkgPathError{}.Error(),
 		},
 	}
 
@@ -936,7 +936,7 @@ func TestRunErrors(t *testing.T) {
 
 			res, err := tc.client.Run(tc.cfg, tc.msgs...)
 			assert.Nil(t, res)
-			assert.ErrorIs(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
 }
@@ -953,7 +953,7 @@ func TestAddPackageErrors(t *testing.T) {
 		client        Client
 		cfg           BaseTxCfg
 		msgs          []vm.MsgAddPackage
-		expectedError error
+		expectedError string
 	}{
 		{
 			name: "Invalid Signer",
@@ -984,7 +984,7 @@ func TestAddPackageErrors(t *testing.T) {
 					Deposit: nil,
 				},
 			},
-			expectedError: ErrMissingSigner,
+			expectedError: ErrMissingSigner.Error(),
 		},
 		{
 			name: "Invalid RPCClient",
@@ -1000,7 +1000,7 @@ func TestAddPackageErrors(t *testing.T) {
 				Memo:           "Test memo",
 			},
 			msgs:          []vm.MsgAddPackage{},
-			expectedError: ErrMissingRPCClient,
+			expectedError: ErrMissingRPCClient.Error(),
 		},
 		{
 			name: "Invalid Gas Fee",
@@ -1031,7 +1031,7 @@ func TestAddPackageErrors(t *testing.T) {
 					Deposit: nil,
 				},
 			},
-			expectedError: ErrInvalidGasFee,
+			expectedError: ErrInvalidGasFee.Error(),
 		},
 		{
 			name: "Negative Gas Wanted",
@@ -1062,7 +1062,7 @@ func TestAddPackageErrors(t *testing.T) {
 					Deposit: nil,
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "0 Gas Wanted",
@@ -1093,7 +1093,7 @@ func TestAddPackageErrors(t *testing.T) {
 					Deposit: nil,
 				},
 			},
-			expectedError: ErrInvalidGasWanted,
+			expectedError: ErrInvalidGasWanted.Error(),
 		},
 		{
 			name: "Invalid Empty Package",
@@ -1120,11 +1120,11 @@ func TestAddPackageErrors(t *testing.T) {
 			msgs: []vm.MsgAddPackage{
 				{
 					Creator: mockAddress,
-					Package: nil,
+					Package: &std.MemPackage{Name: "", Path: ""},
 					Deposit: nil,
 				},
 			},
-			expectedError: ErrEmptyPackage,
+			expectedError: vm.InvalidPkgPathError{}.Error(),
 		},
 	}
 
@@ -1135,7 +1135,7 @@ func TestAddPackageErrors(t *testing.T) {
 
 			res, err := tc.client.AddPackage(tc.cfg, tc.msgs...)
 			assert.Nil(t, res)
-			assert.ErrorIs(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
 }

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/gnolang/gno/gnovm/pkg/gnolang"
 
+	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
 	"github.com/gnolang/gno/tm2/pkg/std"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
@@ -44,12 +46,16 @@ func TestCallSingle_Integration(t *testing.T) {
 		Memo:           "",
 	}
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Msg config
-	msg := MsgCall{
-		PkgPath:  "gno.land/r/demo/deep/very/deep",
-		FuncName: "Render",
-		Args:     []string{"test argument"},
-		Send:     "",
+	msg := vm.MsgCall{
+		Caller:  caller.GetAddress(),
+		PkgPath: "gno.land/r/demo/deep/very/deep",
+		Func:    "Render",
+		Args:    []string{"test argument"},
+		Send:    nil,
 	}
 
 	// Execute call
@@ -88,20 +94,25 @@ func TestCallMultiple_Integration(t *testing.T) {
 		Memo:           "",
 	}
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Msg configs
-	msg1 := MsgCall{
-		PkgPath:  "gno.land/r/demo/deep/very/deep",
-		FuncName: "Render",
-		Args:     []string{""},
-		Send:     "",
+	msg1 := vm.MsgCall{
+		Caller:  caller.GetAddress(),
+		PkgPath: "gno.land/r/demo/deep/very/deep",
+		Func:    "Render",
+		Args:    []string{""},
+		Send:    nil,
 	}
 
 	// Same call, different argument
-	msg2 := MsgCall{
-		PkgPath:  "gno.land/r/demo/deep/very/deep",
-		FuncName: "Render",
-		Args:     []string{"test argument"},
-		Send:     "",
+	msg2 := vm.MsgCall{
+		Caller:  caller.GetAddress(),
+		PkgPath: "gno.land/r/demo/deep/very/deep",
+		Func:    "Render",
+		Args:    []string{"test argument"},
+		Send:    nil,
 	}
 
 	expected := "(\"it works!\" string)\n\n(\"hi test argument\" string)\n\n"
@@ -140,12 +151,16 @@ func TestSendSingle_Integration(t *testing.T) {
 		Memo:           "",
 	}
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Send config for a new address on the blockchain
 	toAddress, _ := crypto.AddressFromBech32("g14a0y9a64dugh3l7hneshdxr4w0rfkkww9ls35p")
 	amount := 10
-	msg := MsgSend{
-		ToAddress: toAddress,
-		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount)}.String(),
+	msg := bank.MsgSend{
+		FromAddress: caller.GetAddress(),
+		ToAddress:   toAddress,
+		Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(amount)}},
 	}
 
 	// Execute send
@@ -189,19 +204,24 @@ func TestSendMultiple_Integration(t *testing.T) {
 		Memo:           "",
 	}
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Msg configs
 	toAddress, _ := crypto.AddressFromBech32("g14a0y9a64dugh3l7hneshdxr4w0rfkkww9ls35p")
 	amount1 := 10
-	msg1 := MsgSend{
-		ToAddress: toAddress,
-		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount1)}.String(),
+	msg1 := bank.MsgSend{
+		FromAddress: caller.GetAddress(),
+		ToAddress:   toAddress,
+		Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(amount1)}},
 	}
 
 	// Same send, different argument
 	amount2 := 20
-	msg2 := MsgSend{
-		ToAddress: toAddress,
-		Send:      std.Coin{Denom: ugnot.Denom, Amount: int64(amount2)}.String(),
+	msg2 := bank.MsgSend{
+		FromAddress: caller.GetAddress(),
+		ToAddress:   toAddress,
+		Amount:      std.Coins{{Denom: ugnot.Denom, Amount: int64(amount2)}},
 	}
 
 	// Execute send
@@ -258,9 +278,14 @@ func main() {
 	println(ufmt.Sprintf("- after: %d", tests.Counter()))
 }`
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Msg configs
-	msg := MsgRun{
+	msg := vm.MsgRun{
+		Caller: caller.GetAddress(),
 		Package: &std.MemPackage{
+			Name: "main",
 			Files: []*std.MemFile{
 				{
 					Name: "main.gno",
@@ -268,7 +293,7 @@ func main() {
 				},
 			},
 		},
-		Send: "",
+		Send: nil,
 	}
 
 	res, err := client.Run(baseCfg, msg)
@@ -325,9 +350,14 @@ func main() {
 	println(ufmt.Sprintf("%s", deep.Render("gnoclient!")))
 }`
 
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
 	// Make Msg configs
-	msg1 := MsgRun{
+	msg1 := vm.MsgRun{
+		Caller: caller.GetAddress(),
 		Package: &std.MemPackage{
+			Name: "main",
 			Files: []*std.MemFile{
 				{
 					Name: "main.gno",
@@ -335,10 +365,12 @@ func main() {
 				},
 			},
 		},
-		Send: "",
+		Send: nil,
 	}
-	msg2 := MsgRun{
+	msg2 := vm.MsgRun{
+		Caller: caller.GetAddress(),
 		Package: &std.MemPackage{
+			Name: "main",
 			Files: []*std.MemFile{
 				{
 					Name: "main.gno",
@@ -346,7 +378,7 @@ func main() {
 				},
 			},
 		},
-		Send: "",
+		Send: nil,
 	}
 
 	expected := "- before: 0\n- after: 10\nhi gnoclient!\n"
@@ -391,10 +423,14 @@ func Echo(str string) string {
 
 	fileName := "echo.gno"
 	deploymentPath := "gno.land/p/demo/integration/test/echo"
-	deposit := ugnot.ValueString(100)
+	deposit := std.Coins{{Denom: ugnot.Denom, Amount: int64(100)}}
+
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
 
 	// Make Msg config
-	msg := MsgAddPackage{
+	msg := vm.MsgAddPackage{
+		Creator: caller.GetAddress(),
 		Package: &std.MemPackage{
 			Name: "echo",
 			Path: deploymentPath,
@@ -423,7 +459,7 @@ func Echo(str string) string {
 	// Query balance to validate deposit
 	baseAcc, _, err := client.QueryAccount(gnolang.DerivePkgAddr(deploymentPath))
 	require.NoError(t, err)
-	assert.Equal(t, baseAcc.GetCoins().String(), deposit)
+	assert.Equal(t, baseAcc.GetCoins(), deposit)
 }
 
 func TestAddPackageMultiple_Integration(t *testing.T) {
@@ -452,7 +488,7 @@ func TestAddPackageMultiple_Integration(t *testing.T) {
 		Memo:           "",
 	}
 
-	deposit := ugnot.ValueString(100)
+	deposit := std.Coins{{Denom: ugnot.Denom, Amount: int64(100)}}
 	deploymentPath1 := "gno.land/p/demo/integration/test/echo"
 
 	body1 := `package echo
@@ -468,7 +504,11 @@ func Hello(str string) string {
 	return "Hello " + str + "!" 
 }`
 
-	msg1 := MsgAddPackage{
+	caller, err := client.Signer.Info()
+	require.NoError(t, err)
+
+	msg1 := vm.MsgAddPackage{
+		Creator: caller.GetAddress(),
 		Package: &std.MemPackage{
 			Name: "echo",
 			Path: deploymentPath1,
@@ -479,10 +519,11 @@ func Hello(str string) string {
 				},
 			},
 		},
-		Deposit: "",
+		Deposit: nil,
 	}
 
-	msg2 := MsgAddPackage{
+	msg2 := vm.MsgAddPackage{
+		Creator: caller.GetAddress(),
 		Package: &std.MemPackage{
 			Name: "hello",
 			Path: deploymentPath2,
@@ -529,7 +570,7 @@ func Hello(str string) string {
 	// Query balance to validate deposit
 	baseAcc, _, err = client.QueryAccount(gnolang.DerivePkgAddr(deploymentPath2))
 	require.NoError(t, err)
-	assert.Equal(t, baseAcc.GetCoins().String(), deposit)
+	assert.Equal(t, baseAcc.GetCoins(), deposit)
 }
 
 // todo add more integration tests:

--- a/gno.land/pkg/gnoclient/util.go
+++ b/gno.land/pkg/gnoclient/util.go
@@ -1,52 +1,11 @@
 package gnoclient
 
-import "github.com/gnolang/gno/tm2/pkg/std"
-
 func (cfg BaseTxCfg) validateBaseTxConfig() error {
 	if cfg.GasWanted <= 0 {
 		return ErrInvalidGasWanted
 	}
 	if cfg.GasFee == "" {
 		return ErrInvalidGasFee
-	}
-
-	return nil
-}
-
-func (msg MsgCall) validateMsgCall() error {
-	if msg.PkgPath == "" {
-		return ErrEmptyPkgPath
-	}
-	if msg.FuncName == "" {
-		return ErrEmptyFuncName
-	}
-
-	return nil
-}
-
-func (msg MsgSend) validateMsgSend() error {
-	if msg.ToAddress.IsZero() {
-		return ErrInvalidToAddress
-	}
-	_, err := std.ParseCoins(msg.Send)
-	if err != nil {
-		return ErrInvalidSendAmount
-	}
-
-	return nil
-}
-
-func (msg MsgRun) validateMsgRun() error {
-	if msg.Package == nil || len(msg.Package.Files) == 0 {
-		return ErrEmptyPackage
-	}
-
-	return nil
-}
-
-func (msg MsgAddPackage) validateMsgAddPackage() error {
-	if msg.Package == nil || len(msg.Package.Files) == 0 {
-		return ErrEmptyPackage
 	}
 
 	return nil


### PR DESCRIPTION
BREAKING CHANGE: The gnoclient API provides "syntax sugar" slices of messages like MsgCall. This PR removes them and instead uses the vm message definitions directly (without modification). This requires users of the gnoclient API to specify all needed fields, including `Caller` but it also simplifies the Sign logic. The concerns of message creation and message handling are now separated.

* Remove "syntax sugar" `MsgCall`, `MsgSend`, `MsgRun` and `MsgAddPackage`.
* Remove the related `validateMsgCall`, `validateMsgSend`, `validateMsgRun` and `validateMsgAddPackage`.
* In `Call`, etc. change the `msgs` param to use `vm.MsgCall`, etc. Use the `ValidateBasic` method of these types.
* Do not set the `Caller` from the `Signer`. Expect the `Caller` field to already be filled in.
* In client_test.go and integration_test.go, specify the `Caller` where needed.
* In client_test.go error tests, change `expectedError` to a string and use `assert.ErrorContains`. (This allows mixing errors that are defined by a type with errors defined as singleton objects.)
* Update contribs/gnodev/pkg/dev/node_state_test.go to use `vm.MsgCall`.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
</details>
