### PR TITLE
feat(boards2): change flagging threshold to be configurable per board

### DIFF
--- a/examples/gno.land/r/nt/boards2/v1/board.gno
+++ b/examples/gno.land/r/nt/boards2/v1/board.gno
@@ -162,6 +162,7 @@ func createDefaultBoardPermissions(owner std.Address) *DefaultPermissions {
 		WithRole(
 			RoleAdmin,
 			PermissionBoardRename,
+			PermissionBoardFlaggingUpdate,
 			PermissionMemberInvite,
 			PermissionMemberRemove,
 			PermissionThreadCreate,

--- a/examples/gno.land/r/nt/boards2/v1/flag.gno
+++ b/examples/gno.land/r/nt/boards2/v1/flag.gno
@@ -39,8 +39,7 @@ type Flaggable interface {
 // Returns whether flag count threshold is reached and item can be hidden.
 //
 // Panics if flag count threshold was already reached.
-func flagItem(bid BoardID, item Flaggable, flag Flag) bool {
-	threshold := getFlaggingThreshold(bid)
+func flagItem(item Flaggable, flag Flag, threshold int) bool {
 	if item.FlagsCount() >= threshold {
 		panic("item flag count threshold exceeded: " + strconv.Itoa(threshold))
 	}

--- a/examples/gno.land/r/nt/boards2/v1/flag.gno
+++ b/examples/gno.land/r/nt/boards2/v1/flag.gno
@@ -3,10 +3,14 @@ package boards2
 import (
 	"std"
 	"strconv"
+
+	"gno.land/p/demo/avl"
 )
 
-// TODO: We should allow changing the threshold, also support value per board
-const flagThreshold = 1
+// DefaultFlaggingThreshold defines the default number of flags that hides flaggable items.
+const DefaultFlaggingThreshold = 1
+
+var gFlaggingThresholds avl.Tree // string(board ID) -> int
 
 type Flag struct {
 	User   std.Address
@@ -35,14 +39,22 @@ type Flaggable interface {
 // Returns whether flag count threshold is reached and item can be hidden.
 //
 // Panics if flag count threshold was already reached.
-func flagItem(item Flaggable, flag Flag) bool {
-	if item.FlagsCount() >= flagThreshold {
-		panic("item flag count threshold exceeded: " + strconv.Itoa(flagThreshold))
+func flagItem(bid BoardID, item Flaggable, flag Flag) bool {
+	threshold := getFlaggingThreshold(bid)
+	if item.FlagsCount() >= threshold {
+		panic("item flag count threshold exceeded: " + strconv.Itoa(threshold))
 	}
 
 	if !item.AddFlag(flag) {
 		panic("item has been already flagged by a current user")
 	}
 
-	return item.FlagsCount() == flagThreshold
+	return item.FlagsCount() == threshold
+}
+
+func getFlaggingThreshold(bid BoardID) int {
+	if v, ok := gFlaggingThresholds.Get(bid.String()); ok {
+		return v.(int)
+	}
+	return DefaultFlaggingThreshold
 }

--- a/examples/gno.land/r/nt/boards2/v1/permission.gno
+++ b/examples/gno.land/r/nt/boards2/v1/permission.gno
@@ -7,19 +7,20 @@ import (
 )
 
 const (
-	PermissionBoardCreate  Permission = "board:create"
-	PermissionBoardRename             = "board:rename"
-	PermissionThreadCreate            = "thread:create"
-	PermissionThreadEdit              = "thread:edit"
-	PermissionThreadDelete            = "thread:delete"
-	PermissionThreadFlag              = "thread:flag"
-	PermissionThreadRepost            = "thread:repost"
-	PermissionReplyCreate             = "reply:create"
-	PermissionReplyDelete             = "reply:delete"
-	PermissionReplyFlag               = "reply:flag"
-	PermissionMemberInvite            = "member:invite"
-	PermissionMemberRemove            = "member:remove"
-	PermissionRoleChange              = "role:change"
+	PermissionBoardCreate         Permission = "board:create"
+	PermissionBoardRename                    = "board:rename"
+	PermissionBoardFlaggingUpdate            = "board:flagging-update"
+	PermissionThreadCreate                   = "thread:create"
+	PermissionThreadEdit                     = "thread:edit"
+	PermissionThreadDelete                   = "thread:delete"
+	PermissionThreadFlag                     = "thread:flag"
+	PermissionThreadRepost                   = "thread:repost"
+	PermissionReplyCreate                    = "reply:create"
+	PermissionReplyDelete                    = "reply:delete"
+	PermissionReplyFlag                      = "reply:flag"
+	PermissionMemberInvite                   = "member:invite"
+	PermissionMemberRemove                   = "member:remove"
+	PermissionRoleChange                     = "role:change"
 )
 
 const (

--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -56,6 +56,26 @@ func RenameBoard(name, newName string) {
 	})
 }
 
+func SetFlaggingThreshold(bid BoardID, threshold int) {
+	if threshold < 1 {
+		panic("invalid flagging threshold")
+	}
+
+	board := mustGetBoard(bid)
+	caller := std.GetOrigCaller()
+	args := Args{bid, threshold}
+	board.perms.WithPermission(caller, PermissionBoardFlaggingUpdate, args, func(Args) {
+		assertBoardExists(bid)
+
+		gFlaggingThresholds.Set(bid.String(), threshold)
+	})
+}
+
+func GetFlaggingThreshold(bid BoardID) int {
+	assertBoardExists(bid)
+	return getFlaggingThreshold(bid)
+}
+
 func FlagThread(bid BoardID, postID PostID, reason string) {
 	caller := std.GetOrigCaller()
 	board := mustGetBoard(bid)
@@ -66,7 +86,7 @@ func FlagThread(bid BoardID, postID PostID, reason string) {
 		panic("post doesn't exist")
 	}
 
-	hide := flagItem(t, NewFlag(caller, reason))
+	hide := flagItem(board.id, t, NewFlag(caller, reason))
 	if hide {
 		t.SetVisible(false)
 	}
@@ -124,7 +144,7 @@ func FlagReply(bid BoardID, threadID, replyID PostID, reason string) {
 	thread := mustGetThread(board, threadID)
 	reply := mustGetReply(thread, replyID)
 
-	hide := flagItem(reply, NewFlag(caller, reason))
+	hide := flagItem(board.id, reply, NewFlag(caller, reason))
 	if hide {
 		reply.SetVisible(false)
 	}

--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -86,7 +86,8 @@ func FlagThread(bid BoardID, postID PostID, reason string) {
 		panic("post doesn't exist")
 	}
 
-	hide := flagItem(board.id, t, NewFlag(caller, reason))
+	threshold := getFlaggingThreshold(bid)
+	hide := flagItem(t, NewFlag(caller, reason), threshold)
 	if hide {
 		t.SetVisible(false)
 	}
@@ -144,7 +145,8 @@ func FlagReply(bid BoardID, threadID, replyID PostID, reason string) {
 	thread := mustGetThread(board, threadID)
 	reply := mustGetReply(thread, replyID)
 
-	hide := flagItem(board.id, reply, NewFlag(caller, reason))
+	threshold := getFlaggingThreshold(bid)
+	hide := flagItem(reply, NewFlag(caller, reason), threshold)
 	if hide {
 		reply.SetVisible(false)
 	}

--- a/examples/gno.land/r/nt/boards2/v1/z_10_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_10_g_filetest.gno
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+
+	boards2.SetFlaggingThreshold(bid, 2)
+	boards2.FlagThread(bid, pid, "")
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+}
+
+// Error:
+// item has been already flagged by a current user

--- a/examples/gno.land/r/nt/boards2/v1/z_16_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_16_a_filetest.gno
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var bid boards2.BoardID
+
+func init() {
+	std.TestSetOrigCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+}
+
+func main() {
+	boards2.SetFlaggingThreshold(bid, 4)
+
+	// Ensure that flagging threshold changed
+	println(boards2.GetFlaggingThreshold(bid))
+}
+
+// Output:
+// 4

--- a/examples/gno.land/r/nt/boards2/v1/z_16_b_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_16_b_filetest.gno
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+const bid boards2.BoardID = 404
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.SetFlaggingThreshold(bid, 1)
+}
+
+// Error:
+// board does not exist with ID: 404

--- a/examples/gno.land/r/nt/boards2/v1/z_16_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_16_c_filetest.gno
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOrigCaller(owner)
+}
+
+func main() {
+	boards2.SetFlaggingThreshold(1, 0)
+}
+
+// Error:
+// invalid flagging threshold


### PR DESCRIPTION
This enables each board to use a flagging threshold different than the default of 1.

Threshold specifies how many flags are required for a thread or comment to be hidden.