### PR TITLE
chore: tidy `misc/loop` mod

### DIFF
--- a/.github/workflows/mod-tidy.yml
+++ b/.github/workflows/mod-tidy.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Check go.mod files are up to date
         working-directory: ${{ inputs.modulepath }}
         run: |
-          make tidy VERIFY_GO_SUMS=true
+          make tidy VERIFY_MOD_SUMS=true

--- a/contribs/gnomigrate/go.mod
+++ b/contribs/gnomigrate/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnolang/gnomigrate
 
-go 1.23
+go 1.22
 
 require (
 	github.com/gnolang/gno v0.0.0-00010101000000-000000000000

--- a/gno.land/pkg/gnoland/types.go
+++ b/gno.land/pkg/gnoland/types.go
@@ -53,6 +53,8 @@ func ReadGenesisTxs(ctx context.Context, path string) ([]TxWithMetadata, error) 
 		scanner = bufio.NewScanner(file)
 	)
 
+	scanner.Buffer(make([]byte, 1_000_000), 2_000_000)
+
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():

--- a/misc/loop/go.sum
+++ b/misc/loop/go.sum
@@ -70,8 +70,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
-github.com/gnolang/tx-archive v0.3.0 h1:5Fr39yAT7nnAPKvcmKmBT+oPiBhMhA0aUAIEeXrYG4I=
-github.com/gnolang/tx-archive v0.3.0/go.mod h1:WDgxSZibE7LkGdiVjkU/lhA35xyXjrSkZp6kwuTvSSw=
 github.com/gnolang/tx-archive v0.4.0 h1:+1Rgo0U0HjLQLq/xqeGdJwtAzo9xWj09t1oZLvrL3bU=
 github.com/gnolang/tx-archive v0.4.0/go.mod h1:seKHGnvxUnDgH/mSsCEdwG0dHY/FrpbUm6Hd0+KMd9w=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Description

This PR tidies the `misc/loop` `go.mod`. I'm not sure how the CI didn't catch this, or why it's green 🤷‍♂️ 

It also fixes the failing CI, but downgrading `gnomigrate` to `1.22` - fun :)

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
