### PR TITLE
feat(github-bot): avoid triage-pending if there is any tech-staff review 

### DIFF
--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -60,7 +60,7 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			If:          c.Not(c.AuthorInTeam(gh, "tech-staff")),
 			Then: r.
 				If(r.Or(
-					r.ApprovalByOrgMembers(gh, 1),
+					r.ReviewByOrgMembers(gh).WithDesiredState(utils.ReviewStateApproved),
 					r.ReviewByTeamMembers(gh, "tech-staff"),
 					r.Draft(),
 				)).

--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gnolang/gno/contribs/github-bot/internal/client"
 	c "github.com/gnolang/gno/contribs/github-bot/internal/conditions"
 	r "github.com/gnolang/gno/contribs/github-bot/internal/requirements"
+	"github.com/gnolang/gno/contribs/github-bot/internal/utils"
 )
 
 type Teams []string
@@ -41,11 +42,11 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			Then: r.And(
 				r.Or(
 					r.AuthorInTeam(gh, "tech-staff"),
-					r.ReviewByTeamMembers(gh, "tech-staff", 1),
+					r.ReviewByTeamMembers(gh, "tech-staff").WithDesiredState(utils.ReviewStateApproved),
 				),
 				r.Or(
 					r.AuthorInTeam(gh, "devrels"),
-					r.ReviewByTeamMembers(gh, "devrels", 1),
+					r.ReviewByTeamMembers(gh, "devrels").WithDesiredState(utils.ReviewStateApproved),
 				),
 			),
 		},
@@ -55,13 +56,13 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			Then:        r.Never(),
 		},
 		{
-			Description: "Pending initial approval by a review team member (and label matches review triage state)",
+			Description: "Pending initial approval by a review team member, or review from tech-staff",
 			If:          c.Not(c.AuthorInTeam(gh, "tech-staff")),
 			Then: r.
 				If(r.Or(
-					r.ReviewByOrgMembers(gh, 1),
+					r.ApprovalByOrgMembers(gh, 1),
+					r.ReviewByTeamMembers(gh, "tech-staff"),
 					r.Draft(),
-					r.ReviewByTeamMembers(gh, "tech-staff", 1),
 				)).
 				// Either there was a first approval from a member, and we
 				// assert that the label for triage-pending is removed...

--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -58,7 +58,11 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			Description: "Pending initial approval by a review team member (and label matches review triage state)",
 			If:          c.Not(c.AuthorInTeam(gh, "tech-staff")),
 			Then: r.
-				If(r.Or(r.ReviewByOrgMembers(gh, 1), r.Draft())).
+				If(r.Or(
+					r.ReviewByOrgMembers(gh, 1),
+					r.Draft(),
+					r.ReviewByTeamMembers(gh, "tech-staff", 1),
+				)).
 				// Either there was a first approval from a member, and we
 				// assert that the label for triage-pending is removed...
 				Then(r.Not(r.Label(gh, "review/triage-pending", r.LabelRemove))).

--- a/contribs/github-bot/internal/requirements/reviewer.go
+++ b/contribs/github-bot/internal/requirements/reviewer.go
@@ -81,9 +81,10 @@ func ReviewByUser(gh *client.GitHub, user string) Requirement {
 
 // Reviewer Requirement.
 type reviewByTeamMembers struct {
-	gh    *client.GitHub
-	team  string
-	count uint
+	gh           *client.GitHub
+	team         string
+	count        uint
+	desiredState string
 }
 
 var _ Requirement = &reviewByTeamMembers{}
@@ -154,7 +155,12 @@ func (r *reviewByTeamMembers) IsSatisfied(pr *github.PullRequest, details treepr
 }
 
 func ReviewByTeamMembers(gh *client.GitHub, team string, count uint) Requirement {
-	return &reviewByTeamMembers{gh, team, count}
+	return &reviewByTeamMembers{
+		gh:           gh,
+		team:         team,
+		count:        1,
+		desiredState: approvedState,
+	}
 }
 
 type reviewByOrgMembers struct {

--- a/contribs/github-bot/internal/utils/github_const.go
+++ b/contribs/github-bot/internal/utils/github_const.go
@@ -12,10 +12,24 @@ const (
 	// Pull Request States.
 	PRStateOpen   = "open"
 	PRStateClosed = "closed"
-
-	// PR Review state.
-	// https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
-	ReviewStateApproved         = "APPROVED"
-	ReviewStateChangesRequested = "CHANGES_REQUESTED"
-	ReviewStateCommented        = "COMMENTED"
 )
+
+// ReviewState is the state of a PR review. See:
+// https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
+type ReviewState string
+
+// Possible values of ReviewState.
+const (
+	ReviewStateApproved         ReviewState = "APPROVED"
+	ReviewStateChangesRequested ReviewState = "CHANGES_REQUESTED"
+	ReviewStateCommented        ReviewState = "COMMENTED"
+)
+
+// Valid determines whether the ReviewState is one of the known ReviewStates.
+func (r ReviewState) Valid() bool {
+	switch r {
+	case ReviewStateApproved, ReviewStateChangesRequested, ReviewStateCommented:
+		return true
+	}
+	return false
+}

--- a/contribs/github-bot/internal/utils/github_const.go
+++ b/contribs/github-bot/internal/utils/github_const.go
@@ -14,5 +14,8 @@ const (
 	PRStateClosed = "closed"
 
 	// PR Review state.
-	ReviewStateApproved = "APPROVED"
+	// https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
+	ReviewStateApproved         = "APPROVED"
+	ReviewStateChangesRequested = "CHANGES_REQUESTED"
+	ReviewStateCommented        = "COMMENTED"
 )


### PR DESCRIPTION
After a first day of experimentation, we determined we don't want the triage-pending label on PRs that have already received a review from a tech-staff member.

Some additional changes:

- Split between `ApprovalBy` and `ReviewBy` in reviewer.go, to distinguish between the requirements that only work with an approval and those that are more generic.
- Don't request a team review if a member of the team already reviewed or is requested for review. (The bot was nagging a bit on some PRs because of this)