### PR TITLE
feat(tm2): Print commit duration when broadcasting transaction

### DIFF
--- a/docs/gno-tooling/cli/gnokey/state-changing-calls.md
+++ b/docs/gno-tooling/cli/gnokey/state-changing-calls.md
@@ -135,14 +135,16 @@ GAS USED:   117564
 HEIGHT:     3990
 EVENTS:     []
 TX HASH:    Ni8Oq5dP0leoT/IRkKUKT18iTv8KLL3bH8OFZiV79kM=
+COMMIT DURATION:  1000ms
 ```
 
 Let's analyze the output, which is standard for any `gnokey` transaction:
-- `GAS WANTED: 200000` - the original amount of gas specified for the transaction
-- `GAS USED:   117564` - the gas used to execute the transaction
-- `HEIGHT:     3990` - the block number at which the transaction was executed at
-- `EVENTS:     []` - [Gno events](../../../concepts/stdlibs/events.md) emitted by the transaction, in this case, none
-- `TX HASH:    Ni8Oq5dP0leoT/IRkKUKT18iTv8KLL3bH8OFZiV79kM=` - the hash of the transaction
+- `GAS WANTED:      200000` - the original amount of gas specified for the transaction
+- `GAS USED:        117564` - the gas used to execute the transaction
+- `HEIGHT:          3990` - the block number at which the transaction was executed at
+- `EVENTS:          []` - [Gno events](../../../concepts/stdlibs/events.md) emitted by the transaction, in this case, none
+- `TX HASH:         Ni8Oq5dP0leoT/IRkKUKT18iTv8KLL3bH8OFZiV79kM=` - the hash of the transaction
+- `COMMIT DURATION: 1000ms` - the time from the transaction submission to being committed on-chain
 
 Congratulations! You have just uploaded a pure package to the Portal Loop network.
 If you wish to deploy to a different network, find the list of all network 
@@ -198,11 +200,12 @@ as well as the Portal Loop remote address, `https://rpc.gno.land:443`.
 After running the command, we can expect an output similar to the following:
 ```bash
 OK!
-GAS WANTED: 2000000
-GAS USED:   489528
-HEIGHT:     24142
-EVENTS:     [{"type":"Transfer","attrs":[{"key":"from","value":""},{"key":"to","value":"g125em6arxsnj49vx35f0n0z34putv5ty3376fg5"},{"key":"value","value":"1000"}],"pkg_path":"gno.land/r/demo/wugnot","func":"Mint"}]
-TX HASH:    Ni8Oq5dP0leoT/IRkKUKT18iTv8KLL3bH8OFZiV79kM=
+GAS WANTED:       2000000
+GAS USED:         489528
+HEIGHT:           24142
+EVENTS:           [{"type":"Transfer","attrs":[{"key":"from","value":""},{"key":"to","value":"g125em6arxsnj49vx35f0n0z34putv5ty3376fg5"},{"key":"value","value":"1000"}],"pkg_path":"gno.land/r/demo/wugnot","func":"Mint"}]
+TX HASH:          Ni8Oq5dP0leoT/IRkKUKT18iTv8KLL3bH8OFZiV79kM=
+COMMIT DURATION:  1000ms
 ```
 
 In this case, we can see that the `Deposit()` function emitted an 
@@ -232,11 +235,12 @@ output:
 (1000 uint64)
 
 OK!
-GAS WANTED: 2000000
-GAS USED:   396457
-HEIGHT:     64839
-EVENTS:     []
-TX HASH:    gQP9fJYrZMTK3GgRiio3/V35smzg/jJ62q7t4TLpdV4=
+GAS WANTED:       2000000
+GAS USED:         396457
+HEIGHT:           64839
+EVENTS:           []
+TX HASH:          gQP9fJYrZMTK3GgRiio3/V35smzg/jJ62q7t4TLpdV4=
+COMMIT DURATION:  1000ms
 ```
 
 At the top, you will see the output of the transaction, specifying the value and

--- a/gno.land/cmd/gnoland/testdata/addpkg.txtar
+++ b/gno.land/cmd/gnoland/testdata/addpkg.txtar
@@ -17,6 +17,7 @@ stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- hello.gno --
 package hello

--- a/gno.land/cmd/gnoland/testdata/addpkg_invalid.txtar
+++ b/gno.land/cmd/gnoland/testdata/addpkg_invalid.txtar
@@ -8,6 +8,7 @@ gnoland start
 
 # check error message
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 stderr 'as string value in return statement'
 stderr '"std" imported and not used'
 

--- a/gno.land/cmd/gnoland/testdata/event_callback.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_callback.txtar
@@ -11,6 +11,7 @@ stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}],\"pkg_path\":\"gno.land\/r\/demo\/cbee\",\"func\":\"subFoo\"},{\"type\":\"bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}],\"pkg_path\":\"gno.land\/r\/demo\/cbee\",\"func\":\"subBar\"}]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- cbee.gno --
 package cbee

--- a/gno.land/cmd/gnoland/testdata/event_defer_callback_loop.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_defer_callback_loop.txtar
@@ -11,6 +11,7 @@ stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"0\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"\"},{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"1\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"\"},{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"2\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"\"},{\"type\":\"ForLoopCompletionEvent\",\"attrs\":\[{\"key\":\"count\",\"value\":\"3\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"forLoopEmitExample\"},{\"type\":\"CallbackEvent\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"\"},{\"type\":\"CallbackCompletionEvent\",\"attrs\":\[{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"callbackEmitExample\"},{\"type\":\"DeferEvent\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"}\],\"pkg_path\":\"gno.land\/r\/demo\/edcl\",\"func\":\"deferEmitExample\"}\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- edcl.gno --
 

--- a/gno.land/cmd/gnoland/testdata/event_for_statement.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_for_statement.txtar
@@ -11,6 +11,7 @@ stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"Foo\"}\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 gnokey maketx call -pkgpath gno.land/r/demo/foree -func Bar -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
 stdout OK!
@@ -19,6 +20,7 @@ stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"Foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"subFoo\"},{\"type\":\"Bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"subBar\"},{\"type\":\"Foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"subFoo\"},{\"type\":\"Bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land\/r\/demo\/foree\",\"func\":\"subBar\"}\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- foree.gno --
 

--- a/gno.land/cmd/gnoland/testdata/event_normal.txtar
+++ b/gno.land/cmd/gnoland/testdata/event_normal.txtar
@@ -11,6 +11,7 @@ stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[{\"type\":\"foo\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"},{\"key\":\"key3\",\"value\":\"value3\"}\],\"pkg_path\":\"gno.land\/r\/demo\/ee\",\"func\":\"SubFoo\"},{\"type\":\"bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land\/r\/demo\/ee\",\"func\":\"SubBar\"}\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 gnokey maketx call -pkgpath gno.land/r/demo/ee -func Bar -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
 stdout OK!
@@ -19,6 +20,7 @@ stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[{\"type\":\"bar\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/ee\",\"func\":\"Bar\"}\]'
 stdout 'TX HASH:    '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- ee.gno --
 package ee

--- a/gno.land/cmd/gnoland/testdata/run.txtar
+++ b/gno.land/cmd/gnoland/testdata/run.txtar
@@ -12,6 +12,7 @@ stdout 'OK!'
 stdout 'GAS WANTED: 200000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- bar/bar.gno --
 package bar

--- a/gno.land/pkg/integration/testdata/adduser.txtar
+++ b/gno.land/pkg/integration/testdata/adduser.txtar
@@ -15,6 +15,7 @@ stdout 'OK!'
 stdout 'GAS WANTED: 200000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 # should fail if user is added after node is started
 ! adduser test5

--- a/gno.land/pkg/integration/testdata/loadpkg_work.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_work.txtar
@@ -13,6 +13,7 @@ stdout 'OK!'
 stdout 'GAS WANTED: 200000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
+stdout 'COMMIT DURATION:  \d+ ms'
 
 -- bar/bar.gno --
 package bar

--- a/tm2/pkg/crypto/keys/client/broadcast.go
+++ b/tm2/pkg/crypto/keys/client/broadcast.go
@@ -88,7 +88,7 @@ func execBroadcast(cfg *BroadcastCfg, args []string, io commands.IO) error {
 		return errors.New("transaction failed %#v\nlog %s", res, res.CheckTx.Log)
 	} else if res.DeliverTx.IsErr() {
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(res.Hash))
-		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
+		io.Println("COMMIT DURATION: ", duration.Milliseconds(), "ms")
 		return errors.New("transaction failed %#v\nlog %s", res, res.DeliverTx.Log)
 	} else {
 		io.Println(string(res.DeliverTx.Data))
@@ -98,7 +98,7 @@ func execBroadcast(cfg *BroadcastCfg, args []string, io commands.IO) error {
 		io.Println("HEIGHT:    ", res.Height)
 		io.Println("EVENTS:    ", string(res.DeliverTx.EncodeEvents()))
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(res.Hash))
-		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
+		io.Println("COMMIT DURATION: ", duration.Milliseconds(), "ms")
 	}
 	return nil
 }

--- a/tm2/pkg/crypto/keys/client/broadcast.go
+++ b/tm2/pkg/crypto/keys/client/broadcast.go
@@ -88,7 +88,7 @@ func execBroadcast(cfg *BroadcastCfg, args []string, io commands.IO) error {
 		return errors.New("transaction failed %#v\nlog %s", res, res.CheckTx.Log)
 	} else if res.DeliverTx.IsErr() {
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(res.Hash))
-		io.Println("EXECUTION TIME: ", duration.Milliseconds(), "ms")
+		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
 		return errors.New("transaction failed %#v\nlog %s", res, res.DeliverTx.Log)
 	} else {
 		io.Println(string(res.DeliverTx.Data))
@@ -98,7 +98,7 @@ func execBroadcast(cfg *BroadcastCfg, args []string, io commands.IO) error {
 		io.Println("HEIGHT:    ", res.Height)
 		io.Println("EVENTS:    ", string(res.DeliverTx.EncodeEvents()))
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(res.Hash))
-		io.Println("EXECUTION TIME: ", duration.Milliseconds(), "ms")
+		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
 	}
 	return nil
 }

--- a/tm2/pkg/crypto/keys/client/maketx.go
+++ b/tm2/pkg/crypto/keys/client/maketx.go
@@ -220,7 +220,7 @@ func ExecSignAndBroadcast(
 	}
 	if bres.DeliverTx.IsErr() {
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
+		io.Println("COMMIT DURATION: ", duration.Milliseconds(), "ms")
 		return errors.Wrap(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
 	}
 
@@ -231,7 +231,7 @@ func ExecSignAndBroadcast(
 	io.Println("HEIGHT:    ", bres.Height)
 	io.Println("EVENTS:    ", string(bres.DeliverTx.EncodeEvents()))
 	io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-	io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
+	io.Println("COMMIT DURATION: ", duration.Milliseconds(), "ms")
 
 	return nil
 }

--- a/tm2/pkg/crypto/keys/client/maketx.go
+++ b/tm2/pkg/crypto/keys/client/maketx.go
@@ -220,7 +220,7 @@ func ExecSignAndBroadcast(
 	}
 	if bres.DeliverTx.IsErr() {
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-		io.Println("EXECUTION TIME: ", duration.Milliseconds(), "ms")
+		io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
 		return errors.Wrap(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
 	}
 
@@ -231,7 +231,7 @@ func ExecSignAndBroadcast(
 	io.Println("HEIGHT:    ", bres.Height)
 	io.Println("EVENTS:    ", string(bres.DeliverTx.EncodeEvents()))
 	io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-	io.Println("EXECUTION TIME: ", duration.Milliseconds(), "ms")
+	io.Println("BROADCAST DURATION: ", duration.Milliseconds(), "ms")
 
 	return nil
 }


### PR DESCRIPTION
The execution time is measured in milliseconds and is printed alongside the transaction details. We also consider adding a flag to control whether this information is printed or not

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
