### PR TITLE
perf(gnolang): use slice not map for Attributes.data per usage performance

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -158,12 +158,14 @@ const (
 	ATTR_SHIFT_RHS
 	ATTR_LAST_BLOCK_STMT
 	ATTR_GLOBAL
+	attr_dummy_terminal
 )
 
 var attr_strs = [...]string{
 	ATTR_PREPROCESSED:    "ATTR_PREPROCESSED",
 	ATTR_PREDEFINED:      "ATTR_PREDEFINED",
 	ATTR_TYPE_VALUE:      "ATTR_TYPE_VALUE",
+	ATTR_TYPEOF_VALUE:    "ATTR_TYPEOF_VALUE",
 	ATTR_IOTA:            "ATTR_IOTA",
 	ATTR_LOOP_DEFINES:    "ATTR_LOOP_DEFINES",
 	ATTR_LOOP_USES:       "ATTR_LOOP_USES",
@@ -190,7 +192,7 @@ type Attributes struct {
 	// to say more than 100 (rough guess), you can then
 	// consider using a map for it instead of a slice
 	// Please see https://github.com/gnolang/gno/issues/3436
-	data [ATTR_GLOBAL - ATTR_PREPROCESSED]any
+	data [attr_dummy_terminal - ATTR_PREPROCESSED]any
 }
 
 func (attr *Attributes) GetLine() int {
@@ -235,11 +237,6 @@ func (attr *Attributes) getAttribute(key GnoAttribute) (any, int, bool) {
 		return nil, -1, false
 	}
 	return attr.data[i], i, true
-}
-
-type attrKV struct {
-	key   GnoAttribute
-	value any
 }
 
 func (attr *Attributes) SetAttribute(key GnoAttribute, value interface{}) {

--- a/gnovm/pkg/gnolang/nodes_test.go
+++ b/gnovm/pkg/gnolang/nodes_test.go
@@ -71,7 +71,6 @@ func BenchmarkAttributesSetGetDel(b *testing.B) {
 	for i := 0; i < n; i++ {
 		keys = append(keys, gnolang.GnoAttribute(i))
 	}
-
 	attrCommon := gnolang.ATTR_TYPEOF_VALUE
 
 	b.ReportAllocs()
@@ -93,8 +92,9 @@ func BenchmarkAttributesSetGetDel(b *testing.B) {
 
 		for _, key := range keys {
 			sink = attrs.GetAttribute(key)
-			attrs.GetAttribute(key)
 		}
+
+		sink = attrs
 	}
 
 	if sink == nil {


### PR DESCRIPTION
# TL;DR: Despite the reduction in memory consumption, the preliminary direct benchmarks show increase in CPU time but in microseconds
```shell
 benchstat before.txt after.txt 
name                   old time/op    new time/op    delta
AttributesSetGetDel-8    12.4µs ± 0%    56.6µs ± 3%  +355.22%  (p=0.000 n=8+9)

name                   old alloc/op   new alloc/op   delta
AttributesSetGetDel-8    9.37kB ± 0%    5.38kB ± 0%   -42.61%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
AttributesSetGetDel-8      11.0 ± 0%     107.0 ± 0%  +872.73%  (p=0.000 n=10+10)
```

## Deep dive
Noticed in profiling stdlibs/bytes that a ton of memory was being used in maps, and that's due to the conventional CS 101 that maps with O(1) lookups, insertions and deletions beat O(n) slices' performance, but when n is small, the memory bloat is not worth it and we can use slices as evidenced in profiles for which there was 30% perceptible reduction in RAM where
* Before:

```shell
Showing nodes accounting for 92.90MB, 83.87% of 110.76MB total
Dropped 51 nodes (cum <= 0.55MB)
Showing top 10 nodes out of 123
      flat  flat%   sum%        cum   cum%
   47.37MB 42.77% 42.77%    47.37MB 42.77%  internal/runtime/maps.newarray
   10.50MB  9.48% 52.25%    10.50MB  9.48%  internal/runtime/maps.NewEmptyMap
       8MB  7.22% 59.47%        8MB  7.22%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*StaticBlock).InitStaticBlock
    7.51MB  6.78% 66.25%    13.03MB 11.76%  github.com/gnolang/gno/gnovm/pkg/gnolang.Go2Gno
    6.02MB  5.43% 71.68%    10.73MB  9.68%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*defaultStore).SetObject
       4MB  3.61% 75.29%        4MB  3.61%  github.com/gnolang/gno/gnovm/pkg/gnolang.NewBlock
    3.47MB  3.13% 78.43%     3.47MB  3.13%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*Allocator).NewDataArray
    2.52MB  2.27% 80.70%     3.52MB  3.18%  github.com/gnolang/gno/gnovm/pkg/gnolang.toKeyValueExprs
       2MB  1.81% 82.51%        2MB  1.81%  runtime.allocm
    1.51MB  1.36% 83.87%     1.51MB  1.36%  runtime/pprof.(*profMap).lookup
```

```shell
Showing nodes accounting for 47.37MB, 42.77% of 110.76MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                           47.37MB   100% |   internal/runtime/maps.newGroups
   47.37MB 42.77% 42.77%    47.37MB 42.77%                | internal/runtime/maps.newarray
----------------------------------------------------------+-------------
                                           32.01MB 78.05% |   github.com/gnolang/gno/gnovm/pkg/gnolang.preprocess1.func1
                                               7MB 17.07% |   github.com/gnolang/gno/gnovm/pkg/gnolang.evalConst (inline)
                                            1.50MB  3.66% |   github.com/gnolang/gno/gnovm/pkg/gnolang.constType (inline)
                                            0.50MB  1.22% |   github.com/gnolang/gno/gnovm/pkg/gnolang.tryPredefine.func1
         0     0% 42.77%    41.01MB 37.03%                | github.com/gnolang/gno/gnovm/pkg/gnolang.(*Attributes).SetAttribute
                                           41.01MB   100% |   runtime.mapassign_faststr
----------------------------------------------------------+-------------
                                            4.50MB   100% |   github.com/gnolang/gno/gnovm/pkg/test.(*TestOptions).runTestFiles
         0     0% 42.77%     4.50MB  4.06%                | github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).RunFiles
                                            4.50MB   100% |   github.com/gnolang/gno/gnovm/pkg/gnolang.(*Machine).runFileDecls
```

and after:

```shell
Showing nodes accounting for 61.99MB, 73.12% of 84.78MB total
Showing top 10 nodes out of 196
      flat  flat%   sum%        cum   cum%
   19.50MB 23.00% 23.00%    19.50MB 23.00%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*Attributes).SetAttribute
   12.52MB 14.76% 37.77%    18.02MB 21.26%  github.com/gnolang/gno/gnovm/pkg/gnolang.Go2Gno
    7.58MB  8.94% 46.70%     9.15MB 10.79%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*defaultStore).SetObject
       5MB  5.90% 52.60%        5MB  5.90%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*StaticBlock).InitStaticBlock
    3.47MB  4.09% 56.69%     3.47MB  4.09%  github.com/gnolang/gno/gnovm/pkg/gnolang.(*Allocator).NewDataArray
       3MB  3.54% 60.24%        3MB  3.54%  github.com/gnolang/gno/gnovm/pkg/gnolang.NewBlock
       3MB  3.54% 63.77%        3MB  3.54%  github.com/gnolang/gno/gnovm/pkg/gnolang.Nx (inline)
    2.77MB  3.26% 67.04%     2.77MB  3.26%  bytes.growSlice
    2.65MB  3.12% 70.16%     2.65MB  3.12%  internal/runtime/maps.newarray
    2.50MB  2.95% 73.12%     2.50MB  2.95%  runtime.allocm
```

Fixes #3436