### PR TITLE
fix(machine): typo leftover `machine.ExceptionStacktrace`

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -546,7 +546,7 @@ func doRecoverInternal(m *gno.Machine, e *error, r any, repanicOutOfGas bool) {
 			*e = errors.Wrapf(
 				errors.New(up.Descriptor),
 				"VM panic: %s\nStacktrace:\n%s\n",
-				up.Descriptor, m.ExceptionsStacktrace(),
+				up.Descriptor, m.ExceptionStacktrace(),
 			)
 			return
 		}


### PR DESCRIPTION
Fix lefover `s` on `gnovm/pkg/gnolang.Machine.ExceptionStacktrace`