### PR TITLE
fix(gnoweb): show contents of source when javascript is disabled

### DIFF
--- a/gno.land/pkg/gnoweb/views/funcs.html
+++ b/gno.land/pkg/gnoweb/views/funcs.html
@@ -94,7 +94,7 @@
 <meta property="og:description" content="{{ .Data.Description }}" />
 <noscript>
   <style type="text/css">
-    #source { display: block; }
+    #source { opacity: 1; }
     #theme-toggle { display: none; }
   </style>
 </noscript>


### PR DESCRIPTION
new result:

![image](https://github.com/user-attachments/assets/8bc4c7bc-e500-4f99-9787-dfcb376a30ea)

it wasn't working because the css in app.css was changed from `display: none` to `opacity: 0`.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
