### PR TITLE
chore: update test6 `genesis.json` info

### DIFF
--- a/misc/deployments/test6.gno.land/README.md
+++ b/misc/deployments/test6.gno.land/README.md
@@ -35,10 +35,10 @@ Some configuration params are required, while others are advised to be set.
   reverse-proxy, and keep this value at `tcp://0.0.0.0:<port>`.
 - `p2p.max_num_outbound_peers` - the max number of outbound peer connections. **Advised to be `40`**.
 - `p2p.persistent_peers` - the persistent peers. ⚠️ **Required to be
-  `g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-01.test6.testnets.gno.land:26656,g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-02.test6.testnets.gno.land:26656`
+  `g1s0x78pl3c2xv2n7hp33lh4jkyqvhg5hlx6huh7@gno-core-sen-01.test6.testnets.gno.land:26656,g1jeta40dllwtrh293498hq0dh0cr3u4gw77h5rc@gno-core-sen-02.test6.testnets.gno.land:26656`
   ** ⚠️.
 - `p2p.seeds` - the bootnode peers. ⚠️ **Required to be
-  `g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-01.test6.testnets.gno.land:26656,g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-02.test6.testnets.gno.land:26656`
+  `g1s0x78pl3c2xv2n7hp33lh4jkyqvhg5hlx6huh7@gno-core-sen-01.test6.testnets.gno.land:26656,g1jeta40dllwtrh293498hq0dh0cr3u4gw77h5rc@gno-core-sen-02.test6.testnets.gno.land:26656`
   ** ⚠️.
 - `p2p.pex` - if using a sentry node architecture, should be `false`. **If not, please set to `true`**.
 - `p2p.external_address` - the advertised peer dial address. If empty, will use the same port as the `p2p.laddr`. This
@@ -59,12 +59,12 @@ You can download the full `genesis.json` using the following steps:
 wget -O genesis.json https://gno-testnets-genesis.s3.eu-central-1.amazonaws.com/test6/genesis.json
 ```
 
-The `shasum` hash of the `genesis.json` should be `9a5e21d0b1ed394a0999f04ac5b88776df702a798b326aad70cf1cd2888a238a`.
+The `shasum` hash of the `genesis.json` should be `f0a07d42b394b9371580294583b3669d4060da73db8d126f70d428856b9a1da7`.
 Verify it by running:
 
 ```sh
 shasum -a 256 genesis.json
-9a5e21d0b1ed394a0999f04ac5b88776df702a798b326aad70cf1cd2888a238a  genesis.json
+f0a07d42b394b9371580294583b3669d4060da73db8d126f70d428856b9a1da7  genesis.json
 ```
 
 **NOTE**: Keep in mind that the generated genesis.json checksum will differ from the downloaded one,

--- a/misc/deployments/test6.gno.land/config.toml
+++ b/misc/deployments/test6.gno.land/config.toml
@@ -116,7 +116,7 @@ max_num_outbound_peers = 40 # Advised value is 40
 max_packet_msg_payload_size = 1024
 
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = ""
+persistent_peers = "g1s0x78pl3c2xv2n7hp33lh4jkyqvhg5hlx6huh7@gno-core-sen-01.test6.testnets.gno.land:26656,g1jeta40dllwtrh293498hq0dh0cr3u4gw77h5rc@gno-core-sen-02.test6.testnets.gno.land:26656"
 
 # Set true to enable the peer-exchange reactor
 pex = true
@@ -128,7 +128,7 @@ private_peer_ids = "g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-01.tes
 recv_rate = 5120000
 
 # Comma separated list of seed nodes to connect to
-seeds = "g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-01.test6.testnets.gno.land:26656,g16384atcuf6ew3ufpwtvhymwfyl2aw390aq8jtt@gno-core-sen-02.test6.testnets.gno.land:26656"
+seeds = "g1s0x78pl3c2xv2n7hp33lh4jkyqvhg5hlx6huh7@gno-core-sen-01.test6.testnets.gno.land:26656,g1jeta40dllwtrh293498hq0dh0cr3u4gw77h5rc@gno-core-sen-02.test6.testnets.gno.land:26656"
 
 # Rate at which packets can be sent, in bytes/second
 send_rate = 5120000

--- a/misc/deployments/test6.gno.land/generate.sh
+++ b/misc/deployments/test6.gno.land/generate.sh
@@ -74,6 +74,19 @@ gnogenesis balances add -balance-sheet $BALANCES_PATH
 # Cleanup
 rm -rf $TMP_DIR
 
+# Update the whitelisted addresses (NT + the faucet)
+printf "\nUpdating whitelisted addresses...\n"
+
+jq '.app_state.auth.params.unrestricted_addrs = [
+  "g148583t5x66zs6p90ehad6l4qefeyaf54s69wql",
+  "g1manfred47kzduec920z88wfr64ylksmdcedlf5"
+]' genesis.json > tmp && mv tmp genesis.json
+
+# Update the restricted denoms (enable token locking)
+printf "\nEnabling token locking...\n"
+
+jq '.app_state.bank.params.restricted_denoms = ["ugnot"]' genesis.json > tmp && mv tmp genesis.json
+
 # Verify that the genesis.json is valid
 printf "\nVerifying genesis.json...\n"
 gnogenesis verify -genesis-path $GENESIS_FILE


### PR DESCRIPTION
## Description

This PR updates the test6 genesis.json, and relevant info, to accommodate for a change in the genesis params:
- added unrestricted addresses (we can't update these through governance proposals if the chain is live)
- enables token locking

```
    "auth": {
      "params": {
        "max_memo_bytes": "65536",
        "tx_sig_limit": "7",
        "tx_size_cost_per_byte": "10",
        "sig_verify_cost_ed25519": "590",
        "sig_verify_cost_secp256k1": "1000",
        "gas_price_change_compressor": "10",
        "target_gas_ratio": "70",
        "initial_gasprice": {
          "gas": "1000",
          "price": "1ugnot"
        },
        "unrestricted_addrs": [
          "g148583t5x66zs6p90ehad6l4qefeyaf54s69wql",
          "g1manfred47kzduec920z88wfr64ylksmdcedlf5"
        ]
      }
    },
    "bank": {
      "params": {
        "restricted_denoms": [
          "ugnot"
        ]
      }
    },
```