### PR TITLE
chore: add r/demo/tests/test20 + add grc20.TokenGetter to reduce boilerplate when using grc20reg

### DIFF
--- a/examples/gno.land/p/demo/grc/grc20/token.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token.gno
@@ -65,6 +65,14 @@ func (tok *Token) RenderHome() string {
 	return str
 }
 
+// Getter returns a TokenGetter function that returns this token. This allows
+// storing indirect pointers to a token in a remote realm.
+func (tok *Token) Getter() TokenGetter {
+	return func() *Token {
+		return tok
+	}
+}
+
 // SpendAllowance decreases the allowance of the specified owner and spender.
 func (led *PrivateLedger) SpendAllowance(owner, spender std.Address, amount uint64) error {
 	if !owner.IsValid() {

--- a/examples/gno.land/r/demo/bar20/bar20.gno
+++ b/examples/gno.land/r/demo/bar20/bar20.gno
@@ -18,8 +18,7 @@ var (
 )
 
 func init() {
-	getter := func() *grc20.Token { return Token }
-	grc20reg.Register(getter, "")
+	grc20reg.Register(Token.Getter(), "")
 }
 
 func Faucet() string {

--- a/examples/gno.land/r/demo/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/foo20/foo20.gno
@@ -22,8 +22,7 @@ var (
 
 func init() {
 	privateLedger.Mint(Ownable.Owner(), 1_000_000*10_000) // @privateLedgeristrator (1M)
-	getter := func() *grc20.Token { return Token }
-	grc20reg.Register(getter, "")
+	grc20reg.Register(Token.Getter(), "")
 }
 
 func TotalSupply() uint64 {

--- a/examples/gno.land/r/demo/grc20factory/grc20factory.gno
+++ b/examples/gno.land/r/demo/grc20factory/grc20factory.gno
@@ -43,8 +43,7 @@ func NewWithAdmin(name, symbol string, decimals uint, initialMint, faucet uint64
 		faucet: faucet,
 	}
 	instances.Set(symbol, &inst)
-	getter := func() *grc20.Token { return token }
-	grc20reg.Register(getter, symbol)
+	grc20reg.Register(token.Getter(), symbol)
 }
 
 func (inst instance) Token() *grc20.Token {

--- a/examples/gno.land/r/demo/tests/test20/gno.mod
+++ b/examples/gno.land/r/demo/tests/test20/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/demo/tests/test20

--- a/examples/gno.land/r/demo/tests/test20/test20.gno
+++ b/examples/gno.land/r/demo/tests/test20/test20.gno
@@ -1,0 +1,20 @@
+// Package test20 implements a deliberately insecure ERC20 token for testing purposes.
+// The Test20 token allows anyone to mint any amount of tokens to any address, making
+// it unsuitable for production use. The primary goal of this package is to facilitate
+// testing and experimentation without any security measures or restrictions.
+//
+//	WARNING: This token is highly insecure and should not be used in any
+//	 production environment. It is intended solely for testing and
+//	 educational purposes.
+package test20
+
+import (
+	"gno.land/p/demo/grc/grc20"
+	"gno.land/r/demo/grc20reg"
+)
+
+var Token, PrivateLedger = grc20.NewToken("Test20", "TST", 4)
+
+func init() {
+	grc20reg.Register(Token.Getter(), "")
+}

--- a/examples/gno.land/r/demo/wugnot/wugnot.gno
+++ b/examples/gno.land/r/demo/wugnot/wugnot.gno
@@ -19,8 +19,7 @@ const (
 )
 
 func init() {
-	getter := func() *grc20.Token { return Token }
-	grc20reg.Register(getter, "")
+	grc20reg.Register(Token.Getter(), "")
 }
 
 func Deposit() {


### PR DESCRIPTION
- add `r/demo/tests/test20`
- add `grc20.TokenGetter` to reduce boilerplate when using `grc20reg.Register(...)`

Replaces #2549
Continues #3135 