### PR TITLE
feat: Adding an official Gnocontribs image in release process

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -86,9 +86,25 @@ builds:
     goarm:
       - "6"
       - "7"
+  # Gno Contribs
   - id: gnobro
     dir: ./contribs/gnodev/cmd/gnobro
     binary: gnobro
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "6"
+      - "7"
+  - id: gnogenesis
+    dir: ./contribs/gnogenesis
+    binary: gnogenesis
     env:
       - CGO_ENABLED=0
     goos:
@@ -300,6 +316,7 @@ dockers:
       - gno.land/genesis/genesis_txs.jsonl
       - examples
       - gnovm/stdlibs
+  
   # gnokey
   - use: buildx
     dockerfile: Dockerfile.release
@@ -504,19 +521,19 @@ dockers:
     ids:
       - gnofaucet
 
-  # gnobro
+  # gnocontribs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
     goarch: amd64
     image_templates:
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-amd64"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-amd64"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
       - "--target=gnobro"
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnobro"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnocontribs"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
@@ -526,17 +543,17 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-arm64v8"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-arm64v8"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-arm64v8"
     build_flag_templates:
-      - "--target=gnobro"
+      - "--target=gnocontribs"
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnobro"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnocontribs"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnobro
+      - gnocontribs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -645,19 +662,19 @@ docker_manifests:
       - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv6
       - ghcr.io/gnolang/{{ .ProjectName }}/gnofaucet:{{ .Env.TAG_VERSION }}-armv7
 
-  # gnobro
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}
+  # gnocontribs
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-armv7
-  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-armv7
+  - name_template: ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}
     image_templates:
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-amd64
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-arm64v8
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-armv6
-      - ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-armv7
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-amd64
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-arm64v8
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-armv6
+      - ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-armv7
 
 docker_signs:
   - cmd: cosign
@@ -707,4 +724,4 @@ nightly:
 
 git:
   ignore_tag_prefixes:
-    - "chain/"
+    - "chain/

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -530,14 +530,14 @@ dockers:
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-amd64"
       - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-amd64"
     build_flag_templates:
-      - "--target=gnobro"
+      - "--target=gnocontribs"
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}/gnocontribs"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnobro
+      - gnocontribs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -560,34 +560,34 @@ dockers:
     goarch: arm
     goarm: 6
     image_templates:
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-armv6"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-armv6"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-armv6"
     build_flag_templates:
-      - "--target=gnobro"
+      - "--target=gnocontribs"
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnobro"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnocontribs"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnobro
+      - gnocontribs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
     goarch: arm
     goarm: 7
     image_templates:
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Version }}-armv7"
-      - "ghcr.io/gnolang/{{ .ProjectName }}/gnobro:{{ .Env.TAG_VERSION }}-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Version }}-armv7"
+      - "ghcr.io/gnolang/{{ .ProjectName }}/gnocontribs:{{ .Env.TAG_VERSION }}-armv7"
     build_flag_templates:
-      - "--target=gnobro"
+      - "--target=gnocontribs"
       - "--platform=linux/arm/v7"
       - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnobro"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}/gnocontribs"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnobro
+      - gnocontribs
 
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -724,4 +724,4 @@ nightly:
 
 git:
   ignore_tag_prefixes:
-    - "chain/
+    - "chain/"

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 project_name: gno
 version: 2
 
@@ -540,6 +541,11 @@ dockers:
     ids:
       - gnobro
       - gnogenesis
+    extra_files:
+      - gno.land/genesis/genesis_balances.txt
+      - gno.land/genesis/genesis_txs.jsonl
+      - examples
+      - gnovm/stdlibs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -557,6 +563,11 @@ dockers:
     ids:
       - gnobro
       - gnogenesis
+    extra_files:
+      - gno.land/genesis/genesis_balances.txt
+      - gno.land/genesis/genesis_txs.jsonl
+      - examples
+      - gnovm/stdlibs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -575,6 +586,11 @@ dockers:
     ids:
       - gnobro
       - gnogenesis
+    extra_files:
+      - gno.land/genesis/genesis_balances.txt
+      - gno.land/genesis/genesis_txs.jsonl
+      - examples
+      - gnovm/stdlibs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -593,6 +609,11 @@ dockers:
     ids:
       - gnobro
       - gnogenesis
+    extra_files:
+      - gno.land/genesis/genesis_balances.txt
+      - gno.land/genesis/genesis_txs.jsonl
+      - examples
+      - gnovm/stdlibs
 
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -87,6 +87,7 @@ builds:
       - "6"
       - "7"
   # Gno Contribs
+  # NOTE: Contribs binary will be added in a single docker image below: gnocontribs
   - id: gnobro
     dir: ./contribs/gnodev/cmd/gnobro
     binary: gnobro
@@ -537,7 +538,8 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnocontribs
+      - gnobro
+      - gnogenesis
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -553,7 +555,8 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnocontribs
+      - gnobro
+      - gnogenesis
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -570,7 +573,8 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnocontribs
+      - gnobro
+      - gnogenesis
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -587,7 +591,8 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
-      - gnocontribs
+      - gnobro
+      - gnogenesis
 
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/

--- a/.github/workflows/releaser-nightly.yml
+++ b/.github/workflows/releaser-nightly.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: ~> v2
-          args: release --clean --nightly --snapshot --config ./.github/goreleaser.yaml
+          args: release --clean --nightly --skip dockerhub --snapshot --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/releaser-nightly.yml
+++ b/.github/workflows/releaser-nightly.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: ~> v2
-          args: release --clean --nightly --skip dockerhub --snapshot --config ./.github/goreleaser.yaml
+          args: release --clean --nightly --snapshot --config ./.github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -61,6 +61,7 @@ FROM base as gnocontribs
 
 COPY     ./gnobro              /usr/bin/gnobro
 COPY     ./gnogenesis          /usr/bin/gnogenesis
-COPY     ./examples            /gnoroot/examples/
+# COPY     ./examples            /gnoroot/examples/
+# Extrafiles...
 
 ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -59,9 +59,8 @@ ENTRYPOINT [ "/usr/bin/gno" ]
 ## ghcr.io/gnolang/gnocontribs
 FROM base as gnocontribs
 
-COPY     ./gno                 /usr/bin/gno
-COPY     ./examples            /gnoroot/examples/
 COPY     ./gnobro              /usr/bin/gnobro
 COPY     ./gnogenesis          /usr/bin/gnogenesis
+COPY     ./examples            /gnoroot/examples/
 
 ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -48,7 +48,7 @@ ENTRYPOINT [ "/usr/bin/gnofaucet" ]
 ## ghcr.io/gnolang/gno
 FROM base as gno
 
-COPY       ./gnobro              /usr/bin/gno
+COPY       ./gno                 /usr/bin/gno
 COPY       ./examples            /gnoroot/examples/
 COPY       ./gnovm/stdlibs       /gnoroot/gnovm/stdlibs/
 COPY       ./gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs/

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -45,14 +45,6 @@ EXPOSE     5050
 ENTRYPOINT [ "/usr/bin/gnofaucet" ]
 
 #
-## ghcr.io/gnolang/gno/gnobro
-FROM base as gnobro
-
-COPY       ./gnobro /usr/bin/gnobro
-EXPOSE     22
-ENTRYPOINT [ "/usr/bin/gnobro" ]
-
-#
 ## ghcr.io/gnolang/gno
 FROM base as gno
 
@@ -62,3 +54,14 @@ COPY     ./gnovm/stdlibs       /gnoroot/gnovm/stdlibs/
 COPY     ./gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs/
 
 ENTRYPOINT [ "/usr/bin/gno" ]
+
+#
+## ghcr.io/gnolang/gnocontribs
+FROM base as gnocontribs
+
+COPY     ./gno                 /usr/bin/gno
+COPY     ./examples            /gnoroot/examples/
+COPY     ./gnobro              /usr/bin/gnobro
+COPY     ./gnogenesis          /usr/bin/gnogenesis
+
+ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -11,11 +11,11 @@ CMD     [ "" ]
 ## ghcr.io/gnolang/gno/gnoland
 FROM base as gnoland
 
-COPY ./gnoland /usr/bin/gnoland
-COPY ./examples /gnoroot/examples/
-COPY ./gnovm/stdlibs /gnoroot/gnovm/stdlibs/
-COPY ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
-COPY ./gno.land/genesis/genesis_txs.jsonl /gnoroot/gno.land/genesis/genesis_txs.jsonl
+COPY     ./gnoland                               /usr/bin/gnoland
+COPY     ./examples                              /gnoroot/examples/
+COPY     ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
+COPY     ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
+COPY     ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 
 EXPOSE 26656 26657
 
@@ -48,10 +48,10 @@ ENTRYPOINT [ "/usr/bin/gnofaucet" ]
 ## ghcr.io/gnolang/gno
 FROM base as gno
 
-COPY     ./gno                 /usr/bin/gno
-COPY     ./examples            /gnoroot/examples/
-COPY     ./gnovm/stdlibs       /gnoroot/gnovm/stdlibs/
-COPY     ./gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs/
+COPY       ./gnobro              /usr/bin/gno
+COPY       ./examples            /gnoroot/examples/
+COPY       ./gnovm/stdlibs       /gnoroot/gnovm/stdlibs/
+COPY       ./gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs/
 
 ENTRYPOINT [ "/usr/bin/gno" ]
 
@@ -59,9 +59,12 @@ ENTRYPOINT [ "/usr/bin/gno" ]
 ## ghcr.io/gnolang/gnocontribs
 FROM base as gnocontribs
 
-COPY     ./gnobro              /usr/bin/gnobro
-COPY     ./gnogenesis          /usr/bin/gnogenesis
-# COPY     ./examples            /gnoroot/examples/
-# Extrafiles...
+COPY       ./gnobro                                /usr/bin/gnobro
+COPY       ./gnogenesis                            /usr/bin/gnogenesis
+COPY       ./examples                              /gnoroot/examples/
+COPY       ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
+COPY       ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
+COPY       ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
+EXPOSE     22
 
 ENTRYPOINT [ "/bin/sh", "-c" ]


### PR DESCRIPTION
Introduces a brand new image: Gnocontribs.
Purpose of this image is collecting from here on different binaries related to the contrib/ folder

At the moment this 2 binaries will be built and included:

- gnobro
- gnogenesis

This PR also explicitly points to the goreleaser PRO schema to avoid YAML validation errors.
