### PR TITLE
fix(gnovm): handle nil MapValue for range

### DIFF
--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -337,10 +337,13 @@ func (m *Machine) doOpExec(op Op) {
 	case OpRangeIterMap:
 		bs := s.(*bodyStmt)
 		xv := m.PeekValue(1)
-		mv := xv.V.(*MapValue)
+		var mv *MapValue
+		if xv.V != nil {
+			mv = xv.V.(*MapValue)
+		}
 		switch bs.NextBodyIndex {
 		case -2: // init.
-			if mv.GetLength() == 0 { // early termination
+			if mv == nil || mv.GetLength() == 0 { // early termination
 				m.PopFrameAndReset()
 				return
 			}

--- a/gnovm/tests/files/map30.gno
+++ b/gnovm/tests/files/map30.gno
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	var v map[string]string = nil
+	for k, v := range v {
+		println(k, v)
+	}
+	for v := range v {
+		println(v)
+	}
+	println("done") // should not panic
+}
+
+// Output:
+// done


### PR DESCRIPTION
#### Issue

Currently, the following code crashes the Gno VM with a panic during execution:

```go
package main

func main() {
	var v map[string]string = nil
	for k, v := range v {
		println(k, v)
	}
	println("done")
}
```

The panic occurs during the evaluation of the `for` loop due to the map being `nil`.
