### PR TITLE
fix(tm2/pkg/*): use fmt.Fprintf instead of buf.Write([]byte(fmt.Sprintf(...))) expenses

### DIFF
--- a/tm2/pkg/amino/codec.go
+++ b/tm2/pkg/amino/codec.go
@@ -115,24 +115,24 @@ func (info *TypeInfo) String() string {
 	buf := poolBytesBuffer.Get()
 	defer poolBytesBuffer.Put(buf)
 
-	buf.Write([]byte("TypeInfo{"))
-	buf.Write([]byte(fmt.Sprintf("Type:%v,", info.Type)))
+	buf.WriteString("TypeInfo{")
+	fmt.Fprintf(buf, "Type:%v,", info.Type)
 	if info.ConcreteInfo.Registered {
-		buf.Write([]byte("Registered:true,"))
-		buf.Write([]byte(fmt.Sprintf("PointerPreferred:%v,", info.PointerPreferred)))
-		buf.Write([]byte(fmt.Sprintf("TypeURL:\"%v\",", info.TypeURL)))
+		buf.WriteString("Registered:true,")
+		fmt.Fprintf(buf, "PointerPreferred:%v,", info.PointerPreferred)
+		fmt.Fprintf(buf, "TypeURL:\"%v\",", info.TypeURL)
 	} else {
-		buf.Write([]byte("Registered:false,"))
+		buf.WriteString("Registered:false,")
 	}
 	if info.ReprType == info {
-		buf.Write([]byte(fmt.Sprintf("ReprType:<self>,")))
+		buf.WriteString("ReprType:<self>,")
 	} else {
-		buf.Write([]byte(fmt.Sprintf("ReprType:\"%v\",", info.ReprType)))
+		fmt.Fprintf(buf, "ReprType:\"%v\",", info.ReprType)
 	}
 	if info.Type.Kind() == reflect.Struct {
-		buf.Write([]byte(fmt.Sprintf("Fields:%v,", info.Fields)))
+		fmt.Fprintf(buf, "Fields:%v,", info.Fields)
 	}
-	buf.Write([]byte("}"))
+	buf.WriteByte('}')
 	return buf.String()
 }
 

--- a/tm2/pkg/amino/wellknown.go
+++ b/tm2/pkg/amino/wellknown.go
@@ -425,7 +425,7 @@ func EncodeJSONTimeValue(w io.Writer, s int64, ns int32) (err error) {
 	x = strings.TrimSuffix(x, "000")
 	x = strings.TrimSuffix(x, "000")
 	x = strings.TrimSuffix(x, ".000")
-	_, err = w.Write([]byte(fmt.Sprintf(`"%vZ"`, x)))
+	_, err = fmt.Fprintf(w, `"%vZ"`, x)
 	return err
 }
 
@@ -456,7 +456,7 @@ func EncodeJSONDurationValue(w io.Writer, s int64, ns int32) (err error) {
 	x = strings.TrimSuffix(x, "000")
 	x = strings.TrimSuffix(x, "000")
 	x = strings.TrimSuffix(x, ".000")
-	_, err = w.Write([]byte(fmt.Sprintf(`"%vs"`, x)))
+	_, err = fmt.Fprintf(w, `"%vs"`, x)
 	return err
 }
 

--- a/tm2/pkg/errors/errors.go
+++ b/tm2/pkg/errors/errors.go
@@ -154,7 +154,7 @@ func (err *cmnError) doTrace(msg string, n int) Error {
 func (err *cmnError) Format(s fmt.State, verb rune) {
 	switch {
 	case verb == 'p':
-		s.Write([]byte(fmt.Sprintf("%p", &err)))
+		fmt.Fprintf(s, "%p", &err)
 	case verb == 'v' && s.Flag('+'):
 		s.Write([]byte("--= Error =--\n"))
 		// Write data.


### PR DESCRIPTION
In the spirit of following along with PR #3434, this change plumbs more uses of fmt.Fprint* as well as buf.WriteByte, buf.WriteString where necessary.