### PR TITLE
fix(grc20): remove unused interface, fix typo

### DIFF
--- a/examples/gno.land/p/demo/grc/grc20/token.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token.gno
@@ -2,14 +2,12 @@ package grc20
 
 import (
 	"std"
-
-	"gno.land/p/demo/grc/exts"
 )
 
 // token implements the Token interface.
 //
 // It is generated with Banker.Token().
-// It can safely be explosed publicly.
+// It can safely be exposed publicly.
 type token struct {
 	banker *Banker
 }
@@ -44,45 +42,4 @@ func (t *token) TransferFrom(from, to std.Address, amount uint64) error {
 		return err
 	}
 	return t.banker.Transfer(from, to, amount)
-}
-
-type Token2 interface {
-	exts.TokenMetadata
-
-	// Returns the amount of tokens in existence.
-	TotalSupply() uint64
-
-	// Returns the amount of tokens owned by `account`.
-	BalanceOf(account std.Address) uint64
-
-	// Moves `amount` tokens from the caller's account to `to`.
-	//
-	// Returns an error if the operation failed.
-	Transfer(to std.Address, amount uint64) error
-
-	// Returns the remaining number of tokens that `spender` will be
-	// allowed to spend on behalf of `owner` through {transferFrom}. This is
-	// zero by default.
-	//
-	// This value changes when {approve} or {transferFrom} are called.
-	Allowance(owner, spender std.Address) uint64
-
-	// Sets `amount` as the allowance of `spender` over the caller's tokens.
-	//
-	// Returns an error if the operation failed.
-	//
-	// IMPORTANT: Beware that changing an allowance with this method brings the risk
-	// that someone may use both the old and the new allowance by unfortunate
-	// transaction ordering. One possible solution to mitigate this race
-	// condition is to first reduce the spender's allowance to 0 and set the
-	// desired value afterwards:
-	// https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-	Approve(spender std.Address, amount uint64) error
-
-	// Moves `amount` tokens from `from` to `to` using the
-	// allowance mechanism. `amount` is then deducted from the caller's
-	// allowance.
-	//
-	// Returns an error if the operation failed.
-	TransferFrom(from, to std.Address, amount uint64) error
 }


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

This PR removes a duplicate, unused interface from the GRC20 package, and fixes a typo.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
- [x Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
