### PR TITLE
feat(gnolint): add lint checks for `Render`

### DIFF
--- a/gnovm/cmd/gno/testdata/lint/render_multiple_cardinality_errors.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_multiple_cardinality_errors.txtar
@@ -1,0 +1,22 @@
+# testing gno tool lint command: Render function with multiple cardinality errors (too many parameters and returns)
+
+! gno tool lint ./multiple_cardinality_errors.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- multiple_cardinality_errors.gno --
+package main
+
+// multiple cardinality errors: too many parameters and return values
+func Render(path string, extra string) (string, error) {
+	return "Hello World " + path, nil 
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+multiple_cardinality_errors.gno:4: Render function should have exactly one parameter, found: 2 parameters, expected: func Render(string) string (code=5)
+multiple_cardinality_errors.gno:4: Render function should return exactly one string value, found: 2 returns, expected: func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_multiple_type_errors.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_multiple_type_errors.txtar
@@ -1,0 +1,22 @@
+# testing gno tool lint command: Render function with multiple type errors (wrong parameter and return types)
+
+! gno tool lint ./multiple_type_errors.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- multiple_type_errors.gno --
+package main
+
+// multiple type errors: wrong parameter type and wrong return type
+func Render(path int) int {
+	return path
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+multiple_type_errors.gno:4: Render function parameter should be of type string, found: int type, expected: func Render(string) string (code=5)
+multiple_type_errors.gno:4: Render function should return a single string, found: int type: expected func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_no_param.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_no_param.txtar
@@ -1,0 +1,21 @@
+# testing gno tool lint command: Render function with no parameter
+
+! gno tool lint ./no_param.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- no_param.gno --
+package test
+
+// no parameter
+func Render() string {
+	return "Hello World"
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+no_param.gno:4: Render function should have exactly one parameter, found: 0 parameters, expected: func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_too_many_params.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_too_many_params.txtar
@@ -1,0 +1,21 @@
+# testing gno tool lint command: Render function with too many parameters
+
+! gno tool lint ./too_many_params.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- too_many_params.gno --
+package main
+
+// too many parameters
+func Render(path string, extra string) string {
+	return "Hello World " + path + extra
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+too_many_params.gno:4: Render function should have exactly one parameter, found: 2 parameters, expected: func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_too_many_returns.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_too_many_returns.txtar
@@ -1,0 +1,21 @@
+# testing gno tool lint command: Render function with too many return values
+
+! gno tool lint ./too_many_returns.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- too_many_returns.gno --
+package main
+
+// too many return values
+func Render(path string) (string, error) {
+	return "Hello World " + path, nil
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+too_many_returns.gno:4: Render function should return exactly one string value, found: 2 returns, expected: func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_valid.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_valid.txtar
@@ -8,6 +8,12 @@ cmp stdout stderr.golden
 -- valid_render.gno --
 package test
 
+type Test struct{}
+// valid as well since it contains a receiver
+func (t *Test) Render(n int) int {
+    return n
+}
+
 // valid Render
 func Render(path string) string {
 	return "Hello World"

--- a/gnovm/cmd/gno/testdata/lint/render_valid.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_valid.txtar
@@ -1,0 +1,20 @@
+# testing gno tool lint command: valid Render function signature
+
+gno tool lint ./valid_render.gno
+
+cmp stdout stdout.golden
+cmp stdout stderr.golden
+
+-- valid_render.gno --
+package test
+
+// valid Render
+func Render(path string) string {
+	return "Hello World"
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --

--- a/gnovm/cmd/gno/testdata/lint/render_wrong_param_type.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_wrong_param_type.txtar
@@ -1,0 +1,23 @@
+# testing gno tool lint command: all invalid Render function signature cases
+
+! gno tool lint ./wrong_param_type.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- wrong_param_type.gno --
+package test
+
+import "fmt"
+
+// wrong parameter type (int vs string)
+func Render(path int) string {
+	return "Hello World" + fmt.Sprint(path)
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+wrong_param_type.gno:6: Render function parameter should be of type string, found: int type, expected: func Render(string) string (code=5)

--- a/gnovm/cmd/gno/testdata/lint/render_wrong_return_type.txtar
+++ b/gnovm/cmd/gno/testdata/lint/render_wrong_return_type.txtar
@@ -1,0 +1,21 @@
+# testing gno tool lint command: Render function with wrong return type
+
+! gno tool lint ./wrong_return_type.gno
+
+cmp stdout stdout.golden
+cmp stderr stderr.golden
+
+-- wrong_return_type.gno --
+package main
+
+// wrong return type (int vs string)
+func Render(path string) int {
+	return 42
+}
+
+-- gno.mod --
+module gno.land/p/test
+
+-- stdout.golden --
+-- stderr.golden --
+wrong_return_type.gno:4: Render function should return a single string, found: int type: expected func Render(string) string (code=5)

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -112,6 +112,8 @@ const (
 
 type Name string
 
+func (n Name) String() string { return string(n) }
+
 // ----------------------------------------
 // Location
 // Acts as an identifier for nodes.


### PR DESCRIPTION
## Issue
- Closes https://github.com/gnolang/gno/issues/4026

## Description
- Adds a func `lintRenderSignature` that asserts a public Render func follows the required signature `func Render(string) string)`
- Adds test files in `testdata/lint` to assert the above

## Testing Validation
- `go test ./gnovm/cmd/gno/ -run Test_Scripts/lint`
![test-lint](https://github.com/user-attachments/assets/0254db34-1588-43e2-a68c-acacd5003794)
