### PR TITLE
fix: fix docs linting

### DIFF
--- a/docs/builders/deploy-packages.md
+++ b/docs/builders/deploy-packages.md
@@ -150,7 +150,7 @@ a third-party web extension wallet, such as Adena.
 [^1]: Read more about package paths [here](../resources/gno-packages.md).
 [^2]: Other network configurations can be found [here](../resources/gnoland-networks.md).
 [^3]: Address namespaces ([PA namespaces](../resources/gno-packages.md#package-path-structure)) are automatically granted to
-users. Users can register a username using the [gno.land user registry](https://gno.land/r/demo/users),
+users. Users can register a username using the [gno.land user registry](https://gno.land/r/gnoland/users),
 which will grant them access to a matching namespace for that specific network.
 [^4]: Automatic gas estimation is being worked on for `gnokey`. Follow progress
 [here](https://github.com/gnolang/gno/pull/3330).

--- a/docs/resources/users-and-teams.md
+++ b/docs/resources/users-and-teams.md
@@ -11,7 +11,7 @@ In gno.land, users can register a unique username that:
 
 To register a username:
 
-1. Visit the user registry realm at [`gno.land/r/demo/users`](https://gno.land/r/demo/users)
+1. Visit the user registry realm at [`gno.land/r/demo/users`](https://gno.land/r/gnoland/users)
 2. Check if your desired username is available
 3. Register using the following command:
 
@@ -85,4 +85,4 @@ For more information on users and namespaces, refer to:
 - [Realms](./realms.md) - Learn about stateful applications that can be deployed under your namespace
 - [Deploying Packages](../builders/deploy-packages.md) - Instructions for deploying code under your namespace
 
-To explore registered users, visit the [User Registry](https://gno.land/r/demo/users) on the Portal Loop network.
+To explore registered users, visit the [User Registry](https://gno.land/r/gnoland/users) on the Portal Loop network.


### PR DESCRIPTION
Currently, the doc linting fails as bellow:

```
Remote links that need checking:
>>> https://gno.land/r/demo/users (found in file: /Users/yo1110/Projects/teritori/gno/docs/builders/deploy-packages.md)
>>> https://gno.land/r/demo/users (found in file: /Users/yo1110/Projects/teritori/gno/docs/resources/users-and-teams.md)
>>> https://gno.land/r/demo/users (found in file: /Users/yo1110/Projects/teritori/gno/docs/resources/users-and-teams.md)
```

This is due to the refactor of `https://gno.land/r/demo/users` => `https://gno.land/r/gnoland/users`. This PR is to fix that issue.