### PR TITLE
fix(gnodev): timestamp issue on reload

### DIFF
--- a/contribs/gnodev/cmd/gnodev/setup_node.go
+++ b/contribs/gnodev/cmd/gnodev/setup_node.go
@@ -43,7 +43,7 @@ func setupDevNode(
 			nodeConfig.InitialTxs[index] = nodeTx
 		}
 
-		logger.Info("genesis file loaded", "path", devCfg.genesisFile, "txs", len(nodeConfig.InitialTxs))
+		logger.Info("genesis file loaded", "path", devCfg.genesisFile, "txs", len(stateTxs))
 	}
 
 	return gnodev.NewDevNode(ctx, nodeConfig)

--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -122,12 +122,12 @@ func NewDevNode(ctx context.Context, cfg *NodeConfig) (*Node, error) {
 	}
 
 	// generate genesis state
-	genesis := NodeGenesisState{
+	genesis := gnoland.GnoGenesisState{
 		Balances: cfg.BalancesList,
 		Txs:      append(pkgsTxs, cfg.InitialTxs...),
 	}
 
-	if err := devnode.rebuildNode(ctx, &genesis); err != nil {
+	if err := devnode.rebuildNode(ctx, genesis); err != nil {
 		return nil, fmt.Errorf("unable to initialize the node: %w", err)
 	}
 
@@ -284,13 +284,13 @@ func (n *Node) Reset(ctx context.Context) error {
 
 	// Append initialTxs
 	txs := append(pkgsTxs, n.initialState...)
-	genesis := NodeGenesisState{
+	genesis := gnoland.GnoGenesisState{
 		Balances: n.config.BalancesList,
 		Txs:      txs,
 	}
 
 	// Reset the node with the new genesis state.
-	err = n.rebuildNode(ctx, &genesis)
+	err = n.rebuildNode(ctx, genesis)
 	if err != nil {
 		return fmt.Errorf("unable to initialize a new node: %w", err)
 	}
@@ -410,7 +410,7 @@ func (n *Node) rebuildNodeFromState(ctx context.Context) error {
 			return fmt.Errorf("unable to load pkgs: %w", err)
 		}
 
-		return n.rebuildNode(ctx, &NodeGenesisState{
+		return n.rebuildNode(ctx, gnoland.GnoGenesisState{
 			Balances: n.config.BalancesList, Txs: txs,
 		})
 	}
@@ -426,14 +426,15 @@ func (n *Node) rebuildNodeFromState(ctx context.Context) error {
 		return fmt.Errorf("unable to load pkgs: %w", err)
 	}
 
+	time.Now().UnixNano()
 	// Create genesis with loaded pkgs + previous state
-	genesis := NodeGenesisState{
+	genesis := gnoland.GnoGenesisState{
 		Balances: n.config.BalancesList,
 		Txs:      append(pkgsTxs, state...),
 	}
 
 	// Reset the node with the new genesis state.
-	err = n.rebuildNode(ctx, &genesis)
+	err = n.rebuildNode(ctx, genesis)
 	n.logger.Info("reload done", "pkgs", len(pkgsTxs), "state applied", len(state))
 
 	// Update node infos

--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -275,8 +275,10 @@ func (n *Node) Reset(ctx context.Context) error {
 		return fmt.Errorf("unable to stop the node: %w", err)
 	}
 
-	// Generate a new genesis state based on the current packages
+	// Reset starting time
 	startTime := time.Now()
+
+	// Generate a new genesis state based on the current packages
 	pkgsTxs, err := n.pkgs.Load(DefaultFee, startTime)
 	if err != nil {
 		return fmt.Errorf("unable to load pkgs: %w", err)
@@ -426,7 +428,6 @@ func (n *Node) rebuildNodeFromState(ctx context.Context) error {
 		return fmt.Errorf("unable to load pkgs: %w", err)
 	}
 
-	time.Now().UnixNano()
 	// Create genesis with loaded pkgs + previous state
 	genesis := gnoland.GnoGenesisState{
 		Balances: n.config.BalancesList,

--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -182,7 +182,7 @@ func (n *Node) getBlockTransactions(blockNum uint64) ([]gnoland.TxWithMetadata, 
 		// fallback on std tx
 		var tx std.Tx
 		if unmarshalErr := amino.Unmarshal(encodedTx, &tx); unmarshalErr != nil {
-			return nil, fmt.Errorf("unable to unmarshal tx: %w", err)
+			return nil, fmt.Errorf("unable to unmarshal tx: %w", unmarshalErr)
 		}
 
 		txs[i] = gnoland.TxWithMetadata{

--- a/contribs/gnodev/pkg/dev/node_state.go
+++ b/contribs/gnodev/pkg/dev/node_state.go
@@ -8,7 +8,66 @@ import (
 	"github.com/gnolang/gno/contribs/gnodev/pkg/events"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
 )
+
+type NodeGenesisState struct {
+	Balances []gnoland.Balance
+	Txs      []gnoland.GenesisTx
+}
+
+func (s *NodeGenesisState) Len() int { return len(s.Txs) }
+
+func (s *NodeGenesisState) GenesisTxs() []gnoland.GenesisTx { return s.Txs }
+
+func (s *NodeGenesisState) GenesisBalances() []gnoland.Balance {
+	return s.Balances
+}
+
+func (s *NodeGenesisState) MetadataGenesisState() *gnoland.MetadataGenesisState {
+	metaState := gnoland.MetadataGenesisState{
+		Balances: s.GenesisBalances(),
+	}
+
+	// Export metadata as well
+	txs := s.GenesisTxs()
+	metaState.Txs = make([]gnoland.MetadataTx, len(txs))
+	for i, tx := range txs {
+		metaState.Txs[i] = gnoland.MetadataTx{
+			GenesisTx: tx.Tx(),
+		}
+
+		if meta := tx.Metadata(); meta != nil {
+			metaState.Txs[i].TxMetadata = *meta
+		}
+	}
+
+	return &metaState
+}
+
+func (s *NodeGenesisState) AppendTxs(txs ...std.Tx) {
+	genesisTxs := make([]gnoland.GenesisTx, len(txs))
+	for i, tx := range txs {
+		genesisTxs[i] = &GnoGenesisTx{tx}
+	}
+	s.Txs = append(s.Txs, genesisTxs...)
+}
+
+func (s *NodeGenesisState) AppendMetadataTxs(txs ...gnoland.MetadataTx) {
+	genesisTxs := make([]gnoland.GenesisTx, len(txs))
+	for i, tx := range txs {
+		genesisTxs[i] = tx
+	}
+
+	s.Txs = append(s.Txs, genesisTxs...)
+}
+
+type GnoGenesisTx struct {
+	StdTx std.Tx
+}
+
+func (g GnoGenesisTx) Tx() std.Tx                           { return g.StdTx }
+func (g GnoGenesisTx) Metadata() *gnoland.GenesisTxMetadata { return nil }
 
 var ErrEmptyState = errors.New("empty state")
 
@@ -84,7 +143,7 @@ func (n *Node) MoveBy(ctx context.Context, x int) error {
 	}
 
 	// Load genesis packages
-	pkgsTxs, err := n.pkgs.Load(DefaultFee)
+	pkgsTxs, err := n.pkgs.Load(DefaultFee, n.startTime)
 	if err != nil {
 		return fmt.Errorf("unable to load pkgs: %w", err)
 	}
@@ -92,13 +151,13 @@ func (n *Node) MoveBy(ctx context.Context, x int) error {
 	newState := n.state[:newIndex]
 
 	// Create genesis with loaded pkgs + previous state
-	genesis := gnoland.GnoGenesisState{
+	genesis := NodeGenesisState{
 		Balances: n.config.BalancesList,
 		Txs:      append(pkgsTxs, newState...),
 	}
 
 	// Reset the node with the new genesis state.
-	if err = n.rebuildNode(ctx, genesis); err != nil {
+	if err = n.rebuildNode(ctx, &genesis); err != nil {
 		return fmt.Errorf("uanble to rebuild node: %w", err)
 	}
 
@@ -132,10 +191,23 @@ func (n *Node) ExportStateAsGenesis(ctx context.Context) (*bft.GenesisDoc, error
 
 	// Get current blockstore state
 	doc := *n.Node.GenesisDoc() // copy doc
-	doc.AppState = gnoland.GnoGenesisState{
+
+	metaState := gnoland.MetadataGenesisState{
 		Balances: n.config.BalancesList,
-		Txs:      state,
 	}
 
+	// Export metadata as well
+	metaState.Txs = make([]gnoland.MetadataTx, len(state))
+	for i, tx := range state {
+		metaState.Txs[i] = gnoland.MetadataTx{
+			GenesisTx: tx.Tx(),
+		}
+
+		if meta := tx.Metadata(); meta != nil {
+			metaState.Txs[i].TxMetadata = *meta
+		}
+	}
+
+	doc.AppState = metaState
 	return &doc, nil
 }

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -285,7 +285,7 @@ func Render(_ string) string {
 	// Span multiple time
 	for i := 0; i < 2; i++ {
 		// Wait a little for time shift
-		time.Sleep(time.Second)
+		time.Sleep(time.Second + (time.Millisecond * 100))
 
 		msg := vm.MsgCall{
 			PkgPath: "gno.land/r/dev/foo",

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -413,6 +413,7 @@ func newTestingDevNode(t *testing.T, pkgslist ...PackagePath) (*Node, *mock.Serv
 
 	// We have to put this to true to force tx to be in separate block
 	cfg.TMConfig.Consensus.SkipTimeoutCommit = true
+	cfg.TMConfig.Consensus.TimeoutPropose = time.Millisecond * 100
 
 	cfg.PackagesPathList = pkgslist
 	cfg.Emitter = emitter

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -285,7 +285,7 @@ func Render(_ string) string {
 	// Span multiple time
 	for i := 0; i < 2; i++ {
 		// Wait a little for time shift
-		time.Sleep(time.Second + (time.Millisecond * 100))
+		time.Sleep(time.Second)
 
 		msg := vm.MsgCall{
 			PkgPath: "gno.land/r/dev/foo",

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -282,9 +282,11 @@ func Render(_ string) string {
 	node, emitter := newTestingDevNode(t, foopkg)
 	assert.Len(t, node.ListPkgs(), 1)
 
-	// Span multiple time
+	// Span multiple times
 	for i := 0; i < 2; i++ {
 		// Wait a little for time shift
+		// XXX: Change this with `Block` event listening, But we will
+		// probably need to update block timestamp to nanoseconds first
 		time.Sleep(time.Second)
 
 		msg := vm.MsgCall{
@@ -411,7 +413,7 @@ func newTestingDevNode(t *testing.T, pkgslist ...PackagePath) (*Node, *mock.Serv
 	// Call NewDevNode with no package should work
 	cfg := DefaultNodeConfig(gnoenv.RootDir())
 
-	// We have to put this to true to force tx to be in separate block
+	// Minimize time between block to avoid tx being set in the same block
 	cfg.TMConfig.Consensus.SkipTimeoutCommit = true
 	cfg.TMConfig.Consensus.TimeoutPropose = time.Millisecond * 100
 

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -410,6 +410,10 @@ func newTestingDevNode(t *testing.T, pkgslist ...PackagePath) (*Node, *mock.Serv
 
 	// Call NewDevNode with no package should work
 	cfg := DefaultNodeConfig(gnoenv.RootDir())
+
+	// We have to put this to true to force tx to be in separate block
+	cfg.TMConfig.Consensus.SkipTimeoutCommit = true
+
 	cfg.PackagesPathList = pkgslist
 	cfg.Emitter = emitter
 	cfg.Logger = logger

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -306,7 +306,7 @@ func Render(_ string) string {
 	times1 := parseJSONTimesList(t, render)
 
 	// Ensure times are correctly expending
-	for i, t2 := range times {
+	for i, t2 := range times1 {
 		if i == 0 {
 			continue
 		}

--- a/contribs/gnodev/pkg/dev/node_test.go
+++ b/contribs/gnodev/pkg/dev/node_test.go
@@ -286,7 +286,7 @@ func Render(_ string) string {
 	foopkg := generateTestingPackage(t, "gno.mod", foobarGnoMod, "foo.gno", fooFile)
 
 	// Call NewDevNode with no package should work
-	cfg := createDefaultNodeConfig(foopkg)
+	cfg := createDefaultTestingNodeConfig(foopkg)
 
 	// XXX(gfanton): Setting this to `false` somehow makes the time block
 	// drift from the time spanned by the VM.
@@ -474,10 +474,17 @@ func generateTestingPackage(t *testing.T, nameFile ...string) PackagePath {
 	}
 }
 
-func createDefaultNodeConfig(pkgslist ...PackagePath) *NodeConfig {
+func createDefaultTestingNodeConfig(pkgslist ...PackagePath) *NodeConfig {
 	cfg := DefaultNodeConfig(gnoenv.RootDir())
 	cfg.PackagesPathList = pkgslist
 	return cfg
+}
+
+func newTestingDevNode(t *testing.T, pkgslist ...PackagePath) (*Node, *mock.ServerEmitter) {
+	t.Helper()
+
+	cfg := createDefaultTestingNodeConfig(pkgslist...)
+	return newTestingDevNodeWithConfig(t, cfg)
 }
 
 func newTestingDevNodeWithConfig(t *testing.T, cfg *NodeConfig) (*Node, *mock.ServerEmitter) {
@@ -500,11 +507,6 @@ func newTestingDevNodeWithConfig(t *testing.T, cfg *NodeConfig) (*Node, *mock.Se
 	})
 
 	return node, emitter
-}
-
-func newTestingDevNode(t *testing.T, pkgslist ...PackagePath) (*Node, *mock.ServerEmitter) {
-	cfg := createDefaultNodeConfig(pkgslist...)
-	return newTestingDevNodeWithConfig(t, cfg)
 }
 
 func newInMemorySigner(t *testing.T, chainid string) *gnoclient.SignerFromKeybase {


### PR DESCRIPTION
- [x] depends on #2941  

resolve #1509  

This PR addresses the timestamp issue on gnodev by implementing the `MetadataTX` changes from #2941. Timestamps will now be correctly handled for `Reload` and `import`/`export`. For `Reset`, the timestamp will be updated to the current time.  

cc @zivkovicmilos @thehowl  

#### ~TODOs~ 
-  [x] test replays (I've only tested it manually)  


<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
- [ ] Added new benchmarks to [generated graphs](https://gnoland.github.io/benchmarks), if any. More info [here](https://github.com/gnolang/gno/blob/master/.benchmarks/README.md).
</details>
