### PR TITLE
Feat/gnodev/run txindexer

### DIFF
--- a/contribs/gnodev/cmd/gnodev/app.go
+++ b/contribs/gnodev/cmd/gnodev/app.go
@@ -620,7 +620,7 @@ func newTXIndexer(appCfg *AppConfig, logger *slog.Logger) (txindexer.Manager, er
 	}
 
 	if !cfg.Enabled {
-		logger.WithGroup(TxIndexerLogName).Info("tx-indexer disabled, using using no-op")
+		logger.WithGroup(TxIndexerLogName).Info("tx-indexer disabled, using no-op")
 		return txindexer.NewNoOp(), nil
 	}
 

--- a/contribs/gnodev/cmd/gnodev/app.go
+++ b/contribs/gnodev/cmd/gnodev/app.go
@@ -401,6 +401,11 @@ func (ds *App) RunServer(ctx context.Context, term *rawterm.RawTerm) error {
 			"lisn", fmt.Sprintf("http://%s", addr))
 	}
 
+	// start tx-indexer if enabled, otherwise this is a no-op
+	if err := ds.txIndexer.Start(ctx); err != nil {
+		cancelWith(err)
+	}
+
 	if ds.cfg.interactive {
 		ds.logger.WithGroup("--- READY").Info("for commands and help, press `h`", "took", time.Since(ds.start))
 	} else {

--- a/contribs/gnodev/cmd/gnodev/app_config.go
+++ b/contribs/gnodev/cmd/gnodev/app_config.go
@@ -42,6 +42,33 @@ type AppConfig struct {
 	unsafeAPI   bool
 	interactive bool
 	paths       string
+
+	// Tx-Indexer Configuration
+	//
+	// Providers configuration to enable the running of tx-indexer alongside
+	// gnodev. Defaults can be overridden by setting the CLI flags. Please view
+	// the tx-indexer repo for documentation on tx-indexer defaults and other
+	// relevant information.
+	// https://github.com/gnolang/tx-indexer
+	//
+	// enable tx-indexer service
+	txIndexerEnabled bool
+	// the absolute path for the indexer DB (embedded)
+	// default: indexer-db
+	txIndexerDBPath string
+	// the maximum HTTP requests allowed per minute per IP, unlimited by default
+	txIndexerHttpRateLimit optionalFlag[int]
+	// the IP:PORT URL for the indexer JSON-RPC server
+	// default: 0.0.0.0:8546
+	txIndexerListenAddress string
+	// the log level for the CLI output
+	txIndexerLogLevel optionalFlag[string]
+	// the range for fetching blockchain data by a single worker
+	txIndexerMaxChunkSize optionalFlag[int]
+	// the amount of slots (workers) the fetcher employs
+	txIndexerMaxSlots optionalFlag[int]
+	// the JSON-RPC URL of the Gno chain
+	txIndexerRemote optionalFlag[string]
 }
 
 func (c *AppConfig) RegisterFlagsWith(fs *flag.FlagSet, defaultCfg AppConfig) {
@@ -113,7 +140,7 @@ func (c *AppConfig) RegisterFlagsWith(fs *flag.FlagSet, defaultCfg AppConfig) {
 	fs.Var(
 		&c.resolvers,
 		"resolver",
-		"list of additional resolvers (`root`, `local`, or `remote`) in the form of <resolver>=<location> will be executed in the given order",
+		"list of additional resolvers (`root`, `local` or `remote`), will be executed in the given order",
 	)
 
 	fs.StringVar(
@@ -217,7 +244,7 @@ func (c *AppConfig) RegisterFlagsWith(fs *flag.FlagSet, defaultCfg AppConfig) {
 		&c.paths,
 		"paths",
 		defaultCfg.paths,
-		`additional paths to preload in the form of "gno.land/r/my/realm", separated by commas; glob is supported`,
+		"additional path(s) to load, separated by comma",
 	)
 
 	fs.BoolVar(
@@ -226,6 +253,16 @@ func (c *AppConfig) RegisterFlagsWith(fs *flag.FlagSet, defaultCfg AppConfig) {
 		defaultCfg.verbose,
 		"enable verbose output for development",
 	)
+
+	// tx-indexer flags
+	fs.BoolVar(&c.txIndexerEnabled, "tx-indexer", false, "Enable tx-indexer service")
+	fs.StringVar(&c.txIndexerDBPath, "tx-indexer-db-path", "indexer-db", "Path to tx-indexer database")
+	fs.Var(&c.txIndexerHttpRateLimit, "tx-indexer-http-rate-limit", "Max HTTP requests allowed per minute per IP")
+	fs.StringVar(&c.txIndexerListenAddress, "tx-indexer-listen-address", "0.0.0.0:8546", "IP:PORT URL for tx-indexer JSON-RPC server")
+	fs.Var(&c.txIndexerLogLevel, "tx-indexer-log-level", "Log level for tx-indexer CLI output")
+	fs.Var(&c.txIndexerMaxChunkSize, "tx-indexer-max-chunk-size", "Range for fetching blockchain data by a single worker")
+	fs.Var(&c.txIndexerMaxSlots, "tx-indexer-max-slots", "Amount of slots (workers) the fetcher employs")
+	fs.Var(&c.txIndexerRemote, "tx-indexer-remote", "JSON-RPC URL of the Gno chain")
 }
 
 func (c *AppConfig) validateConfigFlags() error {

--- a/contribs/gnodev/cmd/gnodev/optional_flag.go
+++ b/contribs/gnodev/cmd/gnodev/optional_flag.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// helper type to know if a flag is set or not
+// vs relying on its zero value
+type optionalFlag[T string | int] struct {
+	set bool
+	v   T
+}
+
+func (o *optionalFlag[T]) Value() *T {
+	if !o.set {
+		return nil
+	}
+
+	return &o.v
+}
+
+func (o *optionalFlag[T]) String() string {
+	if !o.set {
+		return ""
+	}
+
+	switch v := any(o.v).(type) {
+	case string:
+		return v
+	case int:
+		return fmt.Sprintf("%d", v)
+	default:
+		return ""
+	}
+}
+
+func (o *optionalFlag[T]) Set(value string) error {
+	switch any(o.v).(type) {
+	case string:
+		o.v = any(value).(T)
+	case int:
+		v, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("value not int: %w", err)
+		}
+		o.v = any(v).(T)
+	}
+
+	o.set = true
+
+	return nil
+}

--- a/contribs/gnodev/internal/txindexer/README.md
+++ b/contribs/gnodev/internal/txindexer/README.md
@@ -1,0 +1,56 @@
+# Transaction Indexer Package
+
+The `txindexer` package provides functionality to manage and control a
+tx-indexer process for gnodev development. It handles the lifecycle of the
+tx-indexer process, including starting, stopping, and reloading the service. 
+This functionality is provided by a `Service` for which an example of its usage
+is provided below.
+
+## Usage
+
+### Basic Service Example
+
+```go
+// Configure the tx-indexer
+cfg := txindexer.Config{
+    Enabled:       true,
+    DBPath:        "/path/to/db",
+}
+
+// Create a new service
+svc, err := txindexer.NewService(logger, cfg)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Start the tx-indexer
+ctx := context.Background()
+if err := svc.Start(ctx); err != nil {
+    log.Fatal(err)
+}
+
+// Reload the tx-indexer (stops, removes DB, and starts again)
+if err := svc.Reload(ctx); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Process Management
+
+The package provides the following public process management capabilities:
+
+- **Start**: Launches the tx-indexer process with the specified configuration
+- **Reload**: Performs a complete reload by:
+  1. Stopping the current process
+  2. Removing the database
+  3. Starting a new process
+
+## Logging
+
+The tx-indexer process's stdout and stderr output is automatically piped to the
+standard logger used across the gnodev application.
+
+## Dependencies
+
+- Requires the `tx-indexer` binary to be available in the system PATH
+- Uses the standard library's `exec` package for process management. Non-Unix users will not be able to leverage the signal calls used for managing the tx-indexer process.

--- a/contribs/gnodev/internal/txindexer/README.md
+++ b/contribs/gnodev/internal/txindexer/README.md
@@ -2,9 +2,12 @@
 
 The `txindexer` package provides functionality to manage and control a
 tx-indexer process for gnodev development. It handles the lifecycle of the
-tx-indexer process, including starting, stopping, and reloading the service. 
+tx-indexer process, including starting, stopping, reloading the service. 
+Reloading comprises stopping the current process, removing the database, and
+starting it again. It's important to note that since the tx-indexer is in a
+separate repo we use the cmd.Exec package to manage the process.
 This functionality is provided by a `Service` for which an example of its usage
-is provided below.
+is provided below. 
 
 ## Usage
 
@@ -35,16 +38,6 @@ if err := svc.Reload(ctx); err != nil {
 }
 ```
 
-## Process Management
-
-The package provides the following public process management capabilities:
-
-- **Start**: Launches the tx-indexer process with the specified configuration
-- **Reload**: Performs a complete reload by:
-  1. Stopping the current process
-  2. Removing the database
-  3. Starting a new process
-
 ## Logging
 
 The tx-indexer process's stdout and stderr output is automatically piped to the
@@ -53,4 +46,6 @@ standard logger used across the gnodev application.
 ## Dependencies
 
 - Requires the `tx-indexer` binary to be available in the system PATH
-- Uses the standard library's `exec` package for process management. Non-Unix users will not be able to leverage the signal calls used for managing the tx-indexer process.
+- Uses the standard library's `exec` package for process management. Non-Unix 
+users will not be able to leverage the signal calls used for managing the
+tx-indexer process.

--- a/contribs/gnodev/internal/txindexer/config.go
+++ b/contribs/gnodev/internal/txindexer/config.go
@@ -1,0 +1,33 @@
+package txindexer
+
+// Config holds the configuration for the tx-indexer service
+type Config struct {
+	// Enabled indicates whether the tx-indexer is enabled
+	Enabled bool
+	// DBPath is the path to the database file
+	DBPath string
+	// HTTPRateLimit is the rate limit for HTTP requests
+	HTTPRateLimit *int
+	// ListenAddress is the address to listen on for incoming connections
+	ListenAddress string
+	// LogLevel is the log level for the tx-indexer
+	LogLevel *string
+	// MaxChunkSize is the maximum chunk size for fetching data
+	MaxChunkSize *int
+	// MaxSlots is the maximum number of slots (workers) for fetching data
+	MaxSlots *int
+	// Remote is the remote JSON-RPC URL of the Gno chain
+	Remote *string
+}
+
+func (c *Config) validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if c.Enabled && c.DBPath == "" {
+		return ErrInvalidConfigMissingDBPath
+	}
+
+	return nil
+}

--- a/contribs/gnodev/internal/txindexer/errors.go
+++ b/contribs/gnodev/internal/txindexer/errors.go
@@ -1,0 +1,13 @@
+package txindexer
+
+// ErrInvalidConfigMissingDBPath is returned when the db path is missing in
+// the configuration.
+const ErrInvalidConfigMissingDBPath Error = "db path config is required for tx-indexer"
+
+// Error defines helper to create custom errors for the txindexer package.
+type Error string
+
+// Error returns the error message as a string.
+func (e Error) Error() string {
+	return string(e)
+}

--- a/contribs/gnodev/internal/txindexer/manager.go
+++ b/contribs/gnodev/internal/txindexer/manager.go
@@ -1,0 +1,10 @@
+package txindexer
+
+import "context"
+
+// Manager provides the means to manage the tx-indexer application by providing
+// functionality to start, and reload the process.
+type Manager interface {
+	Start(ctx context.Context) error
+	Reload(ctx context.Context) error
+}

--- a/contribs/gnodev/internal/txindexer/manager.go
+++ b/contribs/gnodev/internal/txindexer/manager.go
@@ -6,5 +6,6 @@ import "context"
 // functionality to start, and reload the process.
 type Manager interface {
 	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
 	Reload(ctx context.Context) error
 }

--- a/contribs/gnodev/internal/txindexer/noop.go
+++ b/contribs/gnodev/internal/txindexer/noop.go
@@ -1,0 +1,16 @@
+package txindexer
+
+import "context"
+
+var _ Manager = (*NoOp)(nil)
+
+// NoOp is a no-operation implementation of the tx-indexer manager.
+// // It is used when tx-indexer is not enabled.
+type NoOp struct{}
+
+// NewNoOp creates a new NoOp instance of a tx-indexer manager.
+func NewNoOp() *NoOp { return new(NoOp) }
+
+func (n *NoOp) Start(_ context.Context) error  { return nil }
+func (n *NoOp) Stop(_ context.Context) error   { return nil }
+func (n *NoOp) Reload(_ context.Context) error { return nil }

--- a/contribs/gnodev/internal/txindexer/process.go
+++ b/contribs/gnodev/internal/txindexer/process.go
@@ -109,7 +109,7 @@ func (p *process) syncCmdLogs(ctx context.Context) error {
 
 	stderr, err := p.cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %w", err)
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
 	}
 
 	log := func(r io.Reader) {
@@ -121,6 +121,13 @@ func (p *process) syncCmdLogs(ctx context.Context) error {
 			default:
 				p.logger.Info(s.Text())
 			}
+		}
+
+		err = s.Err()
+		switch {
+		case err == nil, errors.Is(err, os.ErrClosed), errors.Is(err, io.EOF):
+		default:
+			p.logger.Error("error reading from pipe", "error", err)
 		}
 	}
 

--- a/contribs/gnodev/internal/txindexer/process.go
+++ b/contribs/gnodev/internal/txindexer/process.go
@@ -1,0 +1,184 @@
+package txindexer
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	txIndexer = "tx-indexer"
+	start     = "start"
+)
+
+// process manages the tx-indexer process
+type process struct {
+	cmd       *exec.Cmd
+	logger    *slog.Logger
+	cmdGetter func() *exec.Cmd
+}
+
+func newProcess(logger *slog.Logger, cfg Config) *process {
+	return &process{
+		logger:    logger,
+		cmdGetter: newStartCmdGetter(cfg),
+	}
+}
+
+func (p *process) start(ctx context.Context) error {
+	p.newCmd()
+
+	if p.cmd == nil {
+		return fmt.Errorf("tx-indexer command is nil")
+	}
+
+	if err := p.syncCmdLogs(ctx); err != nil {
+		return fmt.Errorf("failed to sync logs with stdout/stderr: %w", err)
+	}
+
+	err := p.cmd.Start()
+	switch {
+	case err == nil, strings.Contains(err.Error(), "already started"):
+		return nil
+	default:
+		return fmt.Errorf("failed to start tx-indexer: %w", err)
+	}
+}
+
+func (p *process) stop(ctx context.Context) error {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+
+	defer p.reset()
+
+	err := p.cmd.Process.Signal(os.Interrupt)
+	switch {
+	case err == nil:
+		p.wait(ctx)
+	case errors.Is(err, os.ErrProcessDone):
+	default:
+		return fmt.Errorf("failed to send interrupt signal: %w", err)
+	}
+
+	return nil
+}
+
+func (p *process) wait(ctx context.Context) {
+	const graceful = time.Second * 3
+
+	done := make(chan error)
+	go func() {
+		if p.cmd == nil || p.cmd.Process == nil {
+			done <- nil
+			return
+		}
+
+		done <- p.cmd.Wait()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-done:
+			if err != nil && !errors.Is(err, os.ErrProcessDone) {
+				p.logger.Error("tx-indexer process exited with error", "error", err)
+			}
+			return
+		case <-time.After(graceful):
+			_ = p.cmd.Process.Kill()
+			p.logger.Error("tx-indexer process killed after timeout", "timeout", graceful)
+			return
+		}
+	}
+}
+
+func (p *process) syncCmdLogs(ctx context.Context) error {
+	stdout, err := p.cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	stderr, err := p.cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	log := func(r io.Reader) {
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				p.logger.Info(s.Text())
+			}
+		}
+	}
+
+	go func() { log(stdout) }()
+	go func() { log(stderr) }()
+
+	return nil
+}
+
+func (p *process) newCmd() {
+	if p.cmd != nil {
+		return
+	}
+	p.cmd = p.cmdGetter()
+}
+
+func (p *process) reset() {
+	p.cmd = nil
+}
+
+/*
+-db-path indexer-db             the absolute path for the indexer DB (embedded)
+-http-rate-limit 0              the maximum HTTP requests allowed per minute per IP, unlimited by default
+-listen-address 0.0.0.0:8546    the IP:PORT URL for the indexer JSON-RPC server
+-log-level info                 the log level for the CLI output
+-max-chunk-size 100             the range for fetching blockchain data by a single worker
+-max-slots 100                  the amount of slots (workers) the fetcher employs
+-remote http://127.0.0.1:26657  the JSON-RPC URL of the Gno chain
+*/
+func startArgs(cfg Config) []string {
+	args := []string{start}
+	if cfg.DBPath != "" {
+		args = append(args, "-db-path="+cfg.DBPath)
+	}
+	if cfg.HTTPRateLimit != nil {
+		args = append(args, "-http-rate-limit="+fmt.Sprint(*cfg.HTTPRateLimit))
+	}
+	if cfg.ListenAddress != "" {
+		args = append(args, "-listen-address="+cfg.ListenAddress)
+	}
+	if cfg.LogLevel != nil {
+		args = append(args, "-log-level="+*cfg.LogLevel)
+	}
+	if cfg.MaxChunkSize != nil {
+		args = append(args, "-max-chunk-size="+fmt.Sprint(*cfg.MaxChunkSize))
+	}
+	if cfg.MaxSlots != nil {
+		args = append(args, "-max-slots="+fmt.Sprint(*cfg.MaxSlots))
+	}
+	if cfg.Remote != nil {
+		args = append(args, "-remote="+*cfg.Remote)
+	}
+
+	return args
+}
+
+func newStartCmdGetter(cfg Config) func() *exec.Cmd {
+	return func() *exec.Cmd {
+		return exec.Command(txIndexer, startArgs(cfg)...)
+	}
+}

--- a/contribs/gnodev/internal/txindexer/process.go
+++ b/contribs/gnodev/internal/txindexer/process.go
@@ -141,15 +141,6 @@ func (p *process) reset() {
 	p.cmd = nil
 }
 
-/*
--db-path indexer-db             the absolute path for the indexer DB (embedded)
--http-rate-limit 0              the maximum HTTP requests allowed per minute per IP, unlimited by default
--listen-address 0.0.0.0:8546    the IP:PORT URL for the indexer JSON-RPC server
--log-level info                 the log level for the CLI output
--max-chunk-size 100             the range for fetching blockchain data by a single worker
--max-slots 100                  the amount of slots (workers) the fetcher employs
--remote http://127.0.0.1:26657  the JSON-RPC URL of the Gno chain
-*/
 func startArgs(cfg Config) []string {
 	args := []string{start}
 	if cfg.DBPath != "" {

--- a/contribs/gnodev/internal/txindexer/service.go
+++ b/contribs/gnodev/internal/txindexer/service.go
@@ -56,7 +56,7 @@ func (s *Service) Start(ctx context.Context) error {
 // 2. Remove the tx-indexer database
 // 3. Start the tx-indexer process again
 func (s *Service) Reload(ctx context.Context) error {
-	if err := s.stop(ctx); err != nil {
+	if err := s.Stop(ctx); err != nil {
 		return err
 	}
 
@@ -74,8 +74,8 @@ func (s *Service) Reload(ctx context.Context) error {
 	return nil
 }
 
-// stop stops the tx-indexer process.
-func (s *Service) stop(ctx context.Context) error {
+// Stop stops the tx-indexer process.
+func (s *Service) Stop(ctx context.Context) error {
 	if err := s.process.stop(ctx); err != nil {
 		const msg = "failed to stop tx-indexer"
 		s.logger.Error(msg, "error", err)

--- a/contribs/gnodev/internal/txindexer/service.go
+++ b/contribs/gnodev/internal/txindexer/service.go
@@ -1,0 +1,126 @@
+package txindexer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var _ Manager = (*Service)(nil)
+
+// Service provides functionality to start, stop, and reload the tx-indexer
+// process using cmd.Exec constructs. The methods are meant to be
+// idempotent and should be safe to call multiple times without causing
+// side effects.
+type Service struct {
+	logger  *slog.Logger
+	dbPath  string
+	listen  string
+	process *process
+}
+
+// NewService returns an instantiated tx-indexer service or an error
+// due to missing dependencies.
+// Example:
+//
+// svc, err := NewService(logger, cfg)
+//
+//	if err != nil {
+//	   return err
+//	}
+//
+// // start the tx-indexer process
+//
+//	if err := svc.Start(ctx); err != nil {
+//	  return err
+//	}
+//
+// reload the tx-indexer process
+//
+//	if err := svc.Reload(ctx); err != nil {
+//	  return err
+//	}
+func NewService(logger *slog.Logger, cfg Config) (*Service, error) {
+	s := Service{
+		logger:  logger,
+		dbPath:  cfg.DBPath,
+		listen:  cfg.ListenAddress,
+		process: newProcess(logger.WithGroup("process"), cfg),
+	}
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// Start starts the tx-indexer process.
+func (s *Service) Start(ctx context.Context) error {
+	if err := s.process.start(ctx); err != nil {
+		const msg = "failed to start tx-indexer"
+		s.logger.Error(msg, "error", err)
+		return fmt.Errorf(msg+": %w", err)
+	}
+
+	s.logger.Info("tx-indexer started", "db_path", s.dbPath, "listen", s.listen)
+
+	return nil
+}
+
+// Reload performs three steps to reload the tx-indexer:
+// 1. Stop the tx-indexer process
+// 2. Remove the tx-indexer database
+// 3. Start the tx-indexer process again
+func (s *Service) Reload(ctx context.Context) error {
+	if err := s.stop(ctx); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(s.dbPath); err != nil {
+		const msg = "failed to remove tx-indexer database"
+		s.logger.Error(msg, "error", err)
+		return fmt.Errorf(msg+": %w", err)
+	}
+	s.logger.Info("tx-indexer database removed", "db_path", s.dbPath)
+
+	if err := s.Start(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop stops the tx-indexer process.
+func (s *Service) stop(ctx context.Context) error {
+	if err := s.process.stop(ctx); err != nil {
+		const msg = "failed to stop tx-indexer"
+		s.logger.Error(msg, "error", err)
+		return fmt.Errorf(msg+": %w", err)
+	}
+
+	s.logger.Info("tx-indexer stopped")
+
+	return nil
+}
+
+func (s *Service) validate() error {
+	var missing []string
+
+	for dep, chk := range map[string]func() bool{
+		"process": func() bool { return s.process != nil },
+		"dbPath":  func() bool { return s.dbPath != "" },
+		"logger":  func() bool { return s.logger != nil },
+	} {
+		if !chk() {
+			missing = append(missing, dep)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("unable to initalize service due to missing dependencies: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}

--- a/contribs/gnodev/internal/txindexer/service.go
+++ b/contribs/gnodev/internal/txindexer/service.go
@@ -22,26 +22,8 @@ type Service struct {
 }
 
 // NewService returns an instantiated tx-indexer service or an error
-// due to missing dependencies.
-// Example:
-//
-// svc, err := NewService(logger, cfg)
-//
-//	if err != nil {
-//	   return err
-//	}
-//
-// // start the tx-indexer process
-//
-//	if err := svc.Start(ctx); err != nil {
-//	  return err
-//	}
-//
-// reload the tx-indexer process
-//
-//	if err := svc.Reload(ctx); err != nil {
-//	  return err
-//	}
+// due to missing dependencies. Please refer to the README for an
+// example usage of the tx-indexer service.
 func NewService(logger *slog.Logger, cfg Config) (*Service, error) {
 	s := Service{
 		logger:  logger,

--- a/contribs/gnodev/internal/txindexer/service.go
+++ b/contribs/gnodev/internal/txindexer/service.go
@@ -40,13 +40,13 @@ func NewService(logger *slog.Logger, cfg Config) (*Service, error) {
 
 // Start starts the tx-indexer process.
 func (s *Service) Start(ctx context.Context) error {
+	s.logger.Info("starting tx-indexer", "db_path", s.dbPath, "listen", s.listen)
+
 	if err := s.process.start(ctx); err != nil {
 		const msg = "failed to start tx-indexer"
 		s.logger.Error(msg, "error", err)
 		return fmt.Errorf(msg+": %w", err)
 	}
-
-	s.logger.Info("tx-indexer started", "db_path", s.dbPath, "listen", s.listen)
 
 	return nil
 }
@@ -56,6 +56,8 @@ func (s *Service) Start(ctx context.Context) error {
 // 2. Remove the tx-indexer database
 // 3. Start the tx-indexer process again
 func (s *Service) Reload(ctx context.Context) error {
+	s.logger.Info("reloading tx-indexer")
+
 	if err := s.Stop(ctx); err != nil {
 		return err
 	}
@@ -76,13 +78,13 @@ func (s *Service) Reload(ctx context.Context) error {
 
 // Stop stops the tx-indexer process.
 func (s *Service) Stop(ctx context.Context) error {
+	s.logger.Info("stopping tx-indexer")
+
 	if err := s.process.stop(ctx); err != nil {
 		const msg = "failed to stop tx-indexer"
 		s.logger.Error(msg, "error", err)
 		return fmt.Errorf(msg+": %w", err)
 	}
-
-	s.logger.Info("tx-indexer stopped")
 
 	return nil
 }

--- a/contribs/gnodev/internal/txindexer/service.go
+++ b/contribs/gnodev/internal/txindexer/service.go
@@ -92,7 +92,7 @@ func (s *Service) Reload(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the tx-indexer process.
+// stop stops the tx-indexer process.
 func (s *Service) stop(ctx context.Context) error {
 	if err := s.process.stop(ctx); err != nil {
 		const msg = "failed to stop tx-indexer"


### PR DESCRIPTION
## Issue
- Closes https://github.com/gnolang/gno/issues/2082

## Description
- Adds an internal package to manage the tx-indexer process for gnodev development
- Flags are passed through from gnodev to tx-indexer, disabled by default

## Testing Validation
Performed validation by doing some basic checks
- Starting gnodev without the tx-indexer flag enabled, assert that tx-indexer process is not started
![no-tx-indexer](https://github.com/user-attachments/assets/1931c253-c0f4-4904-93d3-46dee5689057)

- Starting gnodev with tx-indexer flag enabled, assert tx indexer starts
![tx-indexer-enabled](https://github.com/user-attachments/assets/3022948d-1417-4260-94a0-b82a136b271a)
- Reloading gnodev, assert tx-indexer reloads
```
go run . -tx-indexer -tx-indexer-log-level=warn
r
```
![tx-indexer-reload](https://github.com/user-attachments/assets/cc5079f2-6038-43c2-a76b-1c9673d0e586)

- Resetting via R key gnodev, assert tx-indexer reloads
```
go run . -tx-indexer -tx-indexer-log-level=warn
R
```
![tx-indexer-reset](https://github.com/user-attachments/assets/3521934c-2214-4960-a91c-d33f686efb36)
