### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/tm2/pkg/iavl/node.go
+++ b/tm2/pkg/iavl/node.go
@@ -356,7 +356,7 @@ func (node *Node) getRightNode(t *ImmutableTree) *Node {
 
 // NOTE: mutates height and size
 func (node *Node) calcHeightAndSize(t *ImmutableTree) {
-	node.height = maxInt8(node.getLeftNode(t).height, node.getRightNode(t).height) + 1
+	node.height = max(node.getLeftNode(t).height, node.getRightNode(t).height) + 1
 	node.size = node.getLeftNode(t).size + node.getRightNode(t).size
 }
 

--- a/tm2/pkg/iavl/util.go
+++ b/tm2/pkg/iavl/util.go
@@ -45,13 +45,6 @@ func printNode(ndb *nodeDB, node *Node, indent int) {
 	}
 }
 
-func maxInt8(a, b int8) int8 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func cp(bz []byte) (ret []byte) {
 	ret = make([]byte, len(bz))
 	copy(ret, bz)


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.