### PR TITLE
chore: add proper multisig pubkey display in `gnokey list`

### DIFF
--- a/tm2/pkg/crypto/multisig/threshold_pubkey.go
+++ b/tm2/pkg/crypto/multisig/threshold_pubkey.go
@@ -1,6 +1,9 @@
 package multisig
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 )
@@ -31,7 +34,12 @@ func NewPubKeyMultisigThreshold(k int, pubkeys []crypto.PubKey) crypto.PubKey {
 }
 
 func (pk PubKeyMultisigThreshold) String() string {
-	panic("not yet implemented")
+	var parts []string
+	for _, key := range pk.PubKeys {
+		parts = append(parts, key.String())
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
 }
 
 // VerifyBytes expects sig to be an amino encoded version of a MultiSignature.

--- a/tm2/pkg/crypto/multisig/threshold_pubkey.go
+++ b/tm2/pkg/crypto/multisig/threshold_pubkey.go
@@ -1,7 +1,6 @@
 package multisig
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -34,12 +33,12 @@ func NewPubKeyMultisigThreshold(k int, pubkeys []crypto.PubKey) crypto.PubKey {
 }
 
 func (pk PubKeyMultisigThreshold) String() string {
-	pubKeys := make([]string, 0, len(pk.PubKeys))
-	for _, key := range pk.PubKeys {
-		pubKeys = append(pubKeys, key.String())
+	pubKeys := make([]string, len(pk.PubKeys))
+	for i, key := range pk.PubKeys {
+		pubKeys[i] = key.String()
 	}
 
-	return fmt.Sprintf("[%s]", strings.Join(pubKeys, ", "))
+	return "[" + strings.Join(pubKeys, ", ") + "]"
 }
 
 // VerifyBytes expects sig to be an amino encoded version of a MultiSignature.

--- a/tm2/pkg/crypto/multisig/threshold_pubkey.go
+++ b/tm2/pkg/crypto/multisig/threshold_pubkey.go
@@ -34,7 +34,7 @@ func NewPubKeyMultisigThreshold(k int, pubkeys []crypto.PubKey) crypto.PubKey {
 }
 
 func (pk PubKeyMultisigThreshold) String() string {
-	var pubKeys []string
+	pubKeys := make([]string, 0, len(pk.PubKeys))
 	for _, key := range pk.PubKeys {
 		pubKeys = append(pubKeys, key.String())
 	}

--- a/tm2/pkg/crypto/multisig/threshold_pubkey.go
+++ b/tm2/pkg/crypto/multisig/threshold_pubkey.go
@@ -34,12 +34,12 @@ func NewPubKeyMultisigThreshold(k int, pubkeys []crypto.PubKey) crypto.PubKey {
 }
 
 func (pk PubKeyMultisigThreshold) String() string {
-	var parts []string
+	var pubKeys []string
 	for _, key := range pk.PubKeys {
-		parts = append(parts, key.String())
+		pubKeys = append(pubKeys, key.String())
 	}
 
-	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
+	return fmt.Sprintf("[%s]", strings.Join(pubKeys, ", "))
 }
 
 // VerifyBytes expects sig to be an amino encoded version of a MultiSignature.

--- a/tm2/pkg/crypto/multisig/threshold_pubkey_test.go
+++ b/tm2/pkg/crypto/multisig/threshold_pubkey_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -181,4 +182,33 @@ func generatePubKeysAndSignatures(n int, msg []byte) (pubkeys []crypto.PubKey, s
 		signatures[i], _ = privkey.Sign(msg)
 	}
 	return
+}
+
+func TestPubKeyMultisigThreshold_String(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty set", func(t *testing.T) {
+		t.Parallel()
+
+		pk := PubKeyMultisigThreshold{
+			PubKeys: make([]crypto.PubKey, 0), // empty
+		}
+
+		assert.Equal(t, "[]", pk.String())
+	})
+
+	t.Run("multiple keys", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			keys, _ = generatePubKeysAndSignatures(10, []byte("dummy"))
+			pk      = NewPubKeyMultisigThreshold(5, keys)
+		)
+
+		output := pk.String()
+
+		for _, key := range keys {
+			assert.Contains(t, output, key.String())
+		}
+	})
 }


### PR DESCRIPTION
## Description

This PR fixes a small rendering issue with multisig keys when the user ran `gnokey list`.

Previously:

```shell
multisig-abc (multi) - addr: g1hh8sfuykq3rwdyv4cm60ja83r7jnwsn2d8e4td pub: %!v(PANIC=String method: not yet implemented), path: <nil>
```

Now:
```shell
multisig-abc (multi) - addr: g1hh8sfuykq3rwdyv4cm60ja83r7jnwsn2d8e4td pub: [gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqd5cvr06musw50vf2aak03hlujlupyzvc6fheqk05ly0su4yjp7kualpnuw, gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqdve0luvz8qad075enwfe9w2l6hnqtwmtw47hqry9vjl6pe626g65u5qrnt, gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqw6pcayjsaqxefagcv6n9ez677khejm69mng3dcv3teqtjpazmrv6rxyyt4], path: <nil>
```