### PR TITLE
fix: initialize `gnoland/blog` state

### DIFF
--- a/examples/gno.land/r/gnoland/blog/admin.gno
+++ b/examples/gno.land/r/gnoland/blog/admin.gno
@@ -18,8 +18,8 @@ var (
 
 var (
 	adminAddr     = std.Address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // FIXME: find a way to use this from the main's genesis.
-	moderatorList *avl.Tree
-	commenterList *avl.Tree
+	moderatorList = avl.NewTree()
+	commenterList = avl.NewTree()
 	inPause       bool
 )
 


### PR DESCRIPTION
## Description

This PR initializes the `gnoland/blog` state after changes in #4381 