### PR TITLE
fix: Dockerfile and Dockerfile.release images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,10 +89,10 @@ RUN         apk add --no-cache ca-certificates
 # Gnoland image
 ## ghcr.io/gnolang/gno/gnoland
 FROM        base AS gnoland
-COPY        --from=build-gno /gnoroot/build/gnoland /usr/bin/gnoland
-COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
-COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs
+COPY        --from=build-gno /gnoroot/build/gnoland                         /usr/bin/gnoland
+COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE      26656 26657
@@ -123,9 +123,9 @@ ENTRYPOINT  ["/usr/bin/gnofaucet"]
 # Gnodev image
 ## ghcr.io/gnolang/gno/gnodev
 FROM        base AS gnodev
-COPY        --from=build-gnodev /gnoroot/build/gnodev /usr/bin/gnodev
-COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
+COPY        --from=build-gnodev /gnoroot/build/gnodev                       /usr/bin/gnodev
+COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 # gnoweb port exposed by default
@@ -134,19 +134,19 @@ ENTRYPOINT  ["/usr/bin/gnodev"]
 
 # Gno
 FROM        base AS gno
-COPY        --from=build-gno /gnoroot/build/gno /usr/bin/gno
-COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/build/gno           /usr/bin/gno
+COPY        --from=build-gno /gnoroot/examples            /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs       /gnoroot/gnovm/stdlibs
 COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs /gnoroot/gnovm/tests/stdlibs
 ENTRYPOINT  ["/usr/bin/gno"]
 
 # Gno Contribs [ Gnobro, Gnogenesis ]
 ## ghcr.io/gnolang/gnocontribs
 FROM        base AS gnocontribs
-COPY        --from=build-gnobro /gnoroot/build/gnobro /usr/bin/gnobro
-COPY        --from=build-contribs /gnoroot/build/gnogenesis /usr/bin/gnogenesis
-COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
+COPY        --from=build-gnobro /gnoroot/build/gnobro                       /usr/bin/gnobro
+COPY        --from=build-contribs /gnoroot/build/gnogenesis                 /usr/bin/gnogenesis
+COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE     22
@@ -163,10 +163,10 @@ CMD         ["serve"]
 
 # all, contains everything.
 FROM        base AS all
-COPY        --from=build-gno /gnoroot/build/* /usr/bin/
-COPY        --from=build-gno /gnoroot/examples      /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/build/*                               /usr/bin/
+COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 # gofmt is required by `gnokey maketx addpkg`
-COPY        --from=build-gno /usr/local/go/bin/gofmt /usr/bin
+COPY        --from=build-gno /usr/local/go/bin/gofmt                        /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ FROM        base AS gnodev
 COPY        --from=build-gnodev /gnoroot/build/gnodev                       /usr/bin/gnodev
 COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
 COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 # gnoweb port exposed by default
@@ -146,7 +147,6 @@ FROM        base AS gnocontribs
 COPY        --from=build-gnobro /gnoroot/build/gnobro                       /usr/bin/gnobro
 COPY        --from=build-contribs /gnoroot/build/gnogenesis                 /usr/bin/gnogenesis
 COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
-COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE     22
@@ -166,6 +166,7 @@ FROM        base AS all
 COPY        --from=build-gno /gnoroot/build/*                               /usr/bin/
 COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
 COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 # gofmt is required by `gnokey maketx addpkg`

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,6 +14,7 @@ FROM base AS gnoland
 COPY     ./gnoland                               /usr/bin/gnoland
 COPY     ./examples                              /gnoroot/examples/
 COPY     ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
+COPY     ./gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs/
 COPY     ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 COPY     ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 
@@ -51,6 +52,7 @@ FROM base AS gnodev
 COPY       ./gnodev /usr/bin/gnodev
 COPY       ./examples                              /gnoroot/examples/
 COPY       ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
+COPY       ./gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs/
 COPY       ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 COPY       ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 # gnoweb exposed by default
@@ -75,7 +77,6 @@ FROM base AS gnocontribs
 COPY       ./gnobro                                /usr/bin/gnobro
 COPY       ./gnogenesis                            /usr/bin/gnogenesis
 COPY       ./examples                              /gnoroot/examples/
-COPY       ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
 COPY       ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 COPY       ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 EXPOSE     22

--- a/misc/deployments/bake/README.md
+++ b/misc/deployments/bake/README.md
@@ -17,7 +17,7 @@ docker buildx bake --allow fs=\* --file docker-bake.hcl --set \*.dockerfile=Dock
 * Bake a single target and push to registry, from `${project_root_folder}`
 
 ```sh
-docker buildx bake --allow fs=\* --file misc/deployments/bake/docker-bake.hcl --set \*.context=. --set \*. dockerfile=Dockerfile --push gnoland
+docker buildx bake --allow fs=\* --file misc/deployments/bake/docker-bake.hcl --set \*.context=. --set \*.dockerfile=Dockerfile --push gnoland
 ```
 
 ## See Also


### PR DESCRIPTION
This PR:
- fix wrong paths on `gnobro` / `gnodev` related images
- import `gnovm/tests/stdlibs` on `gnoland`, `gnodev` and `all` images (required)
- remove `gnovm/stdlibs` from `contribs` image (useless?)