### PR TITLE
feat: Gas cost depending on frame size

### DIFF
--- a/gnovm/pkg/gnolang/frame.go
+++ b/gnovm/pkg/gnolang/frame.go
@@ -106,16 +106,7 @@ func (fr *Frame) SetIsRevive() {
 	fr.IsRevive = true
 }
 
-const GasCostFrameSize = 1 // gas cost corresponding to size of Frame struct
-
-func (fr *Frame) EstimateSize() int64 {
-	total := int64(fr.NumOps)
-	total += int64(fr.NumValues)
-	total += int64(fr.NumExprs)
-	total += int64(fr.NumStmts)
-	total += int64(fr.NumBlocks)
-	return total
-}
+const GasCostFrame = 1 // gas cost corresponding to pushing a new max depth for frame stack
 
 //----------------------------------------
 // Defer


### PR DESCRIPTION
## PR Description
#### Summary:
This PR introduces a gas cost for increasing the maximum number of frame stack entries during execution. As a result, calling recursive functions will incur a higher gas cost compared to performing the equivalent logic using loops.
#### Key Changes:

Added a new parameter MaxFrames to the Machine struct to track the maximum number of frames encountered during execution.

Updated PushFrameBasic and PushFrameCall to check if the current number of frames exceeds the previous maximum. If it does, we consume gas (currently set to 1 unit, but configurable).

#### Context & Considerations
- Initially, we attempted to account for the size of each frame (values, arguments, blocks, etc.), but this concern is already addressed in #4546 