### PR TITLE
feat(commondao): simplify tally allowing prop definitions to deal with logic

### DIFF
--- a/examples/gno.land/p/gnoland/commondao/commondao.gno
+++ b/examples/gno.land/p/gnoland/commondao/commondao.gno
@@ -16,10 +16,9 @@ const PathSeparator = "/"
 
 var (
 	ErrInvalidVoteChoice    = errors.New("invalid vote choice")
-	ErrLowParticipation     = errors.New("low participation")
-	ErrNoConcensus          = errors.New("no concensus")
 	ErrNotMember            = errors.New("account is not a member of the DAO")
 	ErrOverflow             = errors.New("next ID overflows uint64")
+	ErrProposalFailed       = errors.New("proposal failed to pass")
 	ErrProposalNotFound     = errors.New("proposal not found")
 	ErrVotingDeadlineNotMet = errors.New("voting deadline not met")
 )
@@ -126,6 +125,15 @@ func (dao *CommonDAO) Propose(creator std.Address, d ProposalDefinition) (*Propo
 	return p, nil
 }
 
+// MustPropose creates a new DAO proposal or panics on error.
+func (dao *CommonDAO) MustPropose(creator std.Address, d ProposalDefinition) *Proposal {
+	p, err := dao.Propose(creator, d)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 // GetActiveProposal returns an active proposal.
 func (dao CommonDAO) GetActiveProposal(proposalID uint64) (_ *Proposal, found bool) {
 	key := makeProposalKey(proposalID)
@@ -176,17 +184,25 @@ func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice, 
 	return nil
 }
 
-func (dao *CommonDAO) Tally(proposalID uint64) error { // TODO: Rethink or refactor tally to return the winning choice
+// Tally counts votes and validates if a proposal passes.
+func (dao *CommonDAO) Tally(proposalID uint64) (passes bool, _ error) {
 	p, found := dao.GetActiveProposal(proposalID)
 	if !found {
-		return ErrProposalNotFound
+		return false, ErrProposalNotFound
 	}
 
 	if p.Status() != StatusActive {
-		return ErrStatusIsNotActive
+		return false, ErrStatusIsNotActive
 	}
 
-	return dao.tallyProposal(p)
+	if err := dao.checkProposalPasses(p); err != nil {
+		// Don't return an error if proposal failed to pass when tallying
+		if err == ErrProposalFailed {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // Execute executes a proposal.
@@ -204,10 +220,18 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 		return ErrVotingDeadlineNotMet
 	}
 
-	// From this point any error results in execution success and proposal failure
+	// From this point any error results in a proposal failure and successful execution
 	err := p.Validate()
+
 	if err == nil {
-		err = dao.executeProposal(p)
+		err = dao.checkProposalPasses(p)
+	}
+
+	if err == nil {
+		// Execute proposal only if it's executable
+		if e, ok := p.Definition().(Executable); ok {
+			err = e.Execute()
+		}
 	}
 
 	// Proposal fails if there is any error during validation and execution process
@@ -215,7 +239,7 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 		p.status = StatusFailed
 		p.statusReason = err.Error()
 	} else {
-		p.status = StatusExecuted
+		p.status = StatusPassed
 	}
 
 	// Whichever the outcome of the validation, tallying
@@ -226,41 +250,16 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 	return nil
 }
 
-func (dao *CommonDAO) tallyProposal(p *Proposal) error {
-	votesCount := 0
-	record := p.VotingRecord()
-	for _, c := range p.VoteChoices() {
-		// Don't count explicit abstentions or invalid votes
-		if c == ChoiceNone || c == ChoiceAbstain {
-			continue
-		}
-
-		votesCount += record.VoteCount(c)
-	}
-
-	membersCount := dao.Members().Size()
-	percentage := float64(votesCount) / float64(membersCount)
-	if percentage < p.Quorum() {
-		return ErrLowParticipation
-	}
-
-	if !p.Definition().Tally(record.ReadOnly(), membersCount) {
-		return ErrNoConcensus
-	}
-	return nil
-}
-
-func (dao *CommonDAO) executeProposal(p *Proposal) error {
-	if p.Status() != StatusActive {
-		return ErrStatusIsNotActive
-	}
-
-	if err := dao.tallyProposal(p); err != nil {
+func (dao *CommonDAO) checkProposalPasses(p *Proposal) error {
+	record := p.VotingRecord().ReadOnly()
+	members := NewMemberSet(*dao.Members())
+	passes, err := p.Definition().Tally(record, members)
+	if err != nil {
 		return err
 	}
 
-	if e, ok := p.Definition().(Executable); ok {
-		return e.Execute()
+	if !passes {
+		return ErrProposalFailed
 	}
 	return nil
 }

--- a/examples/gno.land/p/gnoland/commondao/commondao.gno
+++ b/examples/gno.land/p/gnoland/commondao/commondao.gno
@@ -251,7 +251,7 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 }
 
 func (dao *CommonDAO) checkProposalPasses(p *Proposal) error {
-	record := p.VotingRecord().ReadOnly()
+	record := p.VotingRecord().Readonly()
 	members := NewMemberSet(*dao.Members())
 	passes, err := p.Definition().Tally(record, members)
 	if err != nil {

--- a/examples/gno.land/p/gnoland/commondao/commondao_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/commondao_test.gno
@@ -269,128 +269,80 @@ func TestCommonDAOVote(t *testing.T) {
 }
 
 func TestCommonDAOTally(t *testing.T) {
+	errTest := errors.New("test")
+	member := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
 	cases := []struct {
-		name       string
-		dao        *CommonDAO
-		definition ProposalDefinition
-		votes      []Vote
-		err        error
+		name   string
+		setup  func(*CommonDAO) (proposalID uint64)
+		passes bool
+		err    error
 	}{
 		{
 			name: "pass",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{},
-			votes: []Vote{
-				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
+			setup: func(dao *CommonDAO) uint64 {
+				return dao.MustPropose(member, testPropDef{tallyResult: true}).ID()
 			},
+			passes: true,
 		},
 		{
-			name: "pass with custom vote choices",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{
-				testPropDef{voteChoices: []VoteChoice{"FOO", "BAR"}},
+			name: "fail to pass",
+			setup: func(dao *CommonDAO) uint64 {
+				return dao.MustPropose(member, testPropDef{tallyResult: false}).ID()
 			},
-			votes: []Vote{
-				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: VoteChoice("FOO")},
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: VoteChoice("FOO")},
-			},
+			passes: false,
 		},
 		{
-			name:       "no votes",
-			dao:        New(),
-			definition: majorityPropDef{},
-			err:        ErrLowParticipation,
+			name:  "proposal not found",
+			setup: func(*CommonDAO) uint64 { return 404 },
+			err:   ErrProposalNotFound,
 		},
 		{
-			name: "no quorum",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{},
-			votes: []Vote{
-				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
+			name: "proposal status not active",
+			setup: func(dao *CommonDAO) uint64 {
+				p := dao.MustPropose(member, testPropDef{})
+				p.status = StatusPassed
+				return p.ID()
 			},
-			err: ErrLowParticipation,
+			err: ErrStatusIsNotActive,
 		},
 		{
-			name: "no quorum with custom vote choices",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{
-				testPropDef{voteChoices: []VoteChoice{"FOO", "BAR"}},
+			name: "proposal failed error",
+			setup: func(dao *CommonDAO) uint64 {
+				return dao.MustPropose(member, testPropDef{tallyErr: ErrProposalFailed}).ID()
 			},
-			votes: []Vote{
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: VoteChoice("FOO")},
-			},
-			err: ErrLowParticipation,
+			passes: false,
 		},
 		{
-			name: "no consensus",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{},
-			votes: []Vote{
-				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceNo},
+			name: "error",
+			setup: func(dao *CommonDAO) uint64 {
+				return dao.MustPropose(member, testPropDef{tallyErr: errTest}).ID()
 			},
-			err: ErrNoConcensus,
-		},
-		{
-			name: "no consensus with custom vote choices",
-			dao: New(
-				WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"),
-				WithMember("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"),
-				WithMember("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-			),
-			definition: majorityPropDef{
-				testPropDef{voteChoices: []VoteChoice{"FOO", "BAR"}},
-			},
-			votes: []Vote{
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: VoteChoice("FOO")},
-				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: VoteChoice("BAR")},
-			},
-			err: ErrNoConcensus,
+			err: errTest,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			p, _ := tc.dao.Propose("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", tc.definition)
-			for _, v := range tc.votes {
-				tc.dao.Vote(v.Address, p.ID(), v.Choice, "")
-			}
+			dao := New(WithMember(member))
+			proposalID := tc.setup(dao)
 
-			err := tc.dao.Tally(p.ID())
+			passes, err := dao.Tally(proposalID)
 
 			if tc.err != nil {
-				uassert.Error(t, err, "expect an error")
-			} else {
-				uassert.NoError(t, err, "expect no error")
+				uassert.ErrorIs(t, err, tc.err, "expect an error")
+				uassert.False(t, passes, "expect tally to fail")
+				return
 			}
+
+			uassert.NoError(t, err, "expect no error")
+			uassert.Equal(t, tc.passes, passes, "expect tally success value to match")
 		})
 	}
 }
 
 func TestCommonDAOExecute(t *testing.T) {
-	errValidation := errors.New("validation error")
-	errExecution := errors.New("execution error")
+	errTest := errors.New("test")
+	member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
 	cases := []struct {
 		name         string
 		setup        func() *CommonDAO
@@ -402,18 +354,11 @@ func TestCommonDAOExecute(t *testing.T) {
 		{
 			name: "success",
 			setup: func() *CommonDAO {
-				members := []std.Address{
-					"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
-					"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
-					"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-				}
-				dao := New(WithMember(members[0]), WithMember(members[1]), WithMember(members[2]))
-				p, _ := dao.Propose(members[0], testPropDef{tallyResult: true})
-				p.record.AddVote(Vote{Address: members[0], Choice: ChoiceYes})
-				p.record.AddVote(Vote{Address: members[1], Choice: ChoiceYes})
+				dao := New(WithMember(member))
+				dao.Propose(member, testPropDef{tallyResult: true})
 				return dao
 			},
-			status:     StatusExecuted,
+			status:     StatusPassed,
 			proposalID: 1,
 		},
 		{
@@ -425,10 +370,9 @@ func TestCommonDAOExecute(t *testing.T) {
 		{
 			name: "proposal not active",
 			setup: func() *CommonDAO {
-				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
 				dao := New(WithMember(member))
 				p, _ := dao.Propose(member, testPropDef{})
-				p.status = StatusExecuted
+				p.status = StatusPassed
 				return dao
 			},
 			proposalID: 1,
@@ -437,7 +381,6 @@ func TestCommonDAOExecute(t *testing.T) {
 		{
 			name: "voting deadline not met",
 			setup: func() *CommonDAO {
-				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
 				dao := New(WithMember(member))
 				dao.Propose(member, testPropDef{votingPeriod: time.Minute * 5})
 				return dao
@@ -448,47 +391,38 @@ func TestCommonDAOExecute(t *testing.T) {
 		{
 			name: "validation error",
 			setup: func() *CommonDAO {
-				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
 				dao := New(WithMember(member))
-				dao.Propose(member, testPropDef{validationErr: errValidation})
+				dao.Propose(member, testPropDef{validationErr: errTest})
 				return dao
 			},
 			proposalID:   1,
 			status:       StatusFailed,
-			statusReason: errValidation.Error(),
+			statusReason: errTest.Error(),
 		},
 		{
 			name: "tally error",
 			setup: func() *CommonDAO {
-				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
 				dao := New(WithMember(member))
-				dao.Propose(member, testPropDef{})
+				dao.Propose(member, testPropDef{tallyErr: errTest})
 				return dao
 			},
 			proposalID:   1,
 			status:       StatusFailed,
-			statusReason: ErrLowParticipation.Error(),
+			statusReason: errTest.Error(),
 		},
 		{
 			name: "execution error",
 			setup: func() *CommonDAO {
-				members := []std.Address{
-					"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
-					"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
-					"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-				}
-				dao := New(WithMember(members[0]), WithMember(members[1]), WithMember(members[2]))
-				p, _ := dao.Propose(members[0], testPropDef{
+				dao := New(WithMember(member))
+				dao.Propose(member, testPropDef{
 					tallyResult:  true,
-					executionErr: errExecution,
+					executionErr: errTest,
 				})
-				p.record.AddVote(Vote{Address: members[0], Choice: ChoiceYes})
-				p.record.AddVote(Vote{Address: members[1], Choice: ChoiceYes})
 				return dao
 			},
 			proposalID:   1,
 			status:       StatusFailed,
-			statusReason: errExecution.Error(),
+			statusReason: errTest.Error(),
 		},
 	}
 
@@ -514,11 +448,4 @@ func TestCommonDAOExecute(t *testing.T) {
 			uassert.Equal(t, string(p.StatusReason()), string(tc.statusReason), "status reason must match")
 		})
 	}
-}
-
-type majorityPropDef struct{ testPropDef }
-
-func (majorityPropDef) Tally(r ReadOnlyVotingRecord, membersCount int) bool {
-	_, success := SelectChoiceByAbsoluteMajority(r, membersCount)
-	return success
 }

--- a/examples/gno.land/p/gnoland/commondao/memberset.gno
+++ b/examples/gno.land/p/gnoland/commondao/memberset.gno
@@ -7,7 +7,7 @@ import (
 )
 
 // NewMemberSet creates a new readonly memberset.
-func NewMemberSet(members addrset.Set) MemberSet {
+func NewMemberSet(members addrset.Set) MemberSet { // TODO: Use an interface instead of addrset.Set
 	return MemberSet{members}
 }
 

--- a/examples/gno.land/p/gnoland/commondao/memberset.gno
+++ b/examples/gno.land/p/gnoland/commondao/memberset.gno
@@ -1,0 +1,33 @@
+package commondao
+
+import (
+	"std"
+
+	"gno.land/p/moul/addrset"
+)
+
+// NewMemberSet creates a new readonly memberset.
+func NewMemberSet(members addrset.Set) MemberSet {
+	return MemberSet{members}
+}
+
+// MemberSet contains a readonly list of member addresses.
+type MemberSet struct {
+	members addrset.Set
+}
+
+// Size returns the number of addresses in the set.
+func (s MemberSet) Size() int {
+	return s.members.Size()
+}
+
+// Has checks if an address exists in the set.
+func (s MemberSet) Has(member std.Address) bool {
+	return s.members.Has(member)
+}
+
+// IterateByOffset walks through addresses starting at the given offset.
+// The callback should return true to stop iteration.
+func (s MemberSet) IterateByOffset(offset, count int, fn func(std.Address) bool) {
+	s.members.IterateByOffset(offset, count, fn)
+}

--- a/examples/gno.land/p/gnoland/commondao/memberset_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/memberset_test.gno
@@ -1,0 +1,45 @@
+package commondao
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/uassert"
+	"gno.land/p/moul/addrset"
+)
+
+func TestMemberSetSize(t *testing.T) {
+	var set addrset.Set
+	members := NewMemberSet(set)
+	uassert.Equal(t, 0, members.Size(), "expect size 0")
+
+	set.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	members = NewMemberSet(set)
+	uassert.Equal(t, 1, members.Size(), "expect size 1")
+
+	set.Add("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
+	members = NewMemberSet(set)
+	uassert.Equal(t, 2, members.Size(), "expect size 2")
+}
+
+func TestMemberSetHas(t *testing.T) {
+	var set addrset.Set
+	set.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+
+	members := NewMemberSet(set)
+
+	uassert.True(t, members.Has("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"), "expect member is found")
+	uassert.False(t, members.Has("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"), "expect member is not found")
+}
+
+func TestMemberSetIterateByOffset(t *testing.T) {
+	var set addrset.Set
+	set.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	set.Add("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn") // <--
+	set.Add("g1w4ek2u3jta047h6lta047h6lta047h6l9huexc")
+
+	NewMemberSet(set).IterateByOffset(1, 1, func(addr std.Address) bool {
+		uassert.Equal(t, "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", addr.String(), "expect address to match")
+		return true
+	})
+}

--- a/examples/gno.land/p/gnoland/commondao/proposal.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal.gno
@@ -22,9 +22,18 @@ const (
 	ChoiceAbstain               = "ABSTAIN"
 )
 
+const (
+	QuorumOneThird     float64 = 0.33 // percentage
+	QuorumHalf                 = 0.5
+	QuorumTwoThirds            = 0.66
+	QuorumThreeFourths         = 0.75
+	QuorumFull                 = 1
+)
+
 var (
 	ErrInvalidCreatorAddress      = errors.New("invalid proposal creator address")
 	ErrProposalDefinitionRequired = errors.New("proposal definition is required")
+	ErrNoQuorum                   = errors.New("no quorum")
 	ErrStatusIsNotActive          = errors.New("proposal status is not active")
 )
 
@@ -203,4 +212,24 @@ func (p Proposal) Validate() error {
 // IsValidVoteChoice checks if a vote choice is valid for the proposal.
 func (p Proposal) IsValidVoteChoice(c VoteChoice) bool {
 	return p.voteChoices.Has(string(c))
+}
+
+// IsQuorumReached checks if a participation quorum is reach.
+func IsQuorumReached(quorum float64, r ReadonlyVotingRecord, members MemberSet) bool {
+	if members.Size() <= 0 || quorum < 0 {
+		return false
+	}
+
+	var votesCount int
+	for _, c := range r.Choices() {
+		// Don't count explicit abstentions or invalid votes
+		if c == ChoiceNone || c == ChoiceAbstain {
+			continue
+		}
+
+		votesCount += r.VoteCount(c)
+	}
+
+	percentage := float64(votesCount) / float64(members.Size())
+	return percentage >= quorum
 }

--- a/examples/gno.land/p/gnoland/commondao/proposal.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal.gno
@@ -65,7 +65,7 @@ type (
 		VotingPeriod() time.Duration
 
 		// Tally counts the number of votes and verifies if proposal passes.
-		Tally(r ReadOnlyVotingRecord, members MemberSet) (passes bool, _ error)
+		Tally(r ReadonlyVotingRecord, members MemberSet) (passes bool, _ error)
 	}
 
 	// Validable defines an interface for proposal definitions that require state validation.

--- a/examples/gno.land/p/gnoland/commondao/proposal.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal.gno
@@ -216,7 +216,7 @@ func (p Proposal) IsValidVoteChoice(c VoteChoice) bool {
 
 // IsQuorumReached checks if a participation quorum is reach.
 func IsQuorumReached(quorum float64, r ReadonlyVotingRecord, members MemberSet) bool {
-	if members.Size() <= 0 || quorum < 0 {
+	if members.Size() <= 0 || quorum <= 0 {
 		return false
 	}
 

--- a/examples/gno.land/p/gnoland/commondao/proposal.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal.gno
@@ -8,20 +8,18 @@ import (
 	"gno.land/p/demo/avl"
 )
 
-// DefaultQuorum defines the default quorum required to tally proposal votes.
-const DefaultQuorum = 0.34 // 34%
-
 const (
-	StatusActive   ProposalStatus = "active"
-	StatusFailed                  = "failed"
-	StatusExecuted                = "executed"
+	StatusActive ProposalStatus = "active"
+	StatusFailed                = "failed"
+	StatusPassed                = "passed"
 )
 
 const (
-	ChoiceNone    VoteChoice = ""
-	ChoiceYes                = "YES"
-	ChoiceNo                 = "NO"
-	ChoiceAbstain            = "ABSTAIN"
+	ChoiceNone       VoteChoice = ""
+	ChoiceYes                   = "YES"
+	ChoiceNo                    = "NO"
+	ChoiceNoWithVeto            = "NO WITH VETO"
+	ChoiceAbstain               = "ABSTAIN"
 )
 
 var (
@@ -66,14 +64,8 @@ type (
 		// the voting deadline from the proposal's creationd date.
 		VotingPeriod() time.Duration
 
-		// Quorum returns the percentage of members that must vote to be able to pass a proposal.
-		// This is an optional value. DAOs use a default value when quorum is zero or invalid.
-		// Its value must be between 0 and 1, being 1 = 100% of member votes.
-		Quorum() float64
-
-		// Tally counts the number of votes and verifies that there is consensus.
-		// Tally fails when none of the vote choices wins over the others.
-		Tally(r ReadOnlyVotingRecord, memberCount int) (success bool)
+		// Tally counts the number of votes and verifies if proposal passes.
+		Tally(r ReadOnlyVotingRecord, members MemberSet) (passes bool, _ error)
 	}
 
 	// Validable defines an interface for proposal definitions that require state validation.
@@ -147,15 +139,6 @@ func (p Proposal) ID() uint64 {
 // Proposal definitions define proposal content and behavior.
 func (p Proposal) Definition() ProposalDefinition {
 	return p.definition
-}
-
-// Quorum returns the percentage of members that must vote to be able to pass a proposal.
-func (p Proposal) Quorum() float64 {
-	quorum := p.definition.Quorum()
-	if quorum <= 0 || quorum > 1 {
-		quorum = DefaultQuorum
-	}
-	return quorum
 }
 
 // Status returns the current proposal status.

--- a/examples/gno.land/p/gnoland/commondao/proposal_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal_test.gno
@@ -7,6 +7,7 @@ import (
 
 	"gno.land/p/demo/uassert"
 	"gno.land/p/demo/urequire"
+	"gno.land/p/moul/addrset"
 )
 
 func TestProposalNew(t *testing.T) {
@@ -61,6 +62,197 @@ func TestProposalVoteChoices(t *testing.T) {
 			urequire.Equal(t, len(choices), len(tc.choices), "expect vote choice count to match")
 			for i, c := range choices {
 				urequire.True(t, tc.choices[i] == c, "expect vote choice to match")
+			}
+		})
+	}
+}
+
+func TestIsQuorumReached(t *testing.T) {
+	cases := []struct {
+		name    string
+		quorum  float64
+		members []std.Address
+		votes   []Vote
+		fail    bool
+	}{
+		{
+			name:   "one third",
+			quorum: QuorumOneThird,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
+			},
+		},
+		{
+			name:   "one third no quorum",
+			quorum: QuorumOneThird,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+			},
+			fail: true,
+		},
+		{
+			name:   "half",
+			quorum: QuorumHalf,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+				"g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
+			},
+			votes: []Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
+				{Address: "g1w4ek2u3jta047h6lta047h6lta047h6l9huexc", Choice: ChoiceNo},
+			},
+		},
+		{
+			name:   "half no quorum",
+			quorum: QuorumHalf,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+				"g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceYes},
+			},
+			fail: true,
+		},
+		{
+			name:   "two thirds",
+			quorum: QuorumTwoThirds,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+			},
+			votes: []Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
+				{Address: "g1w4ek2u3jta047h6lta047h6lta047h6l9huexc", Choice: ChoiceNo},
+			},
+		},
+		{
+			name:   "two thirds no quorum",
+			quorum: QuorumTwoThirds,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u3jta047h6lta047h6lta047h6l9huexc", Choice: ChoiceNo},
+			},
+			fail: true,
+		},
+		{
+			name:   "three fourths",
+			quorum: QuorumThreeFourths,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+				"g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
+			},
+			votes: []Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
+				{Address: "g1w4ek2u3jta047h6lta047h6lta047h6l9huexc", Choice: ChoiceNo},
+				{Address: "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt", Choice: ChoiceNo},
+			},
+		},
+		{
+			name:   "three fourths no quorum",
+			quorum: QuorumThreeFourths,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+				"g1w4ek2u3jta047h6lta047h6lta047h6l9huexc",
+				"g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
+			},
+			votes: []Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceYes},
+			},
+			fail: true,
+		},
+		{
+			name:   "full",
+			quorum: QuorumFull,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+			},
+			votes: []Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Choice: ChoiceNo},
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceNo},
+			},
+		},
+		{
+			name:   "full no quorum",
+			quorum: QuorumFull,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceNo},
+			},
+			fail: true,
+		},
+		{
+			name:   "no quorum with empty vote",
+			quorum: QuorumHalf,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceNone},
+			},
+			fail: true,
+		},
+		{
+			name:   "no quorum with abstention",
+			quorum: QuorumHalf,
+			members: []std.Address{
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn",
+			},
+			votes: []Vote{
+				{Address: "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn", Choice: ChoiceAbstain},
+			},
+			fail: true,
+		},
+		{
+			name:   "invalid quorum percentage",
+			quorum: -1,
+			fail:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var members addrset.Set
+			for _, m := range tc.members {
+				members.Add(m)
+			}
+
+			var record VotingRecord
+			for _, v := range tc.votes {
+				record.AddVote(v)
+			}
+
+			success := IsQuorumReached(tc.quorum, record.Readonly(), NewMemberSet(members))
+
+			if tc.fail {
+				uassert.False(t, success, "expect quorum to fail")
+			} else {
+				uassert.True(t, success, "expect quorum to succeed")
 			}
 		})
 	}

--- a/examples/gno.land/p/gnoland/commondao/proposal_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal_test.gno
@@ -79,7 +79,7 @@ func (d testPropDef) VotingPeriod() time.Duration { return d.votingPeriod }
 func (d testPropDef) Validate() error             { return d.validationErr }
 func (d testPropDef) Execute() error              { return d.executionErr }
 
-func (d testPropDef) Tally(ReadOnlyVotingRecord, MemberSet) (bool, error) {
+func (d testPropDef) Tally(ReadonlyVotingRecord, MemberSet) (bool, error) {
 	return d.tallyResult, d.tallyErr
 }
 

--- a/examples/gno.land/p/gnoland/commondao/proposal_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal_test.gno
@@ -19,7 +19,6 @@ func TestProposalNew(t *testing.T) {
 	uassert.NoError(t, err)
 	uassert.Equal(t, p.ID(), id)
 	uassert.NotEqual(t, p.Definition(), nil)
-	uassert.Equal(t, p.Quorum(), DefaultQuorum)
 	uassert.True(t, p.Status() == StatusActive)
 	uassert.Equal(t, p.Creator(), creator)
 	uassert.False(t, p.CreatedAt().IsZero())
@@ -68,19 +67,21 @@ func TestProposalVoteChoices(t *testing.T) {
 }
 
 type testPropDef struct {
-	votingPeriod                time.Duration
-	tallyResult                 bool
-	validationErr, executionErr error
-	voteChoices                 []VoteChoice
+	votingPeriod                          time.Duration
+	tallyResult                           bool
+	validationErr, tallyErr, executionErr error
+	voteChoices                           []VoteChoice
 }
 
-func (testPropDef) Title() string                          { return "" }
-func (testPropDef) Body() string                           { return "" }
-func (testPropDef) Quorum() float64                        { return 0 }
-func (d testPropDef) VotingPeriod() time.Duration          { return d.votingPeriod }
-func (d testPropDef) Validate() error                      { return d.validationErr }
-func (d testPropDef) Tally(ReadOnlyVotingRecord, int) bool { return d.tallyResult }
-func (d testPropDef) Execute() error                       { return d.executionErr }
+func (testPropDef) Title() string                 { return "" }
+func (testPropDef) Body() string                  { return "" }
+func (d testPropDef) VotingPeriod() time.Duration { return d.votingPeriod }
+func (d testPropDef) Validate() error             { return d.validationErr }
+func (d testPropDef) Execute() error              { return d.executionErr }
+
+func (d testPropDef) Tally(ReadOnlyVotingRecord, MemberSet) (bool, error) {
+	return d.tallyResult, d.tallyErr
+}
 
 func (d testPropDef) CustomVoteChoices() []VoteChoice {
 	if len(d.voteChoices) > 0 {

--- a/examples/gno.land/p/gnoland/commondao/record.gno
+++ b/examples/gno.land/p/gnoland/commondao/record.gno
@@ -31,12 +31,12 @@ type (
 
 // VotingRecord stores accounts that voted and vote choices.
 type VotingRecord struct {
-	ReadOnlyVotingRecord
+	ReadonlyVotingRecord
 }
 
-// ReadOnly returns a read only voting record.
-func (r VotingRecord) ReadOnly() ReadOnlyVotingRecord {
-	return r.ReadOnlyVotingRecord
+// Readonly returns a read only voting record.
+func (r VotingRecord) Readonly() ReadonlyVotingRecord {
+	return r.ReadonlyVotingRecord
 }
 
 // AddVote adds a vote to the voting record.
@@ -59,7 +59,7 @@ func (r *VotingRecord) AddVote(vote Vote) (updated bool) {
 // GetProvableMajorityChoice returns the choice voted by the majority.
 // The result is only valid if there is a majority.
 // Caller must validate that the returned choice represents a majority.
-func GetProvableMajorityChoice(r ReadOnlyVotingRecord) VoteChoice { // TODO: Rethink this function
+func GetProvableMajorityChoice(r ReadonlyVotingRecord) VoteChoice { // TODO: Rethink this function
 	var (
 		choice       VoteChoice
 		currentCount int
@@ -79,7 +79,7 @@ func GetProvableMajorityChoice(r ReadOnlyVotingRecord) VoteChoice { // TODO: Ret
 // SelectChoiceByAbsoluteMajority select the vote choice by absolute majority.
 // Vote choice is a majority when chosen by more than half of the votes.
 // Absolute majority considers abstentions when counting votes.
-func SelectChoiceByAbsoluteMajority(r ReadOnlyVotingRecord, membersCount int) (VoteChoice, bool) {
+func SelectChoiceByAbsoluteMajority(r ReadonlyVotingRecord, membersCount int) (VoteChoice, bool) {
 	choice := GetProvableMajorityChoice(r)
 	if r.VoteCount(choice) > int(membersCount/2) {
 		return choice, true
@@ -89,7 +89,7 @@ func SelectChoiceByAbsoluteMajority(r ReadOnlyVotingRecord, membersCount int) (V
 
 // SelectChoiceBySuperMajority select the vote choice by super majority using a 2/3s threshold.
 // Abstentions are not considered when calculating the super majority choice.
-func SelectChoiceBySuperMajority(r ReadOnlyVotingRecord, membersCount int) (VoteChoice, bool) {
+func SelectChoiceBySuperMajority(r ReadonlyVotingRecord, membersCount int) (VoteChoice, bool) {
 	if membersCount < 3 {
 		return "", false
 	}
@@ -104,7 +104,7 @@ func SelectChoiceBySuperMajority(r ReadOnlyVotingRecord, membersCount int) (Vote
 // SelectChoiceByPlurality selects the vote choice by plurality.
 // The choice will be considered a majority if it has votes and if there is no other
 // choice with the same number of votes. A tie won't be considered majority.
-func SelectChoiceByPlurality(r ReadOnlyVotingRecord) (VoteChoice, bool) {
+func SelectChoiceByPlurality(r ReadonlyVotingRecord) (VoteChoice, bool) {
 	var (
 		choice       VoteChoice
 		currentCount int

--- a/examples/gno.land/p/gnoland/commondao/record_readonly.gno
+++ b/examples/gno.land/p/gnoland/commondao/record_readonly.gno
@@ -6,19 +6,19 @@ import (
 	"gno.land/p/demo/avl"
 )
 
-// ReadOnlyVotingRecord defines an read only voting record.
-type ReadOnlyVotingRecord struct {
+// ReadonlyVotingRecord defines an read only voting record.
+type ReadonlyVotingRecord struct {
 	votes avl.Tree // string(address) -> Vote
 	count avl.Tree // string(choice) -> int
 }
 
 // Size returns the total number of votes that record contains.
-func (r ReadOnlyVotingRecord) Size() int {
+func (r ReadonlyVotingRecord) Size() int {
 	return r.votes.Size()
 }
 
 // Choices returns the voting choices that has been voted.
-func (r ReadOnlyVotingRecord) Choices() []VoteChoice {
+func (r ReadonlyVotingRecord) Choices() []VoteChoice {
 	var choices []VoteChoice
 	r.count.Iterate("", "", func(k string, v any) bool {
 		choices = append(choices, VoteChoice(k))
@@ -28,14 +28,14 @@ func (r ReadOnlyVotingRecord) Choices() []VoteChoice {
 }
 
 // Iterate iterates voting record votes.
-func (r ReadOnlyVotingRecord) Iterate(fn VoteIterFn) bool {
+func (r ReadonlyVotingRecord) Iterate(fn VoteIterFn) bool {
 	return r.votes.Iterate("", "", func(_ string, v any) bool {
 		return fn(v.(Vote))
 	})
 }
 
 // VoteCount returns the number of votes for a single voting choice.
-func (r ReadOnlyVotingRecord) VoteCount(c VoteChoice) int {
+func (r ReadonlyVotingRecord) VoteCount(c VoteChoice) int {
 	if v, found := r.count.Get(string(c)); found {
 		return v.(int)
 	}
@@ -43,6 +43,6 @@ func (r ReadOnlyVotingRecord) VoteCount(c VoteChoice) int {
 }
 
 // HasVoted checks if an account already voted.
-func (r ReadOnlyVotingRecord) HasVoted(user std.Address) bool {
+func (r ReadonlyVotingRecord) HasVoted(user std.Address) bool {
 	return r.votes.Has(user.String())
 }

--- a/examples/gno.land/p/gnoland/commondao/record_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/record_test.gno
@@ -160,7 +160,7 @@ func TestGetProvableMajorityChoice(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice := GetProvableMajorityChoice(record.ReadOnly())
+			choice := GetProvableMajorityChoice(record.Readonly())
 
 			uassert.Equal(t, string(choice), string(tc.choice))
 		})
@@ -223,7 +223,7 @@ func TestSelectChoiceByAbsoluteMajority(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := SelectChoiceByAbsoluteMajority(record.ReadOnly(), tc.membersCount)
+			choice, success := SelectChoiceByAbsoluteMajority(record.Readonly(), tc.membersCount)
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")
@@ -287,7 +287,7 @@ func TestSelectChoiceBySuperMajority(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := SelectChoiceBySuperMajority(record.ReadOnly(), tc.membersCount)
+			choice, success := SelectChoiceBySuperMajority(record.Readonly(), tc.membersCount)
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")
@@ -347,7 +347,7 @@ func TestSelectChoiceByPlurality(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := SelectChoiceByPlurality(record.ReadOnly())
+			choice, success := SelectChoiceByPlurality(record.Readonly())
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")

--- a/examples/gno.land/r/gnoland/commondao/proposal_members.gno
+++ b/examples/gno.land/r/gnoland/commondao/proposal_members.gno
@@ -96,7 +96,7 @@ func (p MembersPropDefinition) Validate() error {
 	return err
 }
 
-func (MembersPropDefinition) Tally(r commondao.ReadOnlyVotingRecord, membersCount int) bool {
+func (MembersPropDefinition) Tally(r commondao.ReadonlyVotingRecord, membersCount int) bool {
 	// When DAO has one or two members succeed when there is a YES vote, otherwise
 	// tally requires at least three votes to be able to tally by 2/3s super majority
 	if membersCount < 3 {

--- a/examples/gno.land/r/gnoland/commondao/proposal_members.gno
+++ b/examples/gno.land/r/gnoland/commondao/proposal_members.gno
@@ -39,7 +39,6 @@ type MembersPropDefinition struct {
 
 func (MembersPropDefinition) Title() string               { return "Members Update" }
 func (MembersPropDefinition) VotingPeriod() time.Duration { return time.Hour * 24 * 7 }
-func (MembersPropDefinition) Quorum() float64             { return 0.67 } // two thirds
 
 func (p MembersPropDefinition) Body() string {
 	var b strings.Builder
@@ -96,15 +95,22 @@ func (p MembersPropDefinition) Validate() error {
 	return err
 }
 
-func (MembersPropDefinition) Tally(r commondao.ReadonlyVotingRecord, membersCount int) bool {
+func (MembersPropDefinition) Tally(r commondao.ReadonlyVotingRecord, members commondao.MemberSet) (bool, error) {
 	// When DAO has one or two members succeed when there is a YES vote, otherwise
 	// tally requires at least three votes to be able to tally by 2/3s super majority
-	if membersCount < 3 {
-		return r.VoteCount(commondao.ChoiceYes) > 0
+	if members.Size() < 3 {
+		return r.VoteCount(commondao.ChoiceYes) > 0, nil
 	}
 
-	_, success := commondao.SelectChoiceBySuperMajority(r, membersCount)
-	return success
+	if !commondao.IsQuorumReached(commondao.QuorumTwoThirds, r, members) {
+		return false, commondao.ErrNoQuorum
+	}
+
+	c, success := commondao.SelectChoiceBySuperMajority(r, members.Size())
+	if success {
+		return c == commondao.ChoiceYes, nil
+	}
+	return false, nil
 }
 
 func (p MembersPropDefinition) Execute() error {

--- a/examples/gno.land/r/gnoland/commondao/proposal_members_test.gno
+++ b/examples/gno.land/r/gnoland/commondao/proposal_members_test.gno
@@ -186,7 +186,7 @@ func TestMembersPropDefinitionTally(t *testing.T) {
 				r.AddVote(v)
 			}
 
-			success := p.Tally(r.ReadOnly(), tc.memberCount)
+			success := p.Tally(r.Readonly(), tc.memberCount)
 
 			uassert.Equal(t, tc.success, success, "expect tally success to match")
 		})

--- a/examples/gno.land/r/gnoland/commondao/proposal_members_test.gno
+++ b/examples/gno.land/r/gnoland/commondao/proposal_members_test.gno
@@ -128,13 +128,19 @@ func TestMembersPropDefinitionValidate(t *testing.T) {
 
 func TestMembersPropDefinitionTally(t *testing.T) {
 	cases := []struct {
-		name        string
-		votes       []commondao.Vote
-		memberCount int
-		success     bool
+		name    string
+		members []std.Address
+		votes   []commondao.Vote
+		err     error
+		success bool
 	}{
 		{
 			name: "succeed",
+			members: []std.Address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq",
+			},
 			votes: []commondao.Vote{
 				{
 					Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
@@ -145,49 +151,89 @@ func TestMembersPropDefinitionTally(t *testing.T) {
 					Choice:  commondao.ChoiceYes,
 				},
 			},
-			memberCount: 3,
-			success:     true,
+			success: true,
 		},
 		{
 			name: "fail",
+			members: []std.Address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq",
+			},
+			votes: []commondao.Vote{
+				{
+					Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+					Choice:  commondao.ChoiceNo,
+				},
+				{
+					Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+					Choice:  commondao.ChoiceNo,
+				},
+			},
+		},
+		{
+			name: "no quorum",
+			members: []std.Address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+				"g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq",
+			},
 			votes: []commondao.Vote{
 				{
 					Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
 					Choice:  commondao.ChoiceYes,
 				},
 			},
-			memberCount: 3,
+			err: commondao.ErrNoQuorum,
 		},
 		{
 			name: "succeed with two members",
+			members: []std.Address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			},
 			votes: []commondao.Vote{
 				{
 					Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
 					Choice:  commondao.ChoiceYes,
 				},
 			},
-			memberCount: 2,
-			success:     true,
+			success: true,
 		},
 		{
-			name:        "fail with two members",
-			memberCount: 2,
+			name: "fail with two members",
+			members: []std.Address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
-				r commondao.VotingRecord
-				p MembersPropDefinition
+				p       MembersPropDefinition
+				record  commondao.VotingRecord
+				members addrset.Set
 			)
 
-			for _, v := range tc.votes {
-				r.AddVote(v)
+			for _, m := range tc.members {
+				members.Add(m)
 			}
 
-			success := p.Tally(r.Readonly(), tc.memberCount)
+			for _, v := range tc.votes {
+				record.AddVote(v)
+			}
 
+			success, err := p.Tally(record.Readonly(), commondao.NewMemberSet(members))
+
+			if tc.err != nil {
+				urequire.ErrorIs(t, err, tc.err, "expect an error")
+				uassert.False(t, success, "expect tally to fail")
+				return
+			}
+
+			urequire.NoError(t, err, "expect no error")
 			uassert.Equal(t, tc.success, success, "expect tally success to match")
 		})
 	}

--- a/examples/gno.land/r/gnoland/commondao/z_5_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_5_a_filetest.gno
@@ -4,7 +4,7 @@ import (
 	"std"
 	"time"
 
-	pcommondao "gno.land/p/gnoland/commondao"
+	pdao "gno.land/p/gnoland/commondao"
 
 	"gno.land/r/gnoland/commondao"
 )
@@ -16,18 +16,17 @@ const (
 
 type propDef struct{}
 
-func (propDef) Title() string                                   { return "" }
-func (propDef) Body() string                                    { return "" }
-func (propDef) Quorum() float64                                 { return 0 }
-func (propDef) VotingPeriod() time.Duration                     { return 0 }
-func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return false }
-func (propDef) Execute() error                                  { return nil }
+func (propDef) Title() string                                                 { return "" }
+func (propDef) Body() string                                                  { return "" }
+func (propDef) VotingPeriod() time.Duration                                   { return 0 }
+func (propDef) Validate() error                                               { return nil }
+func (propDef) Tally(pdao.ReadonlyVotingRecord, pdao.MemberSet) (bool, error) { return false, nil }
+func (propDef) Execute() error                                                { return nil }
 
 var (
 	daoID    uint64
-	proposal *pcommondao.Proposal
-	vote     pcommondao.VoteChoice = pcommondao.ChoiceYes
+	proposal *pdao.Proposal
+	vote     pdao.VoteChoice = pdao.ChoiceYes
 )
 
 func init() {
@@ -62,7 +61,7 @@ func main() {
 	}
 
 	println(record.HasVoted(user))
-	record.Iterate(func(v pcommondao.Vote) bool {
+	record.Iterate(func(v pdao.Vote) bool {
 		println(v.Choice == vote)
 	})
 }

--- a/examples/gno.land/r/gnoland/commondao/z_5_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_5_a_filetest.gno
@@ -21,7 +21,7 @@ func (propDef) Body() string                                    { return "" }
 func (propDef) Quorum() float64                                 { return 0 }
 func (propDef) VotingPeriod() time.Duration                     { return 0 }
 func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadOnlyVotingRecord, int) bool { return false }
+func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return false }
 func (propDef) Execute() error                                  { return nil }
 
 var (

--- a/examples/gno.land/r/gnoland/commondao/z_5_e_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_5_e_filetest.gno
@@ -4,7 +4,7 @@ import (
 	"std"
 	"time"
 
-	pcommondao "gno.land/p/gnoland/commondao"
+	pdao "gno.land/p/gnoland/commondao"
 
 	"gno.land/r/gnoland/commondao"
 )
@@ -16,17 +16,16 @@ const (
 
 type propDef struct{}
 
-func (propDef) Title() string                                   { return "" }
-func (propDef) Body() string                                    { return "" }
-func (propDef) Quorum() float64                                 { return 0 }
-func (propDef) VotingPeriod() time.Duration                     { return 0 }
-func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return false }
-func (propDef) Execute() error                                  { return nil }
+func (propDef) Title() string                                                 { return "" }
+func (propDef) Body() string                                                  { return "" }
+func (propDef) VotingPeriod() time.Duration                                   { return 0 }
+func (propDef) Validate() error                                               { return nil }
+func (propDef) Tally(pdao.ReadonlyVotingRecord, pdao.MemberSet) (bool, error) { return false, nil }
+func (propDef) Execute() error                                                { return nil }
 
 var (
 	daoID    uint64
-	proposal *pcommondao.Proposal
+	proposal *pdao.Proposal
 )
 
 func init() {

--- a/examples/gno.land/r/gnoland/commondao/z_5_e_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_5_e_filetest.gno
@@ -21,7 +21,7 @@ func (propDef) Body() string                                    { return "" }
 func (propDef) Quorum() float64                                 { return 0 }
 func (propDef) VotingPeriod() time.Duration                     { return 0 }
 func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadOnlyVotingRecord, int) bool { return false }
+func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return false }
 func (propDef) Execute() error                                  { return nil }
 
 var (

--- a/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
@@ -19,7 +19,7 @@ func (propDef) Body() string                                    { return "" }
 func (propDef) Quorum() float64                                 { return 0 }
 func (propDef) VotingPeriod() time.Duration                     { return 0 }
 func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadOnlyVotingRecord, int) bool { return true }
+func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return true }
 
 func (propDef) Execute() error {
 	executed = true

--- a/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"gno.land/p/demo/testutils"
-	pcommondao "gno.land/p/gnoland/commondao"
+	pdao "gno.land/p/gnoland/commondao"
 
 	"gno.land/r/gnoland/commondao"
 )
@@ -14,12 +14,11 @@ const owner = std.Address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
 
 type propDef struct{}
 
-func (propDef) Title() string                                   { return "" }
-func (propDef) Body() string                                    { return "" }
-func (propDef) Quorum() float64                                 { return 0 }
-func (propDef) VotingPeriod() time.Duration                     { return 0 }
-func (propDef) Validate() error                                 { return nil }
-func (propDef) Tally(pcommondao.ReadonlyVotingRecord, int) bool { return true }
+func (propDef) Title() string                                                 { return "" }
+func (propDef) Body() string                                                  { return "" }
+func (propDef) VotingPeriod() time.Duration                                   { return 0 }
+func (propDef) Validate() error                                               { return nil }
+func (propDef) Tally(pdao.ReadonlyVotingRecord, pdao.MemberSet) (bool, error) { return true, nil }
 
 func (propDef) Execute() error {
 	executed = true
@@ -27,8 +26,8 @@ func (propDef) Execute() error {
 }
 
 var (
-	dao      *pcommondao.CommonDAO
-	proposal *pcommondao.Proposal
+	dao      *pdao.CommonDAO
+	proposal *pdao.Proposal
 	executed bool
 	user1    = testutils.TestAddress("user1")
 	user2    = testutils.TestAddress("user2")
@@ -56,11 +55,11 @@ func init() {
 	proposal, _ = dao.Propose(user1, propDef{})
 
 	// Submit user1 vote
-	commondao.Vote(dao.ID(), proposal.ID(), pcommondao.ChoiceYes, "")
+	commondao.Vote(dao.ID(), proposal.ID(), pdao.ChoiceYes, "")
 
 	// Submit user2 vote
 	std.TestSetOriginCaller(user2)
-	commondao.Vote(dao.ID(), proposal.ID(), pcommondao.ChoiceYes, "")
+	commondao.Vote(dao.ID(), proposal.ID(), pdao.ChoiceYes, "")
 }
 
 func main() {
@@ -71,7 +70,7 @@ func main() {
 		panic("expected proposal to be finished")
 	}
 
-	println(p.Status() == pcommondao.StatusExecuted)
+	println(p.Status() == pdao.StatusPassed)
 	println(executed)
 }
 


### PR DESCRIPTION
Previous implementation of tally counted the votes and checked the that a quorum was reached. That changed to allow devs to implement all the tally logic within the proposal definition. This simplifies the `ProposalDefinition` interface and the CommonDAO type while at the same time allows for more flexibility and a less opinionated tally implementation.