### PR TITLE
feat: Implementation of a new UI package

### DIFF
--- a/examples/gno.land/p/demo/page_builder/gno.mod
+++ b/examples/gno.land/p/demo/page_builder/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/demo/page_builder

--- a/examples/gno.land/p/demo/page_builder/page_builder.gno
+++ b/examples/gno.land/p/demo/page_builder/page_builder.gno
@@ -1,0 +1,78 @@
+package page_builder
+
+import (
+	"strings"
+)
+
+type HTML struct {
+    content []string
+}
+
+func New() *HTML {
+    return &HTML{}
+}
+
+func (html *HTML) H1(text string) {
+	html.content = append(html.content, "<h1>" + text + "</h1>")
+}
+
+func (html *HTML) H2(text string) {
+	html.content = append(html.content, "<h2>" + text + "</h2>")
+}
+
+func (html *HTML) H3(text string) {
+	html.content = append(html.content, "<h3>" + text + "</h3>")
+}
+
+func (html *HTML) P(text string) {
+	html.content = append(html.content, "<p>" + text + "</p>")
+}
+
+func (html *HTML) UL(items []string) {
+	var listItems []string
+	for _, item := range items {
+		listItems = append(listItems, "<li>" + item + "</li>")
+	}
+	html.content = append(html.content, "<ul>\n" + strings.Join(listItems, "\n") + "\n</ul>")
+}
+
+func (html *HTML) OL(items []string) {
+	var listItems []string
+	for _, item := range items {
+		listItems = append(listItems, "<li>" + item + "</li>")
+	}
+	html.content = append(html.content, "<ol>\n" + strings.Join(listItems, "\n") + "\n</ol>")
+}
+
+// TODO: Implement code highlughting
+func (html *HTML) CodeBlock(code string) {
+	html.content = append(html.content, "<pre><code>" + code + "</code></pre>")
+}
+
+func (html *HTML) Image(src string, alt string) {
+	html.content = append(html.content, `<img src="` + src + `" alt="` + alt + `" />`)
+}
+
+func (html *HTML) Link(href string, text string) {
+	html.content = append(html.content, `<a href="` + href + `">` + text + `</a>`)
+}
+
+func (html *HTML) Bold(text string) string {
+	return "<b>" + text + "</b>"
+}
+
+func (html *HTML) Italic(text string) string {
+	return "<i>" + text + "</i>"
+}
+
+func (html *HTML) Strikethrough(text string) string {
+	return "<s>" + text + "</s>"
+}
+
+func (html *HTML) BreakLine() {
+	html.content = append(html.content, "<br>")
+}
+
+func (html *HTML) Render() string {
+    return strings.Join(html.content, "\n")
+}

--- a/examples/gno.land/p/demo/page_builder/page_builder.gno
+++ b/examples/gno.land/p/demo/page_builder/page_builder.gno
@@ -2,77 +2,113 @@ package page_builder
 
 import (
 	"strings"
+	"strconv"
 )
 
-type HTML struct {
-    content []string
+type Div struct {
+	content     []string
+	numColumns  int
 }
 
-func New() *HTML {
-    return &HTML{}
+func New(numColumns int) *Div {
+	return &Div{numColumns: numColumns}
 }
 
-func (html *HTML) H1(text string) {
-	html.content = append(html.content, "<h1>" + text + "</h1>")
+func wrapInTag(tag, text string) string {
+	return "<" + tag + ">" + text + "</" + tag + ">"
 }
 
-func (html *HTML) H2(text string) {
-	html.content = append(html.content, "<h2>" + text + "</h2>")
+func (div *Div) H1(text string) {
+	div.content = append(div.content, wrapInTag("h1", text))
 }
 
-func (html *HTML) H3(text string) {
-	html.content = append(html.content, "<h3>" + text + "</h3>")
+func (div *Div) H2(text string) {
+	div.content = append(div.content, wrapInTag("h2", text))
 }
 
-func (html *HTML) P(text string) {
-	html.content = append(html.content, "<p>" + text + "</p>")
+func (div *Div) H3(text string) {
+	div.content = append(div.content, wrapInTag("h3", text))
 }
 
-func (html *HTML) UL(items []string) {
+func (div *Div) H4(text string) {
+	div.content = append(div.content, wrapInTag("h4", text))
+}
+
+func (div *Div) H5(text string) {
+	div.content = append(div.content, wrapInTag("h5", text))
+}
+
+func (div *Div) H6(text string) {
+	div.content = append(div.content, wrapInTag("h6", text))
+}
+
+func (div *Div) P(text string) {
+	div.content = append(div.content, wrapInTag("p", text))
+}
+
+func (div *Div) UL(items []string) {
+	listItems := wrapListItems(items)
+	div.content = append(div.content, "<ul>\n" + listItems + "\n</ul>")
+}
+
+func (div *Div) OL(items []string) {
+	listItems := wrapListItems(items)
+	div.content = append(div.content, "<ol>\n" + listItems + "\n</ol>")
+}
+
+func wrapListItems(items []string) string {
 	var listItems []string
 	for _, item := range items {
-		listItems = append(listItems, "<li>" + item + "</li>")
+		listItems = append(listItems, wrapInTag("li", item))
 	}
-	html.content = append(html.content, "<ul>\n" + strings.Join(listItems, "\n") + "\n</ul>")
+	return strings.Join(listItems, "\n")
 }
 
-func (html *HTML) OL(items []string) {
-	var listItems []string
-	for _, item := range items {
-		listItems = append(listItems, "<li>" + item + "</li>")
+func (div *Div) CodeBlock(code string) {
+	div.content = append(div.content, "<pre><code>" + code + "</code></pre>")
+}
+
+func (div *Div) Image(src string, alt string) {
+	div.content = append(div.content, `<img src="` + src + `" alt="` + alt + `" />`)
+}
+
+func (div *Div) Link(href string, text string) string {
+	return `<a href="` + href + `">` + text + `</a>`
+}
+
+func (div *Div) Bold(text string) string {
+	return wrapInTag("b", text)
+}
+
+func (div *Div) Italic(text string) string {
+	return wrapInTag("i", text)
+}
+
+func (div *Div) Strikethrough(text string) string {
+	return wrapInTag("s", text)
+}
+
+func (div *Div) HR() {
+	div.content = append(div.content, "<hr>")
+}
+
+func (div *Div) Append(renderedHTML string) {
+	div.content = append(div.content, renderedHTML)
+}
+
+func (div *Div) Render() string {
+	var out strings.Builder
+
+	if div.numColumns > 1 {
+		out.WriteString("<div class='columns-" + strconv.Itoa(div.numColumns) + "'>\n")
+	} else {
+		out.WriteString("<div class='column'>\n")
 	}
-	html.content = append(html.content, "<ol>\n" + strings.Join(listItems, "\n") + "\n</ol>")
-}
 
-// TODO: Implement code highlughting
-func (html *HTML) CodeBlock(code string) {
-	html.content = append(html.content, "<pre><code>" + code + "</code></pre>")
-}
+	for _, c := range div.content {
+		out.WriteString(c + "\n")
+	}
 
-func (html *HTML) Image(src string, alt string) {
-	html.content = append(html.content, `<img src="` + src + `" alt="` + alt + `" />`)
-}
-
-func (html *HTML) Link(href string, text string) {
-	html.content = append(html.content, `<a href="` + href + `">` + text + `</a>`)
-}
-
-func (html *HTML) Bold(text string) string {
-	return "<b>" + text + "</b>"
-}
-
-func (html *HTML) Italic(text string) string {
-	return "<i>" + text + "</i>"
-}
-
-func (html *HTML) Strikethrough(text string) string {
-	return "<s>" + text + "</s>"
-}
-
-func (html *HTML) BreakLine() {
-	html.content = append(html.content, "<br>")
-}
-
-func (html *HTML) Render() string {
-    return strings.Join(html.content, "\n")
+	out.WriteString("</div>")
+	return out.String()
 }

--- a/examples/gno.land/r/gnoland/home/home.gno
+++ b/examples/gno.land/r/gnoland/home/home.gno
@@ -4,279 +4,124 @@ import (
 	"std"
 
 	"gno.land/p/demo/ownable"
-	"gno.land/p/demo/ufmt"
-	"gno.land/p/demo/ui"
+	"gno.land/p/demo/page_builder"
 	blog "gno.land/r/gnoland/blog"
 	events "gno.land/r/gnoland/events"
 )
 
-// XXX: p/demo/ui API is crappy, we need to make it more idiomatic
-// XXX: use an updatable block system to update content from a DAO
-// XXX: var blocks avl.Tree
+type Link struct {
+	Name string
+	URL  string
+}
 
 var (
 	override string
 	admin    = ownable.NewWithAddress("g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq") // @manfred by default
+
+	aboutLinks = []Link{
+		{"About", "about"},
+		{"GitHub", "https://github.com/gnolang"},
+		{"Blog", "blog"},
+		{"Events", "events"},
+		{"Tokenomics (soon)", ""},
+		{"Partners, Fund, Grants", "partners"},
+		{"Explore the Ecosystem", "ecosystem"},
+		{"Careers", "https://jobs.lever.co/allinbits?department=Gno.land"},
+	}
+
+	buildLinks = []Link{
+		{"Write Gno in the browser", "https://play.gno.land"},
+		{"Read about the Gno Language", "gnolang"},
+		{"Visit the official documentation", "https://docs.gno.land"},
+		{"Gno by Example", "https://gno-by-example.com/"},
+		{"Efficient local development for Gno", "https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev"},
+		{"Get testnet GNOTs", "https://faucet.gno.land"},
+	}
+
+	exploreLinks = []Link{
+		{"Discover demo packages", "https://github.com/gnolang/gno/tree/master/examples"},
+		{"Gnoscan", "https://gnoscan.io"},
+		{"Portal Loop", "https://docs.gno.land/concepts/portal-loop"},
+		{"Testnet 4 (Launched July 2024!)", "https://test4.gno.land/"},
+		{"Testnet 3 (archive)", "https://test3.gno.land/"},
+		{"Testnet 2 (archive)", "https://test2.gno.land/"},
+		{"Testnet Faucet Hub (soon)", ""},
+	}
 )
 
 func Render(_ string) string {
-	if override != "" {
-		return override
-	}
+	body := page_builder.New(1)
+	body.Append(renderIntro())
+	body.Append(renderJumbotron())
+	body.Append(renderEvents())
+	body.HR()
+	body.Append(renderPlayground())
+	body.HR()
+	body.H1("To be continued")
 
-	dom := ui.DOM{Prefix: "r/gnoland/home:"}
-	dom.Title = "Welcome to gno.land"
-	dom.Classes = []string{"gno-tmpl-section"}
-
-	// body
-	dom.Body.Append(introSection()...)
-
-	dom.Body.Append(ui.Jumbotron(discoverLinks()))
-
-	dom.Body.Append(
-		ui.Columns{3, []ui.Element{
-			lastBlogposts(4),
-			upcomingEvents(),
-			lastContributions(4),
-		}},
-	)
-
-	dom.Body.Append(ui.HR{})
-	dom.Body.Append(playgroundSection()...)
-	dom.Body.Append(ui.HR{})
-	dom.Body.Append(packageStaffPicks()...)
-	dom.Body.Append(ui.HR{})
-	dom.Body.Append(worxDAO()...)
-	dom.Body.Append(ui.HR{})
-	// footer
-	dom.Footer.Append(
-		ui.Columns{2, []ui.Element{
-			socialLinks(),
-			quoteOfTheBlock(),
-		}},
-	)
-
-	// Testnet disclaimer
-	dom.Footer.Append(
-		ui.HR{},
-		ui.Bold("This is a testnet."),
-		ui.Text("Package names are not guaranteed to be available for production."),
-	)
-
-	return dom.String()
+	return body.Render()
 }
 
-func lastBlogposts(limit int) ui.Element {
-	posts := blog.RenderLastPostsWidget(limit)
-	return ui.Element{
-		ui.H3("[Latest Blogposts](/r/gnoland/blog)"),
-		ui.Text(posts),
-	}
+func renderIntro() string {
+	container := page_builder.New(1)
+	container.H1("Welcome to gno.land")
+	container.H3("We’re building gno.land, set to become the leading open-source smart contract platform, using Gno, an interpreted and fully deterministic variation of the Go programming language for succinct and composable smart contracts.")
+	container.P("With transparent and timeless code, gno.land is the next generation of smart contract platforms, serving as the “GitHub” of the ecosystem, with realms built using fully transparent, auditable code that anyone can inspect and reuse.")
+	container.P("Intuitive and easy to use, gno.land lowers the barrier to web3 and makes censorship-resistant platforms accessible to everyone. If you want to help lay the foundations of a fairer and freer world, join us today.")
+	return container.Render()
 }
 
-func lastContributions(limit int) ui.Element {
-	return ui.Element{
-		ui.H3("Latest Contributions"),
-		// TODO: import r/gh to
-		ui.Link{Text: "View latest contributions", URL: "https://github.com/gnolang/gno/pulls"},
-	}
+func renderJumbotron() string {
+    jumbotron := page_builder.New(3)
+
+    jumbotron.Append(renderLinkDiv("Learn about gno.land", aboutLinks))
+    jumbotron.Append(renderLinkDiv("Build with Gno", buildLinks))
+    jumbotron.Append(renderLinkDiv("Explore the universe", exploreLinks))
+
+    return jumbotron.Render()
 }
 
-func upcomingEvents() ui.Element {
-	out, _ := events.RenderEventWidget(events.MaxWidgetSize)
-	return ui.Element{
-		ui.H3("[Latest Events](/r/gnoland/events)"),
-		ui.Text(out),
-	}
+func renderLinkDiv(header string, links []Link) string {
+    linkDiv := page_builder.New(1)
+    linkDiv.H3(header)
+    
+    var listItems []string
+    for _, link := range links {
+        listItems = append(listItems, linkDiv.Link(link.URL, link.Name))
+    }
+
+    linkDiv.UL(listItems)
+    return linkDiv.Render()
 }
 
-func introSection() ui.Element {
-	return ui.Element{
-		ui.H3("We’re building gno.land, set to become the leading open-source smart contract platform, using Gno, an interpreted and fully deterministic variation of the Go programming language for succinct and composable smart contracts."),
-		ui.Paragraph("With transparent and timeless code, gno.land is the next generation of smart contract platforms, serving as the “GitHub” of the ecosystem, with realms built using fully transparent, auditable code that anyone can inspect and reuse."),
-		ui.Paragraph("Intuitive and easy to use, gno.land lowers the barrier to web3 and makes censorship-resistant platforms accessible to everyone. If you want to help lay the foundations of a fairer and freer world, join us today."),
-	}
+func renderEvents() string {
+    container := page_builder.New(3)
+
+	blogSection := page_builder.New(1)
+	blogSection.H3(blogSection.Link("/r/gnoland/blog", "Latest Blogposts"))
+	blogSection.Append(blog.RenderLastPostsWidget(4))
+	container.Append(blogSection.Render())
+	
+	eventSection := page_builder.New(1)
+	eventSection.H3(eventSection.Link("/r/gnoland/events", "Latest Events"))
+	eventList, _ := events.RenderEventWidget(events.MaxWidgetSize)
+	eventSection.Append(eventList)
+	container.Append(eventSection.Render())
+
+	contributionSection := page_builder.New(1)
+	contributionSection.H3("Latest Contributions")
+	contributionSection.P(contributionSection.Link("https://github.com/gnolang/gno/pulls", "View latest contributions"))
+	container.Append(contributionSection.Render())
+
+    return container.Render()
 }
 
-func worxDAO() ui.Element {
-	// WorxDAO
-	// XXX(manfred): please, let me finish a v0, then we can iterate
-	// highest level == highest responsibility
-	// teams are responsible for components they don't owne
-	// flag : realm maintainers VS facilitators
-	// teams
-	// committee of trustees to create the directory
-	// each directory is a name, has a parent and have groups
-	// homepage team - blocks aggregating events
-	// XXX: TODO
-	/*`
-	# Directory
-
-	* gno.land (owned by group)
-	  *
-	* gnovm
-	  * gnolang (language)
-	  * gnovm
-	    - current challenges / concerns / issues
-	* tm2
-	  * amino
-	  *
-
-	## Contributors
-	``*/
-	return ui.Element{
-		ui.H3("Contributions (WorxDAO & GoR)"),
-		// TODO: GoR dashboard + WorxDAO topics
-		ui.Text(`coming soon`),
-	}
-}
-
-func quoteOfTheBlock() ui.Element {
-	quotes := []string{
-		"Gno is for Truth.",
-		"Gno is for Social Coordination.",
-		"Gno is _not only_ for DeFi.",
-		"Now, you Gno.",
-		"Come for the Go, Stay for the Gno.",
-	}
-	height := std.GetHeight()
-	idx := int(height) % len(quotes)
-	qotb := quotes[idx]
-
-	return ui.Element{
-		ui.H3(ufmt.Sprintf("Quote of the ~Day~ Block#%d", height)),
-		ui.Quote(qotb),
-	}
-}
-
-func socialLinks() ui.Element {
-	return ui.Element{
-		ui.H3("Socials"),
-		ui.BulletList{
-			// XXX: improve UI to support a nice GO api for such links
-			ui.Text("Check out our [community projects](https://github.com/gnolang/awesome-gno)"),
-			ui.Text("![Discord](static/img/ico-discord.svg) [Discord](https://discord.gg/S8nKUqwkPn)"),
-			ui.Text("![Twitter](static/img/ico-twitter.svg) [Twitter](https://twitter.com/_gnoland)"),
-			ui.Text("![Youtube](static/img/ico-youtube.svg) [Youtube](https://www.youtube.com/@_gnoland)"),
-			ui.Text("![Telegram](static/img/ico-telegram.svg) [Telegram](https://t.me/gnoland)"),
-		},
-	}
-}
-
-func playgroundSection() ui.Element {
-	return ui.Element{
-		ui.H3("[Gno Playground](https://play.gno.land)"),
-		ui.Paragraph(`Gno Playground is a web application designed for building, running, testing, and interacting
-with your Gno code, enhancing your understanding of the Gno language. With Gno Playground, you can share your code,
-execute tests, deploy your realms and packages to gno.land, and explore a multitude of other features.`),
-		ui.Paragraph("Experience the convenience of code sharing and rapid experimentation with [Gno Playground](https://play.gno.land)."),
-	}
-}
-
-func packageStaffPicks() ui.Element {
-	// XXX: make it modifiable from a DAO
-	return ui.Element{
-		ui.H3("Explore New Packages and Realms"),
-		ui.Columns{
-			3,
-			[]ui.Element{
-				{
-					ui.H4("[r/gnoland](https://github.com/gnolang/gno/tree/master/examples/gno.land/r/gnoland)"),
-					ui.BulletList{
-						ui.Link{URL: "r/gnoland/blog"},
-						ui.Link{URL: "r/gnoland/dao"},
-						ui.Link{URL: "r/gnoland/faucet"},
-						ui.Link{URL: "r/gnoland/home"},
-						ui.Link{URL: "r/gnoland/pages"},
-					},
-					ui.H4("[r/sys](https://github.com/gnolang/gno/tree/master/examples/gno.land/r/sys)"),
-					ui.BulletList{
-						ui.Link{URL: "r/sys/names"},
-						ui.Link{URL: "r/sys/rewards"},
-						ui.Link{URL: "r/sys/validators"},
-					},
-				}, {
-					ui.H4("[r/demo](https://github.com/gnolang/gno/tree/master/examples/gno.land/r/demo)"),
-					ui.BulletList{
-						ui.Link{URL: "r/demo/boards"},
-						ui.Link{URL: "r/demo/users"},
-						ui.Link{URL: "r/demo/banktest"},
-						ui.Link{URL: "r/demo/foo20"},
-						ui.Link{URL: "r/demo/foo721"},
-						ui.Link{URL: "r/demo/microblog"},
-						ui.Link{URL: "r/demo/nft"},
-						ui.Link{URL: "r/demo/types"},
-						ui.Link{URL: "r/demo/art/gnoface"},
-						ui.Link{URL: "r/demo/art/millipede"},
-						ui.Link{URL: "r/demo/groups"},
-						ui.Text("..."),
-					},
-				}, {
-					ui.H4("[p/demo](https://github.com/gnolang/gno/tree/master/examples/gno.land/p/demo)"),
-					ui.BulletList{
-						ui.Link{URL: "p/demo/avl"},
-						ui.Link{URL: "p/demo/blog"},
-						ui.Link{URL: "p/demo/ui"},
-						ui.Link{URL: "p/demo/ufmt"},
-						ui.Link{URL: "p/demo/merkle"},
-						ui.Link{URL: "p/demo/bf"},
-						ui.Link{URL: "p/demo/flow"},
-						ui.Link{URL: "p/demo/gnode"},
-						ui.Link{URL: "p/demo/grc/grc20"},
-						ui.Link{URL: "p/demo/grc/grc721"},
-						ui.Text("..."),
-					},
-				},
-			},
-		},
-	}
-}
-
-func discoverLinks() ui.Element {
-	return ui.Element{
-		ui.Text(`<div class="columns-3">
-<div class="column">
-
-### Learn about gno.land
-
-- [About](/about)
-- [GitHub](https://github.com/gnolang)
-- [Blog](/blog)
-- [Events](/events)
-- Tokenomics (soon)
-- [Partners, Fund, Grants](/partners)
-- [Explore the Ecosystem](/ecosystem)
-- [Careers](https://jobs.lever.co/allinbits?department=Gno.land)
-
-</div><!-- end column-->
-
-<div class="column">
-
-### Build with Gno
-
-- [Write Gno in the browser](https://play.gno.land)
-- [Read about the Gno Language](/gnolang)
-- [Visit the official documentation](https://docs.gno.land)
-- [Gno by Example](https://gno-by-example.com/)
-- [Efficient local development for Gno](https://docs.gno.land/gno-tooling/cli/gno-tooling-gnodev)
-- [Get testnet GNOTs](https://faucet.gno.land)
-
-</div><!-- end column-->
-<div class="column">
-
-### Explore the universe
-
-- [Discover demo packages](https://github.com/gnolang/gno/tree/master/examples)
-- [Gnoscan](https://gnoscan.io)
-- [Portal Loop](https://docs.gno.land/concepts/portal-loop)
-- [Testnet 4](https://test4.gno.land/) (Launched July 2024!)
-- [Testnet 3](https://test3.gno.land/) (archive)
-- [Testnet 2](https://test2.gno.land/) (archive)
-- Testnet Faucet Hub (soon)
-
-</div><!-- end column-->
-</div><!-- end columns-3-->`),
-	}
+func renderPlayground() string {
+	container := page_builder.New(1)
+	container.H3(container.Link("https://play.gno.land/", "Gno Playground"))
+	container.P("Gno Playground is a web application designed for building, running, testing, and interacting with your Gno code, enhancing your understanding of the Gno language. With Gno Playground, you can share your code, execute tests, deploy your realms and packages to gno.land, and explore a multitude of other features.")
+	container.P("Experience the convenience of code sharing and rapid experimentation with " + container.Link("https://play.gno.land", "Gno Playground."))
+	return container.Render()
 }
 
 func AdminSetOverride(content string) {


### PR DESCRIPTION
This PR (Respone to #2753) introduces the `page_builder` library, which replaces the existing "ui" library with a more idiomatic and efficient Gno API for building pages on gnoweb.

The `page_builder` library allows developers to create structured web pages by first instantiating a Div element, specifying the number of columns. Afterward, functions such as H1, P, Image, and others are called to build the content. Once the page structure is defined, the Render() function is called, which returns well-formatted HTML, bypassing markdown for greater efficiency. Additionally, the library supports markdown elements via the Append function, providing flexibility to include both HTML and markdown content.

### Basic usage of this package:

```go
func Render(_ string){
    pd := page_builder.New(1)
    pd.H1("This is a demo!")
    return pd.Render()
}
```

Following advice from [leon's comment](https://github.com/gnolang/gno/issues/2753#issuecomment-2338748841), this PR includes a partial implementation of the gno.land/home realm as a showcase. In this example, the Append function successfully renders both HTML and markdown elements, demonstrating the library's versatility in real-world projects.

The implementation of home realm isn't 1:1 with the original, but it is meant to be a simple showcase and it can be improved with some more time.

![image](https://github.com/user-attachments/assets/a65853c5-075b-4261-ba5c-d54820338949)
