### PR TITLE
ci: auto-rerun codecov 

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,4 +36,3 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run rerun-codecov.yml -F run_id=${{ github.run_id }}
-          

--- a/.github/workflows/rerun-codecov.yml
+++ b/.github/workflows/rerun-codecov.yml
@@ -26,4 +26,3 @@ jobs:
         run: |
           echo "Rerunning failed jobs for run ${{ inputs.run_id }} ..."
           gh run rerun ${{ inputs.run_id }} --failed
-          


### PR DESCRIPTION
### What does this PR do?
This PR implements github rererun workflows for codecov.

### Why is this change needed?
Using the GitHub CLI, this workaround reruns the original workflow if it fails, up to a retry limit, and introduces a secondary workflow that can be triggered via `workflow_dispatch`. By automatically retrying failed workflow runs, this method improves CI reliability without requiring manual intervention and makes it possible to programmatically handle faulty tests or temporary failures.

### Testing
WIll be tested in the github actions

### Documentation
Reference recommendation: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649

### Related issues
Closes #2825

---
> Please let me know if you have feedback or require any changes. 
