### PR TITLE
chore: update `tx-archive` in portal loop

### DIFF
--- a/misc/loop/cmd/snapshotter.go
+++ b/misc/loop/cmd/snapshotter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/gnolang/tx-archive/backup"
 	"github.com/gnolang/tx-archive/backup/client/http"
-	"github.com/gnolang/tx-archive/backup/writer/legacy"
+	"github.com/gnolang/tx-archive/backup/writer/standard"
 )
 
 const (
@@ -204,7 +204,7 @@ func (s snapshotter) backupTXs(ctx context.Context, rpcURL string) error {
 	}
 	defer instanceBackupFile.Close()
 
-	w := legacy.NewWriter(instanceBackupFile)
+	w := standard.NewWriter(instanceBackupFile)
 
 	// Create the tx-archive backup service
 	c, err := http.NewClient(rpcURL)

--- a/misc/loop/go.mod
+++ b/misc/loop/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/gnolang/gno v0.1.0-nightly.20240627
-	github.com/gnolang/tx-archive v0.3.0
+	github.com/gnolang/tx-archive v0.4.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/misc/loop/go.sum
+++ b/misc/loop/go.sum
@@ -72,6 +72,8 @@ github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1G
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
 github.com/gnolang/tx-archive v0.3.0 h1:5Fr39yAT7nnAPKvcmKmBT+oPiBhMhA0aUAIEeXrYG4I=
 github.com/gnolang/tx-archive v0.3.0/go.mod h1:WDgxSZibE7LkGdiVjkU/lhA35xyXjrSkZp6kwuTvSSw=
+github.com/gnolang/tx-archive v0.4.0 h1:+1Rgo0U0HjLQLq/xqeGdJwtAzo9xWj09t1oZLvrL3bU=
+github.com/gnolang/tx-archive v0.4.0/go.mod h1:seKHGnvxUnDgH/mSsCEdwG0dHY/FrpbUm6Hd0+KMd9w=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Description

This PR updates the `tx-archive` version in portal loop to use the new standard `gnoland.TxWithMetadata` format for transaction sheets.

**BREAKING CHANGE**
The portal loop will now save transactions with the new metadata format

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
