### PR TITLE
fix(test): use ufmt for improved error printing

### DIFF
--- a/gnovm/stdlibs/testing/testing.gno
+++ b/gnovm/stdlibs/testing/testing.gno
@@ -103,7 +103,7 @@ func (t *T) Fail() {
 func (t *T) FailNow() {
 	t.Fail()
 	panic(skipErr("testing: you have recovered a panic attempting to interrupt a test, as a consequence of FailNow. " +
-			"Use testing.Recover to recover panics within tests"))
+		"Use testing.Recover to recover panics within tests"))
 }
 
 func (t *T) Failed() bool {
@@ -186,7 +186,7 @@ func (t *T) Skip(args ...interface{}) {
 func (t *T) SkipNow() {
 	t.skipped = true
 	panic(skipErr("testing: you have recovered a panic attempting to interrupt a test, as a consequence of SkipNow. " +
-			"Use testing.Recover to recover panics within tests"))
+		"Use testing.Recover to recover panics within tests"))
 }
 
 func (t *T) Skipped() bool {

--- a/gnovm/stdlibs/testing/testing.gno
+++ b/gnovm/stdlibs/testing/testing.gno
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"gno.land/p/demo/ufmt"
 )
 
 // ----------------------------------------
@@ -101,7 +103,7 @@ func (t *T) Fail() {
 func (t *T) FailNow() {
 	t.Fail()
 	panic(skipErr("testing: you have recovered a panic attempting to interrupt a test, as a consequence of FailNow. " +
-		"Use testing.Recover to recover panics within tests"))
+			"Use testing.Recover to recover panics within tests"))
 }
 
 func (t *T) Failed() bool {
@@ -184,7 +186,7 @@ func (t *T) Skip(args ...interface{}) {
 func (t *T) SkipNow() {
 	t.skipped = true
 	panic(skipErr("testing: you have recovered a panic attempting to interrupt a test, as a consequence of SkipNow. " +
-		"Use testing.Recover to recover panics within tests"))
+			"Use testing.Recover to recover panics within tests"))
 }
 
 func (t *T) Skipped() bool {
@@ -339,7 +341,7 @@ func tRunner(t *T, fn testingFunc, verbose bool) {
 		case skipErr:
 		default:
 			t.Fail()
-			fmt.Fprintf(os.Stderr, "panic: %v\n", err)
+			fmt.Fprintf(os.Stderr, "panic: %v\n", ufmt.Sprintf("%v", err))
 		}
 
 		dur := unixNano() - start


### PR DESCRIPTION
This avoids the issue where native calls cannot print errors. 
relate: #3802 , #1155 .