### PR TITLE
fix(cmd/gno/clean): allow to run `gno clean -modcache` from anywhere + rename and use `gnomod.ModCachePath` + tmp `GNOHOME` in main tests

### DIFF
--- a/gnovm/cmd/gno/clean.go
+++ b/gnovm/cmd/gno/clean.go
@@ -63,6 +63,19 @@ func execClean(cfg *cleanCfg, args []string, io commands.IO) error {
 		return flag.ErrHelp
 	}
 
+	if cfg.modCache {
+		modCacheDir := gnomod.GetGnoModPath()
+		if !cfg.dryRun {
+			if err := os.RemoveAll(modCacheDir); err != nil {
+				return err
+			}
+		}
+		if cfg.dryRun || cfg.verbose {
+			io.Println("rm -rf", modCacheDir)
+		}
+		return nil
+	}
+
 	path, err := os.Getwd()
 	if err != nil {
 		return err
@@ -80,17 +93,6 @@ func execClean(cfg *cleanCfg, args []string, io commands.IO) error {
 		return err
 	}
 
-	if cfg.modCache {
-		modCacheDir := gnomod.GetGnoModPath()
-		if !cfg.dryRun {
-			if err := os.RemoveAll(modCacheDir); err != nil {
-				return err
-			}
-		}
-		if cfg.dryRun || cfg.verbose {
-			io.Println("rm -rf", modCacheDir)
-		}
-	}
 	return nil
 }
 

--- a/gnovm/cmd/gno/clean.go
+++ b/gnovm/cmd/gno/clean.go
@@ -64,7 +64,7 @@ func execClean(cfg *cleanCfg, args []string, io commands.IO) error {
 	}
 
 	if cfg.modCache {
-		modCacheDir := gnomod.GetGnoModPath()
+		modCacheDir := gnomod.ModCachePath()
 		if !cfg.dryRun {
 			if err := os.RemoveAll(modCacheDir); err != nil {
 				return err

--- a/gnovm/cmd/gno/clean.go
+++ b/gnovm/cmd/gno/clean.go
@@ -54,7 +54,7 @@ func (c *cleanCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.modCache,
 		"modcache",
 		false,
-		"remove the entire module download cache",
+		"remove the entire module download cache and exit",
 	)
 }
 

--- a/gnovm/cmd/gno/clean.go
+++ b/gnovm/cmd/gno/clean.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
 	"github.com/gnolang/gno/gnovm/pkg/gnomod"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
@@ -82,7 +81,7 @@ func execClean(cfg *cleanCfg, args []string, io commands.IO) error {
 	}
 
 	if cfg.modCache {
-		modCacheDir := filepath.Join(gnoenv.HomeDir(), "pkg", "mod")
+		modCacheDir := gnomod.GetGnoModPath()
 		if !cfg.dryRun {
 			if err := os.RemoveAll(modCacheDir); err != nil {
 				return err

--- a/gnovm/cmd/gno/clean_test.go
+++ b/gnovm/cmd/gno/clean_test.go
@@ -36,13 +36,11 @@ func TestCleanApp(t *testing.T) {
 			args:                 []string{"clean", "-modcache"},
 			testDir:              "../../tests/integ/empty_dir",
 			simulateExternalRepo: true,
-			tmpGnoHome:           true,
 		},
 		{
 			args:                 []string{"clean", "-modcache", "-n"},
 			testDir:              "../../tests/integ/empty_dir",
 			simulateExternalRepo: true,
-			tmpGnoHome:           true,
 			stdoutShouldContain:  "rm -rf ",
 		},
 	}

--- a/gnovm/cmd/gno/clean_test.go
+++ b/gnovm/cmd/gno/clean_test.go
@@ -32,6 +32,19 @@ func TestCleanApp(t *testing.T) {
 			testDir:              "../../tests/integ/minimalist_gnomod",
 			simulateExternalRepo: true,
 		},
+		{
+			args:                 []string{"clean", "-modcache"},
+			testDir:              "../../tests/integ/empty_dir",
+			simulateExternalRepo: true,
+			tmpGnoHome:           true,
+		},
+		{
+			args:                 []string{"clean", "-modcache", "-n"},
+			testDir:              "../../tests/integ/empty_dir",
+			simulateExternalRepo: true,
+			tmpGnoHome:           true,
+			stdoutShouldContain:  "rm -rf ",
+		},
 	}
 	testMainCaseRun(t, tc)
 

--- a/gnovm/cmd/gno/env_test.go
+++ b/gnovm/cmd/gno/env_test.go
@@ -18,13 +18,13 @@ func TestEnvApp(t *testing.T) {
 		{args: []string{"env", "foo"}, stdoutShouldBe: "\n"},
 		{args: []string{"env", "foo", "bar"}, stdoutShouldBe: "\n\n"},
 		{args: []string{"env", "GNOROOT"}, stdoutShouldBe: testGnoRootEnv + "\n"},
-		{args: []string{"env", "GNOHOME", "storm"}, stdoutShouldBe: testGnoHomeEnv + "\n\n"},
+		{args: []string{"env", "GNOHOME", "storm"}, stdoutShouldBe: testGnoHomeEnv + "\n\n", notTmpGnohome: true},
 		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOROOT=%q", testGnoRootEnv)},
-		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOHOME=%q", testGnoHomeEnv)},
+		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOHOME=%q", testGnoHomeEnv), notTmpGnohome: true},
 
 		// json
 		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOROOT\": %q", testGnoRootEnv)},
-		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOHOME\": %q", testGnoHomeEnv)},
+		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOHOME\": %q", testGnoHomeEnv), notTmpGnohome: true},
 		{
 			args:           []string{"env", "-json", "GNOROOT"},
 			stdoutShouldBe: fmt.Sprintf("{\n\t\"GNOROOT\": %q\n}\n", testGnoRootEnv),

--- a/gnovm/cmd/gno/env_test.go
+++ b/gnovm/cmd/gno/env_test.go
@@ -18,13 +18,13 @@ func TestEnvApp(t *testing.T) {
 		{args: []string{"env", "foo"}, stdoutShouldBe: "\n"},
 		{args: []string{"env", "foo", "bar"}, stdoutShouldBe: "\n\n"},
 		{args: []string{"env", "GNOROOT"}, stdoutShouldBe: testGnoRootEnv + "\n"},
-		{args: []string{"env", "GNOHOME", "storm"}, stdoutShouldBe: testGnoHomeEnv + "\n\n", notTmpGnohome: true},
+		{args: []string{"env", "GNOHOME", "storm"}, stdoutShouldBe: testGnoHomeEnv + "\n\n", noTmpGnohome: true},
 		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOROOT=%q", testGnoRootEnv)},
-		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOHOME=%q", testGnoHomeEnv), notTmpGnohome: true},
+		{args: []string{"env"}, stdoutShouldContain: fmt.Sprintf("GNOHOME=%q", testGnoHomeEnv), noTmpGnohome: true},
 
 		// json
 		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOROOT\": %q", testGnoRootEnv)},
-		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOHOME\": %q", testGnoHomeEnv), notTmpGnohome: true},
+		{args: []string{"env", "-json"}, stdoutShouldContain: fmt.Sprintf("\"GNOHOME\": %q", testGnoHomeEnv), noTmpGnohome: true},
 		{
 			args:           []string{"env", "-json", "GNOROOT"},
 			stdoutShouldBe: fmt.Sprintf("{\n\t\"GNOROOT\": %q\n}\n", testGnoRootEnv),

--- a/gnovm/cmd/gno/main_test.go
+++ b/gnovm/cmd/gno/main_test.go
@@ -26,7 +26,7 @@ type testMainCase struct {
 	args                 []string
 	testDir              string
 	simulateExternalRepo bool
-	notTmpGnohome        bool
+	noTmpGnohome         bool
 
 	// for the following FooContain+FooBe expected couples, if both are empty,
 	// then the test suite will require that the "got" is not empty.
@@ -59,7 +59,7 @@ func testMainCaseRun(t *testing.T, tc []testMainCase) {
 			mockOut := bytes.NewBufferString("")
 			mockErr := bytes.NewBufferString("")
 
-			if !test.notTmpGnohome {
+			if !test.noTmpGnohome {
 				tmpGnoHome, err := os.MkdirTemp(os.TempDir(), "gnotesthome_")
 				require.NoError(t, err)
 				t.Cleanup(func() { os.RemoveAll(tmpGnoHome) })

--- a/gnovm/cmd/gno/main_test.go
+++ b/gnovm/cmd/gno/main_test.go
@@ -26,7 +26,7 @@ type testMainCase struct {
 	args                 []string
 	testDir              string
 	simulateExternalRepo bool
-	tmpGnoHome           bool
+	notTmpGnohome        bool
 
 	// for the following FooContain+FooBe expected couples, if both are empty,
 	// then the test suite will require that the "got" is not empty.
@@ -59,11 +59,11 @@ func testMainCaseRun(t *testing.T, tc []testMainCase) {
 			mockOut := bytes.NewBufferString("")
 			mockErr := bytes.NewBufferString("")
 
-			if test.tmpGnoHome {
-				gnohome, err := os.MkdirTemp(os.TempDir(), "gnotesthome_")
+			if !test.notTmpGnohome {
+				tmpGnoHome, err := os.MkdirTemp(os.TempDir(), "gnotesthome_")
 				require.NoError(t, err)
-				t.Cleanup(func() { os.RemoveAll(gnohome) })
-				t.Setenv("GNOHOME", gnohome)
+				t.Cleanup(func() { os.RemoveAll(tmpGnoHome) })
+				t.Setenv("GNOHOME", tmpGnoHome)
 			}
 
 			checkOutputs := func(t *testing.T) {

--- a/gnovm/cmd/gno/main_test.go
+++ b/gnovm/cmd/gno/main_test.go
@@ -26,6 +26,7 @@ type testMainCase struct {
 	args                 []string
 	testDir              string
 	simulateExternalRepo bool
+	tmpGnoHome           bool
 
 	// for the following FooContain+FooBe expected couples, if both are empty,
 	// then the test suite will require that the "got" is not empty.
@@ -57,6 +58,13 @@ func testMainCaseRun(t *testing.T, tc []testMainCase) {
 		t.Run(testName, func(t *testing.T) {
 			mockOut := bytes.NewBufferString("")
 			mockErr := bytes.NewBufferString("")
+
+			if test.tmpGnoHome {
+				gnohome, err := os.MkdirTemp(os.TempDir(), "gnotesthome_")
+				require.NoError(t, err)
+				t.Cleanup(func() { os.RemoveAll(gnohome) })
+				t.Setenv("GNOHOME", gnohome)
+			}
 
 			checkOutputs := func(t *testing.T) {
 				t.Helper()

--- a/gnovm/cmd/gno/mod.go
+++ b/gnovm/cmd/gno/mod.go
@@ -177,7 +177,7 @@ func execModDownload(cfg *modDownloadCfg, args []string, io commands.IO) error {
 	}
 
 	// fetch dependencies
-	if err := gnoMod.FetchDeps(gnomod.GetGnoModPath(), cfg.remote, cfg.verbose); err != nil {
+	if err := gnoMod.FetchDeps(gnomod.ModCachePath(), cfg.remote, cfg.verbose); err != nil {
 		return fmt.Errorf("fetch: %w", err)
 	}
 

--- a/gnovm/pkg/gnomod/gnomod.go
+++ b/gnovm/pkg/gnomod/gnomod.go
@@ -19,20 +19,20 @@ import (
 
 const queryPathFile = "vm/qfile"
 
-// GetGnoModPath returns the path for gno modules
-func GetGnoModPath() string {
+// ModCachePath returns the path for gno modules
+func ModCachePath() string {
 	return filepath.Join(gnoenv.HomeDir(), "pkg", "mod")
 }
 
 // PackageDir resolves a given module.Version to the path on the filesystem.
-// If root is dir, it is defaulted to the value of [GetGnoModPath].
+// If root is dir, it is defaulted to the value of [ModCachePath].
 func PackageDir(root string, v module.Version) string {
 	// This is also used internally exactly like filepath.Join; but we'll keep
 	// the calls centralized to make sure we can change the path centrally should
 	// we start including the module version in the path.
 
 	if root == "" {
-		root = GetGnoModPath()
+		root = ModCachePath()
 	}
 	return filepath.Join(root, v.Path)
 }
@@ -89,7 +89,7 @@ func writePackage(remote, basePath, pkgPath string) (requirements []string, err 
 func GnoToGoMod(f File) (*File, error) {
 	// TODO(morgan): good candidate to move to pkg/transpiler.
 
-	gnoModPath := GetGnoModPath()
+	gnoModPath := ModCachePath()
 
 	if !gnolang.IsStdlib(f.Module.Mod.Path) {
 		f.AddModuleStmt(transpiler.TranspileImportPath(f.Module.Mod.Path))


### PR DESCRIPTION
- In `gno clean`, run the `-modcache` case before checking for presence of a `gno.mod` to allow to run `gno clean -modcache` from anywhere (like go)
- Refactor `gno clean -modcache` to use the `gnomod.GetGnoModPath` helper to get the modcache path
- Rename `gnomod.GetGnoModPath` -> `gnomod.ModCachePath`
- Improve `gno` cmd tests by using a tmp `GNOHOME` instead of the system one

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
