### PR TITLE
fix: In dependabot.yml, use the label dependencies everywhere

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "github_actions"
+      - "dependencies"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
As we discussed in the review team meeting, dependabot [gives the warning](https://github.com/gnolang/gno/pull/3954#issuecomment-2727909534) "The following labels could not be found: `github_actions`." The weekly schedule uses the label `dependencies`. This PR updates the daily schedule to also use this label. This should remove the warning.