### PR TITLE
fix: impl empty statement exec

### DIFF
--- a/gnovm/pkg/gnolang/go2gno.go
+++ b/gnovm/pkg/gnolang/go2gno.go
@@ -471,6 +471,8 @@ func Go2Gno(fs *token.FileSet, gon ast.Node) (n Node) {
 			PkgName: pkgName,
 			Decls:   decls,
 		}
+	case *ast.EmptyStmt:
+		return &EmptyStmt{}
 	default:
 		panic(fmt.Sprintf("unknown Go type %v: %s\n",
 			reflect.TypeOf(gon),

--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -769,6 +769,7 @@ EXEC_SWITCH:
 		}
 		m.PushOp(OpBody)
 		m.PushStmt(b.GetBodyStmt())
+	case *EmptyStmt:
 	default:
 		panic(fmt.Sprintf("unexpected statement %#v", s))
 	}

--- a/gnovm/tests/files/goto_empty_stmt.gno
+++ b/gnovm/tests/files/goto_empty_stmt.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	println("Hi")
+	goto done
+done:
+}
+
+// Output:
+// Hi


### PR DESCRIPTION
Implement empty statement in the runtime exec.

Closes https://github.com/gnolang/gno/issues/3202