### PR TITLE
fix(gnovm): allow multiple NaN keys in maps

### DIFF
--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1391,7 +1391,7 @@ func fillTypesOfValue(store Store, val Value) Value {
 			fillTypesTV(store, &cur.Key)
 			fillTypesTV(store, &cur.Value)
 
-			cv.vmap[cur.Key.ComputeMapKey(store, false)] = cur
+			cv.vmap[cur.Key.ComputeMapKey(store, false, cv)] = cur
 		}
 		return cv
 	case TypeValue:

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1459,12 +1459,13 @@ func (tv *TypedValue) AssertNonNegative(msg string) {
 	}
 }
 
-// uvnan is the unsigned value of NaN. It can be contructed by applying the following:
+// uvnan is the unsigned value of NaN. It can be obtained by applying the following:
 // { var nan = math.NaN(); var uvnan = *(*uint64)(unsafe.Pointer(&nan)) }
 const uvnan = 0x7FF8000000000001
 
-// randNaN returns an uint64 representation of NaN with a random payload.
+// randNaN returns an uint64 representation of NaN with a random payload of 53 bits.
 func randNaN() uint64 {
+	//nolint: gosec
 	return rand.Uint64()&^uvnan | uvnan
 }
 

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1465,8 +1465,7 @@ const uvnan = 0x7FF8000000000001
 
 // randNaN returns an uint64 representation of NaN with a random payload of 53 bits.
 func randNaN() uint64 {
-	//nolint: gosec
-	return rand.Uint64()&^uvnan | uvnan
+	return rand.Uint64()&^uvnan | uvnan //nolint:gosec
 }
 
 // IsNaN reports wether tv is an IEEE 754 "not a number" value.

--- a/gnovm/tests/files/map30.gno
+++ b/gnovm/tests/files/map30.gno
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+var NaN = math.NaN()
+
+func main() {
+	fmt.Println(map[float64]int{NaN: 1, NaN: 2})
+}
+
+// Output:
+// map[NaN:1 NaN:2]

--- a/gnovm/tests/files/map31.gno
+++ b/gnovm/tests/files/map31.gno
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+var NaN = float32(math.NaN())
+
+func main() {
+	fmt.Println(map[float32]int{NaN: 1, NaN: 2})
+}
+
+// Output:
+// map[NaN:1 NaN:2]


### PR DESCRIPTION
The behavior of maps with NaN now matches Go.

Fixes #3867.