### PR TITLE
test(boards2): add missing filetests for reply flagging

### DIFF
--- a/examples/gno.land/r/nt/boards2/z_13_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_a_filetest.gno
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid      boards2.BoardID
+	rid, tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, rid, "")
+
+	// Render content must contain a message about the hidden reply
+	content := boards2.Render("test-board/1/2")
+	println(strings.Contains(content, "\n> _Reply is hidden as it has been flagged as inappropriate_\n"))
+}
+
+// Output:
+// true

--- a/examples/gno.land/r/nt/boards2/z_13_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_b_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.FlagReply(404, 1, 1, "")
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_13_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_c_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.FlagReply(bid, 404, 1, "")
+}
+
+// Error:
+// thread does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_13_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_d_filetest.gno
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, 404, "")
+}
+
+// Error:
+// reply does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_13_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_e_filetest.gno
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid      boards2.BoardID
+	rid, tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+	boards2.FlagReply(bid, tid, rid, "")
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, rid, "")
+}
+
+// Error:
+// item flag count threshold exceeded: 1

--- a/examples/gno.land/r/nt/boards2/z_13_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_f_filetest.gno
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	rid, tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, rid, "")
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_13_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_13_g_filetest.gno
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner     = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	moderator = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	rid, tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+
+	// Invite a member using a role with permission to flag replies
+	boards2.InviteMember(bid, moderator, boards2.RoleModerator)
+	std.TestSetOrigCaller(moderator)
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, rid, "")
+
+	// Render content must contain a message about the hidden reply
+	content := boards2.Render("test-board/1/2")
+	println(strings.Contains(content, "\n> _Reply is hidden as it has been flagged as inappropriate_\n"))
+}
+
+// Output:
+// true


### PR DESCRIPTION
Add missing filetests for `FlagReply()` function.

Related to #3623

This covers all tests for the function:
- Successfully flag a reply
- Fail because board is not found
- Fail because thread is not found
- Fail because reply is not found
- Fail because default flag threshold of 1 is exceeded
- Fail because user has no permission to flag a reply
- Successfully flag a thread using a user with permission to flag