### PR TITLE
feat(examples): add URL query params to `mux` package request

### DIFF
--- a/examples/gno.land/p/demo/mux/request.gno
+++ b/examples/gno.land/p/demo/mux/request.gno
@@ -1,6 +1,9 @@
 package mux
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // Request represents an incoming request.
 type Request struct {
@@ -14,6 +17,9 @@ type Request struct {
 
 	// HandlerPath is handler rule that matches a request.
 	HandlerPath string
+
+	// Query contains the parsed URL query parameters.
+	Query url.Values
 }
 
 // GetVar retrieves a variable from the path based on routing rules.

--- a/examples/gno.land/p/demo/mux/router.gno
+++ b/examples/gno.land/p/demo/mux/router.gno
@@ -1,6 +1,9 @@
 package mux
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // Router handles the routing and rendering logic.
 type Router struct {
@@ -18,7 +21,8 @@ func NewRouter() *Router {
 
 // Render renders the output for the given path using the registered route handler.
 func (r *Router) Render(reqPath string) string {
-	clearPath := stripQueryString(reqPath)
+	clearPath, rawQuery, _ := strings.Cut(reqPath, "?")
+	query, _ := url.ParseQuery(rawQuery)
 	reqParts := strings.Split(clearPath, "/")
 
 	for _, route := range r.routes {
@@ -55,6 +59,7 @@ func (r *Router) Render(reqPath string) string {
 				Path:        clearPath,
 				RawPath:     reqPath,
 				HandlerPath: route.Pattern,
+				Query:       query,
 			}
 			res := &ResponseWriter{}
 			route.Fn(res, req)
@@ -63,7 +68,7 @@ func (r *Router) Render(reqPath string) string {
 	}
 
 	// not found
-	req := &Request{Path: reqPath}
+	req := &Request{Path: reqPath, Query: query}
 	res := &ResponseWriter{}
 	r.NotFoundHandler(res, req)
 	return res.Output()
@@ -77,7 +82,6 @@ func (r *Router) HandleFunc(pattern string, fn HandlerFunc) {
 
 // HandleErrFunc registers a route and its error handler function.
 func (r *Router) HandleErrFunc(pattern string, fn ErrHandlerFunc) {
-
 	// Convert ErrHandlerFunc to regular HandlerFunc
 	handler := func(res *ResponseWriter, req *Request) {
 		if err := fn(res, req); err != nil {
@@ -91,14 +95,4 @@ func (r *Router) HandleErrFunc(pattern string, fn ErrHandlerFunc) {
 // SetNotFoundHandler sets custom message for 404 defaultNotFoundHandler.
 func (r *Router) SetNotFoundHandler(handler NotFoundHandler) {
 	r.NotFoundHandler = handler
-}
-
-// stripQueryString removes query string from the request path.
-func stripQueryString(reqPath string) string {
-	i := strings.Index(reqPath, "?")
-	if i == -1 {
-		return reqPath
-	}
-
-	return reqPath[:i]
 }

--- a/examples/gno.land/p/demo/mux/router_test.gno
+++ b/examples/gno.land/p/demo/mux/router_test.gno
@@ -48,6 +48,8 @@ func TestRouter_Render(t *testing.T) {
 					uassert.Equal(t, "bar", val)
 					uassert.Equal(t, "hello/foo/bar?foo=bar&baz", req.RawPath)
 					uassert.Equal(t, "hello/foo/bar", req.Path)
+					uassert.Equal(t, "bar", req.Query.Get("foo"))
+					uassert.Empty(t, req.Query.Get("baz"))
 					rw.Write(key + " " + val)
 				})
 			},
@@ -95,6 +97,7 @@ func TestRouter_Render(t *testing.T) {
 					uassert.Equal(t, "Alice/Bob", path)
 					uassert.Equal(t, "hello/Alice/Bob?foo=bar", req.RawPath)
 					uassert.Equal(t, "hello/Alice/Bob", req.Path)
+					uassert.Equal(t, "bar", req.Query.Get("foo"))
 					rw.Write("Matched: " + path)
 				})
 			},


### PR DESCRIPTION
PR adds a `Query` property with the parsed URL query arguments to the `mux.Request` to be able to get query arguments like:
```go
req.Query.Get("argName")
```