### PR TITLE
fix: txtar timeout

### DIFF
--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -25,7 +25,9 @@ jobs:
     uses: ./.github/workflows/main_template.yml
     with:
       modulepath: "gno.land"
-      tests-extra-args: "-coverpkg=github.com/gnolang/gno/gno.land/..."
+      # FIXME(gfanton): run txtar integration test sequentially using `ts-seq` to avoid timeout, this is a
+      # temporary fix for until cache is properly implemented on typecheck
+      tests-extra-args: "-ts-seq -coverpkg=github.com/gnolang/gno/gno.land/..."
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -23,13 +23,12 @@ jobs:
   main:
     name: Run gno.land suite
     uses: ./.github/workflows/main_template.yml
-    env:
-      # FIXME(gfanton): run txtar integration test sequentially using `ts-seq` to avoid timeout, this is a
-      # temporary fix for until cache is properly implemented on typecheck
-      INMEMORY_TS: true
     with:
       modulepath: "gno.land"
       tests-extra-args: "-coverpkg=github.com/gnolang/gno/gno.land/..."
+      # FIXME(gfanton): run txtar integration test sequentially using `ts-seq` to avoid timeout, this is a
+      # temporary fix for until cache is properly implemented on typecheck
+      tests-ts-seq: true
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/gnoland.yml
+++ b/.github/workflows/gnoland.yml
@@ -23,11 +23,13 @@ jobs:
   main:
     name: Run gno.land suite
     uses: ./.github/workflows/main_template.yml
-    with:
-      modulepath: "gno.land"
+    env:
       # FIXME(gfanton): run txtar integration test sequentially using `ts-seq` to avoid timeout, this is a
       # temporary fix for until cache is properly implemented on typecheck
-      tests-extra-args: "-ts-seq -coverpkg=github.com/gnolang/gno/gno.land/..."
+      INMEMORY_TS: true
+    with:
+      modulepath: "gno.land"
+      tests-extra-args: "-coverpkg=github.com/gnolang/gno/gno.land/..."
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main_template.yml
+++ b/.github/workflows/main_template.yml
@@ -9,7 +9,7 @@ on:
         type: string
       tests-ts-seq: # execute txtar sequentially
         required: false
-        type: bool
+        type: boolean
       go-version:
         description: "Go version to use"
         required: false

--- a/.github/workflows/main_template.yml
+++ b/.github/workflows/main_template.yml
@@ -7,6 +7,9 @@ on:
       tests-extra-args:
         required: false
         type: string
+      tests-ts-seq: # execute txtar sequentially
+        required: false
+        type: bool
       go-version:
         description: "Go version to use"
         required: false
@@ -34,6 +37,7 @@ jobs:
     uses: ./.github/workflows/test_template.yml
     with:
       modulepath: ${{ inputs.modulepath }}
+      tests-ts-seq: ${{ inputs.tests-ts-seq }}
       tests-timeout: "30m"
       go-version: ${{ inputs.go-version }}
       tests-extra-args: ${{ inputs.tests-extra-args }}

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -12,7 +12,7 @@ on:
         type: string
       tests-ts-seq: # execute txtar sequentially
         required: false
-        type: bool
+        type: boolean
       tests-extra-args:
         required: false
         type: string

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -10,6 +10,9 @@ on:
       go-version:
         required: true
         type: string
+      tests-ts-seq: # execute txtar sequentially
+        required: false
+        type: bool
       tests-extra-args:
         required: false
         type: string
@@ -30,17 +33,18 @@ jobs:
       - name: Go test
         working-directory: ${{ inputs.modulepath }}
         env:
+          SEQ_TS: ${{ inputs.tests-ts-seq }}
           TXTARCOVERDIR: /tmp/txtarcoverdir # txtar cover output
           GOCOVERDIR: /tmp/gocoverdir # go cover output
           COVERDIR: /tmp/coverdir # final output
         run: |
           set -x # print commands
-          
+
           mkdir -p "$GOCOVERDIR" "$TXTARCOVERDIR" "$COVERDIR"
-          
+
           # Craft a filter flag based on the module path to avoid expanding coverage on unrelated tags.
           export filter="-pkg=github.com/gnolang/gno/${{ inputs.modulepath }}/..."
-          
+
           # codecov only supports "boolean" coverage (whether a line is
           # covered or not); so using -covermode=count or atomic would be
           # pointless here.
@@ -49,13 +53,13 @@ jobs:
           # 1.23 regarding coverage, so we can use this as a workaround until
           # then.
           go test -covermode=set -timeout ${{ inputs.tests-timeout }} ${{ inputs.tests-extra-args }} ./... -test.gocoverdir=$GOCOVERDIR
-          
+
           # Print results
           (set +x; echo 'go coverage results:')
           go tool covdata percent $filter -i=$GOCOVERDIR
           (set +x; echo 'txtar coverage results:')
           go tool covdata percent $filter -i=$TXTARCOVERDIR
-          
+
           # Generate final coverage output
           go tool covdata textfmt -v 1 $filter -i=$GOCOVERDIR,$TXTARCOVERDIR -o gocoverage.out
 

--- a/gno.land/pkg/integration/process.go
+++ b/gno.land/pkg/integration/process.go
@@ -215,6 +215,7 @@ func RunNodeProcess(ctx context.Context, cfg ProcessConfig, name string, args ..
 
 	address, err := waitForProcessReady(ctx, stdoutPipe, cfg.Stdout)
 	if err != nil {
+		cmd.Process.Kill() // kill process if it isn't ready yet
 		return nil, fmt.Errorf("waiting for readiness: %w", err)
 	}
 

--- a/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
@@ -29,7 +29,7 @@ stdout OK!
 
 # call gov/dao render to check everything the proposal was created
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
-stdout 'This is a proposal to add g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 to \*\*T2\*\*.'
+stdout 'This is a proposal to add `g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0` to \*\*T2\*\*.'
 
 # vote on the proposal
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1000000ugnot -gas-wanted 10000000 -args 0 -args YES -broadcast -chainid=tendermint_test member

--- a/gno.land/pkg/integration/testdata_test.go
+++ b/gno.land/pkg/integration/testdata_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"flag"
 	"os"
 	"strconv"
 	"testing"
@@ -11,25 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	flagInMemoryTS = flag.Bool("ts-inmemory", false,
-		"Make txtar run in memory, without running any side process, forcing test to run sequentially")
-	flagSeqTS = flag.Bool("ts-seq", false,
-		"forcing tests to run sequentially")
-)
-
-func init() {
-	if t, err := strconv.ParseBool(os.Getenv("INMEMORY_TS")); err == nil {
-		*flagInMemoryTS = t
-	}
-
-	if t, err := strconv.ParseBool(os.Getenv("SEQ_TS")); err == nil {
-		*flagSeqTS = t
-	}
-}
-
 func TestTestdata(t *testing.T) {
 	t.Parallel()
+
+	flagInMemoryTS, _ := strconv.ParseBool(os.Getenv("INMEMORY_TS"))
+	flagSeqTS, _ := strconv.ParseBool(os.Getenv("SEQ_TS"))
 
 	p := gno_integration.NewTestingParams(t, "testdata")
 
@@ -43,7 +28,7 @@ func TestTestdata(t *testing.T) {
 	require.NoError(t, err)
 
 	mode := commandKindTesting
-	if *flagInMemoryTS {
+	if flagInMemoryTS {
 		mode = commandKindInMemory
 	}
 
@@ -59,7 +44,7 @@ func TestTestdata(t *testing.T) {
 		return nil
 	}
 
-	if *flagInMemoryTS || *flagSeqTS {
+	if flagInMemoryTS || flagSeqTS {
 		testscript.RunT(tSeqShim{t}, p)
 	} else {
 		testscript.Run(t, p)

--- a/gno.land/pkg/integration/testdata_test.go
+++ b/gno.land/pkg/integration/testdata_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"flag"
 	"os"
 	"strconv"
 	"testing"
@@ -10,11 +11,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	flagInMemoryTS = flag.Bool("ts-inmemory", false,
+		"Make txtar run in memory, without running any side process, forcing test to run sequentially")
+	flagSeqTS = flag.Bool("ts-seq", false,
+		"forcing tests to run sequentially")
+)
+
+func init() {
+	if t, err := strconv.ParseBool(os.Getenv("INMEMORY_TS")); err == nil {
+		*flagInMemoryTS = t
+	}
+
+	if t, err := strconv.ParseBool(os.Getenv("SEQ_TS")); err == nil {
+		*flagSeqTS = t
+	}
+}
+
 func TestTestdata(t *testing.T) {
 	t.Parallel()
-
-	flagInMemoryTS, _ := strconv.ParseBool(os.Getenv("INMEMORY_TS"))
-	flagSeqTS, _ := strconv.ParseBool(os.Getenv("SEQ_TS"))
 
 	p := gno_integration.NewTestingParams(t, "testdata")
 
@@ -28,7 +43,7 @@ func TestTestdata(t *testing.T) {
 	require.NoError(t, err)
 
 	mode := commandKindTesting
-	if flagInMemoryTS {
+	if *flagInMemoryTS {
 		mode = commandKindInMemory
 	}
 
@@ -44,7 +59,7 @@ func TestTestdata(t *testing.T) {
 		return nil
 	}
 
-	if flagInMemoryTS || flagSeqTS {
+	if *flagInMemoryTS || *flagSeqTS {
 		testscript.RunT(tSeqShim{t}, p)
 	} else {
 		testscript.Run(t, p)

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -37,7 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const nodeMaxLifespan = time.Second * 60
+const nodeMaxLifespan = time.Second * 120
 
 var defaultUserBalance = std.Coins{std.NewCoin(ugnot.Denom, 10e8)}
 


### PR DESCRIPTION
This PR disables parallel testing on the txtar integration test until the cache is correctly implemented in the typecheck method during AddPackage.

This is not a fix but rather a temporary solution to ensure the tests pass until the cache is implemented.