### PR TITLE
fix: Fixes #2938 GnoVM Unexpected Crash When Panic Occurs in Tests

### DIFF
--- a/gnovm/cmd/gno/testdata/gno_test/panic_error.txtar
+++ b/gnovm/cmd/gno/testdata/gno_test/panic_error.txtar
@@ -1,0 +1,23 @@
+# Test panic with error output in a test
+
+! gno test .
+
+! stdout .+
+stderr '--- FAIL: TestPanicWithError'
+stderr 'panic: hello world'
+stderr 'FAIL'
+
+-- panic_error.gno --
+package panicerror 
+
+-- panic_error_test.gno --
+package panicerror
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPanicWithError(t *testing.T) {
+	panic(errors.New("hello world"))
+}

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -409,7 +409,7 @@ func (m *Machine) doOpPanic1() {
 	// Pop exception
 	var ex TypedValue = m.PopValue().Copy(m.Alloc)
 	// Panic
-	m.Panic(ex)
+	m.Panic(typedString(ex.Sprint(m)))
 }
 
 func (m *Machine) doOpPanic2() {

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -408,8 +408,14 @@ func (m *Machine) doOpDefer() {
 func (m *Machine) doOpPanic1() {
 	// Pop exception
 	var ex TypedValue = m.PopValue().Copy(m.Alloc)
-	// Panic
-	m.Panic(typedString(ex.Sprint(m)))
+    
+    if ex.T.GetPkgPath() == "errors" {
+        // then it's a normal error 
+        m.Panic(typedString(ex.Sprint(m)))
+    } else {
+        // skipErr 
+        m.Panic(ex)
+    }
 }
 
 func (m *Machine) doOpPanic2() {


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
fixed panic crash on `gno test`  by correctly formatting the argument for `m.Panic`

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
