### PR TITLE
feat: add `/docs` alias to gnoweb

### DIFF
--- a/gno.land/pkg/gnoweb/app.go
+++ b/gno.land/pkg/gnoweb/app.go
@@ -24,6 +24,7 @@ var DefaultAliases = map[string]AliasTarget{
 	"/links":      {"/r/gnoland/pages:p/links", GnowebPath},
 	"/events":     {"/r/gnoland/events", GnowebPath},
 	"/partners":   {"/r/gnoland/pages:p/partners", GnowebPath},
+	"/docs":       {"/u/docs", GnowebPath},
 }
 
 // AppConfig contains configuration for the gnoweb.


### PR DESCRIPTION
## Description

Adds a gno.land/docs alias to gnoweb, to redirect to gno.land/u/docs; this is until we have the ability to embed the full official docs into gnoweb.