### PR TITLE
chore: fix lint issues from `go vet`

### DIFF
--- a/gno.land/pkg/sdk/vm/handler_test.go
+++ b/gno.land/pkg/sdk/vm/handler_test.go
@@ -113,7 +113,7 @@ func TestVmHandlerQuery_Eval(t *testing.T) {
 
 			// Create test package.
 			files := []*gnovm.MemFile{
-				{"hello.gno", `
+				{Name: "hello.gno", Body: `
 package hello
 
 import "std"
@@ -206,7 +206,7 @@ func TestVmHandlerQuery_Funcs(t *testing.T) {
 
 			// Create test package.
 			files := []*gnovm.MemFile{
-				{"hello.gno", `
+				{Name: "hello.gno", Body: `
 package hello
 
 var sl = []int{1,2,3,4,5}
@@ -284,8 +284,8 @@ func TestVmHandlerQuery_File(t *testing.T) {
 
 			// Create test package.
 			files := []*gnovm.MemFile{
-				{"README.md", "# Hello"},
-				{"hello.gno", "package hello\n\nfunc Hello() string { return \"hello\" }\n"},
+				{Name: "README.md", Body: "# Hello"},
+				{Name: "hello.gno", Body: "package hello\n\nfunc Hello() string { return \"hello\" }\n"},
 			}
 			pkgPath := "gno.land/r/hello"
 			msg1 := NewMsgAddPackage(addr, pkgPath, files)

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -314,7 +314,7 @@ func TestVMKeeperParams(t *testing.T) {
 
 	// Create test package.
 	files := []*gnovm.MemFile{
-		{"init.gno", `
+		{Name: "init.gno", Body: `
 package test
 
 import "std"


### PR DESCRIPTION
After merge of #3000, a few missing field names in struct literal were reported. Fix it. No functional change.

<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [*] Added new tests, or not needed, or not feasible
- [*] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [*] Updated the official documentation or not needed
- [*] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
