### PR TITLE
chore: add Berty validator node in conf files

### DIFF
--- a/misc/deployments/test5.gno.land/README.md
+++ b/misc/deployments/test5.gno.land/README.md
@@ -11,7 +11,7 @@ The initial `genesis.json` validator set is consisted of 6 entities (17 validato
 - AiB - the AiB DevOps team (**3 validators**)
 - Onbloc - the [Onbloc](https://onbloc.xyz/) team (**2 validator**)
 - Teritori - the [Teritori](https://teritori.com/) team (**1 validator**)
-- Berty - the [Berty](https://berty.io/) team (**1 validator**)
+- Berty - the [Berty](https://berty.tech/) team (**1 validator**)
 
 Subsequent validators will be added through the governance mechanism in govdao, employing a preliminary simplified
 version Proof of Contribution.
@@ -34,7 +34,7 @@ Some configuration params are required, while others are advised to be set.
   reverse-proxy, and keep this value at `tcp://0.0.0.0:<port>`.
 - `p2p.max_num_outbound_peers` - the max number of outbound peer connections. **Advised to be `40`**.
 - `p2p.persistent_peers` - the persistent peers. ⚠️ **Required to be
-  `TODO`** ⚠️.
+  `g12p9l546ah4qeenhum8v4m2dg92jxcsrfy67yww@163.172.33.181:26656`** ⚠️.
 - `p2p.pex` - if using a sentry node architecture, should be `false`. **If not, please set to `true`**.
 - `p2p.external_address` - the advertised peer dial address. If empty, will use the same port as the `p2p.laddr`. This
   value should be **changed to `{{ your_ip_address }}:26656`**

--- a/misc/deployments/test5.gno.land/config.toml
+++ b/misc/deployments/test5.gno.land/config.toml
@@ -121,7 +121,7 @@ max_num_outbound_peers = 40 # Advised value is 40
 max_packet_msg_payload_size = 1024
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "" # TODO update @Salvo, @Blake, @Sergio, @Norman, @Albert
+persistent_peers = "g12p9l546ah4qeenhum8v4m2dg92jxcsrfy67yww@163.172.33.181:26656" # TODO update @Salvo, @Blake, @Sergio, @Norman, @Albert
 
 # Set true to enable the peer-exchange reactor
 pex = false # Should be `false` if using a sentry node. Otherwise `true`!

--- a/misc/deployments/test5.gno.land/genesis.json
+++ b/misc/deployments/test5.gno.land/genesis.json
@@ -15,6 +15,17 @@
       ]
     }
   },
+  "validators": [
+    {
+      "address": "g1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl",
+      "pub_key": {
+        "@type": "/tm.PubKeyEd25519",
+        "value": "KRPAQ2SLZvQUrc9P2l/DCEH6okMX13bds5Ma/wOQgBM="
+      },
+      "power": "1",
+      "name": "berty-val-1"
+    }
+  ],
   "app_hash": null,
   "app_state": {
     "@type": "/gno.GenesisState",
@@ -52,7 +63,8 @@
       "g18amm3fc00t43dcxsys6udug0czyvqt9e7p23rd=9000000000000000000ugnot",
       "g127l4gkhk0emwsx5tmxe96sp86c05h8vg5tufzq=9000000000000000000ugnot",
       "g16tfrrul20g4jzt3z303raqw8vs8s2pqqh5clwu=9000000000000000000ugnot",
-      "g1a6jf5g6gkhn5rxcvwxq5zjxgwaznjr9r8gehey=9000000000000000000ugnot"
+      "g1a6jf5g6gkhn5rxcvwxq5zjxgwaznjr9r8gehey=9000000000000000000ugnot",
+      "g1qynsu9dwj9lq0m5fkje7jh6qy3md80ztqnshhm=9000000000000000000ugnot"
     ],
     "txs": null
   }

--- a/misc/deployments/test5.gno.land/genesis_balances.txt
+++ b/misc/deployments/test5.gno.land/genesis_balances.txt
@@ -62,7 +62,7 @@ g1sw5xklxjjuv0yvuxy5f5s3l3mnj0nqq626a9wr=9000000000000000000ugnot # Albert
 
 # Berty
 
-# TODO @Jeff please add these here
+g1qynsu9dwj9lq0m5fkje7jh6qy3md80ztqnshhm=9000000000000000000ugnot
 
 # Dragos
 


### PR DESCRIPTION
This PR adds the Berty validator node in the config and README files for the test5 launch.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
