### PR TITLE
chore: suggest using errors.New instead of fmt.Errorf with no parameters

### DIFF
--- a/tm2/pkg/bft/rpc/core/blocks.go
+++ b/tm2/pkg/bft/rpc/core/blocks.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 
 	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
@@ -101,7 +102,7 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 func filterMinMax(height, low, high, limit int64) (int64, int64, error) {
 	// filter negatives
 	if low < 0 || high < 0 {
-		return low, high, fmt.Errorf("heights must be non-negative")
+		return low, high, errors.New("heights must be non-negative")
 	}
 
 	// adjust for default values
@@ -428,7 +429,7 @@ func getHeightWithMin(currentHeight int64, heightPtr *int64, minVal int64) (int6
 			return 0, fmt.Errorf("height must be greater than or equal to %d", minVal)
 		}
 		if height > currentHeight {
-			return 0, fmt.Errorf("height must be less than or equal to the current blockchain height")
+			return 0, errors.New("height must be less than or equal to the current blockchain height")
 		}
 		return height, nil
 	}

--- a/tm2/pkg/bft/types/block.go
+++ b/tm2/pkg/bft/types/block.go
@@ -70,7 +70,7 @@ func (b *Block) ValidateBasic() error {
 			return errors.New("nil LastCommit")
 		}
 		if err := b.LastCommit.ValidateBasic(); err != nil {
-			return fmt.Errorf("wrong LastCommit")
+			return errors.New("wrong LastCommit")
 		}
 	}
 	if err := ValidateHash(b.LastCommitHash); err != nil {
@@ -753,7 +753,7 @@ func (blockID BlockID) Key() string {
 func (blockID BlockID) ValidateBasic() error {
 	// Hash can be empty in case of POLBlockID in Proposal.
 	if err := ValidateHash(blockID.Hash); err != nil {
-		return fmt.Errorf("wrong Hash")
+		return errors.New("wrong Hash")
 	}
 	if err := blockID.PartsHeader.ValidateBasic(); err != nil {
 		return fmt.Errorf("wrong PartsHeader: %w", err)

--- a/tm2/pkg/bft/wal/wal.go
+++ b/tm2/pkg/bft/wal/wal.go
@@ -594,7 +594,7 @@ func (dec *WALReader) ReadMessage() (*TimedWALMessage, *MetaMessage, error) {
 	}
 
 	if len(line64) == 0 {
-		return nil, nil, DataCorruptionError{fmt.Errorf("found empty line")}
+		return nil, nil, DataCorruptionError{errors.New("found empty line")}
 	}
 
 	// special case for MetaMessage.


### PR DESCRIPTION
suggest using errors.New instead of fmt.Errorf with no parameters