### PR TITLE
ci: fix github-bot workflow

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -34,7 +34,7 @@ jobs:
   define-prs-matrix:
     name: Define PRs matrix
     # Prevent bot from retriggering itself and ignore event emitted by codecov
-    if: ${{ github.actor != vars.GH_BOT_LOGIN && github.actor != "codecov[bot]" }}
+    if: ${{ github.actor != vars.GH_BOT_LOGIN && github.actor != 'codecov[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
Fix the github-bot workflow by replacing double quotes by simple ones, see https://github.com/gnolang/gno/actions/runs/12201415150/workflow#L37

<details><summary>Contributors' checklist...</summary>

- [ ] Added new tests, or not needed, or not feasible
- [ ] Provided an example (e.g. screenshot) to aid review or the PR is self-explanatory
- [ ] Updated the official documentation or not needed
- [ ] No breaking changes were made, or a `BREAKING CHANGE: xxx` message was included in the description
- [ ] Added references to related issues and PRs
- [ ] Provided any useful hints for running manual tests
</details>
