### PR TITLE
feat(examples): DAO to propose polls and vote

### DIFF
--- a/examples/gno.land/p/moonia/dao/admin.gno
+++ b/examples/gno.land/p/moonia/dao/admin.gno
@@ -1,0 +1,1 @@
+package dao

--- a/examples/gno.land/p/moonia/dao/dao.gno
+++ b/examples/gno.land/p/moonia/dao/dao.gno
@@ -1,0 +1,71 @@
+package dao
+
+import (
+	"std"
+	"strconv"
+	"gno.land/p/moonia/utils"
+)
+
+type DAO struct {
+	Admin     std.Address
+	Whitelist map[std.Address]bool
+}
+
+func NewDAO() *DAO {
+	return &DAO{
+		Admin:     "",
+		Whitelist: make(map[std.Address]bool),
+	}
+}
+
+func (d *DAO) SetAdmin() string {
+	if d.Admin != "" {
+		panic("Admin is already set.")
+	}
+	caller := utils.GetCaller()
+	d.Admin = caller
+	return "Admin set to: " + caller.String()
+}
+
+func (d *DAO) ShowAdmin() string {
+	if d.Admin == "" {
+		return "_No admin set._"
+	}
+	return "Admin: `" + d.Admin.String() + "`"
+}
+
+func (d *DAO) JoinDAO() string {
+	caller := utils.GetCaller()
+	if d.Whitelist[caller] {
+		panic("You're already a member of the DAO.")
+	}
+	d.Whitelist[caller] = true
+	return "You have successfully joined the DAO."
+}
+
+func (d *DAO) LeaveDAO() string {
+	caller := utils.GetCaller()
+	if !d.Whitelist[caller] {
+		panic("You are not a member of the DAO.")
+	}
+	delete(d.Whitelist, caller)
+	return "You have successfully left the DAO."
+}
+
+func (d *DAO) ShowWhitelist() string {
+	out := "## Whitelist Members ✅\n\n"
+	if len(d.Whitelist) == 0 {
+		return out + "_Whitelist is empty._\n"
+	}
+	for addr := range d.Whitelist {
+		out += "- " + addr.String() + "\n"
+	}
+	return out
+}
+
+func (d *DAO) Stats(totalProposals, activeProposals int) string {
+	return "### Stats\n\n" +
+		"- Total Proposals: " + strconv.Itoa(totalProposals) + "\n" +
+		"- Active Proposals: " + strconv.Itoa(activeProposals) + "\n" +
+		"- Whitelist Members: " + strconv.Itoa(len(d.Whitelist)) + "\n"
+}

--- a/examples/gno.land/p/moonia/dao/gno.mod
+++ b/examples/gno.land/p/moonia/dao/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/moonia/dao

--- a/examples/gno.land/p/moonia/dao/interfaces.gno
+++ b/examples/gno.land/p/moonia/dao/interfaces.gno
@@ -1,0 +1,26 @@
+package dao
+
+// import "std"
+
+type IAdmin interface {
+	SetAdmin() string
+	TransferAdmin(newAdmin string) string
+	// KickMember(addr std.Address) string
+}
+
+type IDao interface {
+	JoinDAO() string
+	LeaveDAO() string
+	ShowWhitelist() string
+	Stats(totalProposals, activeProposals int) string
+}
+
+type IProposal interface {
+	CreateProposal(title string, description string) string
+	CloseProposal(indexStr string) string
+	Vote(indexStr string, voteYesStr string) string
+	EditProposal(indexStr, newTitle, newDescription string) string
+	GetProposal(indexStr string) Proposal
+	ShowProposals() string
+	// SetVotingPeriod(duration string) string // by the proposal owner (maybe admin too)
+}

--- a/examples/gno.land/p/moonia/dao/proposals.gno
+++ b/examples/gno.land/p/moonia/dao/proposals.gno
@@ -1,0 +1,148 @@
+package dao
+
+import (
+	"std"
+	"strconv"
+	"gno.land/p/moonia/utils"
+	"gno.land/p/moul/txlink"
+	"gno.land/p/moul/md"
+)
+
+type Proposal struct {
+	Title       string
+	Description string
+	Creator     std.Address
+	YesVotes    int
+	NoVotes     int
+	Voters      map[std.Address]bool
+	Active      bool
+}
+
+type ProposalStore struct {
+	Proposals []Proposal
+	DAO       *DAO
+}
+
+func NewProposalStore(dao *DAO) *ProposalStore {
+	return &ProposalStore{
+		Proposals: []Proposal{},
+		DAO:       dao,
+	}
+}
+
+func (ps *ProposalStore) CreateProposal(title string, description string) string {
+	caller := utils.GetCaller()
+	if !ps.DAO.Whitelist[caller] {
+		panic("Only whitelisted members can create proposals.")
+	}
+	p := Proposal{
+		Title:       title,
+		Description: description,
+		Creator:     caller,
+		Voters:      make(map[std.Address]bool),
+		Active:      true,
+	}
+	ps.Proposals = append(ps.Proposals, p)
+	return "Proposal created: " + title
+}
+
+func (ps *ProposalStore) CreateProposalTest() string {
+	return ps.CreateProposal("Survey", "Would you like to visit Guatemala?")
+}
+
+func (ps *ProposalStore) CloseProposal(indexStr string) string {
+	index := utils.ParseIndex(indexStr, len(ps.Proposals))
+	p := &ps.Proposals[index]
+	if p.Creator != utils.GetCaller() {
+		panic("Only the proposal creator can close it.")
+	}
+	if !p.Active {
+		panic("Proposal is already closed.")
+	}
+	p.Active = false
+	return "Proposal '" + p.Title + "' has been closed."
+}
+
+// gnokey maketx call -pkgpath "gno.land/r/moonia/home" -func "Vote" -args "0" -args "true" -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid "dev" -remote "tcp://127.0.0.1:26657" g15dz69sch7fkhc9gk57hpe4qea77thmy20apu9x
+func (ps *ProposalStore) Vote(indexStr string, voteYesStr string) string {
+	index := utils.ParseIndex(indexStr, len(ps.Proposals))
+	voteYes := voteYesStr == "true"
+	caller := utils.GetCaller()
+
+	if !ps.DAO.Whitelist[caller] {
+		panic("Only whitelisted members can vote.")
+	}
+
+	p := &ps.Proposals[index]
+	if !p.Active {
+		panic("Voting is closed for this proposal.")
+	}
+	if p.Voters[caller] {
+		panic("You have already voted.")
+	}
+
+	p.Voters[caller] = true
+	if voteYes {
+		p.YesVotes++
+		return "Vote recorded: YES for '" + p.Title + "'"
+	} else {
+		p.NoVotes++
+		return "Vote recorded: NO for '" + p.Title + "'"
+	}
+}
+
+func (ps *ProposalStore) ShowProposals() string {
+	activeOut := "## Active Proposals\n\n"
+	closedOut := "## Closed Proposals\n\n"
+	hasActive := false
+	hasClosed := false
+
+	for i, p := range ps.Proposals {
+		proposalStr := "**[" + strconv.Itoa(i) + "]** " + p.Title + "\n"
+		proposalStr += p.Description + "\n\n"
+		proposalStr += "by _" + p.Creator.String() + "_\n\n"
+		proposalStr += "✅ " + strconv.Itoa(p.YesVotes) + " | ❌ " + strconv.Itoa(p.NoVotes) + "\n"
+
+		if p.Active {
+			hasActive = true
+			proposalStr += "(Active) — " +
+				md.Link("Vote Yes", txlink.Call("Vote", "args", strconv.Itoa(i), "args", "true")) + " | " +
+				md.Link("Vote No", txlink.Call("Vote", "args", strconv.Itoa(i), "args", "false")) + "\n\n" +
+				md.Link("❌ Close proposal", txlink.Call("CloseProposal", "args", strconv.Itoa(i))) + "\n\n ---"
+			activeOut += proposalStr + "\n\n"
+		} else {
+			hasClosed = true
+			proposalStr += "(Closed)\n"
+			closedOut += proposalStr + "\n\n ---- \n\n"
+		}
+	}
+
+	if !hasActive {
+		activeOut += "_No active proposals._\n\n"
+	}
+	if !hasClosed {
+		closedOut += "_No closed proposals._\n\n"
+	}
+	return activeOut + "\n" + closedOut
+}
+
+// gnokey maketx call -pkgpath "gno.land/r/moonia/home" -func "EditProposal" -args "2" -args "hehehehe" -args "hihihihi" -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid "dev" -remote "tcp://127.0.0.1:26657" g15dz69sch7fkhc9gk57hpe4qea77thmy20apu9x
+func (ps *ProposalStore) EditProposal(indexStr, newTitle, newDescription string) string {
+	index := utils.ParseIndex(indexStr, len(ps.Proposals))
+	p := &ps.Proposals[index]
+	if p.Creator != utils.GetCaller() {
+		panic("Only the creator can edit the proposal.")
+	}
+	if !p.Active {
+		panic("Cannot edit a closed proposal.")
+	}
+	p.Title = newTitle
+	p.Description = newDescription
+	return "Proposal updated: " + newTitle + newDescription
+}
+
+// gnokey maketx call -pkgpath "gno.land/r/moonia/home" -func "GetProposal" -args "0" -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid "dev" -remote "tcp://127.0.0.1:26657" g15dz69sch7fkhc9gk57hpe4qea77thmy20apu9x
+func (ps *ProposalStore) GetProposal(indexStr string) Proposal {
+	index := utils.ParseIndex(indexStr, len(ps.Proposals))
+	return ps.Proposals[index]
+}

--- a/examples/gno.land/p/moonia/utils/gno.mod
+++ b/examples/gno.land/p/moonia/utils/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/p/moonia/utils

--- a/examples/gno.land/p/moonia/utils/utils.gno
+++ b/examples/gno.land/p/moonia/utils/utils.gno
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"std"
+	"strconv"
+	"strings"
+)
+
+func GetCaller() std.Address {
+	return std.PreviousRealm().Address()
+}
+
+func Parse(fullpath string) (string, map[string]string) {
+	parts := strings.Split(fullpath, ":")
+	if len(parts) == 2 {
+		return parts[1], map[string]string{}
+	}
+	return "", map[string]string{}
+}
+
+func ParseIndex(indexStr string, max int) int {
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		panic("Invalid index.")
+	}
+	if index < 0 || index >= max {
+		panic("Proposal does not exist.")
+	}
+	return index
+}

--- a/examples/gno.land/r/moonia/home/actions.gno
+++ b/examples/gno.land/r/moonia/home/actions.gno
@@ -1,0 +1,41 @@
+package home
+
+import (
+	"gno.land/p/moonia/dao"
+)
+
+func SetAdmin() string {
+	return ds.DAO.SetAdmin()
+}
+
+func JoinDAO() string {
+	return ds.DAO.JoinDAO()
+}
+
+func LeaveDAO() string {
+	return ds.DAO.LeaveDAO()
+}
+
+func CreateProposalTest() string {
+	return ds.Proposals.CreateProposalTest()
+}
+
+func CreateProposal(title string, description string) string {
+	return ds.Proposals.CreateProposal(title, description)
+}
+
+func Vote(indexStr string, voteYesStr string) string {
+	return ds.Proposals.Vote(indexStr, voteYesStr)
+}
+
+func CloseProposal(indexStr string) string {
+	return ds.Proposals.CloseProposal(indexStr)
+}
+
+func EditProposal(indexStr, newTitle, newDescription string) string {
+	return ds.Proposals.EditProposal(indexStr, newTitle, newDescription)
+}
+
+func GetProposal(indexStr string) dao.Proposal {
+	return ds.Proposals.GetProposal(indexStr)
+}

--- a/examples/gno.land/r/moonia/home/gno.mod
+++ b/examples/gno.land/r/moonia/home/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/moonia/home

--- a/examples/gno.land/r/moonia/home/home.gno
+++ b/examples/gno.land/r/moonia/home/home.gno
@@ -1,0 +1,36 @@
+package home
+
+import (
+	"gno.land/p/moul/txlink"
+	"gno.land/p/moul/md"
+)
+
+func countActive() int {
+	count := 0
+	for _, p := range ds.Proposals.Proposals {
+		if p.Active {
+			count++
+		}
+	}
+	return count
+}
+
+func renderDAO() string {
+	out := "# Moonia's DAO\n\n"
+	out += ds.DAO.ShowAdmin() + "\n\n"
+	out += ds.DAO.Stats(len(ds.Proposals.Proposals), countActive()) + "\n"
+	out += "## Actions:\n\n"
+	if ds.DAO.Admin == "" {
+		out += "- " + md.Link("Set Admin (once)", txlink.Call("SetAdmin")) + "\n"
+	}
+	out += "- " + md.Link("Join DAO", txlink.Call("JoinDAO")) + "\n"
+	out += "- " + md.Link("Leave DAO", txlink.Call("LeaveDAO")) + "\n"
+	out += "- " + md.Link("Create Sample Proposal", txlink.Call("CreateProposalTest")) + "\n"
+	out += ds.DAO.ShowWhitelist() + "\n"
+	out += ds.Proposals.ShowProposals()
+	return out
+}
+
+func Render(path string) string {
+	return renderDAO()
+}

--- a/examples/gno.land/r/moonia/home/init.gno
+++ b/examples/gno.land/r/moonia/home/init.gno
@@ -1,0 +1,22 @@
+package home
+
+import (
+	"gno.land/p/moonia/dao"
+)
+
+var ds DAOState
+
+type DAOState struct {
+	DAO       *dao.DAO
+	Proposals *dao.ProposalStore
+}
+
+func init() {
+	myDao := dao.NewDAO()
+	myProps := dao.NewProposalStore(myDao)
+
+	ds = DAOState{
+		DAO:       myDao,
+		Proposals: myProps,
+	}
+}


### PR DESCRIPTION
A simple DAO that allows members to create polls (proposals) and vote on them.

### Add the following:

#### Realms:
```r/moonia/home```: Renders the DAO interface and exposes user-facing actions.

#### Pure:
```p/moonia/dao```: Core logic of the DAO. Includes membership, proposal creation, voting, and admin controls.

```p/moonia/utils```: Provides helper functions for caller identification and safe index parsing

## Next Steps:
- Implement admin and time methods (e.g. kick members, set voting period for proposals)
- Improve the UI
- Add navigation between pages
- Complete interface implementations
----

I'm also looking for suggestions on file organization. 🚀