### PR TITLE
fix(contribs): close file in execBalancesExport

### DIFF
--- a/contribs/gnogenesis/internal/balances/balances_export.go
+++ b/contribs/gnogenesis/internal/balances/balances_export.go
@@ -60,6 +60,7 @@ func execBalancesExport(cfg *balancesCfg, io commands.IO, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to create output file, %w", err)
 	}
+	defer outputFile.Close()
 
 	// Save the balances
 	for _, balance := range state.Balances {


### PR DESCRIPTION
Ensures that the opened file is not leaked and
closed after use.

Fixes #3032