### PR TITLE
fix: re-enable the portal loop CI

### DIFF
--- a/.github/workflows/portal-loop.yml
+++ b/.github/workflows/portal-loop.yml
@@ -45,7 +45,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   test-portal-loop-docker-compose:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Description

This PR re-enables the portal loop "CI". I won't go into details on why this was needed in the first place, with the intention to not lose absolutely all credibility for our deployment and testing workflows