### PR TITLE
[gnoweb] Allow goldmark extentions

### DIFF
--- a/contribs/gnodev/cmd/gnodev/setup_gnomark.go
+++ b/contribs/gnodev/cmd/gnodev/setup_gnomark.go
@@ -1,0 +1,35 @@
+// File: contribs/gnodev/cmd/gnodev/setup_gnomark.go
+//go:build gnomark
+
+package main
+
+import (
+	"fmt"
+	"github.com/yuin/goldmark"
+	"log/slog"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoweb"
+	mdhtml "github.com/yuin/goldmark/renderer/html"
+)
+
+func init() {
+	gnoweb.SetRenderFactory(RenderWithGnoMark)
+	fmt.Printf("Added GnoMark renderer to gnoweb\n")
+}
+
+// RenderWithGnoMark creates a MarkdownRenderer configured with GnoMark support.
+func RenderWithGnoMark(logger *slog.Logger, cfg *gnoweb.AppConfig) (*gnoweb.MarkdownRenderer, error) {
+	markdownCfg := gnoweb.NewDefaultMarkdownRendererConfig(nil)
+	if cfg.UnsafeHTML {
+		markdownCfg.GoldmarkOptions = append(markdownCfg.GoldmarkOptions, goldmark.WithRendererOptions(
+			mdhtml.WithXHTML(), mdhtml.WithUnsafe(),
+		))
+	}
+	md := goldmark.New(markdownCfg.GoldmarkOptions...)
+	// NOTE: users extending gnoweb can load their own extensions here.
+	// CustomExtension().Extend(md)
+	return &gnoweb.MarkdownRenderer{
+		Logger:   logger,
+		Markdown: md,
+	}, nil
+}

--- a/gno.land/pkg/gnoweb/markdown.go
+++ b/gno.land/pkg/gnoweb/markdown.go
@@ -49,16 +49,16 @@ func NewDefaultMarkdownRendererConfig(chromaOptions []chromahtml.Option) *Markdo
 }
 
 type MarkdownRenderer struct {
-	logger   *slog.Logger
-	markdown goldmark.Markdown
+	Logger   *slog.Logger
+	Markdown goldmark.Markdown
 }
 
 var _ ContentRenderer = (*MarkdownRenderer)(nil)
 
 func NewMarkdownRenderer(logger *slog.Logger, cfg *MarkdownRendererConfig) *MarkdownRenderer {
 	return &MarkdownRenderer{
-		logger:   logger,
-		markdown: goldmark.New(cfg.GoldmarkOptions...),
+		Logger:   logger,
+		Markdown: goldmark.New(cfg.GoldmarkOptions...),
 	}
 }
 
@@ -66,14 +66,14 @@ func (mr *MarkdownRenderer) Render(w io.Writer, u *weburl.GnoURL, src []byte) (m
 	ctx := md.NewGnoParserContext(u)
 
 	// Use Goldmark for Markdown parsing
-	doc := mr.markdown.Parser().Parse(text.NewReader(src), parser.WithContext(ctx))
-	if err := mr.markdown.Renderer().Render(w, src, doc); err != nil {
+	doc := mr.Markdown.Parser().Parse(text.NewReader(src), parser.WithContext(ctx))
+	if err := mr.Markdown.Renderer().Render(w, src, doc); err != nil {
 		return md.Toc{}, fmt.Errorf("unable to render markdown at path %q: %w", u.Path, err)
 	}
 
 	toc, err := md.TocInspect(doc, src, md.TocOptions{MaxDepth: 6, MinDepth: 2})
 	if err != nil {
-		mr.logger.Warn("unable to inspect for TOC elements", "error", err)
+		mr.Logger.Warn("unable to inspect for TOC elements", "error", err)
 	}
 
 	return toc, nil


### PR DESCRIPTION
Revisit https://github.com/gnolang/gno/pull/4186 - adding a better means to customize markdown rendering

### Description

We are introducing a mechanism to allow custom Markdown rendering in gnoweb through an optional build tag and injection of a custom renderer factory.

### Goals
Add setup_gnomark.go behind the gnomark build tag to register a custom Markdown renderer using [Goldmark](https://github.com/yuin/goldmark).

Allow external packages to override the default MarkdownRenderer behavior by injecting a RenderFactory.

Decouple renderer instantiation from hardcoded logic in NewRouter.

### Changes
New file: contribs/gnodev/cmd/gnodev/setup_gnomark.go

Registers a RenderFactory for Markdown rendering using goldmark.

Uses gnoweb.SetRenderFactory() in init() when gnomark tag is set.

gno.land/pkg/gnoweb/app.go

Adds RenderFactory as a configurable function.

Introduces SetRenderFactory() and a default implementation DefaultMarkdown().

Replaces inline Goldmark setup in NewRouter() with the factory.

gno.land/pkg/gnoweb/markdown.go

Renames markdown → Markdown and logger → Logger (exported for custom usage).

Adjusts Render() to use the exported fields, enabling injected implementations to be compatible.

### Motivation
This change provides a clean extension point for advanced Markdown rendering, such as:

Custom extensions (e.g., task lists, Gno-specific syntax)

Developer-only builds with preview rendering

Future toggles for experimental render pipelines