### PR TITLE
fix(gnoweb): NoRender response & test

### DIFF
--- a/gno.land/pkg/gnoweb/app_test.go
+++ b/gno.land/pkg/gnoweb/app_test.go
@@ -47,7 +47,7 @@ func TestRoutes(t *testing.T) {
 		{"/game-of-realms", found, "/contribute"},
 		{"/gor", found, "/contribute"},
 		{"/blog", found, "/r/gnoland/blog"},
-		{"/r/docs/optional_render", http.StatusNoContent, "No Render"},
+		{"/r/docs/optional_render", http.StatusOK, "No Render"},
 		{"/r/not/found/", notFound, ""},
 		{"/404/not/found", notFound, ""},
 		{"/아스키문자가아닌경로", notFound, ""},

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -161,7 +161,7 @@ func (h *WebHandler) GetRealmView(gnourl *GnoURL) (int, *components.View) {
 	meta, err := h.Client.RenderRealm(&content, gnourl.Path, gnourl.EncodeArgs())
 	if err != nil {
 		if errors.Is(err, ErrRenderNotDeclared) {
-			return http.StatusNoContent, components.StatusNoRenderComponent(gnourl.Path)
+			return http.StatusOK, components.StatusNoRenderComponent(gnourl.Path)
 		}
 
 		h.Logger.Error("unable to render realm", "error", err, "path", gnourl.EncodeURL())

--- a/gno.land/pkg/gnoweb/handler_test.go
+++ b/gno.land/pkg/gnoweb/handler_test.go
@@ -147,7 +147,7 @@ func TestWebHandler_NoRender(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusNoContent, rr.Code, "unexpected status code")
-	assert.Containsf(t, rr.Body.String(), "", "rendered body should contain: %q", "No Render")
-	assert.Containsf(t, rr.Body.String(), "", "rendered body should contain: %q", "This realm does not implement a Render() function.")
+	assert.Equal(t, http.StatusOK, rr.Code, "unexpected status code")
+	expectedBody := "This realm does not implement a Render() function."
+	assert.Contains(t, rr.Body.String(), expectedBody, "rendered body should contain: %q", expectedBody)
 }


### PR DESCRIPTION
## Description

Changes the NoRender response to 200, since 204 does not allow for content body. Also fixes a test that didn't catch this.