### PR TITLE
feat(gnoweb): enable strikethrough UI

### DIFF
--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -49,6 +49,7 @@ func NewDefaultHTMLWebClientConfig(client *client.RPCClient) *HTMLWebClientConfi
 			markdown.NewHighlighting(
 				markdown.WithFormatOptions(chromaOptions...),
 			),
+			extension.Strikethrough,
 			extension.Table,
 		),
 	}


### PR DESCRIPTION
This PR adds the strikethrough extension to the Goldmark Markdown parser, enabling the following syntax to strike through text:

`~~Hi~~ Hello, ~there~ world!`

cf: #3355 