### PR TITLE
test(gnovm): run initStaticBlocks in BenchmarkPreprocess

### DIFF
--- a/gnovm/pkg/gnolang/gno_test.go
+++ b/gnovm/pkg/gnolang/gno_test.go
@@ -179,7 +179,7 @@ func BenchmarkIfStatement(b *testing.B) {
 func main() {
 	for i:=0; i<10000; i++ {
 		if i > 10 {
-			
+
 		}
 	}
 }`
@@ -356,6 +356,7 @@ func BenchmarkPreprocess(b *testing.B) {
 			Inc("i"),
 		),
 	))
+	pn := NewPackageNode("hey", "gno.land/p/hey", nil)
 	copies := make([]*FuncDecl, b.N)
 	for i := 0; i < b.N; i++ {
 		copies[i] = main.Copy().(*FuncDecl)
@@ -363,6 +364,8 @@ func BenchmarkPreprocess(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		// initStaticBlocks is always performed before a Preprocess
+		initStaticBlocks(nil, pn, copies[i])
 		main = Preprocess(nil, pkg, copies[i]).(*FuncDecl)
 	}
 }


### PR DESCRIPTION
fixes #2711

The bug in the benchmark was introduced in #2418, which requires to run initStaticBlocks before running Preprocess, in most cases. (in normal scenarios, this is run by PredefineFileSet; however this benchmark is deep into the internals).

Related: #2716. cc/ @sw360cab 

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
