### PR TITLE
feat(boards2): change public delete reply function to soft delete replies

### DIFF
--- a/examples/gno.land/r/demo/boards2/post.gno
+++ b/examples/gno.land/r/demo/boards2/post.gno
@@ -1,3 +1,4 @@
+// Soft delete the reply by changing its body
 package boards2
 
 import (
@@ -146,6 +147,10 @@ func (post *Post) Update(title string, body string) {
 	post.title = title
 	post.body = body
 	post.updatedAt = time.Now()
+}
+
+func (post *Post) HasReplies() bool {
+	return post.replies.Size() > 0
 }
 
 func (thread *Post) GetReply(pid PostID) (_ *Post, found bool) {

--- a/examples/gno.land/r/demo/boards2/post.gno
+++ b/examples/gno.land/r/demo/boards2/post.gno
@@ -1,4 +1,3 @@
-// Soft delete the reply by changing its body
 package boards2
 
 import (

--- a/examples/gno.land/r/demo/boards2/post_test.gno
+++ b/examples/gno.land/r/demo/boards2/post_test.gno
@@ -140,6 +140,7 @@ func TestNewThread(t *testing.T) {
 	uassert.True(t, thread.GetUpdatedAt().IsZero())
 	uassert.Equal(t, title, thread.GetTitle())
 	uassert.Equal(t, body[:77]+"...", thread.GetSummary())
+	uassert.False(t, thread.HasReplies())
 	uassert.Equal(t, url, thread.GetURL())
 	uassert.Equal(t, replyURL, thread.GetReplyFormURL())
 	uassert.Equal(t, repostURL, thread.GetRepostFormURL())
@@ -160,6 +161,7 @@ func TestThreadAddReply(t *testing.T) {
 	uassert.Equal(t, threadID+1, uint(reply.GetPostID()))
 	uassert.Equal(t, reply.GetCreator(), replier)
 	uassert.Equal(t, reply.GetBody(), body)
+	uassert.True(t, thread.HasReplies())
 }
 
 func TestThreadGetReply(t *testing.T) {
@@ -297,6 +299,7 @@ func TestNewReply(t *testing.T) {
 	uassert.Equal(t, uint(replyID), uint(reply.GetPostID()))
 	uassert.False(t, reply.GetCreatedAt().IsZero())
 	uassert.True(t, reply.GetUpdatedAt().IsZero())
+	uassert.False(t, reply.HasReplies())
 	uassert.Equal(t, body[:77]+"...", reply.GetSummary())
 	uassert.Equal(t, url, reply.GetURL())
 	uassert.Equal(t, replyURL, reply.GetReplyFormURL())
@@ -320,6 +323,8 @@ func TestReplyAddReply(t *testing.T) {
 	uassert.Equal(t, parentReplyID+1, uint(reply.GetPostID()))
 	uassert.Equal(t, reply.GetCreator(), replier)
 	uassert.Equal(t, reply.GetBody(), body)
+	uassert.False(t, reply.HasReplies())
+	uassert.True(t, parentReply.HasReplies())
 }
 
 func TestReplyGetReply(t *testing.T) {

--- a/examples/gno.land/r/demo/boards2/public.gno
+++ b/examples/gno.land/r/demo/boards2/public.gno
@@ -174,18 +174,17 @@ func DeleteReply(bid BoardID, threadID, replyID PostID) {
 
 	board := mustGetBoard(bid)
 	thread := mustGetThread(board, threadID)
-	assertReplyExists(thread, replyID)
-
-	// TODO: Hide reply when the caller is the owner of the reply without permission
-	// TODO: Support removing reply and children though proposals?
+	reply := mustGetReply(thread, replyID)
+	assertReplyVisible(reply)
 
 	caller := std.GetOrigCaller()
-	args := Args{bid, threadID, replyID}
-	gPerm.WithPermission(caller, PermissionReplyDelete, args, func(a Args) {
-		board := mustGetBoard(bid)
-		thread := mustGetThread(board, threadID)
-		thread.DeleteReply(replyID)
-	})
+	if caller != reply.GetCreator() {
+		assertHasBoardPermission(board, caller, PermissionReplyDelete)
+	}
+
+	// Soft delete the reply by changing its body
+	// TODO: Should replies be had deleted? If so how do we deal with sub-replies?
+	reply.Update(reply.GetTitle(), "this reply has been deleted")
 }
 
 func EditThread(bid BoardID, threadID PostID, title, body string) {

--- a/examples/gno.land/r/demo/boards2/public.gno
+++ b/examples/gno.land/r/demo/boards2/public.gno
@@ -182,9 +182,13 @@ func DeleteReply(bid BoardID, threadID, replyID PostID) {
 		assertHasBoardPermission(board, caller, PermissionReplyDelete)
 	}
 
-	// Soft delete the reply by changing its body
-	// TODO: Should replies be had deleted? If so how do we deal with sub-replies?
-	reply.Update(reply.GetTitle(), "this reply has been deleted")
+	// Soft delete reply by changing its body when it contains
+	// sub-replies, otherwise hard delete it.
+	if reply.HasReplies() {
+		reply.Update(reply.GetTitle(), "this reply has been deleted")
+	} else {
+		thread.DeleteReply(replyID)
+	}
 }
 
 func EditThread(bid BoardID, threadID PostID, title, body string) {


### PR DESCRIPTION
Replies are soft deleted by replacing their body with a deleted message to keep sub comments

Related to https://github.com/gnolang/gno/pull/3583#pullrequestreview-2569368733