### PR TITLE
fix(gnovm/pkg/test): cache type check results

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -352,8 +352,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 	}
 
 	// Validate Gno syntax and type check.
-	format := true
-	if err := gno.TypeCheckMemPackage(memPkg, gnostore, format); err != nil {
+	if err := gno.TypeCheckMemPackage(memPkg, gnostore, gno.TypeCheckOptions{Format: true}); err != nil {
 		return ErrTypeCheck(err)
 	}
 
@@ -582,8 +581,7 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 	}
 
 	// Validate Gno syntax and type check.
-	format := false
-	if err = gno.TypeCheckMemPackage(memPkg, gnostore, format); err != nil {
+	if err = gno.TypeCheckMemPackage(memPkg, gnostore, gno.TypeCheckOptions{}); err != nil {
 		return "", ErrTypeCheck(err)
 	}
 

--- a/gnovm/cmd/gno/tool_lint.go
+++ b/gnovm/cmd/gno/tool_lint.go
@@ -181,7 +181,7 @@ func execLint(cfg *lintCfg, args []string, io commands.IO) error {
 }
 
 func lintTypeCheck(io commands.IO, memPkg *gnovm.MemPackage, testStore gno.Store) (errorsFound bool, err error) {
-	tcErr := gno.TypeCheckMemPackageTest(memPkg, testStore)
+	tcErr := gno.TypeCheckMemPackage(memPkg, testStore, gno.TypeCheckOptions{Redefinitions: true})
 	if tcErr == nil {
 		return false, nil
 	}

--- a/gnovm/pkg/gnolang/gotypecheck_test.go
+++ b/gnovm/pkg/gnolang/gotypecheck_test.go
@@ -364,8 +364,7 @@ func TestTypeCheckMemPackage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			format := false
-			err := TypeCheckMemPackage(tc.pkg, tc.getter, format)
+			err := TypeCheckMemPackage(tc.pkg, tc.getter, TypeCheckOptions{})
 			if tc.check == nil {
 				assert.NoError(t, err)
 			} else {
@@ -399,8 +398,7 @@ func TestTypeCheckMemPackage_format(t *testing.T) {
 	}
 
 	mpkgGetter := mockPackageGetter{}
-	format := false
-	err := TypeCheckMemPackage(pkg, mpkgGetter, format)
+	err := TypeCheckMemPackage(pkg, mpkgGetter, TypeCheckOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, input, pkg.Files[0].Body) // unchanged
 
@@ -411,8 +409,7 @@ func Hello(name string) string {
 }
 `
 
-	format = true
-	err = TypeCheckMemPackage(pkg, mpkgGetter, format)
+	err = TypeCheckMemPackage(pkg, mpkgGetter, TypeCheckOptions{Format: true})
 	assert.NoError(t, err)
 	assert.NotEqual(t, input, pkg.Files[0].Body)
 	assert.Equal(t, expected, pkg.Files[0].Body)

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -146,6 +146,14 @@ type TestOptions struct {
 
 	filetestBuffer bytes.Buffer
 	outWriter      proxyWriter
+	tcCache        map[string]gno.TypeCheckResult
+}
+
+func (opts *TestOptions) getTcCache() map[string]gno.TypeCheckResult {
+	if opts.tcCache == nil {
+		opts.tcCache = map[string]gno.TypeCheckResult{}
+	}
+	return opts.tcCache
 }
 
 // WriterForStore is the writer that should be passed to [Store], so that


### PR DESCRIPTION
`gno test -run TestFiles` was made 5x slower because the type checker added recently did not cache results of standard libraries and other packages.

This PR fixes it.