### PR TITLE
feat(tm2): Add Specific Block Height query Feature to ABCI Queries

### DIFF
--- a/gno.land/pkg/gnoclient/mock_test.go
+++ b/gno.land/pkg/gnoclient/mock_test.go
@@ -102,6 +102,7 @@ type (
 	mockABCIQuery            func(path string, data []byte) (*ctypes.ResultABCIQuery, error)
 	mockABCIInfo             func() (*ctypes.ResultABCIInfo, error)
 	mockABCIQueryWithOptions func(path string, data []byte, opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error)
+	mockABCIHeight           func(height int64) (*ctypes.ResultABCIQuery, error)
 	mockBroadcastTxAsync     func(tx types.Tx) (*ctypes.ResultBroadcastTx, error)
 	mockBroadcastTxSync      func(tx types.Tx) (*ctypes.ResultBroadcastTx, error)
 	mockGenesis              func() (*ctypes.ResultGenesis, error)
@@ -126,6 +127,7 @@ type mockRPCClient struct {
 	abciQuery            mockABCIQuery
 	abciInfo             mockABCIInfo
 	abciQueryWithOptions mockABCIQueryWithOptions
+	abciHeight           mockABCIHeight
 	broadcastTxAsync     mockBroadcastTxAsync
 	broadcastTxSync      mockBroadcastTxSync
 	genesis              mockGenesis
@@ -169,6 +171,13 @@ func (m *mockRPCClient) ABCIInfo() (*ctypes.ResultABCIInfo, error) {
 func (m *mockRPCClient) ABCIQueryWithOptions(path string, data []byte, opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
 	if m.abciQueryWithOptions != nil {
 		return m.abciQueryWithOptions(path, data, opts)
+	}
+	return nil, nil
+}
+
+func (m *mockRPCClient) ABCIHeight(height int64) (*ctypes.ResultABCIQuery, error) {
+	if m.abciHeight != nil {
+		return m.abciHeight(height)
 	}
 	return nil, nil
 }

--- a/tm2/pkg/bft/rpc/client/batch.go
+++ b/tm2/pkg/bft/rpc/client/batch.go
@@ -161,6 +161,21 @@ func (b *RPCBatch) ABCIQueryWithOptions(path string, data []byte, opts ABCIQuery
 	return nil
 }
 
+func (b *RPCBatch) ABCIHeight(height int64) error {
+	// Prepare the RPC request
+	request, err := newRequest(
+		abciHeightMethod,
+		map[string]any{"height": height},
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create request, %w", err)
+	}
+
+	b.addRequest(request, &ctypes.ResultABCIQuery{})
+
+	return nil
+}
+
 func (b *RPCBatch) BroadcastTxCommit(tx types.Tx) error {
 	// Prepare the RPC request
 	request, err := newRequest(

--- a/tm2/pkg/bft/rpc/client/batch_test.go
+++ b/tm2/pkg/bft/rpc/client/batch_test.go
@@ -209,6 +209,24 @@ func TestRPCBatch_Endpoints(t *testing.T) {
 			},
 		},
 		{
+			abciHeightMethod,
+			&ctypes.ResultABCIQuery{
+				Response: abci.ResponseQuery{
+					Value:  []byte("dummy"),
+					Height: 10,
+				},
+			},
+			func(batch *RPCBatch) {
+				require.NoError(t, batch.ABCIHeight(10))
+			},
+			func(result any) any {
+				castResult, ok := result.(*ctypes.ResultABCIQuery)
+				require.True(t, ok)
+
+				return castResult
+			},
+		},
+		{
 			broadcastTxCommitMethod,
 			&ctypes.ResultBroadcastTxCommit{
 				Hash: []byte("dummy"),

--- a/tm2/pkg/bft/rpc/client/client.go
+++ b/tm2/pkg/bft/rpc/client/client.go
@@ -22,6 +22,7 @@ const (
 	statusMethod             = "status"
 	abciInfoMethod           = "abci_info"
 	abciQueryMethod          = "abci_query"
+	abciHeightMethod         = "abci_height"
 	broadcastTxCommitMethod  = "broadcast_tx_commit"
 	broadcastTxAsyncMethod   = "broadcast_tx_async"
 	broadcastTxSyncMethod    = "broadcast_tx_sync"
@@ -140,6 +141,15 @@ func (c *RPCClient) ABCIQueryWithOptions(path string, data []byte, opts ABCIQuer
 			"height": opts.Height,
 			"prove":  opts.Prove,
 		},
+	)
+}
+
+func (c *RPCClient) ABCIHeight(height int64) (*ctypes.ResultABCIQuery, error) {
+	return sendRequestCommon[ctypes.ResultABCIQuery](
+		c.caller,
+		c.requestTimeout,
+		abciHeightMethod,
+		map[string]any{"height": height},
 	)
 }
 

--- a/tm2/pkg/bft/rpc/client/client_test.go
+++ b/tm2/pkg/bft/rpc/client/client_test.go
@@ -218,6 +218,43 @@ func TestRPCClient_ABCIQuery(t *testing.T) {
 	assert.Equal(t, expectedQuery, query)
 }
 
+func TestRPCClient_ABCIHeight(t *testing.T) {
+	t.Parallel()
+
+	var (
+		height = int64(10)
+
+		expectedResult = &ctypes.ResultABCIQuery{
+			Response: abci.ResponseQuery{
+				Value:  []byte("dummy"),
+				Height: height,
+			},
+		}
+
+		verifyFn = func(t *testing.T, params map[string]any) {
+			t.Helper()
+
+			assert.Equal(t, fmt.Sprintf("%d", height), params["height"])
+		}
+
+		mockClient = generateMockRequestClient(
+			t,
+			abciHeightMethod,
+			verifyFn,
+			expectedResult,
+		)
+	)
+
+	c := NewRPCClient(mockClient)
+
+	// Get the query result from given height
+	result, err := c.ABCIHeight(height)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedResult, result)
+	t.Log(result)
+}
+
 func TestRPCClient_BroadcastTxCommit(t *testing.T) {
 	t.Parallel()
 

--- a/tm2/pkg/bft/rpc/client/e2e_test.go
+++ b/tm2/pkg/bft/rpc/client/e2e_test.go
@@ -210,6 +210,21 @@ func TestRPCClient_E2E_Endpoints(t *testing.T) {
 			},
 		},
 		{
+			abciHeightMethod,
+			&ctypes.ResultABCIQuery{
+				Response: abci.ResponseQuery{
+					Value:  []byte("dummy"),
+					Height: 1000,
+				},
+			},
+			func(client *RPCClient, expectedResult any) {
+				result, err := client.ABCIHeight(1000)
+				require.NoError(t, err)
+
+				assert.Equal(t, expectedResult, result)
+			},
+		},
+		{
 			broadcastTxCommitMethod,
 			&ctypes.ResultBroadcastTxCommit{
 				Hash: []byte("dummy"),

--- a/tm2/pkg/bft/rpc/client/local.go
+++ b/tm2/pkg/bft/rpc/client/local.go
@@ -66,6 +66,10 @@ func (c *Local) ABCIQueryWithOptions(path string, data []byte, opts ABCIQueryOpt
 	return core.ABCIQuery(c.ctx, path, data, opts.Height, opts.Prove)
 }
 
+func (c *Local) ABCIHeight(height int64) (*ctypes.ResultABCIQuery, error) {
+	return core.ABCIHeight(c.ctx, height)
+}
+
 func (c *Local) BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
 	return core.BroadcastTxCommit(c.ctx, tx)
 }

--- a/tm2/pkg/bft/rpc/client/types.go
+++ b/tm2/pkg/bft/rpc/client/types.go
@@ -42,7 +42,7 @@ type ABCIClient interface {
 	ABCIQuery(path string, data []byte) (*ctypes.ResultABCIQuery, error)
 	ABCIQueryWithOptions(path string, data []byte,
 		opts ABCIQueryOptions) (*ctypes.ResultABCIQuery, error)
-
+	ABCIHeight(height int64) (*ctypes.ResultABCIQuery, error)
 	// Writing to abci app
 	BroadcastTxCommit(tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error)
 	BroadcastTxAsync(tx types.Tx) (*ctypes.ResultBroadcastTx, error)

--- a/tm2/pkg/bft/rpc/core/abci.go
+++ b/tm2/pkg/bft/rpc/core/abci.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	rpctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/types"
@@ -66,6 +68,63 @@ func ABCIQuery(ctx *rpctypes.Context, path string, data []byte, height int64, pr
 		return nil, err
 	}
 	logger.Info("ABCIQuery", "path", path, "data", data, "result", resQuery)
+	return &ctypes.ResultABCIQuery{Response: resQuery}, nil
+}
+
+// Query at a specific block height.
+//
+// ```shell
+// curl 'localhost:26657/abci_height?height=100'
+// ```
+//
+// ```go
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
+//
+// err := client.Start()
+//
+//	if err != nil {
+//	  // handle error
+//	}
+//
+// defer client.Stop()
+// result, err := client.ABCIHeight(100)
+// ```
+//
+// > The above command returns JSON structured like this:
+//
+// ```json
+//
+//	{
+//		"error": "",
+//		"result": {
+//			"response": {
+//				"log": "exists",
+//				"height": "100",
+//				// ...
+//			}
+//		},
+//		"id": "",
+//		"jsonrpc": "2.0"
+//	}
+//
+// ```
+//
+// ### Query Parameter
+//
+// - height (int64): The height to query at.
+func ABCIHeight(ctx *rpctypes.Context, height int64) (*ctypes.ResultABCIQuery, error) {
+	if height <= 0 {
+		return nil, fmt.Errorf("height must be greater than 0")
+	}
+
+	resQuery, err := proxyAppQuery.QuerySync(abci.RequestQuery{
+		Height: height,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("ABCIAtHeight", "height", height, "result", resQuery)
 	return &ctypes.ResultABCIQuery{Response: resQuery}, nil
 }
 

--- a/tm2/pkg/bft/rpc/core/routes.go
+++ b/tm2/pkg/bft/rpc/core/routes.go
@@ -30,8 +30,9 @@ var Routes = map[string]*rpc.RPCFunc{
 	"broadcast_tx_async":  rpc.NewRPCFunc(BroadcastTxAsync, "tx"),
 
 	// abci API
-	"abci_query": rpc.NewRPCFunc(ABCIQuery, "path,data,height,prove"),
-	"abci_info":  rpc.NewRPCFunc(ABCIInfo, ""),
+	"abci_query":  rpc.NewRPCFunc(ABCIQuery, "path,data,height,prove"),
+	"abci_info":   rpc.NewRPCFunc(ABCIInfo, ""),
+	"abci_height": rpc.NewRPCFunc(ABCIHeight, "height"),
 }
 
 func AddUnsafeRoutes() {


### PR DESCRIPTION
# Description

Added a new function that performs ABCI queries at a specific block height.

<details><summary>Contributors' checklist...</summary>

- [X] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
