### PR TITLE
chore: remove install.gnogenesis from root makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERIFY_MOD_SUMS ?= false
 ########################################
 # Dev tools
 .PHONY: install
-install: install.gnokey install.gno install.gnodev install.gnogenesis
+install: install.gnokey install.gno install.gnodev
 
 # shortcuts to frequently used commands from sub-components.
 .PHONY: install.gnokey
@@ -45,10 +45,6 @@ install.gno:
 install.gnodev:
 	$(MAKE) --no-print-directory -C ./contribs/gnodev install
 	@printf "\033[0;32m[+] 'gnodev' has been installed. Read more in ./contribs/gnodev/\033[0m\n"
-.PHONY: install.gnogenesis
-install.gnogenesis:
-	$(MAKE) --no-print-directory -C ./contribs/gnogenesis install
-	@printf "\033[0;32m[+] 'gnogenesis' has been installed. Read more in ./contribs/gnogenesis/\033[0m\n"
 
 
 # old aliases

--- a/contribs/gnogenesis/README.md
+++ b/contribs/gnogenesis/README.md
@@ -12,8 +12,8 @@ To install gnogenesis, clone the repository and build the tool:
 
 ```shell
 git clone https://github.com/gnoland/gno.git
-cd gno
-make install.gnogenesis
+cd gno/contribs/gnogenesis
+make install
 ```
 
 This will compile and install `gnogenesis` to your system path, allowing you to run commands directly.

--- a/docs/gno-infrastructure/validators/setting-up-a-new-chain.md
+++ b/docs/gno-infrastructure/validators/setting-up-a-new-chain.md
@@ -30,7 +30,7 @@ Makefile to install the `gnoland` binary:
 
 ```bash
 cd gno.land
-make install.gnoland install.gnogenesis
+make install.gnoland && make -C contribs/gnogenesis install
 ```
 
 To verify that you've installed the binary properly and that you are able to use


### PR DESCRIPTION
Follow-up to #3041.

Not even `gnoland` is part of the core commands in the root makefile, hence it makes no sense for `gnogenesis` to be one of them.