### PR TITLE
fix(tm2): avoid mutex copy in marshal and unmarshal methods

### DIFF
--- a/tm2/pkg/amino/amino.go
+++ b/tm2/pkg/amino/amino.go
@@ -760,7 +760,7 @@ func (cdc *Codec) MarshalJSON(o interface{}) ([]byte, error) {
 	cdc.doAutoseal()
 
 	rv := reflect.ValueOf(o)
-	if rv.Kind() == reflect.Invalid {
+	if !rv.IsValid() {
 		return []byte("null"), nil
 	}
 	rt := rv.Type()

--- a/tm2/pkg/amino/json_test.go
+++ b/tm2/pkg/amino/json_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
-	amino "github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/amino/pkg"
 )
 
@@ -147,6 +149,31 @@ func TestMarshalJSONTime(t *testing.T) {
 		String: "hello",
 		Bytes:  []byte("goodbye"),
 		Time:   time.Now().Round(0).UTC(), // strip monotonic.
+	}
+
+	b, err := cdc.MarshalJSON(s)
+	assert.Nil(t, err)
+
+	var s2 SimpleStruct
+	err = cdc.UnmarshalJSON(b, &s2)
+	assert.Nil(t, err)
+	assert.Equal(t, s, s2)
+}
+
+func TestMarshalJSONPBTime(t *testing.T) {
+	t.Parallel()
+
+	cdc := amino.NewCodec()
+	registerTransports(cdc)
+
+	type SimpleStruct struct {
+		Timestamp *timestamppb.Timestamp
+		Duration  *durationpb.Duration
+	}
+
+	s := SimpleStruct{
+		Timestamp: &timestamppb.Timestamp{Seconds: 1296012345, Nanos: 940483},
+		Duration:  &durationpb.Duration{Seconds: 100},
 	}
 
 	b, err := cdc.MarshalJSON(s)

--- a/tm2/pkg/bitarray/bit_array.go
+++ b/tm2/pkg/bitarray/bit_array.go
@@ -394,8 +394,12 @@ func (bA *BitArray) UnmarshalJSON(bz []byte) error {
 	if b == "null" {
 		// This is required e.g. for encoding/json when decoding
 		// into a pointer with pre-allocated BitArray.
+		bA.mtx.Lock()
+		defer bA.mtx.Unlock()
+
 		bA.Bits = 0
 		bA.Elems = nil
+
 		return nil
 	}
 
@@ -414,6 +418,12 @@ func (bA *BitArray) UnmarshalJSON(bz []byte) error {
 			bA2.SetIndex(i, true)
 		}
 	}
-	*bA = *bA2 //nolint:govet
+
+	bA.mtx.Lock()
+	defer bA.mtx.Unlock()
+
+	bA.Bits = bA2.Bits
+	bA.Elems = bA2.Elems
+
 	return nil
 }


### PR DESCRIPTION
Avoid copying of Mutex at several places.
Add missing lock / unlock calls.
Improve test coverage for protobuf timestamp and duration.

`go vet` doesn't complain anymore on Mutex copy.

Addresses #2954.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [*] Added new tests, or not needed, or not feasible
- [*] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [*] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [*] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
