### PR TITLE
feat(maketx run): prevrealm.IsUser() == true

### DIFF
--- a/gnovm/stdlibs/std/frame.gno
+++ b/gnovm/stdlibs/std/frame.gno
@@ -1,5 +1,7 @@
 package std
 
+import "regexp"
+
 type Realm struct {
 	addr    Address
 	pkgPath string
@@ -21,8 +23,21 @@ func (r Realm) PkgPath() string {
 	return r.pkgPath
 }
 
+var reGnoRunPath = regexp.MustCompile(`^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}/r/(?P<addr>g1[a-z0-9]+)/run$`)
+
 func (r Realm) IsUser() bool {
-	return r.pkgPath == ""
+	// non-code realm.
+	if r.pkgPath == "" {
+		return true
+	}
+
+	// `maketx run`
+	// TODO: replace with the upcoming /e/ ephemeral realms
+	if reGnoRunPath.MatchString(r.pkgPath) {
+		return true
+	}
+
+	return false
 }
 
 func (r Realm) CoinDenom(coinName string) string {


### PR DESCRIPTION
- [x] workaround; `maketx run` is `UserRealm`
- [ ] discuss the workaround
- [ ] fix and complete tests

---

Problem:
![CleanShot 2025-06-20 at 17 48 02](https://github.com/user-attachments/assets/d8b8aaa8-cf91-40d8-9745-67b4f4c8ee5f)

This PR retains the `msgrun realm` as `prevrealm`, but modifies `realm.IsUser()` to return true when `pkgpath` is empty or when `pkgpath` is a `maketx` run path.

Before proceeding with unit tests, I would appreciate more feedback to confirm if this aligns with our goals. Additionally, since I copied the regular expression from the `./gnovm/pkg/gnolang` Go package, this solution is not optimized, and the gas cost is significantly increasing in unit tests. This should not be an issue on-chain if the regular expression global var is persisted as I expect.

Furthermore, we will soon refactor `maketx run` to use a new `/e/` path prefix, which will allow us to eliminate this regular expression entirely.