### PR TITLE
refactor: sdk params context

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -100,8 +100,8 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 	acctKpr := auth.NewAccountKeeper(mainKey, paramsKpr, ProtoGnoAccount)
 	gpKpr := auth.NewGasPriceKeeper(mainKey)
 	bankKpr := bank.NewBankKeeper(acctKpr)
-
-	vmk := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, paramsKpr)
+	sdkPrms := vm.NewSDKParams(paramsKpr)
+	vmk := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, sdkPrms)
 	vmk.Output = cfg.VMOutput
 
 	// Set InitChainer

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -826,7 +826,9 @@ func newGasPriceTestApp(t *testing.T) abci.Application {
 	acctKpr := auth.NewAccountKeeper(mainKey, paramsKpr, ProtoGnoAccount)
 	gpKpr := auth.NewGasPriceKeeper(mainKey)
 	bankKpr := bank.NewBankKeeper(acctKpr)
-	vmk := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, paramsKpr)
+
+	sdkPrms := vm.NewSDKParams(paramsKpr)
+	vmk := vm.NewVMKeeper(baseKey, mainKey, acctKpr, bankKpr, sdkPrms)
 
 	// Set InitChainer
 	icc := cfg.InitChainerConfig

--- a/gno.land/pkg/sdk/vm/builtins.go
+++ b/gno.land/pkg/sdk/vm/builtins.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/sdk/params"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
@@ -60,21 +61,27 @@ func (bnk *SDKBanker) RemoveCoin(b32addr crypto.Bech32Address, denom string, amo
 // SDKParams
 
 type SDKParams struct {
-	vmk *VMKeeper
-	ctx sdk.Context
+	prmk params.ParamsKeeper
 }
 
-func NewSDKParams(vmk *VMKeeper, ctx sdk.Context) *SDKParams {
-	return &SDKParams{
-		vmk: vmk,
-		ctx: ctx,
+func NewSDKParams(prmk params.ParamsKeeper) SDKParams {
+	return SDKParams{
+		prmk: prmk,
 	}
 }
 
-func (prm *SDKParams) SetString(key, value string)      { prm.vmk.prmk.SetString(prm.ctx, key, value) }
-func (prm *SDKParams) SetBool(key string, value bool)   { prm.vmk.prmk.SetBool(prm.ctx, key, value) }
-func (prm *SDKParams) SetInt64(key string, value int64) { prm.vmk.prmk.SetInt64(prm.ctx, key, value) }
-func (prm *SDKParams) SetUint64(key string, value uint64) {
-	prm.vmk.prmk.SetUint64(prm.ctx, key, value)
+func (prm SDKParams) SetString(ctx sdk.Context, key, value string) {
+	prm.prmk.SetString(ctx, key, value)
 }
-func (prm *SDKParams) SetBytes(key string, value []byte) { prm.vmk.prmk.SetBytes(prm.ctx, key, value) }
+func (prm SDKParams) SetBool(ctx sdk.Context, key string, value bool) {
+	prm.prmk.SetBool(ctx, key, value)
+}
+func (prm SDKParams) SetInt64(ctx sdk.Context, key string, value int64) {
+	prm.prmk.SetInt64(ctx, key, value)
+}
+func (prm SDKParams) SetUint64(ctx sdk.Context, key string, value uint64) {
+	prm.prmk.SetUint64(ctx, key, value)
+}
+func (prm SDKParams) SetBytes(ctx sdk.Context, key string, value []byte) {
+	prm.prmk.SetBytes(ctx, key, value)
+}

--- a/gno.land/pkg/sdk/vm/builtins.go
+++ b/gno.land/pkg/sdk/vm/builtins.go
@@ -73,15 +73,19 @@ func NewSDKParams(prmk params.ParamsKeeper) SDKParams {
 func (prm SDKParams) SetString(ctx sdk.Context, key, value string) {
 	prm.prmk.SetString(ctx, key, value)
 }
+
 func (prm SDKParams) SetBool(ctx sdk.Context, key string, value bool) {
 	prm.prmk.SetBool(ctx, key, value)
 }
+
 func (prm SDKParams) SetInt64(ctx sdk.Context, key string, value int64) {
 	prm.prmk.SetInt64(ctx, key, value)
 }
+
 func (prm SDKParams) SetUint64(ctx sdk.Context, key string, value uint64) {
 	prm.prmk.SetUint64(ctx, key, value)
 }
+
 func (prm SDKParams) SetBytes(ctx sdk.Context, key string, value []byte) {
 	prm.prmk.SetBytes(ctx, key, value)
 }

--- a/gno.land/pkg/sdk/vm/common_test.go
+++ b/gno.land/pkg/sdk/vm/common_test.go
@@ -48,10 +48,11 @@ func _setupTestEnv(cacheStdlibs bool) testEnv {
 
 	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms, &bft.Header{ChainID: "test-chain-id"}, log.NewNoopLogger())
 	prmk := paramsm.NewParamsKeeper(iavlCapKey, "params")
+
 	acck := authm.NewAccountKeeper(iavlCapKey, prmk, std.ProtoBaseAccount)
 	bank := bankm.NewBankKeeper(acck)
-
-	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, prmk)
+	sdkprms := NewSDKParams(prmk)
+	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bank, sdkprms)
 
 	mcw := ms.MultiCacheWrap()
 	vmk.Initialize(log.NewNoopLogger(), mcw)

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -384,8 +384,8 @@ func Do() string {
 
 	var foo string
 	var bar int64
-	env.vmk.prmk.GetString(ctx, "gno.land/r/test.foo.string", &foo)
-	env.vmk.prmk.GetInt64(ctx, "gno.land/r/test.bar.int64", &bar)
+	env.vmk.sdkprms.prmk.GetString(ctx, "gno.land/r/test.foo.string", &foo)
+	env.vmk.sdkprms.prmk.GetInt64(ctx, "gno.land/r/test.bar.int64", &bar)
 	assert.Equal(t, "foo2", foo)
 	assert.Equal(t, int64(1337), bar)
 }

--- a/gno.land/pkg/sdk/vm/params.go
+++ b/gno.land/pkg/sdk/vm/params.go
@@ -9,12 +9,12 @@ const (
 
 func (vm *VMKeeper) getChainDomainParam(ctx sdk.Context) string {
 	chainDomain := "gno.land" // default
-	vm.prmk.GetString(ctx, chainDomainParamPath, &chainDomain)
+	vm.sdkprms.prmk.GetString(ctx, chainDomainParamPath, &chainDomain)
 	return chainDomain
 }
 
 func (vm *VMKeeper) getSysUsersPkgParam(ctx sdk.Context) string {
 	var sysUsersPkg string
-	vm.prmk.GetString(ctx, sysUsersPkgParamPath, &sysUsersPkg)
+	vm.sdkprms.prmk.GetString(ctx, sysUsersPkgParamPath, &sysUsersPkg)
 	return sysUsersPkg
 }

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -87,11 +87,11 @@ func newTestParams() *testParams {
 	return &testParams{}
 }
 
-func (tp *testParams) SetBool(key string, val bool)     { /* noop */ }
-func (tp *testParams) SetBytes(key string, val []byte)  { /* noop */ }
-func (tp *testParams) SetInt64(key string, val int64)   { /* noop */ }
-func (tp *testParams) SetUint64(key string, val uint64) { /* noop */ }
-func (tp *testParams) SetString(key string, val string) { /* noop */ }
+func (tp *testParams) SetBool(ctx sdk.Context, key string, val bool)     { /* noop */ }
+func (tp *testParams) SetBytes(ctx sdk.Context, key string, val []byte)  { /* noop */ }
+func (tp *testParams) SetInt64(ctx sdk.Context, key string, val int64)   { /* noop */ }
+func (tp *testParams) SetUint64(ctx sdk.Context, key string, val uint64) { /* noop */ }
+func (tp *testParams) SetString(ctx sdk.Context, key string, val string) { /* noop */ }
 
 // ----------------------------------------
 // main test function

--- a/gnovm/stdlibs/std/context.go
+++ b/gnovm/stdlibs/std/context.go
@@ -19,6 +19,7 @@ type ExecContext struct {
 	OrigSendSpent *std.Coins // mutable
 	Banker        BankerInterface
 	Params        ParamsInterface
+	SDKContext    sdk.Context
 	EventLogger   *sdk.EventLogger
 }
 

--- a/gnovm/stdlibs/std/params.go
+++ b/gnovm/stdlibs/std/params.go
@@ -6,6 +6,7 @@ import (
 	"unicode"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
 )
 
 // ParamsInterface is the interface through which Gno is capable of accessing
@@ -14,36 +15,46 @@ import (
 // The name is what it is to avoid a collision with Gno's Params, when
 // transpiling.
 type ParamsInterface interface {
-	SetString(key, val string)
-	SetBool(key string, val bool)
-	SetInt64(key string, val int64)
-	SetUint64(key string, val uint64)
-	SetBytes(key string, val []byte)
+	SetString(ctx sdk.Context, key, val string)
+	SetBool(ctx sdk.Context, key string, val bool)
+	SetInt64(ctx sdk.Context, key string, val int64)
+	SetUint64(ctx sdk.Context, key string, val uint64)
+	SetBytes(ctx sdk.Context, key string, val []byte)
 }
 
 func X_setParamString(m *gno.Machine, key, val string) {
 	pk := pkey(m, key, "string")
-	GetContext(m).Params.SetString(pk, val)
+	msgCtx := GetContext(m)
+	sdkCtx := msgCtx.SDKContext
+	msgCtx.Params.SetString(sdkCtx, pk, val)
 }
 
 func X_setParamBool(m *gno.Machine, key string, val bool) {
 	pk := pkey(m, key, "bool")
-	GetContext(m).Params.SetBool(pk, val)
+	msgCtx := GetContext(m)
+	sdkCtx := msgCtx.SDKContext
+	msgCtx.Params.SetBool(sdkCtx, pk, val)
 }
 
 func X_setParamInt64(m *gno.Machine, key string, val int64) {
 	pk := pkey(m, key, "int64")
-	GetContext(m).Params.SetInt64(pk, val)
+	msgCtx := GetContext(m)
+	sdkCtx := msgCtx.SDKContext
+	msgCtx.Params.SetInt64(sdkCtx, pk, val)
 }
 
 func X_setParamUint64(m *gno.Machine, key string, val uint64) {
 	pk := pkey(m, key, "uint64")
-	GetContext(m).Params.SetUint64(pk, val)
+	msgCtx := GetContext(m)
+	sdkCtx := msgCtx.SDKContext
+	msgCtx.Params.SetUint64(sdkCtx, pk, val)
 }
 
 func X_setParamBytes(m *gno.Machine, key string, val []byte) {
 	pk := pkey(m, key, "bytes")
-	GetContext(m).Params.SetBytes(pk, val)
+	msgCtx := GetContext(m)
+	sdkCtx := msgCtx.SDKContext
+	msgCtx.Params.SetBytes(sdkCtx, pk, val)
 }
 
 func pkey(m *gno.Machine, key string, kind string) string {


### PR DESCRIPTION
Do NOT merge. 

This is a proof of concept (POC) for refactoring the SDKParams.

` func (prm *SDKParams) SetBool(ctx sdk.Context, key string, value bool) `