### PR TITLE
fix(cmd/gno): reset runtime metrics allocator on each test run

### DIFF
--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -315,7 +315,7 @@ func (opts *TestOptions) runTestFiles(
 		//   RunFiles doesn't do that currently)
 		// - Wrap here.
 		m = Machine(gs, opts.Output, memPkg.Path)
-		m.Alloc = alloc
+		m.Alloc = alloc.Reset()
 		m.SetActivePackage(pv)
 
 		testingpv := m.Store.GetPackage("testing", false)


### PR DESCRIPTION
Ensures that the `allocs` printed by `-print-runtime-metrics` are per-test, like the cycles.

h/t @leohhhn 