### PR TITLE
fix(gnoweb): allow `gno.services` url for analytics

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -241,7 +241,7 @@ func SecureHeadersMiddleware(next http.Handler, strict bool) http.Handler {
 			// cross-site scripting (XSS) and other code injection attacks.
 			// - 'self' allows resources from the same origin.
 			// - 'data:' allows inline images (e.g., base64-encoded images).
-			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://sa.gno.services; style-src 'self'; img-src 'self' data:; font-src 'self'")
 
 			// Enforce HTTPS by telling browsers to only access the site over HTTPS
 			// for a specified duration (1 year in this case). This also applies to


### PR DESCRIPTION
This PR add https://sa.gno.services to CSP whitelist.