### PR TITLE
fix(keeper): realm diff iteration, make it deterministic by sorting path

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1116,11 +1116,21 @@ func (vm *VMKeeper) processStorageDeposit(ctx sdk.Context, caller crypto.Address
 		depositAmt = std.MustParseCoin(params.DefaultDeposit).Amount
 	}
 	price := std.MustParseCoin(params.StoragePrice)
+
+	// Sort paths for determinism
+	sortedRealm := make([]string, 0, len(realmDiffs))
+	for path := range realmDiffs {
+		sortedRealm = append(sortedRealm, path)
+	}
+	slices.SortFunc(sortedRealm, strings.Compare)
+
 	var allErrs error
-	for rlmPath, diff := range realmDiffs {
+	for _, rlmPath := range sortedRealm {
+		diff := realmDiffs[rlmPath]
 		if diff == 0 {
 			continue
 		}
+
 		rlm := gnostore.GetPackageRealm(rlmPath)
 		if diff > 0 {
 			// lock deposit for the additional storage used.


### PR DESCRIPTION
Fix the nondeterministic issue that might be introduced by #4281 (storage deposit). The `processStorageDeposit` function iterates over a map, which can lead to nondeterministic behavior since maps themselves are nondeterministic. Although not optimal, the fix is to sort the realm path before iterating.