### PR TITLE
chore: add Onbloc (validator and genesis account)

### DIFF
--- a/misc/deployments/test5.gno.land/config.toml
+++ b/misc/deployments/test5.gno.land/config.toml
@@ -121,7 +121,8 @@ max_num_outbound_peers = 40 # Advised value is 40
 max_packet_msg_payload_size = 1024
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "" # TODO update @Salvo, @Blake, @Sergio, @Norman, @Albert
+# TODO update @Salvo, @Blake, @Sergio, @Norman, @Albert
+persistent_peers = "g1s40khr8fruvsp2e9tveqyfwgzrqw4fs9kr4hwc@3.18.33.75:26656,g1gdt4c8rs3l4gpmp0f840nj93sv59cag6hn00cd@3.133.216.128:26656" 
 
 # Set true to enable the peer-exchange reactor
 pex = false # Should be `false` if using a sentry node. Otherwise `true`!

--- a/misc/deployments/test5.gno.land/genesis.json
+++ b/misc/deployments/test5.gno.land/genesis.json
@@ -10,11 +10,29 @@
       "TimeIotaMS": "100"
     },
     "Validator": {
-      "PubKeyTypeURLs": [
-        "/tm.PubKeyEd25519"
-      ]
+      "PubKeyTypeURLs": ["/tm.PubKeyEd25519"]
     }
   },
+  "validators": [
+    {
+      "address": "g1arkzjfrte9l97v9q2qye07v0lw07039gaa3hfy",
+      "pub_key": {
+        "@type": "/tm.PubKeyEd25519",
+        "value": "2Y0npl9WoOk9pIs2Dwv9IjsNbiuCWw6srsPKRf4sUro="
+      },
+      "power": "1",
+      "name": "onbloc-val-1"
+    },
+    {
+      "address": "g1x0m33nyne064xdx7tvlfcjwd4xkajjar6h523z",
+      "pub_key": {
+        "@type": "/tm.PubKeyEd25519",
+        "value": "6h57Ku4O6NFK7SS53Zxm/2rJEq4zVeznKvphAei5Z5g"
+      },
+      "power": "1",
+      "name": "onbloc-val-2"
+    }
+  ],
   "app_hash": null,
   "app_state": {
     "@type": "/gno.GenesisState",
@@ -52,7 +70,9 @@
       "g18amm3fc00t43dcxsys6udug0czyvqt9e7p23rd=9000000000000000000ugnot",
       "g127l4gkhk0emwsx5tmxe96sp86c05h8vg5tufzq=9000000000000000000ugnot",
       "g16tfrrul20g4jzt3z303raqw8vs8s2pqqh5clwu=9000000000000000000ugnot",
-      "g1a6jf5g6gkhn5rxcvwxq5zjxgwaznjr9r8gehey=9000000000000000000ugnot"
+      "g1a6jf5g6gkhn5rxcvwxq5zjxgwaznjr9r8gehey=9000000000000000000ugnot",
+      "g1er355fkjksqpdtwmhf5penwa82p0rhqxkkyhk5=9000000000000000000ugnot",
+      "g18l9us6trqaljw39j94wzf5ftxmd9qqkvrxghd2=9000000000000000000ugnot"
     ],
     "txs": null
   }

--- a/misc/deployments/test5.gno.land/genesis_balances.txt
+++ b/misc/deployments/test5.gno.land/genesis_balances.txt
@@ -58,7 +58,8 @@ g1sw5xklxjjuv0yvuxy5f5s3l3mnj0nqq626a9wr=9000000000000000000ugnot # Albert
 
 # Onbloc
 
-# TODO @Dongwon please add these here
+g1er355fkjksqpdtwmhf5penwa82p0rhqxkkyhk5=9000000000000000000ugnot
+g18l9us6trqaljw39j94wzf5ftxmd9qqkvrxghd2=9000000000000000000ugnot
 
 # Berty
 


### PR DESCRIPTION
## modified
1. `config.toml` to add persistent peer
2. `genesis.json` to add validator and genesis account(with balance)
3. `genesis_balances.txt` to add genesis account(with balance)