### PR TITLE
fix(gnovm): allow private struct fields to be set

### DIFF
--- a/gnovm/tests/files/struct59.gno
+++ b/gnovm/tests/files/struct59.gno
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+type X struct {
+	v string
+}
+
+func main() {
+	x := X{v: "a"}
+	fmt.Printf("test %#v\n", x)
+}
+
+// Output:
+// test struct { v string }{v:"a"}


### PR DESCRIPTION
Go reflect doesn't allow to set unexported struct fields. We use `unsafe` to override this limitation.

Fixes #1155 and #3802