### PR TITLE
fix: gnoweb help: Don't make an entry field for "cur realm"

### DIFF
--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -379,6 +379,10 @@ func (h *WebHandler) GetHelpView(gnourl *weburl.GnoURL) (int, *components.View) 
 			continue
 		}
 
+		if len(fun.Params) >= 1 && fun.Params[0].Name == "cur" && fun.Params[0].Type == "realm" {
+			// Don't make an entry field for "cur realm". The signature will still show it.
+			fun.Params = fun.Params[1:]
+		}
 		fsigs = append(fsigs, fun)
 	}
 

--- a/gno.land/pkg/gnoweb/handler.go
+++ b/gno.land/pkg/gnoweb/handler.go
@@ -379,7 +379,7 @@ func (h *WebHandler) GetHelpView(gnourl *weburl.GnoURL) (int, *components.View) 
 			continue
 		}
 
-		if len(fun.Params) >= 1 && fun.Params[0].Name == "cur" && fun.Params[0].Type == "realm" {
+		if len(fun.Params) >= 1 && fun.Params[0].Type == "realm" {
 			// Don't make an entry field for "cur realm". The signature will still show it.
 			fun.Params = fun.Params[1:]
 		}


### PR DESCRIPTION
`gnokey maketx call` doesn't need an arg for "cur realm". Therefore we remove it from `HelpData` shown in the gnoweb help screen.

Resolves #4342