### PR TITLE
chore: fixing docker bake file

### DIFF
--- a/misc/deployments/bake/docker-bake.hcl
+++ b/misc/deployments/bake/docker-bake.hcl
@@ -52,8 +52,6 @@ target "common" {
     "type=sbom",
   ]
   context = "../../../"
-  dockerfile = "Dockerfile.new"
-  
   platforms = [
     "linux/amd64",
     "linux/arm64"


### PR DESCRIPTION
removing leftovers from docker bake file