### PR TITLE
test(boards2): add missing filetests for reply edit

### DIFF
--- a/examples/gno.land/r/nt/boards2/public.gno
+++ b/examples/gno.land/r/nt/boards2/public.gno
@@ -210,6 +210,8 @@ func EditReply(bid BoardID, threadID, replyID PostID, body string) {
 	board := mustGetBoard(bid)
 	thread := mustGetThread(board, threadID)
 	reply := mustGetReply(thread, replyID)
+	assertReplyVisible(reply)
+
 	if std.GetOrigCaller() != reply.GetCreator() {
 		panic("only the reply creator is allowed to edit it")
 	}

--- a/examples/gno.land/r/nt/boards2/public.gno
+++ b/examples/gno.land/r/nt/boards2/public.gno
@@ -201,18 +201,20 @@ func EditThread(bid BoardID, threadID PostID, title, body string) {
 	thread.Update(title, body)
 }
 
-func EditReply(bid BoardID, threadID, replyID PostID, title, body string) {
+func EditReply(bid BoardID, threadID, replyID PostID, body string) {
 	assertIsUserCall()
+
+	body = strings.TrimSpace(body)
+	assertBodyIsNotEmpty(body)
 
 	board := mustGetBoard(bid)
 	thread := mustGetThread(board, threadID)
 	reply := mustGetReply(thread, replyID)
-	caller := std.GetOrigCaller()
-	if caller != reply.GetCreator() {
+	if std.GetOrigCaller() != reply.GetCreator() {
 		panic("only the reply creator is allowed to edit it")
 	}
 
-	reply.Update(title, body)
+	reply.Update("", body)
 }
 
 func InviteMember(bid BoardID, user std.Address, role Role) {

--- a/examples/gno.land/r/nt/boards2/z_12_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_a_filetest.gno
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	body  = "Test reply"
+	path  = "test-board/1/2"
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+}
+
+func main() {
+	boards2.EditReply(bid, tid, rid, body)
+
+	// Render content must contain the modified reply
+	content := boards2.Render(path)
+	println(strings.Contains(content, "\n> "+body+"\n"))
+}
+
+// Output:
+// true

--- a/examples/gno.land/r/nt/boards2/z_12_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_b_filetest.gno
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	body  = "Test reply"
+	path  = "test-board/1/2"
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+
+	// Create a reply and a sub reply
+	parentRID := boards2.CreateReply(bid, tid, 0, "Parent")
+	rid = boards2.CreateReply(bid, tid, parentRID, "Child")
+}
+
+func main() {
+	boards2.EditReply(bid, tid, rid, body)
+
+	// Render content must contain the modified reply
+	content := boards2.Render(path)
+	println(strings.Contains(content, "\n> > "+body+"\n"))
+}
+
+// Output:
+// true

--- a/examples/gno.land/r/nt/boards2/z_12_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_c_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.EditReply(404, 1, 0, "body")
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_12_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_d_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.EditReply(bid, 404, 0, "body")
+}
+
+// Error:
+// thread does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_12_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_e_filetest.gno
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.EditReply(bid, tid, 404, "body")
+}
+
+// Error:
+// reply does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_12_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_f_filetest.gno
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.EditReply(bid, tid, rid, "new body")
+}
+
+// Error:
+// only the reply creator is allowed to edit it

--- a/examples/gno.land/r/nt/boards2/z_12_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_g_filetest.gno
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+
+	// Flag the reply so it's hidden
+	boards2.FlagReply(bid, tid, rid, "reason")
+}
+
+func main() {
+	boards2.EditReply(bid, tid, rid, "body")
+}
+
+// Error:
+// reply with ID: 2 was hidden

--- a/examples/gno.land/r/nt/boards2/z_12_h_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_12_h_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+}
+
+func main() {
+	boards2.EditReply(bid, tid, rid, "")
+}
+
+// Error:
+// body is empty


### PR DESCRIPTION
Add missing filetests for `EditReply()` function.

Related to #3623

This covers all tests for the function:
- Successfully edit of a reply
- Successfully edit of a sub-reply
- Fail because board is not found
- Fail because thread is not found
- Fail because parent reply is not found
- Fail when edited by a user that is not the creator of the reply
- Fail when reply is hidden because is flagged
- Fail w/ empty body