### PR TITLE
fix: Longer package Path Spend More Gas [investigate]

### DIFF
--- a/gno.land/cmd/gnoland/testdata/addpkg_long_pkg_path.txtar
+++ b/gno.land/cmd/gnoland/testdata/addpkg_long_pkg_path.txtar
@@ -1,0 +1,18 @@
+loadpkg gno.land/p/demo/ufmt
+
+# start a new node
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/p/demo/foo/aaaa -gas-fee 1ugnot -gas-wanted 1430000 -broadcast -chainid=tendermint_test test1
+#stdout OK!
+
+-- foo.gno --
+package aaaa
+
+import (
+	"gno.land/p/demo/ufmt"
+)
+
+func Foo() string {
+	return ufmt.Sprintf("foo")
+}

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -404,7 +404,7 @@ type IndexExpr struct { // X[Index]
 	Attributes
 	X     Expr // expression
 	Index Expr // index expression
-	HasOK bool // if true, is form: `value, ok := <X>[<Key>]
+	HasOK bool // if true, is form: `value, ok := <X>[<Key>]`
 }
 
 type SelectorExpr struct { // X.Sel

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -105,7 +105,11 @@ func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer Signature
 			return newCtx, abciResult(err), true
 		}
 
-		newCtx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*store.Gas(len(newCtx.TxBytes())), "txSize")
+		txLen := len(newCtx.TxBytes())
+		println("newCtx.TxBytes() length: ", txLen, "\ncontent: ", string(newCtx.TxBytes()))
+		newCtx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*store.Gas(txLen), "txSize")
+		// newCtx.GasMeter().ConsumeGas(store.Gas(txLen), "txSize")
+		println("xxxxxxxx ante gas consumed", newCtx.GasMeter().GasConsumed())
 
 		if res := ValidateMemo(tx, params); !res.IsOK() {
 			return newCtx, res, true

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -707,6 +707,7 @@ func (app *BaseApp) runTx(mode RunTxMode, txBytes []byte, tx Tx) (result Result)
 	ms := ctx.MultiStore()
 	if mode == RunTxModeDeliver {
 		gasleft := ctx.BlockGasMeter().Remaining()
+		println("runTx gas left", gasleft)
 		ctx = ctx.WithGasMeter(store.NewPassthroughGasMeter(
 			ctx.GasMeter(),
 			gasleft,
@@ -729,7 +730,7 @@ func (app *BaseApp) runTx(mode RunTxMode, txBytes []byte, tx Tx) (result Result)
 			switch ex := r.(type) {
 			case store.OutOfGasException:
 				log := fmt.Sprintf(
-					"out of gas, gasWanted: %d, gasUsed: %d location: %v",
+					"out of gas, gasWanted: %d, gasUsed: %d location: %v", // <- 여기에서 out of gas가 발생
 					gasWanted,
 					ctx.GasMeter().GasConsumed(),
 					ex.Descriptor,
@@ -738,6 +739,7 @@ func (app *BaseApp) runTx(mode RunTxMode, txBytes []byte, tx Tx) (result Result)
 				result.Log = log
 				result.GasWanted = gasWanted
 				result.GasUsed = ctx.GasMeter().GasConsumed()
+				println("runTx gas consumed", result.GasUsed)
 				return
 			default:
 				log := fmt.Sprintf("recovered: %v\nstack:\n%v", r, string(debug.Stack()))

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -730,7 +730,7 @@ func (app *BaseApp) runTx(mode RunTxMode, txBytes []byte, tx Tx) (result Result)
 			switch ex := r.(type) {
 			case store.OutOfGasException:
 				log := fmt.Sprintf(
-					"out of gas, gasWanted: %d, gasUsed: %d location: %v", // <- 여기에서 out of gas가 발생
+					"out of gas, gasWanted: %d, gasUsed: %d location: %v",
 					gasWanted,
 					ctx.GasMeter().GasConsumed(),
 					ex.Descriptor,


### PR DESCRIPTION
# Description

This PR address the process of identifying and resolviong the cause of gas usage variations during deployment based on the length of package path.

## Testing Process

To identify the cause, I conducted tests using txtar testscript. I used the following script, chainging only the length of the package path for check.

```plain
# script file path:  gno.land/cmd/gnoland/testdata/addpkg_long_pkg_path.txtar

loadpkg gno.land/p/demo/ufmt

# start a new node
gnoland start

gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/p/demo/foo/aaa -gas-fee 1ugnot -gas-wanted 1430000 -broadcast -chainid=tendermint_test test1
#stdout OK!

-- foo.gno --
package aaa

import (
	"gno.land/p/demo/ufmt"
)

func Foo() string {
	return ufmt.Sprintf("foo")
}
```

```bash
cd gno.land/cmd/gnoland
go test -v . -run Testdata/addpkg_long
```

Even when an _out of gas_ error occured, the only function visible in the stack trace was the `ExecSignAndBroadcast` function in `maketx.go` file. Therefore, I added additional debugging lines to trace which function were being called.

## Cause Identification

While running the test script, I discovered that the `NewAnteHandler` function was being called repeatedly. This function contains the following line, where `TxSizeCostPerByte` is set a default value of 10:

```go
func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer SignatureVerificationGasConsumer, opts AnteOptions) sdk.AnteHandler {
    // ... 
    newCtx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*store.Gas(len(newCtx.TxBytes())), "txSize")
    // ...
}
```

I added a debugging line like below:

```diff
func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer SignatureVerificationGasConsumer, opts AnteOptions) sdk.AnteHandler {
    // ... 
    newCtx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*store.Gas(len(newCtx.TxBytes())), "txSize")
+   println("xxxxxxxx ante gas consumed", newCtx.GasMeter().GasConsumed())
    // ...
}
```

**Output**

```plain
go test -v . -run Testdata/addpkg_long

=== RUN   TestTestdata
=== RUN   TestTestdata/addpkg_long_pkg_path
xxxxxxxx ante gas consumed 0
xxxxxxxx ante gas consumed 3500
xxxxxxxx ante gas consumed 3500
xxxxxxxx ante gas consumed 3500
    testscript.go:558: WORK=$WORK
        PATH=/Users/not_joon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.darwin-arm64/bin:/opt/anaconda3/envs/py10/bin:/opt/anaconda3/condabin:/Users/not_joon/go/bin:/Users/not_joon/.cargo/bin:/opt/anaconda3/envs/py10/bin:/opt/anaconda3/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/opt/anaconda3/envs/py10/bin:/opt/anaconda3/condabin:/Users/not_joon/Library/Application Support/Coursier/bin:/bin
        GOTRACEBACK=system
        HOME=/no-home
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SID=4dc452c5
        USER_SEED_test1=source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast
        USER_ADDR_test1=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
        GNOROOT=/Users/not_joon/gno-core
        GNOHOME=/var/folders/kl/ny3lwtcn4gqdcwx0mz2lk4z80000gn/T/TestTestdata418531309/001/gno
        
        > loadpkg gno.land/p/demo/ufmt
        "gno.land/p/demo/ufmt" package was added to genesis
        # start a new node (1.550s)
        > gnoland start
        [stdout]
        node started successfully
        
        > gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/p/demo/foo/aaa -gas-fee 1ugnot -gas-wanted 1430000 -broadcast -chainid=tendermint_test test1
        [stdout]
        
        OK!
        GAS WANTED: 1430000
        GAS USED:   1425960
        HEIGHT:     130
        EVENTS:     []
        TX HASH:    /QBcHVwP3Svird/uTUtXTsYxqBTSwHO0JZBQxKqQPCI=
        
        [stderr]
        Enter password.
        
        #stdout OK! (0.000s)
        PASS
        
--- PASS: TestTestdata (1.89s)
    --- PASS: TestTestdata/addpkg_long_pkg_path (1.88s)
PASS
ok      github.com/gnolang/gno/gno.land/cmd/gnoland 
```

I executed the script while chainging the pacakge path to make have different lengths and confirmed that the gas amount changed according to the length of `TxBytes()` as follows:

Case 1: Package path length 22 (gno.land/p/demo/foo/aa)

| `TxSizeCosePerByte` | Consumption at `NewAnteHandler` call | Total gas consumption | Increase |
|---|---|---|---|
| 0  | 0 | 1422130 | 0|
| 1 | 347 | 1422477 | +347 |
| 10 (default value) | 3470| 1425600 | +3470 |


Case 2: Package path length 23 (gno.land/p/demo/foo/aaa)

| `TxSizeCosePerByte` | Consumption at `NewAnteHandler` call | Total gas consumption | Increase |
|---|---|---|---|
| 0  | 0 | 1422460 | 0|
| 1 | 350 | 1422810 | +350 |
| 10 (default value) | 3500 | 1425960 | +3500 |

We can observe that as the length of the package path increases, so does the gas usage. However, since gas usage is calculated based on the length of the transaction data obtained through the `TxBytes` method, we can hypothesize that it is also affected by the length of the contract content, not only the package path.

[TODO]

---

**Related Issue**

#2083 

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
