### PR TITLE
fix(lint): fix 'make install' failure due to bad 'BeginTransaction' c…

### DIFF
--- a/gnovm/cmd/gno/lint.go
+++ b/gnovm/cmd/gno/lint.go
@@ -144,7 +144,7 @@ func execLint(cfg *lintCfg, args []string, io commands.IO) error {
 			// Wrap in cache wrap so execution of the linter doesn't impact
 			// other packages.
 			cw := bs.CacheWrap()
-			gs := ts.BeginTransaction(cw, cw)
+			gs := ts.BeginTransaction(cw, cw, nil)
 
 			// Run type checking
 			if gmFile == nil || !gmFile.Draft {


### PR DESCRIPTION
Addresses #3368 

…all in lint.io

lint.go: add missing 'gasMeter' param to 'BeginTransaction' call

Impact: caused 'make install' to fail on branch 'master' with the following error:

    cmd/gno/lint.go:147:34: not enough arguments in call to ts.BeginTransaction
        have ("github.com/gnolang/gno/tm2/pkg/store/types".Store,
              "github.com/gnolang/gno/tm2/pkg/store/types".Store)
        want ("github.com/gnolang/gno/tm2/pkg/store/types".Store,
              "github.com/gnolang/gno/tm2/pkg/store/types".Store,
              "github.com/gnolang/gno/tm2/pkg/store/types".GasMeter)
    make[1]: *** [install] Error 1

Testing: This fix resolves test failure commanded by `make test`:

    FAIL	github.com/gnolang/gno/gnovm/cmd/gno [build failed]