### PR TITLE
ci(goreleaser): include tests/stdlibs

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -403,7 +403,6 @@ dockers:
       - gno.land/genesis/genesis_txs.jsonl
       - examples
       - gnovm/stdlibs
-      - gnovm/tests/stdlibs
   - use: buildx
     dockerfile: Dockerfile.release
     goos: linux
@@ -426,7 +425,6 @@ dockers:
       - gno.land/genesis/genesis_txs.jsonl
       - examples
       - gnovm/stdlibs
-      - gnovm/tests/stdlibs
 
 docker_manifests:
   # https://goreleaser.com/customization/docker_manifest/


### PR DESCRIPTION
#4563 added these directories to the dockerfiles, but they also need to be added to the goreleaser config. this is why the master CI for goreleaser is failing.