### PR TITLE
fix(cmd/aminoscan): set len=0 in a slice initialization

### DIFF
--- a/tm2/pkg/amino/cmd/aminoscan/colors.go
+++ b/tm2/pkg/amino/cmd/aminoscan/colors.go
@@ -28,7 +28,7 @@ func treat(s string, color string) string {
 }
 
 func treatAll(color string, args ...interface{}) string {
-	parts := make([]string, len(args))
+	parts := make([]string, 0, len(args))
 	for _, arg := range args {
 		parts = append(parts, treat(fmt.Sprintf("%v", arg), color))
 	}


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>


The intention here should be to initialize a slice with a capacity of  `len(args)` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW


