### PR TITLE
fix: handle p2p events properly in cluster tests

### DIFF
--- a/tm2/pkg/internal/p2p/p2p.go
+++ b/tm2/pkg/internal/p2p/p2p.go
@@ -131,10 +131,13 @@ func MakeConnectedPeers(
 		multiplexSwitch.DialPeers(addrs...)
 
 		// Set up an exit timer
-		timer := time.NewTimer(5 * time.Second)
+		timer := time.NewTimer(1 * time.Minute)
 		defer timer.Stop()
 
-		connectedPeers := make(map[p2pTypes.ID]struct{})
+		var (
+			connectedPeers = make(map[p2pTypes.ID]struct{})
+			targetPeers    = cfg.Count - 1
+		)
 
 		for {
 			select {
@@ -143,7 +146,7 @@ func MakeConnectedPeers(
 
 				connectedPeers[ev.PeerID] = struct{}{}
 
-				if len(connectedPeers) == cfg.Count-1 {
+				if len(connectedPeers) == targetPeers {
 					return nil
 				}
 			case <-timer.C:


### PR DESCRIPTION
## Description

This PR fixes an issue with the p2p event stream where events can be missed due to not being actively scooped from the channel, causing tests to hang. This non-blocking nature is by design, the p2p event stream should be non-blocking for subscribers at all times when new events are added.

The PR increases the buffer size for events (from 1 to a reasonable value). For larger event loads, subscribers can handle channel draining caller side without any issues