### PR TITLE
fix(gnoweb): add lexer for gno.mod

### DIFF
--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -258,36 +258,38 @@ func (s *HTMLWebClient) WriteFormatterCSS(w io.Writer) error {
 	return s.Formatter.WriteCSS(w, s.chromaStyle)
 }
 
-// Register custom go.mod (and gno.mod) lexer
-var goModLexer = lexers.Register(chroma.MustNewLexer(
-	&chroma.Config{
-		Name:      "Go/Gno module file",
-		Aliases:   []string{"go-mod", "gomod", "gno-mod", "gnomod"},
-		Filenames: []string{"go.mod", "gno.mod"},
-		MimeTypes: []string{"text/x-go-mod"},
-	},
-	func() chroma.Rules {
-		return chroma.Rules{
-			"root": {
-				{Pattern: `\s+`, Type: chroma.Text, Mutator: nil},
-				{Pattern: `//[^\n\r]*`, Type: chroma.CommentSingle, Mutator: nil},
-				// Keywords
-				{Pattern: `\b(module|require|replace|exclude|gn?o) \b`, Type: chroma.Keyword, Mutator: nil},
-				{Pattern: `\b(indirect)\b`, Type: chroma.NameDecorator, Mutator: nil},
-				// Quoted version strings
-				{Pattern: `"[^"]*"`, Type: chroma.LiteralString, Mutator: nil},
-				// Versions (v1.2.3, v0.0.0-yyyymmddhhmmss-abcdefabcdef) as well as 0.9 version
-				{Pattern: `\b(v?\d+\.\d+(?:\.\d+)?(?:-[0-9]{14}-[a-f0-9]+)?)\b`,
-					Type: chroma.LiteralNumber, Mutator: nil},
-				// Module paths: module/example.com, example.com/something
-				{Pattern: `[a-zA-Z0-9._~\-\/]+(\.[a-zA-Z]{2, Type:})+(/[^\s]+)?`,
-					Type: chroma.NameNamespace, Mutator: nil},
-				// Operator (=> in replace directive)
-				{Pattern: `=>`, Type: chroma.Operator, Mutator: nil},
-				// Everything else (bare words, etc.)
-				{Pattern: `[^\s"//]+`, Type: chroma.Text, Mutator: nil},
-				{Pattern: `\n`, Type: chroma.Text, Mutator: nil},
-			},
-		}
-	},
-))
+func init() {
+	// Register custom go.mod (and gno.mod) lexer
+	lexers.Register(chroma.MustNewLexer(
+		&chroma.Config{
+			Name:      "Go/Gno module file",
+			Aliases:   []string{"go-mod", "gomod", "gno-mod", "gnomod"},
+			Filenames: []string{"go.mod", "gno.mod"},
+			MimeTypes: []string{"text/x-go-mod"},
+		},
+		func() chroma.Rules {
+			return chroma.Rules{
+				"root": {
+					{Pattern: `\s+`, Type: chroma.Text, Mutator: nil},
+					{Pattern: `//[^\n\r]*`, Type: chroma.CommentSingle, Mutator: nil},
+					// Keywords
+					{Pattern: `\b(module|require|replace|exclude|gn?o) \b`, Type: chroma.Keyword, Mutator: nil},
+					{Pattern: `\b(indirect)\b`, Type: chroma.NameDecorator, Mutator: nil},
+					// Quoted version strings
+					{Pattern: `"[^"]*"`, Type: chroma.LiteralString, Mutator: nil},
+					// Versions (v1.2.3, v0.0.0-yyyymmddhhmmss-abcdefabcdef) as well as 0.9 version
+					{Pattern: `\b(v?\d+\.\d+(?:\.\d+)?(?:-[0-9]{14}-[a-f0-9]+)?)\b`,
+						Type: chroma.LiteralNumber, Mutator: nil},
+					// Module paths: module/example.com, example.com/something
+					{Pattern: `[a-zA-Z0-9._~\-\/]+(\.[a-zA-Z]{2, Type:})+(/[^\s]+)?`,
+						Type: chroma.NameNamespace, Mutator: nil},
+					// Operator (=> in replace directive)
+					{Pattern: `=>`, Type: chroma.Operator, Mutator: nil},
+					// Everything else (bare words, etc.)
+					{Pattern: `[^\s"//]+`, Type: chroma.Text, Mutator: nil},
+					{Pattern: `\n`, Type: chroma.Text, Mutator: nil},
+				},
+			}
+		},
+	))
+}

--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -233,7 +233,7 @@ func (s *HTMLWebClient) FormatSource(w io.Writer, fileName string, src []byte) e
 	case ".md":
 		lexer = lexers.Get("markdown")
 	case ".mod":
-		lexer = lexers.Get("gomod")
+		fallthrough // there is no lexer for (gno).mod
 	default:
 		lexer = lexers.Get("txt") // Unsupported file type, default to plain text.
 	}

--- a/gno.land/pkg/gnoweb/webclient_html.go
+++ b/gno.land/pkg/gnoweb/webclient_html.go
@@ -233,7 +233,7 @@ func (s *HTMLWebClient) FormatSource(w io.Writer, fileName string, src []byte) e
 	case ".md":
 		lexer = lexers.Get("markdown")
 	case ".mod":
-		fallthrough // there is no lexer for (gno).mod
+		lexer = lexers.Get("gomod")
 	default:
 		lexer = lexers.Get("txt") // Unsupported file type, default to plain text.
 	}
@@ -257,3 +257,37 @@ func (s *HTMLWebClient) FormatSource(w io.Writer, fileName string, src []byte) e
 func (s *HTMLWebClient) WriteFormatterCSS(w io.Writer) error {
 	return s.Formatter.WriteCSS(w, s.chromaStyle)
 }
+
+// Register custom go.mod (and gno.mod) lexer
+var goModLexer = lexers.Register(chroma.MustNewLexer(
+	&chroma.Config{
+		Name:      "Go/Gno module file",
+		Aliases:   []string{"go-mod", "gomod", "gno-mod", "gnomod"},
+		Filenames: []string{"go.mod", "gno.mod"},
+		MimeTypes: []string{"text/x-go-mod"},
+	},
+	func() chroma.Rules {
+		return chroma.Rules{
+			"root": {
+				{Pattern: `\s+`, Type: chroma.Text, Mutator: nil},
+				{Pattern: `//[^\n\r]*`, Type: chroma.CommentSingle, Mutator: nil},
+				// Keywords
+				{Pattern: `\b(module|require|replace|exclude|gn?o) \b`, Type: chroma.Keyword, Mutator: nil},
+				{Pattern: `\b(indirect)\b`, Type: chroma.NameDecorator, Mutator: nil},
+				// Quoted version strings
+				{Pattern: `"[^"]*"`, Type: chroma.LiteralString, Mutator: nil},
+				// Versions (v1.2.3, v0.0.0-yyyymmddhhmmss-abcdefabcdef) as well as 0.9 version
+				{Pattern: `\b(v?\d+\.\d+(?:\.\d+)?(?:-[0-9]{14}-[a-f0-9]+)?)\b`,
+					Type: chroma.LiteralNumber, Mutator: nil},
+				// Module paths: module/example.com, example.com/something
+				{Pattern: `[a-zA-Z0-9._~\-\/]+(\.[a-zA-Z]{2, Type:})+(/[^\s]+)?`,
+					Type: chroma.NameNamespace, Mutator: nil},
+				// Operator (=> in replace directive)
+				{Pattern: `=>`, Type: chroma.Operator, Mutator: nil},
+				// Everything else (bare words, etc.)
+				{Pattern: `[^\s"//]+`, Type: chroma.Text, Mutator: nil},
+				{Pattern: `\n`, Type: chroma.Text, Mutator: nil},
+			},
+		}
+	},
+))


### PR DESCRIPTION
This PR correctly handles the lexer for the `gno.mod` file while reading the source. ~The lexer for `go.mod` doesn't seem to exist, so we will simply fall back on txt for now.~
Adding a new custom lexer for `go.mod` as well as `gno.mod`