### PR TITLE
fix(gnovm, typecheck): catch overflows from float64->max_float32 for constants

### DIFF
--- a/gnovm/cmd/gno/run_test.go
+++ b/gnovm/cmd/gno/run_test.go
@@ -99,6 +99,10 @@ func TestRunApp(t *testing.T) {
 			}(),
 			errShouldBe: "exit code: 1",
 		},
+		{
+			args:                 []string{"run", "../../tests/overflows/issue-3496/"},
+			recoverShouldContain: "cannot convert 1.7976931348623157e+308 to type float32",
+		},
 		// TODO: a test file
 		// TODO: args
 		// TODO: nativeLibs VS stdlibs

--- a/gnovm/pkg/gnolang/values_conversions.go
+++ b/gnovm/pkg/gnolang/values_conversions.go
@@ -1153,6 +1153,11 @@ GNO_CASE:
 			tv.T = t
 			tv.SetUint64(x)
 		case Float32Kind:
+			var f64 float64 = math.Float64frombits(tv.GetFloat64())
+			if g, w := f64, float64(math.MaxFloat32); g > w {
+				panic(fmt.Sprintf("cannot convert %g to type float32", g))
+			}
+
 			validate(Float64Kind, Float32Kind, func() bool {
 				return softfloat.Fle64(tv.GetFloat64(), math.Float64bits(float64(math.MaxFloat32)))
 			})

--- a/gnovm/tests/overflows/issue-3496/MaxFloat64-to-float32.gno
+++ b/gnovm/tests/overflows/issue-3496/MaxFloat64-to-float32.gno
@@ -1,0 +1,8 @@
+package main
+
+import "math"
+
+func main() {
+    const f = math.MaxFloat64
+    println(float32(f))
+}


### PR DESCRIPTION
With this change we check that the values converted are within the max_float32 limit.

Fixes #3496