### PR TITLE
ci: reciprocally test gnovm and examples when they change

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,9 +6,9 @@ on:
       - master
   pull_request:
     paths:
-      - gnovm/**/*.gno
-      - examples/**/*.gno
-      - examples/**/gno.mod
+      # any change to gnovm code can make examples fail
+      - gnovm/**
+      - examples/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/gnovm.yml
+++ b/.github/workflows/gnovm.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - gnovm/**
       - tm2/** # GnoVM has a dependency on TM2 types
+      - examples/** # gnovm has some tests that depend on examples
       # We trigger the testing workflow for changes to the main go.mod,
       # since this can affect test results
       - go.mod

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,13 +22,6 @@ GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
 # test suite flags.
 GOTEST_FLAGS ?= -v -p 1 -timeout=30m
 
-# Official packages (non-overridable): more reliable and tested modules, distinct from the experimentation area.
-OFFICIAL_PACKAGES = ./gno.land/p
-OFFICIAL_PACKAGES += ./gno.land/r/demo
-OFFICIAL_PACKAGES += ./gno.land/r/gnoland
-OFFICIAL_PACKAGES += ./gno.land/r/sys
-OFFICIAL_PACKAGES += ./gno.land/r/gov
-
 ########################################
 # Dev tools
 .PHONY: transpile
@@ -45,7 +38,7 @@ test:
 
 .PHONY: lint
 lint:
-	go run ../gnovm/cmd/gno tool lint -v $(OFFICIAL_PACKAGES)
+	go run ../gnovm/cmd/gno tool lint -v .
 
 .PHONY: test.sync
 test.sync:

--- a/examples/gno.land/r/x/map_delete/gno.mod
+++ b/examples/gno.land/r/x/map_delete/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/x/map_delete

--- a/examples/gno.land/r/x/nir1218_evaluation_proposal/gno.mod
+++ b/examples/gno.land/r/x/nir1218_evaluation_proposal/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/x/nir1218_evaluation_proposal

--- a/examples/gno.land/r/x/skip_height_to_skip_time/gno.mod
+++ b/examples/gno.land/r/x/skip_height_to_skip_time/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/x/skip_height_to_skip_time

--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -234,12 +234,16 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 
 		startedAt := time.Now()
 		runtimeError := catchRuntimeError(gnoPkgPath, io.Err(), func() {
-			foundErr, lintErr := lintTypeCheck(io, memPkg, opts.TestStore)
-			if lintErr != nil {
-				io.ErrPrintln(lintErr)
-				hasError = true
-			} else if foundErr {
-				hasError = true
+			if modfile == nil || !modfile.Draft {
+				foundErr, lintErr := lintTypeCheck(io, memPkg, opts.TestStore)
+				if lintErr != nil {
+					io.ErrPrintln(lintErr)
+					hasError = true
+				} else if foundErr {
+					hasError = true
+				}
+			} else if cfg.verbose {
+				io.ErrPrintfln("%s: module is draft, skipping type check", gnoPkgPath)
 			}
 			err = test.Test(memPkg, pkg.Dir, opts)
 		})


### PR DESCRIPTION
\+ fix the underlying bug in cmd/gno that was causing the failure.