### PR TITLE
chore(gnovm): `IsUndefined` -> `IsUndefined2`

### DIFF
--- a/gnovm/pkg/gnolang/gonative.go
+++ b/gnovm/pkg/gnolang/gonative.go
@@ -222,7 +222,7 @@ func gno2GoType(t Type) reflect.Type {
 // doesn't really make sense in the general case, and there is a FillValue()
 // function available for eager fetching of ref values.
 func Gno2GoValue(tv *TypedValue, rv reflect.Value) (ret reflect.Value) {
-	if tv.IsUndefined() {
+	if tv.IsUndefined2() {
 		if debug {
 			if !rv.IsValid() {
 				panic("unexpected undefined gno value")
@@ -317,7 +317,7 @@ func Gno2GoValue(tv *TypedValue, rv reflect.Value) (ret reflect.Value) {
 		if av.Data == nil {
 			for i := 0; i < ct.Len; i++ {
 				etv := &av.List[i]
-				if etv.IsUndefined() {
+				if etv.IsUndefined2() {
 					continue
 				}
 				Gno2GoValue(etv, rv.Index(i))
@@ -345,7 +345,7 @@ func Gno2GoValue(tv *TypedValue, rv reflect.Value) (ret reflect.Value) {
 			rv.Set(reflect.MakeSlice(st, svl, svc))
 			for i := 0; i < svl; i++ {
 				etv := &(svb.List[svo+i])
-				if etv.IsUndefined() {
+				if etv.IsUndefined2() {
 					continue
 				}
 				Gno2GoValue(etv, rv.Index(i))

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -1923,7 +1923,7 @@ func (m *Machine) PopFrameAndReturn() {
 	resStart := m.NumValues - numRes
 	for i := 0; i < numRes; i++ {
 		res := m.Values[resStart+i]
-		if res.IsUndefined() && rtypes[i].Type.Kind() != InterfaceKind {
+		if res.IsUndefined2() && rtypes[i].Type.Kind() != InterfaceKind {
 			res.T = rtypes[i].Type
 		}
 		m.Values[fr.NumValues+i] = res

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -2113,7 +2113,7 @@ func (sb *StaticBlock) Define2(isConst bool, n Name, st Type, tv TypedValue) {
 				n))
 		}
 		old := sb.Block.Values[idx]
-		if !old.IsUndefined() && tv.T != nil {
+		if !old.IsUndefined2() && tv.T != nil {
 			if tv.T.Kind() == FuncKind && tv.T.(*FuncType).IsZero() {
 				// special case,
 				// allow re-predefining for func upgrades.

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -127,7 +127,7 @@ func (m *Machine) doOpCall() {
 		m.PushOp(OpCallNativeBody)
 	}
 	// Assign receiver as first parameter, if any.
-	if !fr.Receiver.IsUndefined() {
+	if !fr.Receiver.IsUndefined2() {
 		isMethod = 1
 	}
 	// Convert variadic argument to slice argument.

--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -834,7 +834,7 @@ func (m *Machine) doOpTypeSwitch() {
 				}
 				ct := cx.(*constTypeExpr).Type
 				if ct == nil {
-					if xv.IsUndefined() {
+					if xv.IsUndefined2() {
 						// match nil type with undefined
 						match = true
 					}

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -519,7 +519,7 @@ func (m *Machine) doOpSliceLit2() {
 	// fill in empty values.
 	ste := st.Elem()
 	for i, etv := range es {
-		if etv.IsUndefined() {
+		if etv.IsUndefined2() {
 			es[i] = defaultTypedValue(m.Alloc, ste)
 		}
 	}
@@ -616,7 +616,7 @@ func (m *Machine) doOpStructLit() {
 		ftvs := m.PopValues(el)
 		for _, ftv := range ftvs {
 			if debug {
-				if !ftv.IsUndefined() && ftv.T.Kind() == InterfaceKind {
+				if !ftv.IsUndefined2() && ftv.T.Kind() == InterfaceKind {
 					panic("should not happen")
 				}
 			}
@@ -639,7 +639,7 @@ func (m *Machine) doOpStructLit() {
 				if fnx.Path.Depth != 0 {
 					panic("unexpected struct composite lit key path generation value")
 				}
-				if !ftv.IsUndefined() && ftv.T.Kind() == InterfaceKind {
+				if !ftv.IsUndefined2() && ftv.T.Kind() == InterfaceKind {
 					panic("should not happen")
 				}
 			}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -733,7 +733,7 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 								store, last, cx).(Expr)
 							var ct Type
 							if cxx, ok := cx.(*ConstExpr); ok {
-								if !cxx.IsUndefined() {
+								if !cxx.IsUndefined2() {
 									panic("should not happen")
 								}
 								// only in type switch cases, nil type allowed.
@@ -1021,14 +1021,14 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					if n.Path.Depth == 0 { // uverse
 						cx := evalConst(store, last, n)
 						// built-in functions must be called.
-						if !cx.IsUndefined() &&
+						if !cx.IsUndefined2() &&
 							cx.T.Kind() == FuncKind &&
 							ftype != TRANS_CALL_FUNC {
 							panic(fmt.Sprintf(
 								"use of builtin %s not in function call",
 								n.Name))
 						}
-						if !cx.IsUndefined() && cx.T.Kind() == TypeKind {
+						if !cx.IsUndefined2() && cx.T.Kind() == TypeKind {
 							return constType(n, cx.GetType()), TRANS_CONTINUE
 						}
 						return cx, TRANS_CONTINUE
@@ -1272,7 +1272,7 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						}
 
 						// check legal type for nil
-						if arg0.IsUndefined() {
+						if arg0.IsUndefined2() {
 							switch ct.Kind() { // special case for nil conversion check.
 							case SliceKind, PointerKind, FuncKind, MapKind, InterfaceKind, ChanKind:
 								convertConst(store, last, n, arg0, ct)
@@ -2447,7 +2447,7 @@ func parseAssignFromExprList(
 		if len(valueExprs) > 0 {
 			vx := valueExprs[i]
 			if cx, ok := vx.(*ConstExpr); ok &&
-				!cx.TypedValue.IsUndefined() {
+				!cx.TypedValue.IsUndefined2() {
 				if isConst {
 					// const _ = <const_expr>: static block should contain value
 					tvs[i] = cx.TypedValue

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -949,7 +949,7 @@ func (tv *TypedValue) IsImmutable() bool {
 }
 
 func (tv *TypedValue) IsDefined() bool {
-	return !tv.IsUndefined()
+	return !tv.IsUndefined2()
 }
 
 // XXX replace IsUndefined() with IsUndefined2() and delete IsUndefined, replace.
@@ -1658,7 +1658,7 @@ func (tv *TypedValue) DefineToBlock(other TypedValue) {
 // as in OpRef.
 func (tv *TypedValue) GetPointerToFromTV(alloc *Allocator, store Store, path ValuePath) PointerValue {
 	if debug {
-		if tv.IsUndefined() {
+		if tv.IsUndefined2() {
 			panic("GetPointerToFromTV() on undefined value")
 		}
 	}
@@ -1870,7 +1870,7 @@ func (tv *TypedValue) GetPointerToFromTV(alloc *Allocator, store Store, path Val
 			Base: nil, // a bound method is free floating.
 		}
 	case VPInterface:
-		if dtv.IsUndefined() {
+		if dtv.IsUndefined2() {
 			panic("interface method call on undefined value")
 		}
 		callerPath := dtv.T.GetPkgPath()
@@ -1943,7 +1943,7 @@ func (tv *TypedValue) GetPointerAtIndex(alloc *Allocator, store Store, iv *Typed
 		}
 		mv := tv.V.(*MapValue)
 		pv := mv.GetPointerForKey(alloc, store, iv)
-		if pv.TV.IsUndefined() {
+		if pv.TV.IsUndefined2() {
 			vt := baseOf(tv.T).(*MapType).Value
 			if vt.Kind() != InterfaceKind {
 				// this will get assigned over, so no alloc.

--- a/gnovm/pkg/gnolang/values_conversions.go
+++ b/gnovm/pkg/gnolang/values_conversions.go
@@ -33,7 +33,7 @@ func ConvertTo(alloc *Allocator, store Store, tv *TypedValue, t Type, isConst bo
 		return
 	}
 	// special case for undefined/nil source
-	if tv.IsUndefined() {
+	if tv.IsUndefined2() {
 		switch t.Kind() {
 		case BoolKind, StringKind, IntKind, Int8Kind, Int16Kind, Int32Kind, Int64Kind, UintKind, Uint8Kind, Uint16Kind, Uint32Kind, Uint64Kind, Float32Kind, Float64Kind, BigintKind, BigdecKind:
 			panic(fmt.Sprintf("cannot convert %v to %v", tv, t))

--- a/gnovm/pkg/gnolang/values_string.go
+++ b/gnovm/pkg/gnolang/values_string.go
@@ -452,7 +452,7 @@ func (tv TypedValue) String() string {
 }
 
 func (tv TypedValue) ProtectedString(seen *seenValues) string {
-	if tv.IsUndefined() {
+	if tv.IsUndefined2() {
 		return "(undefined)"
 	}
 	vs := ""

--- a/gnovm/tests/stdlibs/fmt/print.go
+++ b/gnovm/tests/stdlibs/fmt/print.go
@@ -10,7 +10,7 @@ import (
 )
 
 func X_typeString(v gnolang.TypedValue) string {
-	if v.IsUndefined() {
+	if v.IsUndefined2() {
 		return "<nil>"
 	}
 	return v.T.String()


### PR DESCRIPTION
Only leftover `IsUndefined` that hangs the tests is found in `gnovm/pkg/gnolang/values.go`, in `X_valueOfInternal`

Tested with `make _test.filetest` in `gnovm/Makefile`

For #4060