### PR TITLE
fix: gnoweb copy default cmd

### DIFF
--- a/gno.land/pkg/gnoweb/components/ui/help_function.html
+++ b/gno.land/pkg/gnoweb/components/ui/help_function.html
@@ -113,7 +113,7 @@
 # and avoid trusting any computer connected to the internet,
 # as your private keys could be exposed.
 
-gnokey maketx call -pkgpath "{{ $.PkgPath }}" -func "{{ .Name }}"{{ range .Params }} -args "<span data-role="help-code-args" data-arg="{{ .Name }}" data-copy-content=""></span>"{{ end }} -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid "{{ $.ChainId }}" -remote "{{ $.Remote }}" <span data-role="help-code-address">ADDRESS</span></span><span data-code-mode="secure" class="inline">gnokey query -remote "{{ $.Remote }}" auth/accounts/<span data-role="help-code-address">ADDRESS</span>
+gnokey maketx call -pkgpath "{{ $.PkgPath }}" -func "{{ .Name }}"{{ range .Params }} -args "<span data-role="help-code-args" data-arg="{{ .Name }}"></span>"{{ end }} -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid "{{ $.ChainId }}" -remote "{{ $.Remote }}" <span data-role="help-code-address">ADDRESS</span></span><span data-code-mode="secure" class="inline" data-copy-content="help-cmd-{{ .Name }}">gnokey query -remote "{{ $.Remote }}" auth/accounts/<span data-role="help-code-address">ADDRESS</span>
 gnokey maketx call -pkgpath "{{ $.PkgPath }}" -func "{{ .Name }}" {{ range .Params }} -args "<span data-role="help-code-args" data-arg="{{ .Name }}"></span>"{{ end }} -gas-fee 1000000ugnot -gas-wanted 5000000 -send "" <span data-role="help-code-address">ADDRESS</span> > call.tx
 gnokey sign -tx-path call.tx -chainid "{{ $.ChainId }}" -account-number ACCOUNTNUMBER -account-sequence SEQUENCENUMBER <span data-role="help-code-address">ADDRESS</span>
 gnokey broadcast -remote "{{ $.Remote }}" call.tx</span></code></pre>

--- a/gno.land/pkg/gnoweb/components/ui/help_function.html
+++ b/gno.land/pkg/gnoweb/components/ui/help_function.html
@@ -108,7 +108,7 @@
           {{/* prettier-ignore-start */}}
       <pre
         class="font-mono text-gray-600 p-4 pr-10 whitespace-pre-wrap"
-      ><code><span data-code-mode="fast" class="hidden" data-copy-content="help-cmd-{{ .Name }}"># WARNING: This command is running in an INSECURE mode.
+      ><code><span data-code-mode="fast" class="hidden"># WARNING: This command is running in an INSECURE mode.
 # It is strongly recommended to use a hardware device for signing
 # and avoid trusting any computer connected to the internet,
 # as your private keys could be exposed.


### PR DESCRIPTION
This PR aims to fix #4056 by switching `data-copy-content` from `fast mode` to `secure mode` (the new default cmd).