### PR TITLE
ci(labeler): apply contribs label more selectively

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,11 +47,12 @@
           - "LICENSE*"
 
 "🤝 contribs":
-  - changed-files:
-      - any-glob-to-any-file:
-          - contribs/**/*
-      - all-globs-to-all-files:
-          - "!contribs/gnodev/**/*"
+  - all:
+      - changed-files:
+          - all-globs-to-any-file:
+              - contribs/**/*
+          - all-globs-to-all-files:
+              - "!contribs/gnodev/**/*"
 
 "🚀 ci":
   - changed-files:


### PR DESCRIPTION
The labeler configuration would apply the "contribs" label to all PRs which were NOT in gnodev.

This PR fixes it, by specifying the filter under the "all" key, ensuring that both conditions apply at the same time (file in `contribs`, NOT in `gnodev`)