### PR TITLE
feat(gnoweb): activate default goldmark extensions

### DIFF
--- a/examples/gno.land/r/docs/markdown/markdown.gno
+++ b/examples/gno.land/r/docs/markdown/markdown.gno
@@ -153,8 +153,6 @@ Horizontal rules are created using three or more asterisks, hyphens, or undersco
 
 ---
 
-<!-- XXX: add again this feature that was removed -->
-<!--
 ### Task Lists
 
 Gno supports task lists for tracking to-do items:
@@ -162,11 +160,44 @@ Gno supports task lists for tracking to-do items:
 ±±±markdown
 - [x] Completed task
 - [ ] Pending task
+- [ ] Another pending task
+- [x] Another completed task
 ±±±
 
 - [x] Completed task
 - [ ] Pending task
--->
+- [ ] Another pending task
+- [x] Another completed task
+
+### Footnotes
+
+Gno supports footnotes for adding references and citations:
+
+±±±markdown
+Here is a sentence with a footnote[^1].
+
+[^1]: This is the footnote content.
+±±±
+
+Here is a sentence with a footnote[^1].
+
+[^1]: This is the footnote content.
+
+You can also use multiple footnotes in the same document:
+
+±±±markdown
+This is the first sentence with a footnote[^1].
+This is another sentence with a different footnote[^2].
+
+[^1]: First footnote content.
+[^2]: Second footnote content with more details.
+±±±
+
+This is the first sentence with a footnote[^1].
+This is another sentence with a different footnote[^2].
+
+[^1]: First footnote content.
+[^2]: Second footnote content with more details.
 
 ## Tables
 

--- a/gno.land/pkg/gnoweb/markdown.go
+++ b/gno.land/pkg/gnoweb/markdown.go
@@ -36,6 +36,8 @@ func NewDefaultMarkdownRendererConfig(chromaOptions []chromahtml.Option) *Markdo
 
 			extension.Strikethrough,
 			extension.Table,
+			extension.TaskList,
+			extension.Footnote,
 
 			md.NewGnoExtension(
 				md.WithImageValidator(allowSvgDataImage),


### PR DESCRIPTION
This PR aims to activate the default Goldmark missing extensions. It enhances the markdown rendering capabilities in gnoweb:

## Changes Made

- Added extension.TaskList to enable task list support (GitHub-style task lists)
- Added extension.Footnote to enable footnote support (Supports academic-style footnotes)
- Both extensions are now included in the default markdown renderer configuration

## Syntax

- TaskList: Uncommented and enhanced the existing task list section with examples showing both completed (`- [x]`) and pending (`- [ ]`) tasks
- Footnote: Added a new comprehensive section demonstrating footnote usage with proper syntax: `[^1]` for references and `[^1]`: content for definitions

## Impact

- Low risk: These are official Goldmark extensions with stable APIs
- Backward compatible: No breaking changes to existing markdown content
- Enhancement: Adds features we lost with winter gnoweb updates.