### PR TITLE
chore(examples): update `avlhelpers` to use `avl.ITree`

### DIFF
--- a/examples/gno.land/p/demo/avlhelpers/avlhelpers.gno
+++ b/examples/gno.land/p/demo/avlhelpers/avlhelpers.gno
@@ -8,7 +8,7 @@ import (
 // It calls the provided callback function for each key-value pair encountered.
 // If the callback returns true, the iteration is stopped.
 // The prefix and keys are treated as byte strings, ignoring possible multi-byte Unicode runes.
-func IterateByteStringKeysByPrefix(tree avl.Tree, prefix string, cb avl.IterCbFn) {
+func IterateByteStringKeysByPrefix(tree avl.ITree, prefix string, cb avl.IterCbFn) {
 	end := ""
 	n := len(prefix)
 	// To make the end of the search, increment the final character ASCII by one.
@@ -28,7 +28,7 @@ func IterateByteStringKeysByPrefix(tree avl.Tree, prefix string, cb avl.IterCbFn
 // Get a list of keys starting from the given prefix. Limit the
 // number of results to maxResults.
 // The prefix and keys are treated as byte strings, ignoring possible multi-byte Unicode runes.
-func ListByteStringKeysByPrefix(tree avl.Tree, prefix string, maxResults int) []string {
+func ListByteStringKeysByPrefix(tree avl.ITree, prefix string, maxResults int) []string {
 	result := []string{}
 	IterateByteStringKeysByPrefix(tree, prefix, func(key string, value interface{}) bool {
 		result = append(result, key)

--- a/examples/gno.land/p/demo/avlhelpers/z_0_filetest.gno
+++ b/examples/gno.land/p/demo/avlhelpers/z_0_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	tree := avl.Tree{}
+	tree := avl.NewTree()
 
 	{
 		// Empty tree.
@@ -44,7 +44,7 @@ func main() {
 		println("match: " + matches[0])
 	}
 
-	tree = avl.Tree{}
+	tree = avl.NewTree()
 	tree.Set("a\xff", "")
 	tree.Set("a\xff\xff", "")
 	tree.Set("b", "")

--- a/examples/gno.land/r/demo/users/users.gno
+++ b/examples/gno.land/r/demo/users/users.gno
@@ -260,7 +260,7 @@ func GetUserByAddressOrName(input users.AddressOrName) *users.User {
 // Get a list of user names starting from the given prefix. Limit the
 // number of results to maxResults. (This can be used for a name search tool.)
 func ListUsersByPrefix(prefix string, maxResults int) []string {
-	return avlhelpers.ListByteStringKeysByPrefix(name2User, prefix, maxResults)
+	return avlhelpers.ListByteStringKeysByPrefix(&name2User, prefix, maxResults)
 }
 
 func Resolve(input users.AddressOrName) std.Address {


### PR DESCRIPTION
## Description

Updates the AVL helpers to use the new avl.ITree interface.