### PR TITLE
chore: improve error response structure and metadata

### DIFF
--- a/gno.land/pkg/integration/testdata/err_metadata.txtar
+++ b/gno.land/pkg/integration/testdata/err_metadata.txtar
@@ -1,0 +1,50 @@
+# ensure users get proper out of gas errors when they add packages
+
+# start a new node
+gnoland start
+
+! gnokey maketx addpkg -pkgdir $WORK/invalid -pkgpath gno.land/r/invalid -gas-fee 1000000ugnot -gas-wanted 60000 -broadcast -chainid=tendermint_test test1
+
+stderr '--= Error =--'
+stderr 'Data: invalid gno package; type check errors:'
+stderr 'gno.land/r/invalid/invalid.gno:3:11: expected operand, found .EOF.'
+stderr 'Msg Traces:'
+stderr '    0  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/errors/errors.go:28 - deliver transaction failed: log:msg:0,success:false,log:--= Error =--'
+stderr 'Data: vm.TypeCheckError{abciError:vm.abciError{}, Errors:..string{"gno.land/r/invalid/invalid.gno:3:11: expected operand, found .EOF."}}'
+stderr 'Msg Traces:'
+stderr 'Stack Trace:'
+stderr '    0  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/errors.go:69'
+stderr '    1  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/keeper.go:354'
+stderr '    2  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/handler.go:39'
+stderr '    3  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/handler.go:26'
+stderr '    4  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:671'
+stderr '    5  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:860'
+stderr '    6  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/helpers.go:21'
+stderr '    7  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:422'
+stderr '    8  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:399'
+stderr '    9  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/abci/client/local_client.go:180'
+stderr '   10  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/appconn/app_conn.go:144'
+stderr '   11  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/core/abci.go:59'
+stderr '   12  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:581'
+stderr '   13  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:365'
+stderr '   14  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:208'
+stderr '   15  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:162'
+stderr '   16  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:232'
+stderr '   17  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
+stderr '   18  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2747'
+stderr '   19  /Users/moul/go/pkg/mod/github.com/rs/cors@v1.11.1/cors.go:289'
+stderr '   20  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
+stderr '   21  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/http_server.go:212'
+stderr '   22  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/http_server.go:185'
+stderr '   23  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
+stderr '   24  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:3210'
+stderr '   25  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2092'
+stderr '   26  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/runtime/asm_arm64.s:1223'
+stderr '--= /Error =--'
+stderr ',events:..'
+stderr '--= /Error =--'
+
+-- invalid/invalid.gno --
+package invalid
+
+var Foo =

--- a/gno.land/pkg/integration/testdata/err_metadata.txtar
+++ b/gno.land/pkg/integration/testdata/err_metadata.txtar
@@ -5,46 +5,22 @@ gnoland start
 
 ! gnokey maketx addpkg -pkgdir $WORK/invalid -pkgpath gno.land/r/invalid -gas-fee 1000000ugnot -gas-wanted 60000 -broadcast -chainid=tendermint_test test1
 
+stdout 'TX HASH:'
+stdout 'INFO:.*vm.version=develop'
 stderr '--= Error =--'
 stderr 'Data: invalid gno package; type check errors:'
-stderr 'gno.land/r/invalid/invalid.gno:3:11: expected operand, found .EOF.'
+stderr 'gno.land/r/invalid/invalid.gno:.*:.*: expected operand, found .EOF.'
 stderr 'Msg Traces:'
-stderr '    0  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/errors/errors.go:28 - deliver transaction failed: log:msg:0,success:false,log:--= Error =--'
-stderr 'Data: vm.TypeCheckError{abciError:vm.abciError{}, Errors:..string{"gno.land/r/invalid/invalid.gno:3:11: expected operand, found .EOF."}}'
+stderr '    0  .*gno/tm2/pkg/errors/errors.go:.* - deliver transaction failed: log:msg:0,success:false,log:--= Error =--'
+stderr 'Data: vm.TypeCheckError{abciError:vm.abciError{}, Errors:..string{"gno.land/r/invalid/invalid.gno:.*:.*: expected operand, found .EOF."}}'
 stderr 'Msg Traces:'
 stderr 'Stack Trace:'
-stderr '    0  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/errors.go:69'
-stderr '    1  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/keeper.go:354'
-stderr '    2  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/handler.go:39'
-stderr '    3  /Users/moul/go/src/github.com/gnolang/gno/gno.land/pkg/sdk/vm/handler.go:26'
-stderr '    4  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:671'
-stderr '    5  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:860'
-stderr '    6  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/helpers.go:21'
-stderr '    7  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:422'
-stderr '    8  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/sdk/baseapp.go:399'
-stderr '    9  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/abci/client/local_client.go:180'
-stderr '   10  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/appconn/app_conn.go:144'
-stderr '   11  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/core/abci.go:59'
-stderr '   12  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:581'
-stderr '   13  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:365'
-stderr '   14  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:208'
-stderr '   15  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:162'
-stderr '   16  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/handlers.go:232'
-stderr '   17  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
-stderr '   18  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2747'
-stderr '   19  /Users/moul/go/pkg/mod/github.com/rs/cors@v1.11.1/cors.go:289'
-stderr '   20  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
-stderr '   21  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/http_server.go:212'
-stderr '   22  /Users/moul/go/src/github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server/http_server.go:185'
-stderr '   23  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2220'
-stderr '   24  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:3210'
-stderr '   25  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/net/http/server.go:2092'
-stderr '   26  /Users/moul/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/runtime/asm_arm64.s:1223'
+stderr '    0  .*gno.land/pkg/sdk/vm/errors.go:.*'
+#...
 stderr '--= /Error =--'
 stderr ',events:..'
 stderr '--= /Error =--'
 
 -- invalid/invalid.gno --
 package invalid
-
 var Foo =

--- a/gno.land/pkg/sdk/vm/handler.go
+++ b/gno.land/pkg/sdk/vm/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gnolang/gno/gnovm/pkg/version"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -187,7 +188,9 @@ func (vh vmHandler) queryFile(ctx sdk.Context, req abci.RequestQuery) (res abci.
 // misc
 
 func abciResult(err error) sdk.Result {
-	return sdk.ABCIResultFromError(err)
+	res := sdk.ABCIResultFromError(err)
+	res.Info += "vm.version=" + version.Version
+	return res
 }
 
 // returns the second component of a path.

--- a/tm2/pkg/crypto/keys/client/maketx.go
+++ b/tm2/pkg/crypto/keys/client/maketx.go
@@ -212,6 +212,7 @@ func ExecSignAndBroadcast(
 	}
 	if bres.DeliverTx.IsErr() {
 		io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
+		io.Println("INFO:      ", bres.DeliverTx.Info)
 		return errors.Wrapf(bres.DeliverTx.Error, "deliver transaction failed: log:%s", bres.DeliverTx.Log)
 	}
 
@@ -221,6 +222,7 @@ func ExecSignAndBroadcast(
 	io.Println("GAS USED:  ", bres.DeliverTx.GasUsed)
 	io.Println("HEIGHT:    ", bres.Height)
 	io.Println("EVENTS:    ", string(bres.DeliverTx.EncodeEvents()))
+	io.Println("INFO:      ", bres.DeliverTx.Info)
 	io.Println("TX HASH:   ", base64.StdEncoding.EncodeToString(bres.Hash))
 
 	return nil

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -646,6 +646,7 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 	ctx = ctx.WithEventLogger(NewEventLogger())
 
 	msgLogs := make([]string, 0, len(msgs))
+	msgInfos := make([]string, 0, len(msgs))
 	data := make([]byte, 0, len(msgs))
 
 	var (
@@ -675,6 +676,7 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 		// each result.
 		data = append(data, msgResult.Data...)
 		events = append(events, msgResult.Events...)
+		msgInfos = append(msgInfos, msgResult.Info)
 
 		// stop execution and return on first failed message
 		if !msgResult.IsOK() {
@@ -698,6 +700,7 @@ func (app *BaseApp) runMsgs(ctx Context, msgs []Msg, mode RunTxMode) (result Res
 	result.Error = ABCIError(err)
 	result.Data = data
 	result.Events = events
+	result.Info = strings.Join(msgInfos, "\n")
 	result.Log = strings.Join(msgLogs, "\n")
 	result.GasUsed = ctx.GasMeter().GasConsumed()
 	return result

--- a/tm2/pkg/sdk/options.go
+++ b/tm2/pkg/sdk/options.go
@@ -53,7 +53,7 @@ func (app *BaseApp) SetDB(db dbm.DB) {
 
 func (app *BaseApp) SetCMS(cms store.CommitMultiStore) {
 	if app.sealed {
-		panic("SetEndBlocker() on sealed BaseApp")
+		panic("SetCMS() on sealed BaseApp")
 	}
 	app.cms = cms
 }


### PR DESCRIPTION
Adds a `vm.version={version}` when the VM returns an error response. 

Alternatively, we could simplify access to the version and other metadata, possibly with a "gnokey maketx --debug" command. However, I believe this addition is light enough to be included as a built-in feature.