### PR TITLE
test(proof): add failing case

### DIFF
--- a/tm2/pkg/iavl/proof_test.go
+++ b/tm2/pkg/iavl/proof_test.go
@@ -37,7 +37,7 @@ func TestTreeGetWithProof(t *testing.T) {
 	err = proof.VerifyItem(key, val)
 	require.NoError(err, "%+v", err)
 
-	key = []byte{0x1}
+	key = []byte{0x11, 0}
 	val, proof, err = tree.GetWithProof(key)
 	require.NoError(err)
 	require.Empty(val)


### PR DESCRIPTION
Following convo on Signal, I create this draft PR to demonstrate the bug and report all the informations.

# Disclaimer

I didn't test all the different scenarios so there might be other cases of proof generation that are incorrect. The case I present here is the one I had a chance to reproduce, but I found an other scenario where the proof was also incorrect but differently than the case here. 

# Context 

While I was asserting the behavior of tm2 proofs (for the IBC connection with A1), and I found an issue with absence proofs. 

The test `TestTreeGetWithProof()` (modified in this PR) builds a merkle tree with keys `0x11, 0x32, 0x50, 0x72, 0x99`, and so looks like this:

![image](https://github.com/user-attachments/assets/2591f9b3-4016-413f-a0ab-b852667166be)

- *Node label is `KEY / HASH`*
- *The first two leafs are numered with 1 and 2 for the  purpose of the demo.*

After asserting a proof of the presence of the key `0x32`, which is not relevant here, the test asserts a proof of the absence of key `0x1`.  The returned proof is correct and asserts that `0x1` is absent of the tree. In term of leaves, the proof contains only the leaf 1, because `0x1 < 0x11` (key of 1).

Now if that key is changed to `0x1100` like in this PR, the  returned proof is exactly the same as with `0x1`, but this is incorrect because this time `0x1100 > 0x11`. For that proof to be correct, the proof's leaves should contain both 1 and 2 because `0x1100` is between `0x11` and `0x32`.

Hence the verification algorithm returns an error, given that absence of second leaf: `absence not proved by right leaf (need another leaf?)`
