### PR TITLE
fix(gnovm): pass parameter previous path to `FindEmbeddedFieldType` methods

### DIFF
--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -651,7 +651,7 @@ func (pt *PointerType) FindEmbeddedFieldType(callerPath string, n Name, m map[Ty
 		// Pointer to declared types and structs
 		// expose embedded methods and fields.
 		// See tests/selector_test.go for examples.
-		trail, hasPtr, rcvr, field, accessError = findEmbeddedFieldType(callerPath, cet, n, m)
+		trail, hasPtr, rcvr, field, accessError = findEmbeddedFieldType(cet.GetPkgPath(), cet, n, m)
 		if trail != nil { // found
 			hasPtr = true // pt *is* a pointer.
 			switch trail[0].Type {
@@ -991,7 +991,7 @@ func (it *InterfaceType) FindEmbeddedFieldType(callerPath string, n Name, m map[
 		}
 		if et, ok := baseOf(im.Type).(*InterfaceType); ok {
 			// embedded interfaces must be recursively searched.
-			trail, hasPtr, rcvr, ft, accessError = et.FindEmbeddedFieldType(callerPath, n, m)
+			trail, hasPtr, rcvr, ft, accessError = et.FindEmbeddedFieldType(et.PkgPath, n, m)
 			if accessError {
 				// XXX make test case and check against go
 				return nil, false, nil, nil, true
@@ -1642,7 +1642,7 @@ func (dt *DeclaredType) FindEmbeddedFieldType(callerPath string, n Name, m map[T
 		}
 	}
 	// Otherwise, search base.
-	trail, hasPtr, rcvr, ft, accessError = findEmbeddedFieldType(callerPath, dt.Base, n, m)
+	trail, hasPtr, rcvr, ft, accessError = findEmbeddedFieldType(dt.PkgPath, dt.Base, n, m)
 	if trail == nil {
 		return nil, false, nil, nil, accessError
 	}


### PR DESCRIPTION
<!-- please provide a detailed description of the changes made in this pull request. -->
Address #3103 ,
WIP

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
