### PR TITLE
ci(docs): fix go-version-file path

### DIFF
--- a/.github/workflows/docs-linter.yml
+++ b/.github/workflows/docs-linter.yml
@@ -16,12 +16,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
+      - name: Set up Go (docs builder)
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: misc/devdeps/go.mod
 
-      - name: Install dependencies
+      - name: Install dependencies (docs builder)
+        working-directory: misc/devdeps
         run: go mod download
 
       - name: Build docs
@@ -29,6 +30,15 @@ jobs:
 
       - name: Check diff
         run: git diff --exit-code || (echo "Some docs files are not formatted, please run 'make build'." && exit 1)
+
+      - name: Set up Go (docs linter)
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: misc/docs-linter/go.mod
+
+      - name: Install dependencies (docs linter)
+        working-directory: misc/docs-linter
+        run: go mod download
 
       - name: Run linter
         run: make -C docs/ lint


### PR DESCRIPTION
This is a quick fix to get master’s CI back to green. 

It should work even though I noticed while digging in that the `docs` folder’s Makefile has two rules, each calling different go dependencies with their own `go.mod` files requiring different go versions.
It might be wise to refactor this and consolidate everything into a single `go.mod` and probably even moving it to the `docs` folder?