### PR TITLE
feat(gnoweb): add secure headers by default & timeout configuration

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -130,7 +130,7 @@ func (c *webCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.analytics,
 		"with-analytics",
 		defaultWebOptions.analytics,
-		"nable privacy-first analytics",
+		"enable privacy-first analytics",
 	)
 
 	fs.BoolVar(

--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -246,7 +246,7 @@ func SecureHeadersMiddleware(next http.Handler, strict bool) http.Handler {
 			// Enforce HTTPS by telling browsers to only access the site over HTTPS
 			// for a specified duration (1 year in this case). This also applies to
 			// subdomains and allows preloading into the browser's HSTS list.
-			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 		}
 
 		next.ServeHTTP(w, r)

--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -234,7 +234,7 @@ func SecureHeadersMiddleware(next http.Handler, strict bool) http.Handler {
 		// enhances privacy and prevents leakage of sensitive URLs.
 		w.Header().Set("Referrer-Policy", "no-referrer")
 
-		// In `strict` mode, prevent cross-site ressources and enforce https
+		// In `strict` mode, prevent cross-site ressources forgery and enforce https
 		if strict {
 			// Define a Content Security Policy (CSP) to restrict the sources of
 			// scripts, styles, images, and other resources. This helps prevent

--- a/gno.land/pkg/gnoweb/Makefile
+++ b/gno.land/pkg/gnoweb/Makefile
@@ -80,7 +80,8 @@ dev:
 # Go server in development mode
 dev.gnoweb: generate
 	$(run_reflex) -s -r '.*\.(go|html)' -- \
-		go run ../../cmd/gnoweb -assets-dir=${PUBLIC_DIR} -chainid=${CHAIN_ID} -remote=${DEV_REMOTE} \
+		go run ../../cmd/gnoweb -no-strict -assets-dir=${PUBLIC_DIR} -chainid=${CHAIN_ID} -remote=${DEV_REMOTE} \
+
 		2>&1 | $(run_logname) gnoweb
 
 # Tailwind CSS in development mode

--- a/gno.land/pkg/gnoweb/components/ui/icons.html
+++ b/gno.land/pkg/gnoweb/components/ui/icons.html
@@ -1,5 +1,5 @@
 {{ define "ui/icons" }}
-<svg xmlns="http://www.w3.org/2000/svg" style="display: none">
+<svg xmlns="http://www.w3.org/2000/svg" class="hidden">
   <symbol id="ico-search" viewBox="0 0 14 14">
     <title>Search</title>
     <path


### PR DESCRIPTION
This PR adds the following secure headers by default `strict=true` to gnoweb:

```go
func SecureHeadersMiddleware(next http.Handler, strict bool) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		// Prevent MIME type sniffing by browsers. This ensures that the browser
		// does not interpret files as a different MIME type than declared.
		w.Header().Set("X-Content-Type-Options", "nosniff")

		// Prevent the page from being embedded in an iframe. This mitigates
		// clickjacking attacks by ensuring the page cannot be loaded in a frame.
		w.Header().Set("X-Frame-Options", "DENY")

		// Control the amount of referrer information sent in the Referer header.
		// 'no-referrer' ensures that no referrer information is sent, which
		// enhances privacy and prevents leakage of sensitive URLs.
		w.Header().Set("Referrer-Policy", "no-referrer")

		// In `strict` mode, prevent cross-site resource forgery and enforce https
		if strict {
			// Define a Content Security Policy (CSP) to restrict the sources of
			// scripts, styles, images, and other resources. This helps prevent
			// cross-site scripting (XSS) and other code injection attacks.
			// - 'self' allows resources from the same origin.
			// - '*' allows images from any external source.
			// - data: is not included to prevent inline images (e.g., base64-encoded images).
			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' *; font-src 'self'")

			// Enforce HTTPS by telling browsers to only access the site over HTTPS
			// for a specified duration (1 year in this case). This also applies to
			// subdomains and allows preloading into the browser's HSTS list.
			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
		}

		next.ServeHTTP(w, r)
	})
}

```

I've also enforced a timeout on read/write/idle (default to 1 minute).

cc @kristovatlas