### PR TITLE
feat(cmd/gno): perform type checking before test

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -230,10 +230,20 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 
 		memPkg := gno.MustReadMemPackage(pkg.Dir, gnoPkgPath)
 
+		var hasError bool
+
 		startedAt := time.Now()
-		hasError := catchRuntimeError(gnoPkgPath, io.Err(), func() {
+		runtimeError := catchRuntimeError(gnoPkgPath, io.Err(), func() {
+			foundErr, err := lintTypeCheck(io, memPkg, opts.TestStore)
+			if err != nil {
+				io.ErrPrintln(err)
+				hasError = true
+			} else if foundErr {
+				hasError = true
+			}
 			err = test.Test(memPkg, pkg.Dir, opts)
 		})
+		hasError = hasError || runtimeError
 
 		duration := time.Since(startedAt)
 		dstr := fmtDuration(duration)
@@ -242,9 +252,7 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 			if err != nil {
 				io.ErrPrintfln("%s: test pkg: %v", pkg.Dir, err)
 			}
-			io.ErrPrintfln("FAIL")
 			io.ErrPrintfln("FAIL    %s \t%s", pkg.Dir, dstr)
-			io.ErrPrintfln("FAIL")
 			testErrCount++
 		} else {
 			io.ErrPrintfln("ok      %s \t%s", pkg.Dir, dstr)

--- a/gnovm/cmd/gno/testdata/test/lint_error.txtar
+++ b/gnovm/cmd/gno/testdata/test/lint_error.txtar
@@ -1,0 +1,25 @@
+# Test with a valid _test.gno file
+
+! gno test -v .
+
+stdout 'hello123'
+stderr 'PASS: TestAlwaysValid'
+stderr 'declared and not used: x'
+stderr 'FAIL'
+
+-- valid.gno --
+package valid
+
+func fn() {
+	x := 1
+	println("hello123")
+}
+
+-- valid_test.gno --
+package valid
+
+import "testing"
+
+func TestAlwaysValid(t *testing.T) {
+	fn()
+}


### PR DESCRIPTION
Fixes #3831.

Adds type checking as a step before executing a package's tests.