### PR TITLE
docs: improve go<>gno compat document searchability

### DIFF
--- a/docs/reference/go-gno-compatibility.md
+++ b/docs/reference/go-gno-compatibility.md
@@ -61,6 +61,7 @@ rune := rune('a')
 | `func (T1...) T2...`                          | full                   | full (needs more tests)                                    |
 | `*T` (pointers)                               | full                   | full\*                                                     |
 | `chan T` (channels)                           | missing (after launch) | missing (after launch)                                     |
+| `imag`                                        | unsupported            | unsupported                                                |
 
 **\*:** depends on `T`/`T1`/`T2`
 

--- a/docs/reference/go-gno-compatibility.md
+++ b/docs/reference/go-gno-compatibility.md
@@ -61,7 +61,6 @@ rune := rune('a')
 | `func (T1...) T2...`                          | full                   | full (needs more tests)                                    |
 | `*T` (pointers)                               | full                   | full\*                                                     |
 | `chan T` (channels)                           | missing (after launch) | missing (after launch)                                     |
-| `imag`                                        | unsupported            | unsupported                                                |
 
 **\*:** depends on `T`/`T1`/`T2`
 
@@ -273,7 +272,7 @@ Legend:
 [^1]: `builtin` is a "fake" package that exists to document the behaviour of
   some builtin functions. The "fake" package does not currently exist in Gno,
   but [all functions up to Go 1.17 exist](https://pkg.go.dev/builtin@go1.17),
-  except for those relating to complex or channel types.
+  except for those relating to complex (real or imag) or channel types.
 [^2]: `crypto/sha1` and `crypto/md5` implement "deprecated" hashing
   algorithms, widely considered unsafe for cryptographic hashing. Decision on
   whether to include these as part of the official standard libraries is still


### PR DESCRIPTION
Imaginary values are not supported in Gno. Found by fuzzing and compatibility checks between Go and Gno

```go
package main

const (
	ǋ = 0i
)
```