### PR TITLE
chore(boards2): simplify boards realm permissions

### DIFF
--- a/examples/gno.land/r/nt/boards2/v1/permission_default.gno
+++ b/examples/gno.land/r/nt/boards2/v1/permission_default.gno
@@ -228,35 +228,7 @@ func createDefaultPermissions(owner std.Address) *DefaultPermissions {
 	return NewDefaultPermissions(
 		commondao.New(),
 		WithSuperRole(RoleOwner),
-		WithRole(
-			RoleAdmin,
-			PermissionBoardCreate,
-			PermissionBoardRename,
-			PermissionMemberInvite,
-			PermissionMemberRemove,
-			PermissionThreadCreate,
-			PermissionThreadEdit,
-			PermissionThreadDelete,
-			PermissionThreadFlag,
-			PermissionReplyCreate,
-			PermissionReplyDelete,
-			PermissionReplyFlag,
-			PermissionRoleChange,
-		),
-		WithRole(
-			RoleModerator,
-			PermissionThreadCreate,
-			PermissionThreadEdit,
-			PermissionThreadFlag,
-			PermissionReplyCreate,
-			PermissionReplyFlag,
-		),
-		WithRole(
-			RoleGuest,
-			PermissionThreadCreate,
-			PermissionThreadRepost,
-			PermissionReplyCreate,
-		),
+		WithRole(RoleAdmin, PermissionBoardCreate),
 		WithUser(owner, RoleOwner),
 	)
 }

--- a/examples/gno.land/r/nt/boards2/v1/z_1_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_1_b_filetest.gno
@@ -10,12 +10,15 @@ const (
 	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	admin = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
 	user  = std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
-	bid   = boards2.BoardID(0) // Operate on realm DAO instead of individual boards
 )
 
+var bid boards2.BoardID // Operate on board DAO
+
 func init() {
-	// Add an admin member
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
+	// Add an admin member
 	boards2.InviteMember(bid, admin, boards2.RoleAdmin)
 
 	// Next call will be done by the admin member

--- a/examples/gno.land/r/nt/boards2/v1/z_1_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_1_c_filetest.gno
@@ -10,13 +10,16 @@ const (
 	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	admin = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
 	user  = std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
-	bid   = boards2.BoardID(0) // Operate on realm DAO instead of individual boards
 	role  = boards2.RoleAdmin
 )
 
+var bid boards2.BoardID // Operate on board DAO
+
 func init() {
-	// Add an admin member
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
+	// Add an admin member
 	boards2.InviteMember(bid, admin, boards2.RoleAdmin)
 
 	// Next call will be done by the admin member

--- a/examples/gno.land/r/nt/boards2/v1/z_4_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_4_a_filetest.gno
@@ -9,13 +9,13 @@ import (
 const (
 	owner   = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	member  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
-	newRole = boards2.RoleAdmin
+	newRole = boards2.RoleOwner
 	bid     = boards2.BoardID(0) // Operate on realm DAO instead of individual boards
 )
 
 func init() {
 	std.TestSetOrigCaller(owner)
-	boards2.InviteMember(bid, member, boards2.RoleGuest)
+	boards2.InviteMember(bid, member, boards2.RoleAdmin)
 }
 
 func main() {

--- a/examples/gno.land/r/nt/boards2/v1/z_4_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_4_c_filetest.gno
@@ -10,11 +10,14 @@ const (
 	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	owner2 = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
 	admin  = std.Address("g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5")
-	bid    = boards2.BoardID(0) // Operate on realm DAO instead of individual boards
 )
+
+var bid boards2.BoardID // Operate on board DAO
 
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, owner2, boards2.RoleOwner)
 	boards2.InviteMember(bid, admin, boards2.RoleAdmin)
 

--- a/examples/gno.land/r/nt/boards2/v1/z_4_d_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_4_d_filetest.gno
@@ -10,11 +10,14 @@ const (
 	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	admin  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
 	admin2 = std.Address("g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5")
-	bid    = boards2.BoardID(0) // Operate on realm DAO instead of individual boards
 )
+
+var bid boards2.BoardID // Operate on board DAO
 
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, admin, boards2.RoleAdmin)
 	boards2.InviteMember(bid, admin2, boards2.RoleAdmin)
 

--- a/examples/gno.land/r/nt/boards2/v1/z_4_f_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_4_f_filetest.gno
@@ -9,11 +9,14 @@ import (
 const (
 	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	admin = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
-	bid   = boards2.BoardID(0)                                      // Operate on realm DAO members instead of individual boards
 )
+
+var bid boards2.BoardID // Operate on board DAO
 
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, admin, boards2.RoleGuest)
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_4_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_4_g_filetest.gno
@@ -9,11 +9,14 @@ import (
 const (
 	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	admin = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
-	bid   = boards2.BoardID(0)                                      // Operate on realm DAO members instead of individual boards
 )
+
+var bid boards2.BoardID // Operate on board DAO
 
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, admin, boards2.RoleGuest)
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_5_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_5_a_filetest.gno
@@ -9,11 +9,14 @@ import (
 const (
 	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	user  = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
-	bid   = boards2.BoardID(0)                                      // Operate on realm DAO instead of individual boards
 )
+
+var bid boards2.BoardID // Operate on board DAO
 
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, user, boards2.RoleGuest)
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_6_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_6_a_filetest.gno
@@ -9,12 +9,15 @@ import (
 const (
 	owner  = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	member = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
-	bid    = boards2.BoardID(0)                                      // Operate on realm DAO instead of individual boards
 	role   = boards2.RoleGuest
 )
 
+var bid boards2.BoardID // Operate on board DAO
+
 func init() {
 	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test123")
+
 	boards2.InviteMember(bid, member, role)
 }
 


### PR DESCRIPTION
Realm permissions should have minimal permissions. Boards should be treated as independent communities.

At this point it makes sense to only have two roles for the boards realm permissions, owners and admins, where admins can only create boards. Owners are the ones that can manage members in addition to be able to create new boards.

Realm permissions could have more roles and permissions in the future when new features are introduced.