### PR TITLE
fix(tm2): filter validator updates by valid power & pubkey

### DIFF
--- a/tm2/pkg/bft/state/execution.go
+++ b/tm2/pkg/bft/state/execution.go
@@ -328,6 +328,7 @@ func filterValidatorUpdates(abciUpdates []abci.ValidatorUpdate,
 		} else if valUpdate.Power == 0 {
 			// continue, since this is deleting the validator, and thus there is no
 			// pubkey to check
+			validUpdates = append(validUpdates, valUpdate)
 			continue
 		}
 

--- a/tm2/pkg/bft/state/execution_test.go
+++ b/tm2/pkg/bft/state/execution_test.go
@@ -195,7 +195,7 @@ func TestValidateValidatorUpdates(t *testing.T) {
 				"filtered updates length mismatch")
 
 			// Check powers of remaining validators
-			var powers []int64
+			var powers = []int64{}
 			for _, update := range filteredUpdates {
 				powers = append(powers, update.Power)
 			}

--- a/tm2/pkg/bft/state/export_test.go
+++ b/tm2/pkg/bft/state/export_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"log/slog"
+
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
@@ -32,8 +34,8 @@ func UpdateState(
 
 // ValidateValidatorUpdates is an alias for validateValidatorUpdates exported
 // from execution.go, exclusively and explicitly for testing.
-func ValidateValidatorUpdates(abciUpdates []abci.ValidatorUpdate, params abci.ValidatorParams) error {
-	return validateValidatorUpdates(abciUpdates, params)
+func FilterValidatorUpdates(abciUpdates []abci.ValidatorUpdate, params abci.ValidatorParams, logger *slog.Logger) []abci.ValidatorUpdate {
+	return filterValidatorUpdates(abciUpdates, params, logger)
 }
 
 // CalcValidatorsKey is an alias for the private calcValidatorsKey method in


### PR DESCRIPTION
# Prevent node crash on invalid validator pubkey type & invalid voting power
> fix #3842 
--------------------

## Problem

Currently, when a validator with an unsupported public key type (e.g., secp256k1 instead of ed25519) is added through GovDAO, the node crashes with the following error:

```txt
Error on ApplyBlock. Did the application crash? Please restart tendermint       {"module": "consensus", "err": "Error in validator updates: validator {g1jAddress... gpubkey... 1} is using pubkey /tm.PubKeySecp256k1, which is unsupported for consensus"}
```

## Solution

Instead of failing the entire block execution when encountering invalid validator updates, we now filter out invalid validators updates and continue with the valid ones. This makes the system more resilient while maintaining security.

## Changes

Before:

```go
// Old approach - would error and crash
err = validateValidatorUpdates(abciValUpdates, *state.ConsensusParams.Validator)
if err != nil {
    return state, fmt.Errorf("Error in validator updates: %w", err)
}
```

After:

```go
// New approach - filters invalid updates and continues
filteredValUpdates = filterValidatorUpdates(
    abciValUpdates,
    *state.ConsensusParams.Validator,
    blockExec.logger,
)
```

- Added comprehensive logging for filtered validators to help track issues
- Updated tests to verify filtering behavior instead of error conditions

I think this change does not compromise security as invalid validators are still prevented from joining the validator set. The only difference is that the system continues operating instead of crashing when encountering invalid updates.
