### PR TITLE
docs: update token section in bot README

### DIFF
--- a/contribs/github-bot/README.md
+++ b/contribs/github-bot/README.md
@@ -19,10 +19,23 @@ The bot configuration is defined in Go and is located in the file [config.go](./
 
 For the bot to make requests to the GitHub API, it needs a Personal Access Token. The fine-grained permissions to assign to the token for the bot to function are:
 
+#### Repository permissions
+
 - `pull_requests` scope to read is the bare minimum to run the bot in dry-run mode
 - `pull_requests` scope to write to be able to update bot comment, assign user, apply label and request review
 - `contents` scope to read to be able to check if the head branch is up to date with another one
 - `commit_statuses` scope to write to be able to update pull request bot status check
+
+#### Organization permissions
+
+- `members` scope to read to be able to list the members of a team
+
+#### Bot account role
+
+For the bot to create a commit status on a repo - and only for this feature at the time of writing this - the GitHub account of the bot must either:
+
+- have the `write` role on the repo
+- have the `owner` role in the organization that owns the repo
 
 ## Usage
 


### PR DESCRIPTION
Simple update of the bot README to mention the necessary permissions for the bot to operate, see this comment: https://github.com/gnolang/gno/issues/3238#issuecomment-2514895884

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed, or not feasible
- [x] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [x] Updated the official documentation or not needed
- [x] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [x] Added references to related issues and PRs
- [x] Provided any useful hints for running manual tests
</details>
