### PR TITLE
feat: add `EstimateGas` to gnoclient

### DIFF
--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -1,14 +1,13 @@
 package gnoclient
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abciErrors "github.com/gnolang/gno/tm2/pkg/bft/abci/example/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"errors"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"

--- a/gno.land/pkg/gnoclient/client_txs.go
+++ b/gno.land/pkg/gnoclient/client_txs.go
@@ -1,8 +1,11 @@
 package gnoclient
 
 import (
+	"fmt"
+
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
@@ -15,6 +18,8 @@ var (
 	ErrMissingSigner    = errors.New("missing Signer")
 	ErrMissingRPCClient = errors.New("missing RPCClient")
 )
+
+const simulatePath = ".app/simulate"
 
 // BaseTxCfg defines the base transaction configuration, shared by all message types
 type BaseTxCfg struct {
@@ -292,4 +297,44 @@ func (c *Client) BroadcastTxCommit(signedTx *std.Tx) (*ctypes.ResultBroadcastTxC
 	return bres, nil
 }
 
-// TODO: Add more functionality, examples, and unit tests.
+// EstimateGas returns the least amount of gas required
+// for the transaction to go through on the chain (minimum gas wanted).
+// The estimation process assumes the transaction is properly signed
+func (c *Client) EstimateGas(tx *std.Tx) (int64, error) {
+	// Make sure the RPC client is set
+	if err := c.validateRPCClient(); err != nil {
+		return 0, err
+	}
+
+	// Prepare the transaction.
+	// The transaction needs to be amino-binary encoded
+	// in order to be estimated
+	encodedTx, err := amino.Marshal(tx)
+	if err != nil {
+		return 0, fmt.Errorf("unable to marshal tx: %w", err)
+	}
+
+	// Perform the simulation query
+	resp, err := c.RPCClient.ABCIQuery(simulatePath, encodedTx)
+	if err != nil {
+		return 0, fmt.Errorf("unable to perform ABCI query: %w", err)
+	}
+
+	// Extract the query response
+	if err = resp.Response.Error; err != nil {
+		return 0, fmt.Errorf("error encountered during ABCI query: %w", err)
+	}
+
+	var deliverTx abci.ResponseDeliverTx
+	if err = amino.Unmarshal(resp.Response.Value, &deliverTx); err != nil {
+		return 0, fmt.Errorf("unable to unmarshal gas estimation response: %w", err)
+	}
+
+	if err = deliverTx.Error; err != nil {
+		return 0, fmt.Errorf("error encountered during gas estimation: %w", err)
+	}
+
+	// Return the actual value returned by the node
+	// for executing the transaction
+	return deliverTx.GasUsed, nil
+}


### PR DESCRIPTION
## Description

Closes #1826 along with https://github.com/gnolang/tm2-js-client/pull/192

This PR introduces a method `EstimateGas` to estimate the gas used by a transaction in gnoclient.
We can use this call to get a ballpark estimate if a transaction succeeds, and if it does, how much gas it actually used.