### PR TITLE
chore(p/grc721): Distinct Event Types for GRC721 Functions

### DIFF
--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -2,6 +2,7 @@ package grc721
 
 import (
 	"std"
+	"strconv"
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
@@ -120,8 +121,12 @@ func (s *basicNFT) Approve(to std.Address, tid TokenID) error {
 	}
 
 	s.tokenApprovals.Set(string(tid), to.String())
-	event := ApprovalEvent{owner, to, tid}
-	emit(&event)
+	std.Emit(
+		ApprovalEvent,
+		"owner", string(owner),
+		"to", string(to),
+		"tokenId", string(tid),
+	)
 
 	return nil
 }
@@ -219,8 +224,12 @@ func (s *basicNFT) Burn(tid TokenID) error {
 	s.balances.Set(owner.String(), balance)
 	s.owners.Remove(string(tid))
 
-	event := TransferEvent{owner, zeroAddress, tid}
-	emit(&event)
+	std.Emit(
+		BurnEvent,
+		"from", string(owner),
+		"to", "",
+		"tokenId", string(tid),
+	)
 
 	s.afterTokenTransfer(owner, zeroAddress, tid, 1)
 
@@ -238,8 +247,12 @@ func (s *basicNFT) setApprovalForAll(owner, operator std.Address, approved bool)
 	key := owner.String() + ":" + operator.String()
 	s.operatorApprovals.Set(key, approved)
 
-	event := ApprovalForAllEvent{owner, operator, approved}
-	emit(&event)
+	std.Emit(
+		ApprovalForAllEvent,
+		"owner", string(owner),
+		"to", string(to),
+		"approved", strconv.FormatBool(approved),
+	)
 
 	return nil
 }
@@ -291,8 +304,12 @@ func (s *basicNFT) transfer(from, to std.Address, tid TokenID) error {
 	s.balances.Set(to.String(), toBalance)
 	s.owners.Set(string(tid), to)
 
-	event := TransferEvent{from, to, tid}
-	emit(&event)
+	std.Emit(
+		TransferEvent,
+		"from", string(from),
+		"to", string(to),
+		"tokenId", string(tid),
+	)
 
 	s.afterTokenTransfer(from, to, tid, 1)
 
@@ -324,8 +341,12 @@ func (s *basicNFT) mint(to std.Address, tid TokenID) error {
 	s.balances.Set(to.String(), toBalance)
 	s.owners.Set(string(tid), to)
 
-	event := TransferEvent{zeroAddress, to, tid}
-	emit(&event)
+	std.Emit(
+		MintEvent,
+		"from", "",
+		"to", string(to),
+		"tokenId", string(tid),
+	)
 
 	s.afterTokenTransfer(zeroAddress, to, tid, 1)
 

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -250,7 +250,7 @@ func (s *basicNFT) setApprovalForAll(owner, operator std.Address, approved bool)
 	std.Emit(
 		ApprovalForAllEvent,
 		"owner", string(owner),
-		"to", string(to),
+		"to", string(operator),
 		"approved", strconv.FormatBool(approved),
 	)
 

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -227,7 +227,6 @@ func (s *basicNFT) Burn(tid TokenID) error {
 	std.Emit(
 		BurnEvent,
 		"from", string(owner),
-		"to", "",
 		"tokenId", string(tid),
 	)
 
@@ -343,7 +342,6 @@ func (s *basicNFT) mint(to std.Address, tid TokenID) error {
 
 	std.Emit(
 		MintEvent,
-		"from", "",
 		"to", string(to),
 		"tokenId", string(tid),
 	)

--- a/examples/gno.land/p/demo/grc/grc721/grc721_metadata.gno
+++ b/examples/gno.land/p/demo/grc/grc721/grc721_metadata.gno
@@ -85,9 +85,12 @@ func (s *metadataNFT) mint(to std.Address, tid TokenID) error {
 	// Set owner of the token ID to the recipient address
 	s.basicNFT.owners.Set(string(tid), to)
 
-	// Emit transfer event
-	event := TransferEvent{zeroAddress, to, tid}
-	emit(&event)
+	std.Emit(
+		TransferEvent,
+		"from", string(zeroAddress),
+		"to", string(to),
+		"tokenId", string(tid),
+	)
 
 	s.basicNFT.afterTokenTransfer(zeroAddress, to, tid, 1)
 

--- a/examples/gno.land/p/demo/grc/grc721/igrc721.gno
+++ b/examples/gno.land/p/demo/grc/grc721/igrc721.gno
@@ -36,3 +36,11 @@ type ApprovalForAllEvent struct {
 	Operator std.Address
 	Approved bool
 }
+
+const (
+	MintEvent           = "Mint"
+	BurnEvent           = "Burn"
+	TransferEvent       = "Transfer"
+	ApprovalEvent       = "Approval"
+	ApprovalForAllEvent = "ApprovalForAll"
+)

--- a/examples/gno.land/p/demo/grc/grc721/igrc721.gno
+++ b/examples/gno.land/p/demo/grc/grc721/igrc721.gno
@@ -19,24 +19,6 @@ type (
 	TokenURI string
 )
 
-type TransferEvent struct {
-	From    std.Address
-	To      std.Address
-	TokenID TokenID
-}
-
-type ApprovalEvent struct {
-	Owner    std.Address
-	Approved std.Address
-	TokenID  TokenID
-}
-
-type ApprovalForAllEvent struct {
-	Owner    std.Address
-	Operator std.Address
-	Approved bool
-}
-
 const (
 	MintEvent           = "Mint"
 	BurnEvent           = "Burn"

--- a/gno.land/cmd/gnoland/testdata/grc721_emit.txtar
+++ b/gno.land/cmd/gnoland/testdata/grc721_emit.txtar
@@ -1,0 +1,95 @@
+# Test for https://github.com/gnolang/gno/pull/3102
+loadpkg gno.land/p/demo/grc/grc721
+loadpkg gno.land/r/demo/users
+loadpkg gno.land/r/foo721 $WORK/foo721
+
+gnoland start
+
+# Mint
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout '\[{\"type\":\"Mint\",\"attrs\":\[{\"key\":\"to\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"tokenId\",\"value\":\"1\"}],\"pkg_path\":\"gno.land\/r\/foo721\",\"func\":\"mint\"}\]'
+
+# Approve
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout '\[{\"type\":\"Approval\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}],\"pkg_path\":\"gno.land\/r\/foo721\",\"func\":\"Approve\"}\]'
+
+# SetApprovalForAll
+gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout '\[{\"type\":\"ApprovalForAll\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"approved\",\"value\":\"false\"}],\"pkg_path\":\"gno\.land/r/foo721\",\"func\":\"setApprovalForAll\"}\]'
+
+# TransferFrom
+gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout '\[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}],\"pkg_path\":\"gno\.land/r/foo721\",\"func\":\"transfer\"}\]'
+
+# Burn
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Burn -args 1  -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test test1
+stdout '\[{\"type\":\"Burn\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}],\"pkg_path\":\"gno\.land/r/foo721\",\"func\":\"Burn\"}\]'
+
+
+-- foo721/foo721.gno --
+package foo721
+
+import (
+	"std"
+
+	"gno.land/p/demo/grc/grc721"
+	"gno.land/r/demo/users"
+
+	pusers "gno.land/p/demo/users"
+)
+
+var (
+	admin std.Address = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+	foo               = grc721.NewBasicNFT("FooNFT", "FNFT")
+)
+
+// Setters
+
+func Approve(user pusers.AddressOrName, tid grc721.TokenID) {
+	err := foo.Approve(users.Resolve(user), tid)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func SetApprovalForAll(user pusers.AddressOrName, approved bool) {
+	err := foo.SetApprovalForAll(users.Resolve(user), approved)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TransferFrom(from, to pusers.AddressOrName, tid grc721.TokenID) {
+	err := foo.TransferFrom(users.Resolve(from), users.Resolve(to), tid)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Admin
+
+func Mint(to pusers.AddressOrName, tid grc721.TokenID) {
+	caller := std.PrevRealm().Addr()
+	assertIsAdmin(caller)
+	err := foo.Mint(users.Resolve(to), tid)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Burn(tid grc721.TokenID) {
+	caller := std.PrevRealm().Addr()
+	assertIsAdmin(caller)
+	err := foo.Burn(tid)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Util
+
+func assertIsAdmin(address std.Address) {
+	if address != admin {
+		panic("restricted access")
+	}
+}


### PR DESCRIPTION
# Description
Current event(emit) code in p/grc721 really doesn't emits event. 

Therefore, modified code to emit the events.

And similar to #2749, made event type for each function to be unique.



<!-- please provide a detailed description of the changes made in this pull request. -->

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
