### PR TITLE
ci: only run fossa action on workflow_dispatch

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -2,12 +2,6 @@ name: Dependency License Scanning
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/.fossa.yml"
-      - ".github/workflows/fossa.yml"
-  schedule:
-    - cron: '0 0 * * 6' # At 00:00 on saturdays
 
 permissions:
   contents: read
@@ -47,4 +41,3 @@ jobs:
         run: fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"
-


### PR DESCRIPTION
This is only run once every never (ie. when legal requests it)