### PR TITLE
fix(cs): create empty block

### DIFF
--- a/gno.land/pkg/integration/node_testing.go
+++ b/gno.land/pkg/integration/node_testing.go
@@ -183,9 +183,8 @@ func DefaultTestingTMConfig(gnoroot string) *tmcfg.Config {
 
 	tmconfig := tmcfg.TestConfig().SetRootDir(gnoroot)
 	tmconfig.Consensus.WALDisabled = true
-	tmconfig.Consensus.SkipTimeoutCommit = true
-	tmconfig.Consensus.CreateEmptyBlocks = true
-	tmconfig.Consensus.CreateEmptyBlocksInterval = time.Millisecond * 100
+	tmconfig.Consensus.SkipTimeoutCommit = false
+	tmconfig.Consensus.CreateEmptyBlocks = false
 	tmconfig.RPC.ListenAddress = defaultListner
 	tmconfig.P2P.ListenAddress = defaultListner
 	return tmconfig

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -11,8 +11,8 @@ stdout '"coins": "10000000000000ugnot"'
 
 # Tx add package -simulate only, estimate gas used and gas fee
 gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2000000 -gas-fee 1000000ugnot -broadcast -chainid tendermint_test -simulate only test1
-stdout 'GAS USED:   181190'
-stdout 'INFO:       estimated gas usage: 181190, gas fee: 191ugnot, current gas price: 1000gas/1ugnot'
+stdout 'GAS USED:   181182'
+stdout 'INFO:       estimated gas usage: 181182, gas fee: 191ugnot, current gas price: 1000gas/1ugnot'
 
 ## No fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
@@ -20,7 +20,7 @@ stdout '"sequence": "0"'
 stdout '"coins": "10000000000000ugnot"'
 
 # Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 181190 -gas-fee 191ugnot -broadcast -chainid tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 181182 -gas-fee 191ugnot -broadcast -chainid tendermint_test test1
 stdout 'OK'
 
 ## fee is charged and sequence number increased

--- a/tm2/pkg/bft/consensus/state.go
+++ b/tm2/pkg/bft/consensus/state.go
@@ -842,7 +842,7 @@ func (cs *ConsensusState) enterNewRound(height int64, round int) {
 	// we may need an empty "proof" block, and enterPropose immediately.
 	waitForTxs := cs.config.WaitForTxs() && round == 0 && !cs.needProofBlock(height)
 	if waitForTxs {
-		if cs.config.CreateEmptyBlocksInterval > 0 {
+		if cs.config.CreateEmptyBlocks && cs.config.CreateEmptyBlocksInterval > 0 {
 			cs.scheduleTimeout(cs.config.CreateEmptyBlocksInterval, height, round,
 				cstypes.RoundStepNewRound)
 		} else {


### PR DESCRIPTION
This PR fix `CreateEmptyBlock` config param and fix a potential inconsistency in integrations test