### PR TITLE
fix(govdao): remove member does not return empty on no user removed

### DIFF
--- a/examples/gno.land/r/gov/dao/v3/memberstore/types.gno
+++ b/examples/gno.land/r/gov/dao/v3/memberstore/types.gno
@@ -123,7 +123,9 @@ func (mbt MembersByTier) RemoveMember(addr std.Address) (t string) {
 		}
 
 		_, removed := mst.Remove(string(addr))
-		t = tn
+		if removed {
+			t = tn
+		}
 		return removed
 	})
 


### PR DESCRIPTION
this issue leads to be able to promote user, even the user is not from the dao

this includes:
- bypass portfolio requirement
- bypass invitations points (and more globally all checked done in NewMember prop req)