### PR TITLE
feat(examples): p/(salmad)/cid

### DIFF
--- a/examples/gno.land/p/salmad/cid/cid.gno
+++ b/examples/gno.land/p/salmad/cid/cid.gno
@@ -1,0 +1,52 @@
+// Package cid implements Content Identifiers (CIDs) for Gno.
+// CIDs let us uniquely identify content regardless of where it's stored,
+// forming the foundation for content-addressed systems like IPFS.
+//
+// This is a starting point - we'll build it up step by step.
+package cid
+
+import (
+	"errors"
+)
+
+// TODO:
+// 1. Implement multiformat components:
+//    - Multihash: How we hash content and identify which hash function was used
+//    - Multibase: How we encode CIDs as strings (hex, base32, etc.)
+//    - Multicodec: How we identify what type of content we're dealing with
+//
+// 2. Core CID functionality:
+//    - Creation: Simple ways to make CIDs from content
+//    - Parsing: Convert from bytes/strings back to CIDs
+//    - Utilities: String conversion, comparison, etc.
+//
+// 3. Tests:
+//    - Validate the basics work
+//    - Make sure our multiformat implementations are solid
+//    - Check compatibility with IPFS
+
+// Version is just a number that tells us which CID format we're using.
+type Version uint64
+
+const (
+	V0 Version = 0 // CIDv0: Original format, just SHA2-256 + base58
+	V1 Version = 1 // CIDv1: Current format with codec info and flexible encoding
+)
+
+// Standard errors you might encounter when working with CIDs.
+var (
+	ErrCidTooShort      = errors.New("cid: not enough bytes for CID")
+	ErrInvalidVersion   = errors.New("cid: invalid CID version")
+	ErrInvalidMultihash = errors.New("cid: invalid multihash")
+)
+
+// CID is the main structure - it represents a content identifier.
+// It combines a version, content type info, and a hash of the content.
+// 
+// For now, we're using simple types that we'll replace with proper
+// implementations as we build out the package.
+type CID struct {
+	Version Version // 0 or 1
+	Codec   uint64  // What kind of content this points to
+	Hash    []byte  // The hash of the content
+} 

--- a/examples/gno.land/p/salmad/cid/cid_test.gno
+++ b/examples/gno.land/p/salmad/cid/cid_test.gno
@@ -1,0 +1,43 @@
+package cid
+
+import (
+	"testing"
+)
+
+// This is our test file for CIDs - it's pretty simple right now
+// but will grow as we implement more functionality.
+
+// TODO:
+// 1. Test core CID functions once we build them:
+//    - Creating CIDs from actual content
+//    - Parsing CIDs from bytes and strings
+//    - Converting CIDs to strings and back
+//    - Making sure CID equality works right
+//
+// 2. Test our multiformat components:
+//    - Creating and parsing different hash types
+//    - Encoding/decoding with different bases
+//    - Handling various content types
+//
+// 3. Real-world usage tests:
+//    - Using CIDs for content addressing
+//    - Verifying data with CIDs
+//    - Linking documents together
+//    - Simple version control with CIDs
+
+// TestCIDBasics is just a placeholder for now.
+// It shows the structure we'll use for more substantial tests later.
+func TestCIDBasics(t *testing.T) {
+	t.Log("...")
+	
+	// Simple sanity check
+	c := &CID{
+		Version: V1,
+		Codec:   0x55, // Raw content type
+		Hash:    []byte{},
+	}
+	
+	if c.Version != V1 {
+		t.Error("Expected CID version to be V1")
+	}
+} 

--- a/examples/gno.land/p/salmad/cid/gno.mod
+++ b/examples/gno.land/p/salmad/cid/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/salmad/cid 


### PR DESCRIPTION
### Context:

> This was inspired by a discussion with @moul a few weeks back.

Implement a Gno-native version of the [Content Identifier (CID) specification](https://github.com/multiformats/cid) as a reusable package, which is a self-describing content-addressed identifier used in distributed systems. CIDs combine:
1. A multicodec prefix identifying the content type
2. A multihash containing the cryptographic hash and algorithm used
3. A multibase prefix in string representations

### Example Use Cases:

[...]

### Notes:

There is value in implementing the other multiformat standards not specifically used in CID, like multiaddr, multisig, and multistream.

