### PR TITLE
chore(tm2): crypto.Address json Marshal

### DIFF
--- a/tm2/pkg/crypto/bech32_test.go
+++ b/tm2/pkg/crypto/bech32_test.go
@@ -1,6 +1,7 @@
 package crypto_test
 
 import (
+	"encoding/json"
 	"math/rand"
 	"testing"
 
@@ -59,6 +60,7 @@ func TestRandBech32AddrConsistency(t *testing.T) {
 		addr := crypto.AddressFromBytes(pub.Address().Bytes())
 		testMarshal(t, addr, amino.Marshal, amino.Unmarshal)
 		testMarshal(t, addr, amino.MarshalJSON, amino.UnmarshalJSON)
+		testMarshal(t, addr, json.Marshal, json.Unmarshal)
 
 		str := addr.String()
 		res, err := crypto.AddressFromBech32(str)

--- a/tm2/pkg/crypto/crypto.go
+++ b/tm2/pkg/crypto/crypto.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/gnolang/gno/tm2/pkg/bech32"
@@ -59,17 +60,11 @@ func (addr Address) MarshalJSON() ([]byte, error) {
 }
 
 func (addr *Address) UnmarshalJSON(b []byte) error {
-	if len(b) == 0 {
-		return nil
-	}
-	b = bytes.Trim(b, `"`)
-
-	addr2, err := AddressFromBech32(string(b))
-	if err != nil {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	copy(addr[:], addr2[:])
-	return nil
+	return addr.UnmarshalAmino(s)
 }
 
 func (addr Address) MarshalAmino() (string, error) {
@@ -77,6 +72,7 @@ func (addr Address) MarshalAmino() (string, error) {
 }
 
 func (addr *Address) UnmarshalAmino(b32str string) (err error) {
+	// NOTE: also used to unmarshal normal JSON, through UnmarshalJSON.
 	if b32str == "" {
 		return nil // leave addr as zero.
 	}

--- a/tm2/pkg/crypto/crypto.go
+++ b/tm2/pkg/crypto/crypto.go
@@ -53,6 +53,25 @@ func AddressFromBytes(bz []byte) (ret Address) {
 	return
 }
 
+func (addr Address) MarshalJSON() ([]byte, error) {
+	b := AddressToBech32(addr)
+	return []byte(`"` + b + `"`), nil
+}
+
+func (addr *Address) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	b = bytes.Trim(b, `"`)
+
+	addr2, err := AddressFromBech32(string(b))
+	if err != nil {
+		return err
+	}
+	copy(addr[:], addr2[:])
+	return nil
+}
+
 func (addr Address) MarshalAmino() (string, error) {
 	return AddressToBech32(addr), nil
 }


### PR DESCRIPTION
Currently, on any `sdk.Message`, when doing a json.Marshal, the result look like:

```json
{"amount": [{"denom": "ugnot", "amount": 10000000}], "to_address": [109, 116, 186, 231, 239, 107, 120, 148, 194, 146, 166, 150, 161, 244, 93, 201, 25, 61, 216, 223], "from_address": [70, 139, 48, 165, 116, 79, 88, 170, 84, 108, 231, 73, 227, 127, 127, 98, 252, 214, 167, 152]}
```

Now it's returning

```json
{"from_address":"g1g69npft5fav254rvuay7xlmlvt7ddfucgvx8xf","to_address":"g1d46t4el0dduffs5j56t2razaeyvnmkxlduduuw","amount":[{"denom":"ugnot","amount":10000000}]}
```

This is already done for amino Marshalling, it's not for json.