### PR TITLE
fix: stdlibs/os: func Sleep doesn't return a value

### DIFF
--- a/gnovm/tests/stdlibs/os/os.gno
+++ b/gnovm/tests/stdlibs/os/os.gno
@@ -21,7 +21,7 @@ func (w *stderrWriter) Write(p []byte) (n int, err error) {
 }
 
 func Sleep(duration time.Duration) {
-	return sleep(int64(duration))
+	sleep(int64(duration))
 }
 
 // native bindings


### PR DESCRIPTION
Running `make test.components` gives the error:
```
testing/testing.gno:6:2: could not import os (os/os.gno:24:9: sleep(int64(duration)) (no value) used as value) (code=4)
```

To fix: PR https://github.com/gnolang/gno/pull/3677 added the [Sleep function](https://github.com/gnolang/gno/blob/5e017a4e7d89827203c11c6642f844f0fd75a070/gnovm/tests/stdlibs/os/os.gno#L23-L25):
```
func Sleep(duration time.Duration) {
	return sleep(int64(duration))
}
```

But `sleep` doesn't return a value. This PR removes `return`.