### PR TITLE
fix(gnovm): Handle nil `fBlocksMap` in cached packages

### DIFF
--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -282,6 +282,9 @@ func (ds *defaultStore) GetPackage(pkgPath string, isImport bool) *PackageValue 
 	oid := ObjectIDFromPkgPath(pkgPath)
 	if oo, exists := ds.cacheObjects[oid]; exists {
 		pv := oo.(*PackageValue)
+		if pv.fBlocksMap == nil {
+			pv.deriveFBlocksMap(ds)
+		}
 		return pv
 	}
 	// else, load package.


### PR DESCRIPTION
# Description

The `GetPackage` method in `store.go` was returning cached packages without ensuring that their `fBlocksMap` was properly initialized. When a package was retrieved from cache, it could have a `nil` `fBlocksMap`, leading to runtime panics when trying to access file blocks.

To fix this, added a simple nil check and initialization in the `GetPackage` method.

## Problem

During package deployment, we encountered a _"file block missing"_ error that cause the problem in deployment of packages. The error as follows:

```plain
file block missing for file "pool_type.gno"
```

This error occurred when the VM attempted to access file blocks from a cached package whose `fBlocksMap` field was `nil`. I assume that the issue was particularly problematic in complex package import scenarios, such as those found in the gnoswap project where multiple packages with numerous files are interdependent.

## Testing

- `TestGetPackageWithNilFBlocksMap`: Simulates the bug scenario with multi-file packages
- `TestGetPackageFromCacheMultipleTimes`: Ensures repeated access to cached packages works correctly

## Production Verification

Since applying this patch in commit [5dbda84](https://github.com/gnolang/gno/commit/5dbda8429fa832ca5f1b35334c09a2906c7a77a4), the "file block missing" error has not recurred in production deployments.

cc: @jinoosss 
