### PR TITLE
fix(gnoweb): pass encoded query strings to render

### DIFF
--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -117,7 +117,7 @@ func escapeDollarSign(s string) string {
 // EncodeArgs encodes the arguments and query parameters into a string.
 // This function is intended to be passed as a realm `Render` argument.
 func (gnoURL GnoURL) EncodeArgs() string {
-	return gnoURL.Encode(EncodeArgs | EncodeQuery | EncodeNoEscape)
+	return gnoURL.Encode(EncodeArgs | EncodeQuery)
 }
 
 // EncodeURL encodes the path, arguments, and query parameters into a string.

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -579,3 +579,18 @@ func TestEncode(t *testing.T) {
 		})
 	}
 }
+
+func TestGnoURL_EncodeArgs(t *testing.T) {
+	// EncodeArgs is used to pass the values to the render function in Gno.
+	// Thus, it should maintain values escaped as they are in the original URL
+	// where it matters - like =&
+	gurl, err := Parse("/r/demo/users:foo%3d%24bar%26%3fbaz?hey=1&a%2bb=b%2b&%26=%3d")
+	require.NoError(t, err)
+	assert.Equal(t, "foo=$bar&?baz", gurl.Args)
+	assert.Equal(t, url.Values{
+		"hey": {"1"},
+		"a+b": {"b+"},
+		"&":   {"="},
+	}, gurl.Query)
+	assert.Equal(t, "foo=%24bar&%3Fbaz?%26=%3D&a%2Bb=b%2B&hey=1", gurl.EncodeArgs())
+}


### PR DESCRIPTION
see: https://github.com/gnolang/gno/pull/4084#discussion_r2090854152