### PR TITLE
feat(boards2): check replies length and disallow UI breaking Markdown

### DIFF
--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -13,9 +13,19 @@ const (
 
 	// MaxThreadTitleLength defines the maximum length allowed for thread titles.
 	MaxThreadTitleLength = 100
+
+	// MaxReplyLength defines the maximum length allowed for replies.
+	MaxReplyLength = 300
 )
 
-var reBoardName = regexp.MustCompile(`(?i)^[a-z]+[a-z0-9_\-]{2,50}$`)
+var (
+	reBoardName = regexp.MustCompile(`(?i)^[a-z]+[a-z0-9_\-]{2,50}$`)
+
+	// Minimalistic Markdown line prefix checks that if allowed would
+	// break the current UI when submitting a reply. It denies replies
+	// with headings, blockquotes or horizontal lines.
+	reDeniedReplyLinePrefixes = regexp.MustCompile(`(?m)^\s*(#|---|>)+`)
+)
 
 // SetPermissions sets a permissions implementation for boards2 realm or a board.
 func SetPermissions(bid BoardID, p Permissions) {
@@ -321,7 +331,7 @@ func CreateThread(boardID BoardID, title, body string) PostID {
 // The value of `replyID` is only required when creating a reply of another reply.
 func CreateReply(boardID BoardID, threadID, replyID PostID, body string) PostID {
 	body = strings.TrimSpace(body)
-	assertBodyIsNotEmpty(body)
+	assertReplyBodyIsValid(body)
 
 	board := mustGetBoard(boardID)
 	assertBoardIsNotFrozen(board)
@@ -538,7 +548,7 @@ func EditThread(boardID BoardID, threadID PostID, title, body string) {
 // Replies can be updated only by the users who created them.
 func EditReply(boardID BoardID, threadID, replyID PostID, body string) {
 	body = strings.TrimSpace(body)
-	assertBodyIsNotEmpty(body)
+	assertReplyBodyIsValid(body)
 
 	board := mustGetBoard(boardID)
 	assertBoardIsNotFrozen(board)
@@ -769,6 +779,19 @@ func assertThreadIsVisible(thread *Post) {
 func assertReplyIsVisible(thread *Post) {
 	if thread.IsHidden() {
 		panic("reply is hidden")
+	}
+}
+
+func assertReplyBodyIsValid(body string) {
+	assertBodyIsNotEmpty(body)
+
+	if len(body) > MaxReplyLength {
+		n := strconv.Itoa(MaxReplyLength)
+		panic("reply is too long, maximum allowed is " + n + " characters")
+	}
+
+	if reDeniedReplyLinePrefixes.MatchString(body) {
+		panic("using Markdown headings, blockquotes or horizontal lines is not allowed in replies")
 	}
 }
 

--- a/examples/gno.land/r/nt/boards2/v1/z_2_m_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_2_m_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOriginCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.CreateReply(bid, tid, 0, strings.Repeat("x", boards2.MaxReplyLength+1))
+}
+
+// Error:
+// reply is too long, maximum allowed is 300 characters

--- a/examples/gno.land/r/nt/boards2/v1/z_2_n_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_2_n_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"std"
+	"strings"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+var (
+	bid boards2.BoardID
+	tid boards2.PostID
+)
+
+func init() {
+	std.TestSetOriginCaller(owner)
+	bid = boards2.CreateBoard("test-board")
+	tid = boards2.CreateThread(bid, "Foo", "bar")
+}
+
+func main() {
+	boards2.CreateReply(bid, tid, 0, "> Markdown blockquote")
+}
+
+// Error:
+// using Markdown headings, blockquotes or horizontal lines is not allowed in replies

--- a/examples/gno.land/r/nt/boards2/v1/z_2_n_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_2_n_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"std"
-	"strings"
 
 	boards2 "gno.land/r/nt/boards2/v1"
 )


### PR DESCRIPTION
Maximum reply length is restricted to 300 characters and some Markdown prefixes are disallowed to avoid breaking boards2 rendered UI.