### PR TITLE
feat(cmd/gno): add env var to enable profiling

### DIFF
--- a/gnovm/cmd/gno/main.go
+++ b/gnovm/cmd/gno/main.go
@@ -3,11 +3,26 @@ package main
 import (
 	"context"
 	"os"
+	"runtime/pprof"
 
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
 
 func main() {
+	cpup := os.Getenv("CPUPROFILE")
+	if cpup != "" {
+		f, err := os.Create(cpup)
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			panic(err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
 	cmd := newGnocliCmd(commands.NewDefaultIO())
 
 	cmd.Execute(context.Background(), os.Args[1:])


### PR DESCRIPTION
I used this locally to profile executions of gno code and do the batch of improvements I sent in today.

I think it would be good to have this permanently as an env var. 