### PR TITLE
fix(gnodev): remote test errors & contribs CI fixes

### DIFF
--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     paths:
       - contribs/**
+      # We have to trigger the testing workflow for contribs on the following,
+      # since there is a direct depency of contribs to gno.land / tm2 / gnovm.
+      - gno.land/**
+      - gnovm/**
+      - tm2/**
+
   workflow_dispatch:
 
 jobs:
@@ -26,14 +32,14 @@ jobs:
         run: |
           contribs_programs=$(ls -d contribs/*/ | cut -d/ -f2)
           versions_map="{"
-          
+
           for p in $contribs_programs; do
             # Fetch the go version of the contribs entry, and save it
             # to a versions map we can reference later in the workflow
             go_version=$(grep "^go [0-9]" contribs/$p/go.mod | cut -d ' ' -f2)
             versions_map="$versions_map\"$p\":\"$go_version\","
           done
-          
+
           # Close out the JSON
           versions_map="${versions_map%,}"
           versions_map="$versions_map}"

--- a/contribs/gnodev/pkg/packages/resolver_remote.go
+++ b/contribs/gnodev/pkg/packages/resolver_remote.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/token"
 	gopath "path"
-	"strings"
 
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
@@ -43,8 +42,9 @@ func (res *remoteResolver) Resolve(fset *token.FileSet, path string) (*Package, 
 	}
 
 	if err := qres.Response.Error; err != nil {
-		if errors.Is(err, vm.InvalidPkgPathError{}) ||
-			strings.HasSuffix(err.Error(), "is not available") { // XXX: find a better to check this
+		if errors.Is(err, vm.InvalidFileError{}) ||
+			errors.Is(err, vm.InvalidPkgPathError{}) ||
+			errors.Is(err, vm.InvalidPackageError{}) { // XXX: find a better to check this
 			return nil, ErrResolverPackageNotFound
 		}
 


### PR DESCRIPTION
Fix the `gnodev` resolver test error. These errors weren't caught because `gnodev` wasn't triggered on #4410; the `gnodev` tests only run when there are changes to the `gnodev` package itself. 
This PR also ensures that the tests in the `contribs` folder run whenever there are changes to `gno.land`, `tm2`, or `gnovm`, as most of the `gno.mod` files there have a direct dependency on `gno` (essentially `replace gno => ../gno`).