### PR TITLE
feat(cmd/gno): `pkgaddr` sub-command

### DIFF
--- a/gnovm/cmd/gno/main.go
+++ b/gnovm/cmd/gno/main.go
@@ -35,6 +35,7 @@ func newGnocliCmd(io commands.IO) *commands.Command {
 		newEnvCmd(io),
 		newBugCmd(io),
 		newFmtCmd(io),
+		newPkgAddrCmd(io),
 		// graph
 		// vendor -- download deps from the chain in vendor/
 		// list -- list packages

--- a/gnovm/cmd/gno/pkgaddr.go
+++ b/gnovm/cmd/gno/pkgaddr.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+func newPkgAddrCmd(io commands.IO) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "pkgaddr",
+			ShortUsage: "pkgaddr <pkgpath>",
+			ShortHelp:  "`pkgaddr` converts a package path to a package address",
+		},
+		nil,
+		func(_ context.Context, args []string) error {
+			return execPkgAddr(args, io)
+		},
+	)
+}
+
+func execPkgAddr(args []string, io commands.IO) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 arg, got %d", len(args))
+	}
+
+	io.Println(gnolang.DerivePkgAddr(args[0]))
+
+	return nil
+}

--- a/gnovm/cmd/gno/pkgaddr.go
+++ b/gnovm/cmd/gno/pkgaddr.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"flag"
 
 	"github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -24,7 +24,7 @@ func newPkgAddrCmd(io commands.IO) *commands.Command {
 
 func execPkgAddr(args []string, io commands.IO) error {
 	if len(args) != 1 {
-		return fmt.Errorf("expected 1 arg, got %d", len(args))
+		return flag.ErrHelp
 	}
 
 	io.Println(gnolang.DerivePkgAddr(args[0]))

--- a/gnovm/cmd/gno/pkgaddr_test.go
+++ b/gnovm/cmd/gno/pkgaddr_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestPkgAddrApp(t *testing.T) {
+	tc := []testMainCase{
+		{
+			args:        []string{"pkgaddr"},
+			errShouldBe: "expected 1 arg, got 0",
+		},
+
+		{
+			args:           []string{"pkgaddr", "gno.land/r/demo/users"},
+			stdoutShouldBe: "g17m4ga9t9dxn8uf06p3cahdavzfexe33ecg8v2s\n",
+		},
+	}
+
+	testMainCaseRun(t, tc)
+}

--- a/gnovm/cmd/gno/pkgaddr_test.go
+++ b/gnovm/cmd/gno/pkgaddr_test.go
@@ -7,8 +7,13 @@ import (
 func TestPkgAddrApp(t *testing.T) {
 	tc := []testMainCase{
 		{
-			args:        []string{"pkgaddr"},
-			errShouldBe: "expected 1 arg, got 0",
+			args:             []string{"pkgaddr"},
+			errShouldContain: "flag: help requested",
+		},
+
+		{
+			args:             []string{"pkgaddr", "bli", "blu"},
+			errShouldContain: "flag: help requested",
 		},
 
 		{


### PR DESCRIPTION
Adds a `gno` sub-command called `pkgaddr` that takes a string as argument and outputs the corresponding package address using `gnolang.DerivePkgAddr'

Example usage:
```
> gno pkgaddr gno.land/r/demo/users
g17m4ga9t9dxn8uf06p3cahdavzfexe33ecg8v2s
```