### PR TITLE
feat(examples): add `r/leon`

### DIFF
--- a/examples/gno.land/r/leon/config/config.gno
+++ b/examples/gno.land/r/leon/config/config.gno
@@ -1,4 +1,4 @@
-package leon
+package config
 
 import (
 	"errors"
@@ -24,7 +24,7 @@ func Backup() std.Address {
 
 func SetAddress(a std.Address) error {
 	if !a.IsValid() {
-		return errors.New("invalid address")
+		return errors.New("config: invalid address")
 	}
 
 	if err := checkAuthorized(); err != nil {
@@ -37,7 +37,7 @@ func SetAddress(a std.Address) error {
 
 func SetBackup(a std.Address) error {
 	if !a.IsValid() {
-		return errors.New("invalid address")
+		return errors.New("config: invalid address")
 	}
 
 	if err := checkAuthorized(); err != nil {
@@ -55,4 +55,11 @@ func checkAuthorized() error {
 	}
 
 	return nil
+}
+
+func AssertAuthorized() {
+	caller := std.PrevRealm().Addr()
+	if caller != main || caller != backup {
+		panic("config: unauthorized")
+	}
 }

--- a/examples/gno.land/r/leon/config/config.gno
+++ b/examples/gno.land/r/leon/config/config.gno
@@ -1,0 +1,58 @@
+package leon
+
+import (
+	"errors"
+	"std"
+)
+
+var (
+	main   std.Address // leon's main address
+	backup std.Address // backup address
+)
+
+func init() {
+	main = "g125em6arxsnj49vx35f0n0z34putv5ty3376fg5"
+}
+
+func Address() std.Address {
+	return main
+}
+
+func Backup() std.Address {
+	return backup
+}
+
+func SetAddress(a std.Address) error {
+	if !a.IsValid() {
+		return errors.New("invalid address")
+	}
+
+	if err := checkAuthorized(); err != nil {
+		return err
+	}
+
+	main = a
+	return nil
+}
+
+func SetBackup(a std.Address) error {
+	if !a.IsValid() {
+		return errors.New("invalid address")
+	}
+
+	if err := checkAuthorized(); err != nil {
+		return err
+	}
+
+	backup = a
+	return nil
+}
+
+func checkAuthorized() error {
+	caller := std.PrevRealm().Addr()
+	if caller != main || caller != backup {
+		return errors.New("config: unauthorized")
+	}
+
+	return nil
+}

--- a/examples/gno.land/r/leon/config/gno.mod
+++ b/examples/gno.land/r/leon/config/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/leon/config

--- a/examples/gno.land/r/leon/home/gno.mod
+++ b/examples/gno.land/r/leon/home/gno.mod
@@ -1,0 +1,6 @@
+module gno.land/r/leon/home
+
+require (
+	gno.land/r/demo/art/gnoface v0.0.0-latest
+	gno.land/r/demo/art/millipede v0.0.0-latest
+)

--- a/examples/gno.land/r/leon/home/gno.mod
+++ b/examples/gno.land/r/leon/home/gno.mod
@@ -1,6 +1,8 @@
 module gno.land/r/leon/home
 
 require (
+	gno.land/p/demo/ufmt v0.0.0-latest
 	gno.land/r/demo/art/gnoface v0.0.0-latest
 	gno.land/r/demo/art/millipede v0.0.0-latest
+	gno.land/r/leon/config v0.0.0-latest
 )

--- a/examples/gno.land/r/leon/home/home.gno
+++ b/examples/gno.land/r/leon/home/home.gno
@@ -57,7 +57,8 @@ func Render(path string) string {
 }
 
 func renderBlogPosts() string {
-	out := "## Leon's Blog Posts"
+	out := ""
+	//out += "## Leon's Blog Posts"
 
 	// todo fetch blog posts authored by @leohhhn
 	// and render them

--- a/examples/gno.land/r/leon/home/home.gno
+++ b/examples/gno.land/r/leon/home/home.gno
@@ -4,15 +4,57 @@ import (
 	"std"
 	"strconv"
 
+	"gno.land/p/demo/ufmt"
 	"gno.land/r/demo/art/gnoface"
 	"gno.land/r/demo/art/millipede"
+	"gno.land/r/leon/config"
 )
 
-func Render(path string) string {
-	out := ""
+var (
+	pfp string // link to profile picture
+)
 
-	out += "# Leon's Homepage\n\n"
-	out += `<div class="jumbotron">` + "\n\n"
+func init() {
+	pfp = "https://i.imgflip.com/91vskx.jpg"
+}
+
+func UpdatePFP(url string) {
+	config.AssertAuthorized()
+	pfp = url
+}
+
+func Render(path string) string {
+	out := "# Leon's Homepage\n\n"
+
+	out += renderAboutMe()
+	out += "\n\n"
+	out += renderArt()
+
+	return out
+}
+
+func renderAboutMe() string {
+	out := "<div class='columns-3'>"
+
+	out += "<div>\n\n"
+	out += ufmt.Sprintf("![my profile pic](%s)\n\n[My favourite painting](https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog)\n\n", pfp)
+	out += "</div>\n\n"
+
+	out += "<div>\n\n"
+	out += "I'm Leon, a DevRel engineer at gno.land!\n\n"
+	out += "</div>\n\n"
+
+	out += "<div>\n\n"
+	out += "I am a tech enthusiast, life-long learner, and sharer of knowledge.\n\n"
+	out += "</div>\n\n"
+
+	out += "</div>\n\n"
+
+	return out
+}
+
+func renderArt() string {
+	out := `<div class="jumbotron">` + "\n\n"
 	out += "# Gno Art\n\n"
 
 	out += "<div class='columns-3'>"

--- a/examples/gno.land/r/leon/home/home.gno
+++ b/examples/gno.land/r/leon/home/home.gno
@@ -5,22 +5,37 @@ import (
 	"strconv"
 
 	"gno.land/p/demo/ufmt"
+
 	"gno.land/r/demo/art/gnoface"
 	"gno.land/r/demo/art/millipede"
 	"gno.land/r/leon/config"
 )
 
 var (
-	pfp string // link to profile picture
+	pfp        string // link to profile picture
+	pfpCaption string // profile picture caption
+	abtMe      [2]string
 )
 
 func init() {
 	pfp = "https://i.imgflip.com/91vskx.jpg"
+	pfpCaption = "[My favourite painting](https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog)"
+	abtMe = [2]string{
+		"Hi, I'm Leon, a DevRel Engineer at gno.land.",
+		"I am a tech enthusiast, life-long learner, and sharer of knowledge.",
+	}
 }
 
-func UpdatePFP(url string) {
+func UpdatePFP(url, caption string) {
 	config.AssertAuthorized()
 	pfp = url
+	pfpCaption = caption
+}
+
+func UpdateAboutMe(col1, col2 string) {
+	config.AssertAuthorized()
+	abtMe[0] = col1
+	abtMe[1] = col2
 }
 
 func Render(path string) string {
@@ -37,15 +52,16 @@ func renderAboutMe() string {
 	out := "<div class='columns-3'>"
 
 	out += "<div>\n\n"
-	out += ufmt.Sprintf("![my profile pic](%s)\n\n[My favourite painting](https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog)\n\n", pfp)
+	out += ufmt.Sprintf("![my profile pic](%s)\n\n%s\n\n", pfp, pfpCaption)
 	out += "</div>\n\n"
 
 	out += "<div>\n\n"
-	out += "I'm Leon, a DevRel engineer at gno.land!\n\n"
+	out += abtMe[0] + "\n\n"
 	out += "</div>\n\n"
 
 	out += "<div>\n\n"
-	out += "I am a tech enthusiast, life-long learner, and sharer of knowledge.\n\n"
+	out += abtMe[1] + "\n\n"
+	out += "\n\n"
 	out += "</div>\n\n"
 
 	out += "</div>\n\n"

--- a/examples/gno.land/r/leon/home/home.gno
+++ b/examples/gno.land/r/leon/home/home.gno
@@ -19,10 +19,17 @@ var (
 
 func init() {
 	pfp = "https://i.imgflip.com/91vskx.jpg"
-	pfpCaption = "[My favourite painting](https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog)"
+	pfpCaption = "[My favourite painting & pfp](https://en.wikipedia.org/wiki/Wanderer_above_the_Sea_of_Fog)"
 	abtMe = [2]string{
-		"Hi, I'm Leon, a DevRel Engineer at gno.land.",
-		"I am a tech enthusiast, life-long learner, and sharer of knowledge.",
+		`### About me
+Hi, I'm Leon, a DevRel Engineer at gno.land. I am a tech enthusiast, 
+life-long learner, and sharer of knowledge.`,
+		`### Contributions
+My contributions to gno.land can mainly be found 
+[here](https://github.com/gnolang/gno/issues?q=sort:updated-desc+author:leohhhn).
+
+TODO import r/gh
+`,
 	}
 }
 
@@ -42,9 +49,18 @@ func Render(path string) string {
 	out := "# Leon's Homepage\n\n"
 
 	out += renderAboutMe()
+	out += renderBlogPosts()
 	out += "\n\n"
 	out += renderArt()
 
+	return out
+}
+
+func renderBlogPosts() string {
+	out := "## Leon's Blog Posts"
+
+	// todo fetch blog posts authored by @leohhhn
+	// and render them
 	return out
 }
 
@@ -61,10 +77,9 @@ func renderAboutMe() string {
 
 	out += "<div>\n\n"
 	out += abtMe[1] + "\n\n"
-	out += "\n\n"
 	out += "</div>\n\n"
 
-	out += "</div>\n\n"
+	out += "</div><!-- /columns-3 -->\n\n"
 
 	return out
 }
@@ -79,7 +94,8 @@ func renderArt() string {
 	out += renderMillipede()
 	out += "Empty spot :/"
 
-	out += "</div>\n\n"
+	out += "</div><!-- /columns-3 -->\n\n"
+
 	out += "This art is dynamic; it will change with every new block.\n\n"
 	out += `</div><!-- /jumbotron -->` + "\n"
 

--- a/examples/gno.land/r/leon/home/home.gno
+++ b/examples/gno.land/r/leon/home/home.gno
@@ -1,0 +1,46 @@
+package home
+
+import (
+	"std"
+	"strconv"
+
+	"gno.land/r/demo/art/gnoface"
+	"gno.land/r/demo/art/millipede"
+)
+
+func Render(path string) string {
+	out := ""
+
+	out += "# Leon's Homepage\n\n"
+	out += `<div class="jumbotron">` + "\n\n"
+	out += "# Gno Art\n\n"
+
+	out += "<div class='columns-3'>"
+
+	out += renderGnoFace()
+	out += renderMillipede()
+	out += "Empty spot :/"
+
+	out += "</div>\n\n"
+	out += "This art is dynamic; it will change with every new block.\n\n"
+	out += `</div><!-- /jumbotron -->` + "\n"
+
+	return out
+}
+
+func renderGnoFace() string {
+	out := "<div>\n\n"
+	out += gnoface.Render(strconv.Itoa(int(std.GetHeight())))
+	out += "</div>\n\n"
+
+	return out
+}
+
+func renderMillipede() string {
+	out := "<div>\n\n"
+	out += "Millipede\n\n"
+	out += "```\n" + millipede.Draw(int(std.GetHeight())%10+1) + "```\n"
+	out += "</div>\n\n"
+
+	return out
+}


### PR DESCRIPTION
## Description

This PR adds v1 of `r/leon` to the examples folder. It contains `r/leon/home` & `r/leon/config`.
 
For context - this is meant to be a personal realm (or set of realms) that every gno.land user should have at some point. Later, the idea is to have a [special user page](https://github.com/gnolang/gno/issues/2189) which will fetch the `Render()` of `r/username/home`. This will serve like the profile of the user; and the home realm will most likely be upgradeable down the line. 

The reason I am making this a PR and not simply publishing it to the Portal Loop is that it allows for further code changes down the line. `examples/` get loaded into genesis first, and all other replayed addpkg transactions after that, making it possible to have "upgradeable" realms on Portal Loop.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
