### PR TITLE
fix(gnovm): use strconv.UnquoteChar to parse rune literals

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -2153,6 +2153,7 @@ type ValuePather interface {
 // Utility
 
 func (x *BasicLitExpr) GetString() string {
+	// Matches string literal parsing in go/constant.MakeFromLiteral.
 	str, err := strconv.Unquote(x.Value)
 	if err != nil {
 		panic("error in parsing string literal: " + err.Error())

--- a/gnovm/pkg/gnolang/op_eval.go
+++ b/gnovm/pkg/gnolang/op_eval.go
@@ -204,16 +204,14 @@ func (m *Machine) doOpEval() {
 			// and github.com/golang/go/issues/19921
 			panic("imaginaries are not supported")
 		case CHAR:
-			cstr, err := strconv.Unquote(x.Value)
+			// Matching character literal parsing in go/constant.MakeFromLiteral.
+			val := x.Value
+			rne, _, _, err := strconv.UnquoteChar(val[1:len(val)-1], '\'')
 			if err != nil {
 				panic("error in parsing character literal: " + err.Error())
 			}
-			runes := []rune(cstr)
-			if len(runes) != 1 {
-				panic(fmt.Sprintf("error in parsing character literal: 1 rune expected, but got %v (%s)", len(runes), cstr))
-			}
 			tv := TypedValue{T: UntypedRuneType}
-			tv.SetInt32(runes[0])
+			tv.SetInt32(rne)
 			m.PushValue(tv)
 		case STRING:
 			m.PushValue(TypedValue{

--- a/gnovm/tests/files/rune3.gno
+++ b/gnovm/tests/files/rune3.gno
@@ -1,0 +1,10 @@
+package main
+
+const overflow = '\xff'
+
+func main() {
+	println(overflow)
+}
+
+// Output:
+// 255


### PR DESCRIPTION
This fixes a bug, as shown in rune3.gno, whereby rune literals which would not be parsed correctly by `strconv.Unquote` are now parsed correctly. Previously, the test would print out 65533, for the unicode invalid code point.