### PR TITLE
fix: docker image pull should consume reader

### DIFF
--- a/misc/loop/cmd/backup.go
+++ b/misc/loop/cmd/backup.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
+	"log/slog"
+	"os"
 
 	"github.com/gnolang/gno/misc/loop/cmd/cfg"
 	"github.com/gnolang/gno/misc/loop/cmd/portalloop"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
-	"github.com/gnolang/gno/tm2/pkg/log"
 )
 
 func NewBackupCmd(_ commands.IO) *commands.Command {
@@ -26,7 +27,8 @@ func NewBackupCmd(_ commands.IO) *commands.Command {
 }
 
 func execBackup(ctx context.Context, cfg_ *cfg.CmdCfg) error {
-	logger := log.NewNoopLogger()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
 	portalLoopHandler, err := portalloop.NewPortalLoopHandler(cfg_, logger)
 	if err != nil {
 		return err

--- a/misc/loop/cmd/serve.go
+++ b/misc/loop/cmd/serve.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"time"
 
 	"github.com/gnolang/gno/misc/loop/cmd/cfg"
 	"github.com/gnolang/gno/misc/loop/cmd/portalloop"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
-	"github.com/gnolang/gno/tm2/pkg/log"
 )
 
 func NewServeCmd(_ commands.IO) *commands.Command {
@@ -28,7 +29,8 @@ func NewServeCmd(_ commands.IO) *commands.Command {
 }
 
 func execServe(ctx context.Context, cfg_ *cfg.CmdCfg) error {
-	logger := log.NewNoopLogger()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
 	portalLoopHandler, err := portalloop.NewPortalLoopHandler(cfg_, logger)
 	if err != nil {
 		return err

--- a/misc/loop/cmd/switch.go
+++ b/misc/loop/cmd/switch.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
+	"log/slog"
+	"os"
 
 	"github.com/gnolang/gno/misc/loop/cmd/cfg"
 	"github.com/gnolang/gno/misc/loop/cmd/portalloop"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
-	"github.com/gnolang/gno/tm2/pkg/log"
 )
 
 func NewSwitchCmd(_ commands.IO) *commands.Command {
@@ -26,7 +27,8 @@ func NewSwitchCmd(_ commands.IO) *commands.Command {
 }
 
 func execSwitch(ctx context.Context, cfg_ *cfg.CmdCfg) error {
-	logger := log.NewNoopLogger()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
 	portalLoopHandler, err := portalloop.NewPortalLoopHandler(cfg_, logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
- fixing issue of Docker SDK when pulling , if not consuming the reader returned, the pull operation cannot be considered concluded -> if starting a container afterward it will use the previous image respect to the pulled one
- adding real logger to stdout
