### PR TITLE
fix(gnovm): avoid "duplicate key" panic for non-constant literal composite

### DIFF
--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -555,7 +555,7 @@ func (m *Machine) doOpMapLit() {
 			ktv := &kvs[i*2]
 			vtv := kvs[i*2+1]
 			ptr := mv.GetPointerForKey(m.Alloc, m.Store, ktv)
-			if ptr.TV.IsDefined() {
+			if ptr.TV.IsDefined() && isConst(x.Elts[i].Key) {
 				// map key has already been assigned
 				panic(fmt.Sprintf("duplicate key %s in map literal", ktv.V))
 			}

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1459,12 +1459,13 @@ func (tv *TypedValue) AssertNonNegative(msg string) {
 	}
 }
 
-// uvnan is the unsigned value of NaN. It can be contructed by applying the following:
+// uvnan is the unsigned value of NaN. It can be obtained by applying the following:
 // { var nan = math.NaN(); var uvnan = *(*uint64)(unsafe.Pointer(&nan)) }
 const uvnan = 0x7FF8000000000001
 
-// randNaN returns an uint64 representation of NaN with a random payload.
+// randNaN returns an uint64 representation of NaN with a random payload of 53 bits.
 func randNaN() uint64 {
+	//nolint: gosec
 	return rand.Uint64()&^uvnan | uvnan
 }
 

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1465,8 +1465,7 @@ const uvnan = 0x7FF8000000000001
 
 // randNaN returns an uint64 representation of NaN with a random payload of 53 bits.
 func randNaN() uint64 {
-	//nolint: gosec
-	return rand.Uint64()&^uvnan | uvnan
+	return rand.Uint64()&^uvnan | uvnan //nolint:gosec
 }
 
 // IsNaN reports wether tv is an IEEE 754 "not a number" value.

--- a/gnovm/tests/files/composite18.gno
+++ b/gnovm/tests/files/composite18.gno
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	x := 0
+	a := map[int]int{x: 10, -1 * x: 20}
+	fmt.Println(a)
+}
+
+// Output:
+// map[0:20]

--- a/gnovm/tests/files/map30.gno
+++ b/gnovm/tests/files/map30.gno
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+var NaN = math.NaN()
+
+func main() {
+	fmt.Println(map[float64]int{NaN: 1, NaN: 2})
+}
+
+// Output:
+// map[NaN:1 NaN:2]

--- a/gnovm/tests/files/map31.gno
+++ b/gnovm/tests/files/map31.gno
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+var NaN = float32(math.NaN())
+
+func main() {
+	fmt.Println(map[float32]int{NaN: 1, NaN: 2})
+}
+
+// Output:
+// map[NaN:1 NaN:2]


### PR DESCRIPTION
Panic on "duplicate key" only for constant expressions, not ones involving variables.

Note: this applies only to maps, as other indexes or selectors always require constants or identifiers.
    
Fixes #3964.