### PR TITLE
fix(ghverify): fix avl tree iteration in `Render` and `GetFeedDefinitions`

### DIFF
--- a/examples/gno.land/p/demo/gnorkle/gnorkle/instance.gno
+++ b/examples/gno.land/p/demo/gnorkle/gnorkle/instance.gno
@@ -227,7 +227,7 @@ func (i *Instance) GetFeedDefinitions(forAddress string) (string, error) {
 
 		first = false
 		buf.Write(taskBytes)
-		return true
+		return false
 	})
 
 	if err != nil {

--- a/examples/gno.land/r/gnoland/ghverify/contract.gno
+++ b/examples/gno.land/r/gnoland/ghverify/contract.gno
@@ -139,7 +139,7 @@ func Render(_ string) string {
 		result += `"` + handle + `": "` + address.(string) + `"`
 		appendComma = true
 
-		return true
+		return false
 	})
 
 	return result + "}"

--- a/examples/gno.land/r/gnoland/ghverify/contract_test.gno
+++ b/examples/gno.land/r/gnoland/ghverify/contract_test.gno
@@ -9,7 +9,8 @@ import (
 
 func TestVerificationLifecycle(t *testing.T) {
 	defaultAddress := std.GetOrigCaller()
-	userAddress := std.Address(testutils.TestAddress("user"))
+	user1Address := std.Address(testutils.TestAddress("user 1"))
+	user2Address := std.Address(testutils.TestAddress("user 2"))
 
 	// Verify request returns no feeds.
 	result := GnorkleEntrypoint("request")
@@ -18,7 +19,7 @@ func TestVerificationLifecycle(t *testing.T) {
 	}
 
 	// Make a verification request with the created user.
-	std.TestSetOrigCaller(userAddress)
+	std.TestSetOrigCaller(user1Address)
 	RequestVerification("deelawn")
 
 	// A subsequent request from the same address should panic because there is
@@ -42,26 +43,32 @@ func TestVerificationLifecycle(t *testing.T) {
 		t.Fatalf("expected empty request result, got %s", result)
 	}
 
+	// Make a verification request with the created user.
+	std.TestSetOrigCaller(user2Address)
+	RequestVerification("omarsy")
+
 	// Set the caller back to the whitelisted user and verify that the feed data
 	// returned matches what should have been created by the `RequestVerification`
 	// invocation.
 	std.TestSetOrigCaller(defaultAddress)
 	result = GnorkleEntrypoint("request")
-	expResult := `[{"id":"` + string(userAddress) + `","type":"0","value_type":"string","tasks":[{"gno_address":"` +
-		string(userAddress) + `","github_handle":"deelawn"}]}]`
+	expResult := `[{"id":"` + string(user1Address) + `","type":"0","value_type":"string","tasks":[{"gno_address":"` +
+		string(user1Address) + `","github_handle":"deelawn"}]},` +
+		`{"id":"` + string(user2Address) + `","type":"0","value_type":"string","tasks":[{"gno_address":"` +
+		string(user2Address) + `","github_handle":"omarsy"}]}]`
 	if result != expResult {
 		t.Fatalf("expected request result %s, got %s", expResult, result)
 	}
 
 	// Try to trigger feed ingestion from the non-authorized user.
-	std.TestSetOrigCaller(userAddress)
+	std.TestSetOrigCaller(user1Address)
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
 				errMsg = r.(error).Error()
 			}
 		}()
-		GnorkleEntrypoint("ingest," + string(userAddress) + ",OK")
+		GnorkleEntrypoint("ingest," + string(user1Address) + ",OK")
 	}()
 	if errMsg != "caller not whitelisted" {
 		t.Fatalf("expected caller not whitelisted, got %s", errMsg)
@@ -69,15 +76,15 @@ func TestVerificationLifecycle(t *testing.T) {
 
 	// Set the caller back to the whitelisted user and transfer contract ownership.
 	std.TestSetOrigCaller(defaultAddress)
-	SetOwner(userAddress)
+	SetOwner(defaultAddress)
 
 	// Now trigger the feed ingestion from the user and new owner and only whitelisted address.
-	std.TestSetOrigCaller(userAddress)
-	GnorkleEntrypoint("ingest," + string(userAddress) + ",OK")
+	GnorkleEntrypoint("ingest," + string(user1Address) + ",OK")
+	GnorkleEntrypoint("ingest," + string(user2Address) + ",OK")
 
 	// Verify the ingestion autocommitted the value and triggered the post handler.
 	data := Render("")
-	expResult = `{"deelawn": "` + string(userAddress) + `"}`
+	expResult = `{"deelawn": "` + string(user1Address) + `","omarsy": "` + string(user2Address) + `"}`
 	if data != expResult {
 		t.Fatalf("expected render data %s, got %s", expResult, data)
 	}
@@ -89,10 +96,10 @@ func TestVerificationLifecycle(t *testing.T) {
 	}
 
 	// Check that the accessor functions are working as expected.
-	if handle := GetHandleByAddress(string(userAddress)); handle != "deelawn" {
+	if handle := GetHandleByAddress(string(user1Address)); handle != "deelawn" {
 		t.Fatalf("expected deelawn, got %s", handle)
 	}
-	if address := GetAddressByHandle("deelawn"); address != string(userAddress) {
-		t.Fatalf("expected %s, got %s", string(userAddress), address)
+	if address := GetAddressByHandle("deelawn"); address != string(user1Address) {
+		t.Fatalf("expected %s, got %s", string(user1Address), address)
 	}
 }


### PR DESCRIPTION
This pull request resolves a bug in the iteration logic of the `iterate` function from `gno.land/p/demo/avl` (avlTree) as used in two key areas: the `Render` function of `gno.land/r/gnoland/ghverify` and the `GetFeedDefinitions` function of `gno.land/p/demo/gnorkle/gnorkle`.

### Problem:
In both instances, the `iterate` function was returning `true` after processing the first item, which prematurely halted the iteration. As a result, only the first item was processed, and all subsequent items were ignored.

