### PR TITLE
fix(gnoweb): breadcrumb generation for consistent argument and query handling

### DIFF
--- a/gno.land/pkg/gnoweb/components/ui/breadcrumb.html
+++ b/gno.land/pkg/gnoweb/components/ui/breadcrumb.html
@@ -1,18 +1,22 @@
 {{ define "ui/breadcrumb" }}
 <ol
   data-role="header-breadcrumb-search"
-  class="peer-focus-within:hidden flex text-gray-800 font-semibold bg-gray-100 after:absolute after:w-full after:top-0 after:left-0 after:h-full after:block after:bg-gray-100 after:pointer-events-none"
+  class="peer-focus-within:hidden flex leading-snug text-gray-800 font-semibold bg-gray-100 after:absolute after:w-full after:top-0 after:left-0 after:h-full after:block after:bg-gray-100 after:pointer-events-none"
 >
   {{- range $index, $part := .Parts }} {{- if $index }}
-  <li class="flex z-1 before:content-['/'] before:px-[0.18rem] before:text-gray-300 whitespace-nowrap">{{- else }}</li>
+  <li class="flex z-1 before:content-['/'] before:px-[0.18rem] before:pt-0.5 before:text-gray-300 whitespace-nowrap">{{- else }}</li>
 
   <li class="z-1 whitespace-nowrap">
     {{- end }}
-    <a class="hover:bg-green-600 hover:text-light bg-light inline-block rounded-sm px-1 py-px" href="{{ $part.URL }}">{{ $part.Name }}</a>
+    <a class="hover:bg-green-600 border-2 border-transparent hover:text-light bg-light inline-block rounded-sm px-0.5" href="{{ $part.URL }}">{{ $part.Name }}</a>
   </li>
-  {{- end }} {{- if .Args }}
-  <li class="flex z-1 before:content-[':'] before:px-[0.18rem] before:text-gray-300 whitespace-nowrap">
-    <a class="text-light bg-gray-300 inline-block rounded-sm px-1 py-px">{{ .Args }}</a>
+  {{- end }} {{- if .ArgParts }} {{- range $index, $arg := .ArgParts }}
+  <li class="flex z-1 {{ if eq $index 0 }} before:content-[':'] {{ else }} before:content-['/'] {{ end }} before:px-[0.18rem] before:pt-0.5 before:text-gray-300 whitespace-nowrap">
+    <a class="text-light border-2 border-transparent bg-gray-400 hover:bg-green-600 hover:text-light inline-block rounded-sm px-0.5" href="{{ $arg.URL }}">{{ $arg.Name }}</a>
+  </li>
+  {{- end }} {{- end }} {{- range $index, $query := .Queries }}
+  <li class="flex z-1 {{ if eq $index 0 }} before:content-['?'] {{ else }} before:content-['&'] {{ end }} before:px-[0.18rem] before:pt-0.5 before:text-gray-300 whitespace-nowrap">
+    <span class="text-gray-400 border-2 border-gray-400 inline-block rounded-sm px-1">{{ $query.Key }}{{- with $query.Value }}={{ . }}{{- end }}</span>
   </li>
   {{- end }}
 </ol>

--- a/gno.land/pkg/gnoweb/components/ui_breadcrumb.go
+++ b/gno.land/pkg/gnoweb/components/ui_breadcrumb.go
@@ -9,9 +9,15 @@ type BreadcrumbPart struct {
 	URL  string
 }
 
+type QueryParam struct {
+	Key   string
+	Value string
+}
+
 type BreadcrumbData struct {
-	Parts []BreadcrumbPart
-	Args  string
+	Parts    []BreadcrumbPart
+	ArgParts []BreadcrumbPart
+	Queries  []QueryParam
 }
 
 func RenderBreadcrumpComponent(w io.Writer, data BreadcrumbData) error {

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -316,8 +316,31 @@ func generateBreadcrumbPaths(url *weburl.GnoURL) components.BreadcrumbData {
 		})
 	}
 
-	if args := url.EncodeArgs(); args != "" {
-		data.Args = args
+	// Add args
+	if url.Args != "" {
+		argSplit := strings.Split(url.Args, "/")
+		var nonEmptyArgs []string
+		for _, a := range argSplit {
+			if a != "" {
+				nonEmptyArgs = append(nonEmptyArgs, a)
+			}
+		}
+		for i := range nonEmptyArgs {
+			data.ArgParts = append(data.ArgParts, components.BreadcrumbPart{
+				Name: nonEmptyArgs[i],
+				URL:  url.Path + ":" + strings.Join(nonEmptyArgs[:i+1], "/"),
+			})
+		}
+	}
+
+	// Add query params
+	for key, values := range url.Query {
+		for _, v := range values {
+			data.Queries = append(data.Queries, components.QueryParam{
+				Key:   key,
+				Value: v,
+			})
+		}
 	}
 
 	return data


### PR DESCRIPTION
This PR refactors the `generateBreadcrumbPaths` function to provide a consistent model for handling breadcrumb parts extracted from the URL path, arguments, and query parameters. The changes include:

- **Consistent Extraction of Parts:**
  The existing logic that splits the URL path into parts remains unchanged.

- **New Argument Parts (ArgParts):**
  Instead of storing all arguments as a single string, we now split the url.Args value (i.e., the part after the `:`) into individual segments. These segments are processed similarly to the path parts, with cumulative URLs generated for each segment. This provides a more granular and consistent breadcrumb structure.

- **Query Parameters Handling:**
  Query parameters (after the `?`) are iterated over and added to a new Queries slice. Since iterating over an empty map is safe, no additional condition is required here.

- **TODO: update query value on click from input**