### PR TITLE
feat(boards2): add public iteration functions to read minimal board data

### DIFF
--- a/examples/gno.land/r/nt/boards2/v1/board.gno
+++ b/examples/gno.land/r/nt/boards2/v1/board.gno
@@ -33,7 +33,7 @@ type Board struct {
 	createdAt time.Time
 	deleted   avl.Tree // TODO reserved for fast-delete.
 	perms     Permissions
-	readOnly  bool
+	readonly  bool
 }
 
 func newBoard(id BoardID, name string, creator std.Address, p Permissions) *Board {
@@ -73,14 +73,14 @@ func (board *Board) GetPermissions() Permissions {
 	return board.perms
 }
 
-// SetReadOnly updates board's read-only status.
-func (board *Board) SetReadOnly(readOnly bool) {
-	board.readOnly = readOnly
+// SetReadonly updates board's read-only status.
+func (board *Board) SetReadonly(readonly bool) {
+	board.readonly = readonly
 }
 
-// IsReadOnly checks if the board is a read-only board.
-func (board *Board) IsReadOnly() bool {
-	return board.readOnly
+// IsReadonly checks if the board is a read-only board.
+func (board *Board) IsReadonly() bool {
+	return board.readonly
 }
 
 func (board *Board) GetThread(threadID PostID) (_ *Post, found bool) {
@@ -116,7 +116,7 @@ func (board *Board) Render(path string) string {
 	sb.WriteString("on " + board.createdAt.Format(dateFormat))
 	sb.WriteString(", #" + board.id.String() + "_")
 
-	if board.IsReadOnly() {
+	if board.IsReadonly() {
 		sb.WriteString("  \n_**Starting new threads and commenting is disabled**_")
 	}
 
@@ -124,7 +124,7 @@ func (board *Board) Render(path string) string {
 
 	if board.threads.Size() == 0 {
 		sb.WriteString("### This board doesn't have any threads\n")
-		if !board.IsReadOnly() {
+		if !board.IsReadonly() {
 			url := board.GetPostFormURL()
 			sb.WriteString("Do you want to [start a new conversation](" + url + ") in this board ?")
 		}

--- a/examples/gno.land/r/nt/boards2/v1/board_readonly.gno
+++ b/examples/gno.land/r/nt/boards2/v1/board_readonly.gno
@@ -1,0 +1,80 @@
+package boards2
+
+import (
+	"std"
+	"time"
+)
+
+// ReadonlyBoard defines an interface for readonly boards.
+type ReadonlyBoard interface {
+	// ID returns the unique identifier of the board.
+	ID() BoardID
+
+	// Name returns the name of the board.
+	Name() string
+
+	// Aliases returns a list with previous names assigned to the board.
+	Aliases() []string
+
+	// Creator returns board's creator address.
+	Creator() std.Address
+
+	// LastPostID returns the ID assigned to the last created thread.
+	LastPostID() uint64
+
+	// CreatedAt returns the time when board was created.
+	CreatedAt() time.Time
+
+	// IsReadonly returns true when board shouldn't allow the creation of threads and comments.
+	IsReadonly() bool
+
+	// MembersCount returns the number of invited board members.
+	MembersCount() int
+
+	// IterateMembers allows reading the list of invited board members.
+	IterateMembers(offset, count int, fn UsersIterFn)
+}
+
+type readonlyBoard struct {
+	board *Board
+}
+
+func (b readonlyBoard) ID() BoardID {
+	return b.board.id
+}
+
+func (b readonlyBoard) Name() string {
+	return b.board.name
+}
+
+func (b readonlyBoard) Aliases() []string {
+	aliases := make([]string, len(b.board.aliases))
+	for i, s := range b.board.aliases {
+		aliases[i] = s
+	}
+	return aliases
+}
+
+func (b readonlyBoard) Creator() std.Address {
+	return b.board.creator
+}
+
+func (b readonlyBoard) LastPostID() uint64 {
+	return b.board.postsCtr
+}
+
+func (b readonlyBoard) CreatedAt() time.Time {
+	return b.board.createdAt
+}
+
+func (b readonlyBoard) IsReadonly() bool {
+	return b.board.readonly
+}
+
+func (b readonlyBoard) MembersCount() int {
+	return b.board.perms.UsersCount()
+}
+
+func (b readonlyBoard) IterateMembers(offset, count int, fn UsersIterFn) {
+	b.board.perms.IterateUsers(offset, count, fn)
+}

--- a/examples/gno.land/r/nt/boards2/v1/post.gno
+++ b/examples/gno.land/r/nt/boards2/v1/post.gno
@@ -33,7 +33,7 @@ type Post struct {
 	title         string // optional
 	body          string
 	isHidden      bool
-	isReadOnly    bool
+	isReadonly    bool
 	replies       avl.Tree // Post.id -> *Post
 	repliesAll    avl.Tree // Post.id -> *Post (all replies, for top-level posts)
 	reposts       avl.Tree // Board.id -> Post.id
@@ -132,12 +132,12 @@ func (post *Post) IsHidden() bool {
 	return post.isHidden
 }
 
-func (post *Post) SetReadOnly(isReadOnly bool) {
-	post.isReadOnly = isReadOnly
+func (post *Post) SetReadonly(isReadonly bool) {
+	post.isReadonly = isReadonly
 }
 
-func (post *Post) IsReadOnly() bool {
-	return post.isReadOnly
+func (post *Post) IsReadonly() bool {
+	return post.isReadonly
 }
 
 func (post *Post) AddReply(creator std.Address, body string) *Post {
@@ -384,8 +384,8 @@ func (post *Post) renderPostContent(sb *strings.Builder, indent string) {
 		sb.WriteString(newButtonLink("repost", post.GetRepostFormURL()))
 	}
 
-	isReadOnly := post.IsReadOnly() || post.GetBoard().IsReadOnly()
-	if !isReadOnly {
+	isReadonly := post.IsReadonly() || post.GetBoard().IsReadonly()
+	if !isReadonly {
 		sb.WriteString(" ")
 		sb.WriteString(newButtonLink("reply", post.GetReplyFormURL()))
 		sb.WriteString(" ")

--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -526,12 +526,14 @@ func ChangeMemberRole(boardID BoardID, member std.Address, role Role) {
 
 // IterateRealmMembers iterates realm members.
 // The iteration is done only for realm members, board members are not iterated.
-func IterateRealmMembers(offset, count int, fn UsersIterFn) (halted bool) {
+func IterateRealmMembers(offset int, fn UsersIterFn) (halted bool) {
+	count := gPerms.UsersCount() - offset
 	return gPerms.IterateUsers(offset, count, fn)
 }
 
 // IterateBoards iterates realm boards.
-func IterateBoards(offset, count int, fn func(ReadonlyBoard) bool) (halted bool) {
+func IterateBoards(offset int, fn func(ReadonlyBoard) bool) (halted bool) {
+	count := gBoardsByID.Size() - offset
 	return gBoardsByID.IterateByOffset(offset, count, func(_ string, v any) bool {
 		board, _ := v.(*Board)
 		return fn(readonlyBoard{board})

--- a/examples/gno.land/r/nt/boards2/v1/public.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public.gno
@@ -215,7 +215,7 @@ func CreateReply(boardID BoardID, threadID, replyID PostID, body string) PostID 
 	} else {
 		// Try to get parent reply and add a new child reply
 		parent := mustGetReply(thread, replyID)
-		if parent.IsHidden() || parent.IsReadOnly() {
+		if parent.IsHidden() || parent.IsReadonly() {
 			panic("replying to a hidden or frozen reply is not allowed")
 		}
 
@@ -524,6 +524,20 @@ func ChangeMemberRole(boardID BoardID, member std.Address, role Role) {
 	})
 }
 
+// IterateRealmMembers iterates realm members.
+// The iteration is done only for realm members, board members are not iterated.
+func IterateRealmMembers(offset, count int, fn UsersIterFn) (halted bool) {
+	return gPerms.IterateUsers(offset, count, fn)
+}
+
+// IterateBoards iterates realm boards.
+func IterateBoards(offset, count int, fn func(ReadonlyBoard) bool) (halted bool) {
+	return gBoardsByID.IterateByOffset(offset, count, func(_ string, v any) bool {
+		board, _ := v.(*Board)
+		return fn(readonlyBoard{board})
+	})
+}
+
 func assertHasBoardPermission(b *Board, user std.Address, p Permission) {
 	if !b.perms.HasPermission(user, p) {
 		panic("unauthorized")
@@ -537,7 +551,7 @@ func assertBoardExists(id BoardID) {
 }
 
 func assertBoardIsNotFrozen(b *Board) {
-	if b.IsReadOnly() {
+	if b.IsReadonly() {
 		panic("board is frozen")
 	}
 }
@@ -559,13 +573,13 @@ func assertIsValidBoardName(name string) {
 }
 
 func assertThreadIsNotFrozen(t *Post) {
-	if t.IsReadOnly() {
+	if t.IsReadonly() {
 		panic("thread is frozen")
 	}
 }
 
 func assertReplyIsNotFrozen(r *Post) {
-	if r.IsReadOnly() {
+	if r.IsReadonly() {
 		panic("reply is frozen")
 	}
 }

--- a/examples/gno.land/r/nt/boards2/v1/public_freeze.gno
+++ b/examples/gno.land/r/nt/boards2/v1/public_freeze.gno
@@ -7,32 +7,32 @@ import (
 
 // FreezeBoard freezes a board so no more threads and comments can be created or modified.
 func FreezeBoard(boardID BoardID) {
-	setBoardReadOnly(boardID, true)
+	setBoardReadonly(boardID, true)
 }
 
 // UnfreezeBoard removes frozen status from a board.
 func UnfreezeBoard(boardID BoardID) {
-	setBoardReadOnly(boardID, false)
+	setBoardReadonly(boardID, false)
 }
 
 // IsBoardFrozen checks if a board has been frozen.
 func IsBoardFrozen(boardID BoardID) bool {
 	board := mustGetBoard(boardID)
-	return board.IsReadOnly()
+	return board.IsReadonly()
 }
 
 // FreezeThread freezes a thread so thread cannot be replied, modified or deleted.
 //
 // Fails if board is frozen.
 func FreezeThread(boardID BoardID, threadID PostID) {
-	setThreadReadOnly(boardID, threadID, true)
+	setThreadReadonly(boardID, threadID, true)
 }
 
 // UnfreezeThread removes frozen status from a thread.
 //
 // Fails if board is frozen.
 func UnfreezeThread(boardID BoardID, threadID PostID) {
-	setThreadReadOnly(boardID, threadID, false)
+	setThreadReadonly(boardID, threadID, false)
 }
 
 // IsThreadFrozen checks if a thread has been frozen.
@@ -43,7 +43,7 @@ func IsThreadFrozen(boardID BoardID, threadID PostID) bool {
 	thread := mustGetThread(board, threadID)
 	assertThreadIsVisible(thread)
 
-	return board.IsReadOnly() || thread.IsReadOnly()
+	return board.IsReadonly() || thread.IsReadonly()
 }
 
 // UnfreezeReply removes frozen status from a reply.
@@ -51,14 +51,14 @@ func IsThreadFrozen(boardID BoardID, threadID PostID) bool {
 // Fails when parent thread or board are frozen.
 func UnfreezeReply(boardID BoardID, threadID, replyID PostID) {
 	// XXX: Is there a use case for also freezing replies?
-	setReplyReadOnly(boardID, threadID, replyID, false)
+	setReplyReadonly(boardID, threadID, replyID, false)
 }
 
 // FreezeReply freezes a thread reply so it cannot be modified or deleted.
 //
 // Fails when parent thread or board are frozen.
 func FreezeReply(boardID BoardID, threadID, replyID PostID) {
-	setReplyReadOnly(boardID, threadID, replyID, true)
+	setReplyReadonly(boardID, threadID, replyID, true)
 }
 
 // IsReplyFrozen checks if a thread reply has been frozen.
@@ -72,10 +72,10 @@ func IsReplyFrozen(boardID BoardID, threadID, replyID PostID) bool {
 	reply := mustGetReply(thread, replyID)
 	assertReplyIsVisible(reply)
 
-	return board.IsReadOnly() || thread.IsReadOnly() || reply.IsReadOnly()
+	return board.IsReadonly() || thread.IsReadonly() || reply.IsReadonly()
 }
 
-func setReplyReadOnly(boardID BoardID, threadID, replyID PostID, isReadOnly bool) {
+func setReplyReadonly(boardID BoardID, threadID, replyID PostID, isReadonly bool) {
 	assertRealmIsNotLocked()
 
 	board := mustGetBoard(boardID)
@@ -91,11 +91,11 @@ func setReplyReadOnly(boardID BoardID, threadID, replyID PostID, isReadOnly bool
 	reply := mustGetReply(thread, replyID)
 	assertReplyIsVisible(reply)
 
-	if isReadOnly {
+	if isReadonly {
 		assertReplyIsNotFrozen(reply)
 	}
 
-	reply.SetReadOnly(isReadOnly)
+	reply.SetReadonly(isReadonly)
 
 	std.Emit(
 		"ReplyFreeze",
@@ -103,11 +103,11 @@ func setReplyReadOnly(boardID BoardID, threadID, replyID PostID, isReadOnly bool
 		"boardID", boardID.String(),
 		"threadID", threadID.String(),
 		"replyID", replyID.String(),
-		"frozen", strconv.FormatBool(isReadOnly),
+		"frozen", strconv.FormatBool(isReadonly),
 	)
 }
 
-func setThreadReadOnly(boardID BoardID, threadID PostID, isReadOnly bool) {
+func setThreadReadonly(boardID BoardID, threadID PostID, isReadonly bool) {
 	assertRealmIsNotLocked()
 
 	board := mustGetBoard(boardID)
@@ -117,38 +117,38 @@ func setThreadReadOnly(boardID BoardID, threadID PostID, isReadOnly bool) {
 	assertHasBoardPermission(board, caller, PermissionThreadFreeze)
 
 	thread := mustGetThread(board, threadID)
-	if isReadOnly {
+	if isReadonly {
 		assertThreadIsNotFrozen(thread)
 	}
 
-	thread.SetReadOnly(isReadOnly)
+	thread.SetReadonly(isReadonly)
 
 	std.Emit(
 		"ThreadFreeze",
 		"caller", caller.String(),
 		"boardID", boardID.String(),
 		"threadID", threadID.String(),
-		"frozen", strconv.FormatBool(isReadOnly),
+		"frozen", strconv.FormatBool(isReadonly),
 	)
 }
 
-func setBoardReadOnly(boardID BoardID, isReadOnly bool) {
+func setBoardReadonly(boardID BoardID, isReadonly bool) {
 	assertRealmIsNotLocked()
 
 	board := mustGetBoard(boardID)
-	if isReadOnly {
+	if isReadonly {
 		assertBoardIsNotFrozen(board)
 	}
 
 	caller := std.PreviousRealm().Address()
 	assertHasBoardPermission(board, caller, PermissionBoardFreeze)
 
-	board.SetReadOnly(isReadOnly)
+	board.SetReadonly(isReadonly)
 
 	std.Emit(
 		"BoardFreeze",
 		"caller", caller.String(),
 		"boardID", boardID.String(),
-		"frozen", strconv.FormatBool(isReadOnly),
+		"frozen", strconv.FormatBool(isReadonly),
 	)
 }

--- a/examples/gno.land/r/nt/boards2/v1/render.gno
+++ b/examples/gno.land/r/nt/boards2/v1/render.gno
@@ -62,7 +62,7 @@ func renderBoardsList(res *mux.ResponseWriter, req *mux.Request) {
 		res.Write("on " + board.createdAt.Format(dateFormat))
 		res.Write(", #" + board.id.String() + "_  \n")
 		res.Write("_" + strconv.Itoa(board.threads.Size()) + " threads")
-		if board.IsReadOnly() {
+		if board.IsReadonly() {
 			res.Write(", **read-only**")
 		}
 
@@ -105,7 +105,7 @@ func renderBoard(res *mux.ResponseWriter, req *mux.Request) {
 func renderBoardMenu(board *Board, res *mux.ResponseWriter, req *mux.Request) {
 	boardMembersURL := board.GetPath() + "/members"
 
-	if board.IsReadOnly() {
+	if board.IsReadonly() {
 		res.Write(newLink("List Board Members", boardMembersURL))
 		res.Write("\n")
 	} else {

--- a/examples/gno.land/r/nt/boards2/v1/z_23_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_23_a_filetest.gno
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const (
+	owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+	bid   = boards2.BoardID(0)                                      // Operate on realm DAO instead of individual boards
+)
+
+func init() {
+	std.TestSetOriginCaller(owner)
+	boards2.InviteMember(bid, "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj", boards2.RoleOwner)
+	boards2.InviteMember(bid, "g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5", boards2.RoleAdmin)
+}
+
+func main() {
+	boards2.IterateRealmMembers(0, func(u boards2.User) bool {
+		println(u.Address, string(u.Roles[0]))
+		return false
+	})
+}
+
+// Output:
+// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 owner
+// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj owner
+// g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5 admin

--- a/examples/gno.land/r/nt/boards2/v1/z_24_a_filetest.gno
+++ b/examples/gno.land/r/nt/boards2/v1/z_24_a_filetest.gno
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"std"
+
+	boards2 "gno.land/r/nt/boards2/v1"
+)
+
+const owner = std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
+
+func init() {
+	std.TestSetOriginCaller(owner)
+
+	bid := boards2.CreateBoard("test123")
+	boards2.InviteMember(bid, "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj", boards2.RoleAdmin)
+
+	bid = boards2.CreateBoard("foo123")
+	boards2.InviteMember(bid, "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj", boards2.RoleOwner)
+	boards2.InviteMember(bid, "g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5", boards2.RoleAdmin)
+}
+
+func main() {
+	boards2.IterateBoards(0, func(b boards2.ReadonlyBoard) bool {
+		println(b.ID().String())
+		println(b.Name())
+
+		b.IterateMembers(0, b.MembersCount(), func(u boards2.User) bool {
+			println(u.Address, string(u.Roles[0]))
+			return false
+		})
+	})
+}
+
+// Output:
+// 1
+// test123
+// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 owner
+// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj admin
+// 2
+// foo123
+// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 owner
+// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj owner
+// g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5 admin


### PR DESCRIPTION
Iteration functions were added mainly to be able to read the minimal data required for realm migrations.

Initially migrations should only migrate boards with invited members, and also realm members. Threads and comments won't be migrated.

Related to #3494