### PR TITLE
fix(pkg/doc): include Consts and Vars of the type in JSON

### DIFF
--- a/gnovm/pkg/doc/json_doc.go
+++ b/gnovm/pkg/doc/json_doc.go
@@ -40,8 +40,8 @@ type JSONValue struct {
 }
 
 type JSONField struct {
-	Name string
-	Type string
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type JSONFunc struct {

--- a/gnovm/pkg/doc/json_doc.go
+++ b/gnovm/pkg/doc/json_doc.go
@@ -127,6 +127,24 @@ func (d *Documentable) WriteJSONDocumentation() (*JSONDocumentation, error) {
 			Doc:       string(pkg.Markdown(typ.Doc)),
 		})
 
+		// values of this type
+		for _, c := range typ.Consts {
+			jsonDoc.Values = append(jsonDoc.Values, &JSONValueDecl{
+				Signature: mustFormatNode(d.pkgData.fset, c.Decl),
+				Const:     true,
+				Values:    d.extractValueSpecs(pkg, c.Decl.Specs),
+				Doc:       string(pkg.Markdown(c.Doc)),
+			})
+		}
+		for _, v := range typ.Vars {
+			jsonDoc.Values = append(jsonDoc.Values, &JSONValueDecl{
+				Signature: mustFormatNode(d.pkgData.fset, v.Decl),
+				Const:     false,
+				Values:    d.extractValueSpecs(pkg, v.Decl.Specs),
+				Doc:       string(pkg.Markdown(v.Doc)),
+			})
+		}
+
 		// constructors for this type
 		for _, fun := range typ.Funcs {
 			jsonDoc.Funcs = append(jsonDoc.Funcs, &JSONFunc{

--- a/gnovm/pkg/doc/json_doc_test.go
+++ b/gnovm/pkg/doc/json_doc_test.go
@@ -83,6 +83,30 @@ func TestJSONDocumentation(t *testing.T) {
 					},
 				},
 			},
+			{
+				Signature: "const myStructConst *myStruct = &myStruct{a: 1000}",
+				Const:     true,
+				Doc:       "This const belongs to the myStruct type\n",
+				Values: []*JSONValue{
+					{
+						Name: "myStructConst",
+						Doc:  "",
+						Type: "*myStruct",
+					},
+				},
+			},
+			{
+				Signature: "var myStructPtr *myStruct",
+				Const:     false,
+				Doc:       "This var belongs to the myStruct type\n",
+				Values: []*JSONValue{
+					{
+						Name: "myStructPtr",
+						Doc:  "",
+						Type: "*myStruct",
+					},
+				},
+			},
 		},
 		Funcs: []*JSONFunc{
 			{

--- a/gnovm/pkg/doc/testdata/integ/hello/hello.gno
+++ b/gnovm/pkg/doc/testdata/integ/hello/hello.gno
@@ -11,6 +11,12 @@ type myStruct struct{ a int }
 
 var myStructInst = myStruct{a: 1000}
 
+// This var belongs to the myStruct type
+var myStructPtr *myStruct
+
+// This const belongs to the myStruct type
+const myStructConst *myStruct = &myStruct{a: 1000}
+
 // Foo is a method for testing
 func (ms myStruct) Foo() string { return "myStruct.Foo" }
 


### PR DESCRIPTION
This is a follow-on to the vm/qdoc PR https://github.com/gnolang/gno/pull/3459 . We already handle the case where the AST lists type constructors as part of the Type description. We also need to handle the case where consts and vars of the type are listed as part of the Type description (not in the main Consts and Vars sections). See the [updated lines in the hello test](https://github.com/gnolang/gno/blob/a693cd5146591261f90956e1899f5460d39535bc/gnovm/pkg/doc/testdata/integ/hello/hello.gno#L14-L18). 
```
  var myStructPtr *myStruct
  myStructConst *myStruct = &myStruct{a: 1000}
```
For these values to appear in the vm/qdoc result, this PR fix is needed.

We also fix an oversight in the `JSONField` struct to add the json field names.