### PR TITLE
test(pkg/integration): -no-parallel flag for sequential tests

### DIFF
--- a/gno.land/pkg/integration/testdata/gc.txtar
+++ b/gno.land/pkg/integration/testdata/gc.txtar
@@ -3,7 +3,7 @@
 loadpkg gno.land/r/gc $WORK/r/gc
 
 ## start a new node
-gnoland start
+gnoland start -no-parallel
 
 gnokey maketx call -pkgpath gno.land/r/gc -func Alloc -gas-fee 100000ugnot -gas-wanted 3000000 -simulate skip -broadcast -chainid tendermint_test test1
 stdout 'GAS USED:   508635'

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -323,7 +322,7 @@ func gnolandCmd(t *testing.T, nodesManager *NodesManager, gnoRootDir string) fun
 				// however, this should be done if -no-parallel is actually
 				// adopted in a variety of tests.
 				for !nodesManager.sequentialMu.TryLock() {
-					runtime.Gosched()
+					time.Sleep(time.Millisecond * 10)
 				}
 				ts.Defer(nodesManager.sequentialMu.Unlock)
 			} else {


### PR DESCRIPTION
gc.txtar is flaky because it's resource intensive, and should be run on its own to avoid timeouts. This PR adds a `-no-parallel` feature which does that.