### PR TITLE
chore(github-bot): avoid references from bot comment to meta issue

### DIFF
--- a/contribs/github-bot/internal/check/comment.tmpl
+++ b/contribs/github-bot/internal/check/comment.tmpl
@@ -27,7 +27,7 @@
 1. Complete manual checks for the PR, including the guidelines and additional checks if applicable.
 
 ##### 📚 Resources:
-- [Report a bug with the bot](https://github.com/gnolang/gno/issues/3238).
+- [Report a bug with the bot](https://www.github.com/gnolang/gno/issues/3238).
 - [View the bot’s configuration file](https://github.com/gnolang/gno/tree/master/contribs/github-bot/internal/config/config.go).
 
 {{ if or .AutoRules .ManualRules }}<details><summary><b>Debug</b></summary><blockquote>


### PR DESCRIPTION
hack from: https://github.com/orgs/community/discussions/23123#discussioncomment-3239240

This avoids spamming the META issues with useless events from all the PRs which have a bot comment.