### PR TITLE
test(boards2): add missing filetests for reply deletion

### DIFF
--- a/examples/gno.land/r/nt/boards2/public.gno
+++ b/examples/gno.land/r/nt/boards2/public.gno
@@ -179,7 +179,7 @@ func DeleteReply(bid BoardID, threadID, replyID PostID) {
 	// Soft delete reply by changing its body when it contains
 	// sub-replies, otherwise hard delete it.
 	if reply.HasReplies() {
-		reply.Update(reply.GetTitle(), "this reply has been deleted")
+		reply.Update(reply.GetTitle(), "This reply has been deleted")
 	} else {
 		thread.DeleteReply(replyID)
 	}

--- a/examples/gno.land/r/nt/boards2/z_14_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_a_filetest.gno
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+}
+
+func main() {
+	boards2.DeleteReply(bid, tid, rid)
+
+	// Ensure reply doesn't exist
+	println(boards2.Render("test-board/1/2"))
+}
+
+// Output:
+// Reply does not exist with ID: 2

--- a/examples/gno.land/r/nt/boards2/z_14_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_b_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.DeleteReply(404, 1, 1)
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_14_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_c_filetest.gno
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.DeleteReply(bid, 404, 1)
+}
+
+// Error:
+// thread does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_14_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_d_filetest.gno
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.DeleteReply(bid, tid, 404)
+}
+
+// Error:
+// reply does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/z_14_e_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_e_filetest.gno
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/r/nt/boards2"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+
+	rid = boards2.CreateReply(bid, tid, 0, "Parent")
+	boards2.CreateReply(bid, tid, rid, "Child reply")
+}
+
+func main() {
+	boards2.DeleteReply(bid, tid, rid)
+
+	// Render content must contain the releted message instead of reply's body
+	content := boards2.Render("test-board/1/2")
+	println(strings.Contains(content, "\n> This reply has been deleted\n"))
+	println(strings.Contains(content, "\n> > Child reply\n"))
+}
+
+// Output:
+// true
+// true

--- a/examples/gno.land/r/nt/boards2/z_14_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_f_filetest.gno
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+
+	// Call using a user that has not permission to delete replies
+	std.TestSetOrigCaller(user)
+}
+
+func main() {
+	boards2.DeleteReply(bid, tid, rid)
+}
+
+// Error:
+// unauthorized

--- a/examples/gno.land/r/nt/boards2/z_14_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/z_14_g_filetest.gno
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"std"
+
+	"gno.land/r/nt/boards2"
+)
+
+const (
+	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	member = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	tid, rid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+
+	// Invite a member using a role with permission to delete replies
+	boards2.InviteMember(bid, member, boards2.RoleAdmin)
+	std.TestSetOrigCaller(member)
+}
+
+func main() {
+	boards2.DeleteReply(bid, tid, rid)
+
+	// Ensure reply doesn't exist
+	println(boards2.Render("test-board/1/2"))
+}
+
+// Output:
+// Reply does not exist with ID: 2


### PR DESCRIPTION
Add missing filetests for `DeleteReply()` function.

Related to #3623

This covers all tests for the function:
- Successfully delete a reply
- Fail because board is not found
- Fail because thread is not found
- Fail because reply is not found
- Successfully delete a sub-reply
- Fail because user has no permission to delete a reply
- Successfully delete a reply using a user with permission to delete
