### PR TITLE
feat(gnovm): reject overly unformatted Gno files

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -357,6 +357,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 	// Pay deposit from creator.
 	pkgAddr := gno.DerivePkgAddr(pkgPath)
 
+        println("VMKeeper.AddPackage")
 	// TODO: ACLs.
 	// - if r/system/names does not exists -> skip validation.
 	// - loads r/system/names data state.

--- a/gnovm/pkg/gnolang/gotypecheck.go
+++ b/gnovm/pkg/gnolang/gotypecheck.go
@@ -106,6 +106,11 @@ func (g *gnoImporter) ImportFrom(path, _ string, _ types.ImportMode) (*types.Pac
 	return result, err
 }
 
+const MAX_FILESIZE_PERCENT_GROWTH_AFTER_FMT = 10 // Arbitrary value to tolerate newline removals et al.
+const failOnBloatedUnformattedFiles = true
+
+var ErrFilesizeBloatAfterFmt = errors.New("your file's size increased after formatting beyond the tolerable value")
+
 func (g *gnoImporter) parseCheckMemPackage(mpkg *gnovm.MemPackage, fmt bool) (*types.Package, error) {
 	// This map is used to allow for function re-definitions, which are allowed
 	// in Gno (testing context) but not in Go.
@@ -142,11 +147,25 @@ func (g *gnoImporter) parseCheckMemPackage(mpkg *gnovm.MemPackage, fmt bool) (*t
 
 		// enforce formatting
 		if fmt {
+			originalFileSize := len(file.Body)
 			var buf bytes.Buffer
 			err = format.Node(&buf, fset, f)
 			if err != nil {
 				errs = multierr.Append(errs, err)
 				continue
+			}
+
+			if failOnBloatedUnformattedFiles {
+				// TODO: Perhaps write a parser that on detecting even the simplest
+				// formatting change will fail immediately, instead of actually
+				// invoking format.Node all the way.
+				percentDiff := math.Abs(float64(len(file.Body)-buf.Len())/float64(len(file.Body))) * 100
+				if percentDiff >= MAX_FILESIZE_PERCENT_GROWTH_AFTER_FMT {
+					errs = multierr.Append(errs,
+						fmt.Errorf("%w: grew by %.2f yet max tolerable percentage growth is %.2f, please run go-fmt firstly then try again",
+							ErrFilesizeBloatAfterFmt, percentDiff, MAX_FILESIZE_PERCENT_GROWTH_AFTER_FMT))
+					continue
+				}
 			}
 			file.Body = buf.String()
 		}

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1247,17 +1247,7 @@ func MustPackageNameFromFileBody(name, body string) Name {
 	return pkgName
 }
 
-// ReadMemPackage initializes a new MemPackage by reading the OS directory
-// at dir, and saving it with the given pkgPath (import path).
-// The resulting MemPackage will contain the names and content of all *.gno files,
-// and additionally README.md, LICENSE.
-//
-// ReadMemPackage does not perform validation aside from the package's name;
-// the files are not parsed but their contents are merely stored inside a MemFile.
-//
-// NOTE: panics if package name is invalid (characters must be alphanumeric or _,
-// lowercase, and must start with a letter).
-func ReadMemPackage(dir string, pkgPath string) (*gnovm.MemPackage, error) {
+func TraverseDirForGnoMemPackageFiles(dir, pkgPath string) ([]string, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -1287,6 +1277,24 @@ func ReadMemPackage(dir string, pkgPath string) (*gnovm.MemPackage, error) {
 			continue
 		}
 		list = append(list, filepath.Join(dir, file.Name()))
+	}
+	return list, nil
+}
+
+// ReadMemPackage initializes a new MemPackage by reading the OS directory
+// at dir, and saving it with the given pkgPath (import path).
+// The resulting MemPackage will contain the names and content of all *.gno files,
+// and additionally README.md, LICENSE.
+//
+// ReadMemPackage does not perform validation aside from the package's name;
+// the files are not parsed but their contents are merely stored inside a MemFile.
+//
+// NOTE: panics if package name is invalid (characters must be alphanumeric or _,
+// lowercase, and must start with a letter).
+func ReadMemPackage(dir string, pkgPath string) (*gnovm.MemPackage, error) {
+	list, err := TraverseDirForGnoMemPackageFiles(dir, pkgPath)
+	if err != nil {
+		return nil, err
 	}
 	return ReadMemPackageFromList(list, pkgPath)
 }


### PR DESCRIPTION
This change adds a check to ensure that files aren't grossly unformtted beyond 10% of the original value, so as to account for extraneous spaces which will give the true estimate of storage costs.