### PR TITLE
refactor(examples): use std.Address based behaviour

### DIFF
--- a/examples/gno.land/r/demo/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/foo20/foo20.gno
@@ -9,9 +9,7 @@ import (
 	"gno.land/p/demo/grc/grc20"
 	"gno.land/p/demo/ownable"
 	"gno.land/p/demo/ufmt"
-	pusers "gno.land/p/demo/users"
 	"gno.land/r/demo/grc20reg"
-	"gno.land/r/demo/users"
 )
 
 var (
@@ -29,31 +27,24 @@ func TotalSupply() uint64 {
 	return UserTeller.TotalSupply()
 }
 
-func BalanceOf(owner pusers.AddressOrName) uint64 {
-	ownerAddr := users.Resolve(owner)
-	return UserTeller.BalanceOf(ownerAddr)
+func BalanceOf(owner std.Address) uint64 {
+	return UserTeller.BalanceOf(owner)
 }
 
-func Allowance(owner, spender pusers.AddressOrName) uint64 {
-	ownerAddr := users.Resolve(owner)
-	spenderAddr := users.Resolve(spender)
-	return UserTeller.Allowance(ownerAddr, spenderAddr)
+func Allowance(owner, spender std.Address) uint64 {
+	return UserTeller.Allowance(owner, spender)
 }
 
-func Transfer(to pusers.AddressOrName, amount uint64) {
-	toAddr := users.Resolve(to)
-	checkErr(UserTeller.Transfer(toAddr, amount))
+func Transfer(to std.Address, amount uint64) {
+	checkErr(UserTeller.Transfer(to, amount))
 }
 
-func Approve(spender pusers.AddressOrName, amount uint64) {
-	spenderAddr := users.Resolve(spender)
-	checkErr(UserTeller.Approve(spenderAddr, amount))
+func Approve(spender std.Address, amount uint64) {
+	checkErr(UserTeller.Approve(spender, amount))
 }
 
-func TransferFrom(from, to pusers.AddressOrName, amount uint64) {
-	fromAddr := users.Resolve(from)
-	toAddr := users.Resolve(to)
-	checkErr(UserTeller.TransferFrom(fromAddr, toAddr, amount))
+func TransferFrom(from, to std.Address, amount uint64) {
+	checkErr(UserTeller.TransferFrom(from, to, amount))
 }
 
 // Faucet is distributing foo20 tokens without restriction (unsafe).
@@ -64,16 +55,14 @@ func Faucet() {
 	checkErr(privateLedger.Mint(caller, amount))
 }
 
-func Mint(to pusers.AddressOrName, amount uint64) {
+func Mint(to std.Address, amount uint64) {
 	Ownable.AssertCallerIsOwner()
-	toAddr := users.Resolve(to)
-	checkErr(privateLedger.Mint(toAddr, amount))
+	checkErr(privateLedger.Mint(to, amount))
 }
 
-func Burn(from pusers.AddressOrName, amount uint64) {
+func Burn(from std.Address, amount uint64) {
 	Ownable.AssertCallerIsOwner()
-	fromAddr := users.Resolve(from)
-	checkErr(privateLedger.Burn(fromAddr, amount))
+	checkErr(privateLedger.Burn(from, amount))
 }
 
 func Render(path string) string {
@@ -84,9 +73,8 @@ func Render(path string) string {
 	case path == "":
 		return Token.RenderHome()
 	case c == 2 && parts[0] == "balance":
-		owner := pusers.AddressOrName(parts[1])
-		ownerAddr := users.Resolve(owner)
-		balance := UserTeller.BalanceOf(ownerAddr)
+		owner := std.Address(parts[1])
+		balance := UserTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/examples/gno.land/r/demo/foo20/foo20_test.gno
+++ b/examples/gno.land/r/demo/foo20/foo20_test.gno
@@ -6,15 +6,13 @@ import (
 
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
-	pusers "gno.land/p/demo/users"
-	"gno.land/r/demo/users"
 )
 
 func TestReadOnlyPublicMethods(t *testing.T) {
 	var (
-		admin = pusers.AddressOrName("g1manfred47kzduec920z88wfr64ylksmdcedlf5")
-		alice = pusers.AddressOrName(testutils.TestAddress("alice"))
-		bob   = pusers.AddressOrName(testutils.TestAddress("bob"))
+		admin = std.Address("g1manfred47kzduec920z88wfr64ylksmdcedlf5")
+		alice = testutils.TestAddress("alice")
+		bob   = testutils.TestAddress("bob")
 	)
 
 	type test struct {
@@ -39,7 +37,7 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 	}
 
 	// bob uses the faucet.
-	std.TestSetOrigCaller(users.Resolve(bob))
+	std.TestSetOrigCaller(bob)
 	Faucet()
 
 	// check balances #2.
@@ -60,8 +58,8 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 
 func TestErrConditions(t *testing.T) {
 	var (
-		admin = pusers.AddressOrName("g1manfred47kzduec920z88wfr64ylksmdcedlf5")
-		empty = pusers.AddressOrName("")
+		admin = std.Address("g1manfred47kzduec920z88wfr64ylksmdcedlf5")
+		empty = std.Address("")
 	)
 
 	type test struct {

--- a/examples/gno.land/r/demo/wugnot/wugnot.gno
+++ b/examples/gno.land/r/demo/wugnot/wugnot.gno
@@ -6,9 +6,8 @@ import (
 
 	"gno.land/p/demo/grc/grc20"
 	"gno.land/p/demo/ufmt"
-	pusers "gno.land/p/demo/users"
+
 	"gno.land/r/demo/grc20reg"
-	"gno.land/r/demo/users"
 )
 
 var Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0)
@@ -65,34 +64,27 @@ func Render(path string) string {
 
 func TotalSupply() uint64 { return Token.TotalSupply() }
 
-func BalanceOf(owner pusers.AddressOrName) uint64 {
-	ownerAddr := users.Resolve(owner)
-	return Token.BalanceOf(ownerAddr)
+func BalanceOf(owner std.Address) uint64 {
+	return Token.BalanceOf(owner)
 }
 
-func Allowance(owner, spender pusers.AddressOrName) uint64 {
-	ownerAddr := users.Resolve(owner)
-	spenderAddr := users.Resolve(spender)
-	return Token.Allowance(ownerAddr, spenderAddr)
+func Allowance(owner, spender std.Address) uint64 {
+	return Token.Allowance(owner, spender)
 }
 
-func Transfer(to pusers.AddressOrName, amount uint64) {
-	toAddr := users.Resolve(to)
+func Transfer(to std.Address, amount uint64) {
 	userTeller := Token.CallerTeller()
-	checkErr(userTeller.Transfer(toAddr, amount))
+	checkErr(userTeller.Transfer(to, amount))
 }
 
-func Approve(spender pusers.AddressOrName, amount uint64) {
-	spenderAddr := users.Resolve(spender)
+func Approve(spender std.Address, amount uint64) {
 	userTeller := Token.CallerTeller()
-	checkErr(userTeller.Approve(spenderAddr, amount))
+	checkErr(userTeller.Approve(spender, amount))
 }
 
-func TransferFrom(from, to pusers.AddressOrName, amount uint64) {
-	fromAddr := users.Resolve(from)
-	toAddr := users.Resolve(to)
+func TransferFrom(from, to std.Address, amount uint64) {
 	userTeller := Token.CallerTeller()
-	checkErr(userTeller.TransferFrom(fromAddr, toAddr, amount))
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func require(condition bool, msg string) {

--- a/examples/gno.land/r/demo/wugnot/z0_filetest.gno
+++ b/examples/gno.land/r/demo/wugnot/z0_filetest.gno
@@ -7,8 +7,6 @@ import (
 
 	"gno.land/p/demo/testutils"
 	"gno.land/r/demo/wugnot"
-
-	pusers "gno.land/p/demo/users"
 )
 
 var (
@@ -39,7 +37,7 @@ func main() {
 
 func printBalances() {
 	printSingleBalance := func(name string, addr std.Address) {
-		wugnotBal := wugnot.BalanceOf(pusers.AddressOrName(addr))
+		wugnotBal := wugnot.BalanceOf(addr)
 		std.TestSetOrigCaller(addr)
 		robanker := std.GetBanker(std.BankerTypeReadonly)
 		coins := robanker.GetCoins(addr).AmountOf("ugnot")


### PR DESCRIPTION
## Description

To make contracts more simpler(and low computation for execution), it is better for contract to manipulate with only `std.Address` rather than using `users.AddressOrName` and resolving it. ([Discussed with @moul](https://github.com/gnoswap-labs/gnoswap/pull/465#discussion_r1922735140))

Clients such as gnoeky, gnoweb or adena should perform look up(convert username to address) and pass address value to contract.
