### PR TITLE
gnokey: in `maketx addpkg`, change `deposit` to `send`

### DIFF
--- a/gno.land/pkg/keyscli/addpkg.go
+++ b/gno.land/pkg/keyscli/addpkg.go
@@ -58,9 +58,9 @@ func (c *MakeAddPkgCfg) RegisterFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(
 		&c.Deposit,
-		"deposit",
+		"send",
 		"",
-		"deposit coins",
+		"deposit coins to the realm being deployed",
 	)
 }
 


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->

## Description

Changes the `deposit` flag to `send`. I think this change makes sense from the consistency perspective. It's quite obvious that the `send` will go to the deployed realm's address.

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
