### PR TITLE
fix(cs): death loop when `CreateEmptyBlocks==false`

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -464,12 +464,13 @@ func EndBlocker(
 	return func(ctx sdk.Context, _ abci.RequestEndBlock) abci.ResponseEndBlock {
 		// set the auth params value in the ctx.  The EndBlocker will use InitialGasPrice in
 		// the params to calculate the updated gas price.
-		// Only update gas price if gas was consumed in this block to avoid
-		// changing AppHash on empty blocks which breaks needProofBlock logic
-		if acck != nil && gpk != nil && ctx.BlockGasMeter().GasConsumed() > 0 {
+		if acck != nil {
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
+		}
+		if acck != nil && gpk != nil {
 			auth.EndBlocker(ctx, gpk)
 		}
+
 		// Check if there was a valset change
 		if len(collector.getEvents()) == 0 {
 			// No valset updates

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -205,6 +205,13 @@ func (gk GasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {
 func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 	params := ctx.Value(AuthParamsContextKey{}).(Params)
 	gasUsed := ctx.BlockGasMeter().GasConsumed()
+
+	// Only update gas price if gas was consumed to avoid changing AppHash
+	// on empty blocks.
+	if gasUsed <= 0 {
+		return
+	}
+
 	maxBlockGas := ctx.ConsensusParams().Block.MaxGas
 	lgp := gk.LastGasPrice(ctx)
 	newGasPrice := gk.calcBlockGasPrice(lgp, gasUsed, maxBlockGas, params)


### PR DESCRIPTION
address #4538 

~This PR fixes a death loop that occurred when CreateEmptyBlocks was set to false. This issue caused a node to enter an infinite loop due to an impossible condition.~

**UPDATE**
The issue is actually deeper. This PR https://github.com/gnolang/gno/pull/2838 introduced dynamic gas price updates in the `EndBlocker` function. As a result, every block now alters the app `cs.state`, even empty blocks, because the gas price keeper adjusts the gas price based on block gas usage. 

Every block modifies the `AppHash` since the gas price state is updated in the `EndBlocker`. The `needProofBlock` function always returns true because `cs.state.AppHash != lastBlockMeta.Header.AppHash` is consistently true. 
This leads to an infinite loop when `CreateEmptyBlocks == false`, as the node continues to attempt to create proof blocks even when there are no transactions.

So a better fix is probably to make `EndBlocker` only update the gas price when there are transactions (when gas `consumption > 0`). cc @piux2 

fix 51cdf97b1b911dbb4f566311aee2487f0e159ed3

@zivkovicmilos can you double check this 🙏 ?

--- 

I need some help testing to ensure everything functions correctly. cc @jefft0  @mazzy89 @zivkovicmilos 