### PR TITLE
fix: compare gas prices properly

### DIFF
--- a/tm2/pkg/std/gasprice.go
+++ b/tm2/pkg/std/gasprice.go
@@ -65,17 +65,8 @@ func (gp GasPrice) IsGTE(gpB GasPrice) (bool, error) {
 		return false, errors.New("GasPrice.Gas cannot be zero; %+v, %+v", gp, gpB)
 	}
 
-	gpg := big.NewInt(gp.Gas)
-	gpa := big.NewInt(gp.Price.Amount)
+	providedFee := big.NewInt(0).Mul(big.NewInt(gp.Price.Amount), big.NewInt(gp.Gas))
+	requiredFee := big.NewInt(0).Mul(big.NewInt(gpB.Price.Amount), big.NewInt(gpB.Gas))
 
-	gpBg := big.NewInt(gpB.Gas)
-	gpBa := big.NewInt(gpB.Price.Amount)
-
-	prod1 := big.NewInt(0).Mul(gpa, gpBg) // gp's price amount * gpB's gas
-	prod2 := big.NewInt(0).Mul(gpg, gpBa) // gpB's gas * pg's price amount
-	// This is equivalent to checking
-	// That the Fee / GasWanted ratio is greater than or equal to the minimum GasPrice per gas.
-	// This approach helps us avoid dealing with configurations where the value of
-	// the minimum gas price is set to 0.00001ugnot/gas.
-	return prod1.Cmp(prod2) >= 0, nil
+	return providedFee.Cmp(requiredFee) >= 0, nil
 }

--- a/tm2/pkg/std/gasprice_test.go
+++ b/tm2/pkg/std/gasprice_test.go
@@ -78,7 +78,7 @@ func TestGasPriceGTE(t *testing.T) {
 		},
 		// Valid cases: No errors, just compare gas prices
 		{
-			name: "Greater Gas Price",
+			name: "Greater Gas Price: Increased Unit Price (Same Gas Amount)",
 			gp: GasPrice{
 				Gas: 100,
 				Price: Coin{
@@ -91,6 +91,44 @@ func TestGasPriceGTE(t *testing.T) {
 				Price: Coin{
 					Denom:  "atom",
 					Amount: 500,
+				},
+			},
+			expectError: false,
+			expected:    true,
+		},
+		{
+			name: "Greater Gas Price: Increased Gas Amount (Same Unit Price)",
+			gp: GasPrice{
+				Gas: 10000, // greater gas
+				Price: Coin{
+					Denom:  "ugnot",
+					Amount: 1,
+				},
+			},
+			gpB: GasPrice{
+				Gas: 1000,
+				Price: Coin{
+					Denom:  "ugnot",
+					Amount: 1,
+				},
+			},
+			expectError: false,
+			expected:    true,
+		},
+		{
+			name: "Greater Gas Price: Higher Fee Per Gas (and Increased Gas)",
+			gp: GasPrice{
+				Gas: 10000,
+				Price: Coin{
+					Denom:  "ugnot",
+					Amount: 5, // Greater price
+				},
+			},
+			gpB: GasPrice{
+				Gas: 1000,
+				Price: Coin{
+					Denom:  "ugnot",
+					Amount: 1,
 				},
 			},
 			expectError: false,


### PR DESCRIPTION
## Description

This PR fixes a bug in the gas price comparison logic, where a larger gas price would return `false` for being larger, when compared to a smaller gas price:

```shell
Rejected bad transaction	{"module": "mempool", "tx": "E810F32DC9AE46ADECC0B3657369C45B8595307C1E5B18F18C3F3FADDF432FE6", "res": {"Error":{},"Data":null,"Events":null,"Log":"--= Error =--\nData: std.InsufficientFeeError{abciError:std.abciError{}}\nMsg Traces:\n    0  /Users/zmilos/Work/gno/tm2/pkg/std/errors.go:114 - insufficient fees; got: {Gas-Wanted: 100000, Gas-Fee 5ugnot}, fee required: {Gas:1000 Price:1ugnot} as block gas 
```

In this example, a user sent a transaction with the following gas pricing data:
- Gas Wanted: `10000`
- Gas Fee: `5ugnot`

This returned `false`, when being compared to a gas price of `Gas Wanted: 1000, Gas Fee: 1ugnot` 🤷‍♂️ 

The issue was that the function cross-multiplied mismatched fields, comparing fee-per-gas ratios instead of comparing total fees (gas x price), which led to an incorrect result when gas values differ. In this example, it would compare the ratios `0.00005` and `0.001`, and return `false`:

```go
	gpg := big.NewInt(gp.Gas)
	gpa := big.NewInt(gp.Price.Amount)

	gpBg := big.NewInt(gpB.Gas)
	gpBa := big.NewInt(gpB.Price.Amount)

	prod1 := big.NewInt(0).Mul(gpa, gpBg) // gp's price amount * gpB's gas
	prod2 := big.NewInt(0).Mul(gpg, gpBa) // gpB's gas * pg's price amount
	// This is equivalent to checking
	// That the Fee / GasWanted ratio is greater than or equal to the minimum GasPrice per gas.
	// This approach helps us avoid dealing with configurations where the value of
	// the minimum gas price is set to 0.00001ugnot/gas.
	return prod1.Cmp(prod2) >= 0, nil
```

~How our entire testing suite did not catch a bug like this is beyond me, but here we are.~

**EDIT:**
I've figured it out. 

Our `std.Fee` is very misleading.
The amount the user puts in the `tx.Fee` is actually the total amount of whatever the user is willing to pay for the entire transaction, not just a single unit of gas. The effective gas price is the ratio of the maximum gas wanted and the maximum fee (for the entire tx).