### PR TITLE
fix: compile regx before use

### DIFF
--- a/gnovm/cmd/gno/common.go
+++ b/gnovm/cmd/gno/common.go
@@ -276,7 +276,7 @@ func guessIssueFromError(dir, pkgPath string, err error, code gnoCode) gnoIssue 
 	issue.Code = code
 
 	parsedError := strings.TrimSpace(err.Error())
-	match := gno.Re_errorLine.Match(parsedError)
+	match := gno.ReErrorLine.Match(parsedError)
 	if match == nil {
 		issue.Location = fmt.Sprintf("%s:0", filepath.Clean(pkgPath))
 		issue.Msg = err.Error()

--- a/gnovm/pkg/gnolang/mempackage.go
+++ b/gnovm/pkg/gnolang/mempackage.go
@@ -64,12 +64,16 @@ var (
 		r.N("TLD", r.R(2, 63, r.C(`a-z`))))             // top level domain, 2~63 letters.
 	Re_name    = r.G(r.M(`_`), r.C(`a-z`), r.S(r.C(`a-z0-9_`))) // optional leading _, start with letter, no dots!
 	Re_address = r.N("ADDRESS", `g1`, r.P(r.C(`a-z0-9`)))       // starts with g1, all lowercase.
+
+	ReGnoUserPkgPath = Re_gnoUserPkgPath.Compile()
+	ReGnoStdPkgPath  = Re_gnoStdPkgPath.Compile()
+	ReAddress        = Re_address.Compile()
 )
 
 // IsRealmPath determines whether the given pkgpath is for a realm, and as such
 // should persist the global state. It also excludes _test paths.
 func IsRealmPath(pkgPath string) bool {
-	match := Re_gnoUserPkgPath.Match(pkgPath)
+	match := ReGnoUserPkgPath.Match(pkgPath)
 	if match == nil || match.Get("LETTER") != "r" {
 		return false
 	}
@@ -82,7 +86,7 @@ func IsRealmPath(pkgPath string) bool {
 // IsEphemeralPath determines whether the given pkgpath is for an ephemeral realm.
 // Ephemeral realms are temporary and don't persist state between transactions.
 func IsEphemeralPath(pkgPath string) bool {
-	match := Re_gnoUserPkgPath.Match(pkgPath)
+	match := ReGnoUserPkgPath.Match(pkgPath)
 	return match != nil && match.Get("LETTER") == "e"
 }
 
@@ -91,11 +95,11 @@ func IsEphemeralPath(pkgPath string) bool {
 // receive coins on behalf of the user.
 // XXX XXX XXX XXX change DerivePkgAddr().
 func IsGnoRunPath(pkgPath string) (addr string, ok bool) {
-	match := Re_gnoUserPkgPath.Match(pkgPath)
+	match := ReGnoUserPkgPath.Match(pkgPath)
 	if match == nil || match.Get("LETTER") != "e" || match.Get("REPO") != "run" {
 		return "", false
 	}
-	addrmatch := Re_address.Match(match.Get("USER"))
+	addrmatch := ReAddress.Match(match.Get("USER"))
 	if addrmatch == nil {
 		return "", false
 	}
@@ -122,7 +126,7 @@ func IsInternalPath(pkgPath string) (base string, isInternal bool) {
 // It only considers "pure" those starting with gno.land/p/, so it returns false for
 // stdlib packages, realm paths, and run paths. It also excludes _test paths.
 func IsPPackagePath(pkgPath string) bool {
-	match := Re_gnoUserPkgPath.Match(pkgPath)
+	match := ReGnoUserPkgPath.Match(pkgPath)
 	if match == nil || match.Get("LETTER") != "p" {
 		return false
 	}
@@ -135,14 +139,14 @@ func IsPPackagePath(pkgPath string) bool {
 // IsStdlib determines whether pkgPath is for a standard library.
 // Dots are not allowed for stdlib paths.
 func IsStdlib(pkgPath string) bool {
-	match := Re_gnoStdPkgPath.Match(pkgPath)
+	match := ReGnoStdPkgPath.Match(pkgPath)
 	return match != nil
 }
 
 // IsUserlib determines whether pkgPath is for a non-stdlib path.
 // It must be of the form <domain>/<letter>/<user>(/<repo>).
 func IsUserlib(pkgPath string) bool {
-	match := Re_gnoUserPkgPath.Match(pkgPath)
+	match := ReGnoUserPkgPath.Match(pkgPath)
 	return match != nil
 }
 
@@ -428,11 +432,13 @@ const (
 func (mptype MemPackageType) IsAny() bool {
 	return mptype == MPAnyAll || mptype == MPAnyProd || mptype == MPAnyTest || mptype == MPAnyIntegration
 }
+
 func (mptype MemPackageType) AssertNotAny() {
 	if mptype.IsAny() {
 		panic(fmt.Sprintf("undefined any: %#v", mptype))
 	}
 }
+
 func (mptype MemPackageType) Decide(pkgPath string) MemPackageType {
 	switch mptype {
 	case MPAnyAll:
@@ -470,38 +476,47 @@ func (mptype MemPackageType) Decide(pkgPath string) MemPackageType {
 		panic("unexpected mptype")
 	}
 }
+
 func (mptype MemPackageType) IsStdlib() bool {
 	mptype.AssertNotAny()
 	return mptype == MPStdlibAll || mptype == MPStdlibProd || mptype == MPStdlibTest || mptype == MPStdlibIntegration
 }
+
 func (mptype MemPackageType) IsUserlib() bool {
 	mptype.AssertNotAny()
 	return mptype == MPUserAll || mptype == MPUserProd || mptype == MPUserTest || mptype == MPUserIntegration
 }
+
 func (mptype MemPackageType) IsAll() bool {
 	mptype.AssertNotAny()
 	return mptype == MPUserAll || mptype == MPStdlibAll
 }
+
 func (mptype MemPackageType) IsProd() bool {
 	mptype.AssertNotAny()
 	return mptype == MPUserProd || mptype == MPStdlibProd
 }
+
 func (mptype MemPackageType) IsTest() bool {
 	mptype.AssertNotAny()
 	return mptype == MPUserTest || mptype == MPStdlibTest
 }
+
 func (mptype MemPackageType) IsIntegration() bool {
 	mptype.AssertNotAny()
 	return mptype == MPUserIntegration || mptype == MPStdlibIntegration
 }
+
 func (mptype MemPackageType) IsFiletests() bool {
 	mptype.AssertNotAny()
 	return mptype == MPFiletests
 }
+
 func (mptype MemPackageType) IsRunnable() bool {
 	mptype.AssertNotAny()
 	return mptype.IsTest() || mptype.IsProd() || mptype.IsIntegration()
 }
+
 func (mptype MemPackageType) IsStorable() bool {
 	// MPAny* is not a valid mpkg type for storage,
 	// e.g. mpkg.Type should never be MPAnyAll.
@@ -511,6 +526,7 @@ func (mptype MemPackageType) IsStorable() bool {
 	return mptype.IsAll() || mptype.IsProd() || mptype.IsTest()
 	// MP*Integration has no reason to be stored.
 }
+
 func (mptype MemPackageType) AsRunnable() MemPackageType {
 	// If All, demote to Prod.
 	// If Test, keep as is.
@@ -989,8 +1005,8 @@ func ValidateMemPackageAny(mpkg *std.MemPackage) (errs error) {
 	}
 	// Validate mpkg path.
 	if true && // none of these match...
-		!Re_gnoUserPkgPath.Matches(mpkg.Path) &&
-		!Re_gnoStdPkgPath.Matches(mpkg.Path) {
+		!ReGnoUserPkgPath.Matches(mpkg.Path) &&
+		!ReGnoStdPkgPath.Matches(mpkg.Path) {
 		// .ValidateBasic() ensured rePkgPathURL or stdlib path,
 		// but reGnoPkgPathStd is more restrictive.
 		return fmt.Errorf("invalid package/realm path %q", mpkg.Path)

--- a/gnovm/pkg/gnolang/nodes_location.go
+++ b/gnovm/pkg/gnolang/nodes_location.go
@@ -164,7 +164,7 @@ func SpanFromMatch(line, col, endLine, endCol string) (span Span, err error) {
 }
 
 func ParseSpan(spanstr string) (span Span, err error) {
-	match := Re_span.Match(spanstr)
+	match := ReSpan.Match(spanstr)
 	if match == nil {
 		return
 	}
@@ -282,7 +282,7 @@ func Location3(pkgPath string, fname string, span Span) Location {
 }
 
 func ParseLocation(locstr string) (loc Location, err error) {
-	match := Re_location.Match(locstr)
+	match := ReLocation.Match(locstr)
 	if match == nil {
 		return
 	}
@@ -369,6 +369,10 @@ var (
 	Re_location    = r.G(r.N("PATH", r.Pl(r.CN(`:`))), r.M(`/`, r.N("FILE", r.P(r.CN(r.E(`/:`))))), `:`, r.N("SPAN", Re_span))
 	Re_locationish = r.G(r.N("PATH", r.Pl(r.CN(`:`))), r.M(`/`, r.N("FILE", r.P(r.CN(r.E(`/:`))))), `:`, r.N("SPAN", Re_spanish))
 	Re_errorLine   = r.L(r.N("LOC", Re_locationish), r.M(`:`), r.S(` `), r.N("MSG", r.S(`.`)))
+
+	ReLocation  = Re_location.Compile()
+	ReSpan      = Re_span.Compile()
+	ReErrorLine = Re_errorLine.Compile()
 )
 
 /* Compare to...

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -1506,14 +1506,18 @@ func (dt *DeclaredType) TypeID() TypeID {
 	return dt.typeid
 }
 
-var Re_declaredTypeID = r.G(
-	r.N("PATH", r.P(r.CN(r.E(`[.`)))),
-	r.M(r.E(`[`), r.N("LOC", Re_location), r.E(`]`)),
-	r.E(`.`),
-	r.N("NAME", r.P(`.`)))
+var (
+	Re_declaredTypeID = r.G(
+		r.N("PATH", r.P(r.CN(r.E(`[.`)))),
+		r.M(r.E(`[`), r.N("LOC", Re_location), r.E(`]`)),
+		r.E(`.`),
+		r.N("NAME", r.P(`.`)))
+
+	ReDeclaredTypeID = Re_declaredTypeID.Compile()
+)
 
 func ParseDeclaredTypeID(tid string) (pkgPath string, loc string, name string, ok bool) {
-	match := Re_declaredTypeID.Match(tid)
+	match := ReDeclaredTypeID.Match(tid)
 	if match == nil {
 		return
 	}

--- a/gnovm/pkg/repl/repl.go
+++ b/gnovm/pkg/repl/repl.go
@@ -136,7 +136,7 @@ func (r *Repl) RunStatements(code string) {
 				switch rec := rec.(type) {
 				case *gno.PreprocessError:
 					err := rec.Unwrap()
-					match := gno.Re_errorLine.Match(err.Error())
+					match := gno.ReErrorLine.Match(err.Error())
 					if match == nil {
 						r.Errorln(err.Error())
 					} else {
@@ -144,7 +144,7 @@ func (r *Repl) RunStatements(code string) {
 					}
 				case error:
 					err := rec
-					match := gno.Re_errorLine.Match(err.Error())
+					match := gno.ReErrorLine.Match(err.Error())
 					if match == nil {
 						r.Errorln(err.Error())
 					} else {

--- a/tm2/pkg/regx/regx.go
+++ b/tm2/pkg/regx/regx.go
@@ -6,20 +6,19 @@ import (
 	"strings"
 )
 
-// regx is composed from the Go functions below, meaning they are declared in
-// the code, thus not arbitrary and unbounded, so this cache is reasonable, as
-// long as there is no usage like regx(<client_provided_pattern>).
-// That's why regx isn't exposed; you can't do the above without reflect.
-var cache = make(map[regx]*regexp.Regexp)
-
 type regx string // do not expose.
 
 func (rx regx) String() string { return string(rx) }
 
-func (rx regx) Compile() *regexp.Regexp {
+func (rx regx) Compile() *compiledRegx {
+	if !strings.HasPrefix(string(rx), `^`) {
+		rx = `^` + rx
+	}
+	if !strings.HasSuffix(string(rx), `$`) {
+		rx = rx + `$`
+	}
 	rr := regexp.MustCompile(string(rx))
-	cache[rx] = rr
-	return rr
+	return &compiledRegx{rx, *rr}
 }
 
 type match struct {
@@ -36,31 +35,28 @@ func (mm match) Get(name string) string {
 	panic(fmt.Sprintf("no named subexpression %q", name))
 }
 
+type compiledRegx struct {
+	src regx
+	re  regexp.Regexp
+}
+
 // Matches a string by default, adding ^$ if not already present.
 // If you need to match a part of the string, implement "Find()".
-func (rx regx) Match(s string) *match {
-	if !strings.HasPrefix(string(rx), `^`) {
-		rx = `^` + rx
-	}
-	if !strings.HasSuffix(string(rx), `$`) {
-		rx = rx + `$`
-	}
+func (cr *compiledRegx) Match(s string) *match {
 	// s is now canonical w/ ^$.
-	rr, ok := cache[rx]
-	if !ok {
-		rr = rx.Compile()
-	}
-	matches := rr.FindStringSubmatch(s)
+	matches := cr.re.FindStringSubmatch(s)
 	if matches == nil {
 		return nil
 	}
-	return &match{rr.SubexpNames(), matches}
+	return &match{cr.re.SubexpNames(), matches}
 }
 
 // Returns true if matches.
-func (rx regx) Matches(s string) bool {
-	return rx.Match(s) != nil
+func (rx *compiledRegx) Matches(s string) bool {
+	return rx.re.MatchString(s)
 }
+
+func (rx *compiledRegx) Regx() regx { return rx.src }
 
 func r2s(xx regx) string                         { return string(xx) }                     // regx -> string
 func sj(sz ...string) string                     { return strings.Join(sz, ``) }           // string join
@@ -83,25 +79,29 @@ func N(nn string, xs ...regx) regx { return `(?P<` + regx(nn) + `>` + G(xs...) +
 func L(xs ...regx) regx            { return `^` + G(xs...) + `$` }                                   // line
 func O(xs ...regx) regx            { return G(regx(sjd(`|`, mab(r2s, xs)...))) }                     // or
 
-var C_d regx = `\d` // Matches any digit (0-9).
-var C_D regx = `\D` // Matches any non-digit character.
-var C_w regx = `\w` // Matches any alphanumeric character plus "_" (word character).
-var C_W regx = `\W` // Matches any non-word character.
-var C_s regx = `\s` // Matches any whitespace character (space, tab, newline, etc.).
-var C_S regx = `\S` // Matches any non-whitespace character.
+var (
+	C_d regx = `\d` // Matches any digit (0-9).
+	C_D regx = `\D` // Matches any non-digit character.
+	C_w regx = `\w` // Matches any alphanumeric character plus "_" (word character).
+	C_W regx = `\W` // Matches any non-word character.
+	C_s regx = `\s` // Matches any whitespace character (space, tab, newline, etc.).
+	C_S regx = `\S` // Matches any non-whitespace character.
+)
 
-var C_alnum regx = `[:alnum:]`
-var C_cntrl regx = `[:cntrl:]`
-var C_lower regx = `[:lower:]`
-var C_space regx = `[:space:]`
-var C_alpha regx = `[:alpha:]`
-var C_digit regx = `[:digit:]`
-var C_print regx = `[:print:]`
-var C_upper regx = `[:upper:]`
-var C_blank regx = `[:blank:]`
-var C_graph regx = `[:graph:]`
-var C_punct regx = `[:punct:]`
-var C_hexad regx = `[:xdigit:]`
+var (
+	C_alnum regx = `[:alnum:]`
+	C_cntrl regx = `[:cntrl:]`
+	C_lower regx = `[:lower:]`
+	C_space regx = `[:space:]`
+	C_alpha regx = `[:alpha:]`
+	C_digit regx = `[:digit:]`
+	C_print regx = `[:print:]`
+	C_upper regx = `[:upper:]`
+	C_blank regx = `[:blank:]`
+	C_graph regx = `[:graph:]`
+	C_punct regx = `[:punct:]`
+	C_hexad regx = `[:xdigit:]`
+)
 
 // aka "reduce".
 func fab[F func(A, B) B, A any, B any](f F, aa []A, b B) B {


### PR DESCRIPTION
Because Compile() happens dynamically run-time, it can cause concurrent map writes: https://github.com/gnolang/gno/pull/4568

This PR fixes it by making sure the regexes we use at runtime are already compiled during init.

This improves efficiency by not requiring a map lookup each time.