### PR TITLE
ci: skip gnokms flaky test

### DIFF
--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -24,10 +24,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump Runner context
-        env:
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
-        run: echo "$RUNNER_CONTEXT"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -24,6 +24,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Dump Runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go

--- a/contribs/gnokms/internal/common/flags_test.go
+++ b/contribs/gnokms/internal/common/flags_test.go
@@ -13,6 +13,10 @@ import (
 func TestRegistersDontPanic(t *testing.T) {
 	t.Parallel()
 
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping until https://github.com/gnolang/gno/issues/4561 is resolved")
+	}
+
 	t.Run("auth flags", func(t *testing.T) {
 		t.Parallel()
 
@@ -36,6 +40,10 @@ func TestRegistersDontPanic(t *testing.T) {
 
 func TestDefaultAuthKeysFile(t *testing.T) {
 	t.Parallel()
+
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping until https://github.com/gnolang/gno/issues/4561 is resolved")
+	}
 
 	t.Run("valid context", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
This PR add a `t.Skip()` on this flaky test to avoid this error: https://github.com/gnolang/gno/actions/runs/16519712019/job/46718566745#step:4:103

Until #4561 is fixed