### PR TITLE
fix(gnovm): re-enable the debugger in the REPL.

### DIFF
--- a/gnovm/pkg/gnolang/debugger.go
+++ b/gnovm/pkg/gnolang/debugger.go
@@ -74,6 +74,9 @@ func (d *Debugger) Enable(in io.Reader, out io.Writer, f func(string, string) st
 // Disable makes the debugger d inactive.
 func (d *Debugger) Disable() {
 	d.enabled = false
+	d.loc = Location{}
+	d.prevLoc = Location{}
+	d.nextLoc = Location{}
 }
 
 type debugCommand struct {
@@ -287,7 +290,11 @@ func (d *Debugger) Serve(addr string) error {
 // debugUpdateLocation computes the source code location for the current VM state.
 // The result is stored in Debugger.DebugLoc.
 func debugUpdateLocation(m *Machine) {
-	loc := m.LastBlock().Source.GetLocation()
+	loc := m.LastBlock().GetSource(m.Store).GetLocation()
+
+	if loc.PkgPath == "repl" {
+		loc.File = "repl.gno"
+	}
 
 	if m.Debugger.loc.PkgPath == "" ||
 		loc.PkgPath != "" && loc.PkgPath != m.Debugger.loc.PkgPath ||

--- a/gnovm/pkg/gnolang/go2gno.go
+++ b/gnovm/pkg/gnolang/go2gno.go
@@ -102,8 +102,8 @@ func ParseStmts(code string) (stmts []Stmt, err error) {
 	// Go only parses exprs and files,
 	// so wrap in a func body.
 	fset := token.NewFileSet()
-	code = fmt.Sprintf("func(){%s}", code)
-	x, err := parser.ParseExprFrom(fset, "<repl>", code, parser.SkipObjectResolution)
+	code = fmt.Sprintf("func(){%s}\n", code)
+	x, err := parser.ParseExprFrom(fset, "repl.gno", code, parser.SkipObjectResolution)
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +121,7 @@ func ParseStmts(code string) (stmts []Stmt, err error) {
 			return
 		}
 	}()
+
 	// parse with Go2Gno.
 	for _, gostmt := range gostmts {
 		var stmt Stmt
@@ -150,7 +151,7 @@ func MustParseStmts(code string) []Stmt {
 func ParseDecls(code string) (decls []Decl, err error) {
 	// Go only parses exprs and files,
 	// so wrap in a func body.
-	code = fmt.Sprintf("package repl\n%s", code)
+	code = fmt.Sprintf("package repl\n%s\n", code)
 	fn, err := ParseFile("repl.gno", code)
 	if err != nil {
 		return nil, err

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -155,6 +155,13 @@ func (r *Repl) RunStatements(code string) {
 		}()
 	}
 
+	if r.debug {
+		// Activate debugger for this statement only.
+		r.m.Debugger.Enable(os.Stdin, os.Stdout, func(ppath, file string) string { return code })
+		r.debug = false
+		defer r.m.Debugger.Disable()
+	}
+
 	decls, err := gno.ParseDecls(code)
 	if err != nil {
 		stmts, err2 := gno.ParseStmts(code)
@@ -183,5 +190,5 @@ func (r *Repl) Reset() {
 
 // Debug activates the GnoVM debugger for the next evaluation.
 func (r *Repl) Debug() {
-	panic("not yet implemented")
+	r.debug = true
 }


### PR DESCRIPTION
The /debug command was disabled par of #4316. This PR restores it.

A limitation is that a function declared in the REPL can not be debugged due to overlapping locations.