### PR TITLE
fix: skip failed txs in Portal Loop reset

### DIFF
--- a/misc/loop/cmd/snapshotter.go
+++ b/misc/loop/cmd/snapshotter.go
@@ -203,7 +203,7 @@ func (s snapshotter) backupTXs(ctx context.Context, rpcURL string) error {
 	cfg.Watch = false
 
 	// We want to skip failed txs on the Portal Loop reset,
-	// because they might (unexpectedly succeed)
+	// because they might (unexpectedly) succeed
 	cfg.SkipFailedTx = true
 
 	instanceBackupFile, err := os.Create(s.instanceBackupFile)

--- a/misc/loop/cmd/snapshotter.go
+++ b/misc/loop/cmd/snapshotter.go
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/gnolang/tx-archive/backup"
-	"github.com/gnolang/tx-archive/backup/client/http"
+	"github.com/gnolang/tx-archive/backup/client/rpc"
 	"github.com/gnolang/tx-archive/backup/writer/standard"
 )
 
@@ -202,6 +202,10 @@ func (s snapshotter) backupTXs(ctx context.Context, rpcURL string) error {
 	cfg.FromBlock = 1
 	cfg.Watch = false
 
+	// We want to skip failed txs on the Portal Loop reset,
+	// because they might (unexpectedly succeed)
+	cfg.SkipFailedTx = true
+
 	instanceBackupFile, err := os.Create(s.instanceBackupFile)
 	if err != nil {
 		return err
@@ -211,7 +215,7 @@ func (s snapshotter) backupTXs(ctx context.Context, rpcURL string) error {
 	w := standard.NewWriter(instanceBackupFile)
 
 	// Create the tx-archive backup service
-	c, err := http.NewClient(rpcURL)
+	c, err := rpc.NewHTTPClient(rpcURL)
 	if err != nil {
 		return fmt.Errorf("could not create tx-archive client, %w", err)
 	}

--- a/misc/loop/go.mod
+++ b/misc/loop/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/gnolang/gno v0.1.0-nightly.20240627
-	github.com/gnolang/tx-archive v0.4.2
+	github.com/gnolang/tx-archive v0.5.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/misc/loop/go.sum
+++ b/misc/loop/go.sum
@@ -70,8 +70,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/tx-archive v0.4.2 h1:xBBqLLKY9riv9yxpQgVhItCWxIji2rX6xNFmCY1cEOQ=
-github.com/gnolang/tx-archive v0.4.2/go.mod h1:AGUBGO+DCLuKL80a1GJRnpcJ5gxVd9L4jEJXQB9uXp4=
+github.com/gnolang/tx-archive v0.5.0 h1:npM+TfM3ufF2nz1V6hq+RLkCklPbADRZXBjiyPxXVu4=
+github.com/gnolang/tx-archive v0.5.0/go.mod h1:thbXpyYT57ITGABl3hH4ftLSdO8eXaPFPi5hl6jZ2UE=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Description

This PR sets the Portal Loop to skip backing up and looping failed transactions during a loop run.