### PR TITLE
fix(gnolang): make Go2Gno return a prespective error instead of sudden/elusive runtime panic with a bad receiver

### DIFF
--- a/gnovm/pkg/gnolang/go2gno.go
+++ b/gnovm/pkg/gnolang/go2gno.go
@@ -435,6 +435,9 @@ func Go2Gno(fs *token.FileSet, gon ast.Node) (n Node) {
 			if len(gon.Recv.List) > 1 {
 				panic("*ast.FuncDecl cannot have multiple receivers")
 			}
+			if len(gon.Recv.List) == 0 {
+				panic("*ast.FuncDecl has missing receiver")
+			}
 			recv = *Go2Gno(fs, gon.Recv.List[0]).(*FieldTypeExpr)
 		}
 		name := toName(gon.Name)

--- a/gnovm/pkg/gnolang/go2gno.go
+++ b/gnovm/pkg/gnolang/go2gno.go
@@ -433,10 +433,10 @@ func Go2Gno(fs *token.FileSet, gon ast.Node) (n Node) {
 		recv := FieldTypeExpr{}
 		if isMethod {
 			if len(gon.Recv.List) > 1 {
-				panic("*ast.FuncDecl cannot have multiple receivers")
+				panic("method has multiple receivers")
 			}
 			if len(gon.Recv.List) == 0 {
-				panic("*ast.FuncDecl has missing receiver")
+				panic("method has no receiver")
 			}
 			recv = *Go2Gno(fs, gon.Recv.List[0]).(*FieldTypeExpr)
 		}

--- a/gnovm/pkg/gnolang/go2gno_test.go
+++ b/gnovm/pkg/gnolang/go2gno_test.go
@@ -25,15 +25,3 @@ func main(){
 	fmt.Printf("AST:\n%#v\n\n", n)
 	fmt.Printf("AST.String():\n%s\n", n.String())
 }
-
-// Issue https://github.com/gnolang/gno/issues/3727
-func TestParseFile_wonkyFunctionDeclarationConfusesReceiver(t *testing.T) {
-	t.Parallel()
-
-	gocode := `package main
-func() A()
-func main() {}`
-	_, err := ParseFile("main.go", gocode)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "missing receiver")
-}

--- a/gnovm/pkg/gnolang/go2gno_test.go
+++ b/gnovm/pkg/gnolang/go2gno_test.go
@@ -25,3 +25,15 @@ func main(){
 	fmt.Printf("AST:\n%#v\n\n", n)
 	fmt.Printf("AST.String():\n%s\n", n.String())
 }
+
+// Issue https://github.com/gnolang/gno/issues/3727
+func TestParseFile_wonkyFunctionDeclarationConfusesReceiver(t *testing.T) {
+	t.Parallel()
+
+	gocode := `package main
+func() A()
+func main() {}`
+	_, err := ParseFile("main.go", gocode)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing receiver")
+}

--- a/gnovm/tests/files/parse_err0.gno
+++ b/gnovm/tests/files/parse_err0.gno
@@ -1,0 +1,8 @@
+package main
+
+func () A()
+
+func main() {}
+
+// Error:
+// method has no receiver

--- a/gnovm/tests/files/parse_err0.gno
+++ b/gnovm/tests/files/parse_err0.gno
@@ -1,3 +1,5 @@
+// https://github.com/gnolang/gno/issues/3727
+
 package main
 
 func () A()


### PR DESCRIPTION
The pattern:

```go
func() A()
```
confuses Go into expecting a receiver and it returns a compile time error "missing receiver", but previously Gno panicked with a runtime error due to a deference yet the Recv.List was empty. This change fixes that by detecting that condition and prescriptively panicking which can then be relayed reasonably as expecting to the calling user.

Fixes #3727