### PR TITLE
feat: Add a Poll package and realm.

### DIFF
--- a/examples/gno.land/p/demo/poll/gno.mod
+++ b/examples/gno.land/p/demo/poll/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/demo/poll

--- a/examples/gno.land/p/demo/poll/poll.gno
+++ b/examples/gno.land/p/demo/poll/poll.gno
@@ -1,0 +1,151 @@
+package poll
+
+import (
+	"std"
+	"time"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+)
+
+// Poll holds the data for a multi-option poll.
+type Poll struct {
+	Title       string
+	Description string
+	Deadline    time.Time // now a standard time.Time
+	Creator     std.Address
+	Options     []string  // e.g. ["Red", "Green", "Blue"]
+	MaxChoices  int       // how many options a voter can select
+	VoteTotal   int       // total number of votes cast
+	Votes       *avl.Tree // key: voter address, value: []int (indices of Options)
+}
+
+// NewPoll constructs a Poll with the desired configuration.
+func NewPoll(
+	title string,
+	description string,
+	opts []string, // often an empty slice in this refactor
+	maxChoices int,
+	deadline time.Time, // now a time.Time
+	creator std.Address,
+) *Poll {
+	if maxChoices < 1 {
+		panic("maxChoices must be at least 1")
+	}
+	if deadline.Before(time.Now()) {
+		panic("deadline must be in the future")
+	}
+	p := &Poll{
+		Title:       title,
+		Description: description,
+		Deadline:    deadline,
+		Creator:     creator,
+		Options:     opts,
+		MaxChoices:  maxChoices,
+		VoteTotal:   0,
+		Votes:       avl.NewTree(),
+	}
+	return p
+}
+
+// HasVoted returns true if the given address has already cast a vote.
+func (p *Poll) HasVoted(addr std.Address) bool {
+	_, exists := p.Votes.Get(addr.String())
+	return exists
+}
+
+// Vote registers the given list of option indices for the address `voter`.
+func (p *Poll) Vote(voter std.Address, choices []int) {
+	if time.Now().After(p.Deadline) {
+		panic("voting for this poll is closed")
+	}
+	if p.HasVoted(voter) {
+		panic("you have already voted")
+	}
+	if len(choices) == 0 {
+		panic("must select at least one option")
+	}
+	if len(choices) > p.MaxChoices {
+		panic(ufmt.Sprintf("too many selections; the maximum is %d", p.MaxChoices))
+	}
+	for _, cIndex := range choices {
+		if cIndex < 0 || cIndex >= len(p.Options) {
+			panic("invalid option index")
+		}
+	}
+	p.VoteTotal = p.VoteTotal + len(choices)
+	p.Votes.Set(voter.String(), choices)
+}
+
+// Tally returns a slice counting how many votes each option has.
+func (p *Poll) Tally() []int {
+	tally := make([]int, len(p.Options))
+	p.Votes.Iterate("", "", func(_ string, value interface{}) bool {
+		choiceIndices := value.([]int)
+		for _, idx := range choiceIndices {
+			tally[idx]++
+		}
+		return false
+	})
+	return tally
+}
+
+// VoterCount returns how many unique addresses have cast votes.
+func (p *Poll) VoterCount() int {
+	return p.Votes.Size()
+}
+
+// Edit poll metadata (title, description, deadline, maxChoices),
+// *not* the options. This is separate from adding/deleting/editing
+// options one at a time.
+func (p *Poll) Edit(
+	editor std.Address,
+	newTitle string,
+	newDescription string,
+	newDeadline time.Time, // now a time.Time
+	newMaxChoices int,
+) {
+	if editor != p.Creator {
+		panic("only the poll creator can edit this poll")
+	}
+	if time.Now().After(p.Deadline) {
+		panic("poll is already closed (cannot edit closed poll)")
+	}
+	if newDeadline.Before(time.Now()) {
+		panic("deadline must be in the future")
+	}
+	p.Title = newTitle
+	p.Description = newDescription
+	p.Deadline = newDeadline
+	p.MaxChoices = newMaxChoices
+}
+
+//----------------------------------------
+// Option Management
+
+// AddOption appends a new option to the poll.
+func (p *Poll) AddOption(optionText string) {
+	if optionText == "" {
+		panic("option text must not be empty")
+	}
+	p.Options = append(p.Options, optionText)
+}
+
+// EditOption modifies the text of an existing option by index.
+func (p *Poll) EditOption(index int, newText string) {
+	if index < 0 || index >= len(p.Options) {
+		panic("invalid option index")
+	}
+	if newText == "" {
+		panic("new option text must not be empty")
+	}
+	p.Options[index] = newText
+}
+
+// DeleteOption removes one option from the poll by index.
+func (p *Poll) DeleteOption(index int) {
+	if index < 0 || index >= len(p.Options) {
+		panic("invalid option index")
+	}
+	p.Options = append(p.Options[:index], p.Options[index+1:]...)
+}

--- a/examples/gno.land/p/demo/poll/poll_test.gno
+++ b/examples/gno.land/p/demo/poll/poll_test.gno
@@ -1,0 +1,208 @@
+package poll
+
+import (
+	"std"
+	"testing"
+	"time"
+)
+
+func TestNewPoll(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	now := time.Now()
+	deadline := now.Add(time.Hour * 24) // 1 day from now
+
+	p := NewPoll(
+		"Favorite Color",
+		"What is your favorite color?",
+		[]string{"Red", "Blue", "Green"},
+		1,
+		deadline,
+		creator,
+	)
+
+	if p.Title != "Favorite Color" {
+		t.Errorf("expected title 'Favorite Color', got %s", p.Title)
+	}
+	if len(p.Options) != 3 {
+		t.Errorf("expected 3 options, got %d", len(p.Options))
+	}
+	if p.MaxChoices != 1 {
+		t.Errorf("expected maxChoices 1, got %d", p.MaxChoices)
+	}
+	if p.Creator != creator {
+		t.Errorf("expected creator %s, got %s", creator, p.Creator)
+	}
+}
+
+func TestNewPollValidation(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	now := time.Now()
+	pastDeadline := now.Add(-time.Hour) // 1 hour ago
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for past deadline")
+		}
+	}()
+
+	NewPoll(
+		"Test Poll",
+		"Description",
+		[]string{},
+		1,
+		pastDeadline,
+		creator,
+	)
+}
+
+func TestVoting(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	voter := std.Address("g1htpxzv2dkplvzg50nd8fuwt5yg4jn8dgtx076k")
+	now := time.Now()
+	deadline := now.Add(time.Hour * 24)
+
+	p := NewPoll(
+		"Test Poll",
+		"Description",
+		[]string{"Option 1", "Option 2", "Option 3"},
+		2, // max two choices
+		deadline,
+		creator,
+	)
+
+	// Test single vote
+	p.Vote(voter, []int{1})
+
+	if !p.HasVoted(voter) {
+		t.Error("expected HasVoted to return true")
+	}
+
+	tally := p.Tally()
+	if tally[1] != 1 {
+		t.Errorf("expected tally[1] = 1, got %d", tally[1])
+	}
+
+	// Test double voting (should panic)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on double vote")
+		}
+	}()
+	p.Vote(voter, []int{0})
+}
+
+func TestOptionManagement(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	now := time.Now()
+	deadline := now.Add(time.Hour * 24)
+
+	p := NewPoll(
+		"Test Poll",
+		"Description",
+		[]string{},
+		1,
+		deadline,
+		creator,
+	)
+
+	// Test adding options
+	p.AddOption("Option 1")
+	p.AddOption("Option 2")
+
+	if len(p.Options) != 2 {
+		t.Errorf("expected 2 options, got %d", len(p.Options))
+	}
+
+	// Test editing option
+	p.EditOption(0, "Updated Option 1")
+	if p.Options[0] != "Updated Option 1" {
+		t.Errorf("expected 'Updated Option 1', got %s", p.Options[0])
+	}
+
+	// Test deleting option
+	p.DeleteOption(0)
+	if len(p.Options) != 1 {
+		t.Errorf("expected 1 option after deletion, got %d", len(p.Options))
+	}
+	if p.Options[0] != "Option 2" {
+		t.Errorf("expected remaining option to be 'Option 2', got %s", p.Options[0])
+	}
+}
+
+func TestPollEdit(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	nonCreator := std.Address("g1htpxzv2dkplvzg50nd8fuwt5yg4jn8dgtx076k")
+	now := time.Now()
+	deadline := now.Add(time.Hour * 24)
+	newDeadline := now.Add(time.Hour * 48)
+
+	p := NewPoll(
+		"Original Title",
+		"Original Description",
+		[]string{"Option 1"},
+		1,
+		deadline,
+		creator,
+	)
+
+	// Test successful edit
+	p.Edit(
+		creator,
+		"New Title",
+		"New Description",
+		newDeadline,
+		2,
+	)
+
+	if p.Title != "New Title" {
+		t.Errorf("expected title 'New Title', got %s", p.Title)
+	}
+	if p.MaxChoices != 2 {
+		t.Errorf("expected maxChoices 2, got %d", p.MaxChoices)
+	}
+
+	// Test edit by non-creator (should panic)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when non-creator tries to edit")
+		}
+	}()
+	p.Edit(
+		nonCreator,
+		"Unauthorized Edit",
+		"Should Fail",
+		newDeadline,
+		1,
+	)
+}
+
+func TestVoterCount(t *testing.T) {
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	voter1 := std.Address("g1htpxzv2dkplvzg50nd8fuwt5yg4jn8dgtx076k")
+	voter2 := std.Address("g1w3jhxarpv3m8ddxhqj2es8wzcgv4gzurvqc843")
+	now := time.Now()
+	deadline := now.Add(time.Hour * 24)
+
+	p := NewPoll(
+		"Test Poll",
+		"Description",
+		[]string{"Option 1", "Option 2", "Option 3"},
+		2,
+		deadline,
+		creator,
+	)
+
+	if count := p.VoterCount(); count != 0 {
+		t.Errorf("expected initial voter count 0, got %d", count)
+	}
+
+	p.Vote(voter1, []int{0})
+	if count := p.VoterCount(); count != 1 {
+		t.Errorf("expected voter count 1, got %d", count)
+	}
+
+	p.Vote(voter2, []int{1, 2})
+	if count := p.VoterCount(); count != 2 {
+		t.Errorf("expected voter count 2, got %d", count)
+	}
+}

--- a/examples/gno.land/r/demo/polls/gno.mod
+++ b/examples/gno.land/r/demo/polls/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/demo/poll

--- a/examples/gno.land/r/demo/polls/polls.gno
+++ b/examples/gno.land/r/demo/polls/polls.gno
@@ -1,0 +1,272 @@
+package pollrealm
+
+import (
+	"bytes"
+	"std"
+	"strconv"
+	"strings"
+	"time"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/poll"
+	"gno.land/p/demo/seqid"
+	"gno.land/p/demo/ufmt"
+)
+
+//----------------------------------------
+// Global State
+
+var (
+	polls         *avl.Tree // TODO: This would be better as a btree; no need to key off a string, then.
+	pollIDCounter seqid.ID
+	pageSize      = 5
+)
+
+func init() {
+	polls = avl.NewTree()
+}
+
+//----------------------------------------
+// Poll Management Functions
+
+// CreatePoll creates a new poll with no options initially.
+// The deadline parameter should be a date/time string in RFC3339 format,
+// e.g. "2025-12-31T23:59:59Z".
+func CreatePoll(
+	title string,
+	description string,
+	maxChoices int,
+	deadlineStr string,
+) string {
+	caller := std.OriginCaller()
+
+	deadline, err := time.Parse(time.RFC3339, deadlineStr)
+	if err != nil {
+		panic("invalid deadline format; please use RFC3339 format (e.g., 2025-12-31T23:59:59Z)")
+	}
+
+	id := pollIDCounter.Next().String()
+	// Create with an empty slice of options
+	newP := poll.NewPoll(title, description, []string{}, maxChoices, deadline, caller)
+	polls.Set(id, newP)
+
+	return ufmt.Sprintf("Successfully created poll #%s!", id)
+}
+
+// EditPoll modifies basic poll metadata (title, description, deadline, maxChoices)
+// but does NOT change the options. Only the poll creator can edit.
+func EditPoll(
+	id string,
+	newTitle string,
+	newDescription string,
+	newDeadlineStr string,
+	newMaxChoices int,
+) string {
+	newDeadline, err := time.Parse(time.RFC3339, newDeadlineStr)
+	if err != nil {
+		panic("invalid deadline format; please use RFC3339 format (e.g., 2025-12-31T23:59:59Z)")
+	}
+	p := getPoll(id)
+	p.Edit(std.OriginCaller(), newTitle, newDescription, newDeadline, newMaxChoices)
+	polls.Set(id, p)
+	return ufmt.Sprintf("Poll #%s edited successfully!", id)
+}
+
+// AddOption adds a single option string to a poll (before any votes).
+func AddOption(id string, optionText string) string {
+	p := getPoll(id)
+	// Only the creator can add options
+	if p.Creator != std.OriginCaller() {
+		panic("only the poll creator can add options")
+	}
+	// Disallow if any votes have been cast
+	if p.VoterCount() > 0 {
+		panic("cannot add options after the first vote has been cast")
+	}
+	p.AddOption(optionText)
+	polls.Set(id, p)
+	return ufmt.Sprintf("Added a new option to poll #%s", id)
+}
+
+// EditOption changes the text of an existing option in a poll.
+// Allowed even if votes have already been cast, because it does not
+// change the *number* of options.
+func EditOption(id string, optionIndex int, newText string) string {
+	p := getPoll(id)
+	// Only the creator can edit
+	if p.Creator != std.OriginCaller() {
+		panic("only the poll creator can edit options")
+	}
+	p.EditOption(optionIndex, newText)
+	polls.Set(id, p)
+	return ufmt.Sprintf("Edited option #%d in poll %s", optionIndex, id)
+}
+
+// DeleteOption removes an option by index (before any votes).
+func DeleteOption(id string, optionIndex int) string {
+	p := getPoll(id)
+	// Only the creator can delete
+	if p.Creator != std.OriginCaller() {
+		panic("only the poll creator can delete options")
+	}
+	// Disallow deleting if any votes have been cast
+	if p.VoterCount() > 0 {
+		panic("cannot delete options after the first vote has been cast")
+	}
+	p.DeleteOption(optionIndex)
+	polls.Set(id, p)
+	return ufmt.Sprintf("Deleted option #%d from poll %s", optionIndex, id)
+}
+
+// Vote: Cast a vote for the poll with given ID.
+// `choices` is a list of option indices the user picks (a comma-separated string,
+// e.g. "1,2,4"). The string is parsed into a slice of ints.
+func Vote(id string, choices string) string {
+	choiceIndices := parseChoices(choices)
+
+	p := getPoll(id)
+	p.Vote(std.OriginCaller(), choiceIndices)
+	polls.Set(id, p)
+
+	return ufmt.Sprintf("Successfully voted on poll #%s!", id)
+}
+
+//----------------------------------------
+// Rendering
+
+func Render(path string) string {
+	var b bytes.Buffer
+
+	path = strings.TrimSpace(path)
+	if path == "" || strings.HasPrefix(path, "page=") {
+		return renderPollList(&b, path)
+	}
+
+	val, exists := polls.Get(path)
+	if !exists {
+		return renderPollList(&b, "")
+	}
+	p := val.(*poll.Poll)
+	renderSinglePoll(&b, path, p)
+	return b.String()
+}
+
+// renderSinglePoll shows the details of a single poll.
+func renderSinglePoll(b *bytes.Buffer, id string, p *poll.Poll) {
+	b.WriteString(ufmt.Sprintf("# Poll %s: %s\n\n", id, p.Title))
+	b.WriteString(ufmt.Sprintf("**Description:** %s\n\n", p.Description))
+	b.WriteString(ufmt.Sprintf("**Deadline:** %s\n", p.Deadline.Format(time.RFC1123)))
+	b.WriteString(ufmt.Sprintf("**Creator:** %s\n", p.Creator))
+	b.WriteString(ufmt.Sprintf("**MaxChoices:** %d\n", p.MaxChoices))
+
+	tally := p.Tally()
+	b.WriteString("\n## Options:\n")
+	for i, opt := range p.Options {
+		b.WriteString(ufmt.Sprintf("  - (%d) %s — Votes: %d -- %f%%\n", i, opt, tally[i], 100*float64(tally[i])/float64(p.VoteTotal)))
+	}
+
+	b.WriteString(ufmt.Sprintf("\n**Distinct Voters:** %d\n", p.VoterCount()))
+	sumVotes := 0
+	for _, count := range tally {
+		sumVotes += count
+	}
+	if sumVotes > p.VoterCount() && p.MaxChoices > 1 {
+		b.WriteString(
+			ufmt.Sprintf("*Multiple selections (%d) are allowed; total votes can exceed distinct voters.*\n\n", p.MaxChoices))
+	}
+
+	b.WriteString("\n## Detailed Votes:\n")
+	p.Votes.Iterate("", "", func(addr string, val interface{}) bool {
+		indexes := val.([]int)
+		strIndexes := make([]string, len(indexes))
+		for i, num := range indexes {
+			strIndexes[i] = strconv.Itoa(num)
+		}
+		b.WriteString(ufmt.Sprintf("- %s => %s\n", addr, strings.Join(strIndexes, ", ")))
+		return false
+	})
+}
+
+// renderPollList displays a paginated list of all polls.
+func renderPollList(b *bytes.Buffer, path string) string {
+	realmAddr := strings.TrimPrefix(std.CurrentRealm().PkgPath(), "gno.land")
+	b.WriteString("# All Polls\n\n")
+
+	if polls.Size() == 0 {
+		b.WriteString("No polls have been created yet.\n")
+		return b.String()
+	}
+
+	page := 1
+	if strings.HasPrefix(path, "page=") {
+		pStr := strings.TrimPrefix(path, "page=")
+		pInt, err := strconv.Atoi(pStr)
+		if err == nil && pInt > 0 {
+			page = pInt
+		}
+	}
+	start := (page - 1) * pageSize
+	end := start + pageSize
+
+	var ids []string
+	polls.Iterate("", "", func(k string, _ interface{}) bool {
+		ids = append(ids, k)
+		return false
+	})
+
+	if start >= len(ids) {
+		b.WriteString("No polls on this page.\n")
+		return b.String()
+	}
+	if end > len(ids) {
+		end = len(ids)
+	}
+
+	for i := start; i < end; i++ {
+		id := ids[i]
+		val, _ := polls.Get(id)
+		p := val.(*poll.Poll)
+		poll_url := ufmt.Sprintf("%s:%s", realmAddr, id)
+		b.WriteString(ufmt.Sprintf("## [Poll](%s) #%s: %s\n", poll_url, id, p.Title))
+		b.WriteString(ufmt.Sprintf("- Deadline: %s\n", p.Deadline.Format(time.RFC1123)))
+		b.WriteString(ufmt.Sprintf("- Votes cast: %d\n\n", p.VoterCount()))
+	}
+
+	b.WriteString(ufmt.Sprintf("### Page %d\n", page))
+	if page > 1 {
+		b.WriteString(ufmt.Sprintf("[Prev Page](./?page=%d)\n", page-1))
+	}
+	if end < len(ids) {
+		b.WriteString(ufmt.Sprintf("[Next Page](./?page=%d)\n", page+1))
+	}
+	return b.String()
+}
+
+//----------------------------------------
+// Helpers
+
+func getPoll(id string) *poll.Poll {
+	val, exists := polls.Get(id)
+	if !exists {
+		panic(ufmt.Sprintf("poll not found: %s", id))
+	}
+	return val.(*poll.Poll)
+}
+
+// parseChoices converts a comma-separated string of integers (e.g. "0,2,3")
+// into a slice of ints.
+func parseChoices(choices string) []int {
+	if choices == "" {
+		panic("must provide at least one choice index")
+	}
+	parts := strings.Split(choices, ",")
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		val, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			panic(ufmt.Sprintf("invalid choice index: %s", part))
+		}
+		out = append(out, val)
+	}
+	return out
+}

--- a/examples/gno.land/r/demo/polls/polls_test.gno
+++ b/examples/gno.land/r/demo/polls/polls_test.gno
@@ -1,0 +1,235 @@
+package pollrealm
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/avl"
+)
+
+// resetState is a helper function to reset global state for testing
+func resetState() {
+	polls = nil
+	polls = avl.NewTree()
+	pollIDCounter = 0
+}
+
+func TestCreatePoll(t *testing.T) {
+	// Reset global state for test
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	result := CreatePoll(
+		"Test Poll",
+		"Test Description",
+		2,
+		deadline,
+	)
+
+	if !strings.Contains(result, "Successfully created poll #0000001") {
+		t.Errorf("unexpected create result: %s", result)
+	}
+
+	if polls.Size() != 1 {
+		t.Errorf("expected 1 poll, got %d", polls.Size())
+	}
+}
+
+func TestCreatePollValidation(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	pastDeadline := time.Now().Add(-time.Hour).Format(time.RFC3339)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for past deadline")
+		}
+	}()
+
+	CreatePoll(
+		"Test Poll",
+		"Test Description",
+		1,
+		pastDeadline,
+	)
+}
+
+func TestAddAndEditOptions(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	CreatePoll(
+		"Test Poll",
+		"Test Description",
+		2,
+		deadline,
+	)
+
+	// Add options
+	result := AddOption("0000001", "Option 1")
+	if !strings.Contains(result, "Added a new option to poll #0000001") {
+		t.Errorf("unexpected add result: %s", result)
+	}
+
+	AddOption("0000001", "Option 2")
+
+	// Edit option
+	result = EditOption("0000001", 0, "Updated Option 1")
+	if !strings.Contains(result, "Edited option #0 in poll 0000001") {
+		t.Errorf("unexpected edit result: %s", result)
+	}
+
+	// Delete option
+	result = DeleteOption("0000001", 0)
+	if !strings.Contains(result, "Deleted option #0 from poll 0000001") {
+		t.Errorf("unexpected delete result: %s", result)
+	}
+}
+
+func TestVoting(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	CreatePoll(
+		"Test Poll",
+		"Test Description",
+		2,
+		deadline,
+	)
+
+	AddOption("0000001", "Option 1")
+	AddOption("0000001", "Option 2")
+	AddOption("0000001", "Option 3")
+
+	// Test successful vote
+	result := Vote("0000001", "0,1")
+	if !strings.Contains(result, "Successfully voted on poll #0000001") {
+		t.Errorf("unexpected vote result: %s", result)
+	}
+
+	// Test invalid vote (too many choices)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for too many choices")
+		}
+	}()
+	Vote("1", "0,1,2")
+}
+
+func TestEditPoll(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	CreatePoll(
+		"Original Title",
+		"Original Description",
+		1,
+		deadline,
+	)
+
+	newDeadline := time.Now().Add(time.Hour * 48).Format(time.RFC3339)
+	result := EditPoll(
+		"0000001",
+		"New Title",
+		"New Description",
+		newDeadline,
+		2,
+	)
+
+	if !strings.Contains(result, "Poll #0000001 edited successfully") {
+		t.Errorf("unexpected edit result: %s", result)
+	}
+}
+
+func TestRender(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	CreatePoll(
+		"Test Poll",
+		"Test Description",
+		2,
+		deadline,
+	)
+
+	AddOption("0000001", "Option 1")
+	AddOption("0000001", "Option 2")
+
+	// Test poll list rendering
+	listOutput := Render("")
+	if !strings.Contains(listOutput, "# All Polls") {
+		t.Errorf("poll list should contain title")
+	}
+	if !strings.Contains(listOutput, "Test Poll") {
+		t.Errorf("poll list should contain poll title")
+	}
+
+	// Test single poll rendering
+	pollOutput := Render("0000001")
+	if !strings.Contains(pollOutput, "# Poll 0000001: Test Poll") {
+		t.Errorf("single poll view should contain poll title")
+	}
+	if !strings.Contains(pollOutput, "Option 1") {
+		t.Errorf("single poll view should contain options")
+	}
+
+	// Test pagination
+	for i := 0; i < 6; i++ { // Create enough polls for pagination
+		CreatePoll(
+			"Test Poll "+string(rune('A'+i)),
+			"Description",
+			1,
+			deadline,
+		)
+	}
+
+	page2Output := Render("page=2")
+	if !strings.Contains(page2Output, "Page 2") {
+		t.Errorf("pagination not working correctly")
+	}
+}
+
+func TestInvalidPollID(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for invalid poll ID")
+		}
+	}()
+
+	Vote("999", "0") // Should panic - poll doesn't exist
+}
+
+func TestOptionManagementAfterVoting(t *testing.T) {
+	// Reset global state
+	resetState()
+
+	deadline := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	CreatePoll(
+		"Test Poll",
+		"Test Description",
+		1,
+		deadline,
+	)
+
+	AddOption("0000001", "Option 1")
+	AddOption("0000001", "Option 2")
+
+	Vote("0000001", "0")
+
+	// Attempt to add option after voting
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when adding option after voting")
+		}
+	}()
+	AddOption("0000001", "Option 3")
+}


### PR DESCRIPTION
This is a simple polling package and realm. It allows the creation of multi-option polls with the ability to vote for more than one option.

It was based off of Leon's simple polling realm in the docs, but expanded to handle any number of polls with any number of options.

This branch supercedes kh.add-poll-package-and-realm, and this PR replaces #3776. It was far simpler to just make a completely clean new branch with the code than to try to clean up an old rebase.