### PR TITLE
fix: const conversions for 32 bits

### DIFF
--- a/gnovm/pkg/gnolang/values_conversions.go
+++ b/gnovm/pkg/gnolang/values_conversions.go
@@ -151,7 +151,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetUint16(x)
 		case Uint32Kind:
-			validate(IntKind, Uint32Kind, func() bool { return tv.GetInt() >= 0 && tv.GetInt() <= math.MaxUint32 })
+			validate(IntKind, Uint32Kind, func() bool { return tv.GetInt() >= 0 && uint64(tv.GetInt()) <= math.MaxUint32 })
 
 			x := uint32(tv.GetInt())
 			tv.T = t
@@ -501,7 +501,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetInt32(x)
 		case Int64Kind:
-			validate(UintKind, Int64Kind, func() bool { return tv.GetUint() <= math.MaxInt64 })
+			validate(UintKind, Int64Kind, func() bool { return uint64(tv.GetUint()) <= math.MaxInt64 })
 
 			x := int64(tv.GetUint())
 			tv.T = t
@@ -576,7 +576,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetInt32(x)
 		case Int64Kind:
-			validate(Uint8Kind, Int64Kind, func() bool { return int(tv.GetUint8()) <= math.MaxInt64 })
+			validate(Uint8Kind, Int64Kind, func() bool { return true })
 
 			x := int64(tv.GetUint8())
 			tv.T = t
@@ -645,7 +645,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetInt32(x)
 		case Int64Kind:
-			validate(Uint16Kind, Int64Kind, func() bool { return int(tv.GetUint16()) <= math.MaxInt64 })
+			validate(Uint16Kind, Int64Kind, func() bool { return true })
 
 			x := int64(tv.GetUint16())
 			tv.T = t
@@ -791,7 +791,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetInt32(x)
 		case Int64Kind:
-			validate(Uint64Kind, Int64Kind, func() bool { return int(tv.GetUint64()) <= math.MaxInt64 })
+			validate(Uint64Kind, Int64Kind, func() bool { return tv.GetUint64() <= math.MaxInt64 })
 
 			x := int64(tv.GetUint64())
 			tv.T = t
@@ -815,7 +815,7 @@ GNO_CASE:
 			tv.T = t
 			tv.SetUint16(x)
 		case Uint32Kind:
-			validate(Uint64Kind, Uint32Kind, func() bool { return int(tv.GetUint64()) <= math.MaxUint32 })
+			validate(Uint64Kind, Uint32Kind, func() bool { return tv.GetUint64() <= math.MaxUint32 })
 
 			x := uint32(tv.GetUint64())
 			tv.T = t


### PR DESCRIPTION
The const conversion pr broke 32bit platform build because the comparison wasn't portable for that platform. This is a fix.