### PR TITLE
feat(demo/ufmt): add some usefull missing methods: (Fprintx, AppendX, SprintX, PrintX)

### DIFF
--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -5,42 +5,77 @@ package ufmt
 
 import (
 	"errors"
+	"io"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
+
+type buffer []byte
+
+func (b *buffer) write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) writeString(s string) {
+	*b = append(*b, s...)
+}
+
+func (b *buffer) writeByte(c byte) {
+	*b = append(*b, c)
+}
+
+func (b *buffer) writeRune(r rune) {
+	*b = utf8.AppendRune(*b, r)
+}
+
+type printer struct {
+	buf buffer
+}
+
+func newPrinter() *printer {
+	return &printer{}
+}
 
 // Println formats using the default formats for its operands and writes to standard output.
 // Println writes the given arguments to standard output with spaces between arguments
 // and a newline at the end.
-func Println(args ...any) {
-	var strs []string
-	for _, arg := range args {
+func (p *printer) doPrint(args []any) {
+	for i, arg := range args {
+		// Add a space between two arguments.
+		if i > 0 {
+			p.buf.writeRune(' ')
+		}
+
 		switch v := arg.(type) {
 		case string:
-			strs = append(strs, v)
+			p.buf.writeString(v)
 		case (interface{ String() string }):
-			strs = append(strs, v.String())
+			p.buf.writeString(v.String())
 		case error:
-			strs = append(strs, v.Error())
+			p.buf.writeString(v.Error())
 		case float64:
-			strs = append(strs, Sprintf("%f", v))
+			p.buf.writeString(Sprintf("%f", v))
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			strs = append(strs, Sprintf("%d", v))
+			p.buf.writeString(Sprintf("%d", v))
 		case bool:
 			if v {
-				strs = append(strs, "true")
+				p.buf.writeString("true")
 			} else {
-				strs = append(strs, "false")
+				p.buf.writeString("false")
 			}
 		case nil:
-			strs = append(strs, "<nil>")
+			p.buf.writeString("<nil>")
 		default:
-			strs = append(strs, "(unhandled)")
+			p.buf.writeString("(unhandled)")
 		}
 	}
+}
 
-	// TODO: remove println after gno supports os.Stdout
-	println(strings.Join(strs, " "))
+// doPrintln is like doPrint but add a newline after the last argument.
+func (p *printer) doPrintln(a []any) {
+	p.doPrint(a)
+	p.buf.writeByte('\n')
 }
 
 // Sprintf offers similar functionality to Go's fmt.Sprintf, or the sprintf
@@ -51,50 +86,50 @@ func Println(args ...any) {
 //
 // The currently formatted verbs are the following:
 //
-//		%s: places a string value directly.
-//		    If the value implements the interface interface{ String() string },
-//		    the String() method is called to retrieve the value. Same about Error()
-//		    string.
-//		%c: formats the character represented by Unicode code point
-//		%d: formats an integer value using package "strconv".
-//		    Currently supports only uint, uint64, int, int64.
-//		%f: formats a float value, with a default precision of 6.
-//		%e: formats a float with scientific notation; 1.23456e+78
-//		%E: formats a float with scientific notation; 1.23456E+78
-//		%F: The same as %f
-//		%g: formats a float value with %e for large exponents, and %f with full precision for smaller numbers
-//		%G: formats a float value with %G for large exponents, and %F with full precision for smaller numbers
-//		%t: formats a boolean value to "true" or "false".
-//		%x: formats an integer value as a hexadecimal string.
-//		    Currently supports only uint8, []uint8, [32]uint8.
-//		%c: formats a rune value as a string.
-//		    Currently supports only rune, int.
-//		%q: formats a string value as a quoted string.
-//		%T: formats the type of the value.
-//	     %v: formats the value with a default representation appropriate for the value's type
-//		%%: outputs a literal %. Does not consume an argument.
-func Sprintf(format string, args ...any) string {
+//	%s: places a string value directly.
+//	    If the value implements the interface interface{ String() string },
+//	    the String() method is called to retrieve the value. Same about Error()
+//	    string.
+//	%c: formats the character represented by Unicode code point
+//
+//	%d: formats an integer value using package "strconv".
+//	    Currently supports only uint, uint64, int, int64.
+//	%f: formats a float value, with a default precision of 6.
+//	%e: formats a float with scientific notation; 1.23456e+78
+//	%E: formats a float with scientific notation; 1.23456E+78
+//	%F: The same as %f
+//	%g: formats a float value with %e for large exponents, and %f with full precision for smaller numbers
+//	%G: formats a float value with %G for large exponents, and %F with full precision for smaller numbers
+//	%t: formats a boolean value to "true" or "false".
+//	%x: formats an integer value as a hexadecimal string.
+//	    Currently supports only uint8, []uint8, [32]uint8.
+//	%c: formats a rune value as a string.
+//	    Currently supports only rune, int.
+//	%q: formats a string value as a quoted string.
+//	%T: formats the type of the value.
+//	%v: formats the value with a default representation appropriate for the value's type
+//	%%: outputs a literal %. Does not consume an argument.
+func (p *printer) doPrintf(format string, args []any) {
 	// we use runes to handle multi-byte characters
 	sTor := []rune(format)
 	end := len(sTor)
 	argNum := 0
 	argLen := len(args)
-	buf := ""
 
 	for i := 0; i < end; {
 		isLast := i == end-1
-		c := string(sTor[i])
+		c := sTor[i]
 
-		if isLast || c != "%" {
+		if isLast || c != '%' {
 			// we don't check for invalid format like a one ending with "%"
-			buf += string(c)
+			p.buf.writeRune(c)
 			i++
 			continue
 		}
 
-		verb := string(sTor[i+1])
-		if verb == "%" {
-			buf += "%"
+		verb := sTor[i+1]
+		if verb == '%' {
+			p.buf.writeRune('%')
 			i += 2
 			continue
 		}
@@ -106,186 +141,186 @@ func Sprintf(format string, args ...any) string {
 		argNum++
 
 		switch verb {
-		case "v":
+		case 'v':
 			switch v := arg.(type) {
 			case nil:
-				buf += "<nil>"
+				p.buf.writeString("<nil>")
 			case bool:
 				if v {
-					buf += "true"
+					p.buf.writeString("true")
 				} else {
-					buf += "false"
+					p.buf.writeString("false")
 				}
 			case int:
-				buf += strconv.Itoa(v)
+				p.buf.writeString(strconv.Itoa(v))
 			case int8:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int16:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int32:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int64:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case uint:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint8:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint16:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint32:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint64:
-				buf += strconv.FormatUint(v, 10)
+				p.buf.writeString(strconv.FormatUint(v, 10))
 			case float64:
-				buf += strconv.FormatFloat(v, 'g', -1, 64)
+				p.buf.writeString(strconv.FormatFloat(v, 'g', -1, 64))
 			case string:
-				buf += v
+				p.buf.writeString(v)
 			case []byte:
-				buf += string(v)
+				p.buf.write(v)
 			case []rune:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case interface{ String() string }:
-				buf += v.String()
+				p.buf.writeString(v.String())
 			case error:
-				buf += v.Error()
+				p.buf.writeString(v.Error())
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "s":
+		case 's':
 			switch v := arg.(type) {
 			case interface{ String() string }:
-				buf += v.String()
+				p.buf.writeString(v.String())
 			case error:
-				buf += v.Error()
+				p.buf.writeString(v.Error())
 			case string:
-				buf += v
+				p.buf.writeString(v)
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "c":
+		case 'c':
 			switch v := arg.(type) {
 			// rune is int32. Exclude overflowing numeric types and dups (byte, int32):
 			case rune:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case int:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case int8:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case int16:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case uint:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case uint8:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			case uint16:
-				buf += string(v)
+				p.buf.writeString(string(v))
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "d":
+		case 'd':
 			switch v := arg.(type) {
 			case int:
-				buf += strconv.Itoa(v)
+				p.buf.writeString(strconv.Itoa(v))
 			case int8:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int16:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int32:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case int64:
-				buf += strconv.Itoa(int(v))
+				p.buf.writeString(strconv.Itoa(int(v)))
 			case uint:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint8:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint16:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint32:
-				buf += strconv.FormatUint(uint64(v), 10)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
 			case uint64:
-				buf += strconv.FormatUint(v, 10)
+				p.buf.writeString(strconv.FormatUint(v, 10))
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "e", "E", "f", "F", "g", "G":
+		case 'e', 'E', 'f', 'F', 'g', 'G':
 			switch v := arg.(type) {
 			case float64:
 				switch verb {
-				case "e":
-					buf += strconv.FormatFloat(v, byte('e'), -1, 64)
-				case "E":
-					buf += strconv.FormatFloat(v, byte('E'), -1, 64)
-				case "f", "F":
-					buf += strconv.FormatFloat(v, byte('f'), 6, 64)
-				case "g":
-					buf += strconv.FormatFloat(v, byte('g'), -1, 64)
-				case "G":
-					buf += strconv.FormatFloat(v, byte('G'), -1, 64)
+				case 'e':
+					p.buf.writeString(strconv.FormatFloat(v, byte('e'), -1, 64))
+				case 'E':
+					p.buf.writeString(strconv.FormatFloat(v, byte('E'), -1, 64))
+				case 'f', 'F':
+					p.buf.writeString(strconv.FormatFloat(v, byte('f'), 6, 64))
+				case 'g':
+					p.buf.writeString(strconv.FormatFloat(v, byte('g'), -1, 64))
+				case 'G':
+					p.buf.writeString(strconv.FormatFloat(v, byte('G'), -1, 64))
 				}
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "t":
+		case 't':
 			switch v := arg.(type) {
 			case bool:
 				if v {
-					buf += "true"
+					p.buf.writeString("true")
 				} else {
-					buf += "false"
+					p.buf.writeString("false")
 				}
 			default:
-				buf += fallback(verb, v)
+				p.buf.writeString(fallback(verb, v))
 			}
-		case "x":
+		case 'x':
 			switch v := arg.(type) {
 			case uint8:
-				buf += strconv.FormatUint(uint64(v), 16)
+				p.buf.writeString(strconv.FormatUint(uint64(v), 16))
 			default:
-				buf += "(unhandled)"
+				p.buf.writeString("(unhandled)")
 			}
-		case "q":
+		case 'q':
 			switch v := arg.(type) {
 			case string:
-				buf += strconv.Quote(v)
+				p.buf.writeString(strconv.Quote(v))
 			default:
-				buf += "(unhandled)"
+				p.buf.writeString("(unhandled)")
 			}
-		case "T":
+		case 'T':
 			switch arg.(type) {
 			case bool:
-				buf += "bool"
+				p.buf.writeString("bool")
 			case int:
-				buf += "int"
+				p.buf.writeString("int")
 			case int8:
-				buf += "int8"
+				p.buf.writeString("int8")
 			case int16:
-				buf += "int16"
+				p.buf.writeString("int16")
 			case int32:
-				buf += "int32"
+				p.buf.writeString("int32")
 			case int64:
-				buf += "int64"
+				p.buf.writeString("int64")
 			case uint:
-				buf += "uint"
+				p.buf.writeString("uint")
 			case uint8:
-				buf += "uint8"
+				p.buf.writeString("uint8")
 			case uint16:
-				buf += "uint16"
+				p.buf.writeString("uint16")
 			case uint32:
-				buf += "uint32"
+				p.buf.writeString("uint32")
 			case uint64:
-				buf += "uint64"
+				p.buf.writeString("uint64")
 			case string:
-				buf += "string"
+				p.buf.writeString("string")
 			case []byte:
-				buf += "[]byte"
+				p.buf.writeString("[]byte")
 			case []rune:
-				buf += "[]rune"
+				p.buf.writeString("[]rune")
 			default:
-				buf += "unknown"
+				p.buf.writeString("unknown")
 			}
 		// % handled before, as it does not consume an argument
 		default:
-			buf += "(unhandled verb: %" + verb + ")"
+			p.buf.writeString("(unhandled verb: %" + string(verb) + ")")
 		}
 
 		i += 2
@@ -293,7 +328,123 @@ func Sprintf(format string, args ...any) string {
 	if argNum < argLen {
 		panic("too many arguments to ufmt.Sprintf")
 	}
-	return buf
+}
+
+// These routines end in 'f' and take a format string.
+
+// Fprintf formats according to a format specifier and writes to w.
+// It returns the number of bytes written and any write error encountered.
+func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return w.Write(p.buf)
+}
+
+// Printf formats according to a format specifier and writes to standard output.
+// It returns the number of bytes written and any write error encountered.
+func Printf(format string, a ...any) (n int, err error) {
+	// XXX: update this after gno supports os.Stdout
+	var out strings.Builder
+	n, err = Fprintf(&out, format, a)
+	print(out.String())
+	return n, err
+}
+
+// Sprintf formats according to a format specifier and returns the resulting string.
+func Sprintf(format string, a ...any) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return string(p.buf)
+}
+
+// Appendf formats according to a format specifier, appends the result to the byte
+// slice, and returns the updated slice.
+func Appendf(b []byte, format string, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return append(b, p.buf...)
+}
+
+// Fprint formats using the default formats for its operands and writes to w.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Fprint(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrint(a)
+	return w.Write(p.buf)
+}
+
+// Print formats using the default formats for its operands and writes to standard output.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Print(a ...any) (n int, err error) {
+	// XXX: update this after gno supports os.Stdout
+	var out strings.Builder
+	n, err = Fprint(&out, a...)
+	print(out.String())
+	return n, err
+}
+
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Spaces are added between operands when neither is a string.
+func Sprint(a ...any) string {
+	p := newPrinter()
+	p.doPrint(a)
+	s := string(p.buf)
+	return s
+}
+
+// Append formats using the default formats for its operands, appends the result to
+// the byte slice, and returns the updated slice.
+func Append(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrint(a)
+	return append(b, p.buf...)
+}
+
+// These routines end in 'ln', do not take a format string,
+// always add spaces between operands, and add a newline
+// after the last operand.
+
+// Fprintln formats using the default formats for its operands and writes to w.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Fprintln(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintln(a)
+	return w.Write(p.buf)
+}
+
+// Println formats using the default formats for its operands and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Println(a ...any) (n int, err error) {
+	// XXX: update this after gno supports os.Stdout
+	var out strings.Builder
+	n, err = Fprintln(&out, a...)
+	if err != nil {
+		print(out.String())
+	}
+
+	return n, err
+}
+
+// Sprintln formats using the default formats for its operands and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func Sprintln(a ...any) string {
+	p := newPrinter()
+	p.doPrintln(a)
+	return string(p.buf)
+
+}
+
+// Appendln formats using the default formats for its operands, appends the result
+// to the byte slice, and returns the updated slice. Spaces are always added
+// between operands and a newline is appended.
+func Appendln(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintln(a)
+	return append(b, p.buf...)
 }
 
 // This function is used to mimic Go's fmt.Sprintf
@@ -306,7 +457,7 @@ func Sprintf(format string, args ...any) string {
 //
 //	fallback("s", 8) -> "%!s(int=8)"
 //	fallback("d", nil) -> "%!d(<nil>)", and so on.
-func fallback(verb string, arg any) string {
+func fallback(verb rune, arg any) string {
 	var s string
 	switch v := arg.(type) {
 	case string:
@@ -336,7 +487,7 @@ func fallback(verb string, arg any) string {
 	default:
 		s = "(unhandled)"
 	}
-	return "%!" + verb + "(" + s + ")"
+	return "%!" + string(verb) + "(" + s + ")"
 }
 
 // Get the name of the type of `v` as a string.

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -1,6 +1,8 @@
-// Package ufmt provides utility functions for formatting strings, similarly
-// to the Go package "fmt", of which only a subset is currently supported
-// (hence the name µfmt - micro fmt).
+// Package ufmt provides utility functions for formatting strings, similarly to
+// the Go package "fmt", of which only a subset is currently supported (hence
+// the name µfmt - micro fmt). It includes functions like Printf, Sprintf,
+// Fprintf, and Errorf.
+// Supported formatting verbs are documented in the Sprintf function.
 package ufmt
 
 import (
@@ -11,6 +13,7 @@ import (
 	"unicode/utf8"
 )
 
+// buffer accumulates formatted output as a byte slice.
 type buffer []byte
 
 func (b *buffer) write(p []byte) {
@@ -29,6 +32,7 @@ func (b *buffer) writeRune(r rune) {
 	*b = utf8.AppendRune(*b, r)
 }
 
+// printer holds state for formatting operations.
 type printer struct {
 	buf buffer
 }
@@ -37,20 +41,26 @@ func newPrinter() *printer {
 	return &printer{}
 }
 
-// Println formats using the default formats for its operands and writes to standard output.
-// Println writes the given arguments to standard output with spaces between arguments
-// and a newline at the end.
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Sprint writes the given arguments with spaces between arguments.
+func Sprint(a ...any) string {
+	p := newPrinter()
+	p.doPrint(a)
+	return string(p.buf)
+}
+
+// doPrint formats arguments using default formats and writes to printer's buffer.
+// Spaces are added between arguments.
 func (p *printer) doPrint(args []any) {
-	for i, arg := range args {
-		// Add a space between two arguments.
-		if i > 0 {
+	for argNum, arg := range args {
+		if argNum > 0 {
 			p.buf.writeRune(' ')
 		}
 
 		switch v := arg.(type) {
 		case string:
 			p.buf.writeString(v)
-		case (interface{ String() string }):
+		case interface{ String() string }:
 			p.buf.writeString(v.String())
 		case error:
 			p.buf.writeString(v.Error())
@@ -72,7 +82,7 @@ func (p *printer) doPrint(args []any) {
 	}
 }
 
-// doPrintln is like doPrint but add a newline after the last argument.
+// doPrintln appends a newline after formatting arguments with doPrint.
 func (p *printer) doPrintln(a []any) {
 	p.doPrint(a)
 	p.buf.writeByte('\n')
@@ -81,36 +91,49 @@ func (p *printer) doPrintln(a []any) {
 // Sprintf offers similar functionality to Go's fmt.Sprintf, or the sprintf
 // equivalent available in many languages, including C/C++.
 // The number of args passed must exactly match the arguments consumed by the format.
-// A limited number of formatting verbs and features are currently supported,
-// hence the name ufmt (µfmt, micro-fmt).
+// A limited number of formatting verbs and features are currently supported.
 //
-// The currently formatted verbs are the following:
+// Supported verbs:
 //
-//	%s: places a string value directly.
+//	%s: Places a string value directly.
 //	    If the value implements the interface interface{ String() string },
 //	    the String() method is called to retrieve the value. Same about Error()
 //	    string.
-//	%c: formats the character represented by Unicode code point
-//
-//	%d: formats an integer value using package "strconv".
+//	%c: Formats the character represented by Unicode code point
+//	%d: Formats an integer value using package "strconv".
 //	    Currently supports only uint, uint64, int, int64.
-//	%f: formats a float value, with a default precision of 6.
-//	%e: formats a float with scientific notation; 1.23456e+78
-//	%E: formats a float with scientific notation; 1.23456E+78
+//	%f: Formats a float value, with a default precision of 6.
+//	%e: Formats a float with scientific notation; 1.23456e+78
+//	%E: Formats a float with scientific notation; 1.23456E+78
 //	%F: The same as %f
-//	%g: formats a float value with %e for large exponents, and %f with full precision for smaller numbers
-//	%G: formats a float value with %G for large exponents, and %F with full precision for smaller numbers
-//	%t: formats a boolean value to "true" or "false".
-//	%x: formats an integer value as a hexadecimal string.
+//	%g: Formats a float value with %e for large exponents, and %f with full precision for smaller numbers
+//	%G: Formats a float value with %G for large exponents, and %F with full precision for smaller numbers
+//	%t: Formats a boolean value to "true" or "false".
+//	%x: Formats an integer value as a hexadecimal string.
 //	    Currently supports only uint8, []uint8, [32]uint8.
-//	%c: formats a rune value as a string.
+//	%c: Formats a rune value as a string.
 //	    Currently supports only rune, int.
-//	%q: formats a string value as a quoted string.
-//	%T: formats the type of the value.
-//	%v: formats the value with a default representation appropriate for the value's type
-//	%%: outputs a literal %. Does not consume an argument.
+//	%q: Formats a string value as a quoted string.
+//	%T: Formats the type of the value.
+//	%v: Formats the value with a default representation appropriate for the value's type
+//	    - nil: <nil>
+//	    - bool: true/false
+//	    - integers: base 10
+//	    - float64: %g format
+//	    - string: verbatim
+//	    - types with String()/Error(): method result
+//	    - others: (unhandled)
+//	%%: Outputs a literal %. Does not consume an argument.
+//
+// Unsupported verbs or type mismatches produce error strings like "%!d(string=foo)".
+func Sprintf(format string, a ...any) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return string(p.buf)
+}
+
+// doPrintf parses the format string and writes formatted arguments to the buffer.
 func (p *printer) doPrintf(format string, args []any) {
-	// we use runes to handle multi-byte characters
 	sTor := []rune(format)
 	end := len(sTor)
 	argNum := 0
@@ -121,7 +144,6 @@ func (p *printer) doPrintf(format string, args []any) {
 		c := sTor[i]
 
 		if isLast || c != '%' {
-			// we don't check for invalid format like a one ending with "%"
 			p.buf.writeRune(c)
 			i++
 			continue
@@ -134,8 +156,8 @@ func (p *printer) doPrintf(format string, args []any) {
 			continue
 		}
 
-		if argNum > argLen {
-			panic("invalid number of arguments to ufmt.Sprintf")
+		if argNum >= argLen {
+			panic("ufmt: not enough arguments")
 		}
 		arg := args[argNum]
 		argNum++
@@ -167,22 +189,17 @@ func (p *printer) doPrintf(format string, args []any) {
 	}
 
 	if argNum < argLen {
-		panic("too many arguments to ufmt.Sprintf")
+		panic("ufmt: too many arguments")
 	}
 }
 
-// Utility functions for doPrintf
-
+// writeValue handles %v formatting
 func writeValue(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case nil:
 		p.buf.writeString("<nil>")
 	case bool:
-		if v {
-			p.buf.writeString("true")
-		} else {
-			p.buf.writeString("false")
-		}
+		writeBool(p, verb, v)
 	case int:
 		p.buf.writeString(strconv.Itoa(v))
 	case int8:
@@ -220,6 +237,7 @@ func writeValue(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeString handles %s formatting
 func writeString(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case interface{ String() string }:
@@ -233,27 +251,29 @@ func writeString(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeChar handles %c formatting
 func writeChar(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case rune:
 		p.buf.writeString(string(v))
 	case int:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	case int8:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	case int16:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	case uint:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	case uint8:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	case uint16:
-		p.buf.writeString(string(v))
+		p.buf.writeRune(rune(v))
 	default:
 		p.buf.writeString(fallback(verb, v))
 	}
 }
 
+// writeInt handles %d formatting
 func writeInt(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case int:
@@ -281,6 +301,7 @@ func writeInt(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeFloat handles floating-point formatting verbs
 func writeFloat(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case float64:
@@ -301,6 +322,7 @@ func writeFloat(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeBool handles %t formatting
 func writeBool(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case bool:
@@ -314,6 +336,7 @@ func writeBool(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeHex handles %x formatting
 func writeHex(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case uint8:
@@ -323,6 +346,7 @@ func writeHex(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeQuotedString handles %q formatting
 func writeQuotedString(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
 	case string:
@@ -332,6 +356,7 @@ func writeQuotedString(p *printer, verb rune, arg any) {
 	}
 }
 
+// writeType handles %T formatting
 func writeType(p *printer, arg any) {
 	switch arg.(type) {
 	case bool:
@@ -368,7 +393,7 @@ func writeType(p *printer, arg any) {
 }
 
 // Fprintf formats according to a format specifier and writes to w.
-// It returns the number of bytes written and any write error encountered.
+// Returns the number of bytes written and any write error encountered.
 func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
 	p := newPrinter()
 	p.doPrintf(format, a)
@@ -376,20 +401,14 @@ func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
 }
 
 // Printf formats according to a format specifier and writes to standard output.
-// It returns the number of bytes written and any write error encountered.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
 func Printf(format string, a ...any) (n int, err error) {
-	// XXX: update this after gno supports os.Stdout
 	var out strings.Builder
-	n, err = Fprintf(&out, format, a)
+	n, err = Fprintf(&out, format, a...)
 	print(out.String())
 	return n, err
-}
-
-// Sprintf formats according to a format specifier and returns the resulting string.
-func Sprintf(format string, a ...any) string {
-	p := newPrinter()
-	p.doPrintf(format, a)
-	return string(p.buf)
 }
 
 // Appendf formats according to a format specifier, appends the result to the byte
@@ -400,120 +419,90 @@ func Appendf(b []byte, format string, a ...any) []byte {
 	return append(b, p.buf...)
 }
 
-// Fprint formats using the default formats for its operands and writes to w.
-// Spaces are added between operands when neither is a string.
-// It returns the number of bytes written and any write error encountered.
+// Fprint formats using default formats and writes to w.
+// Spaces are added between arguments.
+// Returns the number of bytes written and any write error encountered.
 func Fprint(w io.Writer, a ...any) (n int, err error) {
 	p := newPrinter()
 	p.doPrint(a)
 	return w.Write(p.buf)
 }
 
-// Print formats using the default formats for its operands and writes to standard output.
-// Spaces are added between operands when neither is a string.
-// It returns the number of bytes written and any write error encountered.
+// Print formats using default formats and writes to standard output.
+// Spaces are added between arguments.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
 func Print(a ...any) (n int, err error) {
-	// XXX: update this after gno supports os.Stdout
 	var out strings.Builder
 	n, err = Fprint(&out, a...)
 	print(out.String())
 	return n, err
 }
 
-// Sprint formats using the default formats for its operands and returns the resulting string.
-// Spaces are added between operands when neither is a string.
-func Sprint(a ...any) string {
-	p := newPrinter()
-	p.doPrint(a)
-	return string(p.buf)
-}
-
-// Append formats using the default formats for its operands, appends the result to
-// the byte slice, and returns the updated slice.
+// Append formats using default formats, appends to b, and returns the updated slice.
+// Spaces are added between arguments.
 func Append(b []byte, a ...any) []byte {
 	p := newPrinter()
 	p.doPrint(a)
 	return append(b, p.buf...)
 }
 
-// These routines end in 'ln', do not take a format string,
-// always add spaces between operands, and add a newline
-// after the last operand.
-
-// Fprintln formats using the default formats for its operands and writes to w.
-// Spaces are always added between operands and a newline is appended.
-// It returns the number of bytes written and any write error encountered.
+// Fprintln formats using default formats and writes to w with newline.
+// Returns the number of bytes written and any write error encountered.
 func Fprintln(w io.Writer, a ...any) (n int, err error) {
 	p := newPrinter()
 	p.doPrintln(a)
 	return w.Write(p.buf)
 }
 
-// Println formats using the default formats for its operands and writes to standard output.
-// Spaces are always added between operands and a newline is appended.
-// It returns the number of bytes written and any write error encountered.
+// Println formats using default formats and writes to standard output with newline.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
 func Println(a ...any) (n int, err error) {
-	// XXX: update this after gno supports os.Stdout
 	var out strings.Builder
 	n, err = Fprintln(&out, a...)
-	if err != nil {
-		print(out.String())
-	}
+	print(out.String())
 	return n, err
 }
 
-// Sprintln formats using the default formats for its operands and returns the resulting string.
-// Spaces are always added between operands and a newline is appended.
+// Sprintln formats using default formats and returns the string with newline.
+// Spaces are always added between arguments.
 func Sprintln(a ...any) string {
 	p := newPrinter()
 	p.doPrintln(a)
 	return string(p.buf)
 }
 
-// Appendln formats using the default formats for its operands, appends the result
-// to the byte slice, and returns the updated slice. Spaces are always added
-// between operands and a newline is appended.
+// Appendln formats using default formats, appends to b, and returns the updated slice.
+// Appends a newline after the last argument.
 func Appendln(b []byte, a ...any) []byte {
 	p := newPrinter()
 	p.doPrintln(a)
 	return append(b, p.buf...)
 }
 
-// This function is used to mimic Go's fmt.Sprintf
-// specific behaviour of showing verb/type mismatches,
-// where for example:
-//
-//	fmt.Sprintf("%d", "foo") gives "%!d(string=foo)"
-//
-// Here:
-//
-//	fallback("s", 8) -> "%!s(int=8)"
-//	fallback("d", nil) -> "%!d(<nil>)", and so on.
+// fallback generates error strings for unsupported verb/type combinations.
 func fallback(verb rune, arg any) string {
 	var s string
 	switch v := arg.(type) {
 	case string:
 		s = "string=" + v
-	case (interface{ String() string }):
+	case interface{ String() string }:
 		s = "string=" + v.String()
 	case error:
-		// note: also "string=" in Go fmt
 		s = "string=" + v.Error()
 	case float64:
 		s = "float64=" + Sprintf("%f", v)
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		// note: rune, byte would be dups, being aliases
-		if typename, e := typeToString(v); e != nil {
-			panic("should not happen")
-		} else {
+		if typename, e := typeToString(v); e == nil {
 			s = typename + "=" + Sprintf("%d", v)
+		} else {
+			panic("ufmt: unexpected type error")
 		}
 	case bool:
-		if v {
-			s = "bool=true"
-		} else {
-			s = "bool=false"
-		}
+		s = "bool=" + strconv.FormatBool(v)
 	case nil:
 		s = "<nil>"
 	default:
@@ -522,9 +511,7 @@ func fallback(verb rune, arg any) string {
 	return "%!" + string(verb) + "(" + s + ")"
 }
 
-// Get the name of the type of `v` as a string.
-// The recognized type of v is currently limited to native non-composite types.
-// An error is returned otherwise.
+// typeToString returns the name of basic Go types as string.
 func typeToString(v any) (string, error) {
 	switch v.(type) {
 	case string:
@@ -556,39 +543,22 @@ func typeToString(v any) (string, error) {
 	case bool:
 		return "bool", nil
 	default:
-		return "", errors.New("(unsupported type)")
+		return "", errors.New("unsupported type")
 	}
 }
 
-// errMsg implements the error interface.
+// errMsg implements the error interface for formatted error strings.
 type errMsg struct {
 	msg string
 }
 
-// Error defines the requirements of the error interface.
-// It functions similarly to Go's errors.New()
+// Error returns the formatted error message.
 func (e *errMsg) Error() string {
 	return e.msg
 }
 
-// Errorf is a function that mirrors the functionality of fmt.Errorf.
-//
-// It takes a format string and arguments to create a formatted string,
-// then sets this string as the 'msg' field of an errMsg struct and returns a pointer to this struct.
-//
-// This function operates in a similar manner to Go's fmt.Errorf,
-// providing a way to create formatted error messages.
-//
-// The currently formatted verbs are the following:
-//
-//	%s: places a string value directly.
-//	    If the value implements the interface interface{ String() string },
-//	    the String() method is called to retrieve the value. Same for error.
-//	%c: formats the character represented by Unicode code point
-//	%d: formats an integer value using package "strconv".
-//	    Currently supports only uint, uint64, int, int64.
-//	%t: formats a boolean value to "true" or "false".
-//	%%: outputs a literal %. Does not consume an argument.
+// Errorf formats according to a format specifier and returns an error value.
+// Supports the same verbs as Sprintf. See Sprintf documentation for details.
 func Errorf(format string, args ...any) error {
 	return &errMsg{Sprintf(format, args...)}
 }

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -144,6 +144,7 @@ func (p *printer) doPrintf(format string, args []any) {
 		c := sTor[i]
 
 		if isLast || c != '%' {
+			// we don't check for invalid format like a one ending with "%"
 			p.buf.writeRune(c)
 			i++
 			continue
@@ -181,6 +182,7 @@ func (p *printer) doPrintf(format string, args []any) {
 			writeQuotedString(p, verb, arg)
 		case 'T':
 			writeType(p, arg)
+
 		default:
 			p.buf.writeString("(unhandled verb: %" + string(verb) + ")")
 		}
@@ -254,6 +256,7 @@ func writeString(p *printer, verb rune, arg any) {
 // writeChar handles %c formatting
 func writeChar(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
+	// rune is int32. Exclude overflowing numeric types and dups (byte, int32):
 	case rune:
 		p.buf.writeString(string(v))
 	case int:
@@ -483,7 +486,16 @@ func Appendln(b []byte, a ...any) []byte {
 	return append(b, p.buf...)
 }
 
-// fallback generates error strings for unsupported verb/type combinations.
+// This function is used to mimic Go's fmt.Sprintf
+// specific behaviour of showing verb/type mismatches,
+// where for example:
+//
+//	fmt.Sprintf("%d", "foo") gives "%!d(string=foo)"
+//
+// Here:
+//
+//	fallback("s", 8) -> "%!s(int=8)"
+//	fallback("d", nil) -> "%!d(<nil>)", and so on.f
 func fallback(verb rune, arg any) string {
 	var s string
 	switch v := arg.(type) {

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -142,195 +142,230 @@ func (p *printer) doPrintf(format string, args []any) {
 
 		switch verb {
 		case 'v':
-			switch v := arg.(type) {
-			case nil:
-				p.buf.writeString("<nil>")
-			case bool:
-				if v {
-					p.buf.writeString("true")
-				} else {
-					p.buf.writeString("false")
-				}
-			case int:
-				p.buf.writeString(strconv.Itoa(v))
-			case int8:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int16:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int32:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int64:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case uint:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint8:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint16:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint32:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint64:
-				p.buf.writeString(strconv.FormatUint(v, 10))
-			case float64:
-				p.buf.writeString(strconv.FormatFloat(v, 'g', -1, 64))
-			case string:
-				p.buf.writeString(v)
-			case []byte:
-				p.buf.write(v)
-			case []rune:
-				p.buf.writeString(string(v))
-			case interface{ String() string }:
-				p.buf.writeString(v.String())
-			case error:
-				p.buf.writeString(v.Error())
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeValue(p, verb, arg)
 		case 's':
-			switch v := arg.(type) {
-			case interface{ String() string }:
-				p.buf.writeString(v.String())
-			case error:
-				p.buf.writeString(v.Error())
-			case string:
-				p.buf.writeString(v)
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeString(p, verb, arg)
 		case 'c':
-			switch v := arg.(type) {
-			// rune is int32. Exclude overflowing numeric types and dups (byte, int32):
-			case rune:
-				p.buf.writeString(string(v))
-			case int:
-				p.buf.writeString(string(v))
-			case int8:
-				p.buf.writeString(string(v))
-			case int16:
-				p.buf.writeString(string(v))
-			case uint:
-				p.buf.writeString(string(v))
-			case uint8:
-				p.buf.writeString(string(v))
-			case uint16:
-				p.buf.writeString(string(v))
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeChar(p, verb, arg)
 		case 'd':
-			switch v := arg.(type) {
-			case int:
-				p.buf.writeString(strconv.Itoa(v))
-			case int8:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int16:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int32:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case int64:
-				p.buf.writeString(strconv.Itoa(int(v)))
-			case uint:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint8:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint16:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint32:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 10))
-			case uint64:
-				p.buf.writeString(strconv.FormatUint(v, 10))
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeInt(p, verb, arg)
 		case 'e', 'E', 'f', 'F', 'g', 'G':
-			switch v := arg.(type) {
-			case float64:
-				switch verb {
-				case 'e':
-					p.buf.writeString(strconv.FormatFloat(v, byte('e'), -1, 64))
-				case 'E':
-					p.buf.writeString(strconv.FormatFloat(v, byte('E'), -1, 64))
-				case 'f', 'F':
-					p.buf.writeString(strconv.FormatFloat(v, byte('f'), 6, 64))
-				case 'g':
-					p.buf.writeString(strconv.FormatFloat(v, byte('g'), -1, 64))
-				case 'G':
-					p.buf.writeString(strconv.FormatFloat(v, byte('G'), -1, 64))
-				}
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeFloat(p, verb, arg)
 		case 't':
-			switch v := arg.(type) {
-			case bool:
-				if v {
-					p.buf.writeString("true")
-				} else {
-					p.buf.writeString("false")
-				}
-			default:
-				p.buf.writeString(fallback(verb, v))
-			}
+			writeBool(p, verb, arg)
 		case 'x':
-			switch v := arg.(type) {
-			case uint8:
-				p.buf.writeString(strconv.FormatUint(uint64(v), 16))
-			default:
-				p.buf.writeString("(unhandled)")
-			}
+			writeHex(p, verb, arg)
 		case 'q':
-			switch v := arg.(type) {
-			case string:
-				p.buf.writeString(strconv.Quote(v))
-			default:
-				p.buf.writeString("(unhandled)")
-			}
+			writeQuotedString(p, verb, arg)
 		case 'T':
-			switch arg.(type) {
-			case bool:
-				p.buf.writeString("bool")
-			case int:
-				p.buf.writeString("int")
-			case int8:
-				p.buf.writeString("int8")
-			case int16:
-				p.buf.writeString("int16")
-			case int32:
-				p.buf.writeString("int32")
-			case int64:
-				p.buf.writeString("int64")
-			case uint:
-				p.buf.writeString("uint")
-			case uint8:
-				p.buf.writeString("uint8")
-			case uint16:
-				p.buf.writeString("uint16")
-			case uint32:
-				p.buf.writeString("uint32")
-			case uint64:
-				p.buf.writeString("uint64")
-			case string:
-				p.buf.writeString("string")
-			case []byte:
-				p.buf.writeString("[]byte")
-			case []rune:
-				p.buf.writeString("[]rune")
-			default:
-				p.buf.writeString("unknown")
-			}
-		// % handled before, as it does not consume an argument
+			writeType(p, arg)
 		default:
 			p.buf.writeString("(unhandled verb: %" + string(verb) + ")")
 		}
 
 		i += 2
 	}
+
 	if argNum < argLen {
 		panic("too many arguments to ufmt.Sprintf")
 	}
 }
 
-// These routines end in 'f' and take a format string.
+// Utility functions for doPrintf
+
+func writeValue(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case nil:
+		p.buf.writeString("<nil>")
+	case bool:
+		if v {
+			p.buf.writeString("true")
+		} else {
+			p.buf.writeString("false")
+		}
+	case int:
+		p.buf.writeString(strconv.Itoa(v))
+	case int8:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int16:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int32:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int64:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case uint:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint16:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint32:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint64:
+		p.buf.writeString(strconv.FormatUint(v, 10))
+	case float64:
+		p.buf.writeString(strconv.FormatFloat(v, 'g', -1, 64))
+	case string:
+		p.buf.writeString(v)
+	case []byte:
+		p.buf.write(v)
+	case []rune:
+		p.buf.writeString(string(v))
+	case interface{ String() string }:
+		p.buf.writeString(v.String())
+	case error:
+		p.buf.writeString(v.Error())
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeString(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case interface{ String() string }:
+		p.buf.writeString(v.String())
+	case error:
+		p.buf.writeString(v.Error())
+	case string:
+		p.buf.writeString(v)
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeChar(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case rune:
+		p.buf.writeString(string(v))
+	case int:
+		p.buf.writeString(string(v))
+	case int8:
+		p.buf.writeString(string(v))
+	case int16:
+		p.buf.writeString(string(v))
+	case uint:
+		p.buf.writeString(string(v))
+	case uint8:
+		p.buf.writeString(string(v))
+	case uint16:
+		p.buf.writeString(string(v))
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeInt(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case int:
+		p.buf.writeString(strconv.Itoa(v))
+	case int8:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int16:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int32:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int64:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case uint:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint16:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint32:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint64:
+		p.buf.writeString(strconv.FormatUint(v, 10))
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeFloat(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case float64:
+		switch verb {
+		case 'e':
+			p.buf.writeString(strconv.FormatFloat(v, 'e', -1, 64))
+		case 'E':
+			p.buf.writeString(strconv.FormatFloat(v, 'E', -1, 64))
+		case 'f', 'F':
+			p.buf.writeString(strconv.FormatFloat(v, 'f', 6, 64))
+		case 'g':
+			p.buf.writeString(strconv.FormatFloat(v, 'g', -1, 64))
+		case 'G':
+			p.buf.writeString(strconv.FormatFloat(v, 'G', -1, 64))
+		}
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeBool(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case bool:
+		if v {
+			p.buf.writeString("true")
+		} else {
+			p.buf.writeString("false")
+		}
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+func writeHex(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 16))
+	default:
+		p.buf.writeString("(unhandled)")
+	}
+}
+
+func writeQuotedString(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case string:
+		p.buf.writeString(strconv.Quote(v))
+	default:
+		p.buf.writeString("(unhandled)")
+	}
+}
+
+func writeType(p *printer, arg any) {
+	switch arg.(type) {
+	case bool:
+		p.buf.writeString("bool")
+	case int:
+		p.buf.writeString("int")
+	case int8:
+		p.buf.writeString("int8")
+	case int16:
+		p.buf.writeString("int16")
+	case int32:
+		p.buf.writeString("int32")
+	case int64:
+		p.buf.writeString("int64")
+	case uint:
+		p.buf.writeString("uint")
+	case uint8:
+		p.buf.writeString("uint8")
+	case uint16:
+		p.buf.writeString("uint16")
+	case uint32:
+		p.buf.writeString("uint32")
+	case uint64:
+		p.buf.writeString("uint64")
+	case string:
+		p.buf.writeString("string")
+	case []byte:
+		p.buf.writeString("[]byte")
+	case []rune:
+		p.buf.writeString("[]rune")
+	default:
+		p.buf.writeString("unknown")
+	}
+}
 
 // Fprintf formats according to a format specifier and writes to w.
 // It returns the number of bytes written and any write error encountered.
@@ -390,8 +425,7 @@ func Print(a ...any) (n int, err error) {
 func Sprint(a ...any) string {
 	p := newPrinter()
 	p.doPrint(a)
-	s := string(p.buf)
-	return s
+	return string(p.buf)
 }
 
 // Append formats using the default formats for its operands, appends the result to
@@ -425,7 +459,6 @@ func Println(a ...any) (n int, err error) {
 	if err != nil {
 		print(out.String())
 	}
-
 	return n, err
 }
 
@@ -435,7 +468,6 @@ func Sprintln(a ...any) string {
 	p := newPrinter()
 	p.doPrintln(a)
 	return string(p.buf)
-
 }
 
 // Appendln formats using the default formats for its operands, appends the result

--- a/examples/gno.land/p/demo/ufmt/ufmt.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt.gno
@@ -60,7 +60,7 @@ func (p *printer) doPrint(args []any) {
 		switch v := arg.(type) {
 		case string:
 			p.buf.writeString(v)
-		case interface{ String() string }:
+		case (interface{ String() string }):
 			p.buf.writeString(v.String())
 		case error:
 			p.buf.writeString(v.Error())
@@ -182,7 +182,7 @@ func (p *printer) doPrintf(format string, args []any) {
 			writeQuotedString(p, verb, arg)
 		case 'T':
 			writeType(p, arg)
-
+		// % handled before, as it does not consume an argument
 		default:
 			p.buf.writeString("(unhandled verb: %" + string(verb) + ")")
 		}
@@ -230,7 +230,7 @@ func writeValue(p *printer, verb rune, arg any) {
 		p.buf.write(v)
 	case []rune:
 		p.buf.writeString(string(v))
-	case interface{ String() string }:
+	case (interface{ String() string }):
 		p.buf.writeString(v.String())
 	case error:
 		p.buf.writeString(v.Error())
@@ -242,7 +242,7 @@ func writeValue(p *printer, verb rune, arg any) {
 // writeString handles %s formatting
 func writeString(p *printer, verb rune, arg any) {
 	switch v := arg.(type) {
-	case interface{ String() string }:
+	case (interface{ String() string }):
 		p.buf.writeString(v.String())
 	case error:
 		p.buf.writeString(v.Error())
@@ -501,13 +501,15 @@ func fallback(verb rune, arg any) string {
 	switch v := arg.(type) {
 	case string:
 		s = "string=" + v
-	case interface{ String() string }:
+	case (interface{ String() string }):
 		s = "string=" + v.String()
 	case error:
+		// note: also "string=" in Go fmt
 		s = "string=" + v.Error()
 	case float64:
 		s = "float64=" + Sprintf("%f", v)
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		// note: rune, byte would be dups, being aliases
 		if typename, e := typeToString(v); e == nil {
 			s = typename + "=" + Sprintf("%d", v)
 		} else {

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -1,6 +1,7 @@
 package ufmt
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
@@ -166,9 +167,7 @@ func TestPrintErrors(t *testing.T) {
 	}
 }
 
-// NOTE: Currently, there is no way to get the output of Println without using os.Stdout,
-// so we can only test that it doesn't panic and print arguments well.
-func TestPrinters(t *testing.T) {
+func TestSprint(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []any
@@ -197,55 +196,148 @@ func TestPrinters(t *testing.T) {
 		{
 			name:     "Unhandled type",
 			args:     []any{"Hello", 3.14, []int{1, 2, 3}},
-			expected: "Hello (unhandled) (unhandled)",
+			expected: "Hello 3.140000 (unhandled)",
 		},
 	}
 
-	// TODO: replace os.Stdout with a buffer to capture the output and test it.
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			Println(tt.args...)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sprint(tc.args...)
+			if got != tc.expected {
+				t.Errorf("got %q, want %q.", got, tc.expected)
+			}
 		})
 	}
 }
 
-func TestPrintln(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []any
-		expected string
-	}{
-		{
-			name:     "Empty args",
-			args:     []any{},
-			expected: "",
-		},
-		{
-			name:     "String args",
-			args:     []any{"Hello", "World"},
-			expected: "Hello World",
-		},
-		{
-			name:     "Integer args",
-			args:     []any{1, 2, 3},
-			expected: "1 2 3",
-		},
-		{
-			name:     "Mixed args",
-			args:     []any{"Hello", 42, true, false, "World"},
-			expected: "Hello 42 true false World",
-		},
-		{
-			name:     "Unhandled type",
-			args:     []any{"Hello", 3.14, []int{1, 2, 3}},
-			expected: "Hello (unhandled) (unhandled)",
-		},
+func TestFprintf(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprintf(&buf, "Count: %d, Message: %s", 42, "hello")
+	if err != nil {
+		t.Fatalf("Fprintf failed: %v", err)
 	}
 
-	// TODO: replace os.Stdout with a buffer to capture the output and test it.
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			Println(tt.args...)
-		})
+	const expected = "Count: 42, Message: hello"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrintf(t *testing.T) {
+	n, err := Printf("The answer is %d", 42)
+	if err != nil {
+		t.Fatalf("Printf failed: %v", err)
+	}
+
+	const expected = "The answer is 42"
+	if n != len(expected) {
+		t.Errorf("Expected 14 bytes written, got %d", n)
+	}
+}
+
+func TestAppendf(t *testing.T) {
+	b := []byte("Header: ")
+	result := Appendf(b, "Value %d", 7)
+	const expected = "Header: Value 7"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestFprint(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprint(&buf, "Hello", 42, true)
+	if err != nil {
+		t.Fatalf("Fprint failed: %v", err)
+	}
+
+	const expected = "Hello 42 true"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrint(t *testing.T) {
+	n, err := Print("Mixed", 3.14, false)
+	if err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	const expected = "Mixed 3.140000 false"
+	if n != len(expected) {
+		t.Errorf("Expected 12 bytes written, got %d", n)
+	}
+}
+
+func TestAppend(t *testing.T) {
+	b := []byte{0x01, 0x02}
+	result := Append(b, "Test", 99)
+
+	const expected = "\x01\x02Test 99"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestFprintln(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprintln(&buf, "Line", 1)
+	if err != nil {
+		t.Fatalf("Fprintln failed: %v", err)
+	}
+
+	const expected = "Line 1\n"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrintln(t *testing.T) {
+	n, err := Println("Output", "test")
+	if err != nil {
+		t.Fatalf("Println failed: %v", err)
+	}
+
+	const expected = "Output test\n"
+	if n != len(expected) {
+		t.Errorf("Expected 12 bytes written, got %d", n)
+	}
+}
+
+func TestSprintln(t *testing.T) {
+	result := Sprintln("Item", 42)
+
+	const expected = "Item 42\n"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestAppendln(t *testing.T) {
+	b := []byte("Start:")
+	result := Appendln(b, "End")
+
+	const expected = "Start:End\n"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/examples/gno.land/p/demo/ufmt/ufmt_test.gno
+++ b/examples/gno.land/p/demo/ufmt/ufmt_test.gno
@@ -168,6 +168,47 @@ func TestPrintErrors(t *testing.T) {
 
 // NOTE: Currently, there is no way to get the output of Println without using os.Stdout,
 // so we can only test that it doesn't panic and print arguments well.
+func TestPrinters(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected string
+	}{
+		{
+			name:     "Empty args",
+			args:     []any{},
+			expected: "",
+		},
+		{
+			name:     "String args",
+			args:     []any{"Hello", "World"},
+			expected: "Hello World",
+		},
+		{
+			name:     "Integer args",
+			args:     []any{1, 2, 3},
+			expected: "1 2 3",
+		},
+		{
+			name:     "Mixed args",
+			args:     []any{"Hello", 42, true, false, "World"},
+			expected: "Hello 42 true false World",
+		},
+		{
+			name:     "Unhandled type",
+			args:     []any{"Hello", 3.14, []int{1, 2, 3}},
+			expected: "Hello (unhandled) (unhandled)",
+		},
+	}
+
+	// TODO: replace os.Stdout with a buffer to capture the output and test it.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Println(tt.args...)
+		})
+	}
+}
+
 func TestPrintln(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This PR enhances the `ufmt` package by adding missing methods such as `FprintX`, `AppendX`, `SprintX`, and `PrintX` to ensure full compatibility with the `fmt` function signatures. It also centralizes and improves the logic in a printer, similar to the approach used by the `fmt` package.

Additionally, I have added new tests and moved the logic of `Println` test into `Sprint` test (since the logic has been moved into the printer, we can now test it using the `Sprint` function)