### PR TITLE
fix: CSP to allow pixel gif from simple analytics

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -242,7 +242,7 @@ func SecureHeadersMiddleware(next http.Handler, strict bool) http.Handler {
 			// - 'self' allows resources from the same origin.
 			// - 'data:' allows inline images (e.g., base64-encoded images).
 			// - 'https://gnolang.github.io' allows images from this specific domain - used by gno.land. TODO: use a proper generic whitelisted service
-			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://sa.gno.services; style-src 'self'; img-src 'self' data: https://gnolang.github.io; font-src 'self'")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://sa.gno.services; style-src 'self'; img-src 'self' data: https://gnolang.github.io  https://sa.gno.services; font-src 'self'")
 
 			// Enforce HTTPS by telling browsers to only access the site over HTTPS
 			// for a specified duration (1 year in this case). This also applies to


### PR DESCRIPTION
This PR updates the Content Security Policy (CSP) to allow Simple Analytics to function correctly. The img-src directive now includes https://sa.gno.services, enabling the tracking pixel to load without being blocked.

The tracking pixel (a 1×1 GIF) is essential for Simple Analytics to collect pageview data without requiring JavaScript. When loaded, it sends necessary metadata (e.g., page URL, referrer, user-agent) via the request, allowing privacy-friendly analytics to work. Without this fix, Simple Analytics is unable to capture visits.