### PR TITLE
ci: remove conflicting option to push benchmark on github pages

### DIFF
--- a/.github/workflows/benchmark-master-push.yml
+++ b/.github/workflows/benchmark-master-push.yml
@@ -46,8 +46,6 @@ jobs:
           name: Go Benchmarks
           tool: "go"
           output-file-path: benchmarks.txt
-          # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
           max-items-in-chart: 100
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: "120%"


### PR DESCRIPTION
Just a small fix to allow publication of benchmark on the repository
