### PR TITLE
fix: update loci testing and core behavior to work with cross realms

### DIFF
--- a/examples/gno.land/p/n2p5/loci/loci.gno
+++ b/examples/gno.land/p/n2p5/loci/loci.gno
@@ -25,10 +25,10 @@ func New() *LociStore {
 	}
 }
 
-// Set stores a byte slice in the AVL tree using the `std.CurrentRealm().Address()`
+// Set stores a byte slice in the AVL tree using the `std.PreviousRealm().Address()`
 // string as the key.
 func (s *LociStore) Set(value []byte) {
-	key := string(std.CurrentRealm().Address())
+	key := string(std.PreviousRealm().Address())
 	s.internal.Set(key, value)
 }
 

--- a/examples/gno.land/p/n2p5/loci/loci_test.gno
+++ b/examples/gno.land/p/n2p5/loci/loci_test.gno
@@ -1,79 +1,42 @@
 package loci
 
 import (
+	"std"
 	"testing"
 
 	"gno.land/p/demo/testutils"
 )
 
 func TestLociStore(t *testing.T) {
-	//testing.SetRealm(std.NewCodeRealm("gno.land/r/test/test"))
-
 	t.Run("TestSet", func(t *testing.T) {
 		t.Parallel()
+		testing.SetRealm(std.NewCodeRealm("gno.land/r/test/test"))
+		caller := std.PreviousRealm()
 		store := New()
-		u1 := testutils.TestAddress("u1")
-
-		m1 := []byte("hello")
-		m2 := []byte("world")
-		testing.SetOriginCaller(u1)
-
 		// Ensure that the value is nil before setting it.
-		r1 := store.Get(u1)
-		if r1 != nil {
+		if r1 := store.Get(caller.Address()); r1 != nil {
 			t.Errorf("expected value to be nil, got '%s'", r1)
 		}
-		store.Set(m1)
-		// Ensure that the value is correct after setting it.
-		r2 := store.Get(u1)
-		if string(r2) != "hello" {
+		store.Set([]byte("hello"))
+		if r2 := store.Get(caller.Address()); string(r2) != "hello" {
 			t.Errorf("expected value to be 'hello', got '%s'", r2)
 		}
-		store.Set(m2)
-		// Ensure that the value is correct after overwriting it.
-		r3 := store.Get(u1)
-		if string(r3) != "world" {
+		store.Set([]byte("world"))
+		if r3 := store.Get(caller.Address()); string(r3) != "world" {
 			t.Errorf("expected value to be 'world', got '%s'", r3)
 		}
 	})
 	t.Run("TestGet", func(t *testing.T) {
 		t.Parallel()
+		testing.SetRealm(std.NewCodeRealm("gno.land/r/test/test"))
+		caller := std.PreviousRealm()
 		store := New()
-		u1 := testutils.TestAddress("u1")
-		u2 := testutils.TestAddress("u2")
-		u3 := testutils.TestAddress("u3")
-		u4 := testutils.TestAddress("u4")
-
-		m1 := []byte("hello")
-		m2 := []byte("world")
-		m3 := []byte("goodbye")
-
-		testing.SetOriginCaller(u1)
-		store.Set(m1)
-		testing.SetOriginCaller(u2)
-		store.Set(m2)
-		testing.SetOriginCaller(u3)
-		store.Set(m3)
-
-		// Ensure that the value is correct after setting it.
-		r0 := store.Get(u4)
-		if r0 != nil {
+		store.Set([]byte("hello"))
+		if r0 := store.Get(testutils.TestAddress("nil_user")); r0 != nil {
 			t.Errorf("expected value to be nil, got '%s'", r0)
 		}
-		// Ensure that the value is correct after setting it.
-		r1 := store.Get(u1)
-		if string(r1) != "hello" {
+		if r1 := store.Get(caller.Address()); string(r1) != "hello" {
 			t.Errorf("expected value to be 'hello', got '%s'", r1)
-		}
-		// Ensure that the value is correct after setting it.
-		r2 := store.Get(u2)
-		if string(r2) != "world" {
-			t.Errorf("expected value to be 'world', got '%s'", r2)
-		}
-		// Ensure that the value is correct after setting it.
-		r3 := store.Get(u3)
-		if string(r3) != "goodbye" {
-			t.Errorf("expected value to be 'goodbye', got '%s'", r3)
 		}
 	})
 }

--- a/examples/gno.land/p/n2p5/loci/z_0_filetest.gno
+++ b/examples/gno.land/p/n2p5/loci/z_0_filetest.gno
@@ -1,0 +1,26 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"std"
+
+	"gno.land/p/n2p5/loci"
+)
+
+var store *loci.LociStore
+
+func init() {
+	store = loci.New()
+}
+
+func main() {
+	crossing()
+
+	caller := std.PreviousRealm()
+
+	store.Set([]byte("hello, world"))
+	println(string(store.Get(caller.Address())))
+}
+
+// Output:
+// hello, world

--- a/examples/gno.land/r/n2p5/loci/loci.gno
+++ b/examples/gno.land/r/n2p5/loci/loci.gno
@@ -18,6 +18,7 @@ func init() {
 // Keyed by the address of the caller. It also emits a "set" event with
 // the address of the caller.
 func Set(value string) {
+	crossing()
 	b, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		panic(err)
@@ -29,12 +30,26 @@ func Set(value string) {
 // Get retrieves the value stored at the provided address and
 // returns it as a base64 encoded string.
 func Get(addr std.Address) string {
+	crossing()
 	return base64.StdEncoding.EncodeToString(store.Get(addr))
 }
 
 func Render(path string) string {
 	if path == "" {
-		return about
+		return `
+# Welcome to Loci
+
+Loci is a simple key-value store keyed by the caller's gno.land address. 
+Only the caller can set the value for their address, but anyone can 
+retrieve the value for any address. There are only two functions: Set and Get.
+If you'd like to set a value, simply base64 encode any message you'd like and
+it will be stored in in Loci. If you'd like to retrieve a value, simply provide 
+the address of the value you'd like to retrieve.
+
+For convenience, you can also use gnoweb to view the value for a given address,
+if one exists. For instance append :g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t to
+this URL to view the value stored at that address.
+`
 	}
 	return renderGet(std.Address(path))
 }
@@ -51,18 +66,3 @@ func renderGet(addr std.Address) string {
 
 `, addr, value)
 }
-
-const about = `
-# Welcome to Loci
-
-Loci is a simple key-value store keyed by the caller's gno.land address. 
-Only the caller can set the value for their address, but anyone can 
-retrieve the value for any address. There are only two functions: Set and Get.
-If you'd like to set a value, simply base64 encode any message you'd like and
-it will be stored in in Loci. If you'd like to retrieve a value, simply provide 
-the address of the value you'd like to retrieve.
-
-For convenience, you can also use gnoweb to view the value for a given address,
-if one exists. For instance append :g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t to
-this URL to view the value stored at that address.
-`

--- a/examples/gno.land/r/n2p5/loci/z_0_filetest.gno
+++ b/examples/gno.land/r/n2p5/loci/z_0_filetest.gno
@@ -1,0 +1,48 @@
+// PKGPATH: gno.land/r/test/test
+package test
+
+
+import (
+	"std"
+
+	"gno.land/r/n2p5/loci"
+)
+
+func main() {
+	crossing()
+	caller := std.CurrentRealm()
+	println("caller: " + string(caller.Address()))
+	
+	// test nothing being set, yet.
+	r0 := cross(loci.Get)(caller.Address())
+	println("expect: " + "")
+	println("got   : " + r0)
+
+	// set the value, which uses the CurrentRealm as the caller.
+	input1 := "aGVsbG8sIHdvcmxkCg=="
+	cross(loci.Set)(input1)
+	println("set   : " + string(input1))
+	r1 := cross(loci.Get)(caller.Address())
+	println("expect: " + input1)
+	println("got   : " + r1)
+
+	// change the value, which should override the previous value.
+	input2 := "Z29vZGJ5ZSwgd29ybGQK"
+	cross(loci.Set)(input2)
+	println("set   : " + string(input2))
+	r2 := cross(loci.Get)(caller.Address())
+	println("expect: " + input2)
+	println("got   : " + r2)
+
+}
+
+// Output:
+// caller: g1z7fga7u94pdmamlvcrtvsfwxgsye0qv3rres7n
+// expect:
+// got   :
+// set   : aGVsbG8sIHdvcmxkCg==
+// expect: aGVsbG8sIHdvcmxkCg==
+// got   : aGVsbG8sIHdvcmxkCg==
+// set   : Z29vZGJ5ZSwgd29ybGQK
+// expect: Z29vZGJ5ZSwgd29ybGQK
+// got   : Z29vZGJ5ZSwgd29ybGQK


### PR DESCRIPTION
This restores the originally defined behavior for loci, while also correcting test coverage to conform to the newer requirements with realm crossing.


## gno.land/p/n2p5/loci

- REVERTED  Set behavior to use std.PreviousRealm(). Loci sets the key for its storage based on the PreviousRealm, whether that caller is a user address (a direct call to loci) or from another realm. You can think of this as a "previous realm cubby" where you can store some set of bytes of data, keyed by the PreviousRealm. 
- UPDATED package tests to properly handle PreviousRealm calls
- ADDED /p package filetest to correctly simulate the previous realm behavior.

## gno.land/r/n2p5/loci
- ADDED: filetest to provide test coverage for expected behavior
- UPDATED: Render function to move landing page text in-line into the function  