### PR TITLE
fix(p/grc721): Verify approved address in `isApprovedOrOwner` function

### DIFF
--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -361,12 +361,12 @@ func (s *basicNFT) isApprovedOrOwner(addr std.Address, tid TokenID) bool {
 		return true
 	}
 
-	_, err := s.GetApproved(tid)
+	approved, err := s.GetApproved(tid)
 	if err != nil {
 		return false
 	}
 
-	return true
+	return approved == addr
 }
 
 // Checks if token id already exists

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
@@ -288,10 +288,10 @@ func TestIsApprovedOrOwner(t *testing.T) {
 	uassert.True(t, dummy != nil, "should not be nil")
 
 	var (
-		owner = testutils.TestAddress("owner")
+		owner    = testutils.TestAddress("owner")
 		operator = testutils.TestAddress("operator")
 		approved = testutils.TestAddress("approved")
-		other = testutils.TestAddress("other")
+		other    = testutils.TestAddress("other")
 	)
 
 	tid := TokenID("1")

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
@@ -4,6 +4,7 @@ import (
 	"std"
 	"testing"
 
+	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
 )
 
@@ -280,4 +281,47 @@ func TestSetTokenURI(t *testing.T) {
 	dummyTokenURI, err := dummy.TokenURI(TokenID("1"))
 	uassert.NoError(t, err, "TokenURI error")
 	uassert.Equal(t, string(tokenURI), string(dummyTokenURI))
+}
+
+func TestIsApprovedOrOwner(t *testing.T) {
+	dummy := NewBasicNFT(dummyNFTName, dummyNFTSymbol)
+	uassert.True(t, dummy != nil, "should not be nil")
+
+	var (
+		owner = testutils.TestAddress("owner")
+		operator = testutils.TestAddress("operator")
+		approved = testutils.TestAddress("approved")
+		other = testutils.TestAddress("other")
+	)
+
+	tid := TokenID("1")
+
+	err := dummy.mint(owner, tid)
+	uassert.NoError(t, err)
+
+	// check owner
+	isApprovedOrOwner := dummy.isApprovedOrOwner(owner, tid)
+	uassert.True(t, isApprovedOrOwner, "owner should be approved")
+
+	// check operator
+	testing.SetOriginCaller(owner)
+	err = dummy.SetApprovalForAll(operator, true)
+	uassert.NoError(t, err)
+	isApprovedOrOwner = dummy.isApprovedOrOwner(operator, tid)
+	uassert.True(t, isApprovedOrOwner, "operator should be approved")
+
+	// check approved
+	testing.SetOriginCaller(owner)
+	err = dummy.Approve(approved, tid)
+	uassert.NoError(t, err)
+	isApprovedOrOwner = dummy.isApprovedOrOwner(approved, tid)
+	uassert.True(t, isApprovedOrOwner, "approved address should be approved")
+
+	// check other
+	isApprovedOrOwner = dummy.isApprovedOrOwner(other, tid)
+	uassert.False(t, isApprovedOrOwner, "other address should not be approved")
+
+	// check non-existent token
+	isApprovedOrOwner = dummy.isApprovedOrOwner(owner, TokenID("999"))
+	uassert.False(t, isApprovedOrOwner, "non-existent token should not be approved")
 }


### PR DESCRIPTION
# Description

> _**Note: This issue was identified during an OpenZeppelin audit.**_

When checking approved addresses in the `isApprovedOrOwner` function, it wasn't properly validating the result of the `GetApproved` function. This could lead to the following issues:
1. Unauthorized addresses being incorrectly identified as approved
2. The operator approval verification logic not functioning correctly

So, I've modified it to compare whether the approved address matches the input address.

## Test Result

### Test Code

```go
func TestIsApprovedOrOwner(t *testing.T) {
	dummy := NewBasicNFT(dummyNFTName, dummyNFTSymbol)
	uassert.True(t, dummy != nil, "should not be nil")

	var (
		owner = testutils.TestAddress("owner")
		operator = testutils.TestAddress("operator")
		approved = testutils.TestAddress("approved")
		other = testutils.TestAddress("other")
	)

	tid := TokenID("1")

	err := dummy.mint(owner, tid)
	uassert.NoError(t, err)

	// check owner
	isApprovedOrOwner := dummy.isApprovedOrOwner(owner, tid)
	uassert.True(t, isApprovedOrOwner, "owner should be approved")

	// check operator
	testing.SetOriginCaller(owner)
	err = dummy.SetApprovalForAll(operator, true)
	uassert.NoError(t, err)
	isApprovedOrOwner = dummy.isApprovedOrOwner(operator, tid)
	uassert.True(t, isApprovedOrOwner, "operator should be approved")

	// check approved
	testing.SetOriginCaller(owner)
	err = dummy.Approve(approved, tid)
	uassert.NoError(t, err)
	isApprovedOrOwner = dummy.isApprovedOrOwner(approved, tid)
	uassert.True(t, isApprovedOrOwner, "approved address should be approved")

	// check other
	isApprovedOrOwner = dummy.isApprovedOrOwner(other, tid)
	uassert.False(t, isApprovedOrOwner, "other address should not be approved")

	// check non-existent token
	isApprovedOrOwner = dummy.isApprovedOrOwner(owner, TokenID("999"))
	uassert.False(t, isApprovedOrOwner, "non-existent token should not be approved")
}
```

### Before

```plain
$ gno test examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno -run TestIsApprovedOrOwner

--- FAIL: TestIsApprovedOrOwner (0.01s)
should be false - other address should not be approved
examples/gno.land/p/demo/grc/grc721: test pkg: failed: "TestIsApprovedOrOwner"
FAIL    examples/gno.land/p/demo/grc/grc721     1.63s
```

### After

```plain
ok      examples/gno.land/p/demo/grc/grc721     1.43s
```

## Original Issue

**`isApprovedOrOwner` Does Not Verify Whether addr is Approved**

The `isApprovedOrOwner` function determines whether the `addr` parameter represents either the `owner` or an `approved` operator of the `tid` NFT token. However, when it invokes `s.GetApproved(tid)` to retrieve the approved operator, it merely confirms the presence of an operator without ensuring that this operator matches the addr parameter.