### PR TITLE
feat: add bug label automatically to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report Template
 about: Create a bug report
+labels: "🐞 bug"
 # NOTE: keep in sync with gnovm/cmd/gno/bug.go
 ---
 


### PR DESCRIPTION
Add `🐞 bug` label automatically whenever the "bug report" template is used for a new issue.