### PR TITLE
chore: put collective ownership on most CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 
 # GnoVM/Gnolang.
 /gnovm/                       @gnolang/tech-staff
-/gnovm/stdlibs/               @thehowl
+/gnovm/stdlibs/               @gnolang/tech-staff @thehowl
 /gnovm/pkg/gnolang/           @gnolang/tech-staff @jaekwon
 /gnovm/pkg/doc/               @thehowl
 /gnovm/pkg/repl/              @mvertes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,22 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
+# This file marks who is the "owner" of several files and directory on this GitHub
+# repository. This is mostly used to assign reviews on new PRs.
+#
+# - Directories and files which are assigned to a team should be interepreted as
+#   "collectively owned". GitHub will automatically assign members of the team
+#   to review the PR, in a round-robin fashion.
+# - Directories and files which are owned by one specific user X are to be
+#   interpreted as "primarily maintained by X". Any significant changes to
+#   that given code should be reviewed by X; as if it were another repository
+#   where X is the primary developer. However, ownership here can be ignored if
+#   it arises as a result of refactorings, or other very minor changes to that
+#   specific code.
+# - Directories and files which are owned by a team, and followed by a specific
+#   user Y, are to be interpreted as collectively owned by the team, but where Y
+#   is the main stakeholder in that directory, and should be involved for any
+#   significant changes to ensure alignment with the vision.
+#
+# The list and guidelines are non-definitive and in flux. Use your best judgement.
 
 # Primary repo maintainers.
 *                             @gnolang/tech-staff

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,12 @@
 #   where X is the primary developer. However, ownership here can be ignored if
 #   it arises as a result of refactorings, or other very minor changes to that
 #   specific code.
+#   Directories and files owned by one specific user should be for components
+#   that are somewhat decoupled from the rest of the codebase.
 # - Directories and files which are owned by a team, and followed by a specific
 #   user Y, are to be interpreted as collectively owned by the team, but where Y
 #   is the main stakeholder in that directory, and should be involved for any
-#   significant changes to ensure alignment with the vision.
+#   significant changes to ensure alignment with the original vision.
 #
 # The list and guidelines are non-definitive and in flux. Use your best judgement.
 
@@ -69,10 +71,10 @@
 /gnovm/                       @gnolang/tech-staff
 /gnovm/stdlibs/               @gnolang/tech-staff @thehowl
 /gnovm/pkg/gnolang/           @gnolang/tech-staff @jaekwon
-/gnovm/pkg/doc/               @thehowl
-/gnovm/pkg/repl/              @mvertes
-/gnovm/pkg/transpiler/        @thehowl
-/gnovm/pkg/integration/       @gfanton
+/gnovm/pkg/doc/               @gnolang/tech-staff @thehowl
+/gnovm/pkg/repl/              @gnolang/tech-staff @mvertes
+/gnovm/pkg/transpiler/        @gnolang/tech-staff @thehowl
+/gnovm/pkg/integration/       @gnolang/tech-staff @gfanton
 
 # Contribs
 /contribs/                    @gnolang/tech-staff

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,5 +92,5 @@
 /CONTRIBUTING.md              @gnolang/tech-staff @moul
 /LICENSE.md                   @jaekwon
 /.github/                     @gnolang/tech-staff
-/.github/workflows            @gnolang/tech-staff
+/.github/workflows            @gnolang/devops
 /.github/CODEOWNERS           @jaekwon @moul

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,26 +4,24 @@
 *                             @gnolang/tech-staff
 
 # Tendermint2.
-/tm2/                         @jaekwon @moul @piux2 @zivkovicmilos
-/tm2/pkg/crypto/              @jaekwon @moul @gnolang/security
-/tm2/pkg/crypto/keys/client/  @jaekwon @gnolang/security
-/tm2/pkg/db/                  @ajnavarro
+/tm2/                         @gnolang/tech-staff
+/tm2/pkg/crypto/              @gnolang/tech-staff @gnolang/security
+/tm2/pkg/crypto/keys/client/  @gnolang/tech-staff @gnolang/security @jaekwon
 # TODO: add per package exceptions
 # ...
 
 # Docs & Content.
-/docs/                        @moul
+/docs/                        @gnolang/devrels
 /docs/**.md                   @gnolang/devrels
 /docs/**.gif                  @gnolang/devrels
 /docs/Makefile                @gnolang/devrels
-/README.md                    @moul @gnolang/devrels
+/README.md                    @gnolang/devrels @moul
 /**/README.md                 @gnolang/devrels
 /.gitpod.yml                  @gnolang/devrels
 
 # Gno examples and default contracts.
 /examples/                            @gnolang/tech-staff @gnolang/devrels
 /examples/gno.land/p/demo/            @gnolang/tech-staff @gnolang/devrels
-/examples/gno.land/p/demo/avl/        @jaekwon
 /examples/gno.land/p/demo/bf/         @moul
 /examples/gno.land/p/demo/blog/       @gnolang/devrels
 /examples/gno.land/p/demo/cford32/    @thehowl
@@ -34,7 +32,6 @@
 /examples/gno.land/p/demo/svg/        @moul
 /examples/gno.land/p/demo/tamagotchi/ @moul
 /examples/gno.land/p/demo/ui/         @moul
-/examples/gno.land/r/demo/            @gnolang/tech-staff @gnolang/devrels
 /examples/gno.land/r/demo/art/        @moul
 /examples/gno.land/r/demo/memeland/   @leohhhn
 /examples/gno.land/r/demo/tamagotchi/ @moul
@@ -43,32 +40,19 @@
 /examples/gno.land/r/sys/             @moul
 /examples/gno.land/r/jaekwon/         @jaekwon
 /examples/gno.land/r/manfred/         @moul
+/examples/gno.land/r/morgan/          @thehowl
 
 # Gno.land.
-/gno.land/                    @moul @zivkovicmilos
-/gno.land/cmd/genesis/        @zivkovicmilos
-/gno.land/cmd/gnokey/         @jaekwon @moul @gfanton
-/gno.land/cmd/gnoland/        @zivkovicmilos @gnolang/devops
-/gno.land/cmd/gnoweb/         @gfanton @thehowl
-/gno.land/pkg/gnoclient/      @zivkovicmilos @leohhhn @gfanton
-/gno.land/pkg/gnoland/        @zivkovicmilos @gfanton
-/gno.land/pkg/keyscli/        @jaekwon @moul @gfanton
-/gno.land/pkg/log/            @zivkovicmilos @gfanton
-/gno.land/pkg/sdk/vm/         @moul @gfanton @thehowl
-/gno.land/pkg/integration/    @gfanton
+/gno.land/                    @gnolang/tech-staff
 /gno.land/genesis/            @moul
 #...
 
 # GnoVM/Gnolang.
-/gnovm/                       @jaekwon @moul @piux2 @thehowl
+/gnovm/                       @gnolang/tech-staff
 /gnovm/stdlibs/               @thehowl
-/gnovm/tests/                 @jaekwon @deelawn @thehowl @mvertes
-/gnovm/cmd/gno/               @moul @thehowl
-/gnovm/pkg/gnolang/           @jaekwon @moul @piux2 @deelawn
+/gnovm/pkg/gnolang/           @gnolang/tech-staff @jaekwon
 /gnovm/pkg/doc/               @thehowl
-/gnovm/pkg/repl/              @mvertes @ajnavarro
-/gnovm/pkg/gnomod/            @thehowl
-/gnovm/pkg/gnoenv/            @gfanton
+/gnovm/pkg/repl/              @mvertes
 /gnovm/pkg/transpiler/        @thehowl
 /gnovm/pkg/integration/       @gfanton
 
@@ -80,16 +64,15 @@
 
 # Misc
 /misc/                        @gnolang/tech-staff
-/misc/loop/                   @moul @gnolang/devops
-/misc/deployments/            @moul @gnolang/devops
+/misc/loop/                   @gnolang/devops
+/misc/deployments/            @gnolang/devops
 /misc/genstd/                 @thehowl
 
 # Special files.
 /PLAN.md                      @jaekwon @moul
 /PHILOSOPHY.md                @jaekwon
-/CONTRIBUTING.md              @jaekwon @moul @gnolang/tech-staff
+/CONTRIBUTING.md              @gnolang/tech-staff @moul
 /LICENSE.md                   @jaekwon
-/.github/                     @moul @gnolang/tech-staff
-/.github/workflows            @ajnavarro @moul
+/.github/                     @gnolang/tech-staff
+/.github/workflows            @gnolang/tech-staff
 /.github/CODEOWNERS           @jaekwon @moul
-/go.mod                       @gnolang/tech-staff # no unnecessary dependencies


### PR DESCRIPTION
This PR comes following a discussion in today's "review meeting", where we talked about our current approach to ownership.

One aspect which was talked about was that the current set-up for CODEOWNERS is very "noisy". Opening up a PR often entails tagging many people and teams for review. To try to overcome this, I removed most rules which tried to find "exact people" to own a piece of the code, in favour of collective ownership on the `tech-staff`, `security`, `devrels` and `devops` teams, depending on which part of the code is interested.

I wrote a few lines explaining the differences between assigning a directory to a team, a person, or a team + person, and how the CODEOWNERS file should be interpreted. I wrote them trying to match the practical implications of the CODEOWNERS file (= who gets picked in the requested reviewers) with the "social" / organizational implications.