### PR TITLE
fix: gnoland Dockerfile missing tests directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ FROM        base AS gnoland
 COPY        --from=build-gno /gnoroot/build/gnoland /usr/bin/gnoland
 COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
 COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE      26656 26657


### PR DESCRIPTION
This PR fixes an issue that occurs and prevents the deployment of test7. 
The following error occurs when launching the node with `gnoland start`:
```
"gno.land/p/demo/diff/diff_test.gno:5:2: could not import testing (unknown import path \"testing\")"}}
```

<details>
<summary>Full log</summary>

```bash
/gnoroot # gnoland start --skip-genesis-sig-verification -genesis=./genesis.json

                    __             __
  ___ ____  ___    / /__ ____  ___/ /
 / _ `/ _ \/ _ \_ / / _ `/ _ \/ _  /
 \_, /_//_/\___(_)_/\_,_/_//_/\_,_/
/___/

2025-07-25T09:44:38.986Z	INFO 	Starting multi	{"module": "proxy", "impl": "multi"}
2025-07-25T09:44:38.986Z	INFO 	Starting localClient	{"module": "proxy", "module": "abci-client", "connection": "query", "impl": "localClient"}
2025-07-25T09:44:38.986Z	INFO 	Starting localClient	{"module": "proxy", "module": "abci-client", "connection": "mempool", "impl": "localClient"}
2025-07-25T09:44:38.986Z	INFO 	Starting localClient	{"module": "proxy", "module": "abci-client", "connection": "consensus", "impl": "localClient"}
2025-07-25T09:44:38.986Z	INFO 	Starting EventStoreService	{"module": "eventstore", "impl": "EventStoreService"}
2025-07-25T09:44:38.986Z	INFO 	ABCI Handshake App Info	{"module": "consensus", "height": 0, "hash": "", "abci-version": "", "app-version": ""}
2025-07-25T09:44:38.986Z	INFO 	ABCI Replay Blocks	{"module": "consensus", "appHeight": 0, "storeHeight": 0, "stateHeight": 0}
2025-07-25T09:44:38.987Z	DEBUG	InitChainer: started
2025-07-25T09:44:39.801Z	DEBUG	InitChainer: standard libraries loaded	{"elapsed": "814.399333ms"}
2025-07-25T09:44:47.045Z	ERROR	Unable to deliver genesis tx	{"log": "msg:0,success:false,log:--= Error =--\nData: vm.TypeCheckError{abciError:vm.abciError{}, Errors:[]string{\"gno.land/p/demo/diff/diff_test.gno:5:2: could not import testing (unknown import path \\\"testing\\\")\"}}\nMsg Traces:\nStack Trace:\n    0  /gnoroot/gno.land/pkg/sdk/vm/errors.go:81\n    1  /gnoroot/gno.land/pkg/sdk/vm/keeper.go:471\n    2  /gnoroot/gno.land/pkg/sdk/vm/handler.go:42\n    3  /gnoroot/gno.land/pkg/sdk/vm/handler.go:29\n    4  /gnoroot/tm2/pkg/sdk/baseapp.go:671\n    5  /gnoroot/tm2/pkg/sdk/baseapp.go:862\n    6  /gnoroot/tm2/pkg/sdk/helpers.go:35\n    7  /gnoroot/gno.land/pkg/gnoland/app.go:421\n    8  /gnoroot/gno.land/pkg/gnoland/app.go:318\n    9  /gnoroot/tm2/pkg/sdk/baseapp.go:346\n   10  /gnoroot/tm2/pkg/bft/abci/client/local_client.go:196\n   11  /gnoroot/tm2/pkg/bft/appconn/app_conn.go:66\n   12  /gnoroot/tm2/pkg/bft/consensus/replay.go:305\n   13  /gnoroot/tm2/pkg/bft/consensus/replay.go:263\n   14  /gnoroot/tm2/pkg/bft/node/node.go:246\n   15  /gnoroot/tm2/pkg/bft/node/node.go:399\n   16  /gnoroot/tm2/pkg/bft/node/node.go:132\n   17  /gnoroot/gno.land/cmd/gnoland/start.go:257\n   18  /gnoroot/gno.land/cmd/gnoland/start.go:77\n   19  /gnoroot/tm2/pkg/commands/command.go:265\n   20  /gnoroot/tm2/pkg/commands/command.go:269\n   21  /gnoroot/tm2/pkg/commands/command.go:150\n   22  /gnoroot/tm2/pkg/commands/command.go:127\n   23  /gnoroot/gno.land/cmd/gnoland/root.go:13\n   24  /usr/local/go/src/runtime/proc.go:272\n   25  /usr/local/go/src/runtime/asm_arm64.s:1223\n--= /Error =--\n,events:[]", "error": "invalid gno package; type check errors:\ngno.land/p/demo/diff/diff_test.gno:5:2: could not import testing (unknown import path \"testing\")", "gas-used": 7337912}
github.com/gnolang/gno/gno.land/pkg/gnoland.InitChainerConfig.loadAppState
	/gnoroot/gno.land/pkg/gnoland/app.go:423
github.com/gnolang/gno/gno.land/pkg/gnoland.InitChainerConfig.InitChainer
	/gnoroot/gno.land/pkg/gnoland/app.go:318
github.com/gnolang/gno/tm2/pkg/sdk.(*BaseApp).InitChain
	/gnoroot/tm2/pkg/sdk/baseapp.go:346
github.com/gnolang/gno/tm2/pkg/bft/abci/client.(*localClient).InitChainSync
	/gnoroot/tm2/pkg/bft/abci/client/local_client.go:196
github.com/gnolang/gno/tm2/pkg/bft/appconn.(*consensus).InitChainSync
	/gnoroot/tm2/pkg/bft/appconn/app_conn.go:66
github.com/gnolang/gno/tm2/pkg/bft/consensus.(*Handshaker).ReplayBlocks
	/gnoroot/tm2/pkg/bft/consensus/replay.go:305
github.com/gnolang/gno/tm2/pkg/bft/consensus.(*Handshaker).Handshake
	/gnoroot/tm2/pkg/bft/consensus/replay.go:263
github.com/gnolang/gno/tm2/pkg/bft/node.doHandshake
	/gnoroot/tm2/pkg/bft/node/node.go:246
github.com/gnolang/gno/tm2/pkg/bft/node.NewNode
	/gnoroot/tm2/pkg/bft/node/node.go:399
github.com/gnolang/gno/tm2/pkg/bft/node.DefaultNewNode
	/gnoroot/tm2/pkg/bft/node/node.go:132
main.execStart
	/gnoroot/gno.land/cmd/gnoland/start.go:257
main.newStartCmd.func1
	/gnoroot/gno.land/cmd/gnoland/start.go:77
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run
	/gnoroot/tm2/pkg/commands/command.go:265
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run
	/gnoroot/tm2/pkg/commands/command.go:269
github.com/gnolang/gno/tm2/pkg/commands.(*Command).ParseAndRun
	/gnoroot/tm2/pkg/commands/command.go:150
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Execute
	/gnoroot/tm2/pkg/commands/command.go:127
main.main
	/gnoroot/gno.land/cmd/gnoland/root.go:13
runtime.main
	/usr/local/go/src/runtime/proc.go:272
panic: msg:0,success:false,log:--= Error =--
	Data: vm.TypeCheckError{abciError:vm.abciError{}, Errors:[]string{"gno.land/p/demo/diff/diff_test.gno:5:2: could not import testing (unknown import path \"testing\")"}}
	Msg Traces:
	Stack Trace:
	    0  /gnoroot/gno.land/pkg/sdk/vm/errors.go:81
	    1  /gnoroot/gno.land/pkg/sdk/vm/keeper.go:471
	    2  /gnoroot/gno.land/pkg/sdk/vm/handler.go:42
	    3  /gnoroot/gno.land/pkg/sdk/vm/handler.go:29
	    4  /gnoroot/tm2/pkg/sdk/baseapp.go:671
	    5  /gnoroot/tm2/pkg/sdk/baseapp.go:862
	    6  /gnoroot/tm2/pkg/sdk/helpers.go:35
	    7  /gnoroot/gno.land/pkg/gnoland/app.go:421
	    8  /gnoroot/gno.land/pkg/gnoland/app.go:318
	    9  /gnoroot/tm2/pkg/sdk/baseapp.go:346
	   10  /gnoroot/tm2/pkg/bft/abci/client/local_client.go:196
	   11  /gnoroot/tm2/pkg/bft/appconn/app_conn.go:66
	   12  /gnoroot/tm2/pkg/bft/consensus/replay.go:305
	   13  /gnoroot/tm2/pkg/bft/consensus/replay.go:263
	   14  /gnoroot/tm2/pkg/bft/node/node.go:246
	   15  /gnoroot/tm2/pkg/bft/node/node.go:399
	   16  /gnoroot/tm2/pkg/bft/node/node.go:132
	   17  /gnoroot/gno.land/cmd/gnoland/start.go:257
	   18  /gnoroot/gno.land/cmd/gnoland/start.go:77
	   19  /gnoroot/tm2/pkg/commands/command.go:265
	   20  /gnoroot/tm2/pkg/commands/command.go:269
	   21  /gnoroot/tm2/pkg/commands/command.go:150
	   22  /gnoroot/tm2/pkg/commands/command.go:127
	   23  /gnoroot/gno.land/cmd/gnoland/root.go:13
	   24  /usr/local/go/src/runtime/proc.go:272
	   25  /usr/local/go/src/runtime/asm_arm64.s:1223
	--= /Error =--
	,events:[]

goroutine 1 [running]:
github.com/gnolang/gno/gno.land/pkg/gnoland.PanicOnFailingTxResultHandler({{0xfc1378, 0x4006ca49c0}, 0x2, {0xfbfac0, 0x400011c4c0}, {0xfc15a8, 0x4000488160}, {0x4000336079, 0x5}, {0x0, ...}, ...}, ...)
	/gnoroot/gno.land/pkg/gnoland/app.go:276 +0x94
github.com/gnolang/gno/gno.land/pkg/gnoland.InitChainerConfig.loadAppState({0xe59f28, {0x400003ea20, 0x16}, _, _, {_, _}, {_, _}, {_, ...}, ...}, ...)
	/gnoroot/gno.land/pkg/gnoland/app.go:437 +0x65c
github.com/gnolang/gno/gno.land/pkg/gnoland.InitChainerConfig.InitChainer({_, {_, _}, _, _, {_, _}, {_, _}, {_, ...}, ...}, ...)
	/gnoroot/gno.land/pkg/gnoland/app.go:318 +0x270
github.com/gnolang/gno/tm2/pkg/sdk.(*BaseApp).InitChain(0x4000000120, {{}, {0x0, 0xee0152270, 0x0}, {0x4000336079, 0x5}, 0x400011c490, {0x40000e26c0, 0x4, ...}, ...})
	/gnoroot/tm2/pkg/sdk/baseapp.go:346 +0x294
github.com/gnolang/gno/tm2/pkg/bft/abci/client.(*localClient).InitChainSync(0x7f228?, {{}, {0x0, 0xee0152270, 0x0}, {0x4000336079, 0x5}, 0x400011c490, {0x40000e26c0, 0x4, ...}, ...})
	/gnoroot/tm2/pkg/bft/abci/client/local_client.go:196 +0x138
github.com/gnolang/gno/tm2/pkg/bft/appconn.(*consensus).InitChainSync(0xfa9100?, {{}, {0x0, 0xee0152270, 0x0}, {0x4000336079, 0x5}, 0x400011c490, {0x40000e26c0, 0x4, ...}, ...})
	/gnoroot/tm2/pkg/bft/appconn/app_conn.go:66 +0xc0
github.com/gnolang/gno/tm2/pkg/bft/consensus.(*Handshaker).ReplayBlocks(_, {{0xce300e, 0xb}, {0xce300e, 0xb}, {0xface58, 0x0}, {0x4000336079, 0x5}, 0x0, ...}, ...)
	/gnoroot/tm2/pkg/bft/consensus/replay.go:305 +0xa08
github.com/gnolang/gno/tm2/pkg/bft/consensus.(*Handshaker).Handshake(0x400be27078, {0xfce260, 0x40000947e0})
	/gnoroot/tm2/pkg/bft/consensus/replay.go:263 +0x37c
github.com/gnolang/gno/tm2/pkg/bft/node.doHandshake({_, _}, {{0xce300e, 0xb}, {0xce300e, 0xb}, {0xface58, 0x0}, {0x4000336079, 0x5}, ...}, ...)
	/gnoroot/tm2/pkg/bft/node/node.go:246 +0x144
github.com/gnolang/gno/tm2/pkg/bft/node.NewNode(0x4000325180, {0xfc16f8, 0x4000136870}, 0x40002e2300, {0xffff3cc9ad78, 0x4000136648}, 0x4000173a38, 0xd4eec2f0e8e5b231?, {0xfce1e0, 0x400027e690}, ...)
	/gnoroot/tm2/pkg/bft/node/node.go:399 +0x2a8
github.com/gnolang/gno/tm2/pkg/bft/node.DefaultNewNode(0x4000325180, {0x400003e1c8, 0x15}, {0xfce1e0, 0x400027e690}, 0x4000043c50)
	/gnoroot/tm2/pkg/bft/node/node.go:132 +0x288
main.execStart({0xfc1260, 0x17e7900}, 0x4000338a00, {0xfd2010, 0x4000391ea0})
	/gnoroot/gno.land/cmd/gnoland/start.go:257 +0x700
main.newStartCmd.func1({0xfc1260?, 0x17e7900?}, {0x547220?, 0x400033a840?, 0x4000133440?})
	/gnoroot/gno.land/cmd/gnoland/start.go:77 +0x30
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run(0x11f?, {0xfc1260?, 0x17e7900?})
	/gnoroot/tm2/pkg/commands/command.go:265 +0x174
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run(0x4000146000?, {0xfc1260?, 0x17e7900?})
	/gnoroot/tm2/pkg/commands/command.go:269 +0x124
github.com/gnolang/gno/tm2/pkg/commands.(*Command).ParseAndRun(0x4000146000, {0xfc1260, 0x17e7900}, {0x40001380d0?, 0xe59b58?, 0x40000021c0?})
	/gnoroot/tm2/pkg/commands/command.go:150 +0x4c
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Execute(0xfd2010?, {0xfc1260?, 0x17e7900?}, {0x40001380d0?, 0x1741f18?, 0x40000021c0?})
	/gnoroot/tm2/pkg/commands/command.go:127 +0x28
main.main()
	/gnoroot/gno.land/cmd/gnoland/root.go:13 +0x6c
```

</details>