### PR TITLE
feat(memdb): use tidwall/btree implementation for btree

### DIFF
--- a/contribs/gnodev/go.mod
+++ b/contribs/gnodev/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.5.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.2 // indirect

--- a/contribs/gnodev/go.sum
+++ b/contribs/gnodev/go.sum
@@ -230,6 +230,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.3.7/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/contribs/gnofaucet/go.mod
+++ b/contribs/gnofaucet/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.29.0 // indirect

--- a/contribs/gnofaucet/go.sum
+++ b/contribs/gnofaucet/go.sum
@@ -122,6 +122,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=

--- a/contribs/gnogenesis/go.mod
+++ b/contribs/gnogenesis/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.etcd.io/bbolt v1.3.11 // indirect

--- a/contribs/gnogenesis/go.sum
+++ b/contribs/gnogenesis/go.sum
@@ -131,6 +131,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=
 github.com/zondax/hid v0.9.2/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.3 h1:wEpJt2CEcBJ428md/5MgSLsXLBos98sBOyxNmCjfUCw=

--- a/contribs/gnohealth/go.sum
+++ b/contribs/gnohealth/go.sum
@@ -114,6 +114,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=

--- a/contribs/gnokeykc/go.mod
+++ b/contribs/gnokeykc/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect

--- a/contribs/gnokeykc/go.sum
+++ b/contribs/gnokeykc/go.sum
@@ -137,6 +137,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97yms=
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/contribs/gnomigrate/go.mod
+++ b/contribs/gnomigrate/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.29.0 // indirect

--- a/contribs/gnomigrate/go.sum
+++ b/contribs/gnomigrate/go.sum
@@ -131,6 +131,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=
 github.com/zondax/hid v0.9.2/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.3 h1:wEpJt2CEcBJ428md/5MgSLsXLBos98sBOyxNmCjfUCw=

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	github.com/tidwall/btree v1.7.0
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.29.0
@@ -58,7 +59,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=
 github.com/zondax/hid v0.9.2/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.3 h1:wEpJt2CEcBJ428md/5MgSLsXLBos98sBOyxNmCjfUCw=

--- a/misc/autocounterd/go.mod
+++ b/misc/autocounterd/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect

--- a/misc/autocounterd/go.sum
+++ b/misc/autocounterd/go.sum
@@ -131,6 +131,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=
 github.com/zondax/hid v0.9.2/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.3 h1:wEpJt2CEcBJ428md/5MgSLsXLBos98sBOyxNmCjfUCw=

--- a/misc/loop/go.mod
+++ b/misc/loop/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.29.0 // indirect

--- a/misc/loop/go.sum
+++ b/misc/loop/go.sum
@@ -175,6 +175,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/tm2/pkg/db/memdb/mem_db.go
+++ b/tm2/pkg/db/memdb/mem_db.go
@@ -1,13 +1,14 @@
 package memdb
 
 import (
+	"bytes"
 	"fmt"
-	"sort"
 	"sync"
 
 	"github.com/gnolang/gno/tm2/pkg/colors"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/internal"
+	"github.com/tidwall/btree"
 )
 
 func init() {
@@ -20,12 +21,12 @@ var _ dbm.DB = (*MemDB)(nil)
 
 type MemDB struct {
 	mtx sync.Mutex
-	db  map[string][]byte
+	db  *btree.Map[string, []byte]
 }
 
 func NewMemDB() *MemDB {
 	database := &MemDB{
-		db: make(map[string][]byte),
+		db: btree.NewMap[string, []byte](0),
 	}
 	return database
 }
@@ -41,7 +42,7 @@ func (db *MemDB) Get(key []byte) []byte {
 	defer db.mtx.Unlock()
 	key = internal.NonNilBytes(key)
 
-	value := db.db[string(key)]
+	value, _ := db.db.Get(string(key))
 	return value
 }
 
@@ -51,7 +52,7 @@ func (db *MemDB) Has(key []byte) bool {
 	defer db.mtx.Unlock()
 	key = internal.NonNilBytes(key)
 
-	_, ok := db.db[string(key)]
+	_, ok := db.db.Get(string(key))
 	return ok
 }
 
@@ -78,10 +79,9 @@ func (db *MemDB) SetNoLock(key []byte, value []byte) {
 
 // Implements internal.AtomicSetDeleter.
 func (db *MemDB) SetNoLockSync(key []byte, value []byte) {
-	key = internal.NonNilBytes(key)
 	value = internal.NonNilBytes(value)
 
-	db.db[string(key)] = value
+	db.db.Set(string(key), internal.NonNilBytes(value))
 }
 
 // Implements DB.
@@ -109,7 +109,7 @@ func (db *MemDB) DeleteNoLock(key []byte) {
 func (db *MemDB) DeleteNoLockSync(key []byte) {
 	key = internal.NonNilBytes(key)
 
-	delete(db.db, string(key))
+	db.db.Delete(string(key))
 }
 
 // Implements DB.
@@ -126,12 +126,12 @@ func (db *MemDB) Print() {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	for key, value := range db.db {
-		var keystr, valstr string
-		keystr = colors.DefaultColoredBytesN([]byte(key), 50)
-		valstr = colors.DefaultColoredBytesN(value, 100)
+	db.db.Scan(func(key string, value []byte) bool {
+		keystr := colors.DefaultColoredBytesN([]byte(key), 50)
+		valstr := colors.DefaultColoredBytesN(value, 100)
 		fmt.Printf("%s: %s\n", keystr, valstr)
-	}
+		return true
+	})
 }
 
 // Implements DB.
@@ -141,7 +141,7 @@ func (db *MemDB) Stats() map[string]string {
 
 	stats := make(map[string]string)
 	stats["database.type"] = "memDB"
-	stats["database.size"] = fmt.Sprintf("%d", len(db.db))
+	stats["database.size"] = fmt.Sprintf("%d", db.db.Len())
 	return stats
 }
 
@@ -158,41 +158,129 @@ func (db *MemDB) NewBatch() dbm.Batch {
 
 // Implements DB.
 func (db *MemDB) Iterator(start, end []byte) dbm.Iterator {
+	if len(start) > 0 && len(end) > 0 &&
+		bytes.Compare(start, end) != -1 {
+		panic("cannot create iterator with start >= end: " + fmt.Sprintf("%q < %q", start, end))
+	}
+
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	keys := db.getSortedKeys(start, end, false)
-	return internal.NewMemIterator(db, keys, start, end)
+	res := &iterator{
+		it:    db.db.Iter(),
+		start: string(start),
+		end:   string(end),
+	}
+	if len(start) == 0 {
+		if !res.it.First() {
+			res.invalid = true
+		}
+	} else {
+		if !res.it.Seek(string(start)) {
+			res.invalid = true
+		}
+	}
+	return res
 }
 
 // Implements DB.
 func (db *MemDB) ReverseIterator(start, end []byte) dbm.Iterator {
+	if len(start) != 0 && len(end) != 0 &&
+		bytes.Compare(start, end) != -1 {
+		panic("cannot create iterator with start >= end: " + fmt.Sprintf("%q < %q", start, end))
+	}
+
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	keys := db.getSortedKeys(start, end, true)
-	return internal.NewMemIterator(db, keys, start, end)
-}
-
-// ----------------------------------------
-// Misc.
-
-func (db *MemDB) getSortedKeys(start, end []byte, reverse bool) []string {
-	keys := []string{}
-	for key := range db.db {
-		inDomain := dbm.IsKeyInDomain([]byte(key), start, end)
-		if inDomain {
-			keys = append(keys, key)
+	res := &iterator{
+		it:      db.db.Iter(),
+		start:   string(start),
+		end:     string(end),
+		reverse: true,
+	}
+	if len(end) == 0 {
+		if !res.it.Last() {
+			res.invalid = true
+		}
+	} else {
+		if res.it.Seek(string(end)) {
+			if !res.it.Prev() || res.it.Key() < res.start {
+				res.invalid = true
+			}
+		} else {
+			// if nothing > end is found, use the last item in the map.
+			if !res.it.Last() {
+				res.invalid = true
+			}
 		}
 	}
-	sort.Strings(keys)
-	if reverse {
-		nkeys := len(keys)
-		for i := 0; i < nkeys/2; i++ {
-			temp := keys[i]
-			keys[i] = keys[nkeys-i-1]
-			keys[nkeys-i-1] = temp
+	return res
+}
+
+type iterator struct {
+	it         btree.MapIter[string, []byte]
+	start, end string
+	invalid    bool
+	reverse    bool
+}
+
+// The start & end (exclusive) limits to iterate over.
+// If end < start, then the Iterator goes in reverse order.
+//
+// A domain of ([]byte{12, 13}, []byte{12, 14}) will iterate
+// over anything with the prefix []byte{12, 13}.
+//
+// The smallest key is the empty byte array []byte{} - see BeginningKey().
+// The largest key is the nil byte array []byte(nil) - see EndingKey().
+// CONTRACT: start, end readonly []byte
+func (i *iterator) Domain() (start []byte, end []byte) {
+	if i.reverse {
+		return []byte(i.end), []byte(i.start)
+	}
+	return []byte(i.start), []byte(i.end)
+}
+
+// Valid returns whether the current position is valid.
+// Once invalid, an Iterator is forever invalid.
+func (i *iterator) Valid() bool {
+	return !i.invalid
+}
+
+// Next moves the iterator to the next sequential key in the database, as
+// defined by order of iteration.
+//
+// If Valid returns false, this method will panic.
+func (i *iterator) Next() {
+	if i.invalid {
+		panic("invalid iterator")
+	}
+	if i.reverse {
+		if !i.it.Prev() ||
+			i.it.Key() < i.start {
+			i.invalid = true
+		}
+	} else {
+		if !i.it.Next() ||
+			i.it.Key() >= i.end {
+			i.invalid = true
 		}
 	}
-	return keys
 }
+
+// Key returns the key of the cursor.
+// If Valid returns false, this method will panic.
+// CONTRACT: key readonly []byte
+func (i *iterator) Key() []byte {
+	return []byte(i.it.Key())
+}
+
+// Value returns the value of the cursor.
+// If Valid returns false, this method will panic.
+// CONTRACT: value readonly []byte
+func (i *iterator) Value() []byte {
+	return i.it.Value()
+}
+
+// Close releases the Iterator.
+func (i *iterator) Close() {}

--- a/tm2/pkg/db/memdb/mem_db_test.go
+++ b/tm2/pkg/db/memdb/mem_db_test.go
@@ -15,7 +15,6 @@ func TestIterator(t *testing.T) {
 		end        []byte
 		wantKeys   []string
 		wantValues []string
-		wantPanic  bool
 	}{
 		{
 			name:    "empty database",
@@ -57,15 +56,6 @@ func TestIterator(t *testing.T) {
 			wantKeys:   []string{"prefix1_a", "prefix1_b"},
 			wantValues: []string{"value1", "value2"},
 		},
-		{
-			name: "invalid range should panic",
-			setupDB: func(db *MemDB) {
-				db.Set([]byte("key1"), []byte("value1"))
-			},
-			start:     []byte("z"),
-			end:       []byte("a"),
-			wantPanic: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -73,12 +63,6 @@ func TestIterator(t *testing.T) {
 			db := NewMemDB()
 			tt.setupDB(db)
 
-			if tt.wantPanic {
-				assert.Panics(t, func() {
-					db.Iterator(tt.start, tt.end)
-				})
-				return
-			}
 			iter := db.Iterator(tt.start, tt.end)
 			defer iter.Close()
 

--- a/tm2/pkg/db/memdb/mem_db_test.go
+++ b/tm2/pkg/db/memdb/mem_db_test.go
@@ -1,0 +1,174 @@
+package memdb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterator(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupDB    func(*MemDB)
+		start      []byte
+		end        []byte
+		wantKeys   []string
+		wantValues []string
+		wantPanic  bool
+	}{
+		{
+			name:    "empty database",
+			setupDB: func(db *MemDB) {},
+			start:   nil,
+			end:     nil,
+		},
+		{
+			name: "single key",
+			setupDB: func(db *MemDB) {
+				db.Set([]byte("key1"), []byte("value1"))
+			},
+			start:      nil,
+			end:        nil,
+			wantKeys:   []string{"key1"},
+			wantValues: []string{"value1"},
+		},
+		{
+			name: "multiple keys in range",
+			setupDB: func(db *MemDB) {
+				db.Set([]byte("key1"), []byte("value1"))
+				db.Set([]byte("key2"), []byte("value2"))
+				db.Set([]byte("key3"), []byte("value3"))
+			},
+			start:      []byte("key1"),
+			end:        []byte("key3"),
+			wantKeys:   []string{"key1", "key2"},
+			wantValues: []string{"value1", "value2"},
+		},
+		{
+			name: "prefix iteration",
+			setupDB: func(db *MemDB) {
+				db.Set([]byte("prefix1_a"), []byte("value1"))
+				db.Set([]byte("prefix1_b"), []byte("value2"))
+				db.Set([]byte("prefix2_a"), []byte("value3"))
+			},
+			start:      []byte("prefix1_"),
+			end:        []byte("prefix1_\xff"),
+			wantKeys:   []string{"prefix1_a", "prefix1_b"},
+			wantValues: []string{"value1", "value2"},
+		},
+		{
+			name: "invalid range should panic",
+			setupDB: func(db *MemDB) {
+				db.Set([]byte("key1"), []byte("value1"))
+			},
+			start:     []byte("z"),
+			end:       []byte("a"),
+			wantPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := NewMemDB()
+			tt.setupDB(db)
+
+			if tt.wantPanic {
+				assert.Panics(t, func() {
+					db.Iterator(tt.start, tt.end)
+				})
+				return
+			}
+			iter := db.Iterator(tt.start, tt.end)
+			defer iter.Close()
+
+			var gotKeys []string
+			var gotValues []string
+
+			for ; iter.Valid(); iter.Next() {
+				gotKeys = append(gotKeys, string(iter.Key()))
+				gotValues = append(gotValues, string(iter.Value()))
+			}
+
+			assert.Equal(t, tt.wantKeys, gotKeys)
+			assert.Equal(t, tt.wantValues, gotValues)
+		})
+	}
+}
+
+func TestIterator_Domain(t *testing.T) {
+	db := NewMemDB()
+	start := []byte("0")
+	end := []byte("9")
+
+	iter := db.Iterator(start, end)
+	gotStart, gotEnd := iter.Domain()
+
+	if !bytes.Equal(gotStart, start) {
+		t.Errorf("Domain start: got %v, want %v", gotStart, start)
+	}
+	if !bytes.Equal(gotEnd, end) {
+		t.Errorf("Domain end: got %v, want %v", gotEnd, end)
+	}
+}
+
+func TestIterator_InvalidOperation(t *testing.T) {
+	db := NewMemDB()
+	db.Set([]byte("key"), []byte("value"))
+
+	iter := db.Iterator(nil, nil)
+	iter.Next() // Move past the only key
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic on Next() after iterator becomes invalid")
+		}
+	}()
+
+	iter.Next() // Should panic
+}
+
+func TestReverseIterator(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupDB    func(*MemDB)
+		start      []byte
+		end        []byte
+		wantKeys   []string
+		wantValues []string
+	}{
+		{
+			name: "reverse multiple keys",
+			setupDB: func(db *MemDB) {
+				db.Set([]byte("key1"), []byte("value1"))
+				db.Set([]byte("key2"), []byte("value2"))
+				db.Set([]byte("key3"), []byte("value3"))
+			},
+			start:      []byte("key1"),
+			end:        []byte("key3"),
+			wantKeys:   []string{"key2", "key1"},
+			wantValues: []string{"value2", "value1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := NewMemDB()
+			tt.setupDB(db)
+
+			iter := db.ReverseIterator(tt.start, tt.end)
+			defer iter.Close()
+
+			var gotKeys []string
+			var gotValues []string
+
+			for ; iter.Valid(); iter.Next() {
+				gotKeys = append(gotKeys, string(iter.Key()))
+				gotValues = append(gotValues, string(iter.Value()))
+			}
+
+			assert.Equal(t, tt.wantKeys, gotKeys)
+			assert.Equal(t, tt.wantValues, gotValues)
+		})
+	}
+}

--- a/tm2/pkg/db/types.go
+++ b/tm2/pkg/db/types.go
@@ -1,41 +1,31 @@
 package db
 
-// DBs are goroutine safe.
+// A DB is goroutine safe.
+//
+// NOTE(morgan): these methods used to have comments to describe the semantics;
+// but the semantics described were wrong, and have been removed to avoid doing
+// more harm than good. Inspect the implementations and tests to understand
+// actual details, and maybe update this documentation for the next person who
+// has to deal with this interface.
 type DB interface {
-	// Get returns nil iff key doesn't exist.
-	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
 	Get([]byte) []byte
 
-	// Has checks if a key exists.
-	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
 	Has(key []byte) bool
 
-	// Set sets the key.
-	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key, value readonly []byte
 	Set([]byte, []byte)
 	SetSync([]byte, []byte)
 
-	// Delete deletes the key.
-	// A nil key is interpreted as an empty byteslice.
 	// CONTRACT: key readonly []byte
 	Delete([]byte)
 	DeleteSync([]byte)
 
-	// Iterate over a domain of keys in ascending order. End is exclusive.
-	// Start must be less than end, or the Iterator is invalid.
-	// A nil start is interpreted as an empty byteslice.
-	// If end is nil, iterates up to the last item (inclusive).
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// CONTRACT: start, end readonly []byte
 	Iterator(start, end []byte) Iterator
 
-	// Iterate over a domain of keys in descending order. End is exclusive.
-	// Start must be less than end, or the Iterator is invalid.
-	// If start is nil, iterates up to the first/least item (inclusive).
-	// If end is nil, iterates from the last/greatest item (inclusive).
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// CONTRACT: start, end readonly []byte
 	ReverseIterator(start, end []byte) Iterator


### PR DESCRIPTION
The goal was to improve execution time of tests, and other users of MemDB like gnodev. Ballpark performance improvement should be around 2x. Flamegraph now has most of the time in tests spent in consensus-land:

![image](https://github.com/user-attachments/assets/ad3c4e8a-def8-4b20-ac0c-f21b6c03eb44)