### PR TITLE
fix: uint64 -> int64 and uint -> int

### DIFF
--- a/examples/gno.land/p/demo/grc/exts/token_metadata.gno
+++ b/examples/gno.land/p/demo/grc/exts/token_metadata.gno
@@ -9,5 +9,5 @@ type TokenMetadata interface {
 	GetSymbol() string
 
 	// Returns the decimals places of the token.
-	GetDecimals() uint
+	GetDecimals() int
 }

--- a/examples/gno.land/p/demo/grc/grc1155/basic_grc1155_token.gno
+++ b/examples/gno.land/p/demo/grc/grc1155/basic_grc1155_token.gno
@@ -1,6 +1,7 @@
 package grc1155
 
 import (
+	"math/overflow"
 	"std"
 
 	"gno.land/p/demo/avl"
@@ -9,7 +10,7 @@ import (
 
 type basicGRC1155Token struct {
 	uri               string
-	balances          avl.Tree // "TokenId:Address" -> uint64
+	balances          avl.Tree // "TokenId:Address" -> int64
 	operatorApprovals avl.Tree // "OwnerAddress:OperatorAddress" -> bool
 }
 
@@ -27,7 +28,7 @@ func NewBasicGRC1155Token(uri string) *basicGRC1155Token {
 func (s *basicGRC1155Token) Uri() string { return s.uri }
 
 // BalanceOf returns the input address's balance of the token type requested
-func (s *basicGRC1155Token) BalanceOf(addr std.Address, tid TokenID) (uint64, error) {
+func (s *basicGRC1155Token) BalanceOf(addr std.Address, tid TokenID) (int64, error) {
 	if !isValidAddress(addr) {
 		return 0, ErrInvalidAddress
 	}
@@ -38,16 +39,16 @@ func (s *basicGRC1155Token) BalanceOf(addr std.Address, tid TokenID) (uint64, er
 		return 0, nil
 	}
 
-	return balance.(uint64), nil
+	return balance.(int64), nil
 }
 
 // BalanceOfBatch returns the balance of multiple account/token pairs
-func (s *basicGRC1155Token) BalanceOfBatch(owners []std.Address, batch []TokenID) ([]uint64, error) {
+func (s *basicGRC1155Token) BalanceOfBatch(owners []std.Address, batch []TokenID) ([]int64, error) {
 	if len(owners) != len(batch) {
 		return nil, ErrMismatchLength
 	}
 
-	balanceOfBatch := make([]uint64, len(owners))
+	balanceOfBatch := make([]int64, len(owners))
 
 	for i := 0; i < len(owners); i++ {
 		balanceOfBatch[i], _ = s.BalanceOf(owners[i], batch[i])
@@ -84,13 +85,13 @@ func (s *basicGRC1155Token) IsApprovedForAll(owner, operator std.Address) bool {
 // Safely transfers `tokenId` token from `from` to `to`, checking that
 // contract recipients are aware of the GRC1155 protocol to prevent
 // tokens from being forever locked.
-func (s *basicGRC1155Token) SafeTransferFrom(from, to std.Address, tid TokenID, amount uint64) error {
+func (s *basicGRC1155Token) SafeTransferFrom(from, to std.Address, tid TokenID, amount int64) error {
 	caller := std.OriginCaller()
 	if !s.IsApprovedForAll(caller, from) {
 		return ErrCallerIsNotOwnerOrApproved
 	}
 
-	err := s.safeBatchTransferFrom(from, to, []TokenID{tid}, []uint64{amount})
+	err := s.safeBatchTransferFrom(from, to, []TokenID{tid}, []int64{amount})
 	if err != nil {
 		return err
 	}
@@ -107,7 +108,7 @@ func (s *basicGRC1155Token) SafeTransferFrom(from, to std.Address, tid TokenID, 
 // Safely transfers a `batch` of tokens from `from` to `to`, checking that
 // contract recipients are aware of the GRC1155 protocol to prevent
 // tokens from being forever locked.
-func (s *basicGRC1155Token) SafeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) SafeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []int64) error {
 	caller := std.OriginCaller()
 	if !s.IsApprovedForAll(caller, from) {
 		return ErrCallerIsNotOwnerOrApproved
@@ -129,10 +130,10 @@ func (s *basicGRC1155Token) SafeBatchTransferFrom(from, to std.Address, batch []
 
 // Creates `amount` tokens of token type `id`, and assigns them to `to`. Also checks that
 // contract recipients are using GRC1155 protocol.
-func (s *basicGRC1155Token) SafeMint(to std.Address, tid TokenID, amount uint64) error {
+func (s *basicGRC1155Token) SafeMint(to std.Address, tid TokenID, amount int64) error {
 	caller := std.OriginCaller()
 
-	err := s.mintBatch(to, []TokenID{tid}, []uint64{amount})
+	err := s.mintBatch(to, []TokenID{tid}, []int64{amount})
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func (s *basicGRC1155Token) SafeMint(to std.Address, tid TokenID, amount uint64)
 
 // Batch version of `SafeMint()`. Also checks that
 // contract recipients are using GRC1155 protocol.
-func (s *basicGRC1155Token) SafeBatchMint(to std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) SafeBatchMint(to std.Address, batch []TokenID, amounts []int64) error {
 	caller := std.OriginCaller()
 
 	err := s.mintBatch(to, batch, amounts)
@@ -166,10 +167,10 @@ func (s *basicGRC1155Token) SafeBatchMint(to std.Address, batch []TokenID, amoun
 }
 
 // Destroys `amount` tokens of token type `id` from `from`.
-func (s *basicGRC1155Token) Burn(from std.Address, tid TokenID, amount uint64) error {
+func (s *basicGRC1155Token) Burn(from std.Address, tid TokenID, amount int64) error {
 	caller := std.OriginCaller()
 
-	err := s.burnBatch(from, []TokenID{tid}, []uint64{amount})
+	err := s.burnBatch(from, []TokenID{tid}, []int64{amount})
 	if err != nil {
 		return err
 	}
@@ -180,7 +181,7 @@ func (s *basicGRC1155Token) Burn(from std.Address, tid TokenID, amount uint64) e
 }
 
 // Batch version of `Burn()`
-func (s *basicGRC1155Token) BatchBurn(from std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) BatchBurn(from std.Address, batch []TokenID, amounts []int64) error {
 	caller := std.OriginCaller()
 
 	err := s.burnBatch(from, batch, amounts)
@@ -214,7 +215,7 @@ func (s *basicGRC1155Token) setApprovalForAll(owner, operator std.Address, appro
 }
 
 // Helper for SafeTransferFrom() and SafeBatchTransferFrom()
-func (s *basicGRC1155Token) safeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) safeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []int64) error {
 	if len(batch) != len(amounts) {
 		return ErrMismatchLength
 	}
@@ -223,6 +224,11 @@ func (s *basicGRC1155Token) safeBatchTransferFrom(from, to std.Address, batch []
 	}
 	if from == to {
 		return ErrCannotTransferToSelf
+	}
+	for _, amount := range amounts {
+		if amount < 0 {
+			return ErrInvalidAmount
+		}
 	}
 
 	caller := std.OriginCaller()
@@ -243,8 +249,8 @@ func (s *basicGRC1155Token) safeBatchTransferFrom(from, to std.Address, batch []
 			return err
 		}
 
-		fromBalance -= amount
-		toBalance += amount
+		fromBalance = overflow.Sub64p(fromBalance, amount)
+		toBalance = overflow.Add64p(toBalance, amount)
 		fromBalanceKey := string(tid) + ":" + from.String()
 		toBalanceKey := string(tid) + ":" + to.String()
 		s.balances.Set(fromBalanceKey, fromBalance)
@@ -257,12 +263,17 @@ func (s *basicGRC1155Token) safeBatchTransferFrom(from, to std.Address, batch []
 }
 
 // Helper for SafeMint() and SafeBatchMint()
-func (s *basicGRC1155Token) mintBatch(to std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) mintBatch(to std.Address, batch []TokenID, amounts []int64) error {
 	if len(batch) != len(amounts) {
 		return ErrMismatchLength
 	}
 	if !isValidAddress(to) {
 		return ErrInvalidAddress
+	}
+	for _, amount := range amounts {
+		if amount < 0 {
+			return ErrInvalidAmount
+		}
 	}
 
 	caller := std.OriginCaller()
@@ -275,7 +286,7 @@ func (s *basicGRC1155Token) mintBatch(to std.Address, batch []TokenID, amounts [
 		if err != nil {
 			return err
 		}
-		toBalance += amount
+		toBalance = overflow.Add64p(toBalance, amount)
 		toBalanceKey := string(tid) + ":" + to.String()
 		s.balances.Set(toBalanceKey, toBalance)
 	}
@@ -286,12 +297,17 @@ func (s *basicGRC1155Token) mintBatch(to std.Address, batch []TokenID, amounts [
 }
 
 // Helper for Burn() and BurnBatch()
-func (s *basicGRC1155Token) burnBatch(from std.Address, batch []TokenID, amounts []uint64) error {
+func (s *basicGRC1155Token) burnBatch(from std.Address, batch []TokenID, amounts []int64) error {
 	if len(batch) != len(amounts) {
 		return ErrMismatchLength
 	}
 	if !isValidAddress(from) {
 		return ErrInvalidAddress
+	}
+	for _, amount := range amounts {
+		if amount < 0 {
+			return ErrInvalidAmount
+		}
 	}
 
 	caller := std.OriginCaller()
@@ -307,7 +323,7 @@ func (s *basicGRC1155Token) burnBatch(from std.Address, batch []TokenID, amounts
 		if fromBalance < amount {
 			return ErrBurnAmountExceedsBalance
 		}
-		fromBalance -= amount
+		fromBalance = overflow.Sub64p(fromBalance, amount)
 		fromBalanceKey := string(tid) + ":" + from.String()
 		s.balances.Set(fromBalanceKey, fromBalance)
 	}
@@ -322,20 +338,20 @@ func (s *basicGRC1155Token) setUri(newUri string) {
 	emit(&UpdateURIEvent{newUri})
 }
 
-func (s *basicGRC1155Token) beforeTokenTransfer(operator, from, to std.Address, batch []TokenID, amounts []uint64) {
+func (s *basicGRC1155Token) beforeTokenTransfer(operator, from, to std.Address, batch []TokenID, amounts []int64) {
 	// TODO: Implementation
 }
 
-func (s *basicGRC1155Token) afterTokenTransfer(operator, from, to std.Address, batch []TokenID, amounts []uint64) {
+func (s *basicGRC1155Token) afterTokenTransfer(operator, from, to std.Address, batch []TokenID, amounts []int64) {
 	// TODO: Implementation
 }
 
-func (s *basicGRC1155Token) doSafeTransferAcceptanceCheck(operator, from, to std.Address, tid TokenID, amount uint64) bool {
+func (s *basicGRC1155Token) doSafeTransferAcceptanceCheck(operator, from, to std.Address, tid TokenID, amount int64) bool {
 	// TODO: Implementation
 	return true
 }
 
-func (s *basicGRC1155Token) doSafeBatchTransferAcceptanceCheck(operator, from, to std.Address, batch []TokenID, amounts []uint64) bool {
+func (s *basicGRC1155Token) doSafeBatchTransferAcceptanceCheck(operator, from, to std.Address, batch []TokenID, amounts []int64) bool {
 	// TODO: Implementation
 	return true
 }

--- a/examples/gno.land/p/demo/grc/grc1155/basic_grc1155_token_test.gno
+++ b/examples/gno.land/p/demo/grc/grc1155/basic_grc1155_token_test.gno
@@ -36,10 +36,10 @@ func TestBalanceOf(t *testing.T) {
 
 	balanceAddr1OfToken1, err := dummy.BalanceOf(addr1, tid1)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(0), balanceAddr1OfToken1)
+	uassert.Equal(t, int64(0), balanceAddr1OfToken1)
 
-	dummy.mintBatch(addr1, []TokenID{tid1, tid2}, []uint64{10, 100})
-	dummy.mintBatch(addr2, []TokenID{tid1}, []uint64{20})
+	dummy.mintBatch(addr1, []TokenID{tid1, tid2}, []int64{10, 100})
+	dummy.mintBatch(addr2, []TokenID{tid1}, []int64{20})
 
 	balanceAddr1OfToken1, err = dummy.BalanceOf(addr1, tid1)
 	uassert.NoError(t, err, "should not result in error")
@@ -48,9 +48,9 @@ func TestBalanceOf(t *testing.T) {
 	balanceAddr2OfToken1, err := dummy.BalanceOf(addr2, tid1)
 	uassert.NoError(t, err, "should not result in error")
 
-	uassert.Equal(t, uint64(10), balanceAddr1OfToken1)
-	uassert.Equal(t, uint64(100), balanceAddr1OfToken2)
-	uassert.Equal(t, uint64(20), balanceAddr2OfToken1)
+	uassert.Equal(t, int64(10), balanceAddr1OfToken1)
+	uassert.Equal(t, int64(100), balanceAddr1OfToken2)
+	uassert.Equal(t, int64(20), balanceAddr2OfToken1)
 }
 
 func TestBalanceOfBatch(t *testing.T) {
@@ -65,16 +65,16 @@ func TestBalanceOfBatch(t *testing.T) {
 
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{addr1, addr2}, []TokenID{tid1, tid2})
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(0), balanceBatch[0])
-	uassert.Equal(t, uint64(0), balanceBatch[1])
+	uassert.Equal(t, int64(0), balanceBatch[0])
+	uassert.Equal(t, int64(0), balanceBatch[1])
 
-	dummy.mintBatch(addr1, []TokenID{tid1}, []uint64{10})
-	dummy.mintBatch(addr2, []TokenID{tid2}, []uint64{20})
+	dummy.mintBatch(addr1, []TokenID{tid1}, []int64{10})
+	dummy.mintBatch(addr2, []TokenID{tid2}, []int64{20})
 
 	balanceBatch, err = dummy.BalanceOfBatch([]std.Address{addr1, addr2}, []TokenID{tid1, tid2})
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(10), balanceBatch[0])
-	uassert.Equal(t, uint64(20), balanceBatch[1])
+	uassert.Equal(t, int64(10), balanceBatch[0])
+	uassert.Equal(t, int64(20), balanceBatch[1])
 }
 
 func TestIsApprovedForAll(t *testing.T) {
@@ -126,7 +126,7 @@ func TestSafeTransferFrom(t *testing.T) {
 
 	tid := TokenID("1")
 
-	dummy.mintBatch(caller, []TokenID{tid}, []uint64{100})
+	dummy.mintBatch(caller, []TokenID{tid}, []int64{100})
 
 	err := dummy.SafeTransferFrom(caller, zeroAddress, tid, 10)
 	uassert.Error(t, err, "should result in error")
@@ -140,12 +140,12 @@ func TestSafeTransferFrom(t *testing.T) {
 	// Check balance of caller after transfer
 	balanceOfCaller, err := dummy.BalanceOf(caller, tid)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(40), balanceOfCaller)
+	uassert.Equal(t, int64(40), balanceOfCaller)
 
 	// Check balance of addr after transfer
 	balanceOfAddr, err := dummy.BalanceOf(addr, tid)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(60), balanceOfAddr)
+	uassert.Equal(t, int64(60), balanceOfAddr)
 }
 
 func TestSafeBatchTransferFrom(t *testing.T) {
@@ -161,31 +161,31 @@ func TestSafeBatchTransferFrom(t *testing.T) {
 	tid1 := TokenID("1")
 	tid2 := TokenID("2")
 
-	dummy.mintBatch(caller, []TokenID{tid1, tid2}, []uint64{10, 100})
+	dummy.mintBatch(caller, []TokenID{tid1, tid2}, []int64{10, 100})
 
-	err := dummy.SafeBatchTransferFrom(caller, zeroAddress, []TokenID{tid1, tid2}, []uint64{4, 60})
+	err := dummy.SafeBatchTransferFrom(caller, zeroAddress, []TokenID{tid1, tid2}, []int64{4, 60})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1, tid2}, []uint64{40, 60})
+	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1, tid2}, []int64{40, 60})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1}, []uint64{40, 60})
+	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1}, []int64{40, 60})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1, tid2}, []uint64{4, 60})
+	err = dummy.SafeBatchTransferFrom(caller, addr, []TokenID{tid1, tid2}, []int64{4, 60})
 	uassert.NoError(t, err, "should not result in error")
 
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{caller, addr, caller, addr}, []TokenID{tid1, tid1, tid2, tid2})
 	uassert.NoError(t, err, "should not result in error")
 
 	// Check token1's balance of caller after batch transfer
-	uassert.Equal(t, uint64(6), balanceBatch[0])
+	uassert.Equal(t, int64(6), balanceBatch[0])
 
 	// Check token1's balance of addr after batch transfer
-	uassert.Equal(t, uint64(4), balanceBatch[1])
+	uassert.Equal(t, int64(4), balanceBatch[1])
 
 	// Check token2's balance of caller after batch transfer
-	uassert.Equal(t, uint64(40), balanceBatch[2])
+	uassert.Equal(t, int64(40), balanceBatch[2])
 
 	// Check token2's balance of addr after batch transfer
-	uassert.Equal(t, uint64(60), balanceBatch[3])
+	uassert.Equal(t, int64(60), balanceBatch[3])
 }
 
 func TestSafeMint(t *testing.T) {
@@ -210,11 +210,11 @@ func TestSafeMint(t *testing.T) {
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{addr1, addr2, addr1}, []TokenID{tid1, tid1, tid2})
 	uassert.NoError(t, err, "should not result in error")
 	// Check token1's balance of addr1 after mint
-	uassert.Equal(t, uint64(100), balanceBatch[0])
+	uassert.Equal(t, int64(100), balanceBatch[0])
 	// Check token1's balance of addr2 after mint
-	uassert.Equal(t, uint64(50), balanceBatch[1])
+	uassert.Equal(t, int64(50), balanceBatch[1])
 	// Check token2's balance of addr1 after mint
-	uassert.Equal(t, uint64(200), balanceBatch[2])
+	uassert.Equal(t, int64(200), balanceBatch[2])
 }
 
 func TestSafeBatchMint(t *testing.T) {
@@ -227,23 +227,23 @@ func TestSafeBatchMint(t *testing.T) {
 	tid1 := TokenID("1")
 	tid2 := TokenID("2")
 
-	err := dummy.SafeBatchMint(zeroAddress, []TokenID{tid1, tid2}, []uint64{100, 200})
+	err := dummy.SafeBatchMint(zeroAddress, []TokenID{tid1, tid2}, []int64{100, 200})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.SafeBatchMint(addr1, []TokenID{tid1, tid2}, []uint64{100, 200})
+	err = dummy.SafeBatchMint(addr1, []TokenID{tid1, tid2}, []int64{100, 200})
 	uassert.NoError(t, err, "should not result in error")
-	err = dummy.SafeBatchMint(addr2, []TokenID{tid1, tid2}, []uint64{300, 400})
+	err = dummy.SafeBatchMint(addr2, []TokenID{tid1, tid2}, []int64{300, 400})
 	uassert.NoError(t, err, "should not result in error")
 
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{addr1, addr2, addr1, addr2}, []TokenID{tid1, tid1, tid2, tid2})
 	uassert.NoError(t, err, "should not result in error")
 	// Check token1's balance of addr1 after batch mint
-	uassert.Equal(t, uint64(100), balanceBatch[0])
+	uassert.Equal(t, int64(100), balanceBatch[0])
 	// Check token1's balance of addr2 after batch mint
-	uassert.Equal(t, uint64(300), balanceBatch[1])
+	uassert.Equal(t, int64(300), balanceBatch[1])
 	// Check token2's balance of addr1 after batch mint
-	uassert.Equal(t, uint64(200), balanceBatch[2])
+	uassert.Equal(t, int64(200), balanceBatch[2])
 	// Check token2's balance of addr2 after batch mint
-	uassert.Equal(t, uint64(400), balanceBatch[3])
+	uassert.Equal(t, int64(400), balanceBatch[3])
 }
 
 func TestBurn(t *testing.T) {
@@ -255,22 +255,22 @@ func TestBurn(t *testing.T) {
 	tid1 := TokenID("1")
 	tid2 := TokenID("2")
 
-	dummy.mintBatch(addr, []TokenID{tid1, tid2}, []uint64{100, 200})
-	err := dummy.Burn(zeroAddress, tid1, uint64(60))
+	dummy.mintBatch(addr, []TokenID{tid1, tid2}, []int64{100, 200})
+	err := dummy.Burn(zeroAddress, tid1, int64(60))
 	uassert.Error(t, err, "should result in error")
-	err = dummy.Burn(addr, tid1, uint64(160))
+	err = dummy.Burn(addr, tid1, int64(160))
 	uassert.Error(t, err, "should result in error")
-	err = dummy.Burn(addr, tid1, uint64(60))
+	err = dummy.Burn(addr, tid1, int64(60))
 	uassert.NoError(t, err, "should not result in error")
-	err = dummy.Burn(addr, tid2, uint64(60))
+	err = dummy.Burn(addr, tid2, int64(60))
 	uassert.NoError(t, err, "should not result in error")
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{addr, addr}, []TokenID{tid1, tid2})
 	uassert.NoError(t, err, "should not result in error")
 
 	// Check token1's balance of addr after burn
-	uassert.Equal(t, uint64(40), balanceBatch[0])
+	uassert.Equal(t, int64(40), balanceBatch[0])
 	// Check token2's balance of addr after burn
-	uassert.Equal(t, uint64(140), balanceBatch[1])
+	uassert.Equal(t, int64(140), balanceBatch[1])
 }
 
 func TestBatchBurn(t *testing.T) {
@@ -282,18 +282,18 @@ func TestBatchBurn(t *testing.T) {
 	tid1 := TokenID("1")
 	tid2 := TokenID("2")
 
-	dummy.mintBatch(addr, []TokenID{tid1, tid2}, []uint64{100, 200})
-	err := dummy.BatchBurn(zeroAddress, []TokenID{tid1, tid2}, []uint64{60, 60})
+	dummy.mintBatch(addr, []TokenID{tid1, tid2}, []int64{100, 200})
+	err := dummy.BatchBurn(zeroAddress, []TokenID{tid1, tid2}, []int64{60, 60})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.BatchBurn(addr, []TokenID{tid1, tid2}, []uint64{160, 60})
+	err = dummy.BatchBurn(addr, []TokenID{tid1, tid2}, []int64{160, 60})
 	uassert.Error(t, err, "should result in error")
-	err = dummy.BatchBurn(addr, []TokenID{tid1, tid2}, []uint64{60, 60})
+	err = dummy.BatchBurn(addr, []TokenID{tid1, tid2}, []int64{60, 60})
 	uassert.NoError(t, err, "should not result in error")
 	balanceBatch, err := dummy.BalanceOfBatch([]std.Address{addr, addr}, []TokenID{tid1, tid2})
 	uassert.NoError(t, err, "should not result in error")
 
 	// Check token1's balance of addr after batch burn
-	uassert.Equal(t, uint64(40), balanceBatch[0])
+	uassert.Equal(t, int64(40), balanceBatch[0])
 	// Check token2's balance of addr after batch burn
-	uassert.Equal(t, uint64(140), balanceBatch[1])
+	uassert.Equal(t, int64(140), balanceBatch[1])
 }

--- a/examples/gno.land/p/demo/grc/grc1155/errors.gno
+++ b/examples/gno.land/p/demo/grc/grc1155/errors.gno
@@ -10,4 +10,5 @@ var (
 	ErrCallerIsNotOwnerOrApproved             = errors.New("caller is not token owner or approved")
 	ErrInsufficientBalance                    = errors.New("insufficient balance for transfer")
 	ErrBurnAmountExceedsBalance               = errors.New("burn amount exceeds balance")
+	ErrInvalidAmount                          = errors.New("invalid amount")
 )

--- a/examples/gno.land/p/demo/grc/grc1155/igrc1155.gno
+++ b/examples/gno.land/p/demo/grc/grc1155/igrc1155.gno
@@ -3,10 +3,10 @@ package grc1155
 import "std"
 
 type IGRC1155 interface {
-	SafeTransferFrom(from, to std.Address, tid TokenID, amount uint64) error
-	SafeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []uint64) error
-	BalanceOf(owner std.Address, tid TokenID) (uint64, error)
-	BalanceOfBatch(owners []std.Address, batch []TokenID) ([]uint64, error)
+	SafeTransferFrom(from, to std.Address, tid TokenID, amount int64) error
+	SafeBatchTransferFrom(from, to std.Address, batch []TokenID, amounts []int64) error
+	BalanceOf(owner std.Address, tid TokenID) (int64, error)
+	BalanceOfBatch(owners []std.Address, batch []TokenID) ([]int64, error)
 	SetApprovalForAll(operator std.Address, approved bool) error
 	IsApprovedForAll(owner, operator std.Address) bool
 }
@@ -18,7 +18,7 @@ type TransferSingleEvent struct {
 	From     std.Address
 	To       std.Address
 	TokenID  TokenID
-	Amount   uint64
+	Amount   int64
 }
 
 type TransferBatchEvent struct {
@@ -26,7 +26,7 @@ type TransferBatchEvent struct {
 	From     std.Address
 	To       std.Address
 	Batch    []TokenID
-	Amounts  []uint64
+	Amounts  []int64
 }
 
 type ApprovalForAllEvent struct {

--- a/examples/gno.land/p/demo/grc/grc20/tellers.gno
+++ b/examples/gno.land/p/demo/grc/grc20/tellers.gno
@@ -101,7 +101,7 @@ func (ledger *PrivateLedger) ImpersonateTeller(addr std.Address) Teller {
 // generic tellers methods.
 //
 
-func (ft *fnTeller) Transfer(to std.Address, amount uint64) error {
+func (ft *fnTeller) Transfer(to std.Address, amount int64) error {
 	if ft.accountFn == nil {
 		return ErrReadonly
 	}
@@ -109,7 +109,7 @@ func (ft *fnTeller) Transfer(to std.Address, amount uint64) error {
 	return ft.Token.ledger.Transfer(caller, to, amount)
 }
 
-func (ft *fnTeller) Approve(spender std.Address, amount uint64) error {
+func (ft *fnTeller) Approve(spender std.Address, amount int64) error {
 	if ft.accountFn == nil {
 		return ErrReadonly
 	}
@@ -117,7 +117,7 @@ func (ft *fnTeller) Approve(spender std.Address, amount uint64) error {
 	return ft.Token.ledger.Approve(caller, spender, amount)
 }
 
-func (ft *fnTeller) TransferFrom(owner, to std.Address, amount uint64) error {
+func (ft *fnTeller) TransferFrom(owner, to std.Address, amount int64) error {
 	if ft.accountFn == nil {
 		return ErrReadonly
 	}

--- a/examples/gno.land/p/demo/grc/grc20/tellers_test.gno
+++ b/examples/gno.land/p/demo/grc/grc20/tellers_test.gno
@@ -26,7 +26,7 @@ func TestTeller(t *testing.T) {
 
 	token, ledger := NewToken("Dummy", "DUMMY", 6)
 
-	checkBalances := func(aliceEB, bobEB, carlEB uint64) {
+	checkBalances := func(aliceEB, bobEB, carlEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceEB, bobEB, carlEB)
 		aliceGB := token.BalanceOf(alice)
@@ -35,7 +35,7 @@ func TestTeller(t *testing.T) {
 		got := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceGB, bobGB, carlGB)
 		uassert.Equal(t, got, exp, "invalid balances")
 	}
-	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB uint64) {
+	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("ab=%d ac=%d ba=%d bc=%d ca=%d cb=%s", abEB, acEB, baEB, bcEB, caEB, cbEB)
 		abGB := token.Allowance(alice, bob)
@@ -89,7 +89,7 @@ func TestCallerTeller(t *testing.T) {
 	token, ledger := NewToken("Dummy", "DUMMY", 6)
 	teller := token.CallerTeller()
 
-	checkBalances := func(aliceEB, bobEB, carlEB uint64) {
+	checkBalances := func(aliceEB, bobEB, carlEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceEB, bobEB, carlEB)
 		aliceGB := token.BalanceOf(alice)
@@ -98,7 +98,7 @@ func TestCallerTeller(t *testing.T) {
 		got := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceGB, bobGB, carlGB)
 		uassert.Equal(t, got, exp, "invalid balances")
 	}
-	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB uint64) {
+	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("ab=%d ac=%d ba=%d bc=%d ca=%d cb=%s", abEB, acEB, baEB, bcEB, caEB, cbEB)
 		abGB := token.Allowance(alice, bob)

--- a/examples/gno.land/p/demo/grc/grc20/token.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token.gno
@@ -1,18 +1,18 @@
 package grc20
 
 import (
+	"math"
+	"math/overflow"
 	"std"
 	"strconv"
 
 	"gno.land/p/demo/ufmt"
 )
 
-const MaxUint64 = uint64(1<<63 - 1)
-
 // NewToken creates a new Token.
 // It returns a pointer to the Token and a pointer to the Ledger.
 // Expected usage: Token, admin := NewToken("Dummy", "DUMMY", 4)
-func NewToken(name, symbol string, decimals uint) (*Token, *PrivateLedger) {
+func NewToken(name, symbol string, decimals int) (*Token, *PrivateLedger) {
 	if name == "" {
 		panic("name should not be empty")
 	}
@@ -39,21 +39,21 @@ func (tok Token) GetName() string { return tok.name }
 func (tok Token) GetSymbol() string { return tok.symbol }
 
 // GetDecimals returns the number of decimals used to get the token's precision.
-func (tok Token) GetDecimals() uint { return tok.decimals }
+func (tok Token) GetDecimals() int { return tok.decimals }
 
 // TotalSupply returns the total supply of the token.
-func (tok Token) TotalSupply() uint64 { return tok.ledger.totalSupply }
+func (tok Token) TotalSupply() int64 { return tok.ledger.totalSupply }
 
 // KnownAccounts returns the number of known accounts in the bank.
 func (tok Token) KnownAccounts() int { return tok.ledger.balances.Size() }
 
 // BalanceOf returns the balance of the specified address.
-func (tok Token) BalanceOf(address std.Address) uint64 {
+func (tok Token) BalanceOf(address std.Address) int64 {
 	return tok.ledger.balanceOf(address)
 }
 
 // Allowance returns the allowance of the specified owner and spender.
-func (tok Token) Allowance(owner, spender std.Address) uint64 {
+func (tok Token) Allowance(owner, spender std.Address) int64 {
 	return tok.ledger.allowance(owner, spender)
 }
 
@@ -75,12 +75,15 @@ func (tok *Token) Getter() TokenGetter {
 }
 
 // SpendAllowance decreases the allowance of the specified owner and spender.
-func (led *PrivateLedger) SpendAllowance(owner, spender std.Address, amount uint64) error {
+func (led *PrivateLedger) SpendAllowance(owner, spender std.Address, amount int64) error {
 	if !owner.IsValid() {
 		return ErrInvalidAddress
 	}
 	if !spender.IsValid() {
 		return ErrInvalidAddress
+	}
+	if amount < 0 {
+		return ErrInvalidAmount
 	}
 
 	currentAllowance := led.allowance(owner, spender)
@@ -89,7 +92,7 @@ func (led *PrivateLedger) SpendAllowance(owner, spender std.Address, amount uint
 	}
 
 	key := allowanceKey(owner, spender)
-	newAllowance := currentAllowance - amount
+	newAllowance := overflow.Sub64p(currentAllowance, amount)
 
 	if newAllowance == 0 {
 		led.allowances.Remove(key)
@@ -101,7 +104,7 @@ func (led *PrivateLedger) SpendAllowance(owner, spender std.Address, amount uint
 }
 
 // Transfer transfers tokens from the specified from address to the specified to address.
-func (led *PrivateLedger) Transfer(from, to std.Address, amount uint64) error {
+func (led *PrivateLedger) Transfer(from, to std.Address, amount int64) error {
 	if !from.IsValid() {
 		return ErrInvalidAddress
 	}
@@ -110,6 +113,9 @@ func (led *PrivateLedger) Transfer(from, to std.Address, amount uint64) error {
 	}
 	if from == to {
 		return ErrCannotTransferToSelf
+	}
+	if amount < 0 {
+		return ErrInvalidAmount
 	}
 
 	var (
@@ -122,8 +128,8 @@ func (led *PrivateLedger) Transfer(from, to std.Address, amount uint64) error {
 	}
 
 	var (
-		newToBalance   = toBalance + amount
-		newFromBalance = fromBalance - amount
+		newToBalance   = overflow.Add64p(toBalance, amount)
+		newFromBalance = overflow.Sub64p(fromBalance, amount)
 	)
 
 	led.balances.Set(string(to), newToBalance)
@@ -141,7 +147,10 @@ func (led *PrivateLedger) Transfer(from, to std.Address, amount uint64) error {
 
 // TransferFrom transfers tokens from the specified owner to the specified to address.
 // It first checks if the owner has sufficient balance and then decreases the allowance.
-func (led *PrivateLedger) TransferFrom(owner, spender, to std.Address, amount uint64) error {
+func (led *PrivateLedger) TransferFrom(owner, spender, to std.Address, amount int64) error {
+	if amount < 0 {
+		return ErrInvalidAmount
+	}
 	if led.balanceOf(owner) < amount {
 		return ErrInsufficientBalance
 	}
@@ -158,7 +167,7 @@ func (led *PrivateLedger) TransferFrom(owner, spender, to std.Address, amount ui
 
 	// decrease the allowance only when transfer is successful
 	key := allowanceKey(owner, spender)
-	newAllowance := currentAllowance - amount
+	newAllowance := overflow.Sub64p(currentAllowance, amount)
 
 	if newAllowance == 0 {
 		led.allowances.Remove(key)
@@ -170,9 +179,12 @@ func (led *PrivateLedger) TransferFrom(owner, spender, to std.Address, amount ui
 }
 
 // Approve sets the allowance of the specified owner and spender.
-func (led *PrivateLedger) Approve(owner, spender std.Address, amount uint64) error {
+func (led *PrivateLedger) Approve(owner, spender std.Address, amount int64) error {
 	if !owner.IsValid() || !spender.IsValid() {
 		return ErrInvalidAddress
+	}
+	if amount < 0 {
+		return ErrInvalidAmount
 	}
 
 	led.allowances.Set(allowanceKey(owner, spender), amount)
@@ -188,24 +200,22 @@ func (led *PrivateLedger) Approve(owner, spender std.Address, amount uint64) err
 }
 
 // Mint increases the total supply of the token and adds the specified amount to the specified address.
-func (led *PrivateLedger) Mint(address std.Address, amount uint64) error {
+func (led *PrivateLedger) Mint(address std.Address, amount int64) error {
 	if !address.IsValid() {
 		return ErrInvalidAddress
 	}
-
-	// limit totalSupply to MaxUint64
-	if led.totalSupply > MaxUint64 {
-		return ErrOverflow
+	if amount < 0 {
+		return ErrInvalidAmount
 	}
 
-	// limit amount to MaxUint64 - totalSupply
-	if amount > MaxUint64-led.totalSupply {
-		return ErrOverflow
+	// limit amount to MaxInt64 - totalSupply
+	if amount > overflow.Sub64p(math.MaxInt64, led.totalSupply) {
+		return ErrMintOverflow
 	}
 
 	led.totalSupply += amount
 	currentBalance := led.balanceOf(address)
-	newBalance := currentBalance + amount
+	newBalance := overflow.Add64p(currentBalance, amount)
 
 	led.balances.Set(string(address), newBalance)
 
@@ -220,9 +230,12 @@ func (led *PrivateLedger) Mint(address std.Address, amount uint64) error {
 }
 
 // Burn decreases the total supply of the token and subtracts the specified amount from the specified address.
-func (led *PrivateLedger) Burn(address std.Address, amount uint64) error {
+func (led *PrivateLedger) Burn(address std.Address, amount int64) error {
 	if !address.IsValid() {
 		return ErrInvalidAddress
+	}
+	if amount < 0 {
+		return ErrInvalidAmount
 	}
 
 	currentBalance := led.balanceOf(address)
@@ -230,8 +243,8 @@ func (led *PrivateLedger) Burn(address std.Address, amount uint64) error {
 		return ErrInsufficientBalance
 	}
 
-	led.totalSupply -= amount
-	newBalance := currentBalance - amount
+	led.totalSupply = overflow.Sub64p(led.totalSupply, amount)
+	newBalance := overflow.Sub64p(currentBalance, amount)
 
 	led.balances.Set(string(address), newBalance)
 
@@ -246,21 +259,21 @@ func (led *PrivateLedger) Burn(address std.Address, amount uint64) error {
 }
 
 // balanceOf returns the balance of the specified address.
-func (led PrivateLedger) balanceOf(address std.Address) uint64 {
+func (led PrivateLedger) balanceOf(address std.Address) int64 {
 	balance, found := led.balances.Get(address.String())
 	if !found {
 		return 0
 	}
-	return balance.(uint64)
+	return balance.(int64)
 }
 
 // allowance returns the allowance of the specified owner and spender.
-func (led PrivateLedger) allowance(owner, spender std.Address) uint64 {
+func (led PrivateLedger) allowance(owner, spender std.Address) int64 {
 	allowance, found := led.allowances.Get(allowanceKey(owner, spender))
 	if !found {
 		return 0
 	}
-	return allowance.(uint64)
+	return allowance.(int64)
 }
 
 // allowanceKey returns the key for the allowance of the specified owner and spender.

--- a/examples/gno.land/p/demo/grc/grc20/token_test.gno
+++ b/examples/gno.land/p/demo/grc/grc20/token_test.gno
@@ -1,6 +1,7 @@
 package grc20
 
 import (
+	"math"
 	"std"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestToken(t *testing.T) {
 
 	bank, adm := NewToken("Dummy", "DUMMY", 6)
 
-	checkBalances := func(aliceEB, bobEB, carlEB uint64) {
+	checkBalances := func(aliceEB, bobEB, carlEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceEB, bobEB, carlEB)
 		aliceGB := bank.BalanceOf(alice)
@@ -33,7 +34,7 @@ func TestToken(t *testing.T) {
 		got := ufmt.Sprintf("alice=%d bob=%d carl=%d", aliceGB, bobGB, carlGB)
 		uassert.Equal(t, got, exp, "invalid balances")
 	}
-	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB uint64) {
+	checkAllowances := func(abEB, acEB, baEB, bcEB, caEB, cbEB int64) {
 		t.Helper()
 		exp := ufmt.Sprintf("ab=%d ac=%d ba=%d bc=%d ca=%d cb=%s", abEB, acEB, baEB, bcEB, caEB, cbEB)
 		abGB := bank.Allowance(alice, bob)
@@ -79,17 +80,17 @@ func TestToken(t *testing.T) {
 	checkAllowances(200, 0, 0, 0, 0, 0)
 }
 
-func TestOverflow(t *testing.T) {
+func TestMintOverflow(t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	bob := testutils.TestAddress("bob")
 	tok, adm := NewToken("Dummy", "DUMMY", 6)
 
-	safeValue := uint64(1 << 62)
+	safeValue := int64(1 << 62)
 	urequire.NoError(t, adm.Mint(alice, safeValue))
 	urequire.Equal(t, tok.BalanceOf(alice), safeValue)
 
 	err := adm.Mint(bob, safeValue)
-	uassert.Error(t, err, "expected ErrOverflow")
+	uassert.Error(t, err, "expected ErrMintOverflow")
 }
 
 func TestTransferFromAtomicity(t *testing.T) {
@@ -104,14 +105,14 @@ func TestTransferFromAtomicity(t *testing.T) {
 	token, admin := NewToken("Test", "TEST", 6)
 
 	// owner has 100 tokens, spender has 50 allowance
-	initialBalance := uint64(100)
-	initialAllowance := uint64(50)
+	initialBalance := int64(100)
+	initialAllowance := int64(50)
 
 	urequire.NoError(t, admin.Mint(owner, initialBalance))
 	urequire.NoError(t, admin.Approve(owner, spender, initialAllowance))
 
 	// transfer to an invalid address to force a transfer failure
-	transferAmount := uint64(30)
+	transferAmount := int64(30)
 	err := admin.TransferFrom(owner, spender, invalidRecipient, transferAmount)
 	uassert.Error(t, err, "transfer should fail due to invalid address")
 
@@ -124,7 +125,7 @@ func TestTransferFromAtomicity(t *testing.T) {
 		"allowance should not be reduced when transfer fails")
 }
 
-func TestMintOverflow(t *testing.T) {
+func TestMintUntilOverflow(t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	bob := testutils.TestAddress("bob")
 	tok, adm := NewToken("Dummy", "DUMMY", 6)
@@ -132,42 +133,42 @@ func TestMintOverflow(t *testing.T) {
 	tests := []struct {
 		name           string
 		address        std.Address
-		amount         uint64
+		amount         int64
 		expectedError  error
-		expectedSupply uint64
+		expectedSupply int64
 		description    string
 	}{
 		{
-			name:           "mint value larger than MaxUint64",
+			name:           "mint negative value",
 			address:        alice,
-			amount:         MaxUint64 + 1000,
-			expectedError:  ErrOverflow,
+			amount:         -1,
+			expectedError:  ErrInvalidAmount,
 			expectedSupply: 0,
-			description:    "minting a value larger than MaxUint64 should fail with ErrOverflow",
+			description:    "minting a negative number should fail with ErrInvalidAmount",
 		},
 		{
-			name:           "mint safe value close to MaxUint64",
+			name:           "mint MaxInt64",
 			address:        alice,
-			amount:         MaxUint64 - 1000,
+			amount:         math.MaxInt64 - 1000,
 			expectedError:  nil,
-			expectedSupply: MaxUint64 - 1000,
-			description:    "minting a value close to MaxUint64 should succeed",
+			expectedSupply: math.MaxInt64 - 1000,
+			description:    "minting almost MaxInt64 should succeed",
 		},
 		{
 			name:           "mint small value",
 			address:        bob,
 			amount:         1000,
 			expectedError:  nil,
-			expectedSupply: MaxUint64,
-			description:    "minting a small value when close to MaxUint64 should succeed",
+			expectedSupply: math.MaxInt64,
+			description:    "minting a small value when close to MaxInt64 should succeed",
 		},
 		{
-			name:           "mint value that would exceed MaxUint64",
+			name:           "mint value that would exceed MaxInt64",
 			address:        bob,
 			amount:         1,
-			expectedError:  ErrOverflow,
-			expectedSupply: MaxUint64,
-			description:    "minting any value when at MaxUint64 should fail with ErrOverflow",
+			expectedError:  ErrMintOverflow,
+			expectedSupply: math.MaxInt64,
+			description:    "minting any value when at MaxInt64 should fail with ErrMintOverflow",
 		},
 	}
 
@@ -177,7 +178,7 @@ func TestMintOverflow(t *testing.T) {
 
 			if tt.expectedError != nil {
 				uassert.Error(t, err, tt.description)
-				if err.Error() != tt.expectedError.Error() {
+				if err == nil || err.Error() != tt.expectedError.Error() {
 					t.Errorf("expected error %v, got %v", tt.expectedError, err)
 				}
 			} else {

--- a/examples/gno.land/p/demo/grc/grc20/types.gno
+++ b/examples/gno.land/p/demo/grc/grc20/types.gno
@@ -18,22 +18,22 @@ type Teller interface {
 	exts.TokenMetadata
 
 	// Returns the amount of tokens in existence.
-	TotalSupply() uint64
+	TotalSupply() int64
 
 	// Returns the amount of tokens owned by `account`.
-	BalanceOf(account std.Address) uint64
+	BalanceOf(account std.Address) int64
 
 	// Moves `amount` tokens from the caller's account to `to`.
 	//
 	// Returns an error if the operation failed.
-	Transfer(to std.Address, amount uint64) error
+	Transfer(to std.Address, amount int64) error
 
 	// Returns the remaining number of tokens that `spender` will be
 	// allowed to spend on behalf of `owner` through {transferFrom}. This is
 	// zero by default.
 	//
 	// This value changes when {approve} or {transferFrom} are called.
-	Allowance(owner, spender std.Address) uint64
+	Allowance(owner, spender std.Address) int64
 
 	// Sets `amount` as the allowance of `spender` over the caller's tokens.
 	//
@@ -45,14 +45,14 @@ type Teller interface {
 	// this race condition is to first reduce the spender's allowance to 0
 	// and set the desired value afterwards:
 	// https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-	Approve(spender std.Address, amount uint64) error
+	Approve(spender std.Address, amount int64) error
 
 	// Moves `amount` tokens from `from` to `to` using the
 	// allowance mechanism. `amount` is then deducted from the caller's
 	// allowance.
 	//
 	// Returns an error if the operation failed.
-	TransferFrom(from, to std.Address, amount uint64) error
+	TransferFrom(from, to std.Address, amount int64) error
 }
 
 // Token represents a fungible token with a name, symbol, and a certain number
@@ -68,7 +68,7 @@ type Token struct {
 	// Symbol of the token (e.g., "DUMMY").
 	symbol string
 	// Number of decimal places used for the token's precision.
-	decimals uint
+	decimals int
 	// Pointer to the PrivateLedger that manages balances and allowances.
 	ledger *PrivateLedger
 }
@@ -89,10 +89,10 @@ type TokenGetter func() *Token
 // unrestricted access to all administrative functions.
 type PrivateLedger struct {
 	// Total supply of the token managed by this ledger.
-	totalSupply uint64
-	// std.Address -> uint64
+	totalSupply int64
+	// std.Address -> int64
 	balances avl.Tree
-	// owner.(std.Address)+":"+spender.(std.Address)) -> uint64
+	// owner.(std.Address)+":"+spender.(std.Address)) -> int64
 	allowances avl.Tree
 	// Pointer to the associated Token struct
 	token *Token
@@ -105,7 +105,8 @@ var (
 	ErrCannotTransferToSelf  = errors.New("cannot send transfer to self")
 	ErrReadonly              = errors.New("banker is readonly")
 	ErrRestrictedTokenOwner  = errors.New("restricted to bank owner")
-	ErrOverflow              = errors.New("Mint overflow")
+	ErrMintOverflow          = errors.New("mint overflow")
+	ErrInvalidAmount         = errors.New("invalid amount")
 )
 
 const (

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -32,12 +32,12 @@ func NewBasicNFT(name string, symbol string) *basicNFT {
 	}
 }
 
-func (s *basicNFT) Name() string       { return s.name }
-func (s *basicNFT) Symbol() string     { return s.symbol }
-func (s *basicNFT) TokenCount() uint64 { return uint64(s.owners.Size()) }
+func (s *basicNFT) Name() string      { return s.name }
+func (s *basicNFT) Symbol() string    { return s.symbol }
+func (s *basicNFT) TokenCount() int64 { return int64(s.owners.Size()) }
 
 // BalanceOf returns balance of input address
-func (s *basicNFT) BalanceOf(addr std.Address) (uint64, error) {
+func (s *basicNFT) BalanceOf(addr std.Address) (int64, error) {
 	if err := isValidAddress(addr); err != nil {
 		return 0, err
 	}
@@ -47,7 +47,7 @@ func (s *basicNFT) BalanceOf(addr std.Address) (uint64, error) {
 		return 0, nil
 	}
 
-	return balance.(uint64), nil
+	return balance.(int64), nil
 }
 
 // OwnerOf returns owner of input token id
@@ -375,11 +375,11 @@ func (s *basicNFT) exists(tid TokenID) bool {
 	return found
 }
 
-func (s *basicNFT) beforeTokenTransfer(from, to std.Address, firstTokenId TokenID, batchSize uint64) {
+func (s *basicNFT) beforeTokenTransfer(from, to std.Address, firstTokenId TokenID, batchSize int64) {
 	// TODO: Implementation
 }
 
-func (s *basicNFT) afterTokenTransfer(from, to std.Address, firstTokenId TokenID, batchSize uint64) {
+func (s *basicNFT) afterTokenTransfer(from, to std.Address, firstTokenId TokenID, batchSize int64) {
 	// TODO: Implementation
 }
 

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft.gno
@@ -1,6 +1,7 @@
 package grc721
 
 import (
+	"math/overflow"
 	"std"
 	"strconv"
 
@@ -220,7 +221,7 @@ func (s *basicNFT) Burn(tid TokenID) error {
 	if err != nil {
 		return err
 	}
-	balance -= 1
+	balance = overflow.Sub64p(balance, 1)
 	s.balances.Set(owner.String(), balance)
 	s.owners.Remove(string(tid))
 
@@ -297,8 +298,8 @@ func (s *basicNFT) transfer(from, to std.Address, tid TokenID) error {
 	if err != nil {
 		return err
 	}
-	fromBalance -= 1
-	toBalance += 1
+	fromBalance = overflow.Sub64p(fromBalance, 1)
+	toBalance = overflow.Add64p(toBalance, 1)
 	s.balances.Set(from.String(), fromBalance)
 	s.balances.Set(to.String(), toBalance)
 	s.owners.Set(string(tid), to)
@@ -336,7 +337,7 @@ func (s *basicNFT) mint(to std.Address, tid TokenID) error {
 	if err != nil {
 		return err
 	}
-	toBalance += 1
+	toBalance = overflow.Add64p(toBalance, 1)
 	s.balances.Set(to.String(), toBalance)
 	s.owners.Set(string(tid), to)
 

--- a/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
+++ b/examples/gno.land/p/demo/grc/grc721/basic_nft_test.gno
@@ -39,13 +39,13 @@ func TestTokenCount(t *testing.T) {
 	uassert.True(t, dummy != nil, "should not be nil")
 
 	count := dummy.TokenCount()
-	uassert.Equal(t, uint64(0), count)
+	uassert.Equal(t, int64(0), count)
 
 	dummy.mint("g1var589z07ppjsjd24ukm4uguzwdt0tw7g47cgm", TokenID("1"))
 	dummy.mint("g1var589z07ppjsjd24ukm4uguzwdt0tw7g47cgm", TokenID("2"))
 
 	count = dummy.TokenCount()
-	uassert.Equal(t, uint64(2), count)
+	uassert.Equal(t, int64(2), count)
 }
 
 func TestBalanceOf(t *testing.T) {
@@ -57,7 +57,7 @@ func TestBalanceOf(t *testing.T) {
 
 	balanceAddr1, err := dummy.BalanceOf(addr1)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(0), balanceAddr1)
+	uassert.Equal(t, int64(0), balanceAddr1)
 
 	dummy.mint(addr1, TokenID("1"))
 	dummy.mint(addr1, TokenID("2"))
@@ -69,8 +69,8 @@ func TestBalanceOf(t *testing.T) {
 	balanceAddr2, err := dummy.BalanceOf(addr2)
 	uassert.NoError(t, err, "should not result in error")
 
-	uassert.Equal(t, uint64(2), balanceAddr1)
-	uassert.Equal(t, uint64(1), balanceAddr2)
+	uassert.Equal(t, int64(2), balanceAddr1)
+	uassert.Equal(t, int64(1), balanceAddr2)
 }
 
 func TestOwnerOf(t *testing.T) {
@@ -184,12 +184,12 @@ func TestTransferFrom(t *testing.T) {
 	// Check balance of caller after transfer
 	balanceOfCaller, err := dummy.BalanceOf(caller)
 	uassert.NoError(t, err, "should result in error")
-	uassert.Equal(t, uint64(1), balanceOfCaller)
+	uassert.Equal(t, int64(1), balanceOfCaller)
 
 	// Check balance of addr after transfer
 	balanceOfAddr, err := dummy.BalanceOf(addr)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(1), balanceOfAddr)
+	uassert.Equal(t, int64(1), balanceOfAddr)
 
 	// Check Owner of transferred Token id
 	owner, err := dummy.OwnerOf(TokenID("1"))
@@ -216,12 +216,12 @@ func TestSafeTransferFrom(t *testing.T) {
 	// Check balance of caller after transfer
 	balanceOfCaller, err := dummy.BalanceOf(caller)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(1), balanceOfCaller)
+	uassert.Equal(t, int64(1), balanceOfCaller)
 
 	// Check balance of addr after transfer
 	balanceOfAddr, err := dummy.BalanceOf(addr)
 	uassert.NoError(t, err, "should not result in error")
-	uassert.Equal(t, uint64(1), balanceOfAddr)
+	uassert.Equal(t, int64(1), balanceOfAddr)
 
 	// Check Owner of transferred Token id
 	owner, err := dummy.OwnerOf(TokenID("1"))

--- a/examples/gno.land/p/demo/grc/grc721/grc721_metadata.gno
+++ b/examples/gno.land/p/demo/grc/grc721/grc721_metadata.gno
@@ -55,11 +55,11 @@ func (s *metadataNFT) Symbol() string {
 	return s.basicNFT.Symbol()
 }
 
-func (s *metadataNFT) TokenCount() uint64 {
+func (s *metadataNFT) TokenCount() int64 {
 	return s.basicNFT.TokenCount()
 }
 
-func (s *metadataNFT) BalanceOf(addr std.Address) (uint64, error) {
+func (s *metadataNFT) BalanceOf(addr std.Address) (int64, error) {
 	return s.basicNFT.BalanceOf(addr)
 }
 

--- a/examples/gno.land/p/demo/grc/grc721/grc721_royalty.gno
+++ b/examples/gno.land/p/demo/grc/grc721/grc721_royalty.gno
@@ -10,7 +10,7 @@ import (
 type royaltyNFT struct {
 	*metadataNFT                   // Embedding metadataNFT for NFT functionality
 	tokenRoyaltyInfo     *avl.Tree // AVL tree to store royalty information for each token
-	maxRoyaltyPercentage uint64    // maxRoyaltyPercentage represents the maximum royalty percentage that can be charged every sale
+	maxRoyaltyPercentage int64     // maxRoyaltyPercentage represents the maximum royalty percentage that can be charged every sale
 }
 
 // Ensure that royaltyNFT implements the IGRC2981 interface.
@@ -57,7 +57,7 @@ func (r *royaltyNFT) SetTokenRoyalty(tid TokenID, royaltyInfo RoyaltyInfo) error
 }
 
 // RoyaltyInfo returns the royalty information for the given token ID and sale price.
-func (r *royaltyNFT) RoyaltyInfo(tid TokenID, salePrice uint64) (std.Address, uint64, error) {
+func (r *royaltyNFT) RoyaltyInfo(tid TokenID, salePrice int64) (std.Address, int64, error) {
 	// Retrieve royalty information for the token
 	val, found := r.tokenRoyaltyInfo.Get(string(tid))
 	if !found {
@@ -72,7 +72,7 @@ func (r *royaltyNFT) RoyaltyInfo(tid TokenID, salePrice uint64) (std.Address, ui
 	return royaltyInfo.PaymentAddress, royaltyAmount, nil
 }
 
-func (r *royaltyNFT) calculateRoyaltyAmount(salePrice, percentage uint64) (uint64, error) {
+func (r *royaltyNFT) calculateRoyaltyAmount(salePrice, percentage int64) (int64, error) {
 	royaltyAmount := (salePrice * percentage) / 100
 	return royaltyAmount, nil
 }

--- a/examples/gno.land/p/demo/grc/grc721/grc721_royalty.gno
+++ b/examples/gno.land/p/demo/grc/grc721/grc721_royalty.gno
@@ -1,6 +1,7 @@
 package grc721
 
 import (
+	"math/overflow"
 	"std"
 
 	"gno.land/p/demo/avl"
@@ -73,6 +74,6 @@ func (r *royaltyNFT) RoyaltyInfo(tid TokenID, salePrice int64) (std.Address, int
 }
 
 func (r *royaltyNFT) calculateRoyaltyAmount(salePrice, percentage int64) (int64, error) {
-	royaltyAmount := (salePrice * percentage) / 100
+	royaltyAmount := overflow.Mul64p(salePrice, percentage) / 100
 	return royaltyAmount, nil
 }

--- a/examples/gno.land/p/demo/grc/grc721/grc721_royalty_test.gno
+++ b/examples/gno.land/p/demo/grc/grc721/grc721_royalty_test.gno
@@ -16,10 +16,10 @@ func TestSetTokenRoyalty(t *testing.T) {
 	addr2 := testutils.TestAddress("bob")
 
 	paymentAddress := testutils.TestAddress("john")
-	percentage := uint64(10) // 10%
+	percentage := int64(10) // 10%
 
-	salePrice := uint64(1000)
-	expectRoyaltyAmount := uint64(100)
+	salePrice := int64(1000)
+	expectRoyaltyAmount := int64(100)
 
 	testing.SetOriginCaller(addr1) // addr1
 
@@ -56,7 +56,7 @@ func TestSetTokenRoyalty(t *testing.T) {
 	// Test case: Invalid percentage
 	perr := dummy.SetTokenRoyalty(TokenID("5"), RoyaltyInfo{
 		PaymentAddress: paymentAddress,
-		Percentage:     uint64(200), // over maxRoyaltyPercentage
+		Percentage:     int64(200), // over maxRoyaltyPercentage
 	})
 	uassert.ErrorIs(t, perr, ErrInvalidRoyaltyPercentage)
 

--- a/examples/gno.land/p/demo/grc/grc721/igrc721.gno
+++ b/examples/gno.land/p/demo/grc/grc721/igrc721.gno
@@ -3,7 +3,7 @@ package grc721
 import "std"
 
 type IGRC721 interface {
-	BalanceOf(owner std.Address) (uint64, error)
+	BalanceOf(owner std.Address) (int64, error)
 	OwnerOf(tid TokenID) (std.Address, error)
 	SetTokenURI(tid TokenID, tURI TokenURI) (bool, error)
 	SafeTransferFrom(from, to std.Address, tid TokenID) error

--- a/examples/gno.land/p/demo/grc/grc721/igrc721_royalty.gno
+++ b/examples/gno.land/p/demo/grc/grc721/igrc721_royalty.gno
@@ -6,11 +6,11 @@ import "std"
 type IGRC2981 interface {
 	// RoyaltyInfo retrieves royalty information for a tokenID and salePrice.
 	// It returns the payment address, royalty amount, and an error if any.
-	RoyaltyInfo(tokenID TokenID, salePrice uint64) (std.Address, uint64, error)
+	RoyaltyInfo(tokenID TokenID, salePrice int64) (std.Address, int64, error)
 }
 
 // RoyaltyInfo represents royalty information for a token.
 type RoyaltyInfo struct {
 	PaymentAddress std.Address // PaymentAddress is the address where royalty payment should be sent.
-	Percentage     uint64      // Percentage is the royalty percentage. It indicates the percentage of royalty to be paid for each sale. For example : Percentage = 10 => 10%
+	Percentage     int64       // Percentage is the royalty percentage. It indicates the percentage of royalty to be paid for each sale. For example : Percentage = 10 => 10%
 }

--- a/examples/gno.land/p/demo/grc/grc777/dummy_test.gno
+++ b/examples/gno.land/p/demo/grc/grc777/dummy_test.gno
@@ -16,15 +16,15 @@ func TestInterface(t *testing.T) {
 
 func (impl *dummyImpl) GetName() string                        { panic("not implemented") }
 func (impl *dummyImpl) GetSymbol() string                      { panic("not implemented") }
-func (impl *dummyImpl) GetDecimals() uint                      { panic("not implemented") }
-func (impl *dummyImpl) Granularity() (granularity uint64)      { panic("not implemented") }
-func (impl *dummyImpl) TotalSupply() (supply uint64)           { panic("not implemented") }
-func (impl *dummyImpl) BalanceOf(address std.Address) uint64   { panic("not implemented") }
-func (impl *dummyImpl) Burn(amount uint64, data []byte)        { panic("not implemented") }
+func (impl *dummyImpl) GetDecimals() int                       { panic("not implemented") }
+func (impl *dummyImpl) Granularity() (granularity int64)       { panic("not implemented") }
+func (impl *dummyImpl) TotalSupply() (supply int64)            { panic("not implemented") }
+func (impl *dummyImpl) BalanceOf(address std.Address) int64    { panic("not implemented") }
+func (impl *dummyImpl) Burn(amount int64, data []byte)         { panic("not implemented") }
 func (impl *dummyImpl) AuthorizeOperator(operator std.Address) { panic("not implemented") }
 func (impl *dummyImpl) RevokeOperator(operators std.Address)   { panic("not implemented") }
 func (impl *dummyImpl) DefaultOperators() []std.Address        { panic("not implemented") }
-func (impl *dummyImpl) Send(recipient std.Address, amount uint64, data []byte) {
+func (impl *dummyImpl) Send(recipient std.Address, amount int64, data []byte) {
 	panic("not implemented")
 }
 
@@ -32,10 +32,10 @@ func (impl *dummyImpl) IsOperatorFor(operator, tokenHolder std.Address) bool {
 	panic("not implemented")
 }
 
-func (impl *dummyImpl) OperatorSend(sender, recipient std.Address, amount uint64, data, operatorData []byte) {
+func (impl *dummyImpl) OperatorSend(sender, recipient std.Address, amount int64, data, operatorData []byte) {
 	panic("not implemented")
 }
 
-func (impl *dummyImpl) OperatorBurn(account std.Address, amount uint64, data, operatorData []byte) {
+func (impl *dummyImpl) OperatorBurn(account std.Address, amount int64, data, operatorData []byte) {
 	panic("not implemented")
 }

--- a/examples/gno.land/p/demo/grc/grc777/igrc777.gno
+++ b/examples/gno.land/p/demo/grc/grc777/igrc777.gno
@@ -6,7 +6,7 @@ import (
 	"gno.land/p/demo/grc/exts"
 )
 
-// TODO: use big.Int or a custom uint64 instead of uint64
+// TODO: use big.Int or a custom int64 instead of int64
 
 type IGRC777 interface {
 	exts.TokenMetadata
@@ -16,13 +16,13 @@ type IGRC777 interface {
 	// have amounts that are a multiple of this number.
 	//
 	// For most token contracts, this value will equal 1.
-	Granularity() (granularity uint64)
+	Granularity() (granularity int64)
 
 	// Returns the amount of tokens in existence.
-	TotalSupply() (supply uint64)
+	TotalSupply() (supply int64)
 
 	// Returns the amount of tokens owned by an account (`owner`).
-	BalanceOf(address std.Address) uint64
+	BalanceOf(address std.Address) int64
 
 	// Moves `amount` tokens from the caller's account to `recipient`.
 	//
@@ -38,7 +38,7 @@ type IGRC777 interface {
 	// - `recipient` cannot be the zero address.
 	// - if `recipient` is a contract, it must implement the {IERC777Recipient}
 	// interface.
-	Send(recipient std.Address, amount uint64, data []byte)
+	Send(recipient std.Address, amount int64, data []byte)
 
 	// Destroys `amount` tokens from the caller's account, reducing the
 	// total supply.
@@ -51,7 +51,7 @@ type IGRC777 interface {
 	// Requirements
 	//
 	// - the caller must have at least `amount` tokens.
-	Burn(amount uint64, data []byte)
+	Burn(amount int64, data []byte)
 
 	// Returns true if an account is an operator of `tokenHolder`.
 	// Operators can send and burn tokens on behalf of their owners. All
@@ -107,7 +107,7 @@ type IGRC777 interface {
 	// - `recipient` cannot be the zero address.
 	// - if `recipient` is a contract, it must implement the {IERC777Recipient}
 	// interface.
-	OperatorSend(sender, recipient std.Address, amount uint64, data, operatorData []byte)
+	OperatorSend(sender, recipient std.Address, amount int64, data, operatorData []byte)
 
 	// Destroys `amount` tokens from `account`, reducing the total supply.
 	// The caller must be an operator of `account`.
@@ -122,7 +122,7 @@ type IGRC777 interface {
 	// - `account` cannot be the zero address.
 	// - `account` must have at least `amount` tokens.
 	// - the caller must be an operator for `account`.
-	OperatorBurn(account std.Address, amount uint64, data, operatorData []byte)
+	OperatorBurn(account std.Address, amount int64, data, operatorData []byte)
 }
 
 // Emitted when `amount` tokens are created by `operator` and assigned to `to`.
@@ -131,7 +131,7 @@ type IGRC777 interface {
 type MintedEvent struct {
 	Operator     std.Address
 	To           std.Address
-	Amount       uint64
+	Amount       int64
 	Data         []byte
 	OperatorData []byte
 }
@@ -142,7 +142,7 @@ type MintedEvent struct {
 type BurnedEvent struct {
 	Operator     std.Address
 	From         std.Address
-	Amount       uint64
+	Amount       int64
 	Data         []byte
 	OperatorData []byte
 }
@@ -163,7 +163,7 @@ type SentEvent struct {
 	Operator     std.Address
 	From         std.Address
 	To           std.Address
-	Amount       uint64
+	Amount       int64
 	Data         []byte
 	OperatorData []byte
 }

--- a/examples/gno.land/r/demo/atomicswap/atomicswap_test.gno
+++ b/examples/gno.land/r/demo/atomicswap/atomicswap_test.gno
@@ -153,11 +153,11 @@ func TestNewCustomGRC20Swap_Claim(t *testing.T) {
 	uassert.Equal(t, sender, swap.sender, "expected sender to match")
 	uassert.Equal(t, recipient, swap.recipient, "expected recipient to match")
 	bal := test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	// uassert.Equal(t, swap.amountStr, amount.String(), "expected amount to match")
 	uassert.Equal(t, hashlockHex, swap.hashlock, "expected hashlock to match")
@@ -172,11 +172,11 @@ func TestNewCustomGRC20Swap_Claim(t *testing.T) {
 	uassert.True(t, swap.claimed, "expected claimed to be true")
 
 	bal = test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 
 	// Test refund (should fail because already claimed)
 	uassert.PanicsWithMessage(t, "already claimed", swap.Refund)
@@ -227,11 +227,11 @@ func TestNewCustomGRC20Swap_Refund(t *testing.T) {
 	uassert.Equal(t, sender, swap.sender, "expected sender to match")
 	uassert.Equal(t, recipient, swap.recipient, "expected recipient to match")
 	bal := test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	// Test Refund
 	testing.IssueCoins(pkgAddr, std.Coins{{"ugnot", 100000000}})
@@ -241,11 +241,11 @@ func TestNewCustomGRC20Swap_Refund(t *testing.T) {
 	uassert.True(t, swap.refunded, "expected refunded to be true")
 
 	bal = test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(100_000))
+	uassert.Equal(t, bal, int64(100_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	expected = `- status: refunded
 - sender: g1wdjkuer9wg647h6lta047h6lta047h6l5p6k3k
@@ -291,11 +291,11 @@ func TestNewGRC20Swap_Claim(t *testing.T) {
 	uassert.Equal(t, sender, swap.sender, "expected sender to match")
 	uassert.Equal(t, recipient, swap.recipient, "expected recipient to match")
 	bal := test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	// uassert.Equal(t, swap.amountStr, amount.String(), "expected amount to match")
 	uassert.Equal(t, hashlockHex, swap.hashlock, "expected hashlock to match")
@@ -310,11 +310,11 @@ func TestNewGRC20Swap_Claim(t *testing.T) {
 	uassert.True(t, swap.claimed, "expected claimed to be true")
 
 	bal = test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 
 	// Test refund (should fail because already claimed)
 	uassert.PanicsWithMessage(t, "already claimed", swap.Refund)
@@ -365,11 +365,11 @@ func TestNewGRC20Swap_Refund(t *testing.T) {
 	uassert.Equal(t, sender, swap.sender, "expected sender to match")
 	uassert.Equal(t, recipient, swap.recipient, "expected recipient to match")
 	bal := test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(30_000))
+	uassert.Equal(t, bal, int64(30_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(70_000))
+	uassert.Equal(t, bal, int64(70_000))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	// Test Refund
 	testing.IssueCoins(pkgAddr, std.Coins{{"ugnot", 100000000}})
@@ -379,11 +379,11 @@ func TestNewGRC20Swap_Refund(t *testing.T) {
 	uassert.True(t, swap.refunded, "expected refunded to be true")
 
 	bal = test20.Token.BalanceOf(sender)
-	uassert.Equal(t, bal, uint64(100_000))
+	uassert.Equal(t, bal, int64(100_000))
 	bal = test20.Token.BalanceOf(rlm)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 	bal = test20.Token.BalanceOf(recipient)
-	uassert.Equal(t, bal, uint64(0))
+	uassert.Equal(t, bal, int64(0))
 
 	expected = `- status: refunded
 - sender: g1wdjkuer9wgm97h6lta047h6lta047h6ltj497r

--- a/examples/gno.land/r/demo/bar20/bar20_test.gno
+++ b/examples/gno.land/r/demo/bar20/bar20_test.gno
@@ -11,7 +11,7 @@ func TestPackage(t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	testing.SetOriginCaller(alice)
 
-	urequire.Equal(t, UserTeller.BalanceOf(alice), uint64(0))
+	urequire.Equal(t, UserTeller.BalanceOf(alice), int64(0))
 	urequire.Equal(t, cross(Faucet)(), "OK")
-	urequire.Equal(t, UserTeller.BalanceOf(alice), uint64(1_000_000))
+	urequire.Equal(t, UserTeller.BalanceOf(alice), int64(1_000_000))
 }

--- a/examples/gno.land/r/demo/btree_dao/btree_dao.gno
+++ b/examples/gno.land/r/demo/btree_dao/btree_dao.gno
@@ -145,7 +145,7 @@ func Render(path string) string {
 			balance, err := dao.BalanceOf(addr)
 			if err == nil && balance > 0 {
 				nftList = " (NFTs: "
-				for i := uint64(0); i < balance; i++ {
+				for i := int64(0); i < balance; i++ {
 					if i > 0 {
 						nftList += ", "
 					}
@@ -172,7 +172,7 @@ func Render(path string) string {
 			balance, err := dao.BalanceOf(addr)
 			if err == nil && balance > 0 {
 				nftList = " (NFTs: "
-				for i := uint64(0); i < balance; i++ {
+				for i := int64(0); i < balance; i++ {
 					if i > 0 {
 						nftList += ", "
 					}

--- a/examples/gno.land/r/demo/disperse/disperse.gno
+++ b/examples/gno.land/r/demo/disperse/disperse.gno
@@ -66,6 +66,11 @@ func DisperseGRC20(addresses []std.Address, amounts []int64, symbols []string) {
 	if (len(addresses) != len(amounts)) || (len(amounts) != len(symbols)) {
 		panic(ErrArgLenAndSentLenMismatch)
 	}
+	for _, amount := range amounts {
+		if amount < 0 {
+			panic(ErrInvalidAmount)
+		}
+	}
 
 	for i := 0; i < len(addresses); i++ {
 		cross(tokens.TransferFrom)(symbols[i], caller, addresses[i], amounts[i])

--- a/examples/gno.land/r/demo/disperse/disperse.gno
+++ b/examples/gno.land/r/demo/disperse/disperse.gno
@@ -58,7 +58,7 @@ func DisperseUgnotString(addresses string, amounts string) {
 // DisperseGRC20 disperses tokens to multiple addresses
 // Note that it is necessary to approve the realm to spend the tokens before calling this function
 // see the corresponding filetests for examples
-func DisperseGRC20(addresses []std.Address, amounts []uint64, symbols []string) {
+func DisperseGRC20(addresses []std.Address, amounts []int64, symbols []string) {
 	crossing()
 
 	caller := std.PreviousRealm().Address()

--- a/examples/gno.land/r/demo/disperse/errors.gno
+++ b/examples/gno.land/r/demo/disperse/errors.gno
@@ -9,4 +9,5 @@ var (
 	ErrNegativeCoinAmount           = errors.New("disperse: coin amount cannot be negative")
 	ErrMismatchBetweenSentAndParams = errors.New("disperse: mismatch between coins sent and params called")
 	ErrArgLenAndSentLenMismatch     = errors.New("disperse: mismatch between coins sent and args called")
+	ErrInvalidAmount                = errors.New("disperse: invalid amount")
 )

--- a/examples/gno.land/r/demo/disperse/util.gno
+++ b/examples/gno.land/r/demo/disperse/util.gno
@@ -33,8 +33,8 @@ func splitString(input string) (string, string) {
 	return input[:pos], input[pos:]
 }
 
-func parseTokens(tokens string) ([]uint64, []string, error) {
-	var amounts []uint64
+func parseTokens(tokens string) ([]int64, []string, error) {
+	var amounts []int64
 	var symbols []string
 
 	for _, token := range strings.Split(tokens, ",") {
@@ -44,7 +44,7 @@ func parseTokens(tokens string) ([]uint64, []string, error) {
 			return nil, nil, ErrNegativeCoinAmount
 		}
 
-		amounts = append(amounts, uint64(amount))
+		amounts = append(amounts, int64(amount))
 		symbols = append(symbols, symbol)
 	}
 

--- a/examples/gno.land/r/demo/foo1155/foo1155.gno
+++ b/examples/gno.land/r/demo/foo1155/foo1155.gno
@@ -26,7 +26,7 @@ func mintGRC1155Token(owner std.Address) {
 
 // Getters
 
-func BalanceOf(user std.Address, tid grc1155.TokenID) uint64 {
+func BalanceOf(user std.Address, tid grc1155.TokenID) int64 {
 	balance, err := foo.BalanceOf(user, tid)
 	if err != nil {
 		panic(err)
@@ -35,7 +35,7 @@ func BalanceOf(user std.Address, tid grc1155.TokenID) uint64 {
 	return balance
 }
 
-func BalanceOfBatch(ul []std.Address, batch []grc1155.TokenID) []uint64 {
+func BalanceOfBatch(ul []std.Address, batch []grc1155.TokenID) []int64 {
 	balanceBatch, err := foo.BalanceOfBatch(ul, batch)
 	if err != nil {
 		panic(err)
@@ -57,14 +57,14 @@ func SetApprovalForAll(user std.Address, approved bool) {
 	}
 }
 
-func TransferFrom(from, to std.Address, tid grc1155.TokenID, amount uint64) {
+func TransferFrom(from, to std.Address, tid grc1155.TokenID, amount int64) {
 	err := foo.SafeTransferFrom(from, to, tid, amount)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func BatchTransferFrom(from, to std.Address, batch []grc1155.TokenID, amounts []uint64) {
+func BatchTransferFrom(from, to std.Address, batch []grc1155.TokenID, amounts []int64) {
 	err := foo.SafeBatchTransferFrom(from, to, batch, amounts)
 	if err != nil {
 		panic(err)
@@ -73,7 +73,7 @@ func BatchTransferFrom(from, to std.Address, batch []grc1155.TokenID, amounts []
 
 // Admin
 
-func Mint(to std.Address, tid grc1155.TokenID, amount uint64) {
+func Mint(to std.Address, tid grc1155.TokenID, amount int64) {
 	caller := std.OriginCaller()
 	assertIsAdmin(caller)
 	err := foo.SafeMint(to, tid, amount)
@@ -82,7 +82,7 @@ func Mint(to std.Address, tid grc1155.TokenID, amount uint64) {
 	}
 }
 
-func MintBatch(to std.Address, batch []grc1155.TokenID, amounts []uint64) {
+func MintBatch(to std.Address, batch []grc1155.TokenID, amounts []int64) {
 	caller := std.OriginCaller()
 	assertIsAdmin(caller)
 	err := foo.SafeBatchMint(to, batch, amounts)
@@ -91,7 +91,7 @@ func MintBatch(to std.Address, batch []grc1155.TokenID, amounts []uint64) {
 	}
 }
 
-func Burn(from std.Address, tid grc1155.TokenID, amount uint64) {
+func Burn(from std.Address, tid grc1155.TokenID, amount int64) {
 	caller := std.OriginCaller()
 	assertIsAdmin(caller)
 	err := foo.Burn(from, tid, amount)
@@ -100,7 +100,7 @@ func Burn(from std.Address, tid grc1155.TokenID, amount uint64) {
 	}
 }
 
-func BurnBatch(from std.Address, batch []grc1155.TokenID, amounts []uint64) {
+func BurnBatch(from std.Address, batch []grc1155.TokenID, amounts []int64) {
 	caller := std.OriginCaller()
 	assertIsAdmin(caller)
 	err := foo.BatchBurn(from, batch, amounts)

--- a/examples/gno.land/r/demo/foo1155/foo1155_test.gno
+++ b/examples/gno.land/r/demo/foo1155/foo1155_test.gno
@@ -17,8 +17,8 @@ func TestFoo721(t *testing.T) {
 		expected any
 		fn       func() any
 	}{
-		{"BalanceOf(admin, tid1)", uint64(100), func() any { return BalanceOf(admin, tid1) }},
-		{"BalanceOf(bob, tid1)", uint64(0), func() any { return BalanceOf(bob, tid1) }},
+		{"BalanceOf(admin, tid1)", int64(100), func() any { return BalanceOf(admin, tid1) }},
+		{"BalanceOf(bob, tid1)", int64(0), func() any { return BalanceOf(bob, tid1) }},
 		{"IsApprovedForAll(admin, bob)", false, func() any { return IsApprovedForAll(admin, bob) }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/examples/gno.land/r/demo/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/foo20/foo20.gno
@@ -23,31 +23,31 @@ func init() {
 	cross(grc20reg.Register)(Token.Getter(), "")
 }
 
-func TotalSupply() uint64 {
+func TotalSupply() int64 {
 	return UserTeller.TotalSupply()
 }
 
-func BalanceOf(owner std.Address) uint64 {
+func BalanceOf(owner std.Address) int64 {
 	return UserTeller.BalanceOf(owner)
 }
 
-func Allowance(owner, spender std.Address) uint64 {
+func Allowance(owner, spender std.Address) int64 {
 	return UserTeller.Allowance(owner, spender)
 }
 
-func Transfer(to std.Address, amount uint64) {
+func Transfer(to std.Address, amount int64) {
 	crossing()
 
 	checkErr(UserTeller.Transfer(to, amount))
 }
 
-func Approve(spender std.Address, amount uint64) {
+func Approve(spender std.Address, amount int64) {
 	crossing()
 
 	checkErr(UserTeller.Approve(spender, amount))
 }
 
-func TransferFrom(from, to std.Address, amount uint64) {
+func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
 
 	checkErr(UserTeller.TransferFrom(from, to, amount))
@@ -59,18 +59,18 @@ func Faucet() {
 	crossing()
 
 	caller := std.PreviousRealm().Address()
-	amount := uint64(1_000 * 10_000) // 1k
+	amount := int64(1_000 * 10_000) // 1k
 	checkErr(privateLedger.Mint(caller, amount))
 }
 
-func Mint(to std.Address, amount uint64) {
+func Mint(to std.Address, amount int64) {
 	crossing()
 
 	Ownable.AssertOwnedByPrevious()
 	checkErr(privateLedger.Mint(to, amount))
 }
 
-func Burn(from std.Address, amount uint64) {
+func Burn(from std.Address, amount int64) {
 	crossing()
 
 	Ownable.AssertOwnedByPrevious()

--- a/examples/gno.land/r/demo/foo20/foo20_test.gno
+++ b/examples/gno.land/r/demo/foo20/foo20_test.gno
@@ -17,18 +17,18 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 
 	type test struct {
 		name    string
-		balance uint64
-		fn      func() uint64
+		balance int64
+		fn      func() int64
 	}
 
 	// check balances #1.
 	{
 		tests := []test{
-			{"TotalSupply", 10_000_000_000, func() uint64 { return TotalSupply() }},
-			{"BalanceOf(admin)", 10_000_000_000, func() uint64 { return BalanceOf(admin) }},
-			{"BalanceOf(alice)", 0, func() uint64 { return BalanceOf(alice) }},
-			{"Allowance(admin, alice)", 0, func() uint64 { return Allowance(admin, alice) }},
-			{"BalanceOf(bob)", 0, func() uint64 { return BalanceOf(bob) }},
+			{"TotalSupply", 10_000_000_000, func() int64 { return TotalSupply() }},
+			{"BalanceOf(admin)", 10_000_000_000, func() int64 { return BalanceOf(admin) }},
+			{"BalanceOf(alice)", 0, func() int64 { return BalanceOf(alice) }},
+			{"Allowance(admin, alice)", 0, func() int64 { return Allowance(admin, alice) }},
+			{"BalanceOf(bob)", 0, func() int64 { return BalanceOf(bob) }},
 		}
 		for _, tc := range tests {
 			got := tc.fn()
@@ -43,11 +43,11 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 	// check balances #2.
 	{
 		tests := []test{
-			{"TotalSupply", 10_010_000_000, func() uint64 { return TotalSupply() }},
-			{"BalanceOf(admin)", 10_000_000_000, func() uint64 { return BalanceOf(admin) }},
-			{"BalanceOf(alice)", 0, func() uint64 { return BalanceOf(alice) }},
-			{"Allowance(admin, alice)", 0, func() uint64 { return Allowance(admin, alice) }},
-			{"BalanceOf(bob)", 10_000_000, func() uint64 { return BalanceOf(bob) }},
+			{"TotalSupply", 10_010_000_000, func() int64 { return TotalSupply() }},
+			{"BalanceOf(admin)", 10_000_000_000, func() int64 { return BalanceOf(admin) }},
+			{"BalanceOf(alice)", 0, func() int64 { return BalanceOf(alice) }},
+			{"Allowance(admin, alice)", 0, func() int64 { return Allowance(admin, alice) }},
+			{"BalanceOf(bob)", 10_000_000, func() int64 { return BalanceOf(bob) }},
 		}
 		for _, tc := range tests {
 			got := tc.fn()

--- a/examples/gno.land/r/demo/foo721/foo721.gno
+++ b/examples/gno.land/r/demo/foo721/foo721.gno
@@ -17,7 +17,7 @@ func init() {
 	mintNNFT("g1var589z07ppjsjd24ukm4uguzwdt0tw7g47cgm", 5) // @hariom (5)
 }
 
-func mintNNFT(owner std.Address, n uint64) {
+func mintNNFT(owner std.Address, n int64) {
 	count := foo.TokenCount()
 	for i := count; i < count+n; i++ {
 		tid := grc721.TokenID(ufmt.Sprintf("%d", i))
@@ -27,7 +27,7 @@ func mintNNFT(owner std.Address, n uint64) {
 
 // Getters
 
-func BalanceOf(user std.Address) uint64 {
+func BalanceOf(user std.Address) int64 {
 	balance, err := foo.BalanceOf(user)
 	if err != nil {
 		panic(err)

--- a/examples/gno.land/r/demo/foo721/foo721_test.gno
+++ b/examples/gno.land/r/demo/foo721/foo721_test.gno
@@ -16,8 +16,8 @@ func TestFoo721(t *testing.T) {
 		expected any
 		fn       func() any
 	}{
-		{"BalanceOf(admin)", uint64(10), func() interface{} { return BalanceOf(admin) }},
-		{"BalanceOf(hariom)", uint64(5), func() interface{} { return BalanceOf(hariom) }},
+		{"BalanceOf(admin)", int64(10), func() interface{} { return BalanceOf(admin) }},
+		{"BalanceOf(hariom)", int64(5), func() interface{} { return BalanceOf(hariom) }},
 		{"OwnerOf(0)", admin, func() interface{} { return OwnerOf(grc721.TokenID("0")) }},
 		{"IsApprovedForAll(admin, hariom)", false, func() interface{} { return IsApprovedForAll(admin, hariom) }},
 	} {

--- a/examples/gno.land/r/demo/grc20factory/grc20factory.gno
+++ b/examples/gno.land/r/demo/grc20factory/grc20factory.gno
@@ -17,17 +17,17 @@ type instance struct {
 	token  *grc20.Token
 	ledger *grc20.PrivateLedger
 	admin  *ownable.Ownable
-	faucet uint64 // per-request amount. disabled if 0.
+	faucet int64 // per-request amount. disabled if 0.
 }
 
-func New(name, symbol string, decimals uint, initialMint, faucet uint64) {
+func New(name, symbol string, decimals int, initialMint, faucet int64) {
 	crossing()
 
 	caller := std.PreviousRealm().Address()
 	NewWithAdmin(name, symbol, decimals, initialMint, faucet, caller)
 }
 
-func NewWithAdmin(name, symbol string, decimals uint, initialMint, faucet uint64, admin std.Address) {
+func NewWithAdmin(name, symbol string, decimals int, initialMint, faucet int64, admin std.Address) {
 	crossing()
 
 	exists := instances.Has(symbol)
@@ -63,22 +63,22 @@ func Bank(symbol string) *grc20.Token {
 	return inst.token
 }
 
-func TotalSupply(symbol string) uint64 {
+func TotalSupply(symbol string) int64 {
 	inst := mustGetInstance(symbol)
 	return inst.token.ReadonlyTeller().TotalSupply()
 }
 
-func BalanceOf(symbol string, owner std.Address) uint64 {
+func BalanceOf(symbol string, owner std.Address) int64 {
 	inst := mustGetInstance(symbol)
 	return inst.token.ReadonlyTeller().BalanceOf(owner)
 }
 
-func Allowance(symbol string, owner, spender std.Address) uint64 {
+func Allowance(symbol string, owner, spender std.Address) int64 {
 	inst := mustGetInstance(symbol)
 	return inst.token.ReadonlyTeller().Allowance(owner, spender)
 }
 
-func Transfer(symbol string, to std.Address, amount uint64) {
+func Transfer(symbol string, to std.Address, amount int64) {
 	crossing()
 
 	inst := mustGetInstance(symbol)
@@ -87,7 +87,7 @@ func Transfer(symbol string, to std.Address, amount uint64) {
 	checkErr(teller.Transfer(to, amount))
 }
 
-func Approve(symbol string, spender std.Address, amount uint64) {
+func Approve(symbol string, spender std.Address, amount int64) {
 	crossing()
 
 	inst := mustGetInstance(symbol)
@@ -96,7 +96,7 @@ func Approve(symbol string, spender std.Address, amount uint64) {
 	checkErr(teller.Approve(spender, amount))
 }
 
-func TransferFrom(symbol string, from, to std.Address, amount uint64) {
+func TransferFrom(symbol string, from, to std.Address, amount int64) {
 	crossing()
 
 	inst := mustGetInstance(symbol)
@@ -119,7 +119,7 @@ func Faucet(symbol string) {
 	checkErr(inst.ledger.Mint(caller, inst.faucet))
 }
 
-func Mint(symbol string, to std.Address, amount uint64) {
+func Mint(symbol string, to std.Address, amount int64) {
 	crossing()
 
 	inst := mustGetInstance(symbol)
@@ -127,7 +127,7 @@ func Mint(symbol string, to std.Address, amount uint64) {
 	checkErr(inst.ledger.Mint(to, amount))
 }
 
-func Burn(symbol string, from std.Address, amount uint64) {
+func Burn(symbol string, from std.Address, amount int64) {
 	crossing()
 
 	inst := mustGetInstance(symbol)

--- a/examples/gno.land/r/demo/grc20factory/grc20factory_test.gno
+++ b/examples/gno.land/r/demo/grc20factory/grc20factory_test.gno
@@ -15,17 +15,17 @@ func TestReadOnlyPublicMethods(t *testing.T) {
 
 	type test struct {
 		name    string
-		balance uint64
-		fn      func() uint64
+		balance int64
+		fn      func() int64
 	}
 
-	checkBalances := func(step string, totSup, balAdm, balBob, allowAdmBob, balCarl uint64) {
+	checkBalances := func(step string, totSup, balAdm, balBob, allowAdmBob, balCarl int64) {
 		tests := []test{
-			{"TotalSupply", totSup, func() uint64 { return TotalSupply("FOO") }},
-			{"BalanceOf(admin)", balAdm, func() uint64 { return BalanceOf("FOO", admin) }},
-			{"BalanceOf(bob)", balBob, func() uint64 { return BalanceOf("FOO", bob) }},
-			{"Allowance(admin, bob)", allowAdmBob, func() uint64 { return Allowance("FOO", admin, bob) }},
-			{"BalanceOf(carl)", balCarl, func() uint64 { return BalanceOf("FOO", carl) }},
+			{"TotalSupply", totSup, func() int64 { return TotalSupply("FOO") }},
+			{"BalanceOf(admin)", balAdm, func() int64 { return BalanceOf("FOO", admin) }},
+			{"BalanceOf(bob)", balBob, func() int64 { return BalanceOf("FOO", bob) }},
+			{"Allowance(admin, bob)", allowAdmBob, func() int64 { return Allowance("FOO", admin, bob) }},
+			{"BalanceOf(carl)", balCarl, func() int64 { return BalanceOf("FOO", carl) }},
 		}
 		for _, tc := range tests {
 			reason := ufmt.Sprintf("%s.%s - %s", step, tc.name, "balances do not match")

--- a/examples/gno.land/r/demo/wugnot/wugnot.gno
+++ b/examples/gno.land/r/demo/wugnot/wugnot.gno
@@ -12,8 +12,8 @@ import (
 var Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0)
 
 const (
-	ugnotMinDeposit  uint64 = 1000
-	wugnotMinDeposit uint64 = 1
+	ugnotMinDeposit  int64 = 1000
+	wugnotMinDeposit int64 = 1
 )
 
 func init() {
@@ -27,12 +27,12 @@ func Deposit() {
 	sent := std.OriginSend()
 	amount := sent.AmountOf("ugnot")
 
-	require(uint64(amount) >= ugnotMinDeposit, ufmt.Sprintf("Deposit below minimum: %d/%d ugnot.", amount, ugnotMinDeposit))
+	require(int64(amount) >= ugnotMinDeposit, ufmt.Sprintf("Deposit below minimum: %d/%d ugnot.", amount, ugnotMinDeposit))
 
-	checkErr(adm.Mint(caller, uint64(amount)))
+	checkErr(adm.Mint(caller, int64(amount)))
 }
 
-func Withdraw(amount uint64) {
+func Withdraw(amount int64) {
 	crossing()
 
 	require(amount >= wugnotMinDeposit, ufmt.Sprintf("Deposit below minimum: %d/%d wugnot.", amount, wugnotMinDeposit))
@@ -65,33 +65,33 @@ func Render(path string) string {
 	}
 }
 
-func TotalSupply() uint64 {
+func TotalSupply() int64 {
 	return Token.TotalSupply()
 }
 
-func BalanceOf(owner std.Address) uint64 {
+func BalanceOf(owner std.Address) int64 {
 	return Token.BalanceOf(owner)
 }
 
-func Allowance(owner, spender std.Address) uint64 {
+func Allowance(owner, spender std.Address) int64 {
 	return Token.Allowance(owner, spender)
 }
 
-func Transfer(to std.Address, amount uint64) {
+func Transfer(to std.Address, amount int64) {
 	crossing()
 
 	userTeller := Token.CallerTeller()
 	checkErr(userTeller.Transfer(to, amount))
 }
 
-func Approve(spender std.Address, amount uint64) {
+func Approve(spender std.Address, amount int64) {
 	crossing()
 
 	userTeller := Token.CallerTeller()
 	checkErr(userTeller.Approve(spender, amount))
 }
 
-func TransferFrom(from, to std.Address, amount uint64) {
+func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
 
 	userTeller := Token.CallerTeller()


### PR DESCRIPTION
I noticed that grc20 and probably everything is using uint64. This PR is for turning these into int64s.

Numbers that will be used often in subtraction are better with signed integers.  We should use overflow.Add64p() etc always, instead of raw -/+ operations. The problem is that many developers won't do this; and so will end up writing code where overflow/underflow bugs are masked.

I understand that this is a contentious point, but I'm happy to work on proving my point that this is safer for users if anyone wants. It's the same reason why the default numeric type is int, for len(), cap(), indexing, etc, even though these values can only be non-negative.

// user code
var a, b int64 = ...
c := a - b
if c < 0 { ... }

std.Coins is a int64 for the same reason.

Same thing applies to uint and int. There's almost no reason to use a uint. Decimals() for exampe should return a int.

We should not mix int64 and uint64. Too much surface area for bugs. Think of the signed bit as a protection bit.
See #4054 for example.

```
commit da4a2788abeb69d8c2dcfc56bc387b1327c32ca5
Author: Lee ByeongJun <lbj199874@gmail.com>
Date:   Mon Apr 7 16:50:32 2025 +0900

    fix(p/grc20): Unsafe casting during grc20 minting (#4054)
    
    # Description
    
    The `totalSupply` could overflow when casting from `uint64` to `int64`.
    If `totalSupply` exceeded `2^63-1` (max value for int64), the cast would
    produce a negative value, which when cast back to `uint64` would result
    in an invalid `totalSupply`.
    
    To fix this, modified `Mint` function to check for overflow before
    adding to `totalSupply`. Added explicit overflow checks to prevent any
    potential overflow issues.
```

```go
@@ -192,14 +193,17 @@ func (led *PrivateLedger) Mint(address std.Address, amount uint64) error {
                return ErrInvalidAddress
        }
 
-       // XXX: math/overflow is not supporting uint64.
-       // This checks prevents overflow but makes the totalSupply limited to a uint63.
-       sum, ok := overflow.Add64(int64(led.totalSupply), int64(amount))
-       if !ok {
+       // limit totalSupply to MaxUint64
+       if led.totalSupply > MaxUint64 {
+               return ErrOverflow
+       }
+
+       // limit amount to MaxUint64 - totalSupply
+       if amount > MaxUint64-led.totalSupply {
                return ErrOverflow
        }
```
