### PR TITLE
feat: enable GovDAO to modify account restriction status

### DIFF
--- a/examples/gno.land/r/sys/params/unlock.gno
+++ b/examples/gno.land/r/sys/params/unlock.gno
@@ -1,12 +1,18 @@
 package params
 
-import "gno.land/r/gov/dao"
+import (
+	"gno.land/r/gov/dao"
+	"std"
+	"sys/params"
+)
 
 const (
-	bankModulePrefix    = "bank"
-	restrictedDenomsKey = "restricted_denoms"
-	unlockTransferTitle = "Proposal to unlock the transfer of ugnot."
-	lockTransferTitle   = "Proposal to lock the transfer of ugnot."
+	bankModulePrefix     = "bank"
+	restrictedDenomsKey  = "restricted_denoms"
+	unlockTransferTitle  = "Proposal to unlock the transfer of ugnot."
+	lockTransferTitle    = "Proposal to lock the transfer of ugnot."
+	authModulePrefix     = "auth"
+	unrestrictedAddrsKey = "unrestricted_addrs"
 )
 
 func ProposeUnlockTransferRequest() dao.ProposalRequest {
@@ -15,4 +21,45 @@ func ProposeUnlockTransferRequest() dao.ProposalRequest {
 
 func ProposeLockTransferRequest() dao.ProposalRequest {
 	return NewSysParamStringsPropRequestWithTitle(bankModulePrefix, "p", restrictedDenomsKey, lockTransferTitle, []string{"ugnot"})
+}
+
+func ProposeAddUnrestrictedAcctsRequest(addrs ...std.Address) dao.ProposalRequest {
+
+	addrStrings := params.GetSysParamStrings(authModulePrefix, "p", unrestrictedAddrsKey)
+
+	// Temporary map for duplicate detection
+	existing := make(map[string]struct{}, len(addrStrings))
+	for _, s := range addrStrings {
+		existing[s] = struct{}{}
+	}
+
+	// Append only non-duplicate addresses
+	for _, addr := range addrs {
+		s := addr.String()
+		if _, found := existing[s]; !found {
+			addrStrings = append(addrStrings, s)
+			existing[s] = struct{}{}
+		}
+	}
+
+	return NewSysParamStringsPropRequestWithTitle(authModulePrefix, "p", unrestrictedAddrsKey, "Add unrestricted transfer accounts", addrStrings)
+}
+
+func ProposeRemoveUnrestrictedAcctsRequest(addrs ...std.Address) dao.ProposalRequest {
+	addrStrings := params.GetSysParamStrings(authModulePrefix, "p", unrestrictedAddrsKey)
+
+	removeSet := make(map[string]struct{}, len(addrs))
+
+	for _, addr := range addrs {
+		removeSet[addr.String()] = struct{}{}
+	}
+
+	result := addrStrings[:0] // reuse original memory
+	for _, s := range addrStrings {
+		if _, found := removeSet[s]; !found {
+			result = append(result, s)
+		}
+	}
+
+	return NewSysParamStringsPropRequestWithTitle(authModulePrefix, "p", unrestrictedAddrsKey, "Remove unrestricted transfer accounts", result)
 }

--- a/gno.land/pkg/gnoland/types.go
+++ b/gno.land/pkg/gnoland/types.go
@@ -85,6 +85,11 @@ func (ga *GnoAccount) SetUnrestricted() {
 	ga.setFlag(flagUnrestricted)
 }
 
+// SetRestricted, accounts are restricted when global transfer locking is enabled.
+func (ga *GnoAccount) SetRestricted() {
+	ga.clearFlag(flagUnrestricted)
+}
+
 // IsUnrestricted checks whether the account is flagUnrestricted.
 func (ga *GnoAccount) IsUnrestricted() bool {
 	return ga.hasFlag(flagUnrestricted)

--- a/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
@@ -1,0 +1,211 @@
+## It tests unlocking token transfers through GovDAO voting
+loadpkg gno.land/r/sys/params
+loadpkg gno.land/r/gov/dao/v3/init
+loadpkg gno.land/r/gov/dao
+
+# add user regular1
+adduserfrom regular1 'source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast' 1
+stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
+
+# add user regular2
+adduserfrom regular2 'source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast' 1 1
+stdout 'g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp'
+
+## The -lock-transfer flag is not a Gnoland service flag; it is a flag for the txtar setting.
+gnoland start -lock-transfer
+
+## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
+## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test test1
+
+stdout 'OK!'
+
+gnokey maketx send -send "9999999ugnot" -to $regular2_user_addr -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test test1
+
+stdout 'OK!'
+
+## Restricted simple token transfer for a regular account
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular1
+
+stderr 'restricted token transfer error'
+
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular2
+
+stderr 'restricted token transfer error'
+
+
+## Load member as T1 to be able to vote afterwards
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+
+## Submit a proposal to add a regular use as the unrestricted account.
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_unrestricted.gno
+
+stdout '0'
+
+## Vote for the unrestricted account proposal using test1
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
+
+stdout 'OK!'
+
+## Execute the unrestricted account proposal using test1
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
+
+stdout 'OK!'
+
+## Token transfers for regular1 accounts is allowed.
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular1
+
+stdout 'OK!'
+
+## Token transfers for regular2 accounts is allowed.
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular2
+
+stdout 'OK!'
+
+## Verify the restricted address
+gnokey query params/auth:p:unrestricted_addrs
+stdout '["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5","g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4","g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp"]'
+
+
+## Submit a proposal to remove regular1 and regular2 as the unrestricted accounts.
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_restricted.gno
+
+stdout '1'
+
+## Vote for the remove unrestricted account proposal using test1
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal1.gno
+
+stdout 'OK!'
+
+## Execute the remove unrestricted account proposal using test1
+gnokey maketx run  -gas-fee 100000ugnot -gas-wanted 95000000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal1.gno
+
+stdout 'OK!'
+
+## Verify the restricted address
+gnokey query params/auth:p:unrestricted_addrs
+stdout '["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"]'
+
+## Restricted simple token transfer for a regular account
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular1
+
+stderr 'restricted token transfer error'
+
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 10000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test regular2
+
+stderr 'restricted token transfer error'
+
+## Verify the restricted address
+gnokey query params/auth:p:unrestricted_addrs
+stdout '["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"]'
+
+
+-- run/user_addr.gno --
+
+package main
+
+import(
+  "std"
+)
+
+func main(){
+
+  println(std.OriginCaller())
+
+}
+
+-- run/load_user.gno --
+package main
+
+import (
+  i "gno.land/r/gov/dao/v3/init"
+  "std"
+)
+
+func main() {
+	i.InitWithUsers(std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"))
+}
+
+-- run/propose_unrestricted.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+  "gno.land/r/sys/params"
+)
+
+func main() {
+	pr := params.ProposeAddUnrestrictedAcctsRequest("g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4","g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp")
+  pid := dao.MustCreateProposal(cross,pr)
+  println(pid.String())
+}
+
+-- run/propose_restricted.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+  "gno.land/r/sys/params"
+)
+
+func main() {
+	pr := params.ProposeRemoveUnrestrictedAcctsRequest("g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4","g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp")
+  pid := dao.MustCreateProposal(cross,pr)
+  println(pid.String())
+}
+
+
+-- run/vote_proposal.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+)
+
+func main() {
+	dao.MustVoteOnProposal(cross,dao.VoteRequest{
+		Option:     dao.YesVote,
+		ProposalID: dao.ProposalID(0),
+	})
+}
+
+-- run/exec_proposal.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+)
+
+func main() {
+	ok := dao.ExecuteProposal(cross,dao.ProposalID(0))
+  if ok {
+    println("OK!")
+  }
+}
+
+-- run/vote_proposal1.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+)
+
+func main() {
+	dao.MustVoteOnProposal(cross,dao.VoteRequest{
+		Option:     dao.YesVote,
+		ProposalID: dao.ProposalID(1),
+	})
+}
+-- run/exec_proposal1.gno --
+package main
+
+import (
+  "gno.land/r/gov/dao"
+)
+
+func main() {
+	ok := dao.ExecuteProposal(cross,dao.ProposalID(1))
+  if ok {
+    println("OK!")
+  }
+}

--- a/gno.land/pkg/sdk/vm/builtins.go
+++ b/gno.land/pkg/sdk/vm/builtins.go
@@ -110,6 +110,12 @@ func (prm *SDKParams) SetStrings(key string, value []string) {
 	prm.pmk.SetStrings(prm.ctx, key, value)
 }
 
+func (prm *SDKParams) GetStrings(key string) []string {
+	value := &[]string{}
+	prm.pmk.GetStrings(prm.ctx, key, value)
+	return *value
+}
+
 func (prm *SDKParams) willSetKeeperParams(ctx sdk.Context, key string, value any) {
 	parts := strings.Split(key, ":")
 	if len(parts) == 0 {

--- a/gnovm/stdlibs/generated.go
+++ b/gnovm/stdlibs/generated.go
@@ -1136,6 +1136,50 @@ var nativeFuncs = [...]NativeFunc{
 		},
 	},
 	{
+		"sys/params",
+		"getSysParamStrings",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("string")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("string")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("string")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("[]string")},
+		},
+		true,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  string
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  string
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  string
+				rp2 = reflect.ValueOf(&p2).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+
+			r0 := libs_sys_params.X_getSysParamStrings(
+				m,
+				p0, p1, p2)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+		},
+	},
+	{
 		"testing",
 		"matchString",
 		[]gno.FieldTypeExpr{

--- a/gnovm/stdlibs/std/params.go
+++ b/gnovm/stdlibs/std/params.go
@@ -18,6 +18,7 @@ type ParamsInterface interface {
 	SetUint64(key string, val uint64)
 	SetBytes(key string, val []byte)
 	SetStrings(key string, val []string)
+	GetStrings(key string) []string
 }
 
 func X_setParamString(m *gno.Machine, key, val string) {

--- a/gnovm/stdlibs/sys/params/params.gno
+++ b/gnovm/stdlibs/sys/params/params.gno
@@ -31,9 +31,14 @@ func SetSysParamStrings(module, submodule, name string, val []string) {
 	setSysParamStrings(module, submodule, name, val)
 }
 
+func GetSysParamStrings(module, submodule, name string) []string {
+	return getSysParamStrings(module, submodule, name)
+}
+
 func setSysParamString(module, submodule, name string, val string)
 func setSysParamBool(module, submodule, name string, val bool)
 func setSysParamInt64(module, submodule, name string, val int64)
 func setSysParamUint64(module, submodule, name string, val uint64)
 func setSysParamBytes(module, submodule, name string, val []byte)
 func setSysParamStrings(module, submodule, name string, val []string)
+func getSysParamStrings(module, submodule, name string) []string

--- a/gnovm/stdlibs/sys/params/params.go
+++ b/gnovm/stdlibs/sys/params/params.go
@@ -43,6 +43,12 @@ func X_setSysParamStrings(m *gno.Machine, module, submodule, name string, val []
 	std.GetContext(m).Params.SetStrings(pk, val)
 }
 
+func X_getSysParamStrings(m *gno.Machine, module, submodule, name string) []string {
+
+	pk := prmkey(module, submodule, name)
+	return std.GetContext(m).Params.GetStrings(pk)
+}
+
 func assertSysParamsRealm(m *gno.Machine) {
 	// XXX improve
 	if len(m.Frames) < 2 {

--- a/tm2/pkg/std/account.go
+++ b/tm2/pkg/std/account.go
@@ -40,6 +40,8 @@ type Account interface {
 
 type AccountUnrestricter interface {
 	IsUnrestricted() bool
+	SetUnrestricted()
+	SetRestricted()
 }
 
 //----------------------------------------


### PR DESCRIPTION
## Requirement

https://github.com/gnolang/gno/issues/4143

## Description

- The setting system parameters API is designed to set the full list of parameters as a slice. To update the unrestricted accounts list, we implemented separate add and remove proposal requests to update the status of individual accounts instead of setting the entire list every time an update is needed.
- Added logic to update the status of accounts in auth keeper auth.WillSetParams() upon parameter changes.
- Added GetSystemParams method in sys/params
- Added full-cycle integration tests to update the unrestricted account status from GovDAO.


