### PR TITLE
fix: Update init gas price

### DIFF
--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
-const initGasPrice = "10ugnot/100gas"
+const initGasPrice = "1ugnot/1000gas"
 
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) ([]Balance, error) {


### PR DESCRIPTION
The number is too large due to the increased gas configurations. This change will reduce the cost from 1 gnot to 0.01 gnot for a transaction that uses 10 million gas.