### PR TITLE
feat: validate app_state in gnogenesis verify subcmd

### DIFF
--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -62,6 +62,11 @@ func execVerify(cfg *verifyCfg, io commands.IO) error {
 			return errInvalidGenesisState
 		}
 
+		// Validate the genesis state.auth, state.bank and state.vm
+		if err := gnoland.ValidateGenState(state); err != nil {
+			return fmt.Errorf("invalid genesis state: %w", err)
+		}
+
 		// Validate the initial transactions
 		for index, tx := range state.Txs {
 			if validateErr := tx.Tx.ValidateBasic(); validateErr != nil {

--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -62,7 +62,6 @@ func execVerify(cfg *verifyCfg, io commands.IO) error {
 			return errInvalidGenesisState
 		}
 
-		// Validate the genesis state.auth, state.bank and state.vm
 		if err := gnoland.ValidateGenState(state); err != nil {
 			return fmt.Errorf("invalid genesis state: %w", err)
 		}

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -248,15 +248,15 @@ func DefaultGenState() GnoGenesisState {
 
 func ValidateGenState(state GnoGenesisState) error {
 	if err := auth.ValidateGenesis(state.Auth); err != nil {
-		return err
+		return fmt.Errorf("unable to validate auth state: %w", err)
 	}
 
 	if err := bank.ValidateGenesis(state.Bank); err != nil {
-		return err
+		return fmt.Errorf("unable to validate bank state: %w", err)
 	}
 
 	if err := vmm.ValidateGenesis(state.VM); err != nil {
-		return err
+		return fmt.Errorf("unable to validate vm state: %w", err)
 	}
 
 	return nil

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -245,3 +245,19 @@ func DefaultGenState() GnoGenesisState {
 	}
 	return gs
 }
+
+func ValidateGenState(state GnoGenesisState) error {
+	if err := auth.ValidateGenesis(state.Auth); err != nil {
+		return err
+	}
+
+	if err := bank.ValidateGenesis(state.Bank); err != nil {
+		return err
+	}
+
+	if err := vmm.ValidateGenesis(state.VM); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/gno.land/pkg/gnoland/genesis_test.go
+++ b/gno.land/pkg/gnoland/genesis_test.go
@@ -1,0 +1,63 @@
+package gnoland
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenesis_Verify(t *testing.T) {
+	tests := []struct {
+		name      string
+		genesis   GnoGenesisState
+		expectErr bool
+	}{
+		{"default GenesisState", DefaultGenState(), false},
+		{
+			"invalid GenesisState Auth",
+			GnoGenesisState{
+				Auth: auth.GenesisState{},
+				Bank: bank.DefaultGenesisState(),
+				VM:   vm.DefaultGenesisState(),
+			},
+			true,
+		},
+		{
+			"invalid GenesisState Bank",
+			GnoGenesisState{
+				Auth: auth.DefaultGenesisState(),
+				Bank: bank.GenesisState{
+					Params: bank.Params{
+						RestrictedDenoms: []string{"INVALID!!!"},
+					},
+				},
+				VM: vm.DefaultGenesisState(),
+			},
+			true,
+		},
+		{
+			"invalid GenesisState VM",
+			GnoGenesisState{
+				Auth: auth.DefaultGenesisState(),
+				Bank: bank.DefaultGenesisState(),
+				VM:   vm.GenesisState{},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGenState(tc.genesis)
+			if tc.expectErr {
+				assert.Error(t, err, fmt.Sprintf("TestGenesis_Verify: %s", tc.name))
+			} else {
+				assert.NoError(t, err, fmt.Sprintf("TestGenesis_Verify: %s", tc.name))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR just adds a call to the new `app_state` validation functions in the `gnogenesis verify` subcommand. Without it, a genesis might be considered valid by `verify` but make a gnoland node node panic on launch.