### PR TITLE
refactor(vm): use expected keeper interface

### DIFF
--- a/gno.land/pkg/sdk/vm/builtins.go
+++ b/gno.land/pkg/sdk/vm/builtins.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
-	"github.com/gnolang/gno/tm2/pkg/sdk/params"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
@@ -69,11 +68,11 @@ func (bnk *SDKBanker) RemoveCoin(b32addr crypto.Bech32Address, denom string, amo
 // Users must write code to limit access as appropriate.
 
 type SDKParams struct {
-	pmk params.ParamsKeeper
+	pmk ParamsKeeperI
 	ctx sdk.Context
 }
 
-func NewSDKParams(pmk params.ParamsKeeper, ctx sdk.Context) *SDKParams {
+func NewSDKParams(pmk ParamsKeeperI, ctx sdk.Context) *SDKParams {
 	return &SDKParams{
 		pmk: pmk,
 		ctx: ctx,

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -24,9 +24,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	osm "github.com/gnolang/gno/tm2/pkg/os"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
-	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
-	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
-	"github.com/gnolang/gno/tm2/pkg/sdk/params"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/store"
 	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
@@ -66,9 +63,9 @@ type VMKeeper struct {
 
 	baseKey store.StoreKey
 	iavlKey store.StoreKey
-	acck    auth.AccountKeeper
-	bank    bank.BankKeeper
-	prmk    params.ParamsKeeper
+	acck    AccountKeeperI
+	bank    BankKeeperI
+	prmk    ParamsKeeperI
 
 	// cached, the DeliverTx persistent state.
 	gnoStore gno.Store
@@ -80,9 +77,9 @@ type VMKeeper struct {
 func NewVMKeeper(
 	baseKey store.StoreKey,
 	iavlKey store.StoreKey,
-	acck auth.AccountKeeper,
-	bank bank.BankKeeper,
-	prmk params.ParamsKeeper,
+	acck AccountKeeperI,
+	bank BankKeeperI,
+	prmk ParamsKeeperI,
 ) *VMKeeper {
 	vmk := &VMKeeper{
 		baseKey: baseKey,

--- a/gno.land/pkg/sdk/vm/types.go
+++ b/gno.land/pkg/sdk/vm/types.go
@@ -1,6 +1,33 @@
 package vm
 
-import "github.com/gnolang/gno/tm2/pkg/amino"
+import (
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/sdk/params"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// AccountKeeperI is the limited interface only needed for VM.
+type AccountKeeperI interface {
+	GetAccount(ctx sdk.Context, addr crypto.Address) std.Account
+}
+
+// BankKeeperI is the limited interface only needed for VM.
+type BankKeeperI interface {
+	GetCoins(ctx sdk.Context, addr crypto.Address) std.Coins
+	SendCoins(ctx sdk.Context, fromAddr crypto.Address, toAddr crypto.Address, amt std.Coins) error
+	SubtractCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) (std.Coins, error)
+	AddCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) (std.Coins, error)
+}
+
+// ParamsKeeperI is the limited interface only needed for VM.
+type ParamsKeeperI interface {
+	params.ParamsKeeperI
+
+	IsRegistered(moduleName string) bool
+	GetRegisteredKeeper(moduleName string) params.ParamfulKeeper
+}
 
 // Public facing function signatures.
 // See convertArgToGno() for supported types.


### PR DESCRIPTION
The goal of this PR is to prepare making more usable the GnoVM by potentially other chains.

This follow the pattern that exists in the Cosmos SDK (https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-beta.2/x/gov/types/expected_keepers.go) and that is being used in this repo as well: https://github.com/julienrbrt/gno/blob/71fbdef783b5d72ca603ed45b8fb10434ca0ab11/tm2/pkg/sdk/auth/types.go#L23.