### PR TITLE
feat(gnodev): handle addpkg msg in gnodev

### DIFF
--- a/contribs/gnodev/pkg/proxy/path_interceptor.go
+++ b/contribs/gnodev/pkg/proxy/path_interceptor.go
@@ -321,12 +321,12 @@ func handleTx(bz []byte, upaths uniqPaths) error {
 	for _, msg := range tx.Msgs {
 		switch msg := msg.(type) {
 		case vm.MsgAddPackage:
-			// NOTE: Do not add the package to avoid conflict.
+			// NOTE: Do not add the package itself to avoid conflict.
 			if msg.Package != nil {
 				upaths.addPackageDeps(msg.Package)
 			}
 		case vm.MsgRun:
-			// NOTE: Do not add the package to avoid conflict.
+			// NOTE: Do not add the package itself to avoid conflict.
 			if msg.Package != nil {
 				upaths.addPackageDeps(msg.Package)
 			}

--- a/contribs/gnodev/pkg/proxy/path_interceptor.go
+++ b/contribs/gnodev/pkg/proxy/path_interceptor.go
@@ -332,7 +332,6 @@ func handleTx(bz []byte, upaths uniqPaths) error {
 			}
 		case vm.MsgCall:
 			upaths.addPath(msg.PkgPath)
-
 		}
 	}
 


### PR DESCRIPTION
Recent feedback indicates that people are confused when their dependencies are not resolved while using the `addpkg` message in gnodev. 
This PR automatically resolves dependencies from the `addpkg` message files in gnodev.