### PR TITLE
Draft: Init seems to bypass the need for crossing

### DIFF
--- a/examples/gno.land/r/stackdump/home/gno.mod
+++ b/examples/gno.land/r/stackdump/home/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/stackdump/home

--- a/examples/gno.land/r/stackdump/home/index.gno
+++ b/examples/gno.land/r/stackdump/home/index.gno
@@ -1,0 +1,86 @@
+package home
+
+import (
+	"std"
+	"strings"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+)
+
+var (
+	realmAllowPrefix = []string{}
+	registry         = avl.NewTree()
+	render           []string
+)
+
+func SetOutput(s ...string) {
+	AssertAdminAccess()
+	render = []string{}
+	appendOutput(s...)
+}
+
+func appendOutput(s ...string) {
+	for _, v := range s {
+		render = append(render, v)
+	}
+}
+
+func init() {
+	realmAllowPrefix = append(realmAllowPrefix, std.CurrentRealm().PkgPath()+"/patch")
+	appendOutput("foo", "bar")
+	registry.Set("foo", "testing!")
+	registry.Set("bar", "\n123")
+}
+
+/* Auth API */
+func HasAllowedPrefix() bool {
+	//if std.IsUser() {
+	//    return false
+	//}
+	prevPath := std.PreviousRealm().PkgPath()
+	if prevPath != "" {
+		return false
+	}
+	currentPath := std.CurrentRealm().PkgPath()
+	for _, callerPath := range realmAllowPrefix {
+		if strings.HasPrefix(currentPath, callerPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func AssertAdminAccess() {
+	if !HasAllowedPrefix() {
+		panic("access denied: " + std.PreviousRealm().PkgPath() +
+			" realm must match an allowed prefix:[" + strings.Join(realmAllowPrefix, ",") + "]" +
+			" got: " + std.CurrentRealm().PkgPath())
+	}
+}
+
+func Set(key string, val interface{}) {
+	// AssertAdminAccess()
+	registry.Set(key, val)
+}
+
+func GetString(key string) string {
+	val, _ := registry.Get(key)
+	switch val.(type) {
+	case string, int, float64, bool:
+		return ufmt.Sprintf("%v", val)
+	default:
+		return ""
+	}
+}
+
+func Render(_ string) string {
+	out := strings.Builder{}
+	for _, key := range render {
+		val := GetString(key)
+		if val != "" {
+			out.WriteString(val)
+		}
+	}
+	return out.String()
+}

--- a/examples/gno.land/r/stackdump/home/patch001/gno.mod
+++ b/examples/gno.land/r/stackdump/home/patch001/gno.mod
@@ -1,0 +1,1 @@
+module gno.land/r/stackdump/home/patch001

--- a/examples/gno.land/r/stackdump/home/patch001/patch.gno
+++ b/examples/gno.land/r/stackdump/home/patch001/patch.gno
@@ -1,0 +1,10 @@
+package patch
+
+import (
+	index "gno.land/r/stackdump/home"
+)
+
+func Bug() {
+	crossing()
+	index.Set("foo", "hello world")
+}


### PR DESCRIPTION
So I was using an api for a realm that sets the value of a key in an AVL tree. I went to a subrealm and tried to call the Set(key, value) api call inside of the subrealms init() func. The thing is, it didn't needed crossing at the top to modify the avl tree. But, when I make it just another api call in the subrealm and try to call it, the gnovm panics and tells me I needed crossing. Is there a difference between init and other public functions for crossing? Thanks