### PR TITLE
fix(tm2/pkg/bft,os,p2p): close leaking resources

### DIFF
--- a/tm2/pkg/bft/privval/utils.go
+++ b/tm2/pkg/bft/privval/utils.go
@@ -25,7 +25,7 @@ func IsConnTimeout(err error) bool {
 }
 
 // NewSignerListener creates a new SignerListenerEndpoint using the corresponding listen address
-func NewSignerListener(listenAddr string, logger *slog.Logger) (*SignerListenerEndpoint, error) {
+func NewSignerListener(listenAddr string, logger *slog.Logger) (_ *SignerListenerEndpoint, rerr error) {
 	var listener net.Listener
 
 	protocol, address := osm.ProtocolAndAddress(listenAddr)
@@ -33,6 +33,13 @@ func NewSignerListener(listenAddr string, logger *slog.Logger) (*SignerListenerE
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		if rerr != nil {
+			ln.Close()
+		}
+	}()
+
 	switch protocol {
 	case "unix":
 		listener = NewUnixListener(ln)

--- a/tm2/pkg/os/tempfile.go
+++ b/tm2/pkg/os/tempfile.go
@@ -107,13 +107,16 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) (err error)
 		}
 		break
 	}
+
+	// Clean up in any case.
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
 	if i == atomicWriteFileMaxNumWriteAttempts {
 		return fmt.Errorf("could not create atomic write file after %d attempts", i)
 	}
-
-	// Clean up in any case. Defer stacking order is last-in-first-out.
-	defer os.Remove(f.Name())
-	defer f.Close()
 
 	if n, err := f.Write(data); err != nil {
 		return err

--- a/tm2/pkg/p2p/transport.go
+++ b/tm2/pkg/p2p/transport.go
@@ -147,12 +147,18 @@ func (mt *MultiplexTransport) Close() error {
 }
 
 // Listen starts an active process of listening for incoming connections [NON-BLOCKING]
-func (mt *MultiplexTransport) Listen(addr types.NetAddress) error {
+func (mt *MultiplexTransport) Listen(addr types.NetAddress) (rerr error) {
 	// Reserve a port, and start listening
 	ln, err := net.Listen("tcp", addr.DialString())
 	if err != nil {
 		return fmt.Errorf("unable to listen on address, %w", err)
 	}
+
+	defer func() {
+		if rerr != nil {
+			ln.Close()
+		}
+	}()
 
 	if addr.Port == 0 {
 		// net.Listen on port 0 means the kernel will auto-allocate a port


### PR DESCRIPTION
This change closes some leaking resources that were identified in a preliminary code read.

Fixes #3029
Fixes #3030
Fixes #3031