### PR TITLE
test(boards2): add missing filetests for thread creation

### DIFF
--- a/examples/gno.land/r/nt/boards2/public.gno
+++ b/examples/gno.land/r/nt/boards2/public.gno
@@ -17,7 +17,7 @@ func CreateBoard(name string) BoardID {
 	assertIsUserCall()
 
 	name = strings.TrimSpace(name)
-	assertBoardNameIsNotEmpty(name)
+	assertNameIsNotEmpty(name)
 	assertBoardNameNotExists(name)
 
 	caller := std.GetOrigCaller()
@@ -37,7 +37,7 @@ func RenameBoard(name, newName string) {
 	assertIsUserCall()
 
 	newName = strings.TrimSpace(newName)
-	assertBoardNameIsNotEmpty(newName)
+	assertNameIsNotEmpty(newName)
 	assertBoardNameNotExists(newName)
 
 	board := mustGetBoardByName(name)
@@ -74,6 +74,12 @@ func FlagThread(bid BoardID, postID PostID, reason string) {
 
 func CreateThread(bid BoardID, title, body string) PostID {
 	assertIsUserCall()
+
+	title = strings.TrimSpace(title)
+	assertTitleIsNotEmpty(title)
+
+	body = strings.TrimSpace(body)
+	assertBodyIsNotEmpty(body)
 
 	caller := std.GetOrigCaller()
 	board := mustGetBoard(bid)
@@ -178,6 +184,12 @@ func DeleteReply(bid BoardID, threadID, replyID PostID) {
 func EditThread(bid BoardID, threadID PostID, title, body string) {
 	assertIsUserCall()
 
+	title = strings.TrimSpace(title)
+	assertTitleIsNotEmpty(title)
+
+	body = strings.TrimSpace(body)
+	assertBodyIsNotEmpty(body)
+
 	board := mustGetBoard(bid)
 	thread := mustGetThread(board, threadID)
 	caller := std.GetOrigCaller()
@@ -274,9 +286,21 @@ func assertBoardExists(id BoardID) {
 	}
 }
 
-func assertBoardNameIsNotEmpty(name string) {
+func assertNameIsNotEmpty(name string) {
 	if name == "" {
-		panic("board name is empty")
+		panic("name is empty")
+	}
+}
+
+func assertTitleIsNotEmpty(title string) {
+	if title == "" {
+		panic("title is empty")
+	}
+}
+
+func assertBodyIsNotEmpty(body string) {
+	if body == "" {
+		panic("body is empty")
 	}
 }
 

--- a/examples/gno.land/r/nt/boards2/z_0_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_0_b_filetest.gno
@@ -17,4 +17,4 @@ func main() {
 }
 
 // Error:
-// board name is empty
+// name is empty

--- a/examples/gno.land/r/nt/boards2/z_3_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_3_b_filetest.gno
@@ -21,4 +21,4 @@ func main() {
 }
 
 // Error:
-// board name is empty
+// name is empty

--- a/examples/gno.land/r/nt/boards2/z_8_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_8_a_filetest.gno
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	title = "Test Thread"
+	body  = "Test body"
+	path  = "test-board/1"
+)
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	pid := boards2.CreateThread(bid, title, body)
+
+	// Ensure that returned ID is right
+	println(pid == 1)
+
+	// Render content must contains thread's title and body
+	content := boards2.Render(path)
+	println(strings.HasPrefix(content, "# "+title))
+	println(strings.Contains(content, body))
+}
+
+// Output:
+// true
+// true
+// true

--- a/examples/gno.land/r/nt/boards2/z_8_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_8_b_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.CreateThread(404, "Foo", "bar")
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_8_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_8_c_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.CreateThread(bid, "Foo", "bar")
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_8_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_8_d_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+}
+
+func main() {
+	boards2.CreateThread(bid, "", "bar")
+}
+
+// Error:
+// title is empty

--- a/examples/gno.land/r/nt/boards2/z_8_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_8_e_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+}
+
+func main() {
+	boards2.CreateThread(bid, "Foo", "")
+}
+
+// Error:
+// body is empty


### PR DESCRIPTION
Add missing filetests for `CreateThread()` function.

Related to #3623

This covers all tests for the function:
- Successfully create a thread
- Fail because board is not found
- Fail because user has no permission to create a thread
- Fail w/ empty title
- Fail w/ empty body
