### PR TITLE
chore: add alexiscolin as gnoweb reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,7 @@
 /gno.land/cmd/genesis/        @zivkovicmilos
 /gno.land/cmd/gnokey/         @jaekwon @moul @gfanton
 /gno.land/cmd/gnoland/        @zivkovicmilos @gnolang/devops
-/gno.land/cmd/gnoweb/         @gfanton @thehowl
+/gno.land/cmd/gnoweb/         @gfanton @thehowl @alexiscolin
 /gno.land/pkg/gnoclient/      @zivkovicmilos @leohhhn @gfanton
 /gno.land/pkg/gnoland/        @zivkovicmilos @gfanton
 /gno.land/pkg/keyscli/        @jaekwon @moul @gfanton


### PR DESCRIPTION
As I'll be leading the collective efforts around gnoweb, it would be helpful if I could be automatically pinged for any PR review related to the `gnoweb` folder. This PR adds my GH handle as a codeowner for this directory. 

Thank you for your help!