### PR TITLE
feat: r/docs/home -> r/docs

### DIFF
--- a/examples/gno.land/r/docs/docs.gno
+++ b/examples/gno.land/r/docs/docs.gno
@@ -1,4 +1,4 @@
-package home
+package docs
 
 func Render(_ string) string {
 	return `# Gno Examples Documentation

--- a/examples/gno.land/r/docs/docs_test.gno
+++ b/examples/gno.land/r/docs/docs_test.gno
@@ -1,4 +1,4 @@
-package home
+package docs
 
 import (
 	"strings"

--- a/examples/gno.land/r/docs/gno.mod
+++ b/examples/gno.land/r/docs/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/docs

--- a/examples/gno.land/r/docs/home/gno.mod
+++ b/examples/gno.land/r/docs/home/gno.mod
@@ -1,1 +1,0 @@
-module gno.land/r/docs/home


### PR DESCRIPTION
I initially considered adding a rule in gnoweb to automatically redirect to `/home`. However, I believe it makes more sense to:  
1. Test having a namespace-realm to identify any inconveniences.  
2. Designate `r/docs` as the documentation and `r/docs/home` as the homepage for the "docs" team.  

Later, we might use `r/<handle>/home` to configure a DefaultRealm that enables redirection when accessing `r/<namespace>`. I'm not sure yet, but let's experiment.