### PR TITLE
test(gnovm): test all files in gnovm/tests subdirs

### DIFF
--- a/gnovm/pkg/gnolang/debugger_test.go
+++ b/gnovm/pkg/gnolang/debugger_test.go
@@ -40,7 +40,7 @@ func evalTest(debugAddr, in, file string) (out, err, stacktrace string) {
 		if r := recover(); r != nil {
 			err = fmt.Sprintf("%v", r)
 		}
-		out = strings.TrimSpace(out)
+		out = strings.TrimSuffix(out, "\n")
 		err = strings.TrimSpace(strings.ReplaceAll(err, "../../tests/files/", "files/"))
 	}()
 

--- a/gnovm/pkg/gnolang/values_string.go
+++ b/gnovm/pkg/gnolang/values_string.go
@@ -170,6 +170,9 @@ func (fv *FuncValue) String() string {
 	if fv.Type == nil {
 		return fmt.Sprintf("incomplete-func ?%s(?)?", name)
 	}
+	if name == "" {
+		return fmt.Sprintf("%s{...}", fv.Type.String())
+	}
 	return name
 }
 

--- a/gnovm/tests/files/a31.gno
+++ b/gnovm/tests/files/a31.gno
@@ -2,10 +2,10 @@ package main
 
 func main() {
 	for range []int{0, 1, 2} {
-		print("hello ")
+		print("hello,")
 	}
 	println("")
 }
 
 // Output:
-// hello hello hello
+// hello,hello,hello,

--- a/gnovm/tests/files/assign_unnamed_type/unnamedtype5_filetest.gno
+++ b/gnovm/tests/files/assign_unnamed_type/unnamedtype5_filetest.gno
@@ -34,8 +34,8 @@ func main() {
 
 // Output:
 // 1 (inc main.op)
-// 0
+// 0 func(n int)( int){...}
 // -1 dec
-// 0 ( main.op)
+// 0 (func(n int)( int){...} main.op)
 // -1 dec
 // 1 inc

--- a/gnovm/tests/files/assign_unnamed_type/unnamedtype5a_filetest.gno
+++ b/gnovm/tests/files/assign_unnamed_type/unnamedtype5a_filetest.gno
@@ -27,6 +27,7 @@ func main() {
 }
 
 // Output:
+// func(n int)( int){...}
 // 1
-// ( main.op)
+// (func(n int)( int){...} main.op)
 // -1

--- a/gnovm/tests/files/convert4.gno
+++ b/gnovm/tests/files/convert4.gno
@@ -4,4 +4,5 @@ func main() {
 	println(int(nil))
 }
 
-// Error: cannot convert (undefined) to int
+// Error:
+// cannot convert (undefined) to int

--- a/gnovm/tests/files/convert4.gno
+++ b/gnovm/tests/files/convert4.gno
@@ -5,4 +5,4 @@ func main() {
 }
 
 // Error:
-// cannot convert (undefined) to int
+// main/files/convert4.gno:4:10: cannot convert (undefined) to int

--- a/gnovm/tests/files/convert5.gno
+++ b/gnovm/tests/files/convert5.gno
@@ -7,4 +7,4 @@ func main() {
 }
 
 // Error:
-// cannot convert (undefined) to int
+// main/files/convert5.gno:3:1: cannot convert (undefined) to int

--- a/gnovm/tests/files/convert5.gno
+++ b/gnovm/tests/files/convert5.gno
@@ -6,4 +6,5 @@ func main() {
 	println(ints)
 }
 
-// Error: cannot convert (undefined) to int
+// Error:
+// cannot convert (undefined) to int

--- a/gnovm/tests/files/defer6.gno
+++ b/gnovm/tests/files/defer6.gno
@@ -1,21 +1,21 @@
 package main
 
 func f1() {
-	defer print("f1-begin ")
+	defer print("f1-begin,")
 	f2()
-	defer print("f1-end ")
+	defer print("f1-end,")
 }
 
 func f2() {
-	defer print("f2-begin ")
+	defer print("f2-begin,")
 	f3()
-	defer print("f2-end ")
+	defer print("f2-end,")
 }
 
 func f3() {
-	defer print("f3-begin ")
-	print("hello ")
-	defer print("f3-end ")
+	defer print("f3-begin,")
+	print("hello,")
+	defer print("f3-end,")
 }
 
 func main() {
@@ -24,4 +24,4 @@ func main() {
 }
 
 // Output:
-// hello f3-end f3-begin f2-end f2-begin f1-end f1-begin
+// hello,f3-end,f3-begin,f2-end,f2-begin,f1-end,f1-begin,

--- a/gnovm/tests/files/map15.gno
+++ b/gnovm/tests/files/map15.gno
@@ -6,8 +6,8 @@ func main() {
 	users := make(map[string]string)
 
 	v := users["a"]
-	fmt.Println("v:", v)
+	fmt.Println("v:", v, ";")
 }
 
 // Output:
-// v:
+// v:  ;

--- a/gnovm/tests/files/method27.gno
+++ b/gnovm/tests/files/method27.gno
@@ -13,8 +13,8 @@ type AuthenticatedRequest struct {
 
 func main() {
 	a := &AuthenticatedRequest{}
-	fmt.Println("ua:", a.UserAgent())
+	fmt.Println("ua:", a.UserAgent(), ";")
 }
 
 // Output:
-// ua:
+// ua:  ;

--- a/gnovm/tests/files/types/cmp_iface_2.gno
+++ b/gnovm/tests/files/types/cmp_iface_2.gno
@@ -19,7 +19,7 @@ func (e Error) Error() string {
 func main() {
 	var e0 E
 	e0 = Error(0)
-	fmt.Printf("%T \n", e0)
+	fmt.Printf("%T\n", e0)
 	if e0 == Error(0) {
 		println("what the firetruck?")
 	} else {

--- a/gnovm/tests/files/types/eql_0f2d.gno
+++ b/gnovm/tests/files/types/eql_0f2d.gno
@@ -19,7 +19,7 @@ func (e Error) Error() string {
 func main() {
 	var e0 E
 	e0 = Error(0)
-	fmt.Printf("%T \n", e0)
+	fmt.Printf("%T\n", e0)
 	if e0 == Error(0) {
 		println("what the firetruck?")
 	} else {

--- a/gnovm/tests/files/types/eql_0f2e.gno
+++ b/gnovm/tests/files/types/eql_0f2e.gno
@@ -19,7 +19,7 @@ func (e Error) Error() string {
 func main() {
 	var e0 E
 	e0 = Error(0)
-	fmt.Printf("%T \n", e0)
+	fmt.Printf("%T\n", e0)
 	if Error(0) == e0 {
 		println("what the firetruck?")
 	} else {

--- a/gnovm/tests/files/types/runtime_a2.gno
+++ b/gnovm/tests/files/types/runtime_a2.gno
@@ -8,7 +8,7 @@ func gen() interface{} {
 
 func main() {
 	r := gen()
-	fmt.Printf("%T \n", r)
+	fmt.Printf("%T\n", r)
 }
 
 // Output:

--- a/gnovm/tests/files/types/shift_a12.gno
+++ b/gnovm/tests/files/types/shift_a12.gno
@@ -6,7 +6,7 @@ func main() {
 	a := uint(1)
 	r := uint64(1) << a
 	println(r)
-	fmt.Printf("%T \n", r)
+	fmt.Printf("%T\n", r)
 }
 
 // Output:

--- a/gnovm/tests/files/types/shift_a13.gno
+++ b/gnovm/tests/files/types/shift_a13.gno
@@ -4,7 +4,7 @@ import "fmt"
 
 func main() {
 	var r uint64 = 1 << int8(1)
-	fmt.Printf("%T \n", r)
+	fmt.Printf("%T\n", r)
 	println(r)
 }
 


### PR DESCRIPTION
Changes the EvalFiles tests to support sub-directories in `gnovm/tests`, skipping the `extern` directory as it is used for imports.

Other changes mostly concern not having tests where some output lines terminate with spaces:

- Changed FuncValue.String, so that in case of a closure value the signature is printed, as shown in the `assign_unnamed_type` tests.
- Require all directives to be on a new line (mostly for consistency with 99% of the testing corpus)
- use commas in some places instead of spaces; use `;` for end of line on `Println` statements when they're supposed to print an empty string.
- remove the leading space in the `what the firetruck?` tests.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details> 