### PR TITLE
fix(p/int256): "-0" Output in `ToString` method

### DIFF
--- a/examples/gno.land/p/demo/int256/conversion.gno
+++ b/examples/gno.land/p/demo/int256/conversion.gno
@@ -79,8 +79,9 @@ func (z *Int) ToString() string {
 	}
 
 	t := z.abs.Dec()
-	if z.neg {
+	if z.neg && !z.abs.IsZero() {
 		return "-" + t
 	}
+
 	return t
 }

--- a/examples/gno.land/p/demo/int256/conversion_test.gno
+++ b/examples/gno.land/p/demo/int256/conversion_test.gno
@@ -169,3 +169,66 @@ func TestSetUint256(t *testing.T) {
 		}
 	}
 }
+
+func TestToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *Int
+		expected string
+	}{
+		{
+			name: "Zero from subtraction",
+			setup: func() *Int {
+				minusThree := MustFromDecimal("-3")
+				three := MustFromDecimal("3")
+				return Zero().Add(minusThree, three)
+			},
+			expected: "0",
+		},
+		{
+			name: "Zero from right shift",
+			setup: func() *Int {
+				return Zero().Rsh(One(), 1234)
+			},
+			expected: "0",
+		},
+		{
+			name: "Positive number",
+			setup: func() *Int {
+				return MustFromDecimal("42")
+			},
+			expected: "42",
+		},
+		{
+			name: "Negative number",
+			setup: func() *Int {
+				return MustFromDecimal("-42")
+			},
+			expected: "-42",
+		},
+		{
+			name: "Large positive number",
+			setup: func() *Int {
+				return MustFromDecimal("115792089237316195423570985008687907853269984665640564039457584007913129639935")
+			},
+			expected: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+		},
+		{
+			name: "Large negative number",
+			setup: func() *Int {
+				return MustFromDecimal("-115792089237316195423570985008687907853269984665640564039457584007913129639935")
+			},
+			expected: "-115792089237316195423570985008687907853269984665640564039457584007913129639935",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			z := tt.setup()
+			result := z.ToString()
+			if result != tt.expected {
+				t.Errorf("ToString() = %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Added a check to prevent appending a minus sign to zero values. This ensures that "0" always returned for zero values.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
