### PR TITLE
fix(p/grc20): ensure `TransferFrom` atomicity

### DIFF
--- a/examples/gno.land/p/demo/grc/grc20/token.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token.gno
@@ -144,11 +144,28 @@ func (led *PrivateLedger) TransferFrom(owner, spender, to std.Address, amount ui
 	if led.balanceOf(owner) < amount {
 		return ErrInsufficientBalance
 	}
-	if err := led.SpendAllowance(owner, spender, amount); err != nil {
+
+	// allowance must be sufficient
+	currentAllowance := led.allowance(owner, spender)
+	if currentAllowance < amount {
+		return ErrInsufficientAllowance
+	}
+
+	if err := led.Transfer(owner, to, amount); err != nil {
 		return err
 	}
-	// XXX: since we don't "panic", we should take care of rollbacking spendAllowance if transfer fails.
-	return led.Transfer(owner, to, amount)
+
+	// decrease the allowance only when transfer is successful
+	key := allowanceKey(owner, spender)
+	newAllowance := currentAllowance - amount
+
+	if newAllowance == 0 {
+		led.allowances.Remove(key)
+	} else {
+		led.allowances.Set(key, newAllowance)
+	}
+
+	return nil
 }
 
 // Approve sets the allowance of the specified owner and spender.

--- a/examples/gno.land/p/demo/grc/grc20/token_test.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token_test.gno
@@ -1,6 +1,7 @@
 package grc20
 
 import (
+	"std"
 	"testing"
 
 	"gno.land/p/demo/testutils"
@@ -86,4 +87,36 @@ func TestOverflow(t *testing.T) {
 	urequire.NoError(t, adm.Mint(alice, 2<<62))
 	urequire.Equal(t, tok.BalanceOf(alice), uint64(2<<62))
 	urequire.Error(t, adm.Mint(bob, 2<<62))
+}
+
+func TestTransferFromAtomicity(t *testing.T) {
+	var (
+		owner     = testutils.TestAddress("owner")
+		spender   = testutils.TestAddress("spender")
+		recipient = testutils.TestAddress("recipient")
+
+		invalidRecipient = std.Address("")
+	)
+
+	token, admin := NewToken("Test", "TEST", 6)
+
+	// owner has 100 tokens, spender has 50 allowance
+	initialBalance := uint64(100)
+	initialAllowance := uint64(50)
+
+	urequire.NoError(t, admin.Mint(owner, initialBalance))
+	urequire.NoError(t, admin.Approve(owner, spender, initialAllowance))
+
+	// transfer to an invalid address to force a transfer failure
+	transferAmount := uint64(30)
+	err := admin.TransferFrom(owner, spender, invalidRecipient, transferAmount)
+	uassert.Error(t, err, "transfer should fail due to invalid address")
+
+	ownerBalance := token.BalanceOf(owner)
+	uassert.Equal(t, ownerBalance, initialBalance, "owner balance should remain unchanged")
+
+	// check if allowance was incorrectly reduced
+	remainingAllowance := token.Allowance(owner, spender)
+	uassert.Equal(t, remainingAllowance, initialAllowance,
+		"allowance should not be reduced when transfer fails")
 }


### PR DESCRIPTION
# Description

The current implementation of `TransferFrom` has an atomicity issue where the allowance is reduced before the actual transfer is executed. This can lead to:

- Allowances being spent even when transfers fail
- Inconsistencies between token balances and approval states
- Possible exploitation by malicious actors who could intentionally trigger tranfer failures to drain allowances

## Changes

Modified the `TransferFrom` function to ensure atomic operation by:

1. First checking if there is sufficient allowance
2. Executing the transfer
3. Only reducing the allowance if the transfer succeeds

It's similar to the internal operation of the `SpendAllowance` function previously being used within the `Transferfrom` functions. However, to maintain this atomicity, we needed to modify when the `Transfer` function is called.

This issue was identified during an OpenZeppelin audit.

## Original Issue

**Atomicity of GRC20 TransferFrom**

The [TransferFrom](https://github.com/gnoswap-labs/gno/blob/6539e5ed8d5593869cbb897ece08ee6a508fd7c2/examples/gno.land/p/demo/grc/grc20/token.gno#L141-L152) function calls Transfer to move tokens from the from address to the to address. However, the current implementation [does not check if ](https://github.com/gnoswap-labs/gno/blob/6539e5ed8d5593869cbb897ece08ee6a508fd7c2/examples/gno.land/p/demo/grc/grc20/token.gno#L148)Transfer[ succeeds](https://github.com/gnoswap-labs/gno/blob/6539e5ed8d5593869cbb897ece08ee6a508fd7c2/examples/gno.land/p/demo/grc/grc20/token.gno#L148) before [decrementing the spender’s allowance](https://github.com/gnoswap-labs/gno/blob/6539e5ed8d5593869cbb897ece08ee6a508fd7c2/examples/gno.land/p/demo/grc/grc20/token.gno#L151). If Transfer fails, the allowance is still reduced, violating the atomicity of the operation.

This non-atomic behavior allows allowances to be spent even when transfers fail, creating inconsistencies between token balances and approval states. Users may lose their approved spending limits without tokens being successfully transferred, leading to potential financial losses or exploitation (e.g., malicious actors triggering intentional transfer failures to drain allowances).