### PR TITLE
fix(docs): originpkgaddr type

### DIFF
--- a/docs/reference/stdlibs/std/chain.md
+++ b/docs/reference/stdlibs/std/chain.md
@@ -91,7 +91,7 @@ caller := std.OriginCaller()
 
 ## OriginPkgAddress
 ```go
-func OriginPkgAddress() string
+func OriginPkgAddress() Address
 ```
 Returns the address of the first (entry point) realm/package in a sequence of realm/package calls.
 


### PR DESCRIPTION
## Description

Fixes wrong type in the ref docs. h/t @ajnavarro 