### PR TITLE
feat(cmd/gno): re-use teststore in `lint`

### DIFF
--- a/gno.land/pkg/integration/testing_integration.go
+++ b/gno.land/pkg/integration/testing_integration.go
@@ -750,15 +750,15 @@ func (pl *pkgsLoader) LoadPackage(modroot string, path, name string) error {
 			if err != nil {
 				return fmt.Errorf("unable to read package at %q: %w", currentPkg.Dir, err)
 			}
-			imports, err := packages.Imports(pkg)
+			imports, err := packages.Imports(pkg, nil)
 			if err != nil {
 				return fmt.Errorf("unable to load package imports in %q: %w", currentPkg.Dir, err)
 			}
 			for _, imp := range imports {
-				if imp == currentPkg.Name || gnolang.IsStdlib(imp) {
+				if imp.PkgPath == currentPkg.Name || gnolang.IsStdlib(imp.PkgPath) {
 					continue
 				}
-				currentPkg.Imports = append(currentPkg.Imports, imp)
+				currentPkg.Imports = append(currentPkg.Imports, imp.PkgPath)
 			}
 		}
 

--- a/gnovm/cmd/gno/download_deps.go
+++ b/gnovm/cmd/gno/download_deps.go
@@ -25,13 +25,13 @@ func downloadDeps(io commands.IO, pkgDir string, gnoMod *gnomod.File, fetcher pk
 	if err != nil {
 		return fmt.Errorf("read package at %q: %w", pkgDir, err)
 	}
-	imports, err := packages.Imports(pkg)
+	imports, err := packages.Imports(pkg, nil)
 	if err != nil {
 		return fmt.Errorf("read imports at %q: %w", pkgDir, err)
 	}
 
 	for _, pkgPath := range imports {
-		resolved := gnoMod.Resolve(module.Version{Path: pkgPath})
+		resolved := gnoMod.Resolve(module.Version{Path: pkgPath.PkgPath})
 		resolvedPkgPath := resolved.Path
 
 		if !isRemotePkgPath(resolvedPkgPath) {

--- a/gnovm/cmd/gno/lint.go
+++ b/gnovm/cmd/gno/lint.go
@@ -8,6 +8,7 @@ import (
 	"go/scanner"
 	"go/types"
 	"io"
+	goio "io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -97,6 +98,11 @@ func execLint(cfg *lintCfg, args []string, io commands.IO) error {
 
 	hasError := false
 
+	bs, ts := test.Store(
+		rootDir, false,
+		nopReader{}, goio.Discard, goio.Discard,
+	)
+
 	for _, pkgPath := range pkgPaths {
 		if verbose {
 			io.ErrPrintln(pkgPath)
@@ -120,12 +126,6 @@ func execLint(cfg *lintCfg, args []string, io commands.IO) error {
 			hasError = true
 		}
 
-		stdout, stdin, stderr := io.Out(), io.In(), io.Err()
-		_, testStore := test.Store(
-			rootDir, false,
-			stdin, stdout, stderr,
-		)
-
 		memPkg, err := gno.ReadMemPackage(pkgPath, pkgPath)
 		if err != nil {
 			io.ErrPrintln(issueFromError(pkgPath, err).String())
@@ -133,22 +133,34 @@ func execLint(cfg *lintCfg, args []string, io commands.IO) error {
 			continue
 		}
 
-		// Run type checking
-		if gmFile == nil || !gmFile.Draft {
-			foundErr, err := lintTypeCheck(io, memPkg, testStore)
-			if err != nil {
-				io.ErrPrintln(err)
-				hasError = true
-			} else if foundErr {
-				hasError = true
-			}
-		} else if verbose {
-			io.ErrPrintfln("%s: module is draft, skipping type check", pkgPath)
+		// Perform imports using the parent store.
+		if err := test.LoadImports(ts, memPkg); err != nil {
+			io.ErrPrintln(issueFromError(pkgPath, err).String())
+			hasError = true
+			continue
 		}
 
 		// Handle runtime errors
 		hasRuntimeErr := catchRuntimeError(pkgPath, io.Err(), func() {
-			tm := test.Machine(testStore, stdout, memPkg.Path)
+			// Wrap in cache wrap so execution of the linter doesn't impact
+			// other packages.
+			cw := bs.CacheWrap()
+			gs := ts.BeginTransaction(cw, cw)
+
+			// Run type checking
+			if gmFile == nil || !gmFile.Draft {
+				foundErr, err := lintTypeCheck(io, memPkg, gs)
+				if err != nil {
+					io.ErrPrintln(err)
+					hasError = true
+				} else if foundErr {
+					hasError = true
+				}
+			} else if verbose {
+				io.ErrPrintfln("%s: module is draft, skipping type check", pkgPath)
+			}
+
+			tm := test.Machine(gs, goio.Discard, memPkg.Path)
 			defer tm.Release()
 
 			// Check package
@@ -253,7 +265,7 @@ func guessSourcePath(pkg, source string) string {
 // XXX: Ideally, error handling should encapsulate location details within a dedicated error type.
 var reParseRecover = regexp.MustCompile(`^([^:]+)((?::(?:\d+)){1,2}):? *(.*)$`)
 
-func catchRuntimeError(pkgPath string, stderr io.WriteCloser, action func()) (hasError bool) {
+func catchRuntimeError(pkgPath string, stderr goio.WriteCloser, action func()) (hasError bool) {
 	defer func() {
 		// Errors catched here mostly come from: gnovm/pkg/gnolang/preprocess.go
 		r := recover()
@@ -307,3 +319,7 @@ func issueFromError(pkgPath string, err error) lintIssue {
 	}
 	return issue
 }
+
+type nopReader struct{}
+
+func (nopReader) Read(p []byte) (int, error) { return 0, io.EOF }

--- a/gnovm/cmd/gno/lint.go
+++ b/gnovm/cmd/gno/lint.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"go/scanner"
 	"go/types"
-	"io"
 	goio "io"
 	"os"
 	"path/filepath"
@@ -322,4 +321,4 @@ func issueFromError(pkgPath string, err error) lintIssue {
 
 type nopReader struct{}
 
-func (nopReader) Read(p []byte) (int, error) { return 0, io.EOF }
+func (nopReader) Read(p []byte) (int, error) { return 0, goio.EOF }

--- a/gnovm/cmd/gno/mod.go
+++ b/gnovm/cmd/gno/mod.go
@@ -362,15 +362,12 @@ func getImportToFilesMap(pkgPath string) (map[string][]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		imports, _, err := packages.FileImports(filename, string(data))
+		imports, err := packages.FileImports(filename, string(data), nil)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, imp := range imports {
-			if imp.Error != nil {
-				return nil, err
-			}
 			m[imp.PkgPath] = append(m[imp.PkgPath], filename)
 		}
 	}

--- a/gnovm/cmd/gno/testdata/lint/bad_import.txtar
+++ b/gnovm/cmd/gno/testdata/lint/bad_import.txtar
@@ -19,5 +19,4 @@ module gno.land/p/test
 
 -- stdout.golden --
 -- stderr.golden --
-bad_file.gno:3:8: could not import python (import not found: python) (code=4)
 bad_file.gno:3:8: unknown import path python (code=2)

--- a/gnovm/pkg/doc/dirs.go
+++ b/gnovm/pkg/doc/dirs.go
@@ -131,7 +131,7 @@ func packageImportsRecursive(root string, pkgPath string) []string {
 
 		for _, imp := range sub {
 			if !slices.Contains(res, imp) {
-				res = append(res, imp)
+				res = append(res, imp) //nolint:makezero
 			}
 		}
 	}

--- a/gnovm/pkg/doc/dirs.go
+++ b/gnovm/pkg/doc/dirs.go
@@ -105,10 +105,14 @@ func packageImportsRecursive(root string, pkgPath string) []string {
 		pkg = &gnovm.MemPackage{}
 	}
 
-	res, err := packages.Imports(pkg)
+	resRaw, err := packages.Imports(pkg, nil)
 	if err != nil {
 		// ignore packages with invalid imports
-		res = nil
+		resRaw = nil
+	}
+	res := make([]string, len(resRaw))
+	for idx, imp := range resRaw {
+		res[idx] = imp.PkgPath
 	}
 
 	entries, err := os.ReadDir(root)

--- a/gnovm/pkg/gnomod/pkg.go
+++ b/gnovm/pkg/gnomod/pkg.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gnolang/gno/gnovm"
@@ -122,16 +121,19 @@ func ListPkgs(root string) (PkgList, error) {
 			pkg = &gnovm.MemPackage{}
 		}
 
-		imports, err := packages.Imports(pkg)
+		importsRaw, err := packages.Imports(pkg, nil)
 		if err != nil {
 			// ignore imports on error
-			imports = []string{}
+			importsRaw = nil
 		}
-
-		// remove self and standard libraries from imports
-		imports = slices.DeleteFunc(imports, func(imp string) bool {
-			return imp == gnoMod.Module.Mod.Path || gnolang.IsStdlib(imp)
-		})
+		imports := make([]string, 0, len(importsRaw))
+		for _, imp := range importsRaw {
+			// remove self and standard libraries from imports
+			if imp.PkgPath != gnoMod.Module.Mod.Path &&
+				!gnolang.IsStdlib(imp.PkgPath) {
+				imports = append(imports, imp.PkgPath)
+			}
+		}
 
 		pkgs = append(pkgs, Pkg{
 			Dir:     path,

--- a/gnovm/pkg/packages/imports_test.go
+++ b/gnovm/pkg/packages/imports_test.go
@@ -120,7 +120,7 @@ func TestImports(t *testing.T) {
 
 	pkg, err := gnolang.ReadMemPackage(tmpDir, "test")
 	require.NoError(t, err)
-	imports, err := Imports(pkg)
+	imports, err := Imports(pkg, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, expected, imports)

--- a/gnovm/pkg/packages/imports_test.go
+++ b/gnovm/pkg/packages/imports_test.go
@@ -122,6 +122,10 @@ func TestImports(t *testing.T) {
 	require.NoError(t, err)
 	imports, err := Imports(pkg, nil)
 	require.NoError(t, err)
+	importsStrings := make([]string, len(imports))
+	for idx, imp := range imports {
+		importsStrings[idx] = imp.PkgPath
+	}
 
-	require.Equal(t, expected, imports)
+	require.Equal(t, expected, importsStrings)
 }

--- a/gnovm/pkg/test/filetest.go
+++ b/gnovm/pkg/test/filetest.go
@@ -175,12 +175,20 @@ type runResult struct {
 }
 
 func (opts *TestOptions) runTest(m *gno.Machine, pkgPath, filename string, content []byte) (rr runResult) {
+	pkgName := gno.Name(pkgPath[strings.LastIndexByte(pkgPath, '/')+1:])
+
 	// Eagerly load imports.
 	// This is executed using opts.Store, rather than the transaction store;
 	// it allows us to only have to load the imports once (and re-use the cached
 	// versions). Running the tests in separate "transactions" means that they
 	// don't get the parent store dirty.
-	if err := LoadImports(opts.TestStore, filename, content); err != nil {
+	if err := LoadImports(opts.TestStore, &gnovm.MemPackage{
+		Name: string(pkgName),
+		Path: pkgPath,
+		Files: []*gnovm.MemFile{
+			{Name: filename, Body: string(content)},
+		},
+	}); err != nil {
 		// NOTE: we perform this here, so we can capture the runResult.
 		return runResult{Error: err.Error()}
 	}
@@ -210,7 +218,6 @@ func (opts *TestOptions) runTest(m *gno.Machine, pkgPath, filename string, conte
 	}()
 
 	// Use last element after / (works also if slash is missing).
-	pkgName := gno.Name(pkgPath[strings.LastIndexByte(pkgPath, '/')+1:])
 	if !gno.IsRealmPath(pkgPath) {
 		// Simple case - pure package.
 		pn := gno.NewPackageNode(pkgName, pkgPath, &gno.FileSet{})

--- a/gnovm/pkg/test/imports.go
+++ b/gnovm/pkg/test/imports.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/token"
 	"io"
 	"math/big"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gnolang/gno/gnovm"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/pkg/packages"
 	teststdlibs "github.com/gnolang/gno/gnovm/tests/stdlibs"
@@ -214,13 +216,13 @@ func (e *stackWrappedError) String() string {
 	return fmt.Sprintf("%v\nstack:\n%v", e.err, string(e.stack))
 }
 
-// LoadImports parses the given file and attempts to retrieve all pure packages
+// LoadImports parses the given MemPackage and attempts to retrieve all pure packages
 // from the store. This is mostly useful for "eager import loading", whereby all
 // imports are pre-loaded in a permanent store, so that the tests can use
 // ephemeral transaction stores.
-func LoadImports(store gno.Store, filename string, content []byte) (err error) {
+func LoadImports(store gno.Store, memPkg *gnovm.MemPackage) (err error) {
 	defer func() {
-		// This is slightly different from the handling below; we do not have a
+		// This is slightly different from other similar error handling; we do not have a
 		// machine to work with, as this comes from an import; so we need
 		// "machine-less" alternatives. (like v.String instead of v.Sprint)
 		if r := recover(); r != nil {
@@ -239,14 +241,12 @@ func LoadImports(store gno.Store, filename string, content []byte) (err error) {
 		}
 	}()
 
-	imports, fset, err := packages.FileImports(filename, string(content))
+	fset := token.NewFileSet()
+	imports, err := packages.Imports(memPkg, fset)
 	if err != nil {
 		return err
 	}
 	for _, imp := range imports {
-		if imp.Error != nil {
-			return imp.Error
-		}
 		if gno.IsRealmPath(imp.PkgPath) {
 			// Don't eagerly load realms.
 			// Realms persist state and can change the state of other realms in initialization.


### PR DESCRIPTION
continuing the work of #3119.

this PR makes `gno lint` re-use the same test.Store, speeding up execution (especially on the CI, which lints all packages) by not needing to load all packages for each package that is linted.