### PR TITLE
docs(std/testing): fix NewUserRealm reference usage

### DIFF
--- a/docs/reference/stdlibs/std/testing.md
+++ b/docs/reference/stdlibs/std/testing.md
@@ -106,7 +106,7 @@ Should be used in combination with [`NewUserRealm`](#newuserrealm) &
 #### Usage
 ```go
 addr := std.Address("g1ecely4gjy0yl6s9kt409ll330q9hk2lj9ls3ec")
-std.TestSetRealm(std.NewUserRealm(""))
+std.TestSetRealm(std.NewUserRealm(addr))
 // or 
 std.TestSetRealm(std.NewCodeRealm("gno.land/r/demo/users"))
 ```


### PR DESCRIPTION
FIX: https://docs.gno.land/reference/stdlibs/std/testing/#testsetrealm

FROM

#### Usage
```go
addr := std.Address("g1ecely4gjy0yl6s9kt409ll330q9hk2lj9ls3ec")
std.TestSetRealm(std.NewUserRealm(""))
// or 
std.TestSetRealm(std.NewCodeRealm("gno.land/r/demo/users"))
```

TO

#### Usage
```go
addr := std.Address("g1ecely4gjy0yl6s9kt409ll330q9hk2lj9ls3ec")
std.TestSetRealm(std.NewUserRealm(addr))
// or 
std.TestSetRealm(std.NewCodeRealm("gno.land/r/demo/users"))
```

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
</details>
