### PR TITLE
chore: Update stress test with "cross", latest gnonative

### DIFF
--- a/misc/stress-test/stress-test-many-posts/go.mod
+++ b/misc/stress-test/stress-test-many-posts/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.8
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/gnolang/gnonative v1.8.1
+	github.com/gnolang/gnonative/v4 v4.2.2
 )
 
 require (
@@ -20,7 +20,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/gnolang/gno v0.1.2-0.20240826090356-651f5aac3706 // indirect
-	github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/misc/stress-test/stress-test-many-posts/go.sum
+++ b/misc/stress-test/stress-test-many-posts/go.sum
@@ -57,10 +57,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6 h1:D4dctoTOCk30fbMebwgDYRhcemXrcK7vqjl6MFPUIfc=
-github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6/go.mod h1:fD0uCByVS8JKxQbSPOvJxO0s7vdfh1BBXBcv8d+ApDk=
-github.com/gnolang/gnonative v1.8.1 h1:Ng2f+Ma8RB9SVfBVjV5QlEYi3+xgUzb5zCOfZzWGBUA=
-github.com/gnolang/gnonative v1.8.1/go.mod h1:CUmJscGafDalxdgMu9hTq+9RoEzk75x9aTJNs5t8cQU=
+github.com/gnolang/gnonative/v4 v4.2.2 h1:MxhXQBapoWM42llE5IrU6IM743AKKXQAimFMEdrJIUI=
+github.com/gnolang/gnonative/v4 v4.2.2/go.mod h1:78NvbayMU0oV1yYLfQEQpVfLlLFWlADIuFhBgYhZPSk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/misc/stress-test/stress-test-many-posts/main.go
+++ b/misc/stress-test/stress-test-many-posts/main.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	api_gen "github.com/gnolang/gnonative/api/gen/go"
-	"github.com/gnolang/gnonative/api/gen/go/_goconnect"
-	"github.com/gnolang/gnonative/service"
+	api_gen "github.com/gnolang/gnonative/v4/api/gen/go"
+	"github.com/gnolang/gnonative/v4/api/gen/go/_goconnect"
+	"github.com/gnolang/gnonative/v4/service"
 )
 
 func main() {
@@ -96,7 +96,7 @@ func setup(client _goconnect.GnoNativeServiceClient, test1Address []byte) error 
 		context.Background(),
 		connect.NewRequest(&api_gen.CallRequest{
 			GasFee:        "1000000ugnot",
-			GasWanted:     10_000_000,
+			GasWanted:     50_000_000,
 			CallerAddress: test1Address,
 			Msgs: []*api_gen.MsgCall{{
 				PackagePath: "gno.land/r/demo/boards",
@@ -115,7 +115,7 @@ func setup(client _goconnect.GnoNativeServiceClient, test1Address []byte) error 
 		context.Background(),
 		connect.NewRequest(&api_gen.CallRequest{
 			GasFee:        "1000000ugnot",
-			GasWanted:     10_000_000,
+			GasWanted:     50_000_000,
 			CallerAddress: test1Address,
 			Msgs: []*api_gen.MsgCall{{
 				PackagePath: "gno.land/r/demo/boards",
@@ -147,7 +147,7 @@ import (
 
 func main() {
 	for i := 0; i < ` + strconv.Itoa(postsPerCall) + `; i++ {
-		boards.CreateReply(boards.BoardID(1), boards.PostID(1), boards.PostID(1), "reply")
+		boards.CreateReply(cross, boards.BoardID(1), boards.PostID(1), boards.PostID(1), "reply")
 	}
 }`
 
@@ -163,8 +163,8 @@ func main() {
 		res, err := client.Run(
 			context.Background(),
 			connect.NewRequest(&api_gen.RunRequest{
-				GasFee:        "1000000ugnot",
-				GasWanted:     100_000_000,
+				GasFee:        "10000000ugnot",
+				GasWanted:     1_000_000_000,
 				CallerAddress: test1Address,
 				Msgs: []*api_gen.MsgRun{{
 					Package: code,


### PR DESCRIPTION
This is a followup to PR https://github.com/gnolang/gno/pull/1583 which added a stress test utility. 
* Use the latest gnolang/gnonative
* Add a "cross" param in the call to `boards.CreateReply`
* Increase the amount of gas wanted. (It seems that the VM is consuming a little more gas now.)
