### PR TITLE
fix(gnoweb): footer logo link to navigate to home page

### DIFF
--- a/gno.land/pkg/gnoweb/components/layouts/footer.html
+++ b/gno.land/pkg/gnoweb/components/layouts/footer.html
@@ -3,7 +3,7 @@
   <nav class="max-w-screen-max mx-auto px-4 md:px-10 mb-8 md:mb-0 grid grid-cols-1 md:grid-cols-4 justify-between items-start xl:items-center gap-2 xl:gap-20 pt-2 xl:pt-0">
     <!-- Footer Navigation -->
     <div class="col-span-1 pb-8 md:pb-0">
-      <a class="block h-6 md:h-4" href="">{{ template "ui/logo" }}</a>
+      <a class="block h-6 md:h-4" href="/">{{ template "ui/logo" }}</a>
     </div>
     <div class="flex justify-between md:col-span-3">
       {{ range .Sections }}


### PR DESCRIPTION
This PR is to add "/" to the `href` attribute so the logo correctly links to the home page.
