### PR TITLE
fix(examples): repair expected behavior for mgroup, config, and home

### DIFF
--- a/examples/gno.land/p/n2p5/mgroup/mgroup.gno
+++ b/examples/gno.land/p/n2p5/mgroup/mgroup.gno
@@ -50,7 +50,7 @@ func New(ownerAddress std.Address) *ManagedGroup {
 // AddBackupOwner adds a backup owner to the group by std.Address.
 // If the caller is not the owner, an error is returned.
 func (g *ManagedGroup) AddBackupOwner(addr std.Address) error {
-	if !g.owner.OwnedByCurrent() {
+	if !g.owner.OwnedByPrevious() {
 		return ownable.ErrUnauthorized
 	}
 	return g.addBackupOwner(addr)
@@ -67,7 +67,7 @@ func (g *ManagedGroup) addBackupOwner(addr std.Address) error {
 // RemoveBackupOwner removes a backup owner from the group by std.Address.
 // The owner cannot be removed. If the caller is not the owner, an error is returned.
 func (g *ManagedGroup) RemoveBackupOwner(addr std.Address) error {
-	if !g.owner.OwnedByCurrent() {
+	if !g.owner.OwnedByPrevious() {
 		return ownable.ErrUnauthorized
 	}
 	if !addr.IsValid() {
@@ -84,7 +84,7 @@ func (g *ManagedGroup) RemoveBackupOwner(addr std.Address) error {
 // If the caller is not a backup owner, an error is returned.
 // The caller is automatically added as a member of the group.
 func (g *ManagedGroup) ClaimOwnership() error {
-	caller := std.CurrentRealm().Address()
+	caller := std.PreviousRealm().Address()
 	// already owner, skip
 	if caller == g.Owner() {
 		return nil
@@ -100,7 +100,7 @@ func (g *ManagedGroup) ClaimOwnership() error {
 // AddMember adds a member to the group by std.Address.
 // If the caller is not the owner, an error is returned.
 func (g *ManagedGroup) AddMember(addr std.Address) error {
-	if !g.owner.OwnedByCurrent() {
+	if !g.owner.OwnedByPrevious() {
 		return ownable.ErrUnauthorized
 	}
 	return g.addMember(addr)
@@ -118,7 +118,7 @@ func (g *ManagedGroup) addMember(addr std.Address) error {
 // The owner cannot be removed. If the caller is not the owner,
 // an error is returned.
 func (g *ManagedGroup) RemoveMember(addr std.Address) error {
-	if !g.owner.OwnedByCurrent() {
+	if !g.owner.OwnedByPrevious() {
 		return ownable.ErrUnauthorized
 	}
 	if !addr.IsValid() {

--- a/examples/gno.land/p/n2p5/mgroup/mgroup_test.gno
+++ b/examples/gno.land/p/n2p5/mgroup/mgroup_test.gno
@@ -8,332 +8,298 @@ import (
 	"gno.land/p/demo/ownable"
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
+	"gno.land/p/demo/ufmt"
 )
 
 func TestManagedGroup(t *testing.T) {
-	t.Parallel()
-	testing.SetRealm(std.NewCodeRealm("gno.land/r/test/test"))
+	u1 := std.NewCodeRealm("gno.land/r/test/test/u1")
+	u2 := std.NewCodeRealm("gno.land/r/test/test/u2")
+	u3 := std.NewCodeRealm("gno.land/r/test/test/u3")
+	u4 := std.NewCodeRealm("gno.land/r/test/test/u4")
 
-	u1 := testutils.TestAddress("u1")
-	u2 := testutils.TestAddress("u2")
-	u3 := testutils.TestAddress("u3")
+    probe := func(msg string) {
+        ufmt.Println("probing: " + msg)
+        c := std.CurrentRealm()
+        p := std.PreviousRealm()
+
+        ufmt.Println("current realm " + string(c.Address()) + c.PkgPath())
+        ufmt.Println("previous realm" + string(p.Address()) + p.PkgPath())
+    }
+
+	// testUsingPreviousRealm sets the realm to "gno.land/r/test/test"
+	// and uses the SetRealm in the test as the previous caller
+	testUsingPreviousRealm := func(fn func()) {
+		testing.SetRealm(std.NewCodeRealm("gno.land/r/test/test"))
+		fn()
+	}
 
 	t.Run("AddBackupOwner", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		// happy path
-		{
-			testing.SetOriginCaller(u1)
-			err := g.AddBackupOwner(u2)
-			if err != nil {
+		g := New(u1.Address())
+
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			if err := g.AddBackupOwner(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// ensure checking for authorized caller
-		{
-			testing.SetOriginCaller(u2)
-			err := g.AddBackupOwner(u3)
-			if err != ownable.ErrUnauthorized {
-				t.Errorf("expected %v, got %v", ErrNotBackupOwner.Error(), err.Error())
-			}
-		}
-		// ensure invalid address is caught
-		{
-			testing.SetOriginCaller(u1)
+			// ensure invalid address is caught
 			var badAddr std.Address
-			err := g.AddBackupOwner(badAddr)
-			if err != ErrInvalidAddress {
+			if err := g.AddBackupOwner(badAddr); err != ErrInvalidAddress {
 				t.Errorf("expected %v, got %v", ErrInvalidAddress.Error(), err.Error())
 			}
-		}
+		})
+
+		testing.SetRealm(u3)
+		testUsingPreviousRealm(func(){
+			// an address that is not the owner should not be allowed to add a backup owner
+			if err := g.AddBackupOwner(u4.Address()); err != ownable.ErrUnauthorized {
+				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
+			}
+		})	
+
 	})
 	t.Run("RemoveBackupOwner", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		// happy path
-		{
-			testing.SetOriginCaller(u1)
-			g.AddBackupOwner(u2)
-			err := g.RemoveBackupOwner(u2)
-			if err != nil {
+		g := New(u1.Address())
+
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			g.AddBackupOwner(u2.Address())
+			if err := g.RemoveBackupOwner(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// running this twice should not error.
-		{
-			testing.SetOriginCaller(u1)
-			err := g.RemoveBackupOwner(u2)
-			if err != nil {
+			// running this twice should not error.
+			if err := g.RemoveBackupOwner(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// ensure checking for authorized caller
-		{
-			testing.SetOriginCaller(u2)
-			err := g.RemoveBackupOwner(u3)
-			if err != ownable.ErrUnauthorized {
-				t.Errorf("expected %v, got %v", ErrNotBackupOwner.Error(), err.Error())
-			}
-		}
-		{
-			testing.SetOriginCaller(u1)
 			var badAddr std.Address
-			err := g.RemoveBackupOwner(badAddr)
-			if err != ErrInvalidAddress {
+			if err := g.RemoveBackupOwner(badAddr); err != ErrInvalidAddress {
 				t.Errorf("expected %v, got %v", ErrInvalidAddress.Error(), err.Error())
 			}
-		}
-		{
-			testing.SetOriginCaller(u1)
-			err := g.RemoveBackupOwner(u1)
-			if err != ErrCannotRemoveOwner {
+			if err := g.RemoveBackupOwner(u1.Address()); err != ErrCannotRemoveOwner {
 				t.Errorf("expected %v, got %v", ErrCannotRemoveOwner.Error(), err.Error())
 			}
-		}
+		})
+
+		testing.SetRealm(u3)
+		testUsingPreviousRealm(func(){
+			g.AddBackupOwner(u2.Address())
+			if err := g.RemoveBackupOwner(u2.Address()); err != ownable.ErrUnauthorized {
+				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
+			}
+		})
 	})
+
 	t.Run("ClaimOwnership", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		// add backup owner
-		{
-			testing.SetOriginCaller(u1)
-			err := g.AddBackupOwner(u2)
-			if err != nil {
+		g := New(u1.Address())
+
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			g.AddBackupOwner(u2.Address())
+		})
+		testing.SetRealm(u2)
+		testUsingPreviousRealm(func(){
+			if err := g.ClaimOwnership(); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// happy path
-		{
-			testing.SetOriginCaller(u2)
-			err := g.ClaimOwnership()
-			if err != nil {
-				t.Errorf("expected nil, got %v", err.Error())
-			}
-			if g.Owner() != u2 {
+			if g.Owner() != u2.Address() {
 				t.Errorf("expected %v, got %v", u2, g.Owner())
 			}
-			if !g.IsMember(u2) {
+			if !g.IsMember(u2.Address()) {
 				t.Errorf("expected %v to be a member", u2)
 			}
-		}
-		// running this twice should not error.
-		{
-			testing.SetOriginCaller(u2)
-			err := g.ClaimOwnership()
-			if err != nil {
+			if err := g.ClaimOwnership(); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// ensure checking for authorized caller
-		{
-			testing.SetOriginCaller(u3)
-			err := g.ClaimOwnership()
-			if err != ErrNotMember {
+		})
+		testing.SetRealm(u3)
+		testUsingPreviousRealm(func(){
+			if err := g.ClaimOwnership(); err != ErrNotMember {
 				t.Errorf("expected %v, got %v", ErrNotMember.Error(), err.Error())
-			}
-		}
+			}	
+		})
 	})
+
 	t.Run("AddMember", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		// happy path
-		{
-			testing.SetOriginCaller(u1)
-			err := g.AddMember(u2)
-			uassert.NoError(t, err)
-			if !g.IsMember(u2) {
-				t.Errorf("expected %v to be a member", u2)
-			}
-		}
-		// ensure checking for authorized caller
-		{
-			testing.SetOriginCaller(u2)
-			err := g.AddMember(u3)
-			uassert.ErrorIs(t, err, ownable.ErrUnauthorized)
-		}
-		// ensure invalid address is caught
-		{
-			testing.SetOriginCaller(u1)
-			var badAddr std.Address
-			err := g.AddMember(badAddr)
-			uassert.ErrorContains(t, err, "address is invalid")
-		}
-	})
-	t.Run("RemoveMember", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		// happy path
-		{
-			testing.SetOriginCaller(u1)
-			err := g.AddMember(u2)
-			uassert.NoError(t, err)
-			err = g.RemoveMember(u2)
-			if err != nil {
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			if err := g.AddMember(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-			if g.IsMember(u2) {
+			if !g.IsMember(u2.Address()) {
+				t.Errorf("expected %v to be a member", u2)
+			}
+			var badAddr std.Address
+			if err := g.AddMember(badAddr); err != ErrInvalidAddress {
+				t.Errorf("expected %v, got %v", ErrInvalidAddress, err.Error())
+			}
+		})
+		testing.SetRealm(u3)
+		testUsingPreviousRealm(func(){
+			if err := g.AddMember(u4.Address()); err != ownable.ErrUnauthorized {
+				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
+			}
+		})
+	})
+
+	t.Run("RemoveMember", func(t *testing.T) {
+		g := New(u1.Address())
+		
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			g.AddMember(u2.Address())
+			if err := g.RemoveMember(u2.Address()); err != nil {
+				t.Errorf("expected nil, got %v", err.Error())
+			}
+			if g.IsMember(u2.Address()) {
 				t.Errorf("expected %v to not be a member", u2)
 			}
-		}
-		// running this twice should not error.
-		{
-			testing.SetOriginCaller(u1)
-			err := g.RemoveMember(u2)
-			if err != nil {
+			// running this twice should not error
+			if err := g.RemoveMember(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
-		}
-		// ensure checking for authorized caller
-		{
-			testing.SetOriginCaller(u2)
-			err := g.RemoveMember(u3)
-			if err != ownable.ErrUnauthorized {
-				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized.Error(), err.Error())
-			}
-		}
-		// ensure invalid address is caught
-		{
-			testing.SetOriginCaller(u1)
 			var badAddr std.Address
-			err := g.RemoveMember(badAddr)
-			if err != ErrInvalidAddress {
+			if err := g.RemoveMember(badAddr); err != ErrInvalidAddress {
 				t.Errorf("expected %v, got %v", ErrInvalidAddress.Error(), err.Error())
 			}
-		}
-		// ensure owner cannot be removed
-		{
-			testing.SetOriginCaller(u1)
-			err := g.RemoveMember(u1)
-			if err != ErrCannotRemoveOwner {
+			if err := g.RemoveMember(u1.Address()); err != ErrCannotRemoveOwner {
 				t.Errorf("expected %v, got %v", ErrCannotRemoveOwner.Error(), err.Error())
 			}
-		}
-	})
+		})
+
+		testing.SetRealm(u2)
+		testUsingPreviousRealm(func(){
+			if err := g.RemoveMember(u3.Address()); err != ownable.ErrUnauthorized {
+				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized.Error(), err.Error())
+			}
+		})
+	})	
+
 	t.Run("MemberCount", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		testing.SetOriginCaller(u1)
-
-		uassert.Equal(t, 1, g.MemberCount())
-		err := g.AddMember(u2)
-		uassert.NoError(t, err)
-		uassert.Equal(t, 2, g.MemberCount())
-		err = g.AddMember(u3)
-		uassert.NoError(t, err)
-		uassert.Equal(t, 3, g.MemberCount())
-		g.RemoveMember(u2)
-		uassert.Equal(t, 2, g.MemberCount())
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			uassert.Equal(t, 1, g.MemberCount())
+			g.AddMember(u2.Address())
+			uassert.Equal(t, 2, g.MemberCount())
+			g.AddMember(u3.Address())
+			uassert.Equal(t, 3, g.MemberCount())
+			g.RemoveMember(u2.Address())
+			uassert.Equal(t, 2, g.MemberCount())
+		})
 	})
+
 	t.Run("BackupOwnerCount", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		testing.SetOriginCaller(u1)
-
-		uassert.Equal(t, 1, g.BackupOwnerCount())
-		g.AddBackupOwner(u2)
-		uassert.Equal(t, 2, g.BackupOwnerCount())
-		g.AddBackupOwner(u3)
-		uassert.Equal(t, 3, g.BackupOwnerCount())
-		g.RemoveBackupOwner(u2)
-		uassert.Equal(t, 2, g.BackupOwnerCount())
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			uassert.Equal(t, 1, g.BackupOwnerCount())
+			g.AddBackupOwner(u2.Address())
+			uassert.Equal(t, 2, g.BackupOwnerCount())
+			g.AddBackupOwner(u3.Address())
+			uassert.Equal(t, 3, g.BackupOwnerCount())
+			g.RemoveBackupOwner(u2.Address())
+			uassert.Equal(t, 2, g.BackupOwnerCount())
+		})
 	})
+
 	t.Run("IsMember", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		testing.SetOriginCaller(u1)
-
-		if !g.IsMember(u1) {
-			t.Errorf("expected %v to be a member", u1)
-		}
-		if g.IsMember(u2) {
-			t.Errorf("expected %v to not be a member", u2)
-		}
-		err := g.AddMember(u2)
-		uassert.NoError(t, err)
-		if !g.IsMember(u2) {
-			t.Errorf("expected %v to be a member", u2)
-		}
-	})
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			if !g.IsMember(u1.Address()) {
+				t.Errorf("expected %v to be a member", u1)
+			}
+			if g.IsMember(u2.Address()) {
+				t.Errorf("expected %v to not be a member", u2)
+			}
+			g.AddMember(u2.Address())
+			if !g.IsMember(u2.Address()) {
+				t.Errorf("expected %v to be a member", u2)
+			}
+		})
+	})	
 	t.Run("IsBackupOwner", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		testing.SetOriginCaller(u1)
-
-		if !g.IsBackupOwner(u1) {
-			t.Errorf("expected %v to be a backup owner", u1)
-		}
-		if g.IsBackupOwner(u2) {
-			t.Errorf("expected %v to not be a backup owner", u2)
-		}
-		g.AddBackupOwner(u2)
-		if !g.IsBackupOwner(u2) {
-			t.Errorf("expected %v to be a backup owner", u2)
-		}
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			if !g.IsBackupOwner(u1.Address()) {
+				t.Errorf("expected %v to be a backup owner", u1)
+			}
+			if g.IsBackupOwner(u2.Address()) {
+				t.Errorf("expected %v to not be a backup owner", u2)
+			}
+			g.AddBackupOwner(u2.Address())
+			if !g.IsBackupOwner(u2.Address()) {
+				t.Errorf("expected %v to be a backup owner", u2)
+			}
+		})
 	})
-	t.Run("Owner", func(t *testing.T) {
-		t.Parallel()
-		g := New(u1)
-		testing.SetOriginCaller(u1)
 
-		if g.Owner() != u1 {
-			t.Errorf("expected %v, got %v", u1, g.Owner())
-		}
-		g.AddBackupOwner(u2)
-		if g.Owner() != u1 {
-			t.Errorf("expected %v, got %v", u1, g.Owner())
-		}
-		testing.SetOriginCaller(u2)
-		g.ClaimOwnership()
-		if g.Owner() != u2 {
-			t.Errorf("expected %v, got %v", u2, g.Owner())
-		}
+	t.Run("Owner", func(t *testing.T) {
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			if g.Owner() != u1.Address() {
+				t.Errorf("expected %v, got %v", u1, g.Owner())
+			}
+			g.AddBackupOwner(u2.Address())
+			if g.Owner() != u1.Address() {
+				t.Errorf("expected %v, got %v", u1, g.Owner())
+			}
+		})
+		testing.SetRealm(u2)
+		testUsingPreviousRealm(func(){
+			g.ClaimOwnership()
+			if g.Owner() != u2.Address() {
+				t.Errorf("expected %v, got %v", u2, g.Owner())
+			}
+		})
 	})
 	t.Run("BackupOwners", func(t *testing.T) {
-		t.Parallel()
-		testing.SetOriginCaller(u1)
-		g := New(u1)
-		g.AddBackupOwner(u2)
-		g.AddBackupOwner(u3)
-		owners := g.BackupOwners()
-		if len(owners) != 3 {
-			t.Errorf("expected 2, got %v", len(owners))
-		}
-		if owners[0] != u1.String() {
-			t.Errorf("expected %v, got %v", u2, owners[0])
-		}
-		if owners[1] != u3.String() {
-			t.Errorf("expected %v, got %v", u3, owners[1])
-		}
-		if owners[2] != u2.String() {
-			t.Errorf("expected %v, got %v", u3, owners[1])
-		}
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			g.AddBackupOwner(u2.Address())
+			g.AddBackupOwner(u3.Address())
+			owners := g.BackupOwners()
+			if len(owners) != 3 {
+				t.Errorf("expected 3, got %v", len(owners))
+			}
+			if owners[0] != u1.Address().String() {
+				t.Errorf("expected %v, got %v", u1, owners[0])
+			}
+			if owners[1] != u2.Address().String() {
+				t.Errorf("expected %v, got %v", u2, owners[1])
+			}
+			if owners[2] != u3.Address().String() {
+				t.Errorf("expected %v, got %v", u3, owners[1])
+			}
+		})
 	})
 	t.Run("Members", func(t *testing.T) {
-		t.Parallel()
-		testing.SetOriginCaller(u1)
-		g := New(u1)
-		err := g.AddMember(u2)
-		uassert.NoError(t, err)
-		err = g.AddMember(u3)
-		uassert.NoError(t, err)
-		members := g.Members()
-		if len(members) != 3 {
-			t.Errorf("expected 2, got %v", len(members))
-		}
-		if members[0] != u1.String() {
-			t.Errorf("expected %v, got %v", u2, members[0])
-		}
-		if members[1] != u3.String() {
-			t.Errorf("expected %v, got %v", u3, members[1])
-		}
-		if members[2] != u2.String() {
-			t.Errorf("expected %v, got %v", u3, members[1])
-		}
+		g := New(u1.Address())
+		testing.SetRealm(u1)
+		testUsingPreviousRealm(func(){
+			g.AddMember(u2.Address())
+			g.AddMember(u3.Address())
+			members := g.Members()
+			if len(members) != 3 {
+				t.Errorf("expected 3, got %v", len(members))
+			}
+			if members[0] != u1.Address().String() {
+				t.Errorf("expected %v, got %v", u1, members[0])
+			}
+			if members[1] != u2.Address().String() {
+				t.Errorf("expected %v, got %v", u2, members[1])
+			}
+			if members[2] != u3.Address().String() {
+				t.Errorf("expected %v, got %v", u3, members[1])
+			}
+		})
 	})
 }
 
 func TestSliceWithOffset(t *testing.T) {
-	t.Parallel()
 	testTable := []struct {
 		name          string
 		slice         []string
@@ -409,7 +375,6 @@ func TestSliceWithOffset(t *testing.T) {
 	}
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			tree := avl.NewTree()
 			for _, s := range test.slice {
 				tree.Set(s, struct{}{})

--- a/examples/gno.land/p/n2p5/mgroup/mgroup_test.gno
+++ b/examples/gno.land/p/n2p5/mgroup/mgroup_test.gno
@@ -6,7 +6,6 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ownable"
-	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
 	"gno.land/p/demo/ufmt"
 )
@@ -17,14 +16,14 @@ func TestManagedGroup(t *testing.T) {
 	u3 := std.NewCodeRealm("gno.land/r/test/test/u3")
 	u4 := std.NewCodeRealm("gno.land/r/test/test/u4")
 
-    probe := func(msg string) {
-        ufmt.Println("probing: " + msg)
-        c := std.CurrentRealm()
-        p := std.PreviousRealm()
+	probe := func(msg string) {
+		ufmt.Println("probing: " + msg)
+		c := std.CurrentRealm()
+		p := std.PreviousRealm()
 
-        ufmt.Println("current realm " + string(c.Address()) + c.PkgPath())
-        ufmt.Println("previous realm" + string(p.Address()) + p.PkgPath())
-    }
+		ufmt.Println("current realm " + string(c.Address()) + c.PkgPath())
+		ufmt.Println("previous realm" + string(p.Address()) + p.PkgPath())
+	}
 
 	// testUsingPreviousRealm sets the realm to "gno.land/r/test/test"
 	// and uses the SetRealm in the test as the previous caller
@@ -37,7 +36,7 @@ func TestManagedGroup(t *testing.T) {
 		g := New(u1.Address())
 
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.AddBackupOwner(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
@@ -49,19 +48,19 @@ func TestManagedGroup(t *testing.T) {
 		})
 
 		testing.SetRealm(u3)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			// an address that is not the owner should not be allowed to add a backup owner
 			if err := g.AddBackupOwner(u4.Address()); err != ownable.ErrUnauthorized {
 				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
 			}
-		})	
+		})
 
 	})
 	t.Run("RemoveBackupOwner", func(t *testing.T) {
 		g := New(u1.Address())
 
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddBackupOwner(u2.Address())
 			if err := g.RemoveBackupOwner(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
@@ -80,7 +79,7 @@ func TestManagedGroup(t *testing.T) {
 		})
 
 		testing.SetRealm(u3)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddBackupOwner(u2.Address())
 			if err := g.RemoveBackupOwner(u2.Address()); err != ownable.ErrUnauthorized {
 				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
@@ -92,11 +91,11 @@ func TestManagedGroup(t *testing.T) {
 		g := New(u1.Address())
 
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddBackupOwner(u2.Address())
 		})
 		testing.SetRealm(u2)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.ClaimOwnership(); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
@@ -111,17 +110,17 @@ func TestManagedGroup(t *testing.T) {
 			}
 		})
 		testing.SetRealm(u3)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.ClaimOwnership(); err != ErrNotMember {
 				t.Errorf("expected %v, got %v", ErrNotMember.Error(), err.Error())
-			}	
+			}
 		})
 	})
 
 	t.Run("AddMember", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.AddMember(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
 			}
@@ -134,7 +133,7 @@ func TestManagedGroup(t *testing.T) {
 			}
 		})
 		testing.SetRealm(u3)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.AddMember(u4.Address()); err != ownable.ErrUnauthorized {
 				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized, err.Error())
 			}
@@ -143,9 +142,9 @@ func TestManagedGroup(t *testing.T) {
 
 	t.Run("RemoveMember", func(t *testing.T) {
 		g := New(u1.Address())
-		
+
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddMember(u2.Address())
 			if err := g.RemoveMember(u2.Address()); err != nil {
 				t.Errorf("expected nil, got %v", err.Error())
@@ -167,17 +166,17 @@ func TestManagedGroup(t *testing.T) {
 		})
 
 		testing.SetRealm(u2)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if err := g.RemoveMember(u3.Address()); err != ownable.ErrUnauthorized {
 				t.Errorf("expected %v, got %v", ownable.ErrUnauthorized.Error(), err.Error())
 			}
 		})
-	})	
+	})
 
 	t.Run("MemberCount", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			uassert.Equal(t, 1, g.MemberCount())
 			g.AddMember(u2.Address())
 			uassert.Equal(t, 2, g.MemberCount())
@@ -191,7 +190,7 @@ func TestManagedGroup(t *testing.T) {
 	t.Run("BackupOwnerCount", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			uassert.Equal(t, 1, g.BackupOwnerCount())
 			g.AddBackupOwner(u2.Address())
 			uassert.Equal(t, 2, g.BackupOwnerCount())
@@ -205,7 +204,7 @@ func TestManagedGroup(t *testing.T) {
 	t.Run("IsMember", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if !g.IsMember(u1.Address()) {
 				t.Errorf("expected %v to be a member", u1)
 			}
@@ -217,11 +216,11 @@ func TestManagedGroup(t *testing.T) {
 				t.Errorf("expected %v to be a member", u2)
 			}
 		})
-	})	
+	})
 	t.Run("IsBackupOwner", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if !g.IsBackupOwner(u1.Address()) {
 				t.Errorf("expected %v to be a backup owner", u1)
 			}
@@ -238,7 +237,7 @@ func TestManagedGroup(t *testing.T) {
 	t.Run("Owner", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			if g.Owner() != u1.Address() {
 				t.Errorf("expected %v, got %v", u1, g.Owner())
 			}
@@ -248,7 +247,7 @@ func TestManagedGroup(t *testing.T) {
 			}
 		})
 		testing.SetRealm(u2)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.ClaimOwnership()
 			if g.Owner() != u2.Address() {
 				t.Errorf("expected %v, got %v", u2, g.Owner())
@@ -258,7 +257,7 @@ func TestManagedGroup(t *testing.T) {
 	t.Run("BackupOwners", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddBackupOwner(u2.Address())
 			g.AddBackupOwner(u3.Address())
 			owners := g.BackupOwners()
@@ -279,7 +278,7 @@ func TestManagedGroup(t *testing.T) {
 	t.Run("Members", func(t *testing.T) {
 		g := New(u1.Address())
 		testing.SetRealm(u1)
-		testUsingPreviousRealm(func(){
+		testUsingPreviousRealm(func() {
 			g.AddMember(u2.Address())
 			g.AddMember(u3.Address())
 			members := g.Members()

--- a/examples/gno.land/r/n2p5/config/config.gno
+++ b/examples/gno.land/r/n2p5/config/config.gno
@@ -19,8 +19,8 @@ var (
 // AddBackupOwner adds a backup owner to the Owner Group.
 // A backup owner can claim ownership of the contract.
 func AddBackupOwner(addr std.Address) {
-	err := adminGroup.AddBackupOwner(addr)
-	if err != nil {
+	crossing()
+	if err := adminGroup.AddBackupOwner(addr); err != nil {
 		panic(err)
 	}
 }
@@ -28,8 +28,8 @@ func AddBackupOwner(addr std.Address) {
 // RemoveBackupOwner removes a backup owner from the Owner Group.
 // The primary owner cannot be removed.
 func RemoveBackupOwner(addr std.Address) {
-	err := adminGroup.RemoveBackupOwner(addr)
-	if err != nil {
+	crossing()
+	if err := adminGroup.RemoveBackupOwner(addr); err != nil {
 		panic(err)
 	}
 }
@@ -37,16 +37,16 @@ func RemoveBackupOwner(addr std.Address) {
 // ClaimOwnership allows an authorized user in the ownerGroup
 // to claim ownership of the contract.
 func ClaimOwnership() {
-	err := adminGroup.ClaimOwnership()
-	if err != nil {
+	crossing()
+	if err := adminGroup.ClaimOwnership(); err != nil {
 		panic(err)
 	}
 }
 
 // AddAdmin adds an admin to the Admin Group.
 func AddAdmin(addr std.Address) {
-	err := adminGroup.AddMember(addr)
-	if err != nil {
+	crossing()
+	if err := adminGroup.AddMember(addr); err != nil {
 		panic(err)
 	}
 }
@@ -54,8 +54,8 @@ func AddAdmin(addr std.Address) {
 // RemoveAdmin removes an admin from the Admin Group.
 // The primary owner cannot be removed.
 func RemoveAdmin(addr std.Address) {
-	err := adminGroup.RemoveMember(addr)
-	if err != nil {
+	crossing()
+	if err := adminGroup.RemoveMember(addr); err != nil {
 		panic(err)
 	}
 }

--- a/examples/gno.land/r/n2p5/config/config_test.gno
+++ b/examples/gno.land/r/n2p5/config/config_test.gno
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/ownable"
+	"gno.land/p/demo/testutils"
+)
+
+func TestAddBackupOwner(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	testing.SetOriginCaller(owner)
+	cross(AddBackupOwner)(u1)
+	b := BackupOwners()
+	if b[1] != u1.String() {
+		t.Error("failed to add u1 to backupowners")
+	}
+	testing.SetOriginCaller(u1)
+	r := revive(func(){
+		cross(AddBackupOwner)(u2)
+	})
+	if r != ownable.ErrUnauthorized {
+		t.Error("failed to catch unauthorized access")
+	}
+
+	testing.SetOriginCaller(owner)
+	cross(RemoveBackupOwner)(u1)
+	cross(RemoveBackupOwner)(u2)
+}
+
+func TestRemoveBackupOwner(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	testing.SetOriginCaller(owner)
+	cross(AddBackupOwner)(u1)
+
+	testing.SetOriginCaller(u2)
+	r := revive(func(){
+		cross(RemoveBackupOwner)(u1)
+	})
+	if r != ownable.ErrUnauthorized {
+		t.Error("failed to catch unauthorized access")
+	}
+
+	testing.SetOriginCaller(owner)
+	cross(RemoveBackupOwner)(u1)
+
+	if len(BackupOwners()) != 1 {
+		t.Error("BackupOwners should be length == 1 ")
+	}
+}
+
+func TestClaimOwnership(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	if owner != Owner() {
+		t.Errorf("expected: %v, got: %v", owner, Owner())
+	}
+
+	testing.SetOriginCaller(owner)
+	cross(AddBackupOwner)(u1)
+	
+	testing.SetOriginCaller(u1)
+	cross(ClaimOwnership)()
+
+	if u1 != Owner() {
+		t.Errorf("expected: %v, got: %v", owner, Owner())
+	}
+
+	testing.SetOriginCaller(owner)
+	cross(ClaimOwnership)()
+}
+
+func TestAddAdmin(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	testing.SetOriginCaller(owner)
+	cross(AddAdmin)(u1)
+	admins := Admins()
+	if admins[1] != u1.String() {
+		t.Error("failed to add u1 to admins group")
+	}
+	testing.SetOriginCaller(u1)
+	r := revive(func(){
+		cross(AddAdmin)(u2)
+	})
+	if r != ownable.ErrUnauthorized {
+		t.Error("failed to catch unauthorized access")
+	}
+
+	// cleanup
+	testing.SetOriginCaller(owner)
+	cross(RemoveAdmin)(u1)
+}
+
+func TestRemoveAdmin(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	testing.SetOriginCaller(owner)
+	cross(AddAdmin)(u1)
+
+	testing.SetOriginCaller(u2)
+	r := revive(func(){
+		cross(RemoveAdmin)(u1)
+	})
+	if r != ownable.ErrUnauthorized {
+		t.Error("failed to catch unauthorized access")
+	}
+
+	testing.SetOriginCaller(owner)
+	cross(RemoveAdmin)(u1)
+
+	if len(Admins()) != 1 {
+		t.Error("Admin should be length == 1 ")
+	}
+}
+
+func TestIsAdmin(t *testing.T) {
+	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
+	u1 := testutils.TestAddress("u1")
+	u2 := testutils.TestAddress("u2")
+	
+	testing.SetOriginCaller(owner)
+	cross(AddAdmin)(u1)
+
+	if !IsAdmin(owner) {
+		t.Error("owner should be admin")
+	}
+	if !IsAdmin(u1) {
+		t.Error("u1 should be admin")
+	}
+	if IsAdmin(u2) {
+		t.Error("u2 should not be admin")
+	}	
+}

--- a/examples/gno.land/r/n2p5/config/config_test.gno
+++ b/examples/gno.land/r/n2p5/config/config_test.gno
@@ -12,7 +12,7 @@ func TestAddBackupOwner(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	testing.SetOriginCaller(owner)
 	cross(AddBackupOwner)(u1)
 	b := BackupOwners()
@@ -20,7 +20,7 @@ func TestAddBackupOwner(t *testing.T) {
 		t.Error("failed to add u1 to backupowners")
 	}
 	testing.SetOriginCaller(u1)
-	r := revive(func(){
+	r := revive(func() {
 		cross(AddBackupOwner)(u2)
 	})
 	if r != ownable.ErrUnauthorized {
@@ -36,12 +36,12 @@ func TestRemoveBackupOwner(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	testing.SetOriginCaller(owner)
 	cross(AddBackupOwner)(u1)
 
 	testing.SetOriginCaller(u2)
-	r := revive(func(){
+	r := revive(func() {
 		cross(RemoveBackupOwner)(u1)
 	})
 	if r != ownable.ErrUnauthorized {
@@ -60,14 +60,14 @@ func TestClaimOwnership(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	if owner != Owner() {
 		t.Errorf("expected: %v, got: %v", owner, Owner())
 	}
 
 	testing.SetOriginCaller(owner)
 	cross(AddBackupOwner)(u1)
-	
+
 	testing.SetOriginCaller(u1)
 	cross(ClaimOwnership)()
 
@@ -83,7 +83,7 @@ func TestAddAdmin(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	testing.SetOriginCaller(owner)
 	cross(AddAdmin)(u1)
 	admins := Admins()
@@ -91,7 +91,7 @@ func TestAddAdmin(t *testing.T) {
 		t.Error("failed to add u1 to admins group")
 	}
 	testing.SetOriginCaller(u1)
-	r := revive(func(){
+	r := revive(func() {
 		cross(AddAdmin)(u2)
 	})
 	if r != ownable.ErrUnauthorized {
@@ -107,12 +107,12 @@ func TestRemoveAdmin(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	testing.SetOriginCaller(owner)
 	cross(AddAdmin)(u1)
 
 	testing.SetOriginCaller(u2)
-	r := revive(func(){
+	r := revive(func() {
 		cross(RemoveAdmin)(u1)
 	})
 	if r != ownable.ErrUnauthorized {
@@ -131,7 +131,7 @@ func TestIsAdmin(t *testing.T) {
 	owner := std.Address("g1j39fhg29uehm7twwnhvnpz3ggrm6tprhq65t0t")
 	u1 := testutils.TestAddress("u1")
 	u2 := testutils.TestAddress("u2")
-	
+
 	testing.SetOriginCaller(owner)
 	cross(AddAdmin)(u1)
 
@@ -143,5 +143,5 @@ func TestIsAdmin(t *testing.T) {
 	}
 	if IsAdmin(u2) {
 		t.Error("u2 should not be admin")
-	}	
+	}
 }

--- a/examples/gno.land/r/n2p5/home/home.gno
+++ b/examples/gno.land/r/n2p5/home/home.gno
@@ -16,18 +16,20 @@ var (
 )
 
 func init() {
-	cross(hor.Register)("N2p5's Home Realm", "")
+	cross(hor.Register)("n2p5's Home Realm", "")
 
 }
 
 // Add appends a string to the preview Chonk.
 func Add(chunk string) {
+	crossing()
 	assertAdmin()
 	preview.Add(chunk)
 }
 
 // Flush clears the preview Chonk.
 func Flush() {
+	crossing()
 	assertAdmin()
 	preview.Flush()
 }
@@ -35,6 +37,7 @@ func Flush() {
 // Promote promotes the preview Chonk to the active Chonk
 // and creates a new preview Chonk.
 func Promote() {
+	crossing()
 	assertAdmin()
 	active = preview
 	preview = chonk.New()


### PR DESCRIPTION
This PR restores the expected behavior for `p/n2p5/mgroup`, `r/n2p5/config` and `r/n2p5/home`. While the tests were passing after the updates, the fundamental behavior of how mgroup works was changed. We want PreviousRealm interactivity over crossing so that the PreviousRealm caller can make changes within the permission scheme.

I've also updated and added testing cross all 3 libraries to cover this expected behavior moving forward properly.