### PR TITLE
build(gnovm): remove `gno test stdlibs/...` in makefile

### DIFF
--- a/gnovm/Makefile
+++ b/gnovm/Makefile
@@ -110,7 +110,7 @@ _test.pkg:
 .PHONY: _test.stdlibs
 _test.stdlibs:
 	go test -v ./stdlibs/...
-	go run ./cmd/gno test -v ./stdlibs/...
+	# Stdlibs are already tested in pkg/gnolang.
 
 .PHONY: _test.filetest
 _test.filetest:


### PR DESCRIPTION
We use `TestStdlibs` in pkg/gnolang to test them, so this isn't necessary and currently doesn't work.