### PR TITLE
chore: bump go version in CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.md
@@ -13,7 +13,7 @@ Describe your issue in as much detail as possible here
 
 ### Your environment
 
-* Go version (example: go1.22.4)
+* Go version (example: go1.23.4)
 * OS and CPU architecture (example: linux/amd64)
 * Gno commit hash causing the issue (example: f24690e7ebf325bffcfaf9e328c3df8e6b21e50c)
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - "1.22.x"
+          - "1.23.x"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - "1.22.x"
+          - "1.23.x"
         # unittests: TODO: matrix with contracts
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - "1.22.x"
+          - "1.23.x"
         # unittests: TODO: matrix with contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -83,13 +83,13 @@ jobs:
     uses: ./.github/workflows/build_template.yml
     with:
       modulepath: "examples"
-      go-version: "1.22.x"
+      go-version: "1.23.x"
 
   mod-tidy:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.22.x" ]
+        go-version: [ "1.23.x" ]
         # unittests: TODO: matrix with contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/gnofmt_template.yml
+++ b/.github/workflows/gnofmt_template.yml
@@ -9,7 +9,7 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.22.x"
+        default: "1.23.x"
 
 jobs:
   fmt:

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.22.x"]
+        go-version: ["1.23.x"]
         # unittests: TODO: matrix with contracts
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/main_template.yml
+++ b/.github/workflows/main_template.yml
@@ -11,7 +11,7 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.22.x"
+        default: "1.23.x"
     secrets:
       codecov-token:
         required: true


### PR DESCRIPTION
## Description

Thank you @piux2 for reporting this and fixing it in your PR.

This PR bumps the minimum go version for the CI / workflows to `go 1.23`, as we have dependent tools (like the linter for example) which require at least the `latest go version - 1`.

Following up on:
 https://github.com/gnolang/gno/pull/3766

Related:
https://github.com/gnolang/gno/pull/3767/files