### PR TITLE
feat: bump max-gas same as current genesis

### DIFF
--- a/gno.land/pkg/gnoland/node_inmemory.go
+++ b/gno.land/pkg/gnoland/node_inmemory.go
@@ -60,10 +60,10 @@ func NewDefaultGenesisConfig(chainid, chaindomain string) *bft.GenesisDoc {
 
 func defaultBlockParams() *abci.BlockParams {
 	return &abci.BlockParams{
-		MaxTxBytes:   1_000_000,   // 1MB,
-		MaxDataBytes: 2_000_000,   // 2MB,
-		MaxGas:       100_000_000, // 100M gas
-		TimeIotaMS:   100,         // 100ms
+		MaxTxBytes:   1_000_000,     // 1MB,
+		MaxDataBytes: 2_000_000,     // 2MB,
+		MaxGas:       3_000_000_000, // 3B gas
+		TimeIotaMS:   100,           // 100ms
 	}
 }
 

--- a/gno.land/pkg/integration/node_testing.go
+++ b/gno.land/pkg/integration/node_testing.go
@@ -103,10 +103,10 @@ func DefaultTestingGenesisConfig(gnoroot string, self crypto.PubKey, tmconfig *t
 		ChainID:     tmconfig.ChainID(),
 		ConsensusParams: abci.ConsensusParams{
 			Block: &abci.BlockParams{
-				MaxTxBytes:   1_000_000,   // 1MB,
-				MaxDataBytes: 2_000_000,   // 2MB,
-				MaxGas:       100_000_000, // 100M gas
-				TimeIotaMS:   100,         // 100ms
+				MaxTxBytes:   1_000_000,     // 1MB,
+				MaxDataBytes: 2_000_000,     // 2MB,
+				MaxGas:       3_000_000_000, // 3B gas
+				TimeIotaMS:   100,           // 100ms
 			},
 		},
 		Validators: []bft.GenesisValidator{

--- a/tm2/pkg/bft/types/params.go
+++ b/tm2/pkg/bft/types/params.go
@@ -24,7 +24,7 @@ const (
 	MaxBlockDataBytes int64 = 2000000 // 2MB
 
 	// MaxBlockMaxGas is the max gas limit for the block
-	MaxBlockMaxGas int64 = 100000000 // 100M gas
+	MaxBlockMaxGas int64 = 3000000000 // 3B gas
 
 	// BlockTimeIotaMS is the block time iota (in ms)
 	BlockTimeIotaMS int64 = 100 // ms


### PR DESCRIPTION
## Description

Default gas for genesis has been bumped in #3384
However we still have certain config uses old value.
> env(or config) between actual and testing should be same as much as possible to avoid something like... this works with real gnoland but fail with in memory node.