### PR TITLE
fix: deprecate std.GetOrigCaller

### DIFF
--- a/gnovm/stdlibs/std/native.gno
+++ b/gnovm/stdlibs/std/native.gno
@@ -22,7 +22,7 @@ func GetOrigSend() Coins {
 	return coins
 }
 
-// Deprecated: Unsecure and limiting pattern
+// Deprecated: Unsecure and limiting pattern, use `std.PrevRealm().Addr()` instead
 func GetOrigCaller() Address {
 	return Address(origCaller())
 }

--- a/gnovm/stdlibs/std/native.gno
+++ b/gnovm/stdlibs/std/native.gno
@@ -22,6 +22,7 @@ func GetOrigSend() Coins {
 	return coins
 }
 
+// Deprecated: Unsecure and limiting pattern
 func GetOrigCaller() Address {
 	return Address(origCaller())
 }


### PR DESCRIPTION
<img width="773" alt="Screenshot 2024-10-04 at 18 44 53" src="https://github.com/user-attachments/assets/e6476e35-7bd3-4b41-b25a-e00af07fb96b">

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
