### PR TITLE
test(boards2): add missing filetests for thread deletion

### DIFF
--- a/examples/gno.land/r/nt/boards2/public.gno
+++ b/examples/gno.land/r/nt/boards2/public.gno
@@ -150,6 +150,7 @@ func DeleteThread(bid BoardID, threadID PostID) {
 		assertHasBoardPermission(board, caller, PermissionThreadDelete)
 	}
 
+	// TODO: Discuss how to deal with thread deletion
 	board.DeleteThread(threadID)
 }
 

--- a/examples/gno.land/r/nt/boards2/z_9_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_9_a_filetest.gno
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	title = "Test Thread"
+	body  = "Test body"
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, title, body)
+}
+
+func main() {
+	boards2.DeleteThread(bid, pid)
+
+	// Ensure thread doesn't exist
+	println(boards2.Render("test-board/1"))
+}
+
+// Output:
+// Thread does not exist with ID: 1

--- a/examples/gno.land/r/nt/boards2/z_9_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_9_b_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.DeleteThread(404, 1)
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_9_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_9_c_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.DeleteThread(bid, 404)
+}
+
+// Error:
+// thread does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_9_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_9_d_filetest.gno
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	// Call using a user that has not permission to delete threads
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.DeleteThread(bid, pid)
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_9_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_9_e_filetest.gno
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	member = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	// Invite a member using a role with permission to delete threads
+	boards2.InviteMember(bid, member, boards2.RoleAdmin)
+	std.TestSetOrigCaller(member)
+}
+
+func main() {
+	boards2.DeleteThread(bid, pid)
+
+	// Ensure thread doesn't exist
+	println(boards2.Render("test-board/1"))
+}
+
+// Output:
+// Thread does not exist with ID: 1


### PR DESCRIPTION
Add missing filetests for `DeleteThread()` function.

Related to #3623

This covers all tests for the function:
- Successfully delete a thread
- Fail because board is not found
- Fail because thread is not found
- Fail because user has no permission to delete a thread
- Successfully delete a thread using a user with permission to delete
