### PR TITLE
feat: Add Search Bar with Filter Functionality to Gnoweb

### DIFF
--- a/gno.land/pkg/gnoweb/static/css/app.css
+++ b/gno.land/pkg/gnoweb/static/css/app.css
@@ -33,31 +33,64 @@
   }
   
 /* ############################################## SEARCH-BAR AND ICON */
+
 .text-Area {
   display: none;
-  width: 10em;
-  height: 30px;
-  background-color: var(--border-color);
+  width: 100%;
+  max-width: 20em;
+  height: 35px;
+  background-color: var(--background-color, #f9f9f9);
   border-radius: 5px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-color, #ccc);
   z-index: 1;
   position: relative;
-  padding: 5px;
-  color: white;
+  padding: 8px;
+  color: var(--text-color, #333);
   margin-right: 2rem;
+  font-size: 1em;
+  transition: all 0.3s ease-in-out;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  }
+ .text-Area:hover {
+  border-color: var(--hover-border-color, #888);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
 }
+
+.text-Area:focus {
+  outline: none;
+  border-color: var(--focus-border-color, #007bff);
+  background-color: var(--focus-background-color, #fff);
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+/* Placeholder styling */
+.text-Area::placeholder {
+  color: var(--placeholder-color, #aaa);
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .text-Area {
+  width: 90%;
+  margin-right: 1rem;
+  }
+}
+
 .search-icon {
-  width: 24px;
-  height: 24px;
+  width: 40px;
+  height: 40px;
   cursor: pointer;
   display: block;
+  border-color: white;
+  background-color: var(--docsearch-searchbox-background);
 }
+
 .text-Area.show {
   display: block;
 }
 .searchDiv {
-  width: max-content;
-  padding-right: 20px;
+  width: fit-content;
+  padding: .6rem;
 }
 
 /*** DARK/LIGHT THEME COLORS ***/

--- a/gno.land/pkg/gnoweb/static/css/app.css
+++ b/gno.land/pkg/gnoweb/static/css/app.css
@@ -32,6 +32,33 @@
     src: local("Roboto Mono Bold Italic"), url("/static/font/roboto/RobotoMono-BoldItalic.woff") format("woff");
   }
   
+/* ############################################## SEARCH-BAR AND ICON */
+.text-Area {
+  display: none;
+  width: 10em;
+  height: 30px;
+  background-color: var(--border-color);
+  border-radius: 5px;
+  border: 1px solid var(--border-color);
+  z-index: 1;
+  position: relative;
+  padding: 5px;
+  color: white;
+  margin-right: 2rem;
+}
+.search-icon {
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  display: block;
+}
+.text-Area.show {
+  display: block;
+}
+.searchDiv {
+  width: max-content;
+  padding-right: 20px;
+}
 
 /*** DARK/LIGHT THEME COLORS ***/
 
@@ -268,7 +295,7 @@ input {
   color: var(--text-color, #000);
   width: 25em;
   padding: 0.4rem 0.5rem;
-  max-width: 100%;x
+  max-width: 100%;
 }
 
 blockquote {

--- a/gno.land/pkg/gnoweb/static/js/filter.js
+++ b/gno.land/pkg/gnoweb/static/js/filter.js
@@ -1,0 +1,31 @@
+
+function toggleSearch() {
+    const searchArea = document.getElementById('searchArea');
+    const searchIcon = document.getElementById('search-icon');
+    if (searchArea.classList.contains('show')) {
+        searchArea.classList.remove('show');
+        searchIcon.style.display = 'inline';
+    } else {
+        searchArea.classList.add('show');
+        searchIcon.style.display = 'none';
+    }
+  }
+  
+  // Filter function to show/hide elements based on the input value
+  function filterContent(event) {
+    const filterText = event.target.value.toLowerCase(); // Get search input text in lowercase
+    const contentElements = document.querySelectorAll('.filtrable'); // Get all elements with class 'filtrable'
+
+  
+    contentElements.forEach(element => {
+        const text = element.textContent.toLowerCase();
+        if (text.includes(filterText)) {
+            element.style.display = '';
+        } else {
+            element.style.display = 'none';
+        }
+    });
+  }
+
+  document.getElementById('searchArea').addEventListener('input', filterContent);
+  

--- a/gno.land/pkg/gnoweb/static/js/filter.js
+++ b/gno.land/pkg/gnoweb/static/js/filter.js
@@ -11,11 +11,10 @@ function toggleSearch() {
     }
   }
   
-  // Filter function to show/hide elements based on the input value
+  
   function filterContent(event) {
     const filterText = event.target.value.toLowerCase(); // Get search input text in lowercase
-    const contentElements = document.querySelectorAll('.filtrable'); // Get all elements with class 'filtrable'
-
+    const contentElements = document.querySelectorAll('.filtrable');
   
     contentElements.forEach(element => {
         const text = element.textContent.toLowerCase();

--- a/gno.land/pkg/gnoweb/views/funcs.html
+++ b/gno.land/pkg/gnoweb/views/funcs.html
@@ -20,9 +20,7 @@
 
         <div class="buttons">
           <div class="searchDiv">
-          <svg class="search-icon" id="search-icon" onclick="toggleSearch()" xmlns="http://www.w3.org/2000/svg"  width="40" height="40" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m-1.9-2.1a7.5 7.5 0 1110.5-10.5 7.5 7.5 0 01-10.5 10.5z" />
-          </svg>
+            <svg class="search-icon" id="search-icon" onclick="toggleSearch()" width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g> <path opacity="0.1" fill-rule="evenodd" clip-rule="evenodd" d="M12 3C4.5885 3 3 4.5885 3 12C3 19.4115 4.5885 21 12 21C19.4115 21 21 19.4115 21 12C21 4.5885 19.4115 3 12 3ZM11.5 7.75C9.42893 7.75 7.75 9.42893 7.75 11.5C7.75 13.5711 9.42893 15.25 11.5 15.25C13.5711 15.25 15.25 13.5711 15.25 11.5C15.25 9.42893 13.5711 7.75 11.5 7.75Z" fill="#323232"></path> <path d="M3 12C3 4.5885 4.5885 3 12 3C19.4115 3 21 4.5885 21 12C21 19.4115 19.4115 21 12 21C4.5885 21 3 19.4115 3 12Z" stroke="white" stroke-width="2"></path> <path d="M14 14L16 16" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path> <path d="M15 11.5C15 13.433 13.433 15 11.5 15C9.567 15 8 13.433 8 11.5C8 9.567 9.567 8 11.5 8C13.433 8 15 9.567 15 11.5Z" stroke="white" stroke-width="2"></path> </g></svg>
           <textarea class="text-Area" id="searchArea" placeholder="Search..."></textarea>
           </div>
           

--- a/gno.land/pkg/gnoweb/views/funcs.html
+++ b/gno.land/pkg/gnoweb/views/funcs.html
@@ -19,6 +19,13 @@
         </ul>
 
         <div class="buttons">
+          <div class="searchDiv">
+          <svg class="search-icon" id="search-icon" onclick="toggleSearch()" xmlns="http://www.w3.org/2000/svg"  width="40" height="40" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m-1.9-2.1a7.5 7.5 0 1110.5-10.5 7.5 7.5 0 01-10.5 10.5z" />
+          </svg>
+          <textarea class="text-Area" id="searchArea" placeholder="Search..."></textarea>
+          </div>
+          
           <a href="https://github.com/gnolang/gno">
             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
               <path
@@ -158,6 +165,7 @@
 <script type="text/javascript" src="/static/js/umbrella.min.js"></script>
 <script type="text/javascript" src="/static/js/purify.min.js"></script>
 <script type="text/javascript" src="/static/js/renderer.js"></script>
+<script type="text/javascript" src="/static/js/filter.js"></script>
 <script type="text/javascript">
   function main() {
     const DOM = {
@@ -165,6 +173,9 @@
       realm_render: document.getElementById("realm_render"),
       package_render: document.getElementById("package_file"),
     };
+
+    // for filters
+    const preElement = document.querySelector(".container");
 
     for (const [key, el] of Object.entries(DOM)) {
       if (el === null) continue;
@@ -174,6 +185,14 @@
 
       const parsed = parseContent(document.getElementById("source").innerHTML, isCode);
       el.innerHTML = DOMPurify.sanitize(parsed, { USE_PROFILES: { html: true } });
+    }
+
+    // filters also
+    if (preElement) {
+            preElement.querySelectorAll("*").forEach(element => {
+              console.log("element: ", element);
+              element.classList.add("filtrable");
+            });
     }
   }
 </script>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+
+
+pkill -f 'build/gnoland'
+pkill -f 'build/gnoweb'
+
+# Remove the test directory if it exists
+rm -rf gno.land/testdir
+
+# Navigate to the gno.land directory
+cd gno.land
+
+# Rebuild gnoland and gnoweb to reflect changes
+make build
+
+# Start gnoland and gnoweb
+./build/gnoland start -lazy &
+sleep 5
+./build/gnoweb -bind localhost:8888 &
+sleep 2


### PR DESCRIPTION
This PR implements a search bar with dynamic filtering functionality. It allows users to input search terms and dynamically filter content displayed on the page based on the input. If no match is found, only the header and footer are displayed. When no input is entered, the full content is rendered.

Key Changes:
Added a search bar component.
Implemented conditional content rendering based on search input.
Improved user navigation through filtered search results (Render filtering).
Adjusted the rendering logic to conditionally display content, the header, and footer based on the search results.
Tested the feature across various sections of the site to ensure stability and expected behavior.

Testing and Validation:
- Manually tested the feature to ensure correct behavior under various input scenarios.
- Validated that the page renders the entire content when no input is provided and correctly handles cases where no matches are found.
- No breaking changes were made, as no nodes was altered in the process (mainly javascript).

Contributors Checklist:

Tests made with special characters input to ensure nothing malicious may result from users input.

How to run:
Application is run using the (./build/gnoland start) and (./build/gnoweb -bind localhost:8888) commands or simply by running the 'start.sh' script in the root of the repo.

Next Steps:
Would be glad to make adjustments as needed based on further review and discussions. 
Would be looking into other issues moving forward in case of no further adjustment on filters.

Thank you for your consideration, and I look forward to your feedback!