### PR TITLE
ci: don't test verbosely

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -42,7 +42,7 @@ jobs:
             # confusing and meticulous. There will be some improvements in Go
             # 1.23 regarding coverage, so we can use this as a workaround until
             # then.
-            go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} -v ./... -test.gocoverdir=$GOCOVERDIR
+            go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} ./... -test.gocoverdir=$GOCOVERDIR
 
             # Print results
             (set +x; echo 'go coverage results:')


### PR DESCRIPTION
Let's remove the noise in the tests. This will make sure the logs only show the errors when they happen.