### PR TITLE
feat(gnovm): disallow internal imports

### DIFF
--- a/examples/gno.land/p/demo/flow/io_test.gno
+++ b/examples/gno.land/p/demo/flow/io_test.gno
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	ios_test "internal/os_test"
+	ios_test "os_test"
 )
 
 // XXX ugh, I can't even sleep milliseconds.

--- a/examples/gno.land/p/demo/tamagotchi/z0_filetest.gno
+++ b/examples/gno.land/p/demo/tamagotchi/z0_filetest.gno
@@ -1,9 +1,8 @@
 package main
 
 import (
+	"os_test"
 	"time"
-
-	"internal/os_test"
 
 	"gno.land/p/demo/tamagotchi"
 )

--- a/examples/no_cycles_test.go
+++ b/examples/no_cycles_test.go
@@ -19,7 +19,7 @@ import (
 
 // XXX: move this into `gno lint`
 
-var injectedTestingLibs = []string{"encoding/json", "fmt", "os", "internal/os_test"}
+var injectedTestingLibs = []string{"encoding/json", "fmt", "os", "os_test"}
 
 // TestNoCycles checks that there is no import cycles in stdlibs and non-draft examples
 func TestNoCycles(t *testing.T) {

--- a/gnovm/pkg/test/imports.go
+++ b/gnovm/pkg/test/imports.go
@@ -131,7 +131,7 @@ func StoreWithOptions(
 			pkg.DefineGoNativeValue("Unmarshal", json.Unmarshal)
 			pkg.DefineGoNativeValue("Marshal", json.Marshal)
 			return pkg, pkg.NewPackage()
-		case "internal/os_test":
+		case "os_test":
 			pkg := gno.NewPackageNode("os_test", pkgPath, nil)
 			pkg.DefineNative("Sleep",
 				gno.Flds( // params

--- a/gnovm/tests/files/extern/foo/internal/aa/aa.gno
+++ b/gnovm/tests/files/extern/foo/internal/aa/aa.gno
@@ -1,0 +1,3 @@
+package aa
+
+const A = 456

--- a/gnovm/tests/files/extern/foo/internal/internal.gno
+++ b/gnovm/tests/files/extern/foo/internal/internal.gno
@@ -1,0 +1,3 @@
+package internal
+
+const A = 123

--- a/gnovm/tests/files/extern/foo/internal/internal.gno
+++ b/gnovm/tests/files/extern/foo/internal/internal.gno
@@ -1,3 +1,8 @@
 package internal
 
-const A = 123
+import "github.com/gnolang/gno/_test/foo/internal/aa"
+
+const (
+	A = 123
+	B = aa.A
+)

--- a/gnovm/tests/files/import12.gno
+++ b/gnovm/tests/files/import12.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/p/demo
+
+package demo
+
+import (
+	"internal/bytealg"
+)
+
+func main() {
+	println(bytealg.PrimeRK)
+}
+
+// Error:
+// gno.land/p/demo/files/import12.gno:6:2: cannot import stdlib internal/ package outside of standard library

--- a/gnovm/tests/files/import13.gno
+++ b/gnovm/tests/files/import13.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/p/demo
+
+package demo
+
+import (
+	"github.com/gnolang/gno/_test/foo/internal/aa"
+)
+
+func main() {
+	println(aa.A)
+}
+
+// Error:
+// gno.land/p/demo/files/import13.gno:6:2: internal/ packages can only be imported by packages rooted at the parent of "internal"

--- a/gnovm/tests/files/import13b.gno
+++ b/gnovm/tests/files/import13b.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/p/demo
+
+package demo
+
+import (
+	"github.com/gnolang/gno/_test/foo/internal"
+)
+
+func main() {
+	println(internal.A)
+}
+
+// Error:
+// gno.land/p/demo/files/import13b.gno:6:2: internal/ packages can only be imported by packages rooted at the parent of "internal"

--- a/gnovm/tests/files/import14.gno
+++ b/gnovm/tests/files/import14.gno
@@ -8,10 +8,10 @@ import (
 )
 
 func main() {
-	println(internal.A)
+	println(internal.A, internal.B)
 	println(aa.A)
 }
 
 // Output:
-// 123
+// 123 456
 // 456

--- a/gnovm/tests/files/import14.gno
+++ b/gnovm/tests/files/import14.gno
@@ -1,0 +1,17 @@
+// PKGPATH: github.com/gnolang/gno/_test/foo
+
+package foo
+
+import (
+	"github.com/gnolang/gno/_test/foo/internal"
+	"github.com/gnolang/gno/_test/foo/internal/aa"
+)
+
+func main() {
+	println(internal.A)
+	println(aa.A)
+}
+
+// Output:
+// 123
+// 456


### PR DESCRIPTION
#2190 

This PR disables support for importing /internal/ subdirectories, for packages outside of the root of the internal package.

It remains undecided whether we should allow `maketx call` on the internal package (currently possible on a r/ path)