### PR TITLE
feat: add `ProposalStorage` interface

### DIFF
--- a/examples/gno.land/p/gnoland/commondao/commondao.gno
+++ b/examples/gno.land/p/gnoland/commondao/commondao.gno
@@ -5,9 +5,7 @@ import (
 	"std"
 	"time"
 
-	"gno.land/p/demo/avl"
 	"gno.land/p/demo/avl/list"
-	"gno.land/p/demo/avl/rotree"
 	"gno.land/p/demo/seqid"
 	"gno.land/p/moul/addrset"
 )
@@ -25,27 +23,26 @@ var (
 )
 
 // CommonDAO defines a DAO.
-// TODO: Support optional storage of proposals in a different location
 type CommonDAO struct {
-	id          uint64
-	slug        string
-	name        string
-	description string
-	parent      *CommonDAO
-	children    list.IList
-	members     *addrset.Set // TODO: Consider saving members as groups, PR #3933
-	genID       seqid.ID
-	active      *avl.Tree // string(proposal ID) -> *Proposal
-	finished    *avl.Tree // string(proposal ID) -> *Proposal
+	id                uint64
+	slug              string
+	name              string
+	description       string
+	parent            *CommonDAO
+	children          list.IList
+	members           *addrset.Set // TODO: Consider saving members as groups, PR #3933
+	genID             seqid.ID
+	activeProposals   ProposalStorage
+	finishedProposals ProposalStorage
 }
 
 // New creates a new common DAO.
 func New(options ...Option) *CommonDAO {
 	dao := &CommonDAO{
-		members:  &addrset.Set{},
-		children: &list.List{},
-		active:   avl.NewTree(),
-		finished: avl.NewTree(),
+		members:           &addrset.Set{},
+		children:          &list.List{},
+		activeProposals:   NewProposalStorage(),
+		finishedProposals: NewProposalStorage(),
 	}
 	for _, apply := range options {
 		apply(dao)
@@ -115,14 +112,14 @@ func (dao CommonDAO) Members() *addrset.Set {
 	return dao.members
 }
 
-// ActiveProposals returns all active DAO proposals.
-func (dao CommonDAO) ActiveProposals() rotree.IReadOnlyTree {
-	return dao.active
+// ActiveProposals returns active DAO proposals.
+func (dao CommonDAO) ActiveProposals() ProposalStorage {
+	return dao.activeProposals
 }
 
-// FinishedProposalsi returns all finished DAO proposals.
-func (dao CommonDAO) FinishedProposals() rotree.IReadOnlyTree {
-	return dao.finished
+// FinishedProposalsi returns finished DAO proposals.
+func (dao CommonDAO) FinishedProposals() ProposalStorage {
+	return dao.finishedProposals
 }
 
 // Propose creates a new DAO proposal.
@@ -137,8 +134,7 @@ func (dao *CommonDAO) Propose(creator std.Address, d ProposalDefinition) (*Propo
 		return nil, err
 	}
 
-	key := makeProposalKey(p.ID())
-	dao.active.Set(key, p)
+	dao.activeProposals.Add(p)
 	return p, nil
 }
 
@@ -151,31 +147,13 @@ func (dao *CommonDAO) MustPropose(creator std.Address, d ProposalDefinition) *Pr
 	return p
 }
 
-// GetActiveProposal returns an active proposal.
-func (dao CommonDAO) GetActiveProposal(proposalID uint64) (_ *Proposal, found bool) {
-	key := makeProposalKey(proposalID)
-	if v, ok := dao.active.Get(key); ok {
-		return v.(*Proposal), true
+// GetProposal returns a proposal or nil when proposal is not found.
+func (dao CommonDAO) GetProposal(proposalID uint64) *Proposal {
+	p := dao.activeProposals.Get(proposalID)
+	if p != nil {
+		return p
 	}
-	return nil, false
-}
-
-// GetFinishedProposal returns a finished proposal.
-func (dao CommonDAO) GetFinishedProposal(proposalID uint64) (_ *Proposal, found bool) {
-	key := makeProposalKey(proposalID)
-	if v, ok := dao.finished.Get(key); ok {
-		return v.(*Proposal), true
-	}
-	return nil, false
-}
-
-// GetProposal returns an proposal.
-func (dao CommonDAO) GetProposal(proposalID uint64) (p *Proposal, found bool) {
-	p, found = dao.GetActiveProposal(proposalID)
-	if !found {
-		return dao.GetFinishedProposal(proposalID)
-	}
-	return p, found
+	return dao.finishedProposals.Get(proposalID)
 }
 
 // Vote submits a new vote for a proposal.
@@ -184,8 +162,8 @@ func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice, 
 		return ErrNotMember
 	}
 
-	p, found := dao.GetActiveProposal(proposalID)
-	if !found {
+	p := dao.activeProposals.Get(proposalID)
+	if p == nil {
 		return ErrProposalNotFound
 	}
 
@@ -203,8 +181,8 @@ func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice, 
 
 // Tally counts votes and validates if a proposal passes.
 func (dao *CommonDAO) Tally(proposalID uint64) (passes bool, _ error) {
-	p, found := dao.GetActiveProposal(proposalID)
-	if !found {
+	p := dao.activeProposals.Get(proposalID)
+	if p == nil {
 		return false, ErrProposalNotFound
 	}
 
@@ -224,8 +202,8 @@ func (dao *CommonDAO) Tally(proposalID uint64) (passes bool, _ error) {
 
 // Execute executes a proposal.
 func (dao *CommonDAO) Execute(proposalID uint64) error {
-	p, found := dao.GetActiveProposal(proposalID)
-	if !found {
+	p := dao.activeProposals.Get(proposalID)
+	if p == nil {
 		return ErrProposalNotFound
 	}
 
@@ -261,9 +239,8 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 
 	// Whichever the outcome of the validation, tallying
 	// and execution consider the proposal finished.
-	key := makeProposalKey(p.id)
-	dao.active.Remove(key)
-	dao.finished.Set(key, p)
+	dao.activeProposals.Remove(p.id)
+	dao.finishedProposals.Add(p)
 	return nil
 }
 
@@ -279,8 +256,4 @@ func (dao *CommonDAO) checkProposalPasses(p *Proposal) error {
 		return ErrProposalFailed
 	}
 	return nil
-}
-
-func makeProposalKey(id uint64) string {
-	return seqid.ID(id).String()
 }

--- a/examples/gno.land/p/gnoland/commondao/commondao_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/commondao_test.gno
@@ -171,7 +171,7 @@ func TestCommonDAOPropose(t *testing.T) {
 
 			urequire.NoError(t, err)
 
-			_, found := dao.GetActiveProposal(p.ID())
+			found := dao.ActiveProposals().Has(p.ID())
 			urequire.True(t, found, "proposal not found")
 			uassert.Equal(t, p.Creator(), tc.creator)
 		})
@@ -258,8 +258,8 @@ func TestCommonDAOVote(t *testing.T) {
 
 			urequire.NoError(t, err)
 
-			p, found := dao.GetActiveProposal(tc.proposalID)
-			urequire.True(t, found, "proposal not found")
+			p := dao.ActiveProposals().Get(tc.proposalID)
+			urequire.NotEqual(t, nil, p, "proposal not found")
 
 			record := p.VotingRecord()
 			uassert.True(t, record.HasVoted(tc.member))
@@ -439,11 +439,11 @@ func TestCommonDAOExecute(t *testing.T) {
 
 			urequire.NoError(t, err, "expect no error")
 
-			_, found := dao.GetActiveProposal(tc.proposalID)
+			found := dao.ActiveProposals().Has(tc.proposalID)
 			urequire.False(t, found, "proposal should not be active")
 
-			p, found := dao.GetFinishedProposal(tc.proposalID)
-			urequire.True(t, found, "proposal must be found")
+			p := dao.FinishedProposals().Get(tc.proposalID)
+			urequire.NotEqual(t, nil, p, "proposal must be found")
 			uassert.Equal(t, string(p.Status()), string(tc.status), "status must match")
 			uassert.Equal(t, string(p.StatusReason()), string(tc.statusReason), "status reason must match")
 		})

--- a/examples/gno.land/p/gnoland/commondao/options.gno
+++ b/examples/gno.land/p/gnoland/commondao/options.gno
@@ -70,3 +70,27 @@ func WithMembers(members *addrset.Set) Option {
 		dao.members = members
 	}
 }
+
+// WithActiveProposalStorage assigns a custom storage for active proposals.
+// A default empty proposal storage is used when the custopm storage is nil.
+// Custom storage implementations can be used to store proposals in a different location.
+func WithActiveProposalStorage(s ProposalStorage) Option {
+	return func(dao *CommonDAO) {
+		if s == nil {
+			s = NewProposalStorage()
+		}
+		dao.activeProposals = s
+	}
+}
+
+// WithFinishedProposalStorage assigns a custom storage for finished proposals.
+// A default empty proposal storage is used when the custopm storage is nil.
+// Custom storage implementations can be used to store proposals in a different location.
+func WithFinishedProposalStorage(s ProposalStorage) Option {
+	return func(dao *CommonDAO) {
+		if s == nil {
+			s = NewProposalStorage()
+		}
+		dao.finishedProposals = s
+	}
+}

--- a/examples/gno.land/p/gnoland/commondao/proposal_storage.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal_storage.gno
@@ -1,0 +1,83 @@
+package commondao
+
+import (
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/seqid"
+)
+
+// ProposalStorage defines an interface for proposal storages.
+type ProposalStorage interface {
+	// Has checks if a proposal exists.
+	Has(id uint64) bool
+
+	// Get returns a proposal or nil when proposal doesn't exist.
+	Get(id uint64) *Proposal
+
+	// Add adds a proposal to the storage.
+	Add(*Proposal)
+
+	// Remove removes a proposal from the storage.
+	Remove(id uint64)
+
+	// Size returns the number of proposals that the storage contains.
+	Size() int
+
+	// Iterate iterates proposals.
+	Iterate(offset, count int, fn func(*Proposal) bool) bool
+}
+
+// NewProposalStorage creates a new proposal storage.
+func NewProposalStorage() ProposalStorage {
+	return &proposalStorage{avl.NewTree()}
+}
+
+type proposalStorage struct {
+	storage *avl.Tree // string(proposal ID) -> *Proposal
+}
+
+// Has checks if a proposal exists.
+func (s proposalStorage) Has(id uint64) bool {
+	return s.storage.Has(makeProposalKey(id))
+}
+
+// Get returns a proposal or nil when proposal doesn't exist.
+func (s proposalStorage) Get(id uint64) *Proposal {
+	if v, found := s.storage.Get(makeProposalKey(id)); found {
+		return v.(*Proposal)
+	}
+	return nil
+}
+
+// Add adds a proposal to the storage.
+func (s *proposalStorage) Add(p *Proposal) {
+	if p == nil {
+		return
+	}
+
+	s.storage.Set(makeProposalKey(p.ID()), p)
+}
+
+// Remove removes a proposal from the storage.
+func (s *proposalStorage) Remove(id uint64) {
+	s.storage.Remove(makeProposalKey(id))
+}
+
+// Size returns the number of proposals that the storage contains.
+func (s proposalStorage) Size() int {
+	return s.storage.Size()
+}
+
+// Iterate iterates proposals.
+func (s proposalStorage) Iterate(offset, count int, fn func(*Proposal) bool) bool {
+	if fn == nil {
+		return false
+	}
+
+	return s.storage.IterateByOffset(offset, count, func(_ string, v any) bool {
+		return fn(v.(*Proposal))
+	})
+}
+
+func makeProposalKey(id uint64) string {
+	return seqid.ID(id).String()
+}

--- a/examples/gno.land/p/gnoland/commondao/proposal_storage_test.gno
+++ b/examples/gno.land/p/gnoland/commondao/proposal_storage_test.gno
@@ -1,0 +1,64 @@
+package commondao
+
+import (
+	"testing"
+
+	"gno.land/p/demo/uassert"
+	"gno.land/p/demo/urequire"
+)
+
+func TestProposalStorageAdd(t *testing.T) {
+	p, _ := NewProposal(1, "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", testPropDef{})
+	s := NewProposalStorage()
+	initialSize := s.Size()
+
+	s.Add(p)
+
+	uassert.Equal(t, 0, initialSize, "expect initial storage to be empty")
+	uassert.Equal(t, 1, s.Size(), "expect storage to have one proposal")
+	uassert.True(t, s.Has(p.ID()), "expect proposal to be found")
+}
+
+func TestProposalStorageGet(t *testing.T) {
+	p, _ := NewProposal(1, "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", testPropDef{})
+	s := NewProposalStorage()
+	s.Add(p)
+
+	p2 := s.Get(p.ID())
+
+	urequire.NotEqual(t, nil, p2, "expect proposal to be found")
+	uassert.Equal(t, p.ID(), p2.ID(), "expect proposal ID to match")
+}
+
+func TestProposalStorageRemove(t *testing.T) {
+	p, _ := NewProposal(1, "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", testPropDef{})
+	s := NewProposalStorage()
+	s.Add(p)
+
+	s.Remove(p.ID())
+
+	uassert.Equal(t, 0, s.Size(), "expect storage to be empty")
+	uassert.False(t, s.Has(p.ID()), "expect proposal to be not found")
+}
+
+func TestProposalStorageIterate(t *testing.T) {
+	var (
+		i   int
+		ids = []uint64{22, 33, 44}
+		s   = NewProposalStorage()
+	)
+
+	for _, id := range ids {
+		p, _ := NewProposal(id, "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", testPropDef{})
+		s.Add(p)
+	}
+
+	s.Iterate(0, s.Size(), func(p *Proposal) bool {
+		uassert.Equal(t, ids[i], p.ID(), "expect proposal ID to match")
+
+		i++
+		return i == s.Size()
+	})
+
+	uassert.Equal(t, len(ids), i, "expect storage to iterate all proposals")
+}

--- a/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/z_6_a_filetest.gno
@@ -66,8 +66,8 @@ func init() {
 func main() {
 	commondao.Execute(dao.ID(), proposal.ID())
 
-	p, found := dao.GetFinishedProposal(proposal.ID())
-	if !found {
+	p := dao.FinishedProposals().Get(proposal.ID())
+	if p == nil {
 		panic("expected proposal to be finished")
 	}
 

--- a/examples/gno.land/r/gnoland/commondao/zp_0_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/commondao/zp_0_a_filetest.gno
@@ -34,8 +34,8 @@ func init() {
 func main() {
 	pID := commondao.CreateMembersUpdateProposal(dao.ID(), "", newMembers, removeMembers)
 
-	p, found := dao.GetActiveProposal(pID)
-	if !found {
+	p := dao.ActiveProposals().Get(pID)
+	if p == nil {
 		panic("expected proposal to be created")
 	}
 


### PR DESCRIPTION
Also adds an implementation which is the one used by default.

The new interface allows devs to store proposals in different custom locations.