### PR TITLE
test(cmd/gno): don't fail if tests take more than 10 seconds

### DIFF
--- a/gnovm/cmd/gno/testdata/test/error_correct.txtar
+++ b/gnovm/cmd/gno/testdata/test/error_correct.txtar
@@ -3,8 +3,8 @@
 gno test -v .
 
 stderr '=== RUN   file/x_filetest.gno'
-stderr '--- PASS: file/x_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/x_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- x_filetest.gno --
 package main

--- a/gnovm/cmd/gno/testdata/test/filetest_events.txtar
+++ b/gnovm/cmd/gno/testdata/test/filetest_events.txtar
@@ -3,14 +3,14 @@
 gno test -print-events .
 
 ! stdout .+
-stderr 'ok      \. 	\d\.\d\ds'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 gno test -print-events -v .
 
 stdout 'test'
 stderr '=== RUN   file/valid_filetest.gno'
-stderr '--- PASS: file/valid_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/valid_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- valid.gno --
 package valid

--- a/gnovm/cmd/gno/testdata/test/minim2.txtar
+++ b/gnovm/cmd/gno/testdata/test/minim2.txtar
@@ -2,8 +2,8 @@
 
 gno test .
 
-! stdout .+ 
-stderr 'ok      \. 	\d\.\d\ds'
+! stdout .+
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- minim.gno --
 package minim

--- a/gnovm/cmd/gno/testdata/test/minim3.txtar
+++ b/gnovm/cmd/gno/testdata/test/minim3.txtar
@@ -2,8 +2,8 @@
 
 gno test .
 
-! stdout .+ 
-stderr 'ok      \. 	\d\.\d\ds'
+! stdout .+
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- minim.gno --
 package minim

--- a/gnovm/cmd/gno/testdata/test/multitest_events.txtar
+++ b/gnovm/cmd/gno/testdata/test/multitest_events.txtar
@@ -2,10 +2,10 @@
 
 gno test -print-events .
 
-! stdout .+ 
+! stdout .+
 stderr 'EVENTS: \[{\"type\":\"EventA\",\"attrs\":\[\],\"pkg_path\":\"gno.land/r/.*\",\"func\":\"TestA\"}\]'
 stderr 'EVENTS: \[{\"type\":\"EventB\",\"attrs\":\[{\"key\":\"keyA\",\"value\":\"valA\"}\],\"pkg_path\":\"gno.land/r/.*\",\"func\":\"TestB\"},{\"type\":\"EventC\",\"attrs\":\[{\"key\":\"keyD\",\"value\":\"valD\"}\],\"pkg_path\":\"gno.land/r/.*\",\"func\":\"TestB\"}\]'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- valid.gno --
 package valid

--- a/gnovm/cmd/gno/testdata/test/output_correct.txtar
+++ b/gnovm/cmd/gno/testdata/test/output_correct.txtar
@@ -5,8 +5,8 @@ gno test -v .
 stdout 'hey'
 stdout 'hru?'
 stderr '=== RUN   file/x_filetest.gno'
-stderr '--- PASS: file/x_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/x_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- x_filetest.gno --
 package main

--- a/gnovm/cmd/gno/testdata/test/output_sync.txtar
+++ b/gnovm/cmd/gno/testdata/test/output_sync.txtar
@@ -6,8 +6,8 @@ stdout 'hey'
 stdout '^hru\?'
 
 stderr '=== RUN   file/x_filetest.gno'
-stderr '--- PASS: file/x_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/x_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 cmp x_filetest.gno x_filetest.gno.golden
 

--- a/gnovm/cmd/gno/testdata/test/realm_correct.txtar
+++ b/gnovm/cmd/gno/testdata/test/realm_correct.txtar
@@ -4,8 +4,8 @@ gno test -v .
 
 ! stdout .+ # stdout should be empty
 stderr '=== RUN   file/x_filetest.gno'
-stderr '--- PASS: file/x_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/x_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- x_filetest.gno --
 // PKGPATH: gno.land/r/xx

--- a/gnovm/cmd/gno/testdata/test/realm_sync.txtar
+++ b/gnovm/cmd/gno/testdata/test/realm_sync.txtar
@@ -4,8 +4,8 @@ gno test -v . -update-golden-tests
 
 ! stdout .+ # stdout should be empty
 stderr '=== RUN   file/x_filetest.gno'
-stderr '--- PASS: file/x_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/x_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 cmp x_filetest.gno x_filetest.gno.golden
 

--- a/gnovm/cmd/gno/testdata/test/valid_filetest.txtar
+++ b/gnovm/cmd/gno/testdata/test/valid_filetest.txtar
@@ -3,14 +3,14 @@
 gno test .
 
 ! stdout .+
-stderr 'ok      \. 	\d\.\d\ds'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 gno test -v .
 
 stdout 'test'
 stderr '=== RUN   file/valid_filetest.gno'
-stderr '--- PASS: file/valid_filetest.gno \(\d\.\d\ds\)'
-stderr 'ok      \. 	\d\.\d\ds'
+stderr '--- PASS: file/valid_filetest.gno \(\d+\.\d\ds\)'
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- valid.gno --
 package valid

--- a/gnovm/cmd/gno/testdata/test/valid_test.txtar
+++ b/gnovm/cmd/gno/testdata/test/valid_test.txtar
@@ -2,13 +2,13 @@
 
 gno test .
 
-! stdout .+ 
-stderr 'ok      \. 	\d\.\d\ds'
+! stdout .+
+stderr 'ok      \. 	\d+\.\d\ds'
 
 gno test ./...
 
-! stdout .+ 
-stderr 'ok      \. 	\d\.\d\ds'
+! stdout .+
+stderr 'ok      \. 	\d+\.\d\ds'
 
 -- valid.gno --
 package valid


### PR DESCRIPTION
https://github.com/gnolang/gno/actions/runs/13265575679/job/37032064155

Changes the regex for txtar tests like `\d\.\d\ds` to have a + symbol instead, in case they take longer than 10 seconds.