### PR TITLE
chore(commondao): add `MustValidate` and `MustExecute`

### DIFF
--- a/examples/gno.land/p/nt/commondao/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/proposal.gno
@@ -107,6 +107,28 @@ type (
 	}
 )
 
+// MustValidate validates that a proposal is valid for the current state or panics on error.
+func MustValidate(v Validable) {
+	if v == nil {
+		panic("validable proposal definition is nil")
+	}
+
+	if err := v.Validate(); err != nil {
+		panic(err)
+	}
+}
+
+// MustExecute executes an executable proposal or panics on error.
+func MustExecute(e Executable) {
+	if e == nil {
+		panic("executable proposal definition is nil")
+	}
+
+	if err := e.Execute(cross); err != nil {
+		panic(err)
+	}
+}
+
 // NewProposal creates a new DAO proposal.
 func NewProposal(id uint64, creator std.Address, d ProposalDefinition) (*Proposal, error) {
 	if d == nil {

--- a/examples/gno.land/p/nt/commondao/proposal_test.gno
+++ b/examples/gno.land/p/nt/commondao/proposal_test.gno
@@ -1,6 +1,7 @@
 package commondao
 
 import (
+	"errors"
 	"std"
 	"testing"
 	"time"
@@ -292,18 +293,31 @@ func TestIsQuorumReached(t *testing.T) {
 	}
 }
 
+func TestMustValidate(t *testing.T) {
+	uassert.NotPanics(t, func() {
+		MustValidate(testPropDef{})
+	}, "expect validation to succeed")
+
+	uassert.PanicsWithMessage(t, "validable proposal definition is nil", func() {
+		MustValidate(nil)
+	}, "expect validation to panic with nil definition")
+
+	uassert.PanicsWithMessage(t, "boom!", func() {
+		MustValidate(testPropDef{validationErr: errors.New("boom!")})
+	}, "expect validation to panic")
+}
+
 type testPropDef struct {
-	votingPeriod                          time.Duration
-	tallyResult                           bool
-	validationErr, tallyErr, executionErr error
-	voteChoices                           []VoteChoice
+	votingPeriod            time.Duration
+	tallyResult             bool
+	validationErr, tallyErr error
+	voteChoices             []VoteChoice
 }
 
 func (testPropDef) Title() string                 { return "" }
 func (testPropDef) Body() string                  { return "" }
 func (d testPropDef) VotingPeriod() time.Duration { return d.votingPeriod }
 func (d testPropDef) Validate() error             { return d.validationErr }
-func (d testPropDef) Execute() error              { return d.executionErr }
 
 func (d testPropDef) Tally(ReadonlyVotingRecord, MemberSet) (bool, error) {
 	return d.tallyResult, d.tallyErr

--- a/examples/gno.land/p/nt/commondao/z_commondao_must_execute_0_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/z_commondao_must_execute_0_filetest.gno
@@ -1,0 +1,27 @@
+// PKGPATH: gno.land/r/demo/commondao_test
+package commondao_test
+
+import (
+	"time"
+
+	"gno.land/p/nt/commondao"
+)
+
+type testPropDef struct{}
+
+func (testPropDef) Title() string               { return "" }
+func (testPropDef) Body() string                { return "" }
+func (testPropDef) VotingPeriod() time.Duration { return 0 }
+func (testPropDef) Execute(cur realm) error     { return nil }
+
+func (testPropDef) Tally(commondao.ReadonlyVotingRecord, commondao.MemberSet) (bool, error) {
+	return true, nil
+}
+
+func main() {
+	commondao.MustExecute(testPropDef{})
+	println("ok")
+}
+
+// Output:
+// ok

--- a/examples/gno.land/p/nt/commondao/z_commondao_must_execute_1_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/z_commondao_must_execute_1_filetest.gno
@@ -1,0 +1,30 @@
+// PKGPATH: gno.land/r/demo/commondao_test
+package commondao_test
+
+import (
+	"errors"
+	"time"
+
+	"gno.land/p/nt/commondao"
+)
+
+type testPropDef struct{}
+
+func (testPropDef) Title() string               { return "" }
+func (testPropDef) Body() string                { return "" }
+func (testPropDef) VotingPeriod() time.Duration { return 0 }
+
+func (testPropDef) Tally(commondao.ReadonlyVotingRecord, commondao.MemberSet) (bool, error) {
+	return true, nil
+}
+
+func (testPropDef) Execute(cur realm) error {
+	return errors.New("boom!")
+}
+
+func main() {
+	commondao.MustExecute(testPropDef{})
+}
+
+// Error:
+// boom!

--- a/examples/gno.land/p/nt/commondao/z_commondao_must_execute_2_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/z_commondao_must_execute_2_filetest.gno
@@ -1,0 +1,13 @@
+// PKGPATH: gno.land/r/demo/commondao_test
+package commondao_test
+
+import (
+	"gno.land/p/nt/commondao"
+)
+
+func main() {
+	commondao.MustExecute(nil)
+}
+
+// Error:
+// executable proposal definition is nil


### PR DESCRIPTION
Must functions were used instead of interface methods to keep them minimal and not to force users to implement them for every proposal definition.

See https://github.com/gnolang/gno/pull/4333#discussion_r2134061584