### PR TITLE
chore(examples): support gno-forms in coin checker

### DIFF
--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -118,6 +118,14 @@ func renderBalances(req *mux.Request) string {
 		wasConverted = true
 	}
 
+	banker := std.NewBanker(std.BankerTypeReadonly)
+	balances := banker.GetCoins(std.Address(input))
+
+	if len(balances) == 0 {
+		out += "This address currently has no coins."
+		return out
+	}
+
 	if coin != "" {
 		return renderSingleCoinBalance(coin, input, originalInput, wasConverted)
 	}
@@ -126,19 +134,10 @@ func renderBalances(req *mux.Request) string {
 		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
 	}
 
-	banker := std.NewBanker(std.BankerTypeReadonly)
-
 	user, _ := users.ResolveAny(input)
 	name := "`" + input + "`"
 	if user != nil {
 		name = user.RenderLink("")
-	}
-
-	balances := banker.GetCoins(std.Address(input))
-
-	if len(balances) == 0 {
-		out += "This address currently has no coins."
-		return out
 	}
 
 	out += ufmt.Sprintf("This page shows full coin balances of %s at block #%d\n\n",

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -101,7 +101,7 @@ func renderBalances(req *mux.Request) string {
 	}
 
 	if coin != "" {
-		return renderSingleCoinBalance(req)
+		return renderSingleCoinBalance(coin, input)
 	}
 
 	banker := std.NewBanker(std.BankerTypeReadonly)
@@ -143,26 +143,26 @@ func renderBalances(req *mux.Request) string {
 	return out
 }
 
-func renderSingleCoinBalance(req *mux.Request) string {
-	denom := req.Query.Get("coin")
-	input := req.Query.Get("address")
-
+func renderSingleCoinBalance(denom, input string) string {
 	out := "# Coin balance\n\n"
 	banker := std.NewBanker(std.BankerTypeReadonly)
 
-	if strings.HasPrefix(input, "cosmos") {
-		addr, err := ctg.ConvertCosmosToGno(input)
-		if err != nil {
-			out += "Tried converting a Cosmos address to a Gno address but failed. Please double-check your input."
+	// If input is not a valid Gno address
+	if !std.Address(input).IsValid() {
+		if input == "" {
+			out += "Please input a valid address.\n\n"
 			return out
 		}
+
+		// Try converting input to Gno
+		addr, err := ctg.ConvertAnyToGno(input)
+		if err != nil {
+			out += ufmt.Sprintf("Tried converting `%s` to a Gno address but failed. Please try with a valid bech32 address.", input)
+			return out
+		}
+
 		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
 		input = addr.String()
-	} else {
-		if !std.Address(input).IsValid() {
-			out += "Invalid address."
-			return out
-		}
 	}
 
 	user, _ := users.ResolveAny(input)

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -118,6 +118,10 @@ func renderBalances(req *mux.Request) string {
 		wasConverted = true
 	}
 
+	if wasConverted {
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
+	}
+
 	banker := std.NewBanker(std.BankerTypeReadonly)
 	balances := banker.GetCoins(std.Address(input))
 
@@ -128,10 +132,6 @@ func renderBalances(req *mux.Request) string {
 
 	if coin != "" {
 		return renderSingleCoinBalance(coin, input, originalInput, wasConverted)
-	}
-
-	if wasConverted {
-		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
 	}
 
 	user, _ := users.ResolveAny(input)

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -105,21 +105,25 @@ func renderBalances(req *mux.Request) string {
 		return out
 	}
 
-	// If input is not a valid Gno address
+	originalInput := input
+	var wasConverted bool
+
+	// Try to validate or convert
 	if !std.Address(input).IsValid() {
-		// Try converting input to Gno
 		addr, err := ctg.ConvertAnyToGno(input)
 		if err != nil {
-			out += ufmt.Sprintf("Tried converting `%s` to a Gno address but failed. Please try with a valid bech32 address.", input)
-			return out
+			return out + ufmt.Sprintf("Tried converting `%s` to a Gno address but failed. Please try with a valid bech32 address.\n\n", input)
 		}
-
-		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
 		input = addr.String()
+		wasConverted = true
+	}
+
+	if wasConverted {
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
 	}
 
 	if coin != "" {
-		return renderSingleCoinBalance(coin, input)
+		return renderSingleCoinBalance(coin, input, originalInput, wasConverted)
 	}
 
 	banker := std.NewBanker(std.BankerTypeReadonly)
@@ -166,20 +170,24 @@ func renderBalances(req *mux.Request) string {
 	return out
 }
 
-func renderSingleCoinBalance(denom, input string) string {
+func renderSingleCoinBalance(denom, addr, origInput string, wasConverted bool) string {
 	out := "# Coin balance\n\n"
 	banker := std.NewBanker(std.BankerTypeReadonly)
 
-	user, _ := users.ResolveAny(input)
-	name := "`" + input + "`"
+	if wasConverted {
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", origInput)
+	}
+
+	user, _ := users.ResolveAny(addr)
+	name := "`" + addr + "`"
 	if user != nil {
 		name = user.RenderLink("")
 	}
 
 	out += ufmt.Sprintf("%s has `%d%s` at block #%d\n\n",
-		name, banker.GetCoins(std.Address(input)).AmountOf(denom), denom, std.ChainHeight())
+		name, banker.GetCoins(std.Address(addr)).AmountOf(denom), denom, std.ChainHeight())
 
-	out += "[View full balance list for this address](/r/gnoland/coins:balances?address=" + input + ")"
+	out += "[View full balance list for this address](/r/gnoland/coins:balances?address=" + addr + ")"
 
 	return out
 }

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -28,7 +28,6 @@ import (
 	"gno.land/p/leon/ctg"
 	"gno.land/p/moul/md"
 	"gno.land/p/moul/mdtable"
-	"gno.land/p/moul/realmpath"
 
 	"gno.land/r/sys/users"
 )
@@ -43,7 +42,7 @@ func init() {
 	})
 
 	router.HandleFunc("balances", func(res *mux.ResponseWriter, req *mux.Request) {
-		res.Write(renderBalances(req.RawPath, req..GetVar("address"))
+		res.Write(renderBalances(req))
 	})
 
 	router.HandleFunc("convert/{address}", func(res *mux.ResponseWriter, req *mux.Request) {
@@ -72,16 +71,16 @@ func renderHomepage() string {
 This is a simple, readonly realm that allows users to browse native coin balances. Check your coin balance below!
 
 <gno-form path="balances">
-  <gno-input name="coin" type="text" placeholder="Coin (e.g. ugnot)"" />
-  <gno-input name="address" type="text" placeholder="Address (e.g. g1... or cosmos1...)" />
+	<gno-input name="address" type="text" placeholder="Address (e.g. g1... or cosmos1...)" />
+	<gno-input name="coin" type="text" placeholder="Coin (e.g. ugnot)"" />
 </gno-form>
 
-Here are a few examples on how to use it:
+Here are a few more ways to use this app:
 
-- ~/r/gnoland/coins:balances/<address>~ - show full list of coin balances of an address
-	- [Example](/r/gnoland/coins:balances/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5)
-- ~/r/gnoland/coins:balances/<address>?coin=ugnot~ - shows the balance of an address for a specific coin
-	- [Example](/r/gnoland/coins:balances/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5?coin=ugnot)
+- ~/r/gnoland/coins:balances?address=g1...~ - show full list of coin balances of an address
+	- [Example](/r/gnoland/coins:balances?address=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5)
+- ~/r/gnoland/coins:balances?address=g1...&coin=ugnot~ - shows the balance of an address for a specific coin
+	- [Example](/r/gnoland/coins:balances?address=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5&coin=ugnot)
 - ~/r/gnoland/coins:convert/<cosmos_address>~ - convert Cosmos address to Gno address
 	- [Example](/r/gnoland/coins:convert/cosmos1jg8mtutu9khhfwc4nxmuhcpftf0pajdh6svrgs)
 - ~/r/gnoland/coins:supply/<denom>~ - shows the total supply of denom
@@ -90,73 +89,22 @@ Here are a few examples on how to use it:
 `, "~", "`", -1)
 }
 
-func renderConvertedAddress(addr string) string {
-	out := "# Address converter\n\n"
-
-	gnoAddress, err := ctg.ConvertCosmosToGno(addr)
-	if err != nil {
-		out += err.Error()
-		return out
-	}
-
-	user, _ := users.ResolveAny(gnoAddress.String())
-	name := "`" + gnoAddress.String() + "`"
-	if user != nil {
-		name = user.RenderLink("")
-	}
-
-	out += ufmt.Sprintf("`%s` on Cosmos matches %s on gno.land.\n\n", addr, name)
-	out += "[View `ugnot` balance for this address](/r/gnoland/coins:balances/" + gnoAddress.String() + "?coin=ugnot)\n\n"
-	out += "[View full balance list for this address](/r/gnoland/coins:balances/" + gnoAddress.String() + ")"
-	return out
-}
-
-func renderSingleCoinBalance(banker std.Banker, denom string, addr string) string {
-	out := "# Single coin balance\n\n"
-	if !std.Address(addr).IsValid() {
-		out += "Invalid address."
-		return out
-	}
-
-	user, _ := users.ResolveAny(addr)
-	name := "`" + addr + "`"
-	if user != nil {
-		name = user.RenderLink("")
-	}
-
-	out += ufmt.Sprintf("%s has `%d%s` at block #%d\n\n",
-		name, banker.GetCoins(std.Address(addr)).AmountOf(denom), denom, std.ChainHeight())
-
-	out += "[View full balance list for this address](/r/gnoland/coins:balances/" + addr + ")"
-
-	return out
-}
-
-func renderBalances(rawpath, input string) string {
+func renderBalances(req *mux.Request) string {
 	out := "# Balances\n\n"
 
-	if strings.HasPrefix(input, "cosmos") {
-		addr, err := ctg.ConvertCosmosToGno(input)
-		if err != nil {
-			out += "Tried converting a Cosmos address to a Gno address but failed. Please double-scheck your input."
-			return out
-		}
-		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
-		input = addr.String()
-	} else {
-		if !std.Address(input).IsValid() {
-			out += "Invalid address."
-			return out
-		}
+	input := req.Query.Get("address")
+	coin := req.Query.Get("coin")
+
+	if input == "" {
+		out += "Please input a valid address.\n\n"
+		return out
+	}
+
+	if coin != "" {
+		return renderSingleCoinBalance(req)
 	}
 
 	banker := std.NewBanker(std.BankerTypeReadonly)
-	req := realmpath.Parse(rawpath)
-
-	coin := req.Query.Get("coin")
-	if coin != "" {
-		return renderSingleCoinBalance(banker, coin, input)
-	}
 
 	user, _ := users.ResolveAny(input)
 	name := "`" + input + "`"
@@ -195,21 +143,78 @@ func renderBalances(rawpath, input string) string {
 	return out
 }
 
+func renderSingleCoinBalance(req *mux.Request) string {
+	denom := req.Query.Get("coin")
+	input := req.Query.Get("address")
+
+	out := "# Coin balance\n\n"
+	banker := std.NewBanker(std.BankerTypeReadonly)
+
+	if strings.HasPrefix(input, "cosmos") {
+		addr, err := ctg.ConvertCosmosToGno(input)
+		if err != nil {
+			out += "Tried converting a Cosmos address to a Gno address but failed. Please double-check your input."
+			return out
+		}
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
+		input = addr.String()
+	} else {
+		if !std.Address(input).IsValid() {
+			out += "Invalid address."
+			return out
+		}
+	}
+
+	user, _ := users.ResolveAny(input)
+	name := "`" + input + "`"
+	if user != nil {
+		name = user.RenderLink("")
+	}
+
+	out += ufmt.Sprintf("%s has `%d%s` at block #%d\n\n",
+		name, banker.GetCoins(std.Address(input)).AmountOf(denom), denom, std.ChainHeight())
+
+	out += "[View full balance list for this address](/r/gnoland/coins:balances?address=" + input + ")"
+
+	return out
+}
+
+func renderConvertedAddress(addr string) string {
+	out := "# Address converter\n\n"
+
+	gnoAddress, err := ctg.ConvertCosmosToGno(addr)
+	if err != nil {
+		out += err.Error()
+		return out
+	}
+
+	user, _ := users.ResolveAny(gnoAddress.String())
+	name := "`" + gnoAddress.String() + "`"
+	if user != nil {
+		name = user.RenderLink("")
+	}
+
+	out += ufmt.Sprintf("`%s` on Cosmos matches %s on gno.land.\n\n", addr, name)
+	out += "[View `ugnot` balance for this address](/r/gnoland/coins:balances?address=" + gnoAddress.String() + "&coin=ugnot) - "
+	out += "[View full balance list for this address](/r/gnoland/coins:balances?address=" + gnoAddress.String() + ")"
+	return out
+}
+
 // Helper functions for sorting and pagination
-func getSortField(req *realmpath.Request) string {
+func getSortField(req *mux.Request) string {
 	field := req.Query.Get("sort")
 	switch field {
-	case "denom", "balance": // XXX: add Coins.SortBy{denom,bal} methods
+	case "denom", "balance":
 		return field
 	}
 	return "denom"
 }
 
-func isSortReversed(req *realmpath.Request) bool {
+func isSortReversed(req *mux.Request) bool {
 	return req.Query.Get("order") != "asc"
 }
 
-func renderSortLink(req *realmpath.Request, field, label string) string {
+func renderSortLink(req *mux.Request, field, label string) string {
 	currentField := getSortField(req)
 	currentOrder := req.Query.Get("order")
 

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -112,10 +112,15 @@ func renderBalances(req *mux.Request) string {
 		name = user.RenderLink("")
 	}
 
+	balances := banker.GetCoins(std.Address(input))
+
+	if len(balances) == 0 {
+		out += "This address currently has no coins."
+		return out
+	}
+
 	out += ufmt.Sprintf("This page shows full coin balances of %s at block #%d\n\n",
 		name, std.ChainHeight())
-
-	balances := banker.GetCoins(std.Address(input))
 
 	// Determine sorting
 	if getSortField(req) == "balance" {

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -118,12 +118,12 @@ func renderBalances(req *mux.Request) string {
 		wasConverted = true
 	}
 
-	if wasConverted {
-		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
-	}
-
 	if coin != "" {
 		return renderSingleCoinBalance(coin, input, originalInput, wasConverted)
+	}
+
+	if wasConverted {
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", originalInput)
 	}
 
 	banker := std.NewBanker(std.BankerTypeReadonly)

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -42,8 +42,8 @@ func init() {
 		res.Write(renderHomepage())
 	})
 
-	router.HandleFunc("balances/{address}", func(res *mux.ResponseWriter, req *mux.Request) {
-		res.Write(renderAllBalances(req.RawPath, req.GetVar("address")))
+	router.HandleFunc("balances", func(res *mux.ResponseWriter, req *mux.Request) {
+		res.Write(renderBalances(req.RawPath, req..GetVar("address"))
 	})
 
 	router.HandleFunc("convert/{address}", func(res *mux.ResponseWriter, req *mux.Request) {
@@ -69,7 +69,13 @@ func Render(path string) string {
 func renderHomepage() string {
 	return strings.Replace(`# Gno.land Coins Explorer
 
-This is a simple, readonly realm that allows users to browse native coin balances.
+This is a simple, readonly realm that allows users to browse native coin balances. Check your coin balance below!
+
+<gno-form path="balances">
+  <gno-input name="coin" type="text" placeholder="Coin (e.g. ugnot)"" />
+  <gno-input name="address" type="text" placeholder="Address (e.g. g1... or cosmos1...)" />
+</gno-form>
+
 Here are a few examples on how to use it:
 
 - ~/r/gnoland/coins:balances/<address>~ - show full list of coin balances of an address
@@ -80,6 +86,7 @@ Here are a few examples on how to use it:
 	- [Example](/r/gnoland/coins:convert/cosmos1jg8mtutu9khhfwc4nxmuhcpftf0pajdh6svrgs)
 - ~/r/gnoland/coins:supply/<denom>~ - shows the total supply of denom
 	- Coming soon!
+
 `, "~", "`", -1)
 }
 
@@ -125,7 +132,7 @@ func renderSingleCoinBalance(banker std.Banker, denom string, addr string) strin
 	return out
 }
 
-func renderAllBalances(rawpath, input string) string {
+func renderBalances(rawpath, input string) string {
 	out := "# Balances\n\n"
 
 	if strings.HasPrefix(input, "cosmos") {
@@ -143,22 +150,22 @@ func renderAllBalances(rawpath, input string) string {
 		}
 	}
 
-	user, _ := users.ResolveAny(input)
-	name := "`" + input + "`"
-	if user != nil {
-		name = user.RenderLink("")
-	}
-
 	banker := std.NewBanker(std.BankerTypeReadonly)
-	out += ufmt.Sprintf("This page shows full coin balances of %s at block #%d\n\n",
-		name, std.ChainHeight())
-
 	req := realmpath.Parse(rawpath)
 
 	coin := req.Query.Get("coin")
 	if coin != "" {
 		return renderSingleCoinBalance(banker, coin, input)
 	}
+
+	user, _ := users.ResolveAny(input)
+	name := "`" + input + "`"
+	if user != nil {
+		name = user.RenderLink("")
+	}
+
+	out += ufmt.Sprintf("This page shows full coin balances of %s at block #%d\n\n",
+		name, std.ChainHeight())
 
 	balances := banker.GetCoins(std.Address(input))
 

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -71,7 +71,7 @@ func renderHomepage() string {
 This is a simple, readonly realm that allows users to browse native coin balances. Check your coin balance below!
 
 <gno-form path="balances">
-	<gno-input name="address" type="text" placeholder="Address (e.g. g1... or cosmos1...)" />
+	<gno-input name="address" type="text" placeholder="Valid bech32 address (e.g. g1..., cosmos1..., osmo1...)" />
 	<gno-input name="coin" type="text" placeholder="Coin (e.g. ugnot)"" />
 </gno-form>
 
@@ -81,7 +81,7 @@ Here are a few more ways to use this app:
 	- [Example](/r/gnoland/coins:balances?address=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5)
 - ~/r/gnoland/coins:balances?address=g1...&coin=ugnot~ - shows the balance of an address for a specific coin
 	- [Example](/r/gnoland/coins:balances?address=g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5&coin=ugnot)
-- ~/r/gnoland/coins:convert/<cosmos_address>~ - convert Cosmos address to Gno address
+- ~/r/gnoland/coins:convert/<bech32_addr>~ - convert a bech32 address to a Gno address
 	- [Example](/r/gnoland/coins:convert/cosmos1jg8mtutu9khhfwc4nxmuhcpftf0pajdh6svrgs)
 - ~/r/gnoland/coins:supply/<denom>~ - shows the total supply of denom
 	- Coming soon!
@@ -95,9 +95,27 @@ func renderBalances(req *mux.Request) string {
 	input := req.Query.Get("address")
 	coin := req.Query.Get("coin")
 
-	if input == "" {
-		out += "Please input a valid address.\n\n"
+	if input == "" && coin == "" {
+		out += "Please input a valid address and coin denomination.\n\n"
 		return out
+	}
+
+	if input == "" {
+		out += "Please input a valid bech32 address.\n\n"
+		return out
+	}
+
+	// If input is not a valid Gno address
+	if !std.Address(input).IsValid() {
+		// Try converting input to Gno
+		addr, err := ctg.ConvertAnyToGno(input)
+		if err != nil {
+			out += ufmt.Sprintf("Tried converting `%s` to a Gno address but failed. Please try with a valid bech32 address.", input)
+			return out
+		}
+
+		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
+		input = addr.String()
 	}
 
 	if coin != "" {
@@ -152,24 +170,6 @@ func renderSingleCoinBalance(denom, input string) string {
 	out := "# Coin balance\n\n"
 	banker := std.NewBanker(std.BankerTypeReadonly)
 
-	// If input is not a valid Gno address
-	if !std.Address(input).IsValid() {
-		if input == "" {
-			out += "Please input a valid address.\n\n"
-			return out
-		}
-
-		// Try converting input to Gno
-		addr, err := ctg.ConvertAnyToGno(input)
-		if err != nil {
-			out += ufmt.Sprintf("Tried converting `%s` to a Gno address but failed. Please try with a valid bech32 address.", input)
-			return out
-		}
-
-		out += ufmt.Sprintf("> [!NOTE]\n>  Automatically converted `%s` to its Gno equivalent.\n\n", input)
-		input = addr.String()
-	}
-
 	user, _ := users.ResolveAny(input)
 	name := "`" + input + "`"
 	if user != nil {
@@ -187,7 +187,7 @@ func renderSingleCoinBalance(denom, input string) string {
 func renderConvertedAddress(addr string) string {
 	out := "# Address converter\n\n"
 
-	gnoAddress, err := ctg.ConvertCosmosToGno(addr)
+	gnoAddress, err := ctg.ConvertAnyToGno(addr)
 	if err != nil {
 		out += err.Error()
 		return out
@@ -200,8 +200,8 @@ func renderConvertedAddress(addr string) string {
 	}
 
 	out += ufmt.Sprintf("`%s` on Cosmos matches %s on gno.land.\n\n", addr, name)
-	out += "[View `ugnot` balance for this address](/r/gnoland/coins:balances?address=" + gnoAddress.String() + "&coin=ugnot) - "
-	out += "[View full balance list for this address](/r/gnoland/coins:balances?address=" + gnoAddress.String() + ")"
+	out += "[[View `ugnot` balance for this address]](/r/gnoland/coins:balances?address=" + gnoAddress.String() + "&coin=ugnot) - "
+	out += "[[View full balance list for this address]](/r/gnoland/coins:balances?address=" + gnoAddress.String() + ")"
 	return out
 }
 

--- a/examples/gno.land/r/gnoland/coins/coins_test.gno
+++ b/examples/gno.land/r/gnoland/coins/coins_test.gno
@@ -46,23 +46,23 @@ func TestBalanceChecker(t *testing.T) {
 
 		{
 			name:     "addr1's coin balance",
-			path:     ufmt.Sprintf("balances/%s?coin=%s", addr1.String(), denom1),
+			path:     ufmt.Sprintf("balances?address=%s&coin=%s", addr1.String(), denom1),
 			contains: ufmt.Sprintf("`%s` has `%d%s`", addr1.String(), 1000000, denom1),
 		},
 		{
 			name:     "addr2's full balances",
-			path:     ufmt.Sprintf("balances/%s", addr2.String()),
+			path:     ufmt.Sprintf("balances?address=%s", addr2.String()),
 			contains: ufmt.Sprintf("This page shows full coin balances of `%s` at block", addr2.String()),
 		},
 		{
 			name: "addr2's full balances",
-			path: ufmt.Sprintf("balances/%s", addr2.String()),
+			path: ufmt.Sprintf("balances?address=%s", addr2.String()),
 			contains: `| testtoken1 | 501 |
 | testtoken2 | 12345 |`,
 		},
 		{
 			name:     "addr2's coin balance",
-			path:     ufmt.Sprintf("balances/%s?coin=%s", addr2.String(), denom1),
+			path:     ufmt.Sprintf("balances?address=%s&coin=%s", addr2.String(), denom1),
 			contains: ufmt.Sprintf("`%s` has `%d%s`", addr2.String(), 501, denom1),
 		},
 		{

--- a/examples/gno.land/r/gnoland/coins/coins_test.gno
+++ b/examples/gno.land/r/gnoland/coins/coins_test.gno
@@ -81,6 +81,18 @@ func TestBalanceChecker(t *testing.T) {
 			contains: "Automatically converted `osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09`",
 		},
 		{
+			name:      "no addr",
+			path:      "balances?address=",
+			contains:  "Please input a valid address",
+			wantPanic: false,
+		},
+		{
+			name:      "no addr",
+			path:      "balances?address=&coin=",
+			contains:  "Please input a valid address and coin denomination.",
+			wantPanic: false,
+		},
+		{
 			name:      "invalid path",
 			path:      "invalid",
 			contains:  "404",

--- a/examples/gno.land/r/gnoland/coins/coins_test.gno
+++ b/examples/gno.land/r/gnoland/coins/coins_test.gno
@@ -26,6 +26,9 @@ func TestBalanceChecker(t *testing.T) {
 
 	gnoAddr, _ := ctg.ConvertCosmosToGno("cosmos1s2v4tdskccx2p3yyvzem4mw5nn5fprwcku77hr")
 	osmoAddr := "osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09"
+	gnoAddr1, _ := ctg.ConvertAnyToGno(osmoAddr)
+
+	testing.IssueCoins(gnoAddr1, std.NewCoins(std.NewCoin(denom2, 12345)))
 
 	tests := []struct {
 		name      string

--- a/examples/gno.land/r/gnoland/coins/coins_test.gno
+++ b/examples/gno.land/r/gnoland/coins/coins_test.gno
@@ -25,6 +25,7 @@ func TestBalanceChecker(t *testing.T) {
 	testing.IssueCoins(addr2, std.NewCoins(std.NewCoin(denom2, 12345)))
 
 	gnoAddr, _ := ctg.ConvertCosmosToGno("cosmos1s2v4tdskccx2p3yyvzem4mw5nn5fprwcku77hr")
+	osmoAddr := "osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09"
 
 	tests := []struct {
 		name      string
@@ -43,7 +44,6 @@ func TestBalanceChecker(t *testing.T) {
 		// 	path:     denom,
 		// 	expected: "Balance: 1500000testtoken",
 		// },
-
 		{
 			name:     "addr1's coin balance",
 			path:     ufmt.Sprintf("balances?address=%s&coin=%s", addr1.String(), denom1),
@@ -69,6 +69,16 @@ func TestBalanceChecker(t *testing.T) {
 			name:     "cosmos addr conversion",
 			path:     "convert/cosmos1s2v4tdskccx2p3yyvzem4mw5nn5fprwcku77hr",
 			contains: ufmt.Sprintf("`cosmos1s2v4tdskccx2p3yyvzem4mw5nn5fprwcku77hr` on Cosmos matches `%s`", gnoAddr),
+		},
+		{
+			name:     "balances bech32 auto convert",
+			path:     ufmt.Sprintf("balances?address=%s&coin=%s", osmoAddr, denom1),
+			contains: "Automatically converted `osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09`",
+		},
+		{
+			name:     "single coin balance bech32 auto convert",
+			path:     ufmt.Sprintf("balances?address=%s", osmoAddr),
+			contains: "Automatically converted `osmo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3aq6l09`",
 		},
 		{
 			name:      "invalid path",


### PR DESCRIPTION
## Description

Fixing the coin checker so it supports the newest gno-forms PR.

The issue was that the form can only take you to a pre-determined render path within the realm, without the ability to parametrize it. I had to switch to parametrizing via query parameters. Would appreciate if someone can play around a bit.