### PR TITLE
fix(gnovm): change emit event package path to realm

### DIFF
--- a/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
@@ -1,0 +1,40 @@
+# check events when transferring tokens via the token teller interface
+# add registry
+loadpkg gno.land/r/demo/grc20reg
+loadpkg gno.land/r/demo/foo20
+loadpkg gno.land/r/grc20transfer $WORK
+
+## start a new node
+gnoland start
+
+# run the faucet before transferring the balance
+gnokey maketx call -pkgpath gno.land/r/demo/foo20 -func Faucet -gas-fee 1000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1
+
+# check the event after transferring the grc20 token
+gnokey maketx call -pkgpath gno.land/r/grc20transfer -func TransferBy -args 'gno.land/r/demo/foo20' -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '1000000' -gas-fee 1000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1
+stdout OK!
+stdout 'GAS WANTED: [0-9]+'
+stdout 'GAS USED:   [0-9]+'
+stdout 'HEIGHT:     [0-9]+'
+stdout 'EVENTS:     \[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp\"},{\"key\":\"value\",\"value\":\"1000000\"}\],\"pkg_path\":\"gno.land/r/demo/foo20\"}\]'
+stdout 'TX HASH:    '
+
+-- gnomod.toml --
+module = "gno.land/r/grc20transfer"
+gno = "0.9"
+-- grc20transfer.gno --
+package grc20transfer
+
+import (
+	"std"
+
+	"gno.land/r/demo/grc20reg"
+)
+
+func TransferBy(cur realm, path string, to std.Address, amount int64) {
+	grc20 := grc20reg.MustGet(path)
+	err := grc20.CallerTeller().Transfer(to, amount)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/gno.land/pkg/integration/testdata/grc721_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc721_emit.txtar
@@ -6,23 +6,23 @@ gnoland start
 
 # Mint
 gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 1000000ugnot -gas-wanted 35000000 -broadcast -chainid=tendermint_test test1
-stdout '\[{\"type\":\"Mint\",\"attrs\":\[{\"key\":\"to\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/grc/grc721\"}\]'
+stdout '\[{\"type\":\"Mint\",\"attrs\":\[{\"key\":\"to\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/r/foo721\"}\]'
 
 # Approve
 gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 1000000ugnot -gas-wanted 35000000 -broadcast -chainid=tendermint_test test1
-stdout '\[{\"type\":\"Approval\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/grc/grc721\"}\]'
+stdout '\[{\"type\":\"Approval\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/r/foo721\"}\]'
 
 # SetApprovalForAll
 gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 1000000ugnot -gas-wanted 35000000 -broadcast -chainid=tendermint_test test1
-stdout '\[{\"type\":\"ApprovalForAll\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"approved\",\"value\":\"false\"}\],\"pkg_path\":\"gno.land/p/demo/grc/grc721\"}\]'
+stdout '\[{\"type\":\"ApprovalForAll\",\"attrs\":\[{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"approved\",\"value\":\"false\"}\],\"pkg_path\":\"gno.land/r/foo721\"}\]'
 
 # TransferFrom
 gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 1000000ugnot -gas-wanted 35000000 -broadcast -chainid=tendermint_test test1
-stdout '\[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/grc/grc721\"}\]'
+stdout '\[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/r/foo721\"}\]'
 
 # Burn
 gnokey maketx call -pkgpath gno.land/r/foo721 -func Burn -args 1  -gas-fee 1000000ugnot -gas-wanted 35000000 -broadcast -chainid=tendermint_test test1
-stdout '\[{\"type\":\"Burn\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/grc/grc721\"}\]'
+stdout '\[{\"type\":\"Burn\",\"attrs\":\[{\"key\":\"from\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/r/foo721\"}\]'
 
 
 -- foo721/foo721.gno --

--- a/gnovm/stdlibs/std/emit_event.go
+++ b/gnovm/stdlibs/std/emit_event.go
@@ -18,7 +18,7 @@ func X_emit(m *gno.Machine, typ string, attrs []string) {
 		return
 	}
 
-	pkgPath := currentPkgPath(m)
+	_, pkgPath := currentRealm(m)
 
 	ctx := GetContext(m)
 

--- a/gnovm/stdlibs/std/emit_event_test.go
+++ b/gnovm/stdlibs/std/emit_event_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	pkgPath  = "emit_test"
+	pkgPath  = "gno.land/r/std/emit_test"
 	fileName = "emit_test.gno"
 )
 
@@ -26,8 +26,19 @@ func pushFuncFrame(m *gno.Machine, name gno.Name) {
 			End: gno.Pos{Line: line, Column: 100},
 		},
 	})
+
 	line++
-	fv := &gno.FuncValue{Name: name, PkgPath: m.Package.PkgPath, Source: fd}
+
+	objectInfo := gno.ObjectInfo{
+		ID: gno.ObjectID{
+			PkgID: gno.PkgID{
+				Hashlet: gno.HashBytes([]byte(m.Package.PkgPath)),
+			},
+			NewTime: 1,
+		},
+	}
+	fv := &gno.FuncValue{Name: name, PkgPath: m.Package.PkgPath, Source: fd, ObjectInfo: objectInfo}
+
 	m.PushFrameCall(gno.Call(name), fv, gno.TypedValue{}, false) // fake frame
 }
 

--- a/gnovm/stdlibs/std/native.go
+++ b/gnovm/stdlibs/std/native.go
@@ -151,7 +151,10 @@ func currentPkgPath(m *gno.Machine) (pkgPath string) {
 // currentRealm retrieves the current realm's address and pkgPath.
 // It's not a native binding; but is used within this package to clarify usage.
 func currentRealm(m *gno.Machine) (addr, pkgPath string) {
-	return X_getRealm(m, 0)
+	realm := m.MustPeekCallFrame(2).LastRealm
+	realmAddr := gno.DerivePkgCryptoAddr(realm.Path)
+
+	return realmAddr.Bech32().String(), realm.Path
 }
 
 func X_assertCallerIsRealm(m *gno.Machine) {

--- a/gnovm/stdlibs/std/native.go
+++ b/gnovm/stdlibs/std/native.go
@@ -142,12 +142,6 @@ func X_getRealm(m *gno.Machine, height int) (addr, pkgPath string) {
 	}
 }
 
-// currentPkgPath retrieves the current package's pkgPath.
-// It's not a native binding; but is used within this package to clarify usage.
-func currentPkgPath(m *gno.Machine) (pkgPath string) {
-	return m.MustPeekCallFrame(2).LastPackage.PkgPath
-}
-
 // currentRealm retrieves the current realm's address and pkgPath.
 // It's not a native binding; but is used within this package to clarify usage.
 func currentRealm(m *gno.Machine) (addr, pkgPath string) {

--- a/gnovm/stdlibs/std/native.go
+++ b/gnovm/stdlibs/std/native.go
@@ -146,9 +146,13 @@ func X_getRealm(m *gno.Machine, height int) (addr, pkgPath string) {
 // It's not a native binding; but is used within this package to clarify usage.
 func currentRealm(m *gno.Machine) (addr, pkgPath string) {
 	realm := m.MustPeekCallFrame(2).LastRealm
-	realmAddr := gno.DerivePkgCryptoAddr(realm.Path)
+	if realm == nil {
+		return X_getRealm(m, 0)
+	}
 
-	return realmAddr.Bech32().String(), realm.Path
+	realmPath := realm.Path
+	realmAddr := gno.DerivePkgCryptoAddr(realmPath).Bech32().String()
+	return realmAddr, realmPath
 }
 
 func X_assertCallerIsRealm(m *gno.Machine) {


### PR DESCRIPTION
## Description

This PR improves how the `std.emit` function retrieves the package path when emitting events. Previously, it used the current package's path, but now it uses the current realm's path for more accurate event attribution.

### Technical Background

This change is intended to emit events in Realm.
In order to track meaningful events, it is necessary to be able to track events in the Realm contract.

### Test Results

The newly added integration test retrieves the GRC20 token teller from the GRC20 Registry and transfers the token.
During the transfer, it verifies that the transfer event occurs at the correct realm path (`gno.land/r/demo/foo20`).
