### PR TITLE
chore: fixing extra_files in gnodev

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -354,6 +354,9 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
     ids:
       - gnodev
+    extra_files:
+      - gno.land/genesis/genesis_balances.txt
+      - gno.land/genesis/genesis_txs.jsonl
 
   # gnocontribs
   - use: buildx


### PR DESCRIPTION
fixing extra_files in gnodev