### PR TITLE
chore(keeper): remove debug print in keeper

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gnovm/pkg/doc"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
@@ -271,9 +270,7 @@ func (tsg testStdlibGetter) GetMemPackage(pkgPath string) *std.MemPackage {
 	if sourceMpkg != nil {
 		testMpkg.Files = slices.Concat(sourceMpkg.Files, testMpkg.Files)
 	}
-	if pkgPath == "testing" {
-		spew.Dump(sourceMpkg)
-	}
+
 	tsg.cacheMtx.Lock()
 	tsg.cache[pkgPath] = testMpkg
 	tsg.cacheMtx.Unlock()


### PR DESCRIPTION
Remove a debug print that appeared in `gnodev` and probably in `gnoland`.

<img width="950" height="254" alt="Screenshot 2025-07-28 at 17 32 33" src="https://github.com/user-attachments/assets/531ef1f7-2277-4473-8a86-491d95a0c7b4" />
