### PR TITLE
fix(gnovm): don't print randomly panic outputs to stdout

### DIFF
--- a/gnovm/cmd/gno/run.go
+++ b/gnovm/cmd/gno/run.go
@@ -136,9 +136,7 @@ func execRun(cfg *runCfg, args []string, io commands.IO) error {
 
 	// run files
 	m.RunFiles(files...)
-	runExpr(m, cfg.expr)
-
-	return nil
+	return runExpr(m, cfg.expr)
 }
 
 func parseFiles(fnames []string, stderr io.WriteCloser) ([]*gno.FileNode, error) {
@@ -190,23 +188,23 @@ func listNonTestFiles(dir string) ([]string, error) {
 	return fn, nil
 }
 
-func runExpr(m *gno.Machine, expr string) {
+func runExpr(m *gno.Machine, expr string) (err error) {
+	ex, err := gno.ParseExpr(expr)
+	if err != nil {
+		return fmt.Errorf("could not parse expression: %w", err)
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			switch r := r.(type) {
 			case gno.UnhandledPanicError:
-				fmt.Printf("panic running expression %s: %v\nStacktrace:\n%s\n",
+				err = fmt.Errorf("panic running expression %s: %v\nStacktrace:\n%s",
 					expr, r.Error(), m.ExceptionsStacktrace())
 			default:
-				fmt.Printf("panic running expression %s: %v\nMachine State:%s\nStacktrace:\n%s\n",
+				err = fmt.Errorf("panic running expression %s: %v\nMachine State:%s\nStacktrace:\n%s",
 					expr, r, m.String(), m.Stacktrace().String())
 			}
-			panic(r)
 		}
 	}()
-	ex, err := gno.ParseExpr(expr)
-	if err != nil {
-		panic(fmt.Errorf("could not parse: %w", err))
-	}
 	m.Eval(ex)
+	return nil
 }

--- a/gnovm/cmd/gno/run_test.go
+++ b/gnovm/cmd/gno/run_test.go
@@ -28,8 +28,8 @@ func TestRunApp(t *testing.T) {
 			stdoutShouldContain: "hello, other world!",
 		},
 		{
-			args:                 []string{"run", "../../tests/integ/run_package"},
-			recoverShouldContain: "name main not declared",
+			args:             []string{"run", "../../tests/integ/run_package"},
+			errShouldContain: "name main not declared",
 		},
 		{
 			args:                []string{"run", "-expr", "Hello()", "../../tests/integ/run_package"},
@@ -48,7 +48,7 @@ func TestRunApp(t *testing.T) {
 				"run", "-expr", "otherFile()",
 				"../../tests/integ/run_package/package.gno",
 			},
-			recoverShouldContain: "name otherFile not declared",
+			errShouldContain: "name otherFile not declared",
 		},
 		{
 			args: []string{

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -681,38 +681,10 @@ func (m *Machine) resavePackageValues(rlm *Realm) {
 }
 
 func (m *Machine) RunFunc(fn Name) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch r := r.(type) {
-			case UnhandledPanicError:
-				fmt.Printf("Machine.RunFunc(%q) panic: %s\nStacktrace:\n%s\n",
-					fn, r.Error(), m.ExceptionsStacktrace())
-			default:
-				fmt.Printf("Machine.RunFunc(%q) panic: %v\nMachine State:%s\nStacktrace:\n%s\n",
-					fn, r, m.String(), m.Stacktrace().String())
-			}
-			panic(r)
-		}
-	}()
 	m.RunStatement(S(Call(Nx(fn))))
 }
 
 func (m *Machine) RunMain() {
-	defer func() {
-		r := recover()
-
-		if r != nil {
-			switch r := r.(type) {
-			case UnhandledPanicError:
-				fmt.Printf("Machine.RunMain() panic: %s\nStacktrace:\n%s\n",
-					r.Error(), m.ExceptionsStacktrace())
-			default:
-				fmt.Printf("Machine.RunMain() panic: %v\nMachine State:%s\nStacktrace:\n%s\n",
-					r, m.String(), m.Stacktrace())
-			}
-			panic(r)
-		}
-	}()
 	m.RunStatement(S(Call(X("main"))))
 }
 


### PR DESCRIPTION
Testing `examples` can lead to several outputs of panics, which are often expected (ie. filetests), but are printed because of some code that was previously put in `RunMain` and `RunFunc`.

This PR removes that code.