### PR TITLE
test(boards2): add missing filetests for thread edit

### DIFF
--- a/examples/gno.land/r/nt/boards2/z_11_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_a_filetest.gno
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	title = "Test Thread"
+	body  = "Test body"
+	path  = "test-board/1"
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.EditThread(bid, pid, title, body)
+
+	// Render content must contains thread's title and body
+	content := boards2.Render(path)
+	println(strings.HasPrefix(content, "# "+title))
+	println(strings.Contains(content, body))
+}
+
+// Output:
+// true
+// true

--- a/examples/gno.land/r/nt/boards2/z_11_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_b_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"std"
-	"strings"
 
 	"gno.land/r/nt/boards2"
 )

--- a/examples/gno.land/r/nt/boards2/z_11_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_b_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.EditThread(bid, pid, "", "bar")
+}
+
+// Error:
+// title is empty

--- a/examples/gno.land/r/nt/boards2/z_11_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_c_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"std"
-	"strings"
 
 	"gno.land/r/nt/boards2"
 )

--- a/examples/gno.land/r/nt/boards2/z_11_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_c_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.EditThread(bid, pid, "Foo", "")
+}
+
+// Error:
+// body is empty

--- a/examples/gno.land/r/nt/boards2/z_11_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_d_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"std"
-	"strings"
 
 	"gno.land/r/nt/boards2"
 )

--- a/examples/gno.land/r/nt/boards2/z_11_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_d_filetest.gno
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.EditThread(404, 1, "Foo", "bar")
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_11_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_e_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"std"
-	"strings"
 
 	"gno.land/r/nt/boards2"
 )

--- a/examples/gno.land/r/nt/boards2/z_11_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_e_filetest.gno
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.EditThread(bid, 404, "Foo", "")
+}
+
+// Error:
+// body is empty

--- a/examples/gno.land/r/nt/boards2/z_11_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_f_filetest.gno
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.EditThread(bid, pid, "Foo", "bar")
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_11_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_11_g_filetest.gno
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	admin = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+	title = "Test Thread"
+	body  = "Test body"
+	path  = "test-board/1"
+)
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	// Invite a member using a role with permission to edit threads
+	boards2.InviteMember(bid, admin, boards2.RoleAdmin)
+	std.TestSetOrigCaller(admin)
+}
+
+func main() {
+	boards2.EditThread(bid, pid, title, body)
+
+	// Render content must contains thread's title and body
+	content := boards2.Render(path)
+	println(strings.HasPrefix(content, "# "+title))
+	println(strings.Contains(content, body))
+}
+
+// Output:
+// true
+// true


### PR DESCRIPTION
Add missing filetests for `EditThread()` function.

Related to #3623

This covers all tests for the function:
- Successfully edit a thread
- Fail w/ empty title
- Fail w/ empty body
- Fail because board is not found
- Fail because thread is not found
- Fail because user has no permission to edit a thread
- Successfully edit a thread using a user with permission to delete
