### PR TITLE
chore(p/grc20): Distinct Event Types for GRC20 Functions

### DIFF
--- a/examples/gno.land/p/demo/grc/grc20/banker.gno
+++ b/examples/gno.land/p/demo/grc/grc20/banker.gno
@@ -64,7 +64,7 @@ func (b *Banker) Mint(address std.Address, amount uint64) error {
 	b.balances.Set(string(address), newBalance)
 
 	std.Emit(
-		TransferEvent,
+		MintEvent,
 		"from", "",
 		"to", string(address),
 		"value", strconv.Itoa(int(amount)),
@@ -90,7 +90,7 @@ func (b *Banker) Burn(address std.Address, amount uint64) error {
 	b.balances.Set(string(address), newBalance)
 
 	std.Emit(
-		TransferEvent,
+		BurnEvent,
 		"from", string(address),
 		"to", "",
 		"value", strconv.Itoa(int(amount)),
@@ -146,9 +146,6 @@ func (b *Banker) Transfer(from, to std.Address, amount uint64) error {
 	toBalance := b.BalanceOf(to)
 	fromBalance := b.BalanceOf(from)
 
-	// debug.
-	// println("from", from, "to", to, "amount", amount, "fromBalance", fromBalance, "toBalance", toBalance)
-
 	if fromBalance < amount {
 		return ErrInsufficientBalance
 	}
@@ -165,6 +162,7 @@ func (b *Banker) Transfer(from, to std.Address, amount uint64) error {
 		"to", to.String(),
 		"value", strconv.Itoa(int(amount)),
 	)
+
 	return nil
 }
 

--- a/examples/gno.land/p/demo/grc/grc20/types.gno
+++ b/examples/gno.land/p/demo/grc/grc20/types.gno
@@ -56,6 +56,8 @@ type Token interface {
 }
 
 const (
+	MintEvent     = "Mint"
+	BurnEvent     = "Burn"
 	TransferEvent = "Transfer"
 	ApprovalEvent = "Approval"
 )


### PR DESCRIPTION
# Description

Currently, the event type for grc20 is uniformly set to `TrasferEvent` (execpt for `Approval` function), which necessitated making RPC calls to check every block.

Therefore, I have modified it by adding event types for each function to distinguish them from one another.

In this case, we can reduce the number of RPC calls by retrieving data only when the target event type occurs.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
