### PR TITLE
feat(examples/test): quality of life improvements

### DIFF
--- a/examples/gno.land/p/demo/btree/btree_test.gno
+++ b/examples/gno.land/p/demo/btree/btree_test.gno
@@ -523,91 +523,14 @@ func TestBTree(t *testing.T) {
 	}
 }
 
-func TestStress(t *testing.T) {
-	// Loop through creating B-Trees with a range of degrees from 3 to 12, stepping by 3.
-	// Insert 1000 records into each tree, then search for each record.
-	// Delete half of the records, skipping every other one, then search for each record.
-
-	for degree := 3; degree <= 12; degree += 3 {
-		t.Logf("Testing B-Tree of degree %d\n", degree)
-		tree := New(WithDegree(degree))
-
-		// Insert 1000 records
-		t.Logf("Inserting 1000 records\n")
-		for i := 0; i < 1000; i++ {
-			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
-			tree.Insert(content)
-		}
-
-		// Search for all records
-		for i := 0; i < 1000; i++ {
-			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
-			val := tree.Get(content)
-			if val == nil {
-				t.Errorf("Expected key %v, but didn't find it", content.Key)
-			}
-		}
-
-		// Delete half of the records
-		for i := 0; i < 1000; i += 2 {
-			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
-			tree.Delete(content)
-		}
-
-		// Search for all records
-		for i := 0; i < 1000; i++ {
-			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
-			val := tree.Get(content)
-			if i%2 == 0 {
-				if val != nil {
-					t.Errorf("Didn't expect key %v, but found key:value %v:%v", content.Key, val.(Content).Key, val.(Content).Value)
-				}
-			} else {
-				if val == nil {
-					t.Errorf("Expected key %v, but didn't find it", content.Key)
-				}
-			}
-		}
-	}
-
-	// Now create a very large tree, with 100000 records
-	// Then delete roughly one third of them, using a very basic random number generation scheme
-	// (implement it right here) to determine which records to delete.
-	// Print a few lines using Logf to let the user know what's happening.
-
-	t.Logf("Testing B-Tree of degree 10 with 100000 records\n")
-	tree := New(WithDegree(10))
-
-	// Insert 100000 records
-	t.Logf("Inserting 100000 records\n")
-	for i := 0; i < 100000; i++ {
-		content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
-		tree.Insert(content)
-	}
-
-	// Implement a very basic random number generator
-	seed := 0
-	random := func() int {
-		seed = (seed*1103515245 + 12345) & 0x7fffffff
-		return seed
-	}
-
-	// Delete one third of the records
-	t.Logf("Deleting one third of the records\n")
-	for i := 0; i < 35000; i++ {
-		content := Content{Key: random() % 100000, Value: fmt.Sprintf("Value_%d", i)}
-		tree.Delete(content)
-	}
-}
-
-// Write a test that populates a large B-Tree with 10000 records.
+// Write a test that populates a large B-Tree with 1000 records.
 // It should then `Clone` the tree, make some changes to both the original and the clone,
 // And then clone the clone, and make some changes to all three trees, and then check that the changes are isolated
 // to the tree they were made in.
-
 func TestBTreeCloneIsolation(t *testing.T) {
-	t.Logf("Creating B-Tree of degree 10 with 10000 records\n")
-	tree := genericSeeding(New(WithDegree(10)), 10000)
+	t.Logf("Creating B-Tree of degree 10 with 1000 records\n")
+	size := 1000
+	tree := genericSeeding(New(WithDegree(10)), size)
 
 	// Clone the tree
 	t.Logf("Cloning the tree\n")
@@ -615,7 +538,7 @@ func TestBTreeCloneIsolation(t *testing.T) {
 
 	// Make some changes to the original and the clone
 	t.Logf("Making changes to the original and the clone\n")
-	for i := 0; i < 10000; i += 2 {
+	for i := 0; i < size; i += 2 {
 		content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
 		tree.Delete(content)
 		content = Content{Key: i + 1, Value: fmt.Sprintf("Value_%d", i+1)}
@@ -628,7 +551,7 @@ func TestBTreeCloneIsolation(t *testing.T) {
 
 	// Make some changes to all three trees
 	t.Logf("Making changes to all three trees\n")
-	for i := 0; i < 10000; i += 3 {
+	for i := 0; i < size; i += 3 {
 		content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
 		tree.Delete(content)
 		content = Content{Key: i, Value: fmt.Sprintf("Value_%d", i+1)}
@@ -639,7 +562,7 @@ func TestBTreeCloneIsolation(t *testing.T) {
 
 	// Check that the changes are isolated to the tree they were made in
 	t.Logf("Checking that the changes are isolated to the tree they were made in\n")
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < size; i++ {
 		content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
 		val := tree.Get(content)
 
@@ -676,3 +599,83 @@ func TestBTreeCloneIsolation(t *testing.T) {
 		}
 	}
 }
+
+// --------------------
+// Stress tests. Disabled for testing performance
+
+//func TestStress(t *testing.T) {
+//	// Loop through creating B-Trees with a range of degrees from 3 to 12, stepping by 3.
+//	// Insert 1000 records into each tree, then search for each record.
+//	// Delete half of the records, skipping every other one, then search for each record.
+//
+//	for degree := 3; degree <= 12; degree += 3 {
+//		t.Logf("Testing B-Tree of degree %d\n", degree)
+//		tree := New(WithDegree(degree))
+//
+//		// Insert 1000 records
+//		t.Logf("Inserting 1000 records\n")
+//		for i := 0; i < 1000; i++ {
+//			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
+//			tree.Insert(content)
+//		}
+//
+//		// Search for all records
+//		for i := 0; i < 1000; i++ {
+//			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
+//			val := tree.Get(content)
+//			if val == nil {
+//				t.Errorf("Expected key %v, but didn't find it", content.Key)
+//			}
+//		}
+//
+//		// Delete half of the records
+//		for i := 0; i < 1000; i += 2 {
+//			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
+//			tree.Delete(content)
+//		}
+//
+//		// Search for all records
+//		for i := 0; i < 1000; i++ {
+//			content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
+//			val := tree.Get(content)
+//			if i%2 == 0 {
+//				if val != nil {
+//					t.Errorf("Didn't expect key %v, but found key:value %v:%v", content.Key, val.(Content).Key, val.(Content).Value)
+//				}
+//			} else {
+//				if val == nil {
+//					t.Errorf("Expected key %v, but didn't find it", content.Key)
+//				}
+//			}
+//		}
+//	}
+//
+//	// Now create a very large tree, with 100000 records
+//	// Then delete roughly one third of them, using a very basic random number generation scheme
+//	// (implement it right here) to determine which records to delete.
+//	// Print a few lines using Logf to let the user know what's happening.
+//
+//	t.Logf("Testing B-Tree of degree 10 with 100000 records\n")
+//	tree := New(WithDegree(10))
+//
+//	// Insert 100000 records
+//	t.Logf("Inserting 100000 records\n")
+//	for i := 0; i < 100000; i++ {
+//		content := Content{Key: i, Value: fmt.Sprintf("Value_%d", i)}
+//		tree.Insert(content)
+//	}
+//
+//	// Implement a very basic random number generator
+//	seed := 0
+//	random := func() int {
+//		seed = (seed*1103515245 + 12345) & 0x7fffffff
+//		return seed
+//	}
+//
+//	// Delete one third of the records
+//	t.Logf("Deleting one third of the records\n")
+//	for i := 0; i < 35000; i++ {
+//		content := Content{Key: random() % 100000, Value: fmt.Sprintf("Value_%d", i)}
+//		tree.Delete(content)
+//	}
+//}

--- a/examples/gno.land/p/demo/diff/diff_test.gno
+++ b/examples/gno.land/p/demo/diff/diff_test.gno
@@ -163,6 +163,7 @@ func TestMyersDiff(t *testing.T) {
 			expected: "[-" + strings.Repeat("a", 1000) + "][+" + strings.Repeat("b", 1000) + "]",
 		},
 		//{ // disabled for testing performance
+		// XXX: consider adding a flag to run such tests, not like `-short`, or switching to a `-bench`, maybe.
 		//	name:     "Very long strings",
 		//	old:      strings.Repeat("a", 10000) + "b" + strings.Repeat("a", 10000),
 		//	new:      strings.Repeat("a", 10000) + "c" + strings.Repeat("a", 10000),

--- a/examples/gno.land/p/demo/diff/diff_test.gno
+++ b/examples/gno.land/p/demo/diff/diff_test.gno
@@ -162,12 +162,12 @@ func TestMyersDiff(t *testing.T) {
 			new:      strings.Repeat("b", 1000),
 			expected: "[-" + strings.Repeat("a", 1000) + "][+" + strings.Repeat("b", 1000) + "]",
 		},
-		{
-			name:     "Very long strings",
-			old:      strings.Repeat("a", 10000) + "b" + strings.Repeat("a", 10000),
-			new:      strings.Repeat("a", 10000) + "c" + strings.Repeat("a", 10000),
-			expected: strings.Repeat("a", 10000) + "[-b][+c]" + strings.Repeat("a", 10000),
-		},
+		//{ // disabled for testing performance
+		//	name:     "Very long strings",
+		//	old:      strings.Repeat("a", 10000) + "b" + strings.Repeat("a", 10000),
+		//	new:      strings.Repeat("a", 10000) + "c" + strings.Repeat("a", 10000),
+		//	expected: strings.Repeat("a", 10000) + "[-b][+c]" + strings.Repeat("a", 10000),
+		//},
 	}
 
 	for _, tc := range tests {

--- a/examples/gno.land/p/demo/json/node_test.gno
+++ b/examples/gno.land/p/demo/json/node_test.gno
@@ -285,7 +285,7 @@ func TestNode_GetBool(t *testing.T) {
 	}
 }
 
-func TestNode_GetBool_Fail(t *testing.T) {
+func TestNode_GetBool_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"literally null node", NullNode("")},
@@ -357,7 +357,7 @@ func TestNode_GetNull(t *testing.T) {
 	}
 }
 
-func TestNode_GetNull_Fail(t *testing.T) {
+func TestNode_GetNull_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"number node is null", NumberNode("", 42)},
@@ -435,7 +435,7 @@ func TestNode_GetNumeric_With_Unmarshal(t *testing.T) {
 	}
 }
 
-func TestNode_GetNumeric_Fail(t *testing.T) {
+func TestNode_GetNumeric_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"null node", NullNode("")},
@@ -467,7 +467,7 @@ func TestNode_GetString(t *testing.T) {
 	}
 }
 
-func TestNode_GetString_Fail(t *testing.T) {
+func TestNode_GetString_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"null node", NullNode("")},
@@ -577,7 +577,7 @@ func TestNode_GetArray(t *testing.T) {
 	}
 }
 
-func TestNode_GetArray_Fail(t *testing.T) {
+func TestNode_GetArray_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"null node", NullNode("")},
@@ -736,7 +736,7 @@ func TestNode_Index(t *testing.T) {
 	}
 }
 
-func TestNode_Index_Fail(t *testing.T) {
+func TestNode_Index_NotSucceed(t *testing.T) {
 	tests := []struct {
 		name string
 		node *Node
@@ -854,7 +854,7 @@ func TestNode_GetKey(t *testing.T) {
 	}
 }
 
-func TestNode_GetKey_Fail(t *testing.T) {
+func TestNode_GetKey_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"null node", NullNode("")},
@@ -998,7 +998,7 @@ func TestNode_GetObject(t *testing.T) {
 	}
 }
 
-func TestNode_GetObject_Fail(t *testing.T) {
+func TestNode_GetObject_NotSucceed(t *testing.T) {
 	tests := []simpleNode{
 		{"nil node", (*Node)(nil)},
 		{"get object from null node", NullNode("")},

--- a/examples/gno.land/p/demo/simpledao/dao_test.gno
+++ b/examples/gno.land/p/demo/simpledao/dao_test.gno
@@ -752,7 +752,7 @@ func TestSimpleDAO_ExecuteProposal(t *testing.T) {
 				dao.ExecutionSuccessful,
 			},
 			{
-				"execution failed",
+				"execution not succeeded",
 				dao.ExecutionFailed,
 			},
 		}

--- a/examples/gno.land/p/gov/executor/proposal_test.gno
+++ b/examples/gno.land/p/gov/executor/proposal_test.gno
@@ -11,7 +11,6 @@ import (
 )
 
 func TestExecutor_Callback(t *testing.T) {
-	t.Fail()
 	t.Parallel()
 
 	t.Run("govdao not caller", func(t *testing.T) {

--- a/examples/gno.land/p/gov/executor/proposal_test.gno
+++ b/examples/gno.land/p/gov/executor/proposal_test.gno
@@ -11,6 +11,7 @@ import (
 )
 
 func TestExecutor_Callback(t *testing.T) {
+	t.Fail()
 	t.Parallel()
 
 	t.Run("govdao not caller", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR does two things:
1. Replaces the word "Fail" from test function names with `NotSucceed` - allows for easier ctrl+f search of the output locally and in the CI when something fails during `examples/make test`
2. Disables stress tests for `p/demo/diff` & `p/demo/btree`, cutting the examples/ test time by ~80% (baseline M2 mbp):

```
// master
> time make test
make test  140.04s user 3.09s system 217% cpu 1:05.95 total

// PR
> time make test
make test  27.74s user 1.42s system 157% cpu 18.529 total
```