### PR TITLE
fix(coverage): expand coverage with `-coverpkg`

### DIFF
--- a/.github/workflows/main_template.yml
+++ b/.github/workflows/main_template.yml
@@ -30,8 +30,7 @@ jobs:
         uses: ./.github/workflows/test_template.yml
         with:
             modulepath: ${{ inputs.modulepath }}
-            tests-timeout: "30m"
+            tests-timeout: "40m"
             go-version: "1.22.x"
         secrets:
             codecov-token: ${{ secrets.codecov-token }}
-    

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -36,13 +36,17 @@ jobs:
             mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
 
             # Craft a filter flag based on the module path to avoid expanding coverage on unrelated tags.
-            export filter="-pkg=github.com/gnolang/gno/${{ inputs.modulepath }}/..."
+            export coverpkg="github.com/gnolang/gno/${{ inputs.modulepath }}/..."
+            export filter="-pkg=$coverpkg"
 
             # XXX: Simplify coverage of txtar - the current setup is a bit
             # confusing and meticulous. There will be some improvements in Go
             # 1.23 regarding coverage, so we can use this as a workaround until
             # then.
-            go test -covermode=atomic -timeout ${{ inputs.tests-timeout }} ./... -test.gocoverdir=$GOCOVERDIR
+            go test ./... -coverpkg=$coverpkg \
+                          -covermode=atomic \
+                          -timeout ${{ inputs.tests-timeout }} \
+                          -test.gocoverdir=$GOCOVERDIR
 
             # Print results
             (set +x; echo 'go coverage results:')


### PR DESCRIPTION
Addresses https://github.com/gnolang/gno/pull/3003.

Following https://github.com/gnolang/gno/pull/3003#discussion_r1833428254. This PR expands coverage using `-coverpkg`. It's a generic and alternative approach compared to #3088.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
