### PR TITLE
methods are executed the same as function calls

### DIFF
--- a/examples/gno.land/r/demo/tests/crossrealm/array/crossrealm_array.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/array/crossrealm_array.gno
@@ -1,0 +1,29 @@
+package crossrealm_array
+
+type Foo struct{ name string }
+
+var f = Foo{"foo"}
+
+var Arr = [2]Foo{Foo{"a"}, Foo{"b"}}
+
+var Arr2 = [2]int{1, 2}
+
+func GetArray5() [2]int {
+	return Arr2
+}
+
+func GetArray4() [2]Foo {
+	return Arr
+}
+
+func GetArray() [2]Foo {
+	return [2]Foo{Foo{"a"}, Foo{"b"}}
+}
+
+func GetArray2() [2]*Foo {
+	return [2]*Foo{&Foo{"a"}, &Foo{"b"}}
+}
+
+func GetArray3() [1]*Foo {
+	return [1]*Foo{&f}
+}

--- a/examples/gno.land/r/demo/tests/crossrealm/crossrealm_p.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/crossrealm_p.gno
@@ -17,7 +17,7 @@ func (ls *LocalStruct) String() string {
 var local *LocalStruct
 
 func init() {
-	local = &LocalStruct{A: 123}
+	local = &LocalStruct{A: 123} // this is attached first
 }
 
 // Make1 returns a local object wrapped by a p struct

--- a/examples/gno.land/r/demo/tests/crossrealm/func/crossrealm_func.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/func/crossrealm_func.gno
@@ -1,0 +1,47 @@
+package crossrealm_func
+
+type F func() bool
+
+var f F
+
+func SetCallback(ff F) {
+	f = ff
+}
+
+func ExecuteCallback() {
+	f()
+}
+
+var ff = func() string { return "a" } // parent object already escaped
+
+// XXX, this is special case, for ff, it's closure is referenced,
+// so need to check all embedded items attached?
+// see zrealm_crossrealm38.gno
+func GetFunc() func() string {
+	return ff
+}
+
+func GetFunc2() func() string {
+	return func() string {
+		return "b"
+	}
+}
+
+type MyStruct struct{}
+type MyStruct2 struct{ name string }
+
+func (sv *MyStruct) M() string { return "a" }
+
+var mysv *MyStruct = &MyStruct{}
+
+func (sv2 MyStruct2) M2() string { return "a2" }
+
+var mysv2 = MyStruct2{name: "struct_val"}
+
+func GetMethod() func() string {
+	return mysv.M
+}
+
+func GetMethod2() func() string {
+	return mysv2.M2
+}

--- a/examples/gno.land/r/demo/tests/crossrealm/iface/crossrealm_iface.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/iface/crossrealm_iface.gno
@@ -1,0 +1,35 @@
+package iface
+
+type Foo2 struct{}
+
+// XXX, how about not interface
+type Fooer interface{ Foo() }
+
+var fooer Fooer
+
+func SetFooer(f Fooer) Fooer {
+	fooer = f
+	return fooer
+}
+
+func CallFoo() { fooer.Foo() }
+
+// container in external realm
+type Container struct {
+	name string
+	f    Fooer
+}
+
+var container Container // attached
+
+func RunF() {
+	container.f.Foo()
+}
+func SetContainer(f Fooer) {
+	container.f = f // update
+}
+
+func SetContainer2(f Fooer) {
+	ff := f          // associate to non-attached object
+	SetContainer(ff) // attach container, while ff is not attached
+}

--- a/examples/gno.land/r/demo/tests/crossrealm/map/crossrealm_map.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/map/crossrealm_map.gno
@@ -1,0 +1,44 @@
+// PKGPATH: gno.land/r/crossrealm_map
+package crossrealm_map
+
+type Foo struct{}
+
+var f = Foo{}
+
+var m map[string]int
+
+func init() {
+	m = make(map[string]int)
+	m["a"] = 1
+}
+
+func GetMap() map[string]int {
+	return m
+}
+
+func ModifyMap() {
+	m["a"] = 2
+}
+
+func GetMap2(f func(map[string]int)) {
+	m1 := map[string]int{"a": 1}
+	f(m1)
+}
+
+func GetMap4() map[string]Foo {
+	var m1 = map[string]Foo{"foo": f}
+	return m1
+}
+
+// --------------------------------------
+type MyMap map[string]int
+
+var m2 = MyMap{"a": 1}
+
+func GetMap3() MyMap {
+	return m2
+}
+
+// TODO: add some map with elements of object
+
+// Realm:

--- a/examples/gno.land/r/demo/tests/crossrealm/slice/crossrealm_slice.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/slice/crossrealm_slice.gno
@@ -1,0 +1,124 @@
+package crossrealm_slice
+
+import "gno.land/p/demo/tests/p_crossrealm"
+
+type Fooer interface{ Foo() }
+
+var S []Fooer
+
+func SetSlice(fs []Fooer) {
+	S = fs
+	for _, f := range fs {
+		f.Foo()
+	}
+}
+
+var Arr [3]Fooer
+
+func SetArray(arr [3]Fooer) {
+	Arr = arr
+	for _, f := range Arr {
+		println(f)
+	}
+}
+
+// -------------------------------------
+type XYZ struct{ name string }
+
+var s1 []XYZ // underlying array is real after decl
+var s3 []XYZ
+
+// var s4 []XYZ
+var s4 = make([]XYZ, 1, 2)
+
+// NOTE that if new list allocated, XYZ{"4"} will be copied, and it's a new object
+// var s4 = make([]XYZ, 1)
+var s5 []*XYZ
+var s6 = make([]*XYZ, 2)
+
+var s7 [2]XYZ
+
+var s10 []int
+
+func init() {
+	s1 = append(s1, XYZ{"1"})
+	s1 = append(s1, XYZ{"2"})
+
+	s3 = append(s3, XYZ{"3"})
+	//s4 = append(s4, XYZ{"4"})
+	s4[0] = XYZ{"4"}
+
+	s5 = append(s5, &XYZ{"5"})
+
+	s6[0] = &XYZ{"6"}
+
+	s7[0] = XYZ{"7"}
+	s7[1] = XYZ{"7.1"} // should be real after this
+	s10 = append(s10, 1)
+}
+
+func GetSlice() []XYZ {
+	return s1[:]
+}
+
+// -------------------------------------------------------
+var e1 = XYZ{"1"}
+var e2 = XYZ{"2"}
+
+func GetSlice2() []XYZ {
+	var s2 []XYZ
+	s2 = append(s2, e1)
+	s2 = append(s2, e2)
+	return s2
+}
+
+// ------------------------------------------------------
+func GetSlice3() []XYZ {
+	s3 = append(s3, XYZ{"0"}) // this is real after function
+	return s3
+}
+
+func GetSlice4(f func(s []XYZ)) {
+	s4 = append(s4, XYZ{"0"}) // this is real after this function
+	f(s4)
+}
+
+func GetSlice5() []*XYZ { // TODO, unwrap
+	return s5
+}
+
+func GetSlice6(f func(s []*XYZ)) {
+	s6[1] = &XYZ{"6.1"}
+	f(s6)
+}
+
+func GetSlice7(f func(s [2]XYZ)) {
+	//s7[1] = XYZ{"7.1"}
+	f(s7)
+}
+
+var s8 [1]p_crossrealm.Stringer
+
+func GetSlice8(f p_crossrealm.Stringer) [1]p_crossrealm.Stringer {
+	s8[0] = f
+	return s8
+}
+
+func GetSlice9(f p_crossrealm.Stringer) [1]p_crossrealm.Stringer {
+	var s9 [1]p_crossrealm.Stringer
+	s9[0] = f
+	return s9
+}
+
+// XXX, s10 under array is real, and owned by this realm.
+func GetSlice10() []int {
+	return s10
+}
+
+func GetSlice11(f func(s []int)) {
+	// XXX, this is valid cuz the type of
+	// array is not defined in current realm(or any other),
+	// and the underlying array is not owned by this realm.
+	s11 := []int{1}
+	f(s11)
+}

--- a/examples/gno.land/r/demo/tests/crossrealm/struct/crossrealm_struct.gno
+++ b/examples/gno.land/r/demo/tests/crossrealm/struct/crossrealm_struct.gno
@@ -1,0 +1,73 @@
+package crossrealm_struct
+
+type Bar struct {
+	A int
+}
+
+var bar *Bar
+
+// TODO: deprovision this
+var Bar2 *Bar = &Bar{A: 22} // exported
+var Bar3 Bar = Bar{A: 22}
+
+func (b *Bar) String() {
+	println("b.A: ", b.A)
+}
+
+func SetBar(b *Bar) *Bar {
+	bar = b
+	return bar
+}
+
+func ChangeBar() {
+	Bar2.A += 1
+	//println(Bar2.A)
+}
+
+func (b *Bar) ModifyBar() {
+	b.A += 1
+}
+
+// -------------------------------------------------
+type A struct {
+	name string
+}
+
+type B struct {
+	name string
+}
+
+type D struct {
+	name string
+}
+
+type C struct {
+	A
+	B
+	D
+}
+
+var a A = A{name: "a"}
+var b B = B{name: "b"}
+
+var c *C
+
+func init() {
+	c = &C{}
+	c.A = a
+	c.B = b
+}
+
+func GetStruct(cb func(v *C)) *C {
+	c.D = D{name: "d"} // this is not attached before return
+	cb(c)
+	return c
+}
+
+func GetStruct2(cb func(v *C)) *C {
+	var e = &C{}
+	e.A = a
+	e.B = b
+	cb(e)
+	return e
+}

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -1775,25 +1775,10 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue) {
 	if pv == nil {
 		panic(fmt.Sprintf("package value missing in store: %s", fv.PkgPath))
 	}
-	rlm := pv.GetRealm()
-	if rlm == nil && recv.IsDefined() {
-		obj := recv.GetFirstObject(m.Store)
-		if obj == nil {
-			// could be a nil receiver.
-			// just ignore.
-		} else {
-			recvOID := obj.GetObjectInfo().ID
-			if !recvOID.IsZero() {
-				// override the pv and rlm with receiver's.
-				recvPkgOID := ObjectIDFromPkgID(recvOID.PkgID)
-				pv = m.Store.GetObject(recvPkgOID).(*PackageValue)
-				rlm = pv.GetRealm() // done
-			}
-		}
-	}
+
 	m.Package = pv
-	if rlm != nil && m.Realm != rlm {
-		m.Realm = rlm // enter new realm
+	if rlm := pv.GetRealm(); rlm != nil {
+		m.Realm = rlm // switch to new realm
 	}
 }
 

--- a/gnovm/tests/files/assign_unnamed_type/more/realm_compositelit_filetest.gno
+++ b/gnovm/tests/files/assign_unnamed_type/more/realm_compositelit_filetest.gno
@@ -26,7 +26,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -37,13 +37,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -54,8 +54,8 @@ func main() {
 //                 "@type": "/gno.SliceValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "e256933ba4dfda233a7edb0902880d554118ba6e",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//                     "Hash": "0aa2b21a2fe2cc7c278e88039956c8707a120236",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //                 },
 //                 "Length": "1",
 //                 "Maxcap": "1",
@@ -64,17 +64,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -84,8 +84,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "2b8a024c53e94431e6203115feaf86b36413d7b2",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "dfee6575ebafc924fda642183bb0f8d16b0d0422",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/heap_item_value.gno
+++ b/gnovm/tests/files/heap_item_value.gno
@@ -15,7 +15,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "N": "BAAAAAAAAAA=",
@@ -26,15 +26,15 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "IsEscaped": true,
 //         "ModTime": "0",
 //         "RefCount": "2"
@@ -46,8 +46,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "8c001dde13b1f4dc01fc6d3a5bb4bc0cdfe2a50b",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "0adbf7812105088758da13308ac71206531f676c",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/heap_item_value_init.gno
+++ b/gnovm/tests/files/heap_item_value_init.gno
@@ -19,12 +19,12 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -34,8 +34,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "a05e5e1e2d2a27d94408a9325a58068e60b504df",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "f24d8c3b3b924a754166274405548b15452b047b",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/heap_item_value_init.gno
+++ b/gnovm/tests/files/heap_item_value_init.gno
@@ -8,13 +8,13 @@ type S struct {
 var a, b *S
 
 func init() {
-	a = new(S)
+	a = new(S) // heapItemValue new real
 	a.A = new(int)
 	*a.A = 4
 }
 
 func main() {
-	b = a
+	b = a // dirty, refCount change.
 }
 
 // Realm:

--- a/gnovm/tests/files/zrealm1.gno
+++ b/gnovm/tests/files/zrealm1.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -41,9 +41,9 @@ func main() {
 //         {}
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm10.gno
+++ b/gnovm/tests/files/zrealm10.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "Fields": [
 //         {
 //             "N": "AwAAAAAAAAA=",
@@ -34,9 +34,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "ModTime": "4",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm11.gno
+++ b/gnovm/tests/files/zrealm11.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "Fields": [
 //         {
 //             "N": "//////////8=",
@@ -34,9 +34,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "ModTime": "4",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm13.gno
+++ b/gnovm/tests/files/zrealm13.gno
@@ -36,7 +36,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -61,7 +61,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -69,9 +69,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm14.gno
+++ b/gnovm/tests/files/zrealm14.gno
@@ -36,7 +36,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -59,15 +59,15 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "IsEscaped": true,
 //         "ModTime": "9",
 //         "RefCount": "1"
@@ -79,10 +79,10 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "95dca2f5b12899b6367402ecdac04c7ca59a03d9",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//             "Hash": "f589739a5bfbe87e8f8ae84bfc22ba66dfc42150",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
 //         }
 //     }
 // }
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:9]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9]

--- a/gnovm/tests/files/zrealm15.gno
+++ b/gnovm/tests/files/zrealm15.gno
@@ -40,7 +40,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -63,13 +63,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "10",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -82,15 +82,15 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "10",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "IsEscaped": true,
 //         "ModTime": "10",
 //         "RefCount": "1"
@@ -102,14 +102,14 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "6e4c3c716e28df1d3a25efeb654a7b7a379ce3b0",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//             "Hash": "7b12a482232e93046544aa4a1bc59e00b57b5779",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "IsEscaped": true,
 //         "ModTime": "10",
 //         "RefCount": "1"
@@ -121,9 +121,9 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "e82e410f22425e48d5f6c611160084a4dd50d3d1",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//             "Hash": "812cbc9ff5a63a74ea621ddf1d4d1af8d3806d81",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
 //         }
 //     }
 // }
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:10]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10]

--- a/gnovm/tests/files/zrealm16.gno
+++ b/gnovm/tests/files/zrealm16.gno
@@ -35,7 +35,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -50,7 +50,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -68,18 +68,18 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "ModTime": "11",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "IsEscaped": true,
 //         "ModTime": "11",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -89,14 +89,14 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "7c9f93a63419d852f132afaf2245ddcac5e8c3fb",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//             "Hash": "6dbf7754a96bbd6c8e2d277ac532a2baa01472f2",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "IsEscaped": true,
 //         "ModTime": "11",
 //         "RefCount": "2"
@@ -108,8 +108,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "95dca2f5b12899b6367402ecdac04c7ca59a03d9",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//             "Hash": "f589739a5bfbe87e8f8ae84bfc22ba66dfc42150",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm2.gno
+++ b/gnovm/tests/files/zrealm2.gno
@@ -28,7 +28,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -44,10 +44,10 @@ func main() {
 //         {}
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]

--- a/gnovm/tests/files/zrealm3.gno
+++ b/gnovm/tests/files/zrealm3.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -57,17 +57,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -77,10 +77,10 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "567a18d9c7594ece7956ce54384b0858888bb834",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "1a809ec67c06fdfd61befe293a200b8348010ea8",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]

--- a/gnovm/tests/files/zrealm4.gno
+++ b/gnovm/tests/files/zrealm4.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -72,17 +72,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "5",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "5",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -92,8 +92,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d57ee28f5030eb8c612b374155fd545675633288",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "6be1a84418e268a1867b4fadcbf952698c8cc08c",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm5.gno
+++ b/gnovm/tests/files/zrealm5.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -72,17 +72,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -92,12 +92,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "8a86634afa28ef7d7a1f4272255637f16daae2cd",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "1d2cdc0c007ab843fbb49664c5545a48f5e75a80",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -147,8 +147,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "7c63a8fd451cd7c470c1851f1ead037246422ded",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//                     "Hash": "609b2b0af84c954a21660a4c949175c2c0748a9b",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -156,17 +156,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "5",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "5",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -176,8 +176,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "115779a405a1cae45446397ea897a98a4043cbb2",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "0568bd550b46bdefb78a8e9a94ac3c92f8cca189",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm6.gno
+++ b/gnovm/tests/files/zrealm6.gno
@@ -24,7 +24,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -73,17 +73,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -93,12 +93,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "34a46349a2bc1b58591d0222a145b585452683be",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//             "Hash": "6d0f0903add74bd7a162bdb46c6a9eb49b261d5d",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -148,8 +148,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "81074f5da453299a913435a2ddd05248ee012f8c",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "59bd2daea7fdc237d4699f0739d2c490301ee96c",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -157,17 +157,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "7",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "7",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -177,12 +177,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "5d64092f4f064ca58bdeffa32f6a119545b401c8",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "4268ca2ae2007589ac1cf918d91b9eef75a6e800",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -232,8 +232,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "32593d23afa555fe99d433dbca1130b3843da97a",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//                     "Hash": "0717f2c0b18e55debb637dbfe5d0e62487c46fa6",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -241,17 +241,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "7",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "7",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -261,8 +261,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "131993c49dced230bd7071e9bae8d95e28733b73",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "70e6ee91d46ce3bde68eec80b87067ba0c6f0dc9",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm7.gno
+++ b/gnovm/tests/files/zrealm7.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:11]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -74,17 +74,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -94,12 +94,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "42cd813e173ad23c7873e9605901e8bea1176c96",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//             "Hash": "f73447d1b37ea8352ffb67d8e09c37c9f3c645cd",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -149,8 +149,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "4f88fcdc73a4a94905e8e4044aa50c2ec7bf2227",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//                     "Hash": "88542555891b970292b019c26cae8f1cfc1c6241",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -158,13 +158,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -213,17 +213,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -233,16 +233,16 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d7fbb234dca9f194f35fe5409a62db9daf39b0fc",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "491d8125158bb0112b7db1f8d375e04eb41462de",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -252,12 +252,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "2c172bbe0183ccc73c59d9acb196c45b0331c39e",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//             "Hash": "fb2ae5ffb8bab5eb8cd53357a25069d71af9dd67",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -298,8 +298,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "76a40dcf03d32c312c2213265c14d4de1b12a810",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//                     "Hash": "fdfbe0b8c09e42344d06f7a292b252b81c74a903",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -317,8 +317,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "43f69f24b7827a331921b4af0f667346d186e0c3",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "e8d60c049eae9a6eabe030e6644a49df6fa5da94",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -326,17 +326,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "9",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -346,8 +346,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "92b2f4ebab764951f64086bce480f898f755de5a",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "5b185238029bcdca515c9bf6b8dee0a311d793dc",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm8.gno
+++ b/gnovm/tests/files/zrealm8.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "Fields": [
 //         {
 //             "N": "AgAAAAAAAAA=",
@@ -34,9 +34,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "ModTime": "4",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm9.gno
+++ b/gnovm/tests/files/zrealm9.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -33,9 +33,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "ModTime": "4",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_avl0.gno
+++ b/gnovm/tests/files/zrealm_avl0.gno
@@ -24,11 +24,11 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "ModTime": "7",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -38,12 +38,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "627e8e517e7ae5db0f3b753e2a32b607989198b6",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//             "Hash": "a041c24552aca3c30667d2ec3e396819da33f32b",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -98,17 +98,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -118,12 +118,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "b28057ab7be6383785c0a5503e8a531bdbc21851",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//             "Hash": "496709be5dfef2022e7a72f752de52b329d7c3a3",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -162,8 +162,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "6da365f0d6cacbcdf53cd5a4b125803cddce08c2",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//                     "Hash": "3c84bba4b3b7456eb06d1be1957aef86203439df",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -181,8 +181,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "f216afe7b5a17f4ebdbb98dceccedbc22e237596",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "f8c4da446b29a92575ee85ad2fd1f3fea9b550fd",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -190,17 +190,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -210,8 +210,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "ff1a50d8489090af37a2c7766d659f0d717939b5",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "bb7d8b16d0cbcbab9cd480d71e6aff4d1eb88047",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_avl1.gno
+++ b/gnovm/tests/files/zrealm_avl1.gno
@@ -24,11 +24,11 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "ModTime": "11",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -38,16 +38,16 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "1375f6f96a1a3f298347dc8fc0065afa36cb7f0f",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "60d2961feef6c44d9b7181c236dda585193c8627",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "ModTime": "13",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -57,12 +57,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "b28057ab7be6383785c0a5503e8a531bdbc21851",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//             "Hash": "496709be5dfef2022e7a72f752de52b329d7c3a3",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:15]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:15]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -117,17 +117,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:15",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:14]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:14]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -137,12 +137,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "143aebc820da33550f7338723fb1e2eec575b196",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15"
+//             "Hash": "2a5241423f562efb77b43f2919241269f8b85808",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:15"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:13]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:13]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -181,8 +181,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "cafae89e4d4aaaefe7fdf0691084508d4274a981",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "536650601faf528359128ddedfb6bf2ffaa85572",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -200,8 +200,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "2e733a8e9e74fe14f0a5d10fb0f6728fa53d052d",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
+//                     "Hash": "7e1a4b2cf4b6cc13f3d29b676b9bc408f620e979",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -209,17 +209,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:12]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:12]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -229,12 +229,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "b2e446f490656c19a83c43055de29c96e92a1549",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
+//             "Hash": "cd8b909f99cf0bf25b2534fc7578911d66e24eea",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:11]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -273,8 +273,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "4e56eeb96eb1d9b27cf603140cd03a1622b6358b",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//                     "Hash": "4c09428cb08da2d1b0d153d1364df3e2e5d4561c",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -292,8 +292,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "7b61530859954d1d14b2f696c91c5f37d39c21e7",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//                     "Hash": "0fb6745a840ac6e8914e22ed2af0c50d8e37c695",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -301,17 +301,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -321,10 +321,10 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "fedc6d430b38c985dc6a985b2fcaee97e88ba6da",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//             "Hash": "4879f205b10d37ab82786c53e50c171ffc5152b2",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //         }
 //     }
 // }
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:4]
-// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:4]
+// d[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]

--- a/gnovm/tests/files/zrealm_avl2.gno
+++ b/gnovm/tests/files/zrealm_avl2.gno
@@ -23,11 +23,11 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/test"]
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //         "ModTime": "8",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -37,12 +37,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "0b5493aa4ea42087780bdfcaebab2c3eec351c15",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//             "Hash": "e221551f92f502d199b68084c3d5a30f072bb2e5",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -97,17 +97,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -117,12 +117,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "be751422ef4c2bc068a456f9467d2daca27db8ca",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//             "Hash": "fca04d1bd566818259bd2a4fa74805c0215db218",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //         }
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -161,8 +161,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "9fa04d8791e205a6de2eedce81bb4dbd0883cac7",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//                     "Hash": "9dd79da898cdd530166a659a97d595392ee17c77",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -180,8 +180,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "a55a6a6b2027d6ec5e322aa32d4269b974fe1a4f",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//                     "Hash": "1fba249e8d9732e0f85f59b9784a09b899137506",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -189,17 +189,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     }
 // }
-// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
+// c[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7]={
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "ModTime": "0",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -209,12 +209,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "03d901636a4e56d5bd32a75a7b923c7700c8859a",
-//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//             "Hash": "266b0530d93ebc972cb52c2e0d2ff486dc1d0f94",
+//             "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //         }
 //     }
 // }
-// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
+// u[r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -228,8 +228,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "953a28a33bf1bae93eb1fcb4d1b348ccabcbaabd",
-//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//                     "Hash": "826fadf623de40be71afc9fa99fb05eb595adb2e",
+//                     "ObjectID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -237,9 +237,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "ID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "ModTime": "6",
-//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//         "OwnerID": "r:a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm0.gno
+++ b/gnovm/tests/files/zrealm_crossrealm0.gno
@@ -5,7 +5,7 @@ import (
 	"gno.land/r/demo/tests"
 )
 
-// NOTE: it is valid to persist external realm types.
+// NOTE: it is invalid to persist external realm types.
 var somevalue tests.TestRealmObject
 
 func main() {
@@ -13,5 +13,5 @@ func main() {
 	println(somevalue)
 }
 
-// Output:
-// (struct{("test" string)} gno.land/r/demo/tests.TestRealmObject)
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm1.gno
@@ -5,7 +5,7 @@ import (
 	"gno.land/r/demo/tests"
 )
 
-// NOTE: it is valid to persist external realm types.
+// NOTE: it is invalid to persist external realm types.
 var somevalue tests.TestRealmObject
 
 func init() {
@@ -16,5 +16,5 @@ func main() {
 	println(somevalue)
 }
 
-// Output:
-// (struct{("test" string)} gno.land/r/demo/tests.TestRealmObject)
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm15_struct.gno
+++ b/gnovm/tests/files/zrealm_crossrealm15_struct.gno
@@ -1,0 +1,25 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm"
+)
+
+type fooer struct{}
+
+func (fooer) Foo() { println("hello") }
+
+var f *fooer
+
+func init() {
+	f = &fooer{} // unreal
+	crossrealm.SetFooer(f)
+	crossrealm.CallFooerFoo()
+}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// new escaped mark has no object ID

--- a/gnovm/tests/files/zrealm_crossrealm17.gno
+++ b/gnovm/tests/files/zrealm_crossrealm17.gno
@@ -17,7 +17,7 @@ var f *fooer
 
 func main() {
 	f = &fooer{}
-	c := &container{f}
+	c := &container{f} // heapItemValue not real, so trying attach by value
 	crossrealm.SetFooer(c)
 	crossrealm.CallFooerFoo()
 	print(".")

--- a/gnovm/tests/files/zrealm_crossrealm17a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm17a.gno
@@ -1,0 +1,132 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm"
+)
+
+type container struct {
+	name string
+	f    *fooer
+}
+
+func (container) Foo() { println("hello " + c.f.name) }
+
+type fooer struct{ name string }
+
+var c = &container{name: "local_container"}
+
+func main() {
+	ff := &fooer{name: "local_foo"}
+	c.f = ff
+	crossrealm.SetFooer(c)
+	crossrealm.CallFooerFoo()
+	print(".")
+}
+
+// Output:
+// hello local_foo
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "5",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.container"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_foo"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "RefCount": "1"
+//     }
+// }
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "RefCount": "1"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.fooer"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "90e6414435c56b7ffa17bd575535b7a558b93e22",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:7"
+//         }
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_container"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Hash": "7d3bda685439b3989f18e824762f473f40c944fb",
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:6"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "5",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm18.gno
+++ b/gnovm/tests/files/zrealm_crossrealm18.gno
@@ -7,27 +7,26 @@ import (
 	crossrealm "gno.land/r/demo/tests/crossrealm"
 )
 
-type fooer struct{}
+type fooer struct{ name string }
 
-func (fooer) Foo() { println("hello " + std.CurrentRealm().PkgPath()) }
+func (fooer) Foo() { println("hello from local realm fooer: " + std.CurrentRealm().PkgPath()) }
 
-var f crossrealm.Fooer = crossrealm.SetFooer(&fooer{})
+var local_fooer = &fooer{name: "local_fooer"}
 
 func init() {
+	crossrealm.SetFooer(local_fooer)
 	crossrealm.CallFooerFoo()
 }
 
 func main() {
 	crossrealm.CallFooerFoo()
-	print(".")
+	println(".")
 }
 
 // Output:
-// hello gno.land/r/crossrealm_test
-// hello gno.land/r/crossrealm_test
+// hello from local realm fooer: gno.land/r/crossrealm_test
+// hello from local realm fooer: gno.land/r/crossrealm_test
 // .
-
-// Error:
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm19.gno
+++ b/gnovm/tests/files/zrealm_crossrealm19.gno
@@ -1,0 +1,30 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm"
+)
+
+type fooer struct {
+	s string
+}
+
+func (f *fooer) Foo() {
+	f.s = "B"
+	println("hello")
+}
+
+var f *fooer
+
+func init() {
+	f = &fooer{s: "A"} // unreal, refCount 1, owner f
+	crossrealm.SetFooer(f)
+	crossrealm.CallFooerFoo()
+}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// new escaped mark has no object ID

--- a/gnovm/tests/files/zrealm_crossrealm20a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20a.gno
@@ -2,16 +2,13 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
-
-func init() {
-}
+var b0 crossrealm.Bar // run declarations
 
 func main() {
+	print(".")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm20b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20b.gno
@@ -2,13 +2,19 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
+// associate to a containing object
+type Container struct {
+	name string
+	b    crossrealm.Bar
+}
+
+var c Container
 
 func init() {
+	print(".")
 }
 
 func main() {

--- a/gnovm/tests/files/zrealm_crossrealm20b1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20b1.gno
@@ -1,0 +1,25 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+// associate to a containing object
+type Container struct {
+	name string
+	b    crossrealm.Bar
+}
+
+var c *Container
+
+func init() {
+	c = &Container{name: "Container", b: crossrealm.Bar{A: 1}}
+	println(c.b)
+}
+
+func main() {
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c.gno
@@ -1,0 +1,26 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+// associate to a containing object
+type Container struct {
+	name string
+	b    *crossrealm.Bar
+}
+
+var c = Container{name: "local_container"}
+
+func init() {
+	b0 := &crossrealm.Bar{A: 1} // this is valid association
+	c.b = b0                    // c is real, so panic while association, for b0 is unreal
+}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm20c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c.gno
@@ -23,4 +23,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20c1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c1.gno
@@ -18,4 +18,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20c1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c1.gno
@@ -1,0 +1,21 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+// associate to a containing object
+type Container struct {
+	name string
+	b    *crossrealm.Bar
+}
+
+var c = &Container{name: "local_container", b: &crossrealm.Bar{A: 1}}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm20c2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c2.gno
@@ -1,0 +1,21 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+// associate to a containing object
+type Container struct {
+	name string
+	b    crossrealm.Bar
+}
+
+var c = &Container{name: "local_container", b: crossrealm.Bar{A: 1}}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20c3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20c3.gno
@@ -1,0 +1,19 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+type Node struct {
+	*Node
+}
+
+var root interface{}
+
+func main() {
+	node := &Node{}
+	node.Node = node
+
+	root = node
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm20d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20d.gno
@@ -1,0 +1,18 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+var b0 *crossrealm.Bar = &crossrealm.Bar{A: 11}
+
+func init() {
+}
+
+func main() {
+	print(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm20d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20d.gno
@@ -15,4 +15,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20e.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20e.gno
@@ -1,0 +1,16 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+var b1 *crossrealm.Bar
+
+func main() {
+	b1 = &crossrealm.Bar{A: 22} // this should panic
+	println(b1)
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm20e.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20e.gno
@@ -13,4 +13,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm20f.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20f.gno
@@ -1,0 +1,18 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+)
+
+type Dt *crossrealm.Bar
+
+var b Dt
+
+func main() {
+	b = &crossrealm.Bar{A: 22} // this should panic
+	println(b)
+}
+
+// Error:
+// should not happen

--- a/gnovm/tests/files/zrealm_crossrealm20g.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20g.gno
@@ -2,16 +2,14 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/struct"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
-
-func init() {
-}
+var root interface{}
 
 func main() {
+	root = crossrealm.Bar3
+	println("ok")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm20j.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20j.gno
@@ -1,0 +1,89 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"std"
+
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+}
+
+func (fooer) Foo() { println("hello " + std.CurrentRealm().PkgPath()) }
+
+var f fooer
+
+func main() {
+	f = fooer{name: "local_fooer"} // f is dirty
+	crossrealm.SetContainer2(&f)
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello gno.land/r/crossrealm_test
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_fooer"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// d[f5a516808f8976c33939133293d598ce3bca4e8d:3]
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm20j.gno
+++ b/gnovm/tests/files/zrealm_crossrealm20j.gno
@@ -28,7 +28,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
-// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+// u[r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -49,7 +49,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -57,14 +57,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
 //         "ModTime": "4",
-//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "OwnerID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
 //         "RefCount": "1"
 //     }
 // }
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -78,12 +78,12 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }
-// d[f5a516808f8976c33939133293d598ce3bca4e8d:3]
+// d[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]
 // switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
 // switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21.gno
@@ -24,12 +24,12 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:3]={
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "IsEscaped": true,
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -39,15 +39,15 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "8222b763e9bc04b4b7805e165e9f1324a39f28b6",
-//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//             "Hash": "75480330ecbe91b42c19cb63b3e8908d4ea9900e",
+//             "ObjectID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4"
 //         }
 //     }
 // }
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -61,9 +61,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm21a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21a.gno
@@ -21,4 +21,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm21a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21a.gno
@@ -1,0 +1,24 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+}
+
+func (fooer) Foo() { println("hello") }
+
+func main() {
+	// object attaching to external is main block,
+	// f is an unreal value defined w/i this block,
+	// and invalid to attach to external, panic.
+	f := fooer{name: "local_fooer"}
+	crossrealm.SetContainer2(&f)
+	print(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm21b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21b.gno
@@ -19,4 +19,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm21b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21b.gno
@@ -1,0 +1,22 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"std"
+
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+}
+
+func (fooer) Foo() { println("hello " + std.CurrentRealm().PkgPath()) }
+
+func main() {
+	crossrealm.SetContainer2(&fooer{name: "local_fooer"})
+	print(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm21c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21c.gno
@@ -1,0 +1,65 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+}
+
+func (fooer) Foo() { println("hello") }
+
+var f = fooer{name: "local_fooer"}
+
+func main() {
+	crossrealm.SetContainer2(&f) // the object attached is package block, escaped, so this works.
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21c.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
-// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+// u[r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -46,7 +46,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -54,9 +54,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
 //         "ModTime": "4",
-//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "OwnerID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm21d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21d.gno
@@ -1,0 +1,120 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+	bar
+}
+type bar struct{ name string }
+
+func (fooer) Foo() { println("hello") }
+
+var f = fooer{name: "local_fooer"}
+
+func main() {
+	f.bar = bar{name: "local_bar"} // this makes f dirty, it's real
+	crossrealm.SetContainer2(&f)   // object DidUpdate is package block
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_bar"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_fooer"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/crossrealm_test.bar"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "dac9452dd14f52ea03ff0d5898b481c8e993a412",
+//                 "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:6"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ModTime": "5",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// d[f5a516808f8976c33939133293d598ce3bca4e8d:4]
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21d1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21d1.gno
@@ -29,7 +29,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
-// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+// u[r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -50,7 +50,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "2",
 //                 "TV": null
@@ -58,13 +58,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
 //         "ModTime": "4",
-//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "OwnerID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -89,7 +89,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -97,19 +97,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "ModTime": "6",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -119,8 +119,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "6d19add23dca2c83b923c7d597cefd31a2d5bd90",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//             "Hash": "5b99c134e6faa2e6333fe3f0e7fc480ea5d493d2",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm21d1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21d1.gno
@@ -1,0 +1,128 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+	b    *bar
+}
+type bar struct{ name string }
+
+func (fooer) Foo() { println("hello") }
+
+var f = fooer{name: "local_fooer"} // already real
+var b = &bar{name: "local_bar"}
+
+func main() {
+	f.b = b                      // this makes f dirty, it's real
+	crossrealm.SetContainer2(&f) // object DidUpdate is package block
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_fooer"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.bar"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.bar"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "6d19add23dca2c83b923c7d597cefd31a2d5bd90",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21d2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21d2.gno
@@ -28,7 +28,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
-// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+// u[r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -49,7 +49,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "3",
 //                 "TV": null
@@ -57,9 +57,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
 //         "ModTime": "4",
-//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "OwnerID": "r:5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm21d2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21d2.gno
@@ -1,0 +1,68 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+	bar
+}
+type bar struct{ name string }
+
+func (fooer) Foo() { println("hello") }
+
+var b = bar{name: "bar"}
+var f = fooer{name: "local_fooer", bar: b}
+
+func main() {
+	crossrealm.SetContainer2(&f) // object DidUpdate is package block
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "3",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21e.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21e.gno
@@ -1,0 +1,121 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+	bar
+}
+type bar struct{ name string }
+
+func (f fooer) Foo() { println("hello " + f.bar.name) }
+
+var f = fooer{name: "local_fooer", bar: bar{name: "local_bar_1"}}
+var b = bar{name: "local_bar_2"} // real
+
+func main() {
+	f.bar = b // this makes f dirty
+	crossrealm.SetContainer2(&f)
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello local_bar_2
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// u[5836d1a3cec217737a5553d4c1a03d8897d5f281:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.fooer"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:4",
+//         "ModTime": "4",
+//         "OwnerID": "5836d1a3cec217737a5553d4c1a03d8897d5f281:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_bar_2"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "local_fooer"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/crossrealm_test.bar"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "2653fb8c9edc489f07585ec600dfd1a968d81ca1",
+//                 "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:7"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// d[f5a516808f8976c33939133293d598ce3bca4e8d:4]
+// switchrealm["gno.land/r/demo/tests/crossrealm/iface"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21f.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21f.gno
@@ -1,0 +1,105 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+
+var s *crossrealm.C
+
+func cb(c *crossrealm.C) {
+	s = c
+}
+func main() {
+	crossrealm.GetStruct(cb)
+	println(s)
+}
+
+// Output:
+// &(struct{(ref(5965ae851c02ab677bc8394b408535c1db9b2635:11) gno.land/r/demo/tests/crossrealm/struct.A),(ref(5965ae851c02ab677bc8394b408535c1db9b2635:12) gno.land/r/demo/tests/crossrealm/struct.B),(struct{("d" string)} gno.land/r/demo/tests/crossrealm/struct.D)} gno.land/r/demo/tests/crossrealm/struct.C)
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[5965ae851c02ab677bc8394b408535c1db9b2635:9]={
+//     "ObjectInfo": {
+//         "ID": "5965ae851c02ab677bc8394b408535c1db9b2635:9",
+//         "IsEscaped": true,
+//         "ModTime": "3",
+//         "OwnerID": "5965ae851c02ab677bc8394b408535c1db9b2635:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/demo/tests/crossrealm/struct.C"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "ObjectID": "5965ae851c02ab677bc8394b408535c1db9b2635:10"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm/struct"]
+// c[5965ae851c02ab677bc8394b408535c1db9b2635:14]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "d"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5965ae851c02ab677bc8394b408535c1db9b2635:14",
+//         "ModTime": "0",
+//         "OwnerID": "5965ae851c02ab677bc8394b408535c1db9b2635:10",
+//         "RefCount": "1"
+//     }
+// }
+// u[5965ae851c02ab677bc8394b408535c1db9b2635:10]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/struct.A"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "77afd6587e56836f288520b275bebc4911b7ef57",
+//                 "ObjectID": "5965ae851c02ab677bc8394b408535c1db9b2635:11"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/struct.B"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "c4e78b61af7cd5557452e3d22d20d1c3b1de4b41",
+//                 "ObjectID": "5965ae851c02ab677bc8394b408535c1db9b2635:12"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/struct.D"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "70a58641e15bf62bf3d1d95ce2e8b2048286f42f",
+//                 "ObjectID": "5965ae851c02ab677bc8394b408535c1db9b2635:14"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "5965ae851c02ab677bc8394b408535c1db9b2635:10",
+//         "ModTime": "13",
+//         "OwnerID": "5965ae851c02ab677bc8394b408535c1db9b2635:9",
+//         "RefCount": "1"
+//     }
+// }
+// d[5965ae851c02ab677bc8394b408535c1db9b2635:13]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm21g.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21g.gno
@@ -1,0 +1,17 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/struct"
+
+var s *crossrealm.C
+
+func cb(c *crossrealm.C) {
+	s = c
+}
+func main() {
+	crossrealm.GetStruct2(cb)
+	println(s)
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm21g.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21g.gno
@@ -14,4 +14,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm21h.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21h.gno
@@ -1,0 +1,26 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type fooer struct {
+	name string
+}
+
+func (fooer) Foo() { println("hello") }
+
+var f = fooer{name: "local_fooer"}
+
+var f1 = &f
+
+func main() {
+	crossrealm.SetContainer2(&f)
+	crossrealm.RunF()
+	print(".")
+}
+
+// Output:
+// hello
+// .

--- a/gnovm/tests/files/zrealm_crossrealm22.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22.gno
@@ -38,12 +38,12 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:3]={
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -53,8 +53,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "8222b763e9bc04b4b7805e165e9f1324a39f28b6",
-//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//             "Hash": "75480330ecbe91b42c19cb63b3e8908d4ea9900e",
+//             "ObjectID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4"
 //         }
 //     }
 // }
@@ -62,7 +62,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -76,9 +76,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }
@@ -86,7 +86,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -100,19 +100,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:3]={
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -122,8 +122,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "759fd5b507fff8ea1b18d401550d918387a63445",
-//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//             "Hash": "05f23d7eb396436367d0e5c55f21da75458cc082",
+//             "ObjectID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4"
 //         }
 //     }
 // }
@@ -131,7 +131,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -145,9 +145,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm22_func.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22_func.gno
@@ -38,12 +38,12 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:3]={
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -53,8 +53,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "8222b763e9bc04b4b7805e165e9f1324a39f28b6",
-//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//             "Hash": "75480330ecbe91b42c19cb63b3e8908d4ea9900e",
+//             "ObjectID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4"
 //         }
 //     }
 // }
@@ -62,7 +62,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -76,9 +76,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }
@@ -86,7 +86,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -100,19 +100,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:3]={
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -122,8 +122,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "759fd5b507fff8ea1b18d401550d918387a63445",
-//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//             "Hash": "05f23d7eb396436367d0e5c55f21da75458cc082",
+//             "ObjectID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4"
 //         }
 //     }
 // }
@@ -131,7 +131,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
 // switchrealm["gno.land/r/demo/tests/crossrealm"]
 // switchrealm["gno.land/r/demo/tests/crossrealm_b"]
-// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+// u[r:0edc46caf30c00efd87b6c272673239eafbd051e:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -145,9 +145,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:4",
 //         "ModTime": "5",
-//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "OwnerID": "r:0edc46caf30c00efd87b6c272673239eafbd051e:3",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm22_func.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22_func.gno
@@ -1,0 +1,159 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"std"
+
+	"gno.land/r/demo/tests/crossrealm"
+	"gno.land/r/demo/tests/crossrealm_b"
+)
+
+func main() {
+	f := crossrealm_b.Fooer
+	crossrealm.SetFooerGetter(func() crossrealm.Fooer { return f })
+	crossrealm.CallFooerGetterFoo()
+	f.SetS("B")
+	crossrealm.CallFooerGetterFoo()
+	println(".")
+
+	f.SetS("C")
+	crossrealm.SetFooerGetter(crossrealm_b.FooerGetter)
+	crossrealm.CallFooerGetterFoo()
+	println(".")
+
+	f.SetS("D")
+	crossrealm.SetFooerGetter(crossrealm_b.FooerGetterBuilder())
+	crossrealm.CallFooerGetterFoo()
+	println(".")
+}
+
+// Output:
+// hello A cur=gno.land/r/demo/tests/crossrealm_b prev=gno.land/r/demo/tests/crossrealm
+// hello B cur=gno.land/r/demo/tests/crossrealm_b prev=gno.land/r/demo/tests/crossrealm
+// .
+// hello C cur=gno.land/r/demo/tests/crossrealm_b prev=gno.land/r/demo/tests/crossrealm
+// .
+// hello D cur=gno.land/r/demo/tests/crossrealm_b prev=gno.land/r/demo/tests/crossrealm
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+//     "ObjectInfo": {
+//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/demo/tests/crossrealm_b.fooer"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "8222b763e9bc04b4b7805e165e9f1324a39f28b6",
+//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "B"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ModTime": "5",
+//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "C"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ModTime": "5",
+//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// u[0edc46caf30c00efd87b6c272673239eafbd051e:3]={
+//     "ObjectInfo": {
+//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:2",
+//         "RefCount": "1"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/demo/tests/crossrealm_b.fooer"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "759fd5b507fff8ea1b18d401550d918387a63445",
+//             "ObjectID": "0edc46caf30c00efd87b6c272673239eafbd051e:4"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// u[0edc46caf30c00efd87b6c272673239eafbd051e:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "D"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "0edc46caf30c00efd87b6c272673239eafbd051e:4",
+//         "ModTime": "5",
+//         "OwnerID": "0edc46caf30c00efd87b6c272673239eafbd051e:3",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm_b"]
+// switchrealm["gno.land/r/demo/tests/crossrealm"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm22a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+func main() {
+	f := func() bool {
+		c := b
+		var ls Local_S
+		return true
+	}
+	crossrealm.SetCallback(f)
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm22a1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a1.gno
@@ -1,0 +1,28 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+func main() {
+	var ls = Local_S{name: "Local_S"}
+	f := func() bool {
+		c := b
+		return true
+	}
+	crossrealm.SetCallback(f)
+
+	ls.name = "modified"
+
+	println("ok")
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/gnovm/tests/files/zrealm_crossrealm22a1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a1.gno
@@ -25,4 +25,4 @@ func main() {
 }
 
 // Error:
-// cannot modify external-realm or non-realm object
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm22a2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a2.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+func main() {
+	ls := &Local_S{name: "Local_S"}
+
+	f := func() bool {
+		c := b
+		return true
+	}
+	crossrealm.SetCallback(f)
+
+	ls.name = "modified"
+
+	println("ok")
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/gnovm/tests/files/zrealm_crossrealm22a3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a3.gno
@@ -31,7 +31,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/func"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -45,9 +45,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "ModTime": "5",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm22a3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22a3.gno
@@ -1,0 +1,53 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+var ls = &Local_S{name: "Local_S"}
+
+func main() {
+	f := func() bool {
+		c := b
+		return true
+	}
+	crossrealm.SetCallback(f)
+
+	ls.name = "modified"
+
+	println(ls)
+}
+
+// Output:
+// &(struct{("modified" string)} gno.land/r/crossrealm_test.Local_S)
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "modified"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "5",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "RefCount": "1"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm22b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22b.gno
@@ -1,0 +1,25 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+func main() {
+	ls := Local_S{name: "local_s"} // panic
+	f := func() bool {
+		c := b
+		return true
+	}
+	crossrealm.SetCallback(f)
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm22c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22c.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+func main() {
+	f := func() bool {
+		c := b
+		var ls *Local_S
+		return true
+	}
+	crossrealm.SetCallback(f)
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm22d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22d.gno
@@ -1,0 +1,27 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var f = func() bool {
+	println("callback")
+	return true
+}
+
+func main() {
+	crossrealm.SetCallback(f)
+	crossrealm.ExecuteCallback()
+	println("ok")
+}
+
+// Output:
+// callback
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm22e.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22e.gno
@@ -1,0 +1,30 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/func"
+)
+
+var b = 1
+
+type Local_S struct {
+	name string
+}
+
+var f = func() bool {
+	c := b
+	var ls Local_S
+	return true
+}
+
+func main() {
+	crossrealm.SetCallback(f)
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/func"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm23_pure.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23_pure.gno
@@ -1,0 +1,22 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import "gno.land/p/demo/tests/p_crossrealm"
+
+var b0 p_crossrealm.Container
+
+func init() {
+	b0 = p_crossrealm.Container{
+		A: 1,
+	}
+}
+
+func main() {
+	print(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm23a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23a.gno
@@ -17,7 +17,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:5]={
 //     "Fields": [
 //         {
 //             "N": "AQAAAAAAAAA=",
@@ -29,17 +29,17 @@ func main() {
 //         {}
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -49,8 +49,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "01799eb680e2f34495c1050457f9ccd79795a561",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//             "Hash": "b7ba32ba8f6bd39fe6f6fbc73e7668d5e27ac3fe",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm23a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23a.gno
@@ -1,0 +1,56 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import "gno.land/p/demo/tests/p_crossrealm"
+
+var b0 *p_crossrealm.Container
+
+func main() {
+	b0 = &p_crossrealm.Container{
+		A: 1,
+	}
+	print(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+//     "Fields": [
+//         {
+//             "N": "AQAAAAAAAAA=",
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "32"
+//             }
+//         },
+//         {}
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "RefCount": "1"
+//     }
+// }
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/p/demo/tests/p_crossrealm.Container"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "01799eb680e2f34495c1050457f9ccd79795a561",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//         }
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm23b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23b.gno
@@ -1,0 +1,39 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"gno.land/p/demo/tests"
+)
+
+var root interface{}
+
+func main() {
+	root = tests.F
+	println(root)
+}
+
+// Output:
+// (struct{("p" string)} gno.land/p/demo/tests.Foo)
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "p"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm23c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23c.gno
@@ -1,0 +1,15 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"gno.land/p/demo/tests"
+)
+
+var root = tests.Foo{"p"}
+
+func main() {
+	println(root)
+}
+
+// Output:
+// (struct{("p" string)} gno.land/p/demo/tests.Foo)

--- a/gnovm/tests/files/zrealm_crossrealm23d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23d.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"errors"
+	"io"
+)
+
+func main() {
+	io.EOF = errors.New("modified")
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/gnovm/tests/files/zrealm_crossrealm23e.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23e.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"io"
+)
+
+func main() {
+	a := io.EOF
+	println(a)
+}
+
+// Output:
+// EOF

--- a/gnovm/tests/files/zrealm_crossrealm23f.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23f.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"io"
+)
+
+func main() {
+	a := &io.EOF
+	println(a)
+}
+
+// Output:
+// &(&(ref(4021fadf187fd2c8277aad0fbc5e8fc4e7f1c75f:10) errors.errorString) *errors.errorString)

--- a/gnovm/tests/files/zrealm_crossrealm23f.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23f.gno
@@ -11,4 +11,4 @@ func main() {
 }
 
 // Output:
-// &(&(ref(4021fadf187fd2c8277aad0fbc5e8fc4e7f1c75f:10) errors.errorString) *errors.errorString)
+// &(&(ref(p:4021fadf187fd2c8277aad0fbc5e8fc4e7f1c75f:10) errors.errorString) *errors.errorString)

--- a/gnovm/tests/files/zrealm_crossrealm23g.gno
+++ b/gnovm/tests/files/zrealm_crossrealm23g.gno
@@ -1,0 +1,16 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	"errors"
+	"io"
+)
+
+func main() {
+	a := &io.EOF
+	*a = errors.New("modified")
+	println(a)
+}
+
+// Error:
+// cannot modify external-realm or non-realm object

--- a/gnovm/tests/files/zrealm_crossrealm24_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm24_array.gno
@@ -2,16 +2,14 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/array"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
-
-func init() {
-}
+var root interface{}
 
 func main() {
+	root = crossrealm.GetArray()
+	println(".")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm25_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm25_array.gno
@@ -1,0 +1,16 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/array"
+)
+
+var root interface{}
+
+func main() {
+	root = crossrealm.GetArray2()
+	println(".")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm25_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm25_array.gno
@@ -13,4 +13,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm26_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm26_array.gno
@@ -18,7 +18,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/array"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -34,7 +34,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f429d463f62fe87134a149198611dfa41bd006ec:2"
+//                     "ObjectID": "r:f429d463f62fe87134a149198611dfa41bd006ec:2"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -42,9 +42,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm26_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm26_array.gno
@@ -1,0 +1,50 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/array"
+)
+
+var root interface{}
+
+func main() {
+	root = crossrealm.GetArray3()
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/array"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/demo/tests/crossrealm/array.Foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f429d463f62fe87134a149198611dfa41bd006ec:2"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm27_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm27_array.gno
@@ -2,16 +2,14 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/array"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
-
-func init() {
-}
+var root interface{}
 
 func main() {
+	root = crossrealm.GetArray4()
+	println(".")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm28_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28_array.gno
@@ -18,7 +18,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/array"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -37,9 +37,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm28_array.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28_array.gno
@@ -1,0 +1,45 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/array"
+)
+
+var root interface{}
+
+func main() {
+	root = crossrealm.GetArray5()
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/array"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "N": "AQAAAAAAAAA=",
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "32"
+//             }
+//         },
+//         {
+//             "N": "AgAAAAAAAAA=",
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "32"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm28_slice.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28_slice.gno
@@ -1,0 +1,28 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var fs []crossrealm.Fooer
+
+// the attachment works cuz
+// the object being attached
+// is foo{name: "1"}
+func init() {
+	fs := append(fs, foo{name: "1"})
+}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm28b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28b.gno
@@ -1,0 +1,21 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var arr [2]crossrealm.Fooer // the element attaching is nil, so it's ok
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm28b1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28b1.gno
@@ -1,0 +1,21 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/iface"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var arr [2]crossrealm.Foo2 // object attaching is zero value of struct, panic
+
+func main() {
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c.gno
@@ -1,0 +1,26 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+func main() {
+	var arr []crossrealm.Fooer
+	arr = append(arr, foo{name: "1"})
+	arr = append(arr, foo{name: "2"})
+	arr = append(arr, foo{name: "3"})
+
+	fs := arr[1:]
+	crossrealm.SetSlice(fs)
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28c1.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c1.gno
@@ -1,0 +1,21 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var arr = []crossrealm.Fooer{foo{name: "1"}, foo{name: "2"}, foo{name: "3"}}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm28c2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c2.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = foo{name: "1"}
+var f2 = foo{name: "2"}
+var f3 = foo{name: "3"}
+
+func main() {
+	var arr []crossrealm.Fooer // unreal array
+	arr = append(arr, f1)
+	arr = append(arr, f2)
+	arr = append(arr, f3)
+
+	crossrealm.SetSlice(arr)
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28c3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c3.gno
@@ -39,7 +39,7 @@ func main() {
 // switchrealm["gno.land/r/crossrealm_test"]
 // switchrealm["gno.land/r/crossrealm_test"]
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:7]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -55,7 +55,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -74,7 +74,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "2",
 //                 "TV": null
@@ -93,7 +93,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "3",
 //                 "TV": null
@@ -101,10 +101,10 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:7",
 //         "IsEscaped": true,
 //         "ModTime": "28",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm28c3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c3.gno
@@ -1,0 +1,111 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (*foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = foo{name: "1"}
+var f2 = foo{name: "2"}
+var f3 = foo{name: "3"}
+
+var arr []crossrealm.Fooer
+
+func init() {
+	arr = append(arr, &f1)
+	arr = append(arr, &f2)
+	arr = append(arr, &f3)
+}
+
+func main() {
+	crossrealm.SetSlice(arr)
+	println("ok")
+}
+
+// Output:
+// hello from crossrealm_test
+// hello from crossrealm_test
+// hello from crossrealm_test
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "3",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "IsEscaped": true,
+//         "ModTime": "28",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm28c4.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c4.gno
@@ -1,0 +1,105 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = foo{name: "1"}
+var f2 = foo{name: "2"}
+var f3 = foo{name: "3"}
+
+func main() {
+	var arr [3]crossrealm.Fooer // unreal array
+	arr[0] = &f1
+	arr[1] = &f2
+	arr[2] = &f3
+
+	crossrealm.SetArray(arr)
+	println("ok")
+}
+
+// Output:
+// &(struct{("1" string)} gno.land/r/crossrealm_test.foo)
+// &(struct{("2" string)} gno.land/r/crossrealm_test.foo)
+// &(struct{("3" string)} gno.land/r/crossrealm_test.foo)
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                 },
+//                 "Index": "3",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "1"
+//     }
+// }
+// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:4]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm28c4.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c4.gno
@@ -33,7 +33,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -49,7 +49,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -68,7 +68,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "2",
 //                 "TV": null
@@ -87,7 +87,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:2"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2"
 //                 },
 //                 "Index": "3",
 //                 "TV": null
@@ -95,11 +95,11 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "1"
 //     }
 // }
-// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:4]
+// d[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:4]
 // switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm28c5.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c5.gno
@@ -1,0 +1,30 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+func main() {
+	var f1 = foo{name: "1"}
+	var f2 = foo{name: "2"}
+	var f3 = foo{name: "3"}
+
+	var arr [3]crossrealm.Fooer // unreal array
+
+	arr[0] = &f1
+	arr[1] = &f2
+	arr[2] = &f3
+
+	crossrealm.SetArray(arr)
+	println("ok")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm28c5.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c5.gno
@@ -27,4 +27,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28c6.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c6.gno
@@ -29,7 +29,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -45,7 +45,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -64,7 +64,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -83,7 +83,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "2",
 //                 "TV": null
@@ -91,10 +91,10 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "8",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm28c6.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c6.gno
@@ -1,0 +1,100 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var arr [3]*foo // arr and all elems are all real
+var s []*foo
+
+func init() {
+	var f1 = foo{name: "1"}
+	var f2 = foo{name: "2"}
+	var f3 = foo{name: "3"}
+	arr[0] = &f1
+	arr[1] = &f2
+	arr[2] = &f3
+}
+
+func main() {
+	s = arr[:]
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "8",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm28c7.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c7.gno
@@ -1,0 +1,158 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var s []*foo
+
+func main() {
+	var arr [3]*foo
+
+	var f1 = foo{name: "1"}
+	var f2 = foo{name: "2"}
+	var f3 = foo{name: "3"}
+	arr[0] = &f1
+	arr[1] = &f2
+	arr[2] = &f3
+
+	s = arr[1:] // will attach the whole array
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "1",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "2",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "3",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "IsEscaped": true,
+//         "ModTime": "0",
+//         "RefCount": "2"
+//     }
+// }
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "1"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "RefCount": "1"
+//     }
+// }
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "2"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "RefCount": "1"
+//     }
+// }
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:8]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "3"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:8",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "RefCount": "1"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm28c7.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c7.gno
@@ -28,7 +28,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -44,7 +44,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "1",
 //                 "TV": null
@@ -63,7 +63,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "2",
 //                 "TV": null
@@ -82,7 +82,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "3",
 //                 "TV": null
@@ -90,13 +90,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "IsEscaped": true,
 //         "ModTime": "0",
 //         "RefCount": "2"
 //     }
 // }
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:6]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -110,13 +110,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:6",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "RefCount": "1"
 //     }
 // }
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:7]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -130,13 +130,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:7",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "RefCount": "1"
 //     }
 // }
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:8]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:8]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -150,9 +150,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:8",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:8",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm28c8.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c8.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = foo{name: "1"}
+var f2 = foo{name: "2"}
+var f3 = foo{name: "3"}
+
+func main() {
+	var S []crossrealm.Fooer
+	S = append(S, f1) // NOTE, f1 here is value copy, so it's not real
+	S = append(S, f2)
+	S = append(S, f3)
+
+	crossrealm.SetSlice(S)
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28c9.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28c9.gno
@@ -1,0 +1,32 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = foo{name: "1"}
+var f2 = foo{name: "2"}
+var f3 = foo{name: "3"}
+
+func main() {
+	var arr []crossrealm.Fooer // unreal array
+	arr = append(arr, &f1)
+	arr = append(arr, &f2)
+	arr = append(arr, &f3)
+
+	crossrealm.SetSlice(arr)
+	println("ok")
+}
+
+// Output:
+// hello from crossrealm_test
+// hello from crossrealm_test
+// hello from crossrealm_test
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm28d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28d.gno
@@ -23,4 +23,4 @@ func main() {
 }
 
 // Error:
-// cannot attach a reference to an unattached object from an external realm
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm28d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28d.gno
@@ -1,0 +1,26 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+func main() {
+	var Local_S []crossrealm.Fooer
+	Local_S = append(Local_S, &foo{name: "1"})
+	Local_S = append(Local_S, &foo{name: "2"})
+	Local_S = append(Local_S, &foo{name: "3"})
+
+	fs := Local_S[1:]
+	crossrealm.SetSlice(fs)
+	println("ok")
+}
+
+// Error:
+// cannot attach a reference to an unattached object from an external realm

--- a/gnovm/tests/files/zrealm_crossrealm28d2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28d2.gno
@@ -1,0 +1,166 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var f1 = &foo{name: "1"}
+var f2 = &foo{name: "2"}
+var f3 = &foo{name: "3"}
+
+func main() {
+	var Local_S []crossrealm.Fooer
+	Local_S = append(Local_S, f1)
+	Local_S = append(Local_S, f2) // reference real object, good
+	Local_S = append(Local_S, f3)
+
+	fs := Local_S[1:]
+	crossrealm.SetSlice(fs) // not crossing realm
+	println("ok")
+}
+
+// Output:
+// hello from crossrealm_test
+// hello from crossrealm_test
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:7"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "29",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "5773aa703bad7f19a0b46088a3dee0e05264bc05",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "IsEscaped": true,
+//         "ModTime": "29",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "c8796d0727128e5790ad98d57654f528404d8508",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:6"
+//         }
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "IsEscaped": true,
+//         "ModTime": "29",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "4336baa01760651f4daf8ddf42c3d8b8db48161b",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:8"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm28d2.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28d2.gno
@@ -35,7 +35,7 @@ func main() {
 // switchrealm["gno.land/r/crossrealm_test"]
 // switchrealm["gno.land/r/crossrealm_test"]
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -51,7 +51,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -70,7 +70,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -89,7 +89,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:7"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:7"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -97,18 +97,18 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "29",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -118,17 +118,17 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "5773aa703bad7f19a0b46088a3dee0e05264bc05",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//             "Hash": "bf28fe75967956f5280a4373bb55bf679b424f72",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //         }
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:5]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:5]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:5",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5",
 //         "IsEscaped": true,
 //         "ModTime": "29",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -138,17 +138,17 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "c8796d0727128e5790ad98d57654f528404d8508",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:6"
+//             "Hash": "6b8708e350cc6779d2c93481367e979b77c13ce8",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:6"
 //         }
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:7]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:7]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:7",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:7",
 //         "IsEscaped": true,
 //         "ModTime": "29",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -158,8 +158,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "4336baa01760651f4daf8ddf42c3d8b8db48161b",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:8"
+//             "Hash": "453bb359d5162b7bcb3199950e80f3f2889281a8",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:8"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm28f.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28f.gno
@@ -1,0 +1,28 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (foo) Foo() { println("hello from crossrealm_test") }
+
+var local_S []int
+
+func init() {
+	local_S = crossrealm.GetSlice10()
+}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm28g.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28g.gno
@@ -1,0 +1,24 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+// XXX, no attach, default value is nil for slice
+var local_S []int
+
+var f = func(s1 []int) {
+	local_S = s1
+}
+
+func init() {
+	crossrealm.GetSlice11(f)
+}
+
+func main() {
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/zrealm_crossrealm3.gno
+++ b/gnovm/tests/files/zrealm_crossrealm3.gno
@@ -19,4 +19,4 @@ func main() {
 }
 
 // Error:
-// cannot modify external-realm or non-realm object
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm30.gno
+++ b/gnovm/tests/files/zrealm_crossrealm30.gno
@@ -18,7 +18,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15]={
+// u[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -28,8 +28,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "c341f36102ff3f8e2f54df678a394e385459dadd",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:16"
+//                 "Hash": "ee0b0db2758a60075732af94600fce1f3f0b7b45",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:16"
 //             }
 //         },
 //         {
@@ -39,16 +39,16 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "dd8ac5d5b483b2e2ae7fb7fff494674c82d99367",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:17"
+//                 "Hash": "b5783602afd1983ea7e420869bda47f048f4293b",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:17"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15",
 //         "IsEscaped": true,
 //         "ModTime": "3",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "2"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm30.gno
+++ b/gnovm/tests/files/zrealm_crossrealm30.gno
@@ -1,0 +1,54 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+var SS []crossrealm.XYZ
+
+func main() {
+	SS = crossrealm.GetSlice()
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "c341f36102ff3f8e2f54df678a394e385459dadd",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:16"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "dd8ac5d5b483b2e2ae7fb7fff494674c82d99367",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:17"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:15",
+//         "IsEscaped": true,
+//         "ModTime": "3",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "2"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm31.gno
+++ b/gnovm/tests/files/zrealm_crossrealm31.gno
@@ -2,16 +2,14 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
-
-func init() {
-}
+var SS []crossrealm.XYZ
 
 func main() {
+	SS = crossrealm.GetSlice2()
+	println(".")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm32.gno
+++ b/gnovm/tests/files/zrealm_crossrealm32.gno
@@ -17,7 +17,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -31,13 +31,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "RefCount": "1"
 //     }
 // }
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -51,13 +51,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "RefCount": "1"
 //     }
 // }
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -67,8 +67,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "de4d4b9346995296fbd8210badf8bab1c111e60c",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
+//                 "Hash": "295b6935876d54ed5a9f807f90e006d29dda2394",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
 //             }
 //         },
 //         {
@@ -78,22 +78,22 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "1570e95bdb3313b5a0656b56b9bba96c9c7704aa",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
+//                 "Hash": "bc851a49bc21d4dfe80cbb9d59d72adc24dfaa1e",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "1"
 //     }
 // }
-// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:18]
-// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:19]
+// d[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:18]
+// d[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:19]
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+// u[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -103,8 +103,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "de4d4b9346995296fbd8210badf8bab1c111e60c",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
+//                 "Hash": "295b6935876d54ed5a9f807f90e006d29dda2394",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
 //             }
 //         },
 //         {
@@ -114,13 +114,13 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "1570e95bdb3313b5a0656b56b9bba96c9c7704aa",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
+//                 "Hash": "bc851a49bc21d4dfe80cbb9d59d72adc24dfaa1e",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "IsEscaped": true,
 //         "ModTime": "3",
 //         "RefCount": "2"

--- a/gnovm/tests/files/zrealm_crossrealm32.gno
+++ b/gnovm/tests/files/zrealm_crossrealm32.gno
@@ -1,0 +1,128 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+var SS []crossrealm.XYZ
+
+func main() {
+	SS = crossrealm.GetSlice3()
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "3"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "RefCount": "1"
+//     }
+// }
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "0"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "RefCount": "1"
+//     }
+// }
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "de4d4b9346995296fbd8210badf8bab1c111e60c",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "1570e95bdb3313b5a0656b56b9bba96c9c7704aa",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "1"
+//     }
+// }
+// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:18]
+// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:19]
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "de4d4b9346995296fbd8210badf8bab1c111e60c",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:30"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "1570e95bdb3313b5a0656b56b9bba96c9c7704aa",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:31"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "IsEscaped": true,
+//         "ModTime": "3",
+//         "RefCount": "2"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm33.gno
+++ b/gnovm/tests/files/zrealm_crossrealm33.gno
@@ -27,7 +27,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+// c[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -41,13 +41,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
 //         "ModTime": "0",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
 //         "RefCount": "1"
 //     }
 // }
-// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5]={
+// u[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -57,8 +57,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "9aac0359e72ff36096f642fc4c7d2e134f28993d",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:20"
+//                 "Hash": "c0a8ddd6cc93886c615d83da96acf19574ac4ad5",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:20"
 //             }
 //         },
 //         {
@@ -68,18 +68,18 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "ada47c453e82855b67936f208c6cc6a5c8698dad",
-//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29"
+//                 "Hash": "3eba3f8937283fd19372768c68fa1cfffa65e546",
+//                 "ObjectID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
 //         "IsEscaped": true,
 //         "ModTime": "28",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "2"
 //     }
 // }
-// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:7]
+// d[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:7]
 // switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm33.gno
+++ b/gnovm/tests/files/zrealm_crossrealm33.gno
@@ -1,0 +1,85 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+var SS []crossrealm.XYZ
+
+var f = func(s []crossrealm.XYZ) {
+	SS = s
+}
+
+func main() {
+	// XXX, even elem of the array is not real,
+	// but the array is already attached to
+	// external realm, so the elem has no
+	// chance to attach to this realm.
+	// so it is valid.
+	crossrealm.GetSlice4(f)
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// c[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29]={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "16"
+//             },
+//             "V": {
+//                 "@type": "/gno.StringValue",
+//                 "value": "0"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29",
+//         "ModTime": "0",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
+//         "RefCount": "1"
+//     }
+// }
+// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "9aac0359e72ff36096f642fc4c7d2e134f28993d",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:20"
+//             }
+//         },
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/demo/tests/crossrealm/slice.XYZ"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "ada47c453e82855b67936f208c6cc6a5c8698dad",
+//                 "ObjectID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:29"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:5",
+//         "IsEscaped": true,
+//         "ModTime": "28",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "2"
+//     }
+// }
+// d[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:7]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm34.gno
+++ b/gnovm/tests/files/zrealm_crossrealm34.gno
@@ -1,0 +1,16 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+var SS []*crossrealm.XYZ
+
+func main() {
+	SS = crossrealm.GetSlice5()
+	println(".")
+}
+
+// Output:
+// .

--- a/gnovm/tests/files/zrealm_crossrealm34a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm34a.gno
@@ -1,0 +1,20 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+var SS []*crossrealm.XYZ
+
+var f = func(s []*crossrealm.XYZ) {
+	SS = s
+}
+
+func main() {
+	crossrealm.GetSlice6(f)
+	println(".")
+}
+
+// Output:
+// .

--- a/gnovm/tests/files/zrealm_crossrealm34b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm34b.gno
@@ -2,16 +2,18 @@
 package crossrealm_test
 
 import (
-	"gno.land/r/demo/tests"
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
 )
 
-// NOTE: it is invalid to persist value of external realm types.
-var somevalue tests.TestRealmObject
+var SS [2]crossrealm.XYZ
 
-func init() {
+var f = func(s [2]crossrealm.XYZ) {
+	SS = s
 }
 
 func main() {
+	crossrealm.GetSlice7(f)
+	println(".")
 }
 
 // Error:

--- a/gnovm/tests/files/zrealm_crossrealm35.gno
+++ b/gnovm/tests/files/zrealm_crossrealm35.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
-// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14]={
+// u[r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -41,7 +41,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -49,18 +49,18 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14",
+//         "ID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14",
 //         "ModTime": "28",
-//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "OwnerID": "r:ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "28",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -70,13 +70,13 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//             "Hash": "1bf7494bc7ed56efdcddd47d6cc18e3410344a83",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //         }
 //     }
 // }
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:6]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -92,7 +92,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -100,18 +100,18 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:6",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "3"
 //     },
 //     "Value": {
@@ -121,8 +121,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//             "Hash": "1bf7494bc7ed56efdcddd47d6cc18e3410344a83",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm35.gno
+++ b/gnovm/tests/files/zrealm_crossrealm35.gno
@@ -1,0 +1,128 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (*foo) String() string { return "hey" }
+
+var f = &foo{"foo"}
+
+var arr interface{}
+
+func main() {
+	arr = crossrealm.GetSlice8(f) // real array value from external realm
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// u[ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:14",
+//         "ModTime": "28",
+//         "OwnerID": "ff34c6500d0daee58e4ac9899c0e7ecc131db63e:2",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "28",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "3"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm35a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm35a.gno
@@ -1,0 +1,78 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import (
+	crossrealm "gno.land/r/demo/tests/crossrealm/slice"
+)
+
+type foo struct {
+	name string
+}
+
+func (*foo) String() string { return "hey" }
+
+var f = &foo{"foo"}
+
+var arr interface{}
+
+func main() {
+	arr = crossrealm.GetSlice9(f)
+	println(".")
+}
+
+// Output:
+// .
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "Data": null,
+//     "List": [
+//         {
+//             "T": {
+//                 "@type": "/gno.PointerType",
+//                 "Elt": {
+//                     "@type": "/gno.RefType",
+//                     "ID": "gno.land/r/crossrealm_test.foo"
+//                 }
+//             },
+//             "V": {
+//                 "@type": "/gno.PointerValue",
+//                 "Base": {
+//                     "@type": "/gno.RefValue",
+//                     "Escaped": true,
+//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                 },
+//                 "Index": "0",
+//                 "TV": null
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.foo"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm35a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm35a.gno
@@ -26,7 +26,7 @@ func main() {
 // Realm:
 // switchrealm["gno.land/r/demo/tests/crossrealm/slice"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:6]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -42,7 +42,7 @@ func main() {
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
 //                     "Escaped": true,
-//                     "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                     "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -50,18 +50,18 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:6",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -71,8 +71,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "de578df5354e812a94f64e23eed06e9705d2b4ef",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//             "Hash": "1bf7494bc7ed56efdcddd47d6cc18e3410344a83",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm37_map.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37_map.gno
@@ -1,0 +1,54 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/map"
+
+var m1 map[string]int
+
+func main() {
+	m1 = crossrealm.GetMap()
+	println(m1)
+	crossrealm.ModifyMap()
+	println(m1)
+}
+
+// Output:
+// map{("a" string):(1 int)}
+// map{("a" string):(2 int)}
+
+// Realm:
+// switchrealm["gno.land/r/demo/tests/crossrealm/map"]
+// switchrealm["gno.land/r/demo/tests/crossrealm/map"]
+// switchrealm["gno.land/r/crossrealm_test"]
+// u[5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6]={
+//     "List": {
+//         "List": [
+//             {
+//                 "Key": {
+//                     "T": {
+//                         "@type": "/gno.PrimitiveType",
+//                         "value": "16"
+//                     },
+//                     "V": {
+//                         "@type": "/gno.StringValue",
+//                         "value": "a"
+//                     }
+//                 },
+//                 "Value": {
+//                     "N": "AgAAAAAAAAA=",
+//                     "T": {
+//                         "@type": "/gno.PrimitiveType",
+//                         "value": "32"
+//                     }
+//                 }
+//             }
+//         ]
+//     },
+//     "ObjectInfo": {
+//         "ID": "5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6",
+//         "IsEscaped": true,
+//         "ModTime": "3",
+//         "OwnerID": "5a06306c27263d4b9ae8f2f30e82f8ef014042cd:2",
+//         "RefCount": "2"
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm37_map.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37_map.gno
@@ -20,7 +20,7 @@ func main() {
 // switchrealm["gno.land/r/demo/tests/crossrealm/map"]
 // switchrealm["gno.land/r/demo/tests/crossrealm/map"]
 // switchrealm["gno.land/r/crossrealm_test"]
-// u[5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6]={
+// u[r:5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6]={
 //     "List": {
 //         "List": [
 //             {
@@ -45,10 +45,10 @@ func main() {
 //         ]
 //     },
 //     "ObjectInfo": {
-//         "ID": "5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6",
+//         "ID": "r:5a06306c27263d4b9ae8f2f30e82f8ef014042cd:6",
 //         "IsEscaped": true,
 //         "ModTime": "3",
-//         "OwnerID": "5a06306c27263d4b9ae8f2f30e82f8ef014042cd:2",
+//         "OwnerID": "r:5a06306c27263d4b9ae8f2f30e82f8ef014042cd:2",
 //         "RefCount": "2"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm37a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37a.gno
@@ -19,7 +19,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:4]={
 //     "List": {
 //         "List": [
 //             {
@@ -44,9 +44,9 @@ func main() {
 //         ]
 //     },
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_crossrealm37a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37a.gno
@@ -1,0 +1,54 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/map"
+
+var local_m map[string]int
+
+var f = func(m map[string]int) {
+	local_m = m
+}
+
+func main() {
+	crossrealm.GetMap2(f)
+	println("ok")
+}
+
+// Output:
+// ok
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:4]={
+//     "List": {
+//         "List": [
+//             {
+//                 "Key": {
+//                     "T": {
+//                         "@type": "/gno.PrimitiveType",
+//                         "value": "16"
+//                     },
+//                     "V": {
+//                         "@type": "/gno.StringValue",
+//                         "value": "a"
+//                     }
+//                 },
+//                 "Value": {
+//                     "N": "AQAAAAAAAAA=",
+//                     "T": {
+//                         "@type": "/gno.PrimitiveType",
+//                         "value": "32"
+//                     }
+//                 }
+//             }
+//         ]
+//     },
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:4",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     }
+// }
+// switchrealm["gno.land/r/demo/tests/crossrealm/map"]
+// switchrealm["gno.land/r/crossrealm_test"]

--- a/gnovm/tests/files/zrealm_crossrealm37b.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37b.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/map"
+
+var local_m crossrealm.MyMap // default value is nil
+
+func main() {
+	local_m = crossrealm.GetMap3()
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm37c.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37c.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/map"
+
+var root interface{}
+
+func main() {
+	root = crossrealm.GetMap4()
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm37d.gno
+++ b/gnovm/tests/files/zrealm_crossrealm37d.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/map"
+
+var root interface{}
+
+func main() {
+	root = crossrealm.GetMap3()
+	println("ok")
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm40_a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm40_a.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/func"
+
+var f func() string
+
+func main() {
+	f = crossrealm.GetMethod2()
+	println(f)
+}
+
+// Error:
+// cannot attach a value of a type defined by another realm

--- a/gnovm/tests/files/zrealm_crossrealm40_method.gno
+++ b/gnovm/tests/files/zrealm_crossrealm40_method.gno
@@ -1,0 +1,14 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+import crossrealm "gno.land/r/demo/tests/crossrealm/func"
+
+var f func() string
+
+func main() {
+	f = crossrealm.GetMethod()
+	println(f)
+}
+
+// Output:
+// <*gno.land/r/demo/tests/crossrealm/func.MyStruct>.M(*gno.land/r/demo/tests/crossrealm/func.MyStruct)(string)

--- a/gnovm/tests/files/zrealm_crossrealm41_method_local.gno
+++ b/gnovm/tests/files/zrealm_crossrealm41_method_local.gno
@@ -1,0 +1,120 @@
+// PKGPATH: gno.land/r/crossrealm_test
+package crossrealm_test
+
+var f func() string
+
+type MyStruct struct{}
+
+func (sv *MyStruct) M() string { return "a" }
+
+var mysv *MyStruct = &MyStruct{}
+
+func main() {
+	f = mysv.M
+	println(f)
+}
+
+// Output:
+// <*gno.land/r/crossrealm_test.MyStruct>.M(*gno.land/r/crossrealm_test.MyStruct)(string)
+
+// Realm:
+// switchrealm["gno.land/r/crossrealm_test"]
+// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+//     "Func": {
+//         "Closure": {
+//             "@type": "/gno.RefValue",
+//             "Escaped": true,
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//         },
+//         "FileName": "files/zrealm_crossrealm41_method_local.gno",
+//         "IsMethod": true,
+//         "Name": "M",
+//         "NativeName": "",
+//         "NativePkg": "",
+//         "PkgPath": "gno.land/r/crossrealm_test",
+//         "Source": {
+//             "@type": "/gno.RefNode",
+//             "BlockNode": null,
+//             "Location": {
+//                 "Column": "1",
+//                 "File": "files/zrealm_crossrealm41_method_local.gno",
+//                 "Line": "8",
+//                 "PkgPath": "gno.land/r/crossrealm_test"
+//             }
+//         },
+//         "Type": {
+//             "@type": "/gno.FuncType",
+//             "IsClosure": false,
+//             "Params": [
+//                 {
+//                     "Embedded": false,
+//                     "Name": "sv",
+//                     "Tag": "",
+//                     "Type": {
+//                         "@type": "/gno.PointerType",
+//                         "Elt": {
+//                             "@type": "/gno.RefType",
+//                             "ID": "gno.land/r/crossrealm_test.MyStruct"
+//                         }
+//                     }
+//                 }
+//             ],
+//             "Results": [
+//                 {
+//                     "Embedded": false,
+//                     "Name": "",
+//                     "Tag": "",
+//                     "Type": {
+//                         "@type": "/gno.PrimitiveType",
+//                         "value": "16"
+//                     }
+//                 }
+//             ]
+//         }
+//     },
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ModTime": "0",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "1"
+//     },
+//     "Receiver": {
+//         "T": {
+//             "@type": "/gno.PointerType",
+//             "Elt": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/crossrealm_test.MyStruct"
+//             }
+//         },
+//         "V": {
+//             "@type": "/gno.PointerValue",
+//             "Base": {
+//                 "@type": "/gno.RefValue",
+//                 "Escaped": true,
+//                 "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//             },
+//             "Index": "0",
+//             "TV": null
+//         }
+//     }
+// }
+// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+//     "ObjectInfo": {
+//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "IsEscaped": true,
+//         "ModTime": "6",
+//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "RefCount": "2"
+//     },
+//     "Value": {
+//         "T": {
+//             "@type": "/gno.RefType",
+//             "ID": "gno.land/r/crossrealm_test.MyStruct"
+//         },
+//         "V": {
+//             "@type": "/gno.RefValue",
+//             "Hash": "c2dcd6b8b5bbe275e4cd7b90b0333aaf02e120eb",
+//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//         }
+//     }
+// }

--- a/gnovm/tests/files/zrealm_crossrealm41_method_local.gno
+++ b/gnovm/tests/files/zrealm_crossrealm41_method_local.gno
@@ -19,12 +19,12 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/crossrealm_test"]
-// c[f5a516808f8976c33939133293d598ce3bca4e8d:6]={
+// c[r:f5a516808f8976c33939133293d598ce3bca4e8d:6]={
 //     "Func": {
 //         "Closure": {
 //             "@type": "/gno.RefValue",
 //             "Escaped": true,
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:5"
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:5"
 //         },
 //         "FileName": "files/zrealm_crossrealm41_method_local.gno",
 //         "IsMethod": true,
@@ -73,9 +73,9 @@ func main() {
 //         }
 //     },
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:6",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:6",
 //         "ModTime": "0",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "1"
 //     },
 //     "Receiver": {
@@ -91,19 +91,19 @@ func main() {
 //             "Base": {
 //                 "@type": "/gno.RefValue",
 //                 "Escaped": true,
-//                 "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:3"
+//                 "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3"
 //             },
 //             "Index": "0",
 //             "TV": null
 //         }
 //     }
 // }
-// u[f5a516808f8976c33939133293d598ce3bca4e8d:3]={
+// u[r:f5a516808f8976c33939133293d598ce3bca4e8d:3]={
 //     "ObjectInfo": {
-//         "ID": "f5a516808f8976c33939133293d598ce3bca4e8d:3",
+//         "ID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:3",
 //         "IsEscaped": true,
 //         "ModTime": "6",
-//         "OwnerID": "f5a516808f8976c33939133293d598ce3bca4e8d:2",
+//         "OwnerID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:2",
 //         "RefCount": "2"
 //     },
 //     "Value": {
@@ -113,8 +113,8 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "c2dcd6b8b5bbe275e4cd7b90b0333aaf02e120eb",
-//             "ObjectID": "f5a516808f8976c33939133293d598ce3bca4e8d:4"
+//             "Hash": "ac7d76a3d0898d35ddd1f96e37bc596399928137",
+//             "ObjectID": "r:f5a516808f8976c33939133293d598ce3bca4e8d:4"
 //         }
 //     }
 // }

--- a/gnovm/tests/files/zrealm_example.gno
+++ b/gnovm/tests/files/zrealm_example.gno
@@ -24,7 +24,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/example"]
-// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:11]={
+// c[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:11]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -37,13 +37,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:11",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:11",
 //         "ModTime": "0",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:10]={
+// c[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:10]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -72,23 +72,23 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "f190df54e397e2006cee3fc525bcc1b4d556e4c4",
-//                 "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:11"
+//                 "Hash": "0df7427101e263c586a307ff8d14d6b6d34117c4",
+//                 "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:11"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
 //         "ModTime": "0",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
 //         "RefCount": "1"
 //     }
 // }
-// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:9]={
+// c[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:9]={
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
 //         "ModTime": "0",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -98,12 +98,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "a74fad6da10f1cec74ad3a8751490b4dca957761",
-//             "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10"
+//             "Hash": "122407cf2a9297da3d572f131cb647633df98900",
+//             "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:10"
 //         }
 //     }
 // }
-// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:8]={
+// c[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:8]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -127,8 +127,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "8b11b3d07ddeb034f70a114c9433ec6bd5cbf899",
-//                     "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9"
+//                     "Hash": "398175e75cdd5013733e87c72156acad90f78adc",
+//                     "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:9"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -167,17 +167,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
 //         "ModTime": "0",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:7",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:7",
 //         "RefCount": "1"
 //     }
 // }
-// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:7]={
+// c[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:7]={
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:7",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:7",
 //         "ModTime": "0",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:6",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:6",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -187,12 +187,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "869abdac30a3ae78b2191806e1c894c48e399122",
-//             "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:8"
+//             "Hash": "a864d30b0497eec996739b6740a387ece26d13c9",
+//             "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:8"
 //         }
 //     }
 // }
-// u[1ffd45e074aa1b8df562907c95ad97526b7ca187:6]={
+// u[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:6]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -206,8 +206,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "a919087d0eba652876f9a8df18b30ec5ddc8c26e",
-//                     "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:7"
+//                     "Hash": "f695e807587d8f5eafc96ec986d285d92ed31873",
+//                     "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:7"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -215,13 +215,13 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:6",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:6",
 //         "ModTime": "6",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:5",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:5",
 //         "RefCount": "1"
 //     }
 // }
-// u[1ffd45e074aa1b8df562907c95ad97526b7ca187:5]={
+// u[r:1ffd45e074aa1b8df562907c95ad97526b7ca187:5]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -240,8 +240,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "dfdeb7ed80c5b030c3a5e9701d00c66203de6f57",
-//                 "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:6"
+//                 "Hash": "abc8b9cffe6efd08be3158fb611babf76389d52f",
+//                 "ObjectID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:6"
 //             }
 //         },
 //         {
@@ -253,9 +253,9 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:5",
+//         "ID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:5",
 //         "ModTime": "6",
-//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:4",
+//         "OwnerID": "r:1ffd45e074aa1b8df562907c95ad97526b7ca187:4",
 //         "RefCount": "1"
 //     }
 // }

--- a/gnovm/tests/files/zrealm_std1.gno
+++ b/gnovm/tests/files/zrealm_std1.gno
@@ -25,7 +25,7 @@ func main() {
 }
 
 // Output:
-// (slice[ref(1ed29bd278d735e20e296bd4afe927501941392f:5)] std.AddressList)
+// (slice[ref(r:1ed29bd278d735e20e296bd4afe927501941392f:5)] std.AddressList)
 // error: address already exists
 // has: true
 // has: false

--- a/gnovm/tests/files/zrealm_std2.gno
+++ b/gnovm/tests/files/zrealm_std2.gno
@@ -26,7 +26,7 @@ func main() {
 }
 
 // Output:
-// (slice[ref(1ed29bd278d735e20e296bd4afe927501941392f:5)] std.AddressList)
+// (slice[ref(r:1ed29bd278d735e20e296bd4afe927501941392f:5)] std.AddressList)
 // error: address already exists
 // has: true
 // has: false

--- a/gnovm/tests/files/zrealm_tests0.gno
+++ b/gnovm/tests/files/zrealm_tests0.gno
@@ -26,7 +26,7 @@ func main() {
 
 // Realm:
 // switchrealm["gno.land/r/demo/tests"]
-// c[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19]={
+// c[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19]={
 //     "Fields": [
 //         {
 //             "T": {
@@ -40,17 +40,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19",
+//         "ID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19",
 //         "ModTime": "0",
-//         "OwnerID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18",
+//         "OwnerID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18",
 //         "RefCount": "1"
 //     }
 // }
-// c[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18]={
+// c[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18]={
 //     "ObjectInfo": {
-//         "ID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18",
+//         "ID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18",
 //         "ModTime": "0",
-//         "OwnerID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17",
+//         "OwnerID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -60,12 +60,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "6b9b731f6118c2419f23ba57e1481679f17f4a8f",
-//             "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19"
+//             "Hash": "93c8b678657f67ff13ac39b31d8db778d96695e5",
+//             "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:19"
 //         }
 //     }
 // }
-// c[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17]={
+// c[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17]={
 //     "Data": null,
 //     "List": [
 //         {
@@ -80,8 +80,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "4e0d77a91ba35733bf82329317bf8c8dffa6f655",
-//                     "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12"
+//                     "Hash": "b421f4333ca7eee6058e0740311145e4f725c6df",
+//                     "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -99,8 +99,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "fa414e1770821b8deb8e6d46d97828c47f7d5fa5",
-//                     "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15"
+//                     "Hash": "c41afec0e0214d8c10709fb43273d731e81b7559",
+//                     "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -118,8 +118,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "aaa64d049cf8660d689780acac9f546f270eaa4e",
-//                     "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18"
+//                     "Hash": "a5b168f123f4f641086e0b9cb319860a8fb330ac",
+//                     "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:18"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -127,17 +127,17 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17",
+//         "ID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:17",
 //         "ModTime": "0",
-//         "OwnerID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:2",
+//         "OwnerID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:2",
 //         "RefCount": "1"
 //     }
 // }
-// u[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12]={
+// u[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12]={
 //     "ObjectInfo": {
-//         "ID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12",
+//         "ID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:12",
 //         "ModTime": "17",
-//         "OwnerID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:11",
+//         "OwnerID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:11",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -147,16 +147,16 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "f163acee63433b44deb3168fef87beb588847322",
-//             "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:13"
+//             "Hash": "712ead1805462af46e84473fe440faec02d9e37d",
+//             "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:13"
 //         }
 //     }
 // }
-// u[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15]={
+// u[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15]={
 //     "ObjectInfo": {
-//         "ID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15",
+//         "ID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:15",
 //         "ModTime": "17",
-//         "OwnerID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:14",
+//         "OwnerID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:14",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -166,12 +166,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "2a96c074210eb2db31b7941e31d62deb04e59937",
-//             "ObjectID": "0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:16"
+//             "Hash": "0e8a951402efc97b905432060a6cf80124c6ff29",
+//             "ObjectID": "r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:16"
 //         }
 //     }
 // }
-// d[0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:14]
+// d[r:0ffe7732b4d549b4cf9ec18bd68641cd2c75ad0a:14]
 // switchrealm["gno.land/r/demo/tests_foo"]
 // switchrealm["gno.land/r/demo/tests_foo"]
 // switchrealm["gno.land/r/demo/tests_foo"]


### PR DESCRIPTION
This is a different attempt at the same goal of #2958, attempting to implement a different set of rules.

---

- At the end of a cross-realm function call, any unreal object reachable by the realm's real object becomes real, and with the owner set to that function's realm.
	- **Why:** anything a realm decides to persist should be that realm's responsibility to store and keep stored.
	- A realm may not attach types declared in another realm (though it may reference them).
		- **Why:** the methods of a realm's type should always consider as being  
- A cross-realm function call must always return real references, or values.
	- **Why:** getting a reference value from another realm should be "safe" in knowing that the cost of storing that reference is constant (the cost of the reference), rather than also of the returned object.
- When an object is real, it has an owner. Only its owner is capable of modifying the object.
	- The PackageValue of a pure package is recursively owned by a pseudo-realm, which doesn't allow modifications on these values after they've become real.
		- **Why:** all values in a pure package should be permanently immutable, both by that same pure package, other pure packages and all realms.
- A method call is considered the same as a function call to where that method is declared.
	- **i.e.:** If it is a pure package, the realm is the maintained the same as the caller. If it is a method in a realm, it is switched over to that realm.
	- **Why:** methods should not be considered special. Switching behaviour on the attachment of the receiver also makes it hard to understand what realm the function should be executed in. Also this makes methods work the same whether they're on a real or unreal value.