### PR TITLE
chore(benchops): require build tags for running command

### DIFF
--- a/gnovm/cmd/benchops/README.md
+++ b/gnovm/cmd/benchops/README.md
@@ -8,10 +8,10 @@
 
 The benchmark only involves the GnoVM and the persistent store. It benchmarks the bare minimum components, and the results are isolated from other components. We use standardize gno contract to perform the benchmarking.
 
-This mode is the best for benchmarking each major release and/or changes in GnoVM.
+This mode is the best for benchmarking each major release and/or changes in GnoVM. Build it using the GnoVM Makefile:
 
-    make opcode
-    make storage
+    make build.bench.opcode
+    make build.bench.storage
 
 ### Production mode
 

--- a/gnovm/cmd/benchops/tags_required.go
+++ b/gnovm/cmd/benchops/tags_required.go
@@ -1,0 +1,7 @@
+//go:build !benchmarkingops && !benchmarkingstorage
+
+package main
+
+func init() {
+	panic("build tags benchmarkingops or benchmarkingstorage are required for measuring benchmarks")
+}

--- a/gnovm/cmd/benchops/tags_required.go
+++ b/gnovm/cmd/benchops/tags_required.go
@@ -2,6 +2,10 @@
 
 package main
 
+import "testing"
+
 func init() {
-	panic("build tags benchmarkingops or benchmarkingstorage are required for measuring benchmarks")
+	if !testing.Testing() {
+		panic("build tags benchmarkingops or benchmarkingstorage are required for measuring benchmarks")
+	}
 }


### PR DESCRIPTION
This makes execution of benchops panic if it is compiled incorrectly. Additionally, I updated the README