### PR TITLE
chore: fix `examples` workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -71,15 +71,18 @@ jobs:
       # TODO: consider running lint on every other directories, maybe in "warning" mode?
     # TODO: track coverage
   fmt:
-    name: Run gno fmt
+    name: Run gno fmt on examples
+    uses: ./.github/workflows/gnofmt_template.yml
+    with:
+      path: "examples/..."
+
+  check-fmt:
+    name: Check for unformatted gno example files
     runs-on: ubuntu-latest
+    needs: fmt # needs gno fmt ./examples/ to run first
     steps:
-      - name: gno fmt
-        uses: ./.github/workflows/gnofmt_template.yml
-        with:
-          path: "examples/..."
-      - name: Check for unformatted gno files
-        run: |
+      - uses: actions/checkout@v4
+      - run: |
           git diff --exit-code || (echo "Some gno files are not formatted, please run 'make fmt'." && exit 1)
 
   mod-tidy:


### PR DESCRIPTION
## Description

This PR fixes the `examples` workflow that attempted to use the `gnofmt_template.yml` for running `gno fmt` on the examples folder.

The issue was that `gnofmt_template.yml` is a reusable workflow, not an action, and the way the `fmt` job was structured in the `examples` workflow was calling it like an action.