### PR TITLE
feat(gnovm):  Result Caching for filetest

### DIFF
--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -28,6 +28,7 @@ type testCfg struct {
 	printEvents         bool
 	debug               bool
 	debugAddr           string
+	noCache             bool
 }
 
 func newTestCmd(io commands.IO) *commands.Command {
@@ -159,6 +160,13 @@ func (c *testCfg) RegisterFlags(fs *flag.FlagSet) {
 		"",
 		"enable interactive debugger using tcp address in the form [host]:port",
 	)
+
+	fs.BoolVar(
+		&c.noCache,
+		"no-cache",
+		false,
+		"disable test result caching",
+	)
 }
 
 func execTest(cfg *testCfg, args []string, io commands.IO) error {
@@ -206,6 +214,7 @@ func execTest(cfg *testCfg, args []string, io commands.IO) error {
 	opts.Metrics = cfg.printRuntimeMetrics
 	opts.Events = cfg.printEvents
 	opts.Debug = cfg.debug
+	opts.NoCache = cfg.noCache
 
 	buildErrCount := 0
 	testErrCount := 0

--- a/gnovm/pkg/test/cache.go
+++ b/gnovm/pkg/test/cache.go
@@ -1,0 +1,266 @@
+package test
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+)
+
+const (
+	// TestCacheDirName is the name of the directory where test cache is stored
+	TestCacheDirName = ".gno-test-cache"
+)
+
+type TestCache struct {
+	Key TestCacheKey
+	// Test result output
+	Output string `json:"output"`
+	// Test execution time
+	Duration time.Duration `json:"duration"`
+	// Timestamp when the cache was created
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// TestCacheKey represents the key information for test cache validation
+type TestCacheKey struct {
+	// Hash of test file content
+	FileHash string `json:"fileHash"`
+	// Package dependency information
+	Dependencies map[string]PackageInfo `json:"dependencies"`
+}
+
+// PackageInfo contains information about a package's state
+type PackageInfo struct {
+	// Hash of all package files combined
+	ContentHash string `json:"contentHash"`
+	// Import path of the package
+	Path string `json:"path"`
+	// Package files and their hashes
+	Files map[string]string `json:"files"`
+}
+
+// TestFuncCache represents the cache for a single test function
+type TestFuncCache struct {
+	Key TestCacheKey
+	// Test function name
+	TestName string `json:"testName"`
+	// Test result output
+	Output string `json:"output"`
+	// Test execution time
+	Duration time.Duration `json:"duration"`
+	// Timestamp when the cache was created
+	Timestamp time.Time `json:"timestamp"`
+	// Test result
+	Result report `json:"result"`
+}
+
+// TestFileCache represents the cache for a test file containing multiple test functions
+type TestFileCache struct {
+	// Map of test function name to its cache
+	Tests map[string]*TestFuncCache `json:"tests"`
+}
+
+// cacheDir returns the path to the test cache directory
+func cacheDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	cacheDir := filepath.Join(homeDir, TestCacheDirName)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create cache directory: %w", err)
+	}
+	return cacheDir, nil
+}
+
+// cacheFilePath returns the path to the cache file for a given test file
+func cacheFilePath(testFile string) (string, error) {
+	cacheDir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	// Use hash of absolute path to avoid file name collisions
+	absPath, err := filepath.Abs(testFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(absPath)))
+	return filepath.Join(cacheDir, hash+".json"), nil
+}
+
+// loadTestCache loads the cached test result for a given test file
+func loadTestCache(testFile string, content []byte) (*TestCache, error) {
+	cacheFile, err := cacheFilePath(testFile)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	var cache TestCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cache: %w", err)
+	}
+
+	if !isValidCache(&cache, testFile, content) {
+		return nil, nil
+	}
+
+	return &cache, nil
+}
+
+// saveTestCache saves the test result to cache
+func saveTestCache(testFile string, content []byte, output string, duration time.Duration) error {
+	cacheFile, err := cacheFilePath(testFile)
+	if err != nil {
+		return err
+	}
+
+	key, err := computeCacheKey(testFile, content)
+	if err != nil {
+		return fmt.Errorf("failed to compute cache key: %w", err)
+	}
+
+	cache := TestCache{
+		Key:       key,
+		Output:    output,
+		Duration:  duration,
+		Timestamp: time.Now(),
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache: %w", err)
+	}
+
+	if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	return nil
+}
+
+// computeCacheKey generates a cache key for the given test file
+func computeCacheKey(testFile string, content []byte) (TestCacheKey, error) {
+	key := TestCacheKey{
+		FileHash:     fmt.Sprintf("%x", sha256.Sum256(content)),
+		Dependencies: make(map[string]PackageInfo),
+	}
+
+	fileNode, err := gno.ParseFile(testFile, string(content))
+	if err != nil {
+		return key, fmt.Errorf("failed to parse file: %w", err)
+	}
+
+	// process each import declaration
+	decls := fileNode.Decls
+	for _, decl := range decls {
+		if decl == nil {
+			continue
+		}
+		if importDecl, ok := decl.(*gno.ImportDecl); ok {
+			if importDecl.PkgPath == "" {
+				continue
+			}
+			key.Dependencies[importDecl.PkgPath] = PackageInfo{
+				Path: importDecl.PkgPath,
+			}
+		}
+	}
+
+	return key, nil
+}
+
+// isValidCache checks if the cached result is still valid
+func isValidCache(cache *TestCache, testFile string, content []byte) bool {
+	currentKey, err := computeCacheKey(testFile, content)
+	if err != nil {
+		return false
+	}
+
+	// Check file content hash
+	if cache.Key.FileHash != currentKey.FileHash {
+		return false
+	}
+
+	// Check all dependencies
+	for path, currentInfo := range currentKey.Dependencies {
+		cachedInfo, exists := cache.Key.Dependencies[path]
+		if !exists {
+			return false
+		}
+
+		// Compare package content hash
+		if cachedInfo.ContentHash != currentInfo.ContentHash {
+			return false
+		}
+
+		// Compare individual files
+		if !reflect.DeepEqual(cachedInfo.Files, currentInfo.Files) {
+			return false
+		}
+	}
+
+	// Check if any cached dependency no longer exists
+	for path := range cache.Key.Dependencies {
+		if _, exists := currentKey.Dependencies[path]; !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+// loadTestFileCache loads the cached test results for all test functions in a file
+func loadTestFileCache(testFile string, content []byte) (*TestFileCache, error) {
+	cacheFile, err := cacheFilePath(testFile)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &TestFileCache{Tests: make(map[string]*TestFuncCache)}, nil
+		}
+		return nil, fmt.Errorf("failed to read cache file: %w", err)
+	}
+
+	var cache TestFileCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cache: %w", err)
+	}
+
+	return &cache, nil
+}
+
+// saveTestFileCache saves the test results for all test functions in a file
+func saveTestFileCache(testFile string, cache *TestFileCache) error {
+	cacheFile, err := cacheFilePath(testFile)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache: %w", err)
+	}
+
+	if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+
+	return nil
+}

--- a/gnovm/pkg/test/cache_test.go
+++ b/gnovm/pkg/test/cache_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestCache(t *testing.T) {
+	t.Run("getCacheDir", func(t *testing.T) {
+		dir, err := cacheDir()
+		require.NoError(t, err)
+		require.NotEmpty(t, dir)
+
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		require.True(t, info.IsDir())
+	})
+
+	t.Run("cache operations", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testFile := filepath.Join(tmpDir, "test.gno")
+		testContent := []byte("package main\n\nfunc main() {}")
+		err := os.WriteFile(testFile, testContent, 0o644)
+		require.NoError(t, err)
+
+		output := "test output"
+		duration := time.Second
+		err = saveTestCache(testFile, testContent, output, duration)
+		require.NoError(t, err)
+
+		cache, err := loadTestCache(testFile, testContent)
+		require.NoError(t, err)
+		require.NotNil(t, cache)
+
+		assert.Equal(t, output, cache.Output)
+		assert.Equal(t, duration, cache.Duration)
+		assert.NotEmpty(t, cache.Key.FileHash)
+		assert.NotZero(t, cache.Timestamp)
+
+		modifiedContent := []byte("package main\n\nfunc main() { println() }")
+		cache, err = loadTestCache(testFile, modifiedContent)
+		require.NoError(t, err)
+		assert.Nil(t, cache)
+	})
+
+	t.Run("cache file path collision", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		testFile1 := filepath.Join(tmpDir, "dir1", "test.gno")
+		testFile2 := filepath.Join(tmpDir, "dir2", "test.gno")
+
+		require.NoError(t, os.MkdirAll(filepath.Dir(testFile1), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(testFile2), 0o755))
+
+		content1 := []byte("package main\n\nfunc test1() {}")
+		content2 := []byte("package main\n\nfunc test2() {}")
+
+		require.NoError(t, os.WriteFile(testFile1, content1, 0o644))
+		require.NoError(t, os.WriteFile(testFile2, content2, 0o644))
+
+		// make sure the cache file paths for each file are different
+		path1, err := cacheFilePath(testFile1)
+		require.NoError(t, err)
+
+		path2, err := cacheFilePath(testFile2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, path1, path2)
+	})
+
+	t.Run("invalid cache operations", func(t *testing.T) {
+		cache, err := loadTestCache("non_existent_file.gno", []byte{})
+		require.NoError(t, err)
+		assert.Nil(t, cache)
+
+		tmpDir := t.TempDir()
+		testFile := filepath.Join(tmpDir, "invalid.gno")
+		err = os.WriteFile(testFile, []byte("invalid json"), 0o644)
+		require.NoError(t, err)
+
+		cacheFile, err := cacheFilePath(testFile)
+		require.NoError(t, err)
+		err = os.WriteFile(cacheFile, []byte("invalid json"), 0o644)
+		require.NoError(t, err)
+
+		cache, err = loadTestCache(testFile, []byte("test content"))
+		assert.Error(t, err)
+		assert.Nil(t, cache)
+	})
+}

--- a/gnovm/pkg/test/test_test.go
+++ b/gnovm/pkg/test/test_test.go
@@ -1,0 +1,240 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/gnovm"
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadTestFuncs(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkgName  string
+		fileBody string
+		want     []testFunc
+	}{
+		{
+			name:    "empty file set",
+			pkgName: "test",
+			fileBody: `
+				package test
+			`,
+			want: nil,
+		},
+		{
+			name:    "single test function",
+			pkgName: "test",
+			fileBody: `
+				package test
+				func TestSomething(t *testing.T) {}
+			`,
+			want: []testFunc{
+				{Package: "test", Name: "TestSomething"},
+			},
+		},
+		{
+			name:    "multiple test functions",
+			pkgName: "test",
+			fileBody: `
+				package test
+				func TestOne(t *testing.T) {}
+				func TestTwo(t *testing.T) {}
+				func helper() {}
+				func TestThree(t *testing.T) {}
+			`,
+			want: []testFunc{
+				{Package: "test", Name: "TestOne"},
+				{Package: "test", Name: "TestTwo"},
+				{Package: "test", Name: "TestThree"},
+			},
+		},
+		{
+			name:    "non-test functions",
+			pkgName: "test",
+			fileBody: `
+				package test
+				func helper() {}
+				func regular() {}
+				func test() {}
+			`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the test file
+			file, err := gno.ParseFile("test.gno", tt.fileBody)
+			if err != nil {
+				t.Fatalf("failed to parse test file: %v", err)
+			}
+
+			fileSet := &gno.FileSet{}
+			fileSet.AddFiles(file)
+
+			// Run the function
+			got := loadTestFuncs(tt.pkgName, fileSet)
+
+			// Assert the results
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseMemPackageTests(t *testing.T) {
+	tests := []struct {
+		name        string
+		memPkg      *gnovm.MemPackage
+		wantTSet    bool // Whether there are regular test files
+		wantITSet   bool // Whether there are integration test files
+		wantITFiles int  // Number of integration test files
+		wantFTFiles int  // Number of file test files
+	}{
+		{
+			name: "empty package",
+			memPkg: &gnovm.MemPackage{
+				Name:  "test",
+				Path:  "test",
+				Files: nil,
+			},
+			wantTSet:    false,
+			wantITSet:   false,
+			wantITFiles: 0,
+			wantFTFiles: 0,
+		},
+		{
+			name: "case with only regular test files",
+			memPkg: &gnovm.MemPackage{
+				Name: "test",
+				Path: "test",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "something_test.gno",
+						Body: `package test
+							func TestSomething(t *testing.T) {}`,
+					},
+				},
+			},
+			wantTSet:    true,
+			wantITSet:   false,
+			wantITFiles: 0,
+			wantFTFiles: 0,
+		},
+		{
+			name: "case with only integration test files",
+			memPkg: &gnovm.MemPackage{
+				Name: "test",
+				Path: "test",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "integration_test.gno",
+						Body: `package test_test
+							func TestIntegration(t *testing.T) {}`,
+					},
+				},
+			},
+			wantTSet:    false,
+			wantITSet:   true,
+			wantITFiles: 1,
+			wantFTFiles: 0,
+		},
+		{
+			name: "case with only file tests",
+			memPkg: &gnovm.MemPackage{
+				Name: "test",
+				Path: "test",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "something_filetest.gno",
+						Body: `package test
+							// File test content`,
+					},
+				},
+			},
+			wantTSet:    false,
+			wantITSet:   false,
+			wantITFiles: 0,
+			wantFTFiles: 1,
+		},
+		{
+			name: "case with all types of test files",
+			memPkg: &gnovm.MemPackage{
+				Name: "test",
+				Path: "test",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "normal_test.gno",
+						Body: `package test
+							func TestNormal(t *testing.T) {}`,
+					},
+					{
+						Name: "integration_test.gno",
+						Body: `package test_test
+							func TestIntegration(t *testing.T) {}`,
+					},
+					{
+						Name: "file_filetest.gno",
+						Body: `package test
+							// File test content`,
+					},
+					{
+						Name: "regular.gno",
+						Body: `package test
+							func Regular() {}`,
+					},
+				},
+			},
+			wantTSet:    true,
+			wantITSet:   true,
+			wantITFiles: 1,
+			wantFTFiles: 1,
+		},
+		{
+			name: "ignore files with incorrect extensions",
+			memPkg: &gnovm.MemPackage{
+				Name: "test",
+				Path: "test",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "test.txt",
+						Body: "Any content",
+					},
+				},
+			},
+			wantTSet:    false,
+			wantITSet:   false,
+			wantITFiles: 0,
+			wantFTFiles: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tset, itset, itfiles, ftfiles := parseMemPackageTests(tt.memPkg)
+
+			// Check regular test files
+			if tt.wantTSet {
+				assert.NotNil(t, tset)
+				assert.Greater(t, len(tset.Files), 0)
+			} else {
+				assert.Equal(t, 0, len(tset.Files))
+			}
+
+			// Check integration test files
+			if tt.wantITSet {
+				assert.NotNil(t, itset)
+				assert.Greater(t, len(itset.Files), 0)
+			} else {
+				assert.Equal(t, 0, len(itset.Files))
+			}
+
+			// Check number of integration test files
+			assert.Equal(t, tt.wantITFiles, len(itfiles))
+
+			// Check number of file test files
+			assert.Equal(t, tt.wantFTFiles, len(ftfiles))
+		})
+	}
+}


### PR DESCRIPTION
# Description

Cache the test results for filetest. For `*_test.gno` files, caching has not yet been implemented since previous test execution results can sometimes affect other tests.

1. Test Result Caching:
    - Cached results are reused when test file content remains unchanged
    - Cache is stored in the `~/.gno-test-cache` directory
2. Cache Invalidation:
    - Automatically invalidated cache when test file content changes
    - Cache usage can be completely disabled with the `-no-cache` flag [^1]

## Usage

Please run the test command as you would for a regular test execution when not using the no-cache option.

```plain
gno test <test_path> -v
```

When running the same test more than once without any modifications, it will be marked as CACHED as shown below. (Using the avl package as an example.)

```plain
$ gno test examples/gno.land/p/demo/avl/node_test.gno -v

...
=== RUN   TestTreeReverseIterateByOffset
--- PASS: TestTreeReverseIterateByOffset (0.00s)
=== RUN   file/z_0_filetest.gno
=== CACHED file/z_0_filetest.gno (0.01s)
false 2
=== RUN   file/z_1_filetest.gno
=== CACHED file/z_1_filetest.gno (0.01s)
false 3
=== RUN   file/z_2_filetest.gno
=== CACHED file/z_2_filetest.gno (0.01s)
false 3
ok      examples/gno.land/p/demo/avl    1.18s
```

To disable caching, add the `-no-cache` flag as shown below:

```plain
gno test <test_path> -v -no-cache
```

```plain
$ gno test examples/gno.land/p/demo/avl/node_test.gno -v -no-cache

...
--- PASS: TestTreeIterateByOffset (0.00s)
=== RUN   TestTreeReverseIterateByOffset
--- PASS: TestTreeReverseIterateByOffset (0.00s)
=== RUN   file/z_0_filetest.gno
false 2
--- PASS: file/z_0_filetest.gno (0.01s)
=== RUN   file/z_1_filetest.gno
false 3
--- PASS: file/z_1_filetest.gno (0.02s)
=== RUN   file/z_2_filetest.gno
false 3
--- PASS: file/z_2_filetest.gno (0.02s)
ok      examples/gno.land/p/demo/avl    1.39s
```

[^1]: While Go doesn't have a no-cache flag, the idiomatic approach is to use `-count 1`.