### PR TITLE
docs: updated missing gnofaucet README

### DIFF
--- a/contribs/gnofaucet/README.md
+++ b/contribs/gnofaucet/README.md
@@ -1,0 +1,25 @@
+# Start a local faucet
+
+## Step1:
+
+Make sure you have started gnoland
+    
+    ../../gno.land/build/gnoland start -lazy
+
+## Step2:
+
+Start the faucet.
+
+    ./build/gnofaucet serve -chain-id dev -mnemonic "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+
+By default, the faucet sends out 10,000,000ugnot (10gnot) per request. 
+
+## Step3:
+
+Make sure you have started website
+
+    ../../gno.land/build/gnoweb
+
+Request testing tokens from following URL, Have fun!
+
+    http://localhost:8888/faucet

--- a/examples/gno.land/r/demo/boards/README.md
+++ b/examples/gno.land/r/demo/boards/README.md
@@ -58,7 +58,8 @@ your `ACCOUNT_ADDR` and `KEYNAME`
 
 Instead of editing `gno.land/genesis/genesis_balances.txt`, a more general solution (with more steps)
 is to run a local "faucet" and use the web browser to add $GNOT. (This can be done at any time.)
-See this page: https://github.com/gnolang/gno/blob/master/gno.land/cmd/gnofaucet/README.md
+See this page: https://github.com/gnolang/gno/blob/master/contribs/gnofaucet/README.md
+
 
 ### Start the `gnoland` node.
 


### PR DESCRIPTION
The quickstart guide on the gno README had outdated gnofaucet information:
https://github.com/gnolang/gno/blob/master/examples/gno.land/r/demo/boards/README.md#alternative-run-a-faucet-to-add-gnot

Refactored and updated the orphaned gnofaucet README from:
https://github.com/gnolang/gno/blob/98cc986cbeb4d911944711a102334eb5d0cb4727/gno.land/cmd/gnofaucet/README.md

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
