### PR TITLE
feat(boards2): change flagging to allow realm owners to hide with a single flag

### DIFF
--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -141,8 +141,12 @@ func FlagThread(boardID BoardID, threadID PostID, reason string) {
 	board := mustGetBoard(boardID)
 	assertBoardIsNotFrozen(board)
 
+	// Check permission to flag when caller is not a realm owner
 	caller := std.OriginCaller()
-	assertHasBoardPermission(board, caller, PermissionThreadFlag)
+	isRealmOwner := gPerms.HasRole(caller, RoleOwner)
+	if !isRealmOwner {
+		assertHasBoardPermission(board, caller, PermissionThreadFlag)
+	}
 
 	t, ok := board.GetThread(threadID)
 	if !ok {
@@ -153,8 +157,10 @@ func FlagThread(boardID BoardID, threadID PostID, reason string) {
 		User:   caller,
 		Reason: reason,
 	}
+
+	// Realm owners can hide with a single flag
 	hide := flagItem(t, f, getFlaggingThreshold(boardID))
-	if hide {
+	if hide || isRealmOwner {
 		t.SetVisible(false)
 	}
 }
@@ -215,8 +221,12 @@ func FlagReply(boardID BoardID, threadID, replyID PostID, reason string) {
 	board := mustGetBoard(boardID)
 	assertBoardIsNotFrozen(board)
 
+	// Check permission to flag when caller is not a realm owner
 	caller := std.OriginCaller()
-	assertHasBoardPermission(board, caller, PermissionThreadFlag)
+	isRealmOwner := gPerms.HasRole(caller, RoleOwner)
+	if !isRealmOwner {
+		assertHasBoardPermission(board, caller, PermissionReplyFlag)
+	}
 
 	thread := mustGetThread(board, threadID)
 	reply := mustGetReply(thread, replyID)
@@ -225,8 +235,10 @@ func FlagReply(boardID BoardID, threadID, replyID PostID, reason string) {
 		User:   caller,
 		Reason: reason,
 	}
+
+	// Realm owners can hide with a single flag
 	hide := flagItem(reply, f, getFlaggingThreshold(boardID))
-	if hide {
+	if hide || isRealmOwner {
 		reply.SetVisible(false)
 	}
 }

--- a/examples/gno.land/r/nt/boards2/v1/z_10_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_10_a_filetest.gno
@@ -6,7 +6,10 @@ import (
 	boards2 "gno.land/r/nt/boards2/v1"
 )
 
-const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+const (
+	owner     = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	moderator = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
 
 var (
 	bid boards2.BoardID
@@ -16,6 +19,11 @@ var (
 func init() {
 	std.TestSetOriginCaller(owner)
 	bid = boards2.CreateBoard("test-board")
+
+	// Invite a moderator to the new board
+	boards2.InviteMember(bid, moderator, boards2.RoleModerator)
+
+	// Create a new thread as a moderator
 	pid = boards2.CreateThread(bid, "Foo", "bar")
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_10_c_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_10_c_filetest.gno
@@ -21,6 +21,7 @@ func init() {
 	bid = boards2.CreateBoard("test-board")
 	pid = boards2.CreateThread(bid, "Foo", "bar")
 
+	// Make the next call as an uninvited user
 	std.TestSetOriginCaller(user)
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_10_g_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_10_g_filetest.gno
@@ -6,7 +6,10 @@ import (
 	boards2 "gno.land/r/nt/boards2/v1"
 )
 
-const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+const (
+	owner     = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	moderator = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
 
 var (
 	bid boards2.BoardID
@@ -15,10 +18,17 @@ var (
 
 func init() {
 	std.TestSetOriginCaller(owner)
-	bid = boards2.CreateBoard("test-board")
-	pid = boards2.CreateThread(bid, "Foo", "bar")
 
+	// Created a board with a specific flagging threshold
+	bid = boards2.CreateBoard("test-board")
 	boards2.SetFlaggingThreshold(bid, 2)
+
+	// Invite a moderator to the new board
+	boards2.InviteMember(bid, moderator, boards2.RoleModerator)
+
+	// Create a new thread and flag it as a moderator
+	std.TestSetOriginCaller(moderator)
+	pid = boards2.CreateThread(bid, "Foo", "bar")
 	boards2.FlagThread(bid, pid, "")
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_10_h_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_10_h_filetest.gno
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	pid boards2.PostID
+)
+
+func init() {
+	std.TestSetOriginCaller(owner)
+
+	// Created a board with flagging threshold greater than 1
+	bid = boards2.CreateBoard("test-board")
+	boards2.SetFlaggingThreshold(bid, 2)
+
+	// Create a thread so the realm owner can flag and hide it with a single flag
+	pid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.FlagThread(bid, pid, "")
+
+	// Ensure that original thread content not visible
+	println(boards2.Render("test-board/1"))
+}
+
+// Output:
+// Thread with ID: 1 has been flagged as inappropriate

--- a/examples/gno.land/r/nt/boards2/v1/z_13_h_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_13_h_filetest.gno
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const (
+	owner     = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	moderator = std.Address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
+)
+
+var (
+	bid      boards2.BoardID
+	rid, tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOriginCaller(owner)
+
+	// Created a board with flagging threshold greater than 1
+	bid = boards2.CreateBoard("test-board")
+	boards2.SetFlaggingThreshold(bid, 2)
+
+	// Create a reply so the realm owner can flag and hide it with a single flag
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+	rid = boards2.CreateReply(bid, tid, 0, "body")
+}
+
+func main() {
+	boards2.FlagReply(bid, tid, rid, "")
+
+	// Render content must contain a message about the hidden reply
+	content := boards2.Render("test-board/1/2")
+	println(strings.Contains(content, "\n> _Reply is hidden as it has been flagged as inappropriate_\n"))
+}
+
+// Output:
+// true


### PR DESCRIPTION
Flagging a thread or comment as a realm owner hides either of them with a single flag independently of the board's flagging threshold