### PR TITLE
feat: choose pruning strategy from `config.toml`

### DIFF
--- a/gno.land/cmd/gnoland/config_set.go
+++ b/gno.land/cmd/gnoland/config_set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/config"
 	"github.com/gnolang/gno/tm2/pkg/bft/state/eventstore/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	storeTypes "github.com/gnolang/gno/tm2/pkg/store/types"
 )
 
 var errInvalidConfigSetArgs = errors.New("invalid number of config set arguments provided")
@@ -149,6 +150,10 @@ func saveStringToValue(value string, dstValue reflect.Value) error {
 		val := parseEventStoreParams(value)
 
 		dstValue.Set(reflect.ValueOf(val))
+	case storeTypes.PruneStrategy:
+		val := reflect.ValueOf(value)
+
+		dstValue.Set(val.Convert(dstValue.Type()))
 	default:
 		return fmt.Errorf("unsupported type, %s", dstValue.Type().Name())
 	}

--- a/gno.land/cmd/gnoland/config_set_test.go
+++ b/gno.land/cmd/gnoland/config_set_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/state/eventstore/file"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -810,6 +811,35 @@ func TestConfig_Set_Mempool(t *testing.T) {
 			},
 			func(loadedCfg *config.Config, value string) {
 				assert.Equal(t, value, fmt.Sprintf("%d", loadedCfg.Mempool.CacheSize))
+			},
+		},
+	}
+
+	verifySetTestTableCommon(t, testTable)
+}
+
+func TestConfig_Set_Application(t *testing.T) {
+	t.Parallel()
+
+	testTable := []testSetCase{
+		{
+			"min gas prices updated",
+			[]string{
+				"application.min_gas_prices",
+				"10foo/3gas",
+			},
+			func(loadedCfg *config.Config, value string) {
+				assert.Equal(t, value, loadedCfg.Application.MinGasPrices)
+			},
+		},
+		{
+			"prune strategy updated",
+			[]string{
+				"application.prune_strategy",
+				"everything",
+			},
+			func(loadedCfg *config.Config, value string) {
+				assert.Equal(t, types.PruneStrategy(value), loadedCfg.Application.PruneStrategy)
 			},
 		},
 	}

--- a/gno.land/cmd/gnoland/start.go
+++ b/gno.land/cmd/gnoland/start.go
@@ -239,7 +239,6 @@ func execStart(ctx context.Context, c *startCfg, io commands.IO) error {
 
 	// Create a top-level shared event switch
 	evsw := events.NewEventSwitch()
-	minGasPrices := cfg.Application.MinGasPrices
 
 	// Create application and node
 	cfg.LocalApp, err = gnoland.NewApp(
@@ -248,9 +247,9 @@ func execStart(ctx context.Context, c *startCfg, io commands.IO) error {
 			SkipFailingTxs:      c.skipFailingGenesisTxs,
 			SkipSigVerification: c.skipGenesisSigVerification,
 		},
+		cfg.Application,
 		evsw,
 		logger,
-		minGasPrices,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create the Gnoland app, %w", err)

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -21,11 +21,13 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	sdkCfg "github.com/gnolang/gno/tm2/pkg/sdk/config"
 	"github.com/gnolang/gno/tm2/pkg/sdk/params"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/store"
 	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
 	"github.com/gnolang/gno/tm2/pkg/store/iavl"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
 
 	// Only goleveldb is supported for now.
 	_ "github.com/gnolang/gno/tm2/pkg/db/_tags"
@@ -41,6 +43,7 @@ type AppOptions struct {
 	SkipGenesisVerification bool               // default to verify genesis transactions
 	InitChainerConfig                          // options related to InitChainer
 	MinGasPrices            string             // optional
+	PruneStrategy           types.PruneStrategy
 }
 
 // TestAppOptions provides a "ready" default [AppOptions] for use with
@@ -56,6 +59,7 @@ func TestAppOptions(db dbm.DB) *AppOptions {
 			CacheStdlibLoad:        true,
 		},
 		SkipGenesisVerification: true,
+		PruneStrategy:           types.PruneNothingStrategy,
 	}
 }
 
@@ -87,6 +91,9 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 	if cfg.MinGasPrices != "" {
 		appOpts = append(appOpts, sdk.SetMinGasPrices(cfg.MinGasPrices))
 	}
+
+	appOpts = append(appOpts, sdk.SetPruningOptions(cfg.PruneStrategy.Options()))
+
 	// Create BaseApp.
 	baseApp := sdk.NewBaseApp("gnoland", cfg.Logger, cfg.DB, baseKey, mainKey, appOpts...)
 	baseApp.SetAppVersion("dev")
@@ -204,9 +211,9 @@ func NewTestGenesisAppConfig() GenesisAppConfig {
 func NewApp(
 	dataRootDir string,
 	genesisCfg GenesisAppConfig,
+	appCfg *sdkCfg.AppConfig,
 	evsw events.EventSwitch,
 	logger *slog.Logger,
-	minGasPrices string,
 ) (abci.Application, error) {
 	var err error
 
@@ -217,8 +224,9 @@ func NewApp(
 			GenesisTxResultHandler: PanicOnFailingTxResultHandler,
 			StdlibDir:              filepath.Join(gnoenv.RootDir(), "gnovm", "stdlibs"),
 		},
-		MinGasPrices:            minGasPrices,
+		MinGasPrices:            appCfg.MinGasPrices,
 		SkipGenesisVerification: genesisCfg.SkipSigVerification,
+		PruneStrategy:           appCfg.PruneStrategy,
 	}
 	if genesisCfg.SkipFailingTxs {
 		cfg.GenesisTxResultHandler = NoopGenesisTxResultHandler

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/gnolang/gno/tm2/pkg/sdk/config"
 	"github.com/gnolang/gno/tm2/pkg/sdk/params"
 	"github.com/gnolang/gno/tm2/pkg/sdk/testutils"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -136,7 +137,7 @@ func TestNewApp(t *testing.T) {
 	// NewApp should have good defaults and manage to run InitChain.
 	td := t.TempDir()
 
-	app, err := NewApp(td, NewTestGenesisAppConfig(), events.NewEventSwitch(), log.NewNoopLogger(), "")
+	app, err := NewApp(td, NewTestGenesisAppConfig(), config.DefaultAppConfig(), events.NewEventSwitch(), log.NewNoopLogger())
 	require.NoError(t, err, "NewApp should be successful")
 
 	resp := app.InitChain(abci.RequestInitChain{

--- a/tm2/pkg/sdk/config/config.go
+++ b/tm2/pkg/sdk/config/config.go
@@ -1,34 +1,53 @@
 package config
 
 import (
-	"github.com/gnolang/gno/tm2/pkg/errors"
+	"errors"
+	"fmt"
+
 	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
 
 // -----------------------------------------------------------------------------
 // Application Config
 
+var (
+	ErrInvalidMinGasPrices  = errors.New("invalid min gas prices")
+	ErrInvalidPruneStrategy = errors.New("invalid prune strategy")
+)
+
 // AppConfig defines the configuration options for the Application
 type AppConfig struct {
 	// Lowest gas prices accepted by a validator in the form of "100tokenA/3gas;10tokenB/5gas" separated by semicolons
 	MinGasPrices string `json:"min_gas_prices" toml:"min_gas_prices" comment:"Lowest gas prices accepted by a validator"`
+
+	// The enforced state pruning stategy for the app
+	PruneStrategy types.PruneStrategy `json:"prune_strategy" toml:"prune_strategy" comment:"State pruning strategy [everything, nothing, syncable]"`
 }
 
 // DefaultAppConfig returns a default configuration for the application
 func DefaultAppConfig() *AppConfig {
 	return &AppConfig{
-		MinGasPrices: "",
+		MinGasPrices:  "",
+		PruneStrategy: types.PruneNothingStrategy,
 	}
 }
 
 // ValidateBasic performs basic validation, checking format and param bounds, etc., and
 // returns an error if any check fails.
 func (cfg *AppConfig) ValidateBasic() error {
-	if cfg.MinGasPrices == "" {
-		return nil
+	// Make sure the minimum gas prices are valid, if set
+	if cfg.MinGasPrices != "" {
+		if _, err := std.ParseGasPrices(cfg.MinGasPrices); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidMinGasPrices, err)
+		}
 	}
-	if _, err := std.ParseGasPrices(cfg.MinGasPrices); err != nil {
-		return errors.Wrap(err, "invalid min gas prices")
+
+	// Make sure the prune strategy is recognized
+	if cfg.PruneStrategy != types.PruneEverythingStrategy &&
+		cfg.PruneStrategy != types.PruneNothingStrategy &&
+		cfg.PruneStrategy != types.PruneSyncableStrategy {
+		return fmt.Errorf("%w: %q", ErrInvalidPruneStrategy, cfg.PruneStrategy)
 	}
 
 	return nil

--- a/tm2/pkg/store/types/options.go
+++ b/tm2/pkg/store/types/options.go
@@ -38,3 +38,24 @@ var (
 	// PruneSyncable means only those states not needed for state syncing will be deleted (keeps last 100 + every 10000th)
 	PruneSyncable = NewPruningOptions(100, 10000)
 )
+
+type PruneStrategy string
+
+const (
+	PruneEverythingStrategy PruneStrategy = "everything"
+	PruneNothingStrategy    PruneStrategy = "nothing"
+	PruneSyncableStrategy   PruneStrategy = "syncable"
+)
+
+// Options returns the corresponding prune options.
+// If the pruning strategy is invalid, defaults to no pruning.
+func (s PruneStrategy) Options() PruningOptions {
+	switch s {
+	case PruneEverythingStrategy:
+		return PruneEverything
+	case PruneSyncableStrategy:
+		return PruneSyncable
+	default:
+		return PruneNothing
+	}
+}


### PR DESCRIPTION
## Description

This PR allows the node operator to choose a pruning strategy from the `config.toml`.
It also cleans up some configuration tests, and enables `height` queries from `gnokey`.

Closes #4339