### PR TITLE
chore: add missing 'make generate' in examples/ folder

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -23,10 +23,14 @@ jobs:
           - name: Check generated files are up to date
             working-directory: ${{ inputs.modulepath }}
             run: |
-              make generate
+              if make -qp | grep -q '^generate:'; then
+                make generate
 
-              if [ "$(git status -s)" != "" ]; then
-                echo "command 'make generate' creates file that differ from git tree, please run 'make generate' and commit:"
-                git status -s
-                exit 1
+                if [ "$(git status -s)" != "" ]; then
+                  echo "command 'make generate' creates files that differ from the git tree, please run 'make generate' and commit:"
+                  git status -s
+                  exit 1
+                fi
+              else
+                echo "'make generate' rule not found, skipping."
               fi

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -26,7 +26,7 @@ jobs:
               make generate
 
               if [ "$(git status -s)" != "" ]; then
-                echo "command 'go generate' creates file that differ from git tree, please run 'go generate' and commit:"
+                echo "command 'make generate' creates file that differ from git tree, please run 'make generate' and commit:"
                 git status -s
                 exit 1
               fi

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -63,3 +63,8 @@ fmt:
 .PHONY: tidy
 tidy:
 	go run github.com/gnolang/gno/gnovm/cmd/gno mod tidy -v --recursive
+
+.PHONY: generate
+generate:
+	go generate ./...
+	$(MAKE) fmt


### PR DESCRIPTION
- fixes problems i introduced in #3578.
- 15ff464012264733734f93d456169672b8c5ea48 - fixes https://github.com/gnolang/gno/actions/runs/13222603746/job/36909546479?pr=3700.
- b9fee1771819f442cfcae17ce5aae4b20a85ef49 - fixes `red` master.]