### PR TITLE
feat(gnokey): `-broadcast=true` by default

### DIFF
--- a/gno.land/pkg/keyscli/maketx.go
+++ b/gno.land/pkg/keyscli/maketx.go
@@ -70,7 +70,7 @@ func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(
 		&c.Broadcast,
 		"broadcast",
-		false,
+		true,
 		"sign and broadcast",
 	)
 


### PR DESCRIPTION
## Description

Flips the broadcast flag in `gnokey` to true by default. 