### PR TITLE
feat: optimize jitter factor calculation

### DIFF
--- a/tm2/pkg/p2p/switch.go
+++ b/tm2/pkg/p2p/switch.go
@@ -517,8 +517,7 @@ func calculateBackoff(
 	// Below is the code to add a jitter factor to the interval.
 	// Read random bytes into an 8 bytes buffer (size of an int64).
 	var randBytes [8]byte
-	_, err := rand.Read(randBytes[:])
-	if err != nil {
+	if _, err := rand.Read(randBytes[:]); err != nil {
 		return interval
 	}
 

--- a/tm2/pkg/p2p/switch.go
+++ b/tm2/pkg/p2p/switch.go
@@ -357,7 +357,7 @@ func (sw *MultiplexSwitch) runRedialLoop(ctx context.Context) {
 
 	type backoffItem struct {
 		lastDialTime time.Time
-		attempts     int
+		attempts     uint
 	}
 
 	var (
@@ -487,7 +487,7 @@ func (sw *MultiplexSwitch) runRedialLoop(ctx context.Context) {
 // by the number of attempts. The returned interval is capped at maxInterval and has a
 // jitter factor applied to it (+/- 10% of interval, max 10 sec).
 func calculateBackoff(
-	attempts int,
+	attempts uint,
 	baseInterval time.Duration,
 	maxInterval time.Duration,
 ) time.Duration {

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -823,3 +823,70 @@ func TestMultiplexSwitch_DialPeers(t *testing.T) {
 		}
 	})
 }
+
+func TestCalculateBackoff(t *testing.T) {
+	t.Parallel()
+
+	checkJitterRange := func(t *testing.T, expectedAbs, actual time.Duration) {
+		t.Helper()
+		require.LessOrEqual(t, actual, expectedAbs)
+		require.GreaterOrEqual(t, actual, expectedAbs*-1)
+	}
+
+	// Test that the default jitter factor is 10% of the backoff duration.
+	t.Run("percentage jitter", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 0; i < 1000; i++ {
+			checkJitterRange(t, 100*time.Millisecond, calculateBackoff(0, time.Second, 10*time.Minute)-time.Second)
+			checkJitterRange(t, 200*time.Millisecond, calculateBackoff(1, time.Second, 10*time.Minute)-2*time.Second)
+			checkJitterRange(t, 400*time.Millisecond, calculateBackoff(2, time.Second, 10*time.Minute)-4*time.Second)
+			checkJitterRange(t, 800*time.Millisecond, calculateBackoff(3, time.Second, 10*time.Minute)-8*time.Second)
+			checkJitterRange(t, 1600*time.Millisecond, calculateBackoff(4, time.Second, 10*time.Minute)-16*time.Second)
+		}
+	})
+
+	// Test that the jitter factor is capped at 10 sec.
+	t.Run("capped jitter", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 0; i < 1000; i++ {
+			checkJitterRange(t, 10*time.Second, calculateBackoff(7, time.Second, 10*time.Minute)-128*time.Second)
+			checkJitterRange(t, 10*time.Second, calculateBackoff(10, time.Second, 20*time.Minute)-1024*time.Second)
+			checkJitterRange(t, 10*time.Second, calculateBackoff(20, time.Second, 300*time.Hour)-1048576*time.Second)
+		}
+	})
+
+	// Test that the backoff interval is based on the baseInterval.
+	t.Run("base interval", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 0; i < 1000; i++ {
+			checkJitterRange(t, 4800*time.Millisecond, calculateBackoff(4, 3*time.Second, 10*time.Minute)-48*time.Second)
+			checkJitterRange(t, 8*time.Second, calculateBackoff(3, 10*time.Second, 10*time.Minute)-80*time.Second)
+			checkJitterRange(t, 10*time.Second, calculateBackoff(5, 3*time.Hour, 100*time.Hour)-96*time.Hour)
+		}
+	})
+
+	// Test that the backoff interval is capped at maxInterval +/- jitter factor.
+	t.Run("max interval", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 0; i < 1000; i++ {
+			checkJitterRange(t, 100*time.Millisecond, calculateBackoff(10, 10*time.Hour, time.Second)-time.Second)
+			checkJitterRange(t, 1600*time.Millisecond, calculateBackoff(10, 10*time.Hour, 16*time.Second)-16*time.Second)
+			checkJitterRange(t, 10*time.Second, calculateBackoff(10, 10*time.Hour, 128*time.Second)-128*time.Second)
+		}
+	})
+
+	// Test parameters sanitization for base and max intervals.
+	t.Run("parameters sanitization", func(t *testing.T) {
+		t.Parallel()
+
+		for i := 0; i < 1000; i++ {
+			checkJitterRange(t, 100*time.Millisecond, calculateBackoff(0, -10, -10)-time.Second)
+			checkJitterRange(t, 1600*time.Millisecond, calculateBackoff(4, -10, -10)-16*time.Second)
+			checkJitterRange(t, 10*time.Second, calculateBackoff(7, -10, 10*time.Minute)-128*time.Second)
+		}
+	})
+}


### PR DESCRIPTION
This PR modifies the backoff calculation in two ways:

1.	The jitter factor is now calculated based on a percentage of the interval and then added to the interval. Specifically, the jitter will be plus or minus 10% of the interval duration (so in the case of a 1s interval, the jitter will be a random duration between -0.1s and +0.1s, and the sum will therefore be a duration between 0.9s and 1.1s). The jitter is capped at a maximum of 10s (so in the case of a 5m interval, the jitter will be a random duration between -10s and +10s, and the sum will therefore be a duration between 4m50s and 5m10s).

2.	The jitter factor is applied to the interval even when it has been capped at the `maxInterval`. Therefore, the following call ⁠`calculateBackoff(10, time.Second, 10*time.Minute)` will return a duration between 9m50s and 10m10s instead of consistently returning 10m as before.

Fixes https://github.com/gnolang/gno/issues/3621.