### PR TITLE
fix(tm2/iavl/benchmarks): skip benchmarks that run for too long

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -12,10 +12,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gnolang/overflow"
+
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/store"
-	"github.com/gnolang/overflow"
 )
 
 // Exception represents a panic that originates from a gno program.
@@ -2216,6 +2217,10 @@ func (m *Machine) String() string {
 
 	for i := len(m.Blocks) - 1; i > 0; i-- {
 		b := m.Blocks[i]
+		if b == nil {
+			continue
+		}
+
 		gen := builder.Len()/3 + 1
 		gens := "@" // strings.Repeat("@", gen)
 

--- a/tm2/pkg/iavl/benchmarks/bench_test.go
+++ b/tm2/pkg/iavl/benchmarks/bench_test.go
@@ -170,9 +170,14 @@ func BenchmarkMedium(b *testing.B) {
 }
 
 func BenchmarkLarge(b *testing.B) {
+	b.Skip("large is too large")
+
 	ls := db.BackendList()
 	bs := make([]benchmark, 0, len(ls))
 	for _, backend := range ls {
+		if backend == db.BoltDBBackend {
+			continue
+		}
 		bs = append(bs, benchmark{backend, 1_000_000, 100, 16, 40})
 	}
 	runBenchmarks(b, bs)


### PR DESCRIPTION
Fixing some benchmarks that were failing after activating benchmark runs at PRs and master.
