### PR TITLE
fix: use the `genesis/genesis_txs.jsonl` for the portal loop 

### DIFF
--- a/misc/loop/scripts/start.sh
+++ b/misc/loop/scripts/start.sh
@@ -11,10 +11,11 @@ GENESIS_BALANCES_FILE=${GENESIS_BALANCES_FILE:-""}
 
 SEEDS=${SEEDS:-""}
 PERSISTENT_PEERS=${PERSISTENT_PEERS:-""}
+FINAL_GENESIS_TXS_SHEET="/gnoroot/gno.land/genesis/genesis_txs.jsonl"
 
-echo "" >> /gnoroot/gno.land/genesis/genesis_txs.jsonl
+echo "" >> $FINAL_GENESIS_TXS_SHEET
 echo "" >> /gnoroot/gno.land/genesis/genesis_balances.jsonl
-cat "${GENESIS_BACKUP_FILE}" >> /gnoroot/gno.land/genesis/genesis_txs.jsonl
+cat "${GENESIS_BACKUP_FILE}" >> $FINAL_GENESIS_TXS_SHEET
 cat "${GENESIS_BALANCES_FILE}" >> /gnoroot/gno.land/genesis/genesis_balances.jsonl
 
 # Initialize the secrets
@@ -35,6 +36,7 @@ gnoland config set p2p.persistent_peers "${PERSISTENT_PEERS}"
 # reading and piping to the gnoland genesis commands
 exec gnoland start \
          --chainid="${CHAIN_ID}" \
+         --genesis-txs-file="${FINAL_GENESIS_TXS_SHEET}" \
          --lazy \
          --skip-failing-genesis-txs \
          --skip-genesis-sig-verification


### PR DESCRIPTION
## Description

This PR specifies the base file for the Portal Loop genesis transactions, as it is empty by default.