### PR TITLE
fix(tm2): Improve hash comparison messages in consensus error handling

### DIFF
--- a/tm2/pkg/bft/state/validation.go
+++ b/tm2/pkg/bft/state/validation.go
@@ -63,31 +63,31 @@ func validateBlock(stateDB dbm.DB, state State, block *types.Block) error {
 
 	// Validate app info
 	if !bytes.Equal(block.AppHash, state.AppHash) {
-		return fmt.Errorf("wrong Block.Header.AppHash.  Expected %X, got %v",
+		return fmt.Errorf("wrong Block.Header.AppHash.  Expected %X, got %X",
 			state.AppHash,
 			block.AppHash,
 		)
 	}
 	if !bytes.Equal(block.ConsensusHash, state.ConsensusParams.Hash()) {
-		return fmt.Errorf("wrong Block.Header.ConsensusHash.  Expected %X, got %v",
+		return fmt.Errorf("wrong Block.Header.ConsensusHash.  Expected %X, got %X",
 			state.ConsensusParams.Hash(),
 			block.ConsensusHash,
 		)
 	}
 	if !bytes.Equal(block.LastResultsHash, state.LastResultsHash) {
-		return fmt.Errorf("wrong Block.Header.LastResultsHash.  Expected %X, got %v",
+		return fmt.Errorf("wrong Block.Header.LastResultsHash.  Expected %X, got %X",
 			state.LastResultsHash,
 			block.LastResultsHash,
 		)
 	}
 	if !bytes.Equal(block.ValidatorsHash, state.Validators.Hash()) {
-		return fmt.Errorf("wrong Block.Header.ValidatorsHash.  Expected %X, got %v",
+		return fmt.Errorf("wrong Block.Header.ValidatorsHash.  Expected %X, got %X",
 			state.Validators.Hash(),
 			block.ValidatorsHash,
 		)
 	}
 	if !bytes.Equal(block.NextValidatorsHash, state.NextValidators.Hash()) {
-		return fmt.Errorf("wrong Block.Header.NextValidatorsHash.  Expected %X, got %v",
+		return fmt.Errorf("wrong Block.Header.NextValidatorsHash.  Expected %X, got %X",
 			state.NextValidators.Hash(),
 			block.NextValidatorsHash,
 		)

--- a/tm2/pkg/bft/state/validation_test.go
+++ b/tm2/pkg/bft/state/validation_test.go
@@ -1,9 +1,11 @@
 package state_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/bft/mempool/mock"
@@ -29,51 +31,125 @@ func TestValidateBlockHeader(t *testing.T) {
 	blockExec := sm.NewBlockExecutor(stateDB, log.NewTestingLogger(t), proxyApp.Consensus(), mock.Mempool{})
 	lastCommit := types.NewCommit(types.BlockID{}, nil)
 
-	// some bad values
+	validHash := tmhash.Sum([]byte("this hash is valid"))
 	wrongHash := tmhash.Sum([]byte("this hash is wrong"))
+
+	wrongAddress := ed25519.GenPrivKey().PubKey().Address()
+	invalidAddress := crypto.Address{}
 
 	// Manipulation of any header field causes failure.
 	testCases := []struct {
 		name          string
 		malleateBlock func(block *types.Block)
+		expectedError string
 	}{
-		{"BlockVersion wrong", func(block *types.Block) { block.Version += "-wrong" }},
-		{"AppVersion wrong", func(block *types.Block) { block.AppVersion += "-wrong" }},
-		{"ChainID wrong", func(block *types.Block) { block.ChainID = "not-the-real-one" }},
-		{"Height wrong", func(block *types.Block) { block.Height += 10 }},
-		{"Time wrong", func(block *types.Block) { block.Time = block.Time.Add(-time.Second * 1) }},
-		{"NumTxs wrong", func(block *types.Block) { block.NumTxs += 10 }},
-		{"TotalTxs wrong", func(block *types.Block) { block.TotalTxs += 10 }},
-
-		{"LastBlockID wrong", func(block *types.Block) { block.LastBlockID.PartsHeader.Total += 10 }},
-		{"LastCommitHash wrong", func(block *types.Block) { block.LastCommitHash = wrongHash }},
-		{"DataHash wrong", func(block *types.Block) { block.DataHash = wrongHash }},
-
-		{"ValidatorsHash wrong", func(block *types.Block) { block.ValidatorsHash = wrongHash }},
-		{"NextValidatorsHash wrong", func(block *types.Block) { block.NextValidatorsHash = wrongHash }},
-		{"ConsensusHash wrong", func(block *types.Block) { block.ConsensusHash = wrongHash }},
-		{"AppHash wrong", func(block *types.Block) { block.AppHash = wrongHash }},
-		{"LastResultsHash wrong", func(block *types.Block) { block.LastResultsHash = wrongHash }},
-
-		{"Proposer wrong", func(block *types.Block) { block.ProposerAddress = ed25519.GenPrivKey().PubKey().Address() }},
-		{"Proposer invalid", func(block *types.Block) { block.ProposerAddress = crypto.Address{} /* zero */ }},
+		{
+			"BlockVersion wrong",
+			func(block *types.Block) { block.Version += "-wrong" },
+			"wrong Block.Header.Version",
+		},
+		{
+			"AppVersion wrong",
+			func(block *types.Block) { block.AppVersion += "-wrong" },
+			"wrong Block.Header.AppVersion",
+		},
+		{
+			"ChainID wrong",
+			func(block *types.Block) { block.ChainID = "not-the-real-one" },
+			"wrong Block.Header.ChainID",
+		},
+		{
+			"Height wrong",
+			func(block *types.Block) { block.Height += 10 },
+			"",
+		},
+		{
+			"Time wrong",
+			func(block *types.Block) { block.Time = block.Time.Add(-time.Second * 1) },
+			"",
+		},
+		{
+			"NumTxs wrong",
+			func(block *types.Block) { block.NumTxs += 10 },
+			"wrong Header.NumTxs",
+		},
+		{
+			"TotalTxs wrong",
+			func(block *types.Block) { block.TotalTxs += 10 },
+			"wrong Block.Header.TotalTxs",
+		},
+		{
+			"LastBlockID wrong",
+			func(block *types.Block) { block.LastBlockID.PartsHeader.Total += 10 },
+			"wrong Block.Header.LastBlockID",
+		},
+		{
+			"LastCommitHash wrong",
+			func(block *types.Block) { block.LastCommitHash = wrongHash },
+			"wrong Header.LastCommitHash",
+		},
+		{
+			"DataHash wrong",
+			func(block *types.Block) { block.DataHash = wrongHash },
+			"wrong Header.DataHash",
+		},
+		{
+			"ValidatorsHash wrong",
+			func(block *types.Block) { block.ValidatorsHash = wrongHash },
+			"wrong Block.Header.ValidatorsHash",
+		},
+		{
+			"NextValidatorsHash wrong",
+			func(block *types.Block) { block.NextValidatorsHash = wrongHash },
+			"wrong Block.Header.NextValidatorsHash",
+		},
+		{
+			"ConsensusHash wrong",
+			func(block *types.Block) { block.ConsensusHash = wrongHash },
+			"wrong Block.Header.ConsensusHash",
+		},
+		{
+			"AppHash mismatch",
+			func(block *types.Block) { block.AppHash = wrongHash },
+			fmt.Sprintf("wrong Block.Header.AppHash.  Expected %X, got %X", validHash, wrongHash),
+		},
+		{
+			"LastResultsHash wrong",
+			func(block *types.Block) { block.LastResultsHash = wrongHash },
+			fmt.Sprintf("wrong Block.Header.LastResultsHash.  Expected %X, got %X", validHash, wrongHash),
+		},
+		{
+			"Proposer wrong",
+			func(block *types.Block) { block.ProposerAddress = wrongAddress },
+			fmt.Sprintf("Block.Header.ProposerAddress, %X, is not a validator", wrongAddress),
+		},
+		{
+			"Proposer invalid",
+			func(block *types.Block) { block.ProposerAddress = invalidAddress /* zero */ },
+			fmt.Sprintf("Block.Header.ProposerAddress, %X, is not a validator", invalidAddress),
+		},
 	}
 
 	// Build up state for multiple heights
 	for height := int64(1); height < validationTestsStopHeight; height++ {
 		proposerAddr := state.Validators.GetProposer().Address
+		state.AppHash = validHash
+		state.LastResultsHash = validHash
+
 		/*
-			Invalid blocks don't pass
+		   Invalid blocks don't pass
 		*/
 		for _, tc := range testCases {
-			block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, proposerAddr)
-			tc.malleateBlock(block)
-			err := blockExec.ValidateBlock(state, block)
-			require.Error(t, err, tc.name)
+			t.Run(tc.name, func(t *testing.T) {
+				block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, proposerAddr)
+				tc.malleateBlock(block)
+				err := blockExec.ValidateBlock(state, block)
+				assert.ErrorContains(t, err, tc.expectedError, tc.name)
+			})
 		}
 
 		/*
-			A good block passes
+		   A good block passes
 		*/
 		var err error
 		state, _, lastCommit, err = makeAndCommitGoodBlock(state, height, lastCommit, proposerAddr, blockExec, privVals)

--- a/tm2/pkg/bft/state/validation_test.go
+++ b/tm2/pkg/bft/state/validation_test.go
@@ -140,12 +140,10 @@ func TestValidateBlockHeader(t *testing.T) {
 		   Invalid blocks don't pass
 		*/
 		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, proposerAddr)
-				tc.malleateBlock(block)
-				err := blockExec.ValidateBlock(state, block)
-				assert.ErrorContains(t, err, tc.expectedError, tc.name)
-			})
+			block, _ := state.MakeBlock(height, makeTxs(height), lastCommit, proposerAddr)
+			tc.malleateBlock(block)
+			err := blockExec.ValidateBlock(state, block)
+			assert.ErrorContains(t, err, tc.expectedError, tc.name)
 		}
 
 		/*


### PR DESCRIPTION
Relates to https://github.com/gnolang/gno/issues/2773

**Description:**  
This PR enhances the error messaging in the **validateBlock** function by formatting the hash values as a hexadecimal string instead of a byte array. This change improves readability during consensus failures
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
