### PR TITLE
feat(commondao): simplify proposal definition requirements

### DIFF
--- a/examples/gno.land/p/nt/commondao/commondao.gno
+++ b/examples/gno.land/p/nt/commondao/commondao.gno
@@ -160,10 +160,7 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 	// From this point any error results in execution success and proposal failure
 	err := p.Validate()
 	if err == nil {
-		err = dao.Tally(p)
-		if err == nil {
-			err = dao.executeProposal(p)
-		}
+		err = dao.executeProposal(p)
 	}
 
 	// Proposal fails if there is any error during validation and execution process
@@ -185,6 +182,10 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 func (dao *CommonDAO) executeProposal(p *Proposal) error {
 	if p.Status() != StatusActive {
 		return ErrStatusIsNotActive
+	}
+
+	if err := dao.Tally(p); err != nil {
+		return err
 	}
 
 	if e, ok := p.Definition().(Executable); ok {

--- a/examples/gno.land/p/nt/commondao/commondao.gno
+++ b/examples/gno.land/p/nt/commondao/commondao.gno
@@ -12,11 +12,12 @@ import (
 
 var (
 	ErrInvalidVoteChoice    = errors.New("invalid vote choice")
+	ErrLowParticipation     = errors.New("low participation")
 	ErrMemberExists         = errors.New("member already exist")
+	ErrNoConcensus          = errors.New("no concensus")
 	ErrNotMember            = errors.New("account is not a member of the DAO")
 	ErrOverflow             = errors.New("next ID overflows uint64")
 	ErrProposalNotFound     = errors.New("proposal not found")
-	ErrStatusIsNotActive    = errors.New("proposal status is not active")
 	ErrVotingDeadlineNotMet = errors.New("voting deadline not met")
 )
 
@@ -134,6 +135,7 @@ func (dao CommonDAO) GetFinishedProposal(proposalID uint64) (_ *Proposal, found 
 
 // Vote submits a new vote for a proposal.
 func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice) error {
+	// TODO: Support other voting options though the proposal definition
 	if c != ChoiceYes && c != ChoiceNo && c != ChoiceAbstain {
 		return ErrInvalidVoteChoice
 	}
@@ -149,30 +151,21 @@ func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice) 
 	return p.record.AddVote(member, c)
 }
 
-func (dao *CommonDAO) Tally(p *Proposal) Stats {
-	// Initialize stats considering only yes/no votes
+func (dao *CommonDAO) Tally(p *Proposal) error {
+	// TODO: Support other voting options though the proposal definition
 	record := p.VotingRecord()
-	stats := Stats{
-		YayVotes: record.VoteCount(ChoiceYes),
-		NayVotes: record.VoteCount(ChoiceNo),
-	}
-	votesCount := stats.YayVotes + stats.NayVotes
+	votesCount := record.VoteCount(ChoiceYes) + record.VoteCount(ChoiceNo) // Only consider YES/NO votes
 	membersCount := len(dao.Members())
-	stats.Abstained = membersCount - votesCount
 
 	percentage := float64(votesCount) / float64(membersCount)
 	if percentage < p.Quorum() {
-		p.status = StatusFailed
-		p.statusReason = "low participation"
-		return stats
+		return ErrLowParticipation
 	}
 
 	if !p.Definition().Tally(record, membersCount) {
-		p.status = StatusFailed
-		p.statusReason = "no consensus"
+		return ErrNoConcensus
 	}
-
-	return stats
+	return nil
 }
 
 // Execute executes a proposal.
@@ -190,26 +183,21 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 		return ErrVotingDeadlineNotMet
 	}
 
-	// Validate proposal before executing it
-	def := p.Definition()
-	err := def.Validate()
+	// From this point any error results in execution success and proposal failure
+	err := p.Validate()
+	if err == nil {
+		err = dao.Tally(p)
+		if err == nil {
+			err = dao.executeProposal(p)
+		}
+	}
+
+	// Proposal fails if there is any error during validation and execution process
 	if err != nil {
 		p.status = StatusFailed
 		p.statusReason = err.Error()
 	} else {
-		// Tally votes and update proposal status
-		dao.Tally(p)
-
-		// Execute proposal only when the majority vote wins
-		if p.Status() != StatusFailed {
-			err = def.Execute()
-			if err != nil {
-				p.status = StatusFailed
-				p.statusReason = err.Error()
-			} else {
-				p.status = StatusExecuted
-			}
-		}
+		p.status = StatusExecuted
 	}
 
 	// Whichever the outcome of the validation, tallying
@@ -217,7 +205,18 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 	key := makeProposalKey(p.id)
 	dao.active.Remove(key)
 	dao.finished.Set(key, p)
-	return err
+	return nil
+}
+
+func (dao *CommonDAO) executeProposal(p *Proposal) error {
+	if p.Status() != StatusActive {
+		return ErrStatusIsNotActive
+	}
+
+	if e, ok := p.Definition().(Executable); ok {
+		return e.Execute()
+	}
+	return nil
 }
 
 func makeProposalKey(id uint64) string {

--- a/examples/gno.land/p/nt/commondao/commondao_test.gno
+++ b/examples/gno.land/p/nt/commondao/commondao_test.gno
@@ -241,12 +241,10 @@ func TestCommonDAOVote(t *testing.T) {
 
 func TestCommonDAOTally(t *testing.T) {
 	cases := []struct {
-		name         string
-		dao          *CommonDAO
-		votes        []Vote
-		status       ProposalStatus
-		statusReason string
-		stats        Stats
+		name  string
+		dao   *CommonDAO
+		votes []Vote
+		err   error
 	}{
 		{
 			name: "pass",
@@ -259,14 +257,11 @@ func TestCommonDAOTally(t *testing.T) {
 				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
 				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
 			},
-			status: StatusActive,
-			stats:  Stats{YayVotes: 2, Abstained: 1},
 		},
 		{
-			name:         "no votes",
-			dao:          New(),
-			status:       StatusFailed,
-			statusReason: "low participation",
+			name: "no votes",
+			dao:  New(),
+			err:  ErrLowParticipation,
 		},
 		{
 			name: "no quorum",
@@ -278,9 +273,7 @@ func TestCommonDAOTally(t *testing.T) {
 			votes: []Vote{
 				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
 			},
-			status:       StatusFailed,
-			statusReason: "low participation",
-			stats:        Stats{YayVotes: 1, Abstained: 2},
+			err: ErrLowParticipation,
 		},
 		{
 			name: "no consensus",
@@ -293,9 +286,7 @@ func TestCommonDAOTally(t *testing.T) {
 				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
 				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceNo},
 			},
-			status:       StatusFailed,
-			statusReason: "no consensus",
-			stats:        Stats{YayVotes: 1, NayVotes: 1, Abstained: 1},
+			err: ErrNoConcensus,
 		},
 	}
 
@@ -306,13 +297,13 @@ func TestCommonDAOTally(t *testing.T) {
 				p.record.AddVote(v.Address, v.Choice)
 			}
 
-			stats := tc.dao.Tally(p)
+			err := tc.dao.Tally(p)
 
-			uassert.Equal(t, string(p.Status()), string(tc.status))
-			uassert.Equal(t, p.StatusReason(), tc.statusReason)
-			uassert.Equal(t, stats.YayVotes, tc.stats.YayVotes)
-			uassert.Equal(t, stats.NayVotes, tc.stats.NayVotes)
-			uassert.Equal(t, stats.Abstained, tc.stats.Abstained)
+			if tc.err != nil {
+				uassert.Error(t, err, "expect an error")
+			} else {
+				uassert.NoError(t, err, "expect no error")
+			}
 		})
 	}
 }
@@ -385,7 +376,18 @@ func TestCommonDAOExecute(t *testing.T) {
 			proposalID:   1,
 			status:       StatusFailed,
 			statusReason: errValidation.Error(),
-			err:          errValidation,
+		},
+		{
+			name: "tally error",
+			setup: func() *CommonDAO {
+				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
+				dao := New(WithMember(member))
+				p, _ := dao.Propose(member, testPropDef{})
+				return dao
+			},
+			proposalID:   1,
+			status:       StatusFailed,
+			statusReason: ErrLowParticipation.Error(),
 		},
 		{
 			name: "execution error",
@@ -407,7 +409,6 @@ func TestCommonDAOExecute(t *testing.T) {
 			proposalID:   1,
 			status:       StatusFailed,
 			statusReason: errExecution.Error(),
-			err:          errExecution,
 		},
 	}
 
@@ -418,19 +419,19 @@ func TestCommonDAOExecute(t *testing.T) {
 			err := dao.Execute(tc.proposalID)
 
 			if tc.err != nil {
-				urequire.ErrorIs(t, err, tc.err)
+				urequire.ErrorIs(t, err, tc.err, "expect error to match")
 				return
 			}
 
-			urequire.NoError(t, err)
+			urequire.NoError(t, err, "expect no error")
 
 			_, found := dao.GetActiveProposal(tc.proposalID)
 			urequire.False(t, found, "proposal should not be active")
 
 			p, found := dao.GetFinishedProposal(tc.proposalID)
-			urequire.True(t, found, "proposal not found")
-			uassert.Equal(t, string(p.Status()), string(tc.status))
-			uassert.Equal(t, string(p.StatusReason()), string(tc.statusReason))
+			urequire.True(t, found, "proposal must be found")
+			uassert.Equal(t, string(p.Status()), string(tc.status), "status must match")
+			uassert.Equal(t, string(p.StatusReason()), string(tc.statusReason), "status reason must match")
 		})
 	}
 }

--- a/examples/gno.land/p/nt/commondao/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/proposal.gno
@@ -17,13 +17,14 @@ const (
 
 const (
 	ChoiceAbstain VoteChoice = ""
-	ChoiceYes                = "yes"
-	ChoiceNo                 = "no"
+	ChoiceYes                = "YES"
+	ChoiceNo                 = "NO"
 )
 
 var (
 	ErrInvalidCreatorAddress      = errors.New("invalid proposal creator address")
 	ErrProposalDefinitionRequired = errors.New("proposal definition is required")
+	ErrStatusIsNotActive          = errors.New("proposal status is not active")
 )
 
 type (
@@ -66,17 +67,22 @@ type (
 		// Its value must be between 0 and 1, being 1 = 100% of member votes.
 		Quorum() float64
 
-		// Validate validates that the proposal is valid.
-		// Validations are optional and allow the validation of the current state before proposal execution.
-		Validate() error
-
 		// Tally counts the number of votes and verifies that there is consensus.
 		// Tally fails when none of the vote choices wins over the others.
 		Tally(r ReadOnlyVotingRecord, memberCount int) (success bool)
+	}
 
+	// Validable defines an interface for proposal definitions that require state validation.
+	// Validation is done before execution and normally also during proposal rendering.
+	Validable interface {
+		// Validate validates that the proposal is valid for the current state.
+		Validate() error
+	}
+
+	// Executable defines an interface for proposal definitions that modify state on approval.
+	// Once proposals are executed they are archived and considered finished.
+	Executable interface {
 		// Execute executes the proposal.
-		// Once proposal are executed they are archived and considered finished.
-		// Execution allows changing the state after a proposal passes.
 		Execute() error
 	}
 )
@@ -152,4 +158,17 @@ func (p Proposal) StatusReason() string {
 // VotingDeadline returns the deadline after which no more votes should be allowed.
 func (p Proposal) VotingDeadline() time.Time {
 	return p.votingDeadline
+}
+
+// Validate validates that a proposal is valid for the current state.
+// Validation is done when proposal status is active and when the definition supports validation.
+func (p Proposal) Validate() error {
+	if p.status != StatusActive {
+		return nil
+	}
+
+	if v, ok := p.definition.(Validable); ok {
+		return v.Validate()
+	}
+	return nil
 }


### PR DESCRIPTION
PR changes `ProposalDefinition` interface to make validation and execution optional.

It also removes proposal stats as they can be created by the caller when needed.