### PR TITLE
test(boards2): add missing filetests for board creation

### DIFF
--- a/examples/gno.land/r/nt/boards2/z_0_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_0_g_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.CreateBoard("short")
+}
+
+// Error:
+// the minimum allowed board name length is 6 characters

--- a/examples/gno.land/r/nt/boards2/z_0_h_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_0_h_filetest.gno
@@ -1,0 +1,34 @@
+package main
+
+// SEND: 200000000ugnot
+
+import (
+	"std"
+
+	"gno.land/r/demo/users"
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	member = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+	name   = "test123"
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+
+	// Test1 is the boards owner and its address has a user already registered
+	// so a new member must register a user with the new board name.
+	boards2.InviteMember(0, member, boards2.RoleOwner) // Operate on realm DAO members instead of individual boards
+	std.TestSetOrigCaller(member)
+	users.Register("", name, "")
+}
+
+func main() {
+	bid := boards2.CreateBoard(name)
+	println("ID =", bid)
+}
+
+// Output:
+// ID = 1

--- a/examples/gno.land/r/nt/boards2/z_0_i_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_0_i_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.CreateBoard("test123")
+}
+
+// Error:
+// unauthorized


### PR DESCRIPTION
Add a missing filetests for `CreateBoard()` function.

Related to #3623 

This covers all tests for the function:
- Creation success
- Fail w/ empty board name
- Fail w/ existing board name
- Fail w/ non user call
- Fail w/ an address as board name
- Fail because name is registered and not owned in `users` realm
- Fail w/ short name
- Creation success with owned name registered in `users` realm
- Fail for non realm DAO member