### PR TITLE
fix(tm2): overflow check when computing remaining gas.

### DIFF
--- a/tm2/pkg/store/types/gas.go
+++ b/tm2/pkg/store/types/gas.go
@@ -79,7 +79,7 @@ func (g *basicGasMeter) Limit() Gas {
 }
 
 func (g *basicGasMeter) Remaining() Gas {
-	return g.Limit() - g.GasConsumedToLimit()
+	return overflow.Sub64p(g.Limit(), g.GasConsumedToLimit())
 }
 
 func (g *basicGasMeter) GasConsumedToLimit() Gas {


### PR DESCRIPTION
Panic on overflow when computing the remaining gas, to avoid inconsistent and wrong gas amounts.