### PR TITLE
feat(gnovm): handle blank‐identifier type

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2590,6 +2590,9 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 				//
 				// In short, the relationship between tmp and dst is:
 				//   `type dst tmp`.
+				if n.Name == blankIdentifier {
+					return n, TRANS_CONTINUE
+				}
 				dst := last.GetSlot(store, n.Name, true).GetType()
 				switch dst := dst.(type) {
 				case *FuncType:

--- a/gnovm/tests/files/struct62.gno
+++ b/gnovm/tests/files/struct62.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	println("hello")
+}
+
+type _ struct{}
+
+// Output:
+// hello


### PR DESCRIPTION
closes #4366