### PR TITLE
ci: add go caching

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -12,13 +12,13 @@ jobs:
     generated:
         runs-on: ubuntu-latest
         steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+
           - name: Install Go
             uses: actions/setup-go@v5
             with:
               go-version: ${{ inputs.go-version }}
-
-          - name: Checkout code
-            uses: actions/checkout@v4
 
           - name: Check generated files are up to date
             working-directory: ${{ inputs.modulepath }}

--- a/.github/workflows/lint_template.yml
+++ b/.github/workflows/lint_template.yml
@@ -13,12 +13,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -18,12 +18,12 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
         - name: Install Go
           uses: actions/setup-go@v5
           with:
               go-version: ${{ inputs.go-version }}
-        - name: Checkout code
-          uses: actions/checkout@v4
         - name: Go test
           working-directory:  ${{ inputs.modulepath }}
           env:


### PR DESCRIPTION
`actions/setup-go` requires `actions/checkout` to read the `go.sum` file.

![CleanShot 2024-11-08 at 11 55 28@2x](https://github.com/user-attachments/assets/9014b6f4-d415-487a-a624-d5879e69d2c2)
