### PR TITLE
fix(gnovm): support len() on nil map

### DIFF
--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -2090,6 +2090,8 @@ func (tv *TypedValue) GetLength() int {
 			return bt.Len
 		case *SliceType:
 			return 0
+		case *MapType:
+			return 0
 		case *PointerType:
 			if at, ok := bt.Elt.(*ArrayType); ok {
 				return at.Len

--- a/gnovm/tests/files/len9.gno
+++ b/gnovm/tests/files/len9.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	var a map[string]string
+
+	println(len(a))
+}
+
+// Output:
+// 0


### PR DESCRIPTION
This would panic at runtime due to a missed condition in TypedValue.GetLength.