### PR TITLE
chore(gno): intended json on filetests's Events: directives

### DIFF
--- a/examples/gno.land/r/demo/event/z1_filetest.gno
+++ b/examples/gno.land/r/demo/event/z1_filetest.gno
@@ -8,4 +8,27 @@ func main() {
 }
 
 // Events:
-// [{"type":"TAG","attrs":[{"key":"key","value":"foo"}],"pkg_path":"gno.land/r/demo/event","func":"Emit"},{"type":"TAG","attrs":[{"key":"key","value":"bar"}],"pkg_path":"gno.land/r/demo/event","func":"Emit"}]
+// [
+//   {
+//     "type": "TAG",
+//     "attrs": [
+//       {
+//         "key": "key",
+//         "value": "foo"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/demo/event",
+//     "func": "Emit"
+//   },
+//   {
+//     "type": "TAG",
+//     "attrs": [
+//       {
+//         "key": "key",
+//         "value": "bar"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/demo/event",
+//     "func": "Emit"
+//   }
+// ]

--- a/gnovm/cmd/gno/testdata/gno_test/filetest_events.txtar
+++ b/gnovm/cmd/gno/testdata/gno_test/filetest_events.txtar
@@ -30,4 +30,22 @@ func main() {
 // test
 
 // Events:
-// [{"type":"EventA","attrs":[],"pkg_path":"","func":"main"},{"type":"EventB","attrs":[{"key":"keyA","value":"valA"}],"pkg_path":"","func":"main"}]
+// [
+//   {
+//     "type": "EventA",
+//     "attrs": [],
+//     "pkg_path": "",
+//     "func": "main"
+//   },
+//   {
+//     "type": "EventB",
+//     "attrs": [
+//       {
+//         "key": "keyA",
+//         "value": "valA"
+//       }
+//     ],
+//     "pkg_path": "",
+//     "func": "main"
+//   }
+// ]

--- a/gnovm/tests/file.go
+++ b/gnovm/tests/file.go
@@ -374,7 +374,7 @@ func RunFileTest(rootDir string, path string, opts ...RunFileTestOption) error {
 				}
 				// check result
 				events := m.Context.(*teststd.TestExecContext).EventLogger.Events()
-				evtjson, err := json.Marshal(events)
+				evtjson, err := json.MarshalIndent(events, "", "  ")
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Closer to the current `// Realm:` output, and more git-friendly.

Bigger example in #3003.