### PR TITLE
chore: fixing ldflags for gnodev build in Goreleaser

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -72,7 +72,7 @@ builds:
     binary: gnodev
     ldflags:
       # using hardcoded ldflag
-      - -X main.build="-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot"
+      - -X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
 fixing ldflags for gnodev build in Goreleaser