### PR TITLE
 RFC: feat(keys/client): support automatic gas calculation with -simulate test 

### DIFF
--- a/gno.land/pkg/keyscli/addpkg.go
+++ b/gno.land/pkg/keyscli/addpkg.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
-	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
@@ -101,32 +100,9 @@ func execMakeAddPkg(cfg *MakeAddPkgCfg, args []string, io commands.IO) error {
 		panic(fmt.Sprintf("found an empty package %q", cfg.PkgPath))
 	}
 
-	// parse gas wanted & fee.
-	gaswanted := cfg.RootCfg.GasWanted
-	gasfee, err := std.ParseCoin(cfg.RootCfg.GasFee)
-	if err != nil {
-		panic(err)
-	}
-	// construct msg & tx and marshal.
-	msg := vm.MsgAddPackage{
+	return client.MakeTransaction(vm.MsgAddPackage{
 		Creator: creator,
 		Package: memPkg,
 		Deposit: deposit,
-	}
-	tx := std.Tx{
-		Msgs:       []std.Msg{msg},
-		Fee:        std.NewFee(gaswanted, gasfee),
-		Signatures: nil,
-		Memo:       cfg.RootCfg.Memo,
-	}
-
-	if cfg.RootCfg.Broadcast {
-		err := client.ExecSignAndBroadcast(cfg.RootCfg, args, tx, io)
-		if err != nil {
-			return err
-		}
-	} else {
-		io.Println(string(amino.MustMarshalJSON(tx)))
-	}
-	return nil
+	}, cfg.RootCfg, args, io)
 }

--- a/gno.land/pkg/keyscli/maketx.go
+++ b/gno.land/pkg/keyscli/maketx.go
@@ -1,22 +1,9 @@
 package keyscli
 
 import (
-	"flag"
-
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 )
-
-type MakeTxCfg struct {
-	RootCfg *client.BaseCfg
-
-	GasWanted int64
-	GasFee    string
-	Memo      string
-
-	Broadcast bool
-	ChainID   string
-}
 
 func NewMakeTxCmd(rootCfg *client.BaseCfg, io commands.IO) *commands.Command {
 	cfg := &client.MakeTxCfg{
@@ -43,41 +30,4 @@ func NewMakeTxCmd(rootCfg *client.BaseCfg, io commands.IO) *commands.Command {
 	)
 
 	return cmd
-}
-
-func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
-	fs.Int64Var(
-		&c.GasWanted,
-		"gas-wanted",
-		0,
-		"gas requested for tx",
-	)
-
-	fs.StringVar(
-		&c.GasFee,
-		"gas-fee",
-		"",
-		"gas payment fee",
-	)
-
-	fs.StringVar(
-		&c.Memo,
-		"memo",
-		"",
-		"any descriptive text",
-	)
-
-	fs.BoolVar(
-		&c.Broadcast,
-		"broadcast",
-		false,
-		"sign and broadcast",
-	)
-
-	fs.StringVar(
-		&c.ChainID,
-		"chainid",
-		"dev",
-		"chainid to sign for (only useful if --broadcast)",
-	)
 }

--- a/tm2/pkg/crypto/keys/client/broadcast.go
+++ b/tm2/pkg/crypto/keys/client/broadcast.go
@@ -22,10 +22,6 @@ type BroadcastCfg struct {
 
 	// internal
 	tx *std.Tx
-	// Set by SignAndBroadcastHandler, similar to DryRun.
-	// If true, simulation is attempted but not printed;
-	// the result is only returned in case of an error.
-	testSimulate bool
 }
 
 func NewBroadcastCmd(rootCfg *BaseCfg, io commands.IO) *commands.Command {
@@ -114,15 +110,10 @@ func BroadcastHandler(cfg *BroadcastCfg) (*ctypes.ResultBroadcastTxCommit, error
 		return nil, err
 	}
 
-	// Both for DryRun and testSimulate, we perform simulation.
-	// However, DryRun always returns here, while in case of success
-	// testSimulate continues onto broadcasting the transaction.
-	if cfg.DryRun || cfg.testSimulate {
+	// For -dry-run, run SimulateTx.
+	if cfg.DryRun {
 		res, err := SimulateTx(cli, bz)
-		hasError := err != nil || res.CheckTx.IsErr() || res.DeliverTx.IsErr()
-		if cfg.DryRun || hasError {
-			return res, err
-		}
+		return res, err
 	}
 
 	bres, err := cli.BroadcastTxCommit(bz)

--- a/tm2/pkg/crypto/keys/client/maketx.go
+++ b/tm2/pkg/crypto/keys/client/maketx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
+	"strconv"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
@@ -13,31 +14,93 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
+// MakeTxConfig contains the configuration to create (and potentially broadcast)
+// a transaction.
 type MakeTxCfg struct {
 	RootCfg *BaseCfg
 
-	GasWanted int64
+	// Tx options.
+	GasWanted GasWantedValue
 	GasFee    string
 	Memo      string
 
+	// Broadcast-related options.
 	Broadcast bool
-	// Valid options are SimulateTest, SimulateSkip or SimulateOnly.
-	Simulate string
-	ChainID  string
+	Simulate  SimulateValue
+	ChainID   string
 }
+
+// GasWantedValue is the maximum amount of gas requested for the execution of
+// the transaction.
+type GasWantedValue int64
+
+// GasWantedAuto is the default value of [GasWantedValue]. If a [MakeTxCfg] has
+// Broadcast set to true and Simulate set to [SimulateTest], then the
+// transaction simulation will determine the "real" value of GasWanted, as well
+// as the GasFee if unset.
+const GasWantedAuto GasWantedValue = 0
+
+// String returns the string value of i, implementing [flag.Value].
+func (i GasWantedValue) String() string {
+	if i == GasWantedAuto {
+		return "auto"
+	}
+	return strconv.FormatInt(int64(i), 10)
+}
+
+// Set sets i to the corresponding value in s, implementing [flag.Value].
+func (i *GasWantedValue) Set(s string) error {
+	if s == "auto" {
+		*i = GasWantedAuto
+		return nil
+	}
+	pi, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	if pi <= 0 {
+		return fmt.Errorf("invalid value for GasWantedValue: %d", pi)
+	}
+	*i = GasWantedValue(pi)
+	return nil
+}
+
+// SimulateValue is the custom flag value for the -simulate flag.
+type SimulateValue byte
 
 // These are the valid options for MakeTxConfig.Simulate.
 const (
-	SimulateTest = "test"
-	SimulateSkip = "skip"
-	SimulateOnly = "only"
+	SimulateTest SimulateValue = iota
+	SimulateSkip
+	SimulateOnly
 )
 
-func (c *MakeTxCfg) Validate() error {
-	switch c.Simulate {
-	case SimulateTest, SimulateSkip, SimulateOnly:
+// String returns the string value of sv, implementing [flag.Value].
+func (sv SimulateValue) String() string {
+	switch sv {
+	case SimulateTest:
+		return "test"
+	case SimulateSkip:
+		return "skip"
+	case SimulateOnly:
+		return "only"
 	default:
-		return fmt.Errorf("invalid simulate option: %q", c.Simulate)
+		panic("invalid simulate value")
+	}
+}
+
+// Set parses s into a value for sv, implementing [flag.Value].
+func (sv *SimulateValue) Set(s string) error {
+	switch s {
+	case "test":
+		*sv = SimulateTest
+	case "skip":
+		*sv = SimulateSkip
+	case "only":
+		*sv = SimulateOnly
+	default:
+		return fmt.Errorf(`invalid simulate flag value: %q `+
+			`(must be "test", "skip" or "only")`, s)
 	}
 	return nil
 }
@@ -65,10 +128,9 @@ func NewMakeTxCmd(rootCfg *BaseCfg, io commands.IO) *commands.Command {
 }
 
 func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
-	fs.Int64Var(
+	fs.Var(
 		&c.GasWanted,
 		"gas-wanted",
-		0,
 		"gas requested for tx",
 	)
 
@@ -93,10 +155,9 @@ func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
 		"sign, simulate and broadcast",
 	)
 
-	fs.StringVar(
+	fs.Var(
 		&c.Simulate,
 		"simulate",
-		"test",
 		`select how to simulate the transaction (only useful with --broadcast); valid options are
 		- test: attempts simulating the transaction, and if successful performs broadcasting (default)
 		- skip: avoids performing transaction simulation
@@ -109,6 +170,93 @@ func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
 		"dev",
 		"chainid to sign for (only useful with --broadcast)",
 	)
+}
+
+// MakeTransaction performs the transaction using the given message and
+// MakeTxCfg.
+func MakeTransaction(msg std.Msg, cfg *MakeTxCfg, args []string, io commands.IO) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	switch {
+	case cfg.GasWanted == GasWantedAuto && !cfg.Broadcast:
+		return errors.New("without -broadcast, -gas-wanted must be set to an integer value")
+	case cfg.GasWanted == GasWantedAuto && cfg.Simulate != SimulateTest:
+		return errors.New("-gas-wanted must be set to an integer value if -simulate is not test")
+	case cfg.GasWanted != GasWantedAuto && cfg.GasFee != "":
+		return errors.New("-gas-fee not specified")
+	}
+
+	// construct msg & tx and marshal.
+	tx := std.Tx{
+		Msgs: []std.Msg{msg},
+		Memo: cfg.Memo,
+	}
+
+	if cfg.Broadcast {
+		err := ExecSignAndBroadcast(cfg, args, tx, io)
+		if err != nil {
+			return err
+		}
+	} else {
+		// parse gas wanted & fee.
+		gasWanted := cfg.GasWanted
+		gasFee, err := std.ParseCoin(cfg.GasFee)
+		if err != nil {
+			return errors.Wrap(err, "parsing gas fee coin")
+		}
+		tx.Fee = std.NewFee(int64(gasWanted), gasFee)
+
+		io.Println(string(amino.MustMarshalJSON(tx)))
+	}
+	return nil
+}
+
+func ExecSignAndBroadcast(
+	cfg *MakeTxCfg,
+	args []string,
+	tx std.Tx,
+	io commands.IO,
+) error {
+	baseopts := cfg.RootCfg
+
+	// query account
+	nameOrBech32 := args[0]
+
+	var err error
+	var pass string
+	if baseopts.Quiet {
+		pass, err = io.GetPassword("", baseopts.InsecurePasswordStdin)
+	} else {
+		pass, err = io.GetPassword("Enter password.", baseopts.InsecurePasswordStdin)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	bres, err := SignAndBroadcastHandler(cfg, nameOrBech32, tx, pass)
+	if err != nil {
+		return errors.Wrap(err, "broadcast tx")
+	}
+	if bres.CheckTx.IsErr() {
+		return errors.Wrapf(bres.CheckTx.Error, "check transaction failed: log:%s", bres.CheckTx.Log)
+	}
+	if bres.DeliverTx.IsErr() {
+		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
+		return errors.Wrapf(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
+	}
+
+	io.Println(string(bres.DeliverTx.Data))
+	io.Println("OK!")
+	io.Println("GAS WANTED:", bres.DeliverTx.GasWanted)
+	io.Println("GAS USED:  ", bres.DeliverTx.GasUsed)
+	io.Println("HEIGHT:    ", bres.Height)
+	io.Println("EVENTS:    ", string(bres.DeliverTx.EncodeEvents()))
+	io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
+
+	return nil
 }
 
 func SignAndBroadcastHandler(
@@ -160,68 +308,47 @@ func SignAndBroadcastHandler(
 		decryptPass: pass,
 	}
 
-	if err := signTx(&tx, kb, sOpts, kOpts); err != nil {
-		return nil, fmt.Errorf("unable to sign transaction, %w", err)
-	}
-
 	// broadcast signed tx
 	bopts := &BroadcastCfg{
 		RootCfg: baseopts,
 		tx:      &tx,
 
-		DryRun:       cfg.Simulate == SimulateOnly,
-		testSimulate: cfg.Simulate == SimulateTest,
+		DryRun: cfg.Simulate == SimulateOnly,
+	}
+
+	if cfg.Simulate == SimulateTest {
+		bopts.DryRun = true
+		if cfg.GasWanted == GasWantedAuto {
+			tx.Fee.GasWanted = AutoGasDefaultWanted
+			if tx.Fee.GasFee.IsZero() {
+				tx.Fee.GasFee = AutoGasDefaultFee
+			}
+		}
+		if err := signTx(&tx, kb, sOpts, kOpts); err != nil {
+			return nil, fmt.Errorf("unable to sign transaction, %w", err)
+		}
+		resp, err := BroadcastHandler(bopts)
+		if err != nil {
+			return resp, err
+		}
+		if cfg.GasWanted == GasWantedAuto {
+			used := resp.DeliverTx.GasUsed
+			tx.Fee.GasWanted = min(used + used/10, AutoGasDefaultWanted)
+			if err := signTx(&tx, kb, sOpts, kOpts); err != nil {
+				return nil, fmt.Errorf("unable to sign transaction, %w", err)
+			}
+		}
+		bopts.DryRun = false
+	} else {
+		if err := signTx(&tx, kb, sOpts, kOpts); err != nil {
+			return nil, fmt.Errorf("unable to sign transaction, %w", err)
+		}
 	}
 
 	return BroadcastHandler(bopts)
 }
 
-func ExecSignAndBroadcast(
-	cfg *MakeTxCfg,
-	args []string,
-	tx std.Tx,
-	io commands.IO,
-) error {
-	if err := cfg.Validate(); err != nil {
-		return err
-	}
-
-	baseopts := cfg.RootCfg
-
-	// query account
-	nameOrBech32 := args[0]
-
-	var err error
-	var pass string
-	if baseopts.Quiet {
-		pass, err = io.GetPassword("", baseopts.InsecurePasswordStdin)
-	} else {
-		pass, err = io.GetPassword("Enter password.", baseopts.InsecurePasswordStdin)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	bres, err := SignAndBroadcastHandler(cfg, nameOrBech32, tx, pass)
-	if err != nil {
-		return errors.Wrap(err, "broadcast tx")
-	}
-	if bres.CheckTx.IsErr() {
-		return errors.Wrapf(bres.CheckTx.Error, "check transaction failed: log:%s", bres.CheckTx.Log)
-	}
-	if bres.DeliverTx.IsErr() {
-		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-		return errors.Wrapf(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
-	}
-
-	io.Println(string(bres.DeliverTx.Data))
-	io.Println("OK!")
-	io.Println("GAS WANTED:", bres.DeliverTx.GasWanted)
-	io.Println("GAS USED:  ", bres.DeliverTx.GasUsed)
-	io.Println("HEIGHT:    ", bres.Height)
-	io.Println("EVENTS:    ", string(bres.DeliverTx.EncodeEvents()))
-	io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
-
-	return nil
-}
+var (
+	AutoGasDefaultWanted int64 = 10_000_000
+	AutoGasDefaultFee = std.Coin{Denom: "ugnot", Amount: 1_000_000}
+)


### PR DESCRIPTION
Addresses #1826 (and potentially resolves, if this can be seen as a good implementation?).

This PR implements gas calculations in a manner similar to what's described [in this comment](https://github.com/gnolang/gno/issues/1826#issuecomment-2098927582); but I'm making this PR as a proof of concept before moving ahead and adding tests and cleaning up the code.

What this PR enables, is to work locally with gnodev with `gnokey` commands as simple as the following:

```console
$ gnokey maketx call -pkgpath "gno.land/r/demo/counter" -func "Increment" -broadcast test1
Enter password.
(5 int)


OK!
GAS WANTED: 101000
GAS USED:   91809
HEIGHT:     11
EVENTS:     []
TX HASH:    ahbx2M9cIxOuZqSNWLhjAVPb0YxeCBKOrHpm+wi4jjw=
```

For how this works, here's a brief description from `gnokey maketx --help`:

```
  -gas-fee ...                    gas payment fee; automatically set with -gas-wanted auto
  -gas-wanted auto                gas requested for tx; with auto, exclusively with -broadcast and -simulate test,
                                  detect required gas from the transaction simulation. transaction is simulated with
                                  max_gas = 10000000, then run with min(gas_used * 1.10, max_gas)
```

The objective is to take advantage of the fact we're now doing transaction simulation in `gnokey`, to try to use that for calculating the amount of gas used in the transaction. 

1. Do we want this?
2. Right now `-gas-fee` is always 1gnot (as this field is ignored on-chain for now, anyway). How should it eventually be calculated? Should we ask the user for confirmation?
3. The values for max_gas and gas_fee are set with globals in `crypto/keys/client`, so that other clients aside from `keyscli` can modify them. Should we prefer something else?

TODO: additional improvement, `13k` `13m` `13g`