### PR TITLE
chore: Trigger CI tests on changes to the main go.mod

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -14,6 +14,9 @@ on:
       # Changes to examples/ can create failures in gno.land, eg. txtars,
       # see: https://github.com/gnolang/gno/pull/3590
       - examples/**
+      # We trigger the testing workflow for changes to the main go.mod,
+      # since this can affect test results
+      - go.mod
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - gnovm/**
       - tm2/** # GnoVM has a dependency on TM2 types
+      # We trigger the testing workflow for changes to the main go.mod,
+      # since this can affect test results
+      - go.mod
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tm2.yml
+++ b/.github/workflows/tm2.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - tm2/**
+      # We trigger the testing workflow for changes to the main go.mod,
+      # since this can affect test results
+      - go.mod
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Resolves https://github.com/gnolang/gno/issues/3312

After a dependabot commit, the dependabot-tidy workflow [runs `make tidy`](https://github.com/gnolang/gno/blob/b392287f0d2c8262b5a020cd045b79a16ccb41fd/.github/workflows/dependabot-tidy.yml#L33). This changes `go.mod` in the subfolders of various tools, but these do not trigger the main CI test workflows. However, note that `make tidy` often also changes the main `go.mod` file. In this case, and other cases, it makes sense that a change in the main `go.mod` file should trigger the testing workflows since a change to dependency versions could effect test results.

This PR updates workflow yml files for the global tests to trigger on a change the main `go.mod` file.

(Thanks to feedback from @zivkovicmilos.)