### PR TITLE
chore: change r/sys/names admin

### DIFF
--- a/examples/gno.land/r/sys/names/verifier.gno
+++ b/examples/gno.land/r/sys/names/verifier.gno
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	Ownable = ownable.NewWithAddress("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // dropped in genesis via Enable
+	Ownable = ownable.NewWithAddress("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // dropped in genesis via Enable
 
 	enabled = false
 )


### PR DESCRIPTION
## Description

Changes the admin to @moul so we can enable namespaces and drop the ownable for the Portal Loop.