### PR TITLE
fix(lint): ignore init function when we delete redefinition function

### DIFF
--- a/gnovm/cmd/gno/testdata/lint/issue_3930.txtar
+++ b/gnovm/cmd/gno/testdata/lint/issue_3930.txtar
@@ -1,0 +1,27 @@
+gno tool lint .
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- hello.gno --
+package hello
+
+import (
+"fmt"
+"math"
+)
+
+func init() {
+	fmt.Println("here", math.MaxInt)
+}
+
+func init() {
+	println("second")
+}
+
+func Get(){}
+-- gno.mod --
+module gno.land/r/demo/hello
+
+-- stdout.golden --
+-- stderr.golden --

--- a/gnovm/pkg/gnolang/gotypecheck.go
+++ b/gnovm/pkg/gnolang/gotypecheck.go
@@ -163,8 +163,9 @@ func (g *gnoImporter) parseCheckMemPackage(mpkg *gnovm.MemPackage, fmt bool) (*t
 func deleteOldIdents(idents map[string]func(), f *ast.File) {
 	for _, decl := range f.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
+		// ignore methods and init functions
 		//nolint:goconst
-		if !ok || fd.Recv != nil || fd.Name.Name == "init" { // ignore methods
+		if !ok || fd.Recv != nil || fd.Name.Name == "init" {
 			continue
 		}
 		if del := idents[fd.Name.Name]; del != nil {

--- a/gnovm/pkg/gnolang/gotypecheck.go
+++ b/gnovm/pkg/gnolang/gotypecheck.go
@@ -163,7 +163,8 @@ func (g *gnoImporter) parseCheckMemPackage(mpkg *gnovm.MemPackage, fmt bool) (*t
 func deleteOldIdents(idents map[string]func(), f *ast.File) {
 	for _, decl := range f.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Recv != nil { // ignore methods
+		//nolint:goconst
+		if !ok || fd.Recv != nil || fd.Name.Name == "init" { // ignore methods
 			continue
 		}
 		if del := idents[fd.Name.Name]; del != nil {

--- a/gnovm/pkg/gnolang/gotypecheck_test.go
+++ b/gnovm/pkg/gnolang/gotypecheck_test.go
@@ -239,6 +239,66 @@ func TestTypeCheckMemPackage(t *testing.T) {
 			},
 			errContains("undefined: std", "a_completely_different_identifier and not used"),
 		},
+		{
+			// Both inits should be considered, without an "imported and not
+			// used" error.
+			"ImportTwoInits",
+			&gnovm.MemPackage{
+				Name: "gns",
+				Path: "gno.land/r/demo/gns",
+				Files: []*gnovm.MemFile{
+					{
+						Name: "gns.gno",
+						Body: `
+							package gns
+							import (
+								"std"
+								"math/overflow"
+							)
+
+							var sink any
+
+							func init() {
+								sink = std.Address("admin")
+							}
+
+							func init() {
+								sink = overflow.Add(1, 2)
+							}
+							`,
+					},
+				},
+			},
+			mockPackageGetter{
+				&gnovm.MemPackage{
+					Name: "std",
+					Path: "std",
+					Files: []*gnovm.MemFile{
+						{
+							Name: "gnovm.gno",
+							Body: `
+								package std
+								type Address string`,
+						},
+					},
+				},
+				&gnovm.MemPackage{
+					Name: "overflow",
+					Path: "math/overflow",
+					Files: []*gnovm.MemFile{
+						{
+							Name: "overflow.gno",
+							Body: `
+								package overflow
+								func Add(a, b int) int {
+									return a + b
+								}`,
+						},
+					},
+				},
+			},
+			nil,
+		},
 	}
 
 	cacheMpg := mockPackageGetterCounts{

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -322,7 +322,7 @@ func checkDuplicates(fset *FileSet) error {
 			var name Name
 			switch d := d.(type) {
 			case *FuncDecl:
-				if d.Name == "init" { //nolint:goconst
+				if d.Name == "init" {
 					continue
 				}
 				name = d.Name


### PR DESCRIPTION
closes: #3930, closes #3961