### PR TITLE
chore: remove leftover `docker-integration` make directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ install_gnokey: install.gnokey
 install_gno: install.gno
 
 .PHONY: test
-test: test.components test.docker
+test: test.components
 
 .PHONY: test.components
 test.components:
@@ -63,14 +63,6 @@ test.components:
 	$(MAKE) --no-print-directory -C gno.land test
 	$(MAKE) --no-print-directory -C examples test
 	$(MAKE) --no-print-directory -C misc     test
-
-.PHONY: test.docker
-test.docker:
-	@if hash docker 2>/dev/null; then \
-		go test --tags=docker -count=1 -v ./misc/docker-integration; \
-	else \
-		echo "[-] 'docker' is missing, skipping ./misc/docker-integration tests."; \
-	fi
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
## Description

This PR removes the leftover make directive for the broken docker-integration tests, previously removed in #3172 

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
