### PR TITLE
feat: add gnoweb codeowners

### DIFF
--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -57,6 +57,17 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			),
 		},
 		{
+			Description: "Changes related to gnoweb must be reviewed by its codeowners",
+			If: c.And(
+				c.BaseBranch("^master$"),
+				c.FileChanged(gh, "^gno.land/pkg/gnoweb/"),
+			),
+			Then: r.Or(
+				r.ReviewByUser(gh, "alexiscolin"),
+				r.ReviewByUser(gh, "gfanton"),
+			),
+		},
+		{
 			Description: "Must not contain the \"don't merge\" label",
 			If:          c.Label("don't merge"),
 			Then:        r.Never(),

--- a/contribs/github-bot/internal/requirements/reviewer.go
+++ b/contribs/github-bot/internal/requirements/reviewer.go
@@ -36,10 +36,21 @@ func deduplicateReviews(reviews []*github.PullRequestReview) []*github.PullReque
 				result = append(result, rev)
 				added[rev.User.GetLogin()] = len(result) - 1
 			}
+		case utils.ReviewStateDismissed:
+			// this state just dismisses any previous review, so remove previous
+			// entry for this user if it exists.
+			if ok {
+				result[idx] = nil
+			}
 		default:
 			panic(fmt.Sprintf("invalid review state %q", rev.GetState()))
 		}
 	}
+	// Remove nil entries from the result (dismissed reviews).
+	result = slices.DeleteFunc(result, func(r *github.PullRequestReview) bool {
+		return r == nil
+	})
+
 	return result
 }
 

--- a/contribs/github-bot/internal/requirements/reviewer_test.go
+++ b/contribs/github-bot/internal/requirements/reviewer_test.go
@@ -68,6 +68,16 @@ func Test_deduplicateReviews(t *testing.T) {
 				{User: &github.User{Login: github.String("userB")}, State: github.String("CHANGES_REQUESTED")},
 			},
 		},
+		{
+			name: "two authors - approval/changes requested then dismissed",
+			reviews: []*github.PullRequestReview{
+				{User: &github.User{Login: github.String("user1")}, State: github.String("APPROVED")},
+				{User: &github.User{Login: github.String("user1")}, State: github.String("DISMISSED")},
+				{User: &github.User{Login: github.String("user2")}, State: github.String("CHANGES_REQUESTED")},
+				{User: &github.User{Login: github.String("user2")}, State: github.String("DISMISSED")},
+			},
+			expected: []*github.PullRequestReview{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/contribs/github-bot/internal/utils/github_const.go
+++ b/contribs/github-bot/internal/utils/github_const.go
@@ -23,6 +23,7 @@ const (
 	ReviewStateApproved         ReviewState = "APPROVED"
 	ReviewStateChangesRequested ReviewState = "CHANGES_REQUESTED"
 	ReviewStateCommented        ReviewState = "COMMENTED"
+	ReviewStateDismissed        ReviewState = "DISMISSED"
 )
 
 // Valid determines whether the ReviewState is one of the known ReviewStates.


### PR DESCRIPTION
This PR:
- add dismissed review state support to the bot: https://github.com/gnolang/gno/pull/3890/commits/90cdc51cb5df295fac4e7a1d712f304a98a4e4af (requested here: https://github.com/gnolang/gno/issues/3238#issuecomment-2701523356)
- add gnoweb codeowners to the config: https://github.com/gnolang/gno/pull/3890/commits/f0001ccf2891cab12607a4ee0d400354204a7731 (requested here: https://github.com/gnolang/gno/issues/3238#issuecomment-2693794519)

Note: It might be cleaner in the future to create codeowner teams for different parts of the codebase  (e.g. a `gnoweb-codeowners` team for `gfanton` and `alexiscolin`) rather than manually listing each user in the config. Something to think about.