### PR TITLE
chore: fix typos in documentation files

### DIFF
--- a/docs/resources/gno-interrealm.md
+++ b/docs/resources/gno-interrealm.md
@@ -54,7 +54,7 @@ else's pen it is still your signature; signature:pen :: current:borrowed.
 A crossing method declared in a realm cannot modify the receiver if the object
 resides in a different realm. However not all methods are required to be
 crossing methods, and crossing methods may still read the state of the
-receiver (and in general anything reacheable is readible).
+receiver (and in general anything reachable is readible).
 
 New unreal objects reachable from the borrowed realm (or current realm if there
 was no method call that borrowed) become persisted in the borrowed realm (or

--- a/docs/resources/gno-memory-model.md
+++ b/docs/resources/gno-memory-model.md
@@ -16,7 +16,7 @@ performance.
 
 All values in Gno are stored represented as (type, value) tuples.  Vars in
 scope blocks, fields in structs, elements in arrays, keys and values of maps
-are all respresented by the same `TypedValue` struct.
+are all represented by the same `TypedValue` struct.
 
 This tuple representation lets the Gno VM implementation logic be simpler with
 less code.  Reading and writing values are the same whether the static type of

--- a/docs/resources/gno-stdlibs.md
+++ b/docs/resources/gno-stdlibs.md
@@ -13,7 +13,7 @@ a domain-like format at the beginning of their import path. For example:
 - `import "strings"` refers to a standard library
 - `import "gno.land/p/demo/avl"` refers to an on-chain package.
 
-To see concrete implementation details & API references of the `std` pacakge,
+To see concrete implementation details & API references of the `std` package,
 see the reference section.
 
 ## Accessing documentation


### PR DESCRIPTION
Fix several typos in documentation files:

- docs/resources/gno-interrealm.md: Fix "reacheable" to "reachable"
- docs/resources/gno-memory-model.md: Fix "respresented" to "represented" 
- docs/resources/gno-stdlibs.md: Fix "pacakge" to "package"

These changes improve readability and correctness of the documentation.