### PR TITLE
test(boards2): add missing filetests for thread flagging

### DIFF
--- a/examples/gno.land/r/nt/boards2/flag.gno
+++ b/examples/gno.land/r/nt/boards2/flag.gno
@@ -5,6 +5,7 @@ import (
 	"strconv"
 )
 
+// TODO: We should allow changing the threshold, also support value per board
 const flagThreshold = 1
 
 type Flag struct {

--- a/examples/gno.land/r/nt/boards2/z_10_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_a_filetest.gno
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+
+	// Ensure that original thread content not visible
+	println(boards2.Render("test-board/1"))
+}
+
+// Output:
+// Thread with ID: 1 has been flagged as inappropriate

--- a/examples/gno.land/r/nt/boards2/z_10_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_b_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.FlagThread(404, 1, "")
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_10_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_c_filetest.gno
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_10_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_d_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.FlagThread(bid, 404, "")
+}
+
+// Error:
+// post doesn't exist

--- a/examples/gno.land/r/nt/boards2/z_10_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_e_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+	boards2.FlagThread(bid, pid, "")
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+}
+
+// Error:
+// item flag count threshold exceeded: 1

--- a/examples/gno.land/r/nt/boards2/z_10_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_10_f_filetest.gno
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner     = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	moderator = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	// Invite a member using a role with permission to flag threads
+	boards2.InviteMember(bid, moderator, boards2.RoleModerator)
+	std.TestSetOrigCaller(moderator)
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+
+	// Ensure that original thread content not visible
+	println(boards2.Render("test-board/1"))
+}
+
+// Output:
+// Thread with ID: 1 has been flagged as inappropriate


### PR DESCRIPTION
Add missing filetests for `FlagThread()` function.

Related to #3623

This covers all tests for the function:
- Successfully flag a thread
- Fail because board is not found
- Fail because user has no permission to flag a thread
- Fail because thread is not found
- Fail because default flag threshold of 1 is exceeded
- Successfully flag a thread using a user with permission to flag