### PR TITLE
feat(examples): add samcrew daokit

### DIFF
--- a/examples/gno.land/p/samcrew/basedao/actions.gno
+++ b/examples/gno.land/p/samcrew/basedao/actions.gno
@@ -1,0 +1,154 @@
+package basedao
+
+import (
+	"errors"
+	"std"
+
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/moul/md"
+	"gno.land/p/samcrew/daokit"
+)
+
+// ADD MEMBER
+
+const ActionAddMemberKind = "gno.land/p/samcrew/basedao.AddMember"
+
+type ActionAddMember struct {
+	Address std.Address
+	Roles   []string
+}
+
+func (a *ActionAddMember) String() string {
+	return ufmt.Sprintf("Add member %s with roles %v", a.Address, a.Roles)
+}
+
+func NewAddMemberHandler(dao *DAOPrivate) daokit.ActionHandler {
+	return daokit.NewActionHandler(ActionAddMemberKind, func(ipayload interface{}) {
+		payload, ok := ipayload.(*ActionAddMember)
+		if !ok {
+			panic(errors.New("invalid payload type"))
+		}
+		dao.Members.AddMember(payload.Address.String(), payload.Roles)
+	})
+}
+
+func NewAddMemberAction(payload *ActionAddMember) daokit.Action {
+	return daokit.NewAction(ActionAddMemberKind, payload)
+}
+
+// REMOVE MEMBER
+
+const ActionRemoveMemberKind = "gno.land/p/samcrew/basedao.RemoveMember"
+
+func NewRemoveMemberHandler(dao *DAOPrivate) daokit.ActionHandler {
+	return daokit.NewActionHandler(ActionRemoveMemberKind, func(ipayload interface{}) {
+		addr, ok := ipayload.(std.Address)
+		if !ok {
+			panic(errors.New("invalid payload type"))
+		}
+		dao.Members.RemoveMember(addr.String())
+	})
+}
+
+func NewRemoveMemberAction(addr std.Address) daokit.Action {
+	return daokit.NewAction(ActionRemoveMemberKind, addr)
+}
+
+// ASSIGN ROLE
+
+const ActionAssignRoleKind = "gno.land/p/samcrew/basedao.AssignRole"
+
+type ActionAssignRole struct {
+	Address std.Address
+	Role    string
+}
+
+func (a *ActionAssignRole) String() string {
+	return ufmt.Sprintf("Assign role %q to user %s", a.Role, a.Address)
+}
+
+func NewAssignRoleHandler(dao *DAOPrivate) daokit.ActionHandler {
+	return daokit.NewActionHandler(ActionAssignRoleKind, func(i interface{}) {
+		payload, ok := i.(*ActionAssignRole)
+		if !ok {
+			panic(errors.New("invalid payload type"))
+		}
+		dao.Members.AddRoleToMember(payload.Address.String(), payload.Role)
+	})
+}
+
+func NewAssignRoleAction(payload *ActionAssignRole) daokit.Action {
+	return daokit.NewAction(ActionAssignRoleKind, payload)
+}
+
+// UNASSIGN ROLE
+
+const ActionUnassignRoleKind = "gno.land/p/samcrew/basedao.UnassignRole"
+
+type ActionUnassignRole struct {
+	Address std.Address
+	Role    string
+}
+
+func (a *ActionUnassignRole) String() string {
+	return ufmt.Sprintf("Remove role %q from user %s", a.Role, a.Address)
+}
+
+func NewUnassignRoleHandler(dao *DAOPrivate) daokit.ActionHandler {
+	return daokit.NewActionHandler(ActionUnassignRoleKind, func(i interface{}) {
+		payload, ok := i.(*ActionUnassignRole)
+		if !ok {
+			panic(errors.New("invalid payload type"))
+		}
+		dao.Members.RemoveRoleFromMember(payload.Address.String(), payload.Role)
+	})
+}
+
+func NewUnassignRoleAction(payload *ActionUnassignRole) daokit.Action {
+	return daokit.NewAction(ActionUnassignRoleKind, payload)
+}
+
+// EDIT PROFILE
+
+const ActionEditProfileKind = "gno.land/p/samcrew/basedao.EditProfile"
+
+type ActionEditProfile struct {
+	kv [][2]string
+}
+
+func (a *ActionEditProfile) String() string {
+	elems := []string{}
+	for _, v := range a.kv {
+		elems = append(elems, v[0]+": "+v[1])
+	}
+	return md.BulletList(elems)
+}
+
+func NewEditProfileAction(kv ...[2]string) daokit.Action {
+	return daokit.NewAction(ActionEditProfileKind, &ActionEditProfile{kv: kv})
+}
+
+func NewEditProfileHandler(setter ProfileStringSetter, allowedFields []string) daokit.ActionHandler {
+	return daokit.NewActionHandler(ActionEditProfileKind, func(i interface{}) {
+		action, ok := i.(*ActionEditProfile)
+		if !ok {
+			panic(errors.New("invalid action type"))
+		}
+		for _, elem := range action.kv {
+			k, v := elem[0], elem[1]
+			if len(allowedFields) > 0 && !stringSliceContains(allowedFields, k) {
+				panic(ufmt.Errorf("unauthorized field %q", k))
+			}
+			setter(cross, k, v)
+		}
+	})
+}
+
+func stringSliceContains(s []string, target string) bool {
+	for _, elem := range s {
+		if elem == target {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/gno.land/p/samcrew/basedao/basedao.gno
+++ b/examples/gno.land/p/samcrew/basedao/basedao.gno
@@ -1,0 +1,163 @@
+package basedao
+
+import (
+	"errors"
+	"std"
+
+	"gno.land/p/demo/mux"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+)
+
+type daoPublic struct {
+	impl *DAOPrivate
+}
+
+func (d *daoPublic) Propose(req daokit.ProposalRequest) uint64 {
+	return d.impl.Propose(req)
+}
+
+func (d *daoPublic) Execute(id uint64) {
+	d.impl.Execute(id)
+}
+
+func (d *daoPublic) Vote(id uint64, vote daocond.Vote) {
+	d.impl.Vote(id, vote)
+}
+
+// DAO is meant for internal realm usage and should not be exposed
+type DAOPrivate struct {
+	Core             *daokit.Core
+	Members          *MembersStore
+	RenderRouter     *mux.Router
+	GetProfileString ProfileStringGetter
+	Realm            std.Realm
+}
+
+type Config struct {
+	Name               string
+	Description        string
+	ImageURI           string
+	Members            *MembersStore
+	NoDefaultHandlers  bool
+	NoDefaultRendering bool
+	InitialCondition   daocond.Condition
+	SetProfileString   ProfileStringSetter
+	GetProfileString   ProfileStringGetter
+	NoCreationEvent    bool
+}
+
+type ProfileStringSetter func(cur realm, field string, value string) bool
+type ProfileStringGetter func(addr std.Address, field string, def string) string
+
+const EventBaseDAOCreated = "BaseDAOCreated"
+
+func New(conf *Config) (daokit.DAO, *DAOPrivate) {
+	// XXX: emit events from memberstore
+
+	members := conf.Members
+	if members == nil {
+		members = NewMembersStore(nil, nil)
+	}
+
+	if conf.GetProfileString == nil {
+		panic(errors.New("GetProfileString is required"))
+	}
+
+	core := daokit.NewCore()
+	dao := &DAOPrivate{
+		Core:             core,
+		Members:          members,
+		GetProfileString: conf.GetProfileString,
+		Realm:            std.CurrentRealm(),
+	}
+	dao.initRenderingRouter()
+
+	if !conf.NoDefaultRendering {
+		dao.InitDefaultRendering()
+	}
+
+	if conf.SetProfileString != nil {
+		conf.SetProfileString(cross, "DisplayName", conf.Name)
+		conf.SetProfileString(cross, "Bio", conf.Description)
+		conf.SetProfileString(cross, "Avatar", conf.ImageURI)
+	}
+
+	if !conf.NoDefaultHandlers {
+		if conf.InitialCondition == nil {
+			conf.InitialCondition = daocond.MembersThreshold(0.6, members.IsMember, members.MembersCount)
+		}
+
+		if conf.SetProfileString != nil {
+			dao.Core.Resources.Set(&daokit.Resource{
+				Handler:   NewEditProfileHandler(conf.SetProfileString, []string{"DisplayName", "Bio", "Avatar"}),
+				Condition: conf.InitialCondition,
+			})
+		}
+
+		defaultResources := []daokit.Resource{
+			{
+				Handler:     NewAddMemberHandler(dao),
+				Condition:   conf.InitialCondition,
+				DisplayName: "Add Member",
+				Description: "This proposal allows you to add a new member to the DAO.",
+			},
+			{
+				Handler:     NewRemoveMemberHandler(dao),
+				Condition:   conf.InitialCondition,
+				DisplayName: "Remove Member",
+				Description: "This proposal allows you to remove a member from the DAO.",
+			},
+			{
+				Handler:     NewAssignRoleHandler(dao),
+				Condition:   conf.InitialCondition,
+				DisplayName: "Assign Role",
+				Description: "This proposal allows you to assign a role to a member.",
+			},
+			{
+				Handler:     NewUnassignRoleHandler(dao),
+				Condition:   conf.InitialCondition,
+				DisplayName: "Unassign Role",
+				Description: "This proposal allows you to unassign a role from a member.",
+			},
+		}
+		// register management handlers
+		for _, resource := range defaultResources {
+			dao.Core.Resources.Set(&resource)
+		}
+
+	}
+
+	if !conf.NoCreationEvent {
+		std.Emit(EventBaseDAOCreated)
+	}
+
+	return &daoPublic{impl: dao}, dao
+}
+
+func (d *DAOPrivate) Vote(proposalID uint64, vote daocond.Vote) {
+	if len(vote) > 16 {
+		panic("invalid vote")
+	}
+
+	voterID := d.assertCallerIsMember()
+	d.Core.Vote(voterID, proposalID, vote)
+}
+
+func (d *DAOPrivate) Execute(proposalID uint64) {
+	_ = d.assertCallerIsMember()
+	d.Core.Execute(proposalID)
+}
+
+func (d *DAOPrivate) Propose(req daokit.ProposalRequest) uint64 {
+	proposerID := d.assertCallerIsMember()
+	return d.Core.Propose(proposerID, req)
+}
+
+func (d *DAOPrivate) assertCallerIsMember() string {
+	id := std.PreviousRealm().Address().String()
+	if !d.Members.IsMember(id) {
+		panic(errors.New("caller is not a member"))
+	}
+	return id
+}

--- a/examples/gno.land/p/samcrew/basedao/basedao_test.gno
+++ b/examples/gno.land/p/samcrew/basedao/basedao_test.gno
@@ -1,0 +1,722 @@
+package basedao
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/urequire"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+)
+
+var (
+	alice = testutils.TestAddress("alice")
+	bob   = testutils.TestAddress("bob")
+	carol = testutils.TestAddress("carol")
+	dave  = testutils.TestAddress("dave")
+)
+
+func TestNewDAO(t *testing.T) {
+	initialRoles := []RoleInfo{
+		{Name: "admin", Description: "Admin is the superuser"},
+	}
+	initialMembers := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	conf := &Config{
+		Name:             "My DAO",
+		Description:      "My DAO Description",
+		Members:          NewMembersStore(initialRoles, initialMembers),
+		GetProfileString: func(addr std.Address, field, def string) string { return "" },
+	}
+
+	daoRealm := std.NewCodeRealm("gno.land/r/testing/daorealm")
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(daoRealm)
+	_, dao := New(conf)
+	roles := dao.Members.GetRoles()
+	if len(roles) != 1 {
+		t.Errorf("Expected 1 role, got %d", len(roles))
+	}
+	if roles[0] != "admin" {
+		t.Errorf("Expected role 'admin', got %s", roles[0])
+	}
+
+	for _, member := range initialMembers {
+		addr := member.Address
+		if !dao.Members.IsMember(addr) {
+			t.Errorf("Expected member %s to be a member", addr)
+		}
+		if len(member.Roles) == 1 && !dao.Members.HasRole(addr, member.Roles[0]) {
+			t.Errorf("Expected member %s to have role %s", addr, member.Roles[0])
+		}
+	}
+
+	urequire.Equal(t, 4, dao.Core.ResourcesCount(), "expected 4 resources")
+	urequire.Equal(t, dao.Realm.PkgPath(), daoRealm.PkgPath())
+
+	// XXX: check realm and profile
+}
+
+func TestPropose(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.6, members)
+
+	type testNewProposalInput struct {
+		proposalReq daokit.ProposalRequest
+		proposer    std.Address
+	}
+
+	type tesNewProposalExpected struct {
+		title        string
+		description  string
+		proposer     std.Address
+		messsageType string
+		panic        bool
+	}
+
+	type testNewProposal struct {
+		input    testNewProposalInput
+		expected tesNewProposalExpected
+	}
+
+	type testNewProposalTable map[string]testNewProposal
+
+	tests := testNewProposalTable{
+		"Success": {
+			input: testNewProposalInput{
+				proposalReq: tdao.mockProposalRequest,
+				proposer:    alice,
+			},
+			expected: tesNewProposalExpected{
+				title:        "My Proposal",
+				description:  "My Proposal Description",
+				proposer:     alice,
+				messsageType: "valid",
+				panic:        false,
+			},
+		},
+		"Non-member": {
+			input: testNewProposalInput{
+				proposalReq: tdao.mockProposalRequest,
+				proposer:    dave,
+			},
+			expected: tesNewProposalExpected{
+				panic: true,
+			},
+		},
+		"Unknown action type": {
+			input: testNewProposalInput{
+				proposalReq: tdao.unknownProposalRequest,
+				proposer:    alice,
+			},
+			expected: tesNewProposalExpected{
+				panic: true,
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if test.expected.panic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, got none")
+					}
+				}()
+			}
+			*tdao.mockHandlerCalled = false
+			func() {
+				testing.SetOriginCaller(test.input.proposer)
+			}()
+			id := tdao.dao.Propose(test.input.proposalReq)
+
+			urequire.False(t, *tdao.mockHandlerCalled, "execute should not be called")
+
+			proposal := tdao.privdao.Core.Proposals.GetProposal(id)
+			if proposal.Title != test.expected.title {
+				t.Errorf("Expected title %s, got %s", test.expected.title, proposal.Title)
+			}
+			if proposal.Description != test.expected.description {
+				t.Errorf("Expected description %s, got %s", test.expected.description, proposal.Description)
+			}
+			if proposal.ProposerID != test.expected.proposer.String() {
+				t.Errorf("Expected proposer %s, got %s", test.expected.proposer, proposal.ProposerID)
+			}
+			if proposal.Action.Type() != test.expected.messsageType {
+				t.Errorf("Expected action type %s, got %s", test.expected.messsageType, proposal.Action.Type())
+			}
+		})
+	}
+}
+
+func TestVote(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.6, members)
+
+	tdao.dao.Propose(tdao.mockProposalRequest)
+
+	type testVoteInput struct {
+		proposalID uint64
+		vote       daocond.Vote
+		voter      std.Address
+	}
+
+	type testVoteExpected struct {
+		eval  bool
+		panic string
+	}
+
+	type testVote struct {
+		input    testVoteInput
+		expected testVoteExpected
+	}
+
+	type testVoteTable map[string]testVote
+
+	tests := testVoteTable{
+		"Success no": {
+			input: testVoteInput{
+				proposalID: 1,
+				vote:       "no",
+				voter:      alice,
+			},
+			expected: testVoteExpected{
+				eval: false,
+			},
+		},
+		"Success yes": {
+			input: testVoteInput{
+				proposalID: 1,
+				vote:       "yes",
+				voter:      alice,
+			},
+			expected: testVoteExpected{
+				eval: true,
+			},
+		},
+		"Unknown proposal": {
+			input: testVoteInput{
+				proposalID: 2,
+				vote:       "yes",
+				voter:      alice,
+			},
+			expected: testVoteExpected{
+				panic: "proposal not found",
+			},
+		},
+		"Non-member": {
+			input: testVoteInput{
+				proposalID: 1,
+				vote:       "yes",
+				voter:      dave,
+			},
+			expected: testVoteExpected{
+				panic: "caller is not a member",
+			},
+		},
+		"Invalid vote": {
+			input: testVoteInput{
+				proposalID: 1,
+				vote:       "very-long-vote-very-long-vote-very-long-vote",
+				voter:      alice,
+			},
+			expected: testVoteExpected{
+				panic: "invalid vote",
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			run := func() {
+				func() {
+					testing.SetOriginCaller(test.input.voter)
+				}()
+				tdao.dao.Vote(test.input.proposalID, test.input.vote)
+
+			}
+
+			*tdao.mockHandlerCalled = false
+
+			if test.expected.panic != "" {
+				urequire.PanicsWithMessage(t, test.expected.panic, run)
+			} else {
+				urequire.NotPanics(t, run)
+				urequire.False(t, *tdao.mockHandlerCalled, "execute should not be called")
+				proposal := tdao.privdao.Core.Proposals.GetProposal(test.input.proposalID)
+				eval := proposal.Condition.Eval(proposal.Ballot)
+				if eval != test.expected.eval {
+					t.Errorf("Expected eval %t, got %t", test.expected.eval, eval)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteProposal(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.6, members)
+
+	tdao.dao.Propose(tdao.mockProposalRequest)
+
+	type testExecuteInput struct {
+		proposalID uint64
+		executor   std.Address
+		haveVote   bool
+		voter      std.Address
+	}
+
+	type testExecuteExpected struct {
+		panic bool
+	}
+
+	type testExecute struct {
+		input    testExecuteInput
+		expected testExecuteExpected
+	}
+
+	type testExecuteTable map[string]testExecute
+
+	tests := testExecuteTable{
+		"Conditions not met": {
+			input: testExecuteInput{
+				proposalID: 1,
+				executor:   alice,
+				haveVote:   false,
+				voter:      alice,
+			},
+			expected: testExecuteExpected{
+				panic: true,
+			},
+		},
+		"Success": {
+			input: testExecuteInput{
+				proposalID: 1,
+				executor:   alice,
+				haveVote:   true,
+				voter:      alice,
+			},
+			expected: testExecuteExpected{
+				panic: false,
+			},
+		},
+		"Unknown proposal": {
+			input: testExecuteInput{
+				proposalID: 2,
+				executor:   alice,
+				haveVote:   false,
+				voter:      alice,
+			},
+			expected: testExecuteExpected{
+				panic: true,
+			},
+		},
+		"Non-member": {
+			input: testExecuteInput{
+				proposalID: 1,
+				executor:   dave,
+				haveVote:   false,
+				voter:      alice,
+			},
+			expected: testExecuteExpected{
+				panic: true,
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if test.expected.panic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, got none")
+					}
+				}()
+			}
+
+			if test.input.haveVote {
+				func() {
+					testing.SetOriginCaller(test.input.voter)
+				}()
+				tdao.dao.Vote(test.input.proposalID, "yes")
+
+			}
+
+			func() {
+				testing.SetOriginCaller(test.input.executor)
+			}()
+			tdao.dao.Execute(test.input.proposalID)
+
+			proposal := tdao.privdao.Core.Proposals.GetProposal(test.input.proposalID)
+
+			if proposal.Status != daokit.ProposalStatusExecuted {
+				t.Errorf("Expected status %s, got %s", daokit.ProposalStatusExecuted, proposal.Status)
+			}
+		})
+	}
+}
+
+func TestInstantExecute(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.6, members)
+
+	type testInstantExecuteInput struct {
+		proposalReq daokit.ProposalRequest
+		executor    std.Address
+	}
+
+	type testInstantExecuteExpected struct {
+		panic bool
+	}
+
+	type testInstantExecute struct {
+		input    testInstantExecuteInput
+		expected testInstantExecuteExpected
+	}
+
+	type testInstantExecuteTable map[string]testInstantExecute
+
+	tests := testInstantExecuteTable{
+		"Success": {
+			input: testInstantExecuteInput{
+				proposalReq: tdao.mockProposalRequest,
+				executor:    alice,
+			},
+			expected: testInstantExecuteExpected{
+				panic: false,
+			},
+		},
+		"Unknown action type": {
+			input: testInstantExecuteInput{
+				proposalReq: tdao.unknownProposalRequest,
+				executor:    alice,
+			},
+			expected: testInstantExecuteExpected{
+				panic: true,
+			},
+		},
+		"Non-member": {
+			input: testInstantExecuteInput{
+				proposalReq: tdao.mockProposalRequest,
+				executor:    dave,
+			},
+			expected: testInstantExecuteExpected{
+				panic: true,
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if test.expected.panic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, got none")
+					}
+				}()
+			}
+
+			func() {
+				testing.SetOriginCaller(test.input.executor)
+			}()
+			tdao.dao.Propose(test.input.proposalReq)
+		})
+	}
+}
+
+func TestGetMembers(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.6, members)
+
+	expectedMembers := []string{alice.String(), bob.String(), carol.String()}
+	m := tdao.privdao.Members.GetMembers()
+	if len(m) != len(expectedMembers) {
+		t.Errorf("Expected %d members, got %d", len(expectedMembers), len(m))
+	}
+
+	for _, eMember := range expectedMembers {
+		if !tdao.privdao.Members.IsMember(eMember) {
+			t.Errorf("Expected member %s to be a member", eMember)
+		}
+	}
+}
+
+func TestAddMemberProposal(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+	}
+	tdao := newTestingDAO(t, 0.2, members)
+
+	if tdao.privdao.Members.IsMember(bob.String()) {
+		t.Errorf("Expected member %s to not be a member", bob.String())
+	}
+
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action: NewAddMemberAction(&ActionAddMember{
+			Address: bob,
+			Roles:   []string{"admin"},
+		}),
+	})
+
+	if !tdao.privdao.Members.IsMember(bob.String()) {
+		t.Errorf("Expected member %s to be a member", bob.String())
+	}
+
+	if !tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to have role 'admin'", bob.String())
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	proposalWithUnknownRole := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action: NewAddMemberAction(&ActionAddMember{
+			Address: bob,
+			Roles:   []string{"unknown"},
+		}),
+	}
+	daokit.InstantExecute(tdao.dao, proposalWithUnknownRole)
+}
+
+func TestRemoveMemberProposal(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{"admin"}},
+	}
+	tdao := newTestingDAO(t, 0.2, members)
+
+	if !tdao.privdao.Members.IsMember(bob.String()) {
+		t.Errorf("Expected member %s to be a member", bob.String())
+	}
+
+	if !tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to have role 'admin'", bob.String())
+	}
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewRemoveMemberAction(bob),
+	})
+
+	if tdao.privdao.Members.IsMember(bob.String()) {
+		t.Errorf("Expected user %s to not be a member", bob.String())
+	}
+
+	if tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected user %s to not have role 'admin'", bob.String())
+	}
+}
+
+func TestAddRoleToUserProposal(t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+	}
+	tdao := newTestingDAO(t, 0.2, members)
+
+	if tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to not have role 'admin'", bob.String())
+	}
+
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewAssignRoleAction(&ActionAssignRole{Address: bob, Role: "admin"}),
+	})
+	if !tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to have role 'admin'", bob.String())
+	}
+
+	defer func() {
+		// FIXME: this will pass if any other steps panics
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewAssignRoleAction(&ActionAssignRole{Address: alice, Role: "unknown"}),
+	})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewAssignRoleAction(&ActionAssignRole{Address: carol, Role: "admin"}),
+	})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewAssignRoleAction(&ActionAssignRole{Address: bob, Role: "admin"}),
+	})
+}
+
+func TestRemoveRoleFromUserProposal(t *testing.T) {
+	members := []Member{
+		{
+			alice.String(),
+			[]string{"admin"},
+		},
+		{
+			bob.String(),
+			[]string{"admin"},
+		},
+	}
+	tdao := newTestingDAO(t, 0.2, members)
+
+	if !tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to have role 'admin'", bob.String())
+	}
+	daokit.InstantExecute(tdao.dao, daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: bob, Role: "admin"}),
+	})
+
+	if tdao.privdao.Members.HasRole(bob.String(), "admin") {
+		t.Errorf("Expected member %s to not have role 'admin'", bob.String())
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	proposalWithUnknowkRole := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: alice, Role: "unknown"}),
+	}
+	testing.SetOriginCaller(alice)
+	daokit.InstantExecute(tdao.dao, proposalWithUnknowkRole)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	proposalWithNonMember := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: carol, Role: "admin"}),
+	}
+	testing.SetOriginCaller(alice)
+	daokit.InstantExecute(tdao.dao, proposalWithNonMember)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, got none")
+		}
+	}()
+
+	proposalWithNonRole := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: bob, Role: "admin"}),
+	}
+	testing.SetOriginCaller(alice)
+	daokit.InstantExecute(tdao.dao, proposalWithNonRole)
+}
+
+type testingDAOContext struct {
+	dao                    daokit.DAO
+	privdao                *DAOPrivate
+	mockHandlerCalled      *bool
+	mockHandler            daokit.ActionHandler
+	mockProposalRequest    daokit.ProposalRequest
+	unknownProposalRequest daokit.ProposalRequest
+}
+
+func newTestingDAO(t *testing.T, threshold float64, members []Member) *testingDAOContext {
+	roles := []RoleInfo{{Name: "admin", Description: "Admin is the superuser"}}
+	membersStore := NewMembersStore(roles, members)
+	initialCondition := daocond.MembersThreshold(threshold, membersStore.IsMember, membersStore.MembersCount)
+
+	conf := &Config{
+		Name:             "My DAO",
+		Description:      "My DAO Description",
+		Members:          membersStore,
+		InitialCondition: initialCondition,
+		GetProfileString: func(addr std.Address, field, def string) string { return "" },
+	}
+
+	daoRealm := std.NewCodeRealm("gno.land/r/testing/daorealm")
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(daoRealm)
+	pubdao, dao := New(conf)
+
+	mockHandlerCalled := false
+	mockHandler := daokit.NewActionHandler("valid", func(_ interface{}) { mockHandlerCalled = true })
+	dao.Core.Resources.Set(&daokit.Resource{
+		Handler:   mockHandler,
+		Condition: daocond.MembersThreshold(0.2, dao.Members.IsMember, dao.Members.MembersCount),
+	})
+
+	mockProposalRequest := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      daokit.NewAction("valid", nil),
+	}
+
+	unknownProposalRequest := daokit.ProposalRequest{
+		Title:       "My Proposal",
+		Description: "My Proposal Description",
+		Action:      daokit.NewAction("unknown", nil),
+	}
+
+	return &testingDAOContext{
+		dao:                    pubdao,
+		privdao:                dao,
+		mockHandlerCalled:      &mockHandlerCalled,
+		mockHandler:            mockHandler,
+		mockProposalRequest:    mockProposalRequest,
+		unknownProposalRequest: unknownProposalRequest,
+	}
+}

--- a/examples/gno.land/p/samcrew/basedao/gnomod.toml
+++ b/examples/gno.land/p/samcrew/basedao/gnomod.toml
@@ -2,4 +2,4 @@ module = "gno.land/p/samcrew/basedao"
 gno = "0.9"
 
 [addpkg]
-creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"
+  creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/basedao/gnomod.toml
+++ b/examples/gno.land/p/samcrew/basedao/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/samcrew/basedao"
+gno = "0.9"
+
+[addpkg]
+creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/basedao/members.gno
+++ b/examples/gno.land/p/samcrew/basedao/members.gno
@@ -1,0 +1,341 @@
+package basedao
+
+import (
+	"std"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/json"
+)
+
+type MembersStore struct {
+	Roles   *avl.Tree // role name -> *Role
+	Members *avl.Tree // string -> *avl.Tree [roles -> struct{}]
+}
+
+type Member struct {
+	Address string
+	Roles   []string
+}
+
+type RoleInfo struct {
+	Name        string
+	Description string
+}
+
+type Role struct {
+	Name        string
+	Description string
+	Members     *avl.Tree // string -> struct{}
+}
+
+const EventAddMember = "BaseDAOAddMember"
+const EventRemoveMember = "BaseDAORemoveMember"
+
+func NewMembersStore(initialRoles []RoleInfo, initialMembers []Member) *MembersStore {
+	res := &MembersStore{
+		Roles:   avl.NewTree(),
+		Members: avl.NewTree(),
+	}
+	res.setRoles(initialRoles)
+	res.setMembers(initialMembers)
+	return res
+}
+
+func (m *MembersStore) HasRole(member string, role string) bool {
+	rolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		return false
+	}
+	roles, ok := rolesRaw.(*avl.Tree)
+	if !ok {
+		return false
+	}
+	return roles.Has(role)
+}
+
+func (m *MembersStore) IsMember(member string) bool {
+	return m.Members.Has(member)
+}
+
+func (m *MembersStore) RoleInfo(role string) RoleInfo {
+	roleDataRaw, ok := m.Roles.Get(role)
+	if !ok {
+		panic("role does not exist")
+	}
+	roleData, ok := roleDataRaw.(*Role)
+	if !ok {
+		panic("a value of memberstore.roles is not a Role, should not happen")
+	}
+	return RoleInfo{
+		Name:        roleData.Name,
+		Description: roleData.Description,
+	}
+}
+
+func (m *MembersStore) MembersCount() uint64 {
+	return uint64(m.Members.Size())
+}
+
+func (m *MembersStore) GetMembers() []string {
+	members := make([]string, 0, m.Members.Size())
+	m.Members.Iterate("", "", func(key string, value interface{}) bool {
+		members = append(members, key)
+		return false
+	})
+	return members
+}
+
+func (m *MembersStore) GetRoles() []string {
+	i := 0
+	res := make([]string, m.Roles.Size())
+	m.Roles.Iterate("", "", func(key string, value interface{}) bool {
+		res[i] = key
+		i++
+		return false
+	})
+	return res
+}
+
+func (m *MembersStore) GetMemberRoles(member string) []string {
+	rolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		return []string{}
+	}
+	roles, ok := rolesRaw.(*avl.Tree)
+	if !ok {
+		return []string{}
+	}
+	i := 0
+	res := make([]string, roles.Size())
+	roles.Iterate("", "", func(key string, value interface{}) bool {
+		res[i] = key
+		i++
+		return false
+	})
+	return res
+}
+
+func (m *MembersStore) CountMemberRoles(member string) int {
+	rolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		return 0
+	}
+	roles, ok := rolesRaw.(*avl.Tree)
+	if !ok {
+		return 0
+	}
+	return roles.Size()
+}
+
+func (m *MembersStore) GetMembersWithRole(role string) []string {
+	roleDataRaw, ok := m.Roles.Get(role)
+	if !ok {
+		return []string{}
+	}
+	roleData, ok := roleDataRaw.(*Role)
+	if !ok {
+		return []string{}
+	}
+	i := 0
+	res := make([]string, roleData.Members.Size())
+	roleData.Members.Iterate("", "", func(key string, value interface{}) bool {
+		res[i] = key
+		i++
+		return false
+	})
+	return res
+}
+
+func (m *MembersStore) CountMembersWithRole(role string) uint32 {
+	return uint32(len(m.GetMembersWithRole(role)))
+}
+
+func (m *MembersStore) setRoles(roles []RoleInfo) {
+	for _, role := range roles {
+		m.AddRole(role)
+	}
+}
+
+func (m *MembersStore) setMembers(members []Member) {
+	for _, member := range members {
+		m.AddMember(member.Address, member.Roles)
+	}
+}
+
+func (m *MembersStore) AddMember(member string, roles []string) {
+	if m.IsMember(member) {
+		panic("member already exists")
+	}
+
+	membersRoles := avl.NewTree()
+	for _, role := range roles {
+		if !m.Roles.Has(role) {
+			panic("role: " + role + " does not exist")
+		}
+		membersRoles.Set(role, struct{}{})
+	}
+	m.Members.Set(member, membersRoles)
+
+	std.Emit(EventAddMember,
+		"address", member,
+	)
+}
+
+func (m *MembersStore) RemoveMember(member string) {
+	if !m.IsMember(member) {
+		panic("member does not exist")
+	}
+
+	memberRolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		panic("should not happen")
+	}
+	memberRoles, ok := memberRolesRaw.(*avl.Tree)
+	if !ok {
+		panic("a value of memberstore.members is not an avl.Tree, should not happen")
+	}
+
+	memberRoles.Iterate("", "", func(key string, value interface{}) bool {
+		roleRaw, ok := m.Roles.Get(key)
+		if !ok {
+			return false
+		}
+		role, ok := roleRaw.(*Role)
+		if !ok {
+			panic("a value of memberstore.roles is not a Role, should not happen")
+		}
+		role.Members.Remove(role.Name)
+		return false
+	})
+	m.Members.Remove(member)
+
+	std.Emit(EventRemoveMember,
+		"address", member,
+	)
+}
+
+func (m *MembersStore) AddRole(role RoleInfo) {
+	if m.Roles.Has(role.Name) {
+		panic("role already exists")
+	}
+
+	roleData := &Role{
+		Name:        role.Name,
+		Description: role.Description,
+		Members:     avl.NewTree(),
+	}
+
+	m.Roles.Set(role.Name, roleData)
+}
+
+func (m *MembersStore) RemoveRole(role string) {
+	roleDataRaw, ok := m.Roles.Get(role)
+	if !ok {
+		panic("role does not exist")
+	}
+	roleData, ok := roleDataRaw.(*Role)
+	if !ok {
+		panic("a value of memberstore.roles is not a Role, should not happen")
+	}
+
+	roleData.Members.Iterate("", "", func(key string, value interface{}) bool {
+		memberRaw, ok := m.Members.Get(key)
+		if !ok {
+			return false
+		}
+		member, ok := memberRaw.(*avl.Tree)
+		if !ok {
+			panic("a value of memberstore.members is not an avl.Tree, should not happen")
+		}
+		member.Remove(role)
+		return false
+	})
+	m.Roles.Remove(role)
+}
+
+func (m *MembersStore) AddRoleToMember(member string, role string) {
+	if !m.IsMember(member) {
+		panic("member does not exist")
+	}
+	if !m.Roles.Has(role) {
+		panic("role " + role + " does not exist")
+	}
+	if m.HasRole(member, role) {
+		panic("member already has the role")
+	}
+
+	memberRolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		panic("should not happen")
+	}
+	memberRoles, ok := memberRolesRaw.(*avl.Tree)
+	if !ok {
+		panic("a value of memberstore.members is not an avl.Tree, should not happen")
+	}
+
+	roleDataRaw, ok := m.Roles.Get(role)
+	if !ok {
+		panic("should not happen")
+	}
+	roleData, ok := roleDataRaw.(*Role)
+	if !ok {
+		panic("a value of memberstore.roles is not a Role, should not happen")
+	}
+
+	roleData.Members.Set(member, struct{}{})
+	memberRoles.Set(role, struct{}{})
+}
+
+func (m *MembersStore) RemoveRoleFromMember(member string, role string) {
+	if !m.IsMember(member) {
+		panic("member does not exist")
+	}
+	if !m.Roles.Has(role) {
+		panic("role " + role + " does not exist")
+	}
+	if !m.HasRole(member, role) {
+		panic("member does not have the role")
+	}
+
+	memberRolesRaw, ok := m.Members.Get(member)
+	if !ok {
+		panic("should not happen")
+	}
+	memberRoles, ok := memberRolesRaw.(*avl.Tree)
+	if !ok {
+		panic("a value of memberstore.members is not an avl.Tree, should not happen")
+	}
+
+	roleDataRaw, ok := m.Roles.Get(role)
+	if !ok {
+		panic("should not happen")
+	}
+	roleData, ok := roleDataRaw.(*Role)
+	if !ok {
+		panic("a value of memberstore.roles is not a Role, should not happen")
+	}
+
+	memberRoles.Remove(role)
+	roleData.Members.Remove(member)
+}
+
+func (m *MembersStore) GetMembersJSON() string {
+	// XXX: replace with protoc-gen-gno
+	members := []*json.Node{}
+	for _, memberID := range m.GetMembers() {
+		roles := []*json.Node{}
+		for _, role := range m.GetMemberRoles(memberID) {
+			roles = append(roles, json.StringNode("", role))
+		}
+		members = append(members, json.ObjectNode("", map[string]*json.Node{
+			"address": json.StringNode("", memberID),
+			"roles":   json.ArrayNode("", roles),
+		}))
+	}
+	node := json.ArrayNode("", members)
+	bz, err := json.Marshal(node)
+	if err != nil {
+		panic(err)
+	}
+	return string(bz)
+}

--- a/examples/gno.land/p/samcrew/basedao/render.gno
+++ b/examples/gno.land/p/samcrew/basedao/render.gno
@@ -1,0 +1,329 @@
+package basedao
+
+import (
+	"std"
+	"strconv"
+	"strings"
+
+	"gno.land/p/demo/mux"
+	"gno.land/p/demo/seqid"
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/samcrew/daokit"
+)
+
+// WELL KNOWN PATHS
+const (
+	HOME_PATH             = ""
+	HOME_NO_PROFILE_PATH  = "noprofile"
+	CONFIG_PATH           = "config"
+	PROPOSAL_HISTORY_PATH = "history"
+	MEMBER_DETAIL_PATH    = "member/{address}"
+	PROPOSAL_DETAIL_PATH  = "proposal/{id}"
+	FALLBACK_DISPLAY_NAME = "Anon"
+)
+
+func (d *DAOPrivate) initRenderingRouter() {
+	if d.RenderRouter == nil {
+		d.RenderRouter = mux.NewRouter()
+	}
+}
+
+func (d *DAOPrivate) InitDefaultRendering() {
+	d.RenderRouter.HandleFunc(HOME_PATH, d.MuxHomePage)
+	d.RenderRouter.HandleFunc(HOME_NO_PROFILE_PATH, d.MuxHomePage)
+	d.RenderRouter.HandleFunc(CONFIG_PATH, d.MuxConfigPage)
+	d.RenderRouter.HandleFunc(PROPOSAL_HISTORY_PATH, d.MuxProposalHistoryPage)
+	d.RenderRouter.HandleFunc(MEMBER_DETAIL_PATH, d.MuxMemberDetailPage)
+	d.RenderRouter.HandleFunc(PROPOSAL_DETAIL_PATH, d.MuxProposalDetailPage)
+}
+
+func (d *DAOPrivate) Render(path string) string {
+	return d.RenderRouter.Render(path)
+}
+
+// DEFAULT_HANDLERS
+
+func (d *DAOPrivate) MuxHomePage(res *mux.ResponseWriter, req *mux.Request) {
+	res.Write(d.HomePageView())
+}
+
+func (d *DAOPrivate) MuxConfigPage(res *mux.ResponseWriter, req *mux.Request) {
+	res.Write(d.ConfigPageView())
+}
+
+func (d *DAOPrivate) MuxProposalHistoryPage(res *mux.ResponseWriter, req *mux.Request) {
+	res.Write(d.ProposalHistoryPageView())
+}
+
+func (d *DAOPrivate) MuxMemberDetailPage(res *mux.ResponseWriter, req *mux.Request) {
+	res.Write(d.MemberDetailPageView(req.GetVar("address")))
+}
+
+func (d *DAOPrivate) MuxProposalDetailPage(res *mux.ResponseWriter, req *mux.Request) {
+	id, err := strconv.ParseUint(req.GetVar("id"), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	res.Write(d.ProposalDetailPageView(id))
+}
+
+// PUBLIC PAGES
+
+func (d *DAOPrivate) HomePageView() string {
+	return d.HomeProfileHeaderView(false) +
+		d.HomeMembersView() +
+		d.HomeProposalsView()
+}
+
+func (d *DAOPrivate) ConfigPageView() string {
+	return d.ConfigHeaderView() +
+		d.ConfigRolesView() +
+		d.ConfigResourcesView()
+}
+
+func (d *DAOPrivate) ProposalHistoryPageView() string {
+	return d.ProposalHistoryHeaderView() +
+		d.ProposalHistoryView()
+}
+
+func (d *DAOPrivate) MemberDetailPageView(address string) string {
+	return d.MemberDetailHeaderView() +
+		d.MemberDetailView(address)
+}
+
+func (d *DAOPrivate) ProposalDetailPageView(idu uint64) string {
+	return d.ProposalDetailHeaderView() +
+		d.ProposalDetailView(idu)
+}
+
+// --- PUBLIC COMPONENT VIEWS ---
+
+// HOME PAGE COMPONENTS VIEWS
+
+func (d *DAOPrivate) HomeProfileHeaderView(noprofile bool) string {
+	s := ""
+	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
+	description := d.GetProfileString(d.Realm.Address(), "Bio", "Created with daokit")
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+
+	if !noprofile {
+		s += ufmt.Sprintf("# %s\n\n", name)
+		imageURI := d.GetProfileString(d.Realm.Address(), "Avatar", "")
+		if imageURI != "" {
+			s += ufmt.Sprintf("![Image](%s)\n\n", imageURI)
+		}
+		s += ufmt.Sprintf("%s\n\n", description)
+	}
+
+	s += ufmt.Sprintf("> Realm address: %s\n\n", d.Realm.Address())
+	s += ufmt.Sprintf("Discover more about this DAO on the [configuration page ⚙️](%s:%s)\n\n", linkPath, CONFIG_PATH)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+
+	return s
+}
+
+func (d *DAOPrivate) HomeMembersView() string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+	s := ""
+	s += ufmt.Sprintf("## Members 👤 \n\n")
+	i := 1
+	d.Members.Members.Iterate("", "", func(key string, value interface{}) bool {
+		s += ufmt.Sprintf("- **Member %d: [%s](%s:%s/%s)**\n\n", i, key, linkPath, "member", key)
+		s += ufmt.Sprintf("	- **Profile:** %s\n", d.GetProfileString(std.Address(key), "DisplayName", FALLBACK_DISPLAY_NAME))
+		s += ufmt.Sprintf(" 	- **Roles:** %s\n\n", strings.Join(d.Members.GetMemberRoles(key), ", "))
+		i += 1
+		return false
+	})
+	s += ufmt.Sprintf("> You can find more information about a member by clicking on their address\n\n")
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) HomeProposalsView() string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+	s := ""
+	s += ufmt.Sprintf("## Proposals 🗳️ \n\n")
+	i := 0
+	d.Core.Proposals.Tree.Iterate("", "", func(key string, value interface{}) bool {
+		proposal := value.(*daokit.Proposal)
+		if proposal.Status != daokit.ProposalStatusOpen {
+			return false
+		}
+		id, err := seqid.FromString(key)
+		if err != nil {
+			panic(err)
+		}
+		s += ufmt.Sprintf("- **Proposal %d: [%s](%s:%s/%d)**\n\n", uint64(id), proposal.Title, linkPath, "proposal", uint64(id))
+		i += 1
+		return false
+	})
+	if i == 0 {
+		s += ufmt.Sprintf("\t⚠️ There are no running proposals at the moment\n\n")
+	}
+	s += ufmt.Sprintf("> See the [proposal history 📜](%s:%s) for more information\n\n", linkPath, PROPOSAL_HISTORY_PATH)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+// CONFIG PAGE COMPONENTS VIEWS
+
+func (d *DAOPrivate) ConfigHeaderView() string {
+	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
+	s := ""
+	s += ufmt.Sprintf("# %s - Config ⚙️\n\n", name)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) ConfigRolesView() string {
+	roles := d.Members.GetRoles()
+	s := ""
+	s += ufmt.Sprintf("## Roles 🏷️\n\n")
+	for _, role := range roles {
+		s += ufmt.Sprintf("- %s\n\n", role)
+		info := d.Members.RoleInfo(role)
+		s += ufmt.Sprintf("  %s\n\n", info.Description)
+	}
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) ConfigResourcesView() string {
+	s := ""
+	s += ufmt.Sprintf("## Resources 📦\n\n")
+	i := 1
+	d.Core.Resources.Tree.Iterate("", "", func(key string, value interface{}) bool {
+		resource := value.(*daokit.Resource)
+		s += ufmt.Sprintf("- **Resource #%d: %s**\n\n", i, key)
+		// TODO: add doc to handler and print here
+		s += ufmt.Sprintf("  - **Name:** %s\n", resource.DisplayName)
+		s += ufmt.Sprintf("  - **Description:** %s\n", resource.Description)
+		s += ufmt.Sprintf("  - **Condition:** %s\n\n", resource.Condition.Render())
+		i += 1
+		return false
+	})
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+// HISTORY PAGE COMPONENTS VIEWS
+
+func (d *DAOPrivate) ProposalHistoryHeaderView() string {
+	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
+	s := ""
+	s += ufmt.Sprintf("# %s - Proposal History\n\n", name)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) ProposalHistoryView() string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+	s := ""
+	s += ufmt.Sprintf("## Proposals 🗳️\n\n")
+	i := 1
+	d.Core.Proposals.Tree.Iterate("", "", func(key string, value interface{}) bool {
+		proposal, ok := value.(*daokit.Proposal)
+		if !ok {
+			panic("unexpected invalid proposal type")
+		}
+		id, err := seqid.FromString(key)
+		if err != nil {
+			panic(err)
+		}
+		s += ufmt.Sprintf("- **Proposal %d: [%s](%s:%s/%d) - %s**\n\n", uint64(id), proposal.Title, linkPath, "proposal", uint64(id), proposal.Status)
+		i += 1
+		return false
+	})
+	s += ufmt.Sprintf("[Add a new proposal 🗳️](%s$help)\n\n", linkPath)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+// MEMBER DETAIL PAGE COMPONENTS VIEWS
+
+func (d *DAOPrivate) MemberDetailHeaderView() string {
+	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
+	s := ""
+	s += ufmt.Sprintf("# %s - Member Detail\n\n", name)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) MemberDetailView(address string) string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+	roles := d.Members.GetMemberRoles(address)
+	displayName := d.GetProfileString(std.Address(address), "DisplayName", FALLBACK_DISPLAY_NAME)
+	bio := d.GetProfileString(std.Address(address), "Bio", "No bio")
+	pp := d.GetProfileString(std.Address(address), "Avatar", "")
+	s := ""
+	s += ufmt.Sprintf("## Profile 👤\n\n")
+	s += ufmt.Sprintf("- **Display Name:** %s\n\n", displayName)
+	s += ufmt.Sprintf("- **Bio:** %s\n\n", bio)
+	if pp != "" {
+		s += ufmt.Sprintf("![Avatar](%s)\n\n", pp)
+	}
+	s += ufmt.Sprintf("## Roles 🏷️\n\n")
+	for _, role := range roles {
+		s += ufmt.Sprintf("- %s\n\n", role)
+	}
+	s += ufmt.Sprintf("> Learn more about the roles on the [configuration page ⚙️](%s:%s)\n\n", linkPath, CONFIG_PATH)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+// PROPOSAL DETAIL PAGE COMPONENTS VIEWS
+
+func (d *DAOPrivate) ProposalDetailHeaderView() string {
+	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
+	s := ""
+	s += ufmt.Sprintf("# %s - Proposal Detail\n\n", name)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func (d *DAOPrivate) ProposalDetailView(idu uint64) string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
+	id := seqid.ID(idu)
+	proposal := d.Core.Proposals.GetProposal(uint64(id))
+	s := ""
+	s += ufmt.Sprintf("## Title - %s 📜\n\n", proposal.Title)
+	s += ufmt.Sprintf("## Description 📝\n\n%s\n\n", proposal.Description)
+	s += ufmt.Sprintf("## Resource - %s 📦\n\n", proposal.Action.Type())
+	resource := d.Core.Resources.Get(proposal.Action.Type())
+	s += ufmt.Sprintf("  - **Name:** %s\n", resource.DisplayName)
+	s += ufmt.Sprintf("  - **Description:** %s\n", resource.Description)
+	s += ufmt.Sprintf("  - **Condition:** %s\n\n", resource.Condition.Render())
+	s += ("---\n\n")
+	s += proposal.Action.String() + "\n\n"
+	s += ("---\n\n")
+	if proposal.Status == daokit.ProposalStatusOpen {
+		s += ufmt.Sprintf("## Status - Open 🟡\n\n")
+		s += ufmt.Sprintf("[Vote on this proposal 🗳️](%s$help)\n\n", linkPath)
+	} else if proposal.Status == daokit.ProposalStatusPassed {
+		s += ufmt.Sprintf("## Status - Passed 🟢\n\n")
+		s += ufmt.Sprintf("[Execute this proposal 🗳️](%s$help)\n\n", linkPath)
+	} else if proposal.Status == daokit.ProposalStatusExecuted {
+		s += ufmt.Sprintf("## Status - Executed ✅\n\n")
+	} else {
+		s += ufmt.Sprintf("## Status - Closed 🔴\n\n")
+	}
+	s += ufmt.Sprintf("> proposed by %s 👤\n\n", proposal.ProposerID)
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	s += ufmt.Sprintf("## Votes 🗳️\n\n%s\n\n", proposal.Condition.RenderWithVotes(proposal.Ballot))
+	s += ufmt.Sprintf("\n--------------------------------\n")
+	return s
+}
+
+func getLinkPath(pkgPath string) string {
+	slashIdx := strings.IndexRune(pkgPath, '/')
+	if slashIdx != 1 {
+		return pkgPath[slashIdx:]
+	}
+	return ""
+}

--- a/examples/gno.land/p/samcrew/daocond/ballot_avl.gno
+++ b/examples/gno.land/p/samcrew/daocond/ballot_avl.gno
@@ -1,0 +1,43 @@
+package daocond
+
+import (
+	"gno.land/p/demo/avl"
+)
+
+type BallotAVL struct {
+	tree *avl.Tree
+}
+
+func NewBallot() Ballot {
+	return &BallotAVL{tree: avl.NewTree()}
+}
+
+// Implements Ballot interface
+func (b *BallotAVL) Vote(voter string, vote Vote) {
+	b.tree.Set(voter, vote)
+}
+
+// Implements Ballot interface
+func (b *BallotAVL) Get(voter string) Vote {
+	vote, ok := b.tree.Get(voter)
+	if !ok {
+		return VoteAbstain
+	}
+	return vote.(Vote)
+}
+
+// Implements Ballot interface
+func (b *BallotAVL) Total() int {
+	return b.tree.Size()
+}
+
+// Implements Ballot interface
+func (b *BallotAVL) Iterate(fn func(voter string, vote Vote) bool) {
+	b.tree.Iterate("", "", func(key string, value interface{}) bool {
+		v, ok := value.(Vote)
+		if !ok {
+			return false
+		}
+		return fn(key, v)
+	})
+}

--- a/examples/gno.land/p/samcrew/daocond/cond_and.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_and.gno
@@ -1,0 +1,55 @@
+package daocond
+
+import (
+	"strings"
+)
+
+type andCond struct {
+	conditions []Condition
+}
+
+func And(conditions ...Condition) Condition {
+	if len(conditions) < 2 {
+		panic("at least two conditions are required")
+	}
+	return &andCond{conditions: conditions}
+}
+
+// Eval implements Condition.
+func (c *andCond) Eval(ballot Ballot) bool {
+	for _, condition := range c.conditions {
+		if !condition.Eval(ballot) {
+			return false
+		}
+	}
+	return true
+}
+
+// Signal implements Condition.
+func (c *andCond) Signal(ballot Ballot) float64 {
+	totalSignal := 0.0
+	for _, condition := range c.conditions {
+		totalSignal += condition.Signal(ballot)
+	}
+	return totalSignal / float64(len(c.conditions))
+}
+
+// Render implements Condition.
+func (c *andCond) Render() string {
+	renders := []string{}
+	for _, condition := range c.conditions {
+		renders = append(renders, condition.Render())
+	}
+	return "[" + strings.Join(renders, " AND ") + "]"
+}
+
+// RenderWithVotes implements Condition.
+func (c *andCond) RenderWithVotes(ballot Ballot) string {
+	renders := []string{}
+	for _, condition := range c.conditions {
+		renders = append(renders, condition.RenderWithVotes(ballot))
+	}
+	return "[" + strings.Join(renders, " AND ") + "]"
+}
+
+var _ Condition = (*andCond)(nil)

--- a/examples/gno.land/p/samcrew/daocond/cond_gnolovedao.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_gnolovedao.gno
@@ -1,0 +1,148 @@
+package daocond
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+
+	"gno.land/p/demo/ufmt"
+)
+
+type gnolovDaoCondThreshold struct {
+	threshold            float64
+	roles                []string
+	hasRoleFn            func(memberId string, role string) bool
+	usersWithRoleCountFn func(role string) uint32
+}
+
+var roleWeights = []float64{3.0, 2.0, 1.0}
+
+// This is our implementation of the govdao codition following Jae Kwon's specification: https://gist.github.com/jaekwon/918ad325c4c8f7fb5d6e022e33cb7eb3
+func GnoloveDAOCondThreshold(threshold float64, roles []string, hasRoleFn func(memberId string, role string) bool, usersWithRoleCountFn func(role string) uint32) Condition {
+	if threshold <= 0 || threshold > 1 {
+		panic(errors.New("invalid threshold"))
+	}
+	if usersWithRoleCountFn == nil {
+		panic(errors.New("nil usersWithRoleCountFn"))
+	}
+	if hasRoleFn == nil {
+		panic(errors.New("nil hasRoleFn"))
+	}
+	if len(roles) > 3 {
+		panic("the gnolove dao condition handles at most 3 roles")
+	}
+	return &gnolovDaoCondThreshold{
+		threshold:            threshold,
+		roles:                roles,
+		hasRoleFn:            hasRoleFn,
+		usersWithRoleCountFn: usersWithRoleCountFn,
+	}
+}
+
+// Eval implements Condition.
+func (c *gnolovDaoCondThreshold) Eval(ballot Ballot) bool {
+	return c.yesRatio(ballot) >= c.threshold
+}
+
+// Signal implements Condition.
+func (c *gnolovDaoCondThreshold) Signal(ballot Ballot) float64 {
+	return math.Min(c.yesRatio(ballot)/c.threshold, 1)
+}
+
+// Render implements Condition.
+func (c *gnolovDaoCondThreshold) Render() string {
+	rolePowers := []string{}
+	for i, role := range c.roles {
+		weight := strconv.FormatFloat(roleWeights[i], 'f', 2, 64) // ufmt.Sprintf("%.2f", ...) is not working
+		rolePowers = append(rolePowers, ufmt.Sprintf("%s => %s power", role, weight))
+	}
+	return ufmt.Sprintf("%g%% of total voting power | %s", c.threshold*100, strings.Join(rolePowers, " | "))
+}
+
+// RenderWithVotes implements Condition.
+func (c *gnolovDaoCondThreshold) RenderWithVotes(ballot Ballot) string {
+	vPowers, totalPower := c.computeVotingPowers()
+	rolePowers := []string{}
+	for _, role := range c.roles {
+		weight := strconv.FormatFloat(vPowers[role], 'f', 2, 64) // ufmt.Sprintf("%.2f", ...) is not working
+		rolePowers = append(rolePowers, ufmt.Sprintf("%s => %s power", role, weight))
+	}
+	s := ""
+	s += ufmt.Sprintf("%g%% of total voting power | %s\n\n", c.threshold*100, strings.Join(rolePowers, " | "))
+	s += ufmt.Sprintf("Threshold needed: %g%% of total voting power\n\n", c.threshold*100)
+	s += ufmt.Sprintf("Yes: %d/%d\n\n", c.yesRatio(ballot), totalPower)
+	s += ufmt.Sprintf("Voting power needed: %g%% of total voting power\n\n", c.threshold*totalPower)
+	return s
+}
+
+var _ Condition = (*gnolovDaoCondThreshold)(nil)
+
+func (c *gnolovDaoCondThreshold) yesRatio(ballot Ballot) float64 {
+	var totalYes float64
+	votingPowersByTier, totalPower := c.computeVotingPowers()
+	// Case when there are zero T1s
+	if totalPower == 0.0 {
+		return totalPower
+	}
+
+	ballot.Iterate(func(voter string, vote Vote) bool {
+		if vote != VoteYes {
+			return false
+		}
+		tier := c.getUserRole(voter)
+		totalYes += votingPowersByTier[tier]
+		return false
+	})
+	return totalYes / totalPower
+}
+
+func (c *gnolovDaoCondThreshold) getUserRole(userID string) string {
+	for _, role := range c.roles {
+		if c.hasRoleFn(userID, role) {
+			return role
+		}
+	}
+	panic("No role found for user")
+}
+
+func (c *gnolovDaoCondThreshold) computeVotingPowers() (map[string]float64, float64) {
+	votingPowers := make(map[string]float64)
+	totalPower := 0.0
+	countsMembersPerRole := make(map[string]float64)
+
+	for _, role := range c.roles {
+		countsMembersPerRole[role] = float64(c.usersWithRoleCountFn(role))
+	}
+
+	for i, role := range c.roles {
+		if i == 0 {
+			votingPowers[role] = roleWeights[0] // Highest tier always gets max power (3.0)
+		} else {
+			votingPowers[role] = computePower(countsMembersPerRole[c.roles[0]], countsMembersPerRole[role], roleWeights[i])
+		}
+		totalPower += votingPowers[role] * countsMembersPerRole[role]
+	}
+
+	return votingPowers, totalPower
+}
+
+// max power here is the number of votes each tier gets when we have
+// the same number of member on each tier
+// T2 = 2.0 and T1 = 1.0 with the ration T1/Tn
+// we compute the actual ratio
+func computePower(T1, Tn, maxPower float64) float64 {
+	// If there are 0 Tn (T2, T3) just return the max power
+	// we could also return 0.0 as voting power
+	if Tn <= 0.0 {
+		return maxPower
+	}
+
+	computedPower := (T1 / Tn) * maxPower
+	if computedPower >= maxPower {
+		// If computed power is bigger than the max, this happens if Tn is lower than T1
+		// cap the max power to max power.
+		return maxPower
+	}
+	return computedPower
+}

--- a/examples/gno.land/p/samcrew/daocond/cond_gnolovedao_test.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_gnolovedao_test.gno
@@ -1,0 +1,333 @@
+package daocond
+
+import (
+	"testing"
+
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/demo/urequire"
+)
+
+/*
+Example 1:
+T1 100 members --> 300 VP, 3 votes per member
+T2 100 members --> 200 VP, 2 votes per member
+T3 100 members --> 100 VP, 1 votes per member
+Example 2:
+
+T1 100 members --> 300 VP, 3 votes per member
+T2 50 members --> 100 VP, 2 votes per member *
+T3 10 members --> 10 VP, 1 votes per member *
+Example 3:
+
+T1 100 members --> 300 VP, 3 votes per member
+T2 200 members --> 200 VP, 1 votes per member *
+T3 100 members --> 100 VP, 1 votes per member
+Example 4:
+
+T1 100 members --> 300 VP, 3 votes per member
+T2 200 members --> 200 VP, 1 votes per member *
+T3 1000 members --> 100 VP, 0.1 votes per member
+*/
+func TestComputeVotingPowers(t *testing.T) {
+	type gnoloveDaoComposition struct {
+		t1s                int
+		t2s                int
+		t3s                int
+		abstainT3          bool
+		expectedTotalPower float64
+		expectedPowers     map[string]float64
+	}
+	tests := map[string]gnoloveDaoComposition{
+		"example 1": {
+			t1s:                100,
+			t2s:                100,
+			t3s:                100,
+			abstainT3:          false,
+			expectedTotalPower: 600,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 2.0,
+				"T3": 1.0,
+			},
+		},
+		"example 2": {
+			t1s:                100,
+			t2s:                50,
+			t3s:                10,
+			abstainT3:          false,
+			expectedTotalPower: 410,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 2.0,
+				"T3": 1.0,
+			},
+		},
+		"example 3": {
+			t1s:                100,
+			t2s:                200,
+			t3s:                100,
+			abstainT3:          false,
+			expectedTotalPower: 600,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 1.0,
+				"T3": 1.0,
+			},
+		},
+		"example 4": {
+			t1s:                100,
+			t2s:                200,
+			t3s:                1000,
+			abstainT3:          false,
+			expectedTotalPower: 600,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 1.0,
+				"T3": 0.1,
+			},
+		},
+		"0 -T1s": {
+			t1s:                0,
+			t2s:                100,
+			t3s:                100,
+			abstainT3:          false,
+			expectedTotalPower: 0,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 0.0,
+				"T3": 0.0,
+			},
+		},
+		"100 T1, 1 T2, 1 T3": {
+			t1s:                100,
+			t2s:                1,
+			t3s:                1,
+			abstainT3:          false,
+			expectedTotalPower: 303,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 2.0,
+				"T3": 1.0,
+			},
+		},
+		"T3 Abstaining": {
+			t1s:                100,
+			t2s:                100,
+			t3s:                100,
+			expectedTotalPower: 500,
+			abstainT3:          true,
+			expectedPowers: map[string]float64{
+				"T1": 3.0,
+				"T2": 2.0,
+			},
+		},
+	}
+
+	for name, composition := range tests {
+		t.Run(name, func(t *testing.T) {
+			dao := newMockDAO()
+			for i := 0; i < composition.t1s; i++ {
+				dao.addUser(ufmt.Sprintf("%d_T1", i), []string{"T1"})
+			}
+			for i := 0; i < composition.t2s; i++ {
+				dao.addUser(ufmt.Sprintf("%d_T2", i), []string{"T2"})
+			}
+			for i := 0; i < composition.t3s; i++ {
+				dao.addUser(ufmt.Sprintf("%d_T3", i), []string{"T3"})
+			}
+
+			roles := []string{"T1", "T2"}
+			if !composition.abstainT3 {
+				roles = append(roles, "T3")
+			}
+
+			cond := &gnolovDaoCondThreshold{
+				threshold:            0.6,
+				hasRoleFn:            dao.hasRole,
+				roles:                roles,
+				usersWithRoleCountFn: dao.usersWithRoleCount,
+			}
+			votingPowers, totalPower := cond.computeVotingPowers()
+			for tier, expectedPower := range composition.expectedPowers {
+				if votingPowers[tier] != expectedPower {
+					t.Fail()
+				}
+			}
+
+			if totalPower != composition.expectedTotalPower {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestEval(t *testing.T) {
+	type gnoloveDaoVotes struct {
+		votesT1      []Vote
+		votesT2      []Vote
+		votesT3      []Vote
+		threshold    float64
+		expectedEval bool
+		expectedYes  float64
+		abstainT3    bool
+		panic        bool
+	}
+	tests := map[string]gnoloveDaoVotes{
+		"2/6% Yes": { //0.3333
+			votesT1:      []Vote{VoteNo},                             // 3 voting power
+			votesT2:      []Vote{VoteYes, VoteYes, VoteYes, VoteYes}, // 2 voting power combined
+			votesT3:      []Vote{VoteNo},
+			expectedEval: false,
+			abstainT3:    false,
+			threshold:    0.45,
+			expectedYes:  2.0 / 6.0,
+			panic:        false,
+		},
+		"50% Yes": {
+			votesT1:      []Vote{VoteNo},                             // 3 voting power
+			votesT2:      []Vote{VoteYes, VoteYes, VoteYes, VoteYes}, // 2 voting power combined
+			votesT3:      []Vote{VoteYes},
+			expectedEval: true,
+			abstainT3:    false,
+			threshold:    0.45,
+			expectedYes:  3.0 / 6.0,
+			panic:        false,
+		},
+		"several T2 & T3": {
+			votesT1: []Vote{VoteNo, VoteNo}, // 6 voting power
+			// 10 T2 total power (2/3) powerT1 = 4, 4/10 0.4 each
+			votesT2: []Vote{VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes},
+			// 4 T3 total power (1/3) powerT1 = 2, 2/4 0.5 each
+			votesT3:      []Vote{VoteYes, VoteNo, VoteYes, VoteNo},
+			expectedEval: false,
+			abstainT3:    false,
+			threshold:    0.42, //total power = 6+4+2 T3yes = 1, T2yes = 4 T1yes = 0 totalYes = 0.41666666666 (5/12)
+			expectedYes:  5.0 / 12.0,
+			panic:        false,
+		},
+		"several T2 & T3 eval true": {
+			votesT1: []Vote{VoteNo, VoteNo}, // 6 voting power
+			// 10 T2 total power (2/3) powerT1 = 4, 4/10 0.4 each
+			votesT2: []Vote{VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes, VoteYes},
+			// 4 T3 total power (1/3) powerT1 = 2, 2/4 0.5 each
+			votesT3:      []Vote{VoteYes, VoteYes, VoteYes, VoteNo},
+			expectedEval: true,
+			abstainT3:    false,
+			threshold:    0.42, //total power = 6+4+2 T3yes = 1.5, T2yes = 4 T1yes = 0 totalYes = 0.45833333333 (5.5/12)
+			expectedYes:  5.5 / 12.0,
+			panic:        false,
+		},
+		"only T1s": {
+			votesT1:      []Vote{VoteYes, VoteNo}, // 6 voting power
+			expectedEval: false,
+			abstainT3:    false,
+			threshold:    0.6,
+			expectedYes:  3.0 / 6.0,
+			panic:        false,
+		},
+		"only T3s": { // as T2 & T3 power is capped as power of T1, in this case the power will be 0 everywhere
+			votesT3:      []Vote{VoteYes, VoteYes, VoteYes, VoteYes}, // voting power = 0, 0 each
+			expectedEval: false,
+			abstainT3:    false,
+			threshold:    0.6,
+			expectedYes:  0.0,
+		},
+		"T3 abstaining": {
+			votesT1:      []Vote{VoteYes, VoteNo}, // 6 voting power
+			votesT2:      []Vote{VoteYes, VoteYes},
+			votesT3:      []Vote{},
+			expectedEval: true,
+			abstainT3:    true,
+			threshold:    0.6,
+			expectedYes:  7.0 / 10.0,
+			panic:        false,
+		},
+		"T3 abstaining w/ votes": {
+			votesT1:      []Vote{VoteYes, VoteNo}, // 6 voting power
+			votesT2:      []Vote{VoteYes, VoteYes},
+			votesT3:      []Vote{VoteYes, VoteNo},
+			expectedEval: true,
+			abstainT3:    true,
+			threshold:    0.6,
+			expectedYes:  7.0 / 10.0,
+			panic:        true, // a user with T3 when T3 is abstaining should panic
+		},
+	}
+
+	for name, tdata := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tdata.panic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("The code did not panic")
+					}
+				}()
+			}
+			votes := map[string]Vote{}
+			dao := newMockDAO()
+			for i, vote := range tdata.votesT1 {
+				userID := ufmt.Sprintf("%d_T1", i)
+				dao.addUser(userID, []string{"T1"})
+				votes[userID] = vote
+			}
+
+			for i, vote := range tdata.votesT2 {
+				userID := ufmt.Sprintf("%d_T2", i)
+				dao.addUser(userID, []string{"T2"})
+				votes[userID] = vote
+			}
+
+			for i, vote := range tdata.votesT3 {
+				userID := ufmt.Sprintf("%d_T3", i)
+				dao.addUser(userID, []string{"T3"})
+				votes[userID] = vote
+			}
+			ballot := NewBallot()
+			for userId, vote := range votes {
+				ballot.Vote(userId, vote)
+			}
+			roles := []string{"T1", "T2"}
+			if !tdata.abstainT3 {
+				roles = append(roles, "T3")
+			}
+			cond := GnoloveDAOCondThreshold(tdata.threshold, roles, dao.hasRole, dao.usersWithRoleCount)
+			// Get percent of total yes
+			urequire.Equal(t, tdata.expectedEval, cond.Eval(ballot))
+		})
+	}
+}
+
+type mockDAO struct {
+	members map[string][]string
+	roles   map[string][]string
+}
+
+func newMockDAO() *mockDAO {
+	return &mockDAO{
+		members: map[string][]string{},
+		roles:   map[string][]string{}, // roles to users
+	}
+}
+
+func (m *mockDAO) addUser(memberId string, roles []string) {
+	m.members[memberId] = roles
+	for _, memberRole := range roles {
+		m.roles[memberRole] = append(m.roles[memberRole], memberId)
+	}
+}
+func (m *mockDAO) usersWithRoleCount(role string) uint32 {
+	return uint32(len(m.roles[role]))
+}
+
+func (m *mockDAO) hasRole(memberId string, role string) bool {
+	roles, ok := m.members[memberId]
+	if !ok {
+		return false
+	}
+	for _, memberRole := range roles {
+		if memberRole == role {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/gno.land/p/samcrew/daocond/cond_members_threshold.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_members_threshold.gno
@@ -1,0 +1,71 @@
+package daocond
+
+import (
+	"errors"
+	"math"
+
+	"gno.land/p/demo/ufmt"
+)
+
+type membersThresholdCond struct {
+	isMemberFn     func(memberId string) bool
+	membersCountFn func() uint64
+	threshold      float64
+}
+
+func MembersThreshold(threshold float64, isMemberFn func(memberId string) bool, membersCountFn func() uint64) Condition {
+	if threshold <= 0 || threshold > 1 {
+		panic(errors.New("invalid threshold"))
+	}
+	if isMemberFn == nil {
+		panic(errors.New("nil isMemberFn"))
+	}
+	if membersCountFn == nil {
+		panic(errors.New("nil membersCountFn"))
+	}
+	return &membersThresholdCond{
+		threshold:      threshold,
+		isMemberFn:     isMemberFn,
+		membersCountFn: membersCountFn,
+	}
+}
+
+// Eval implements Condition.
+func (c *membersThresholdCond) Eval(ballot Ballot) bool {
+	return c.yesRatio(ballot) >= c.threshold
+}
+
+// Signal implements Condition.
+func (c *membersThresholdCond) Signal(ballot Ballot) float64 {
+	return math.Min(c.yesRatio(ballot)/c.threshold, 1)
+}
+
+// Render implements Condition.
+func (c *membersThresholdCond) Render() string {
+	return ufmt.Sprintf("%g%% of members", c.threshold*100)
+}
+
+// RenderWithVotes implements Condition.
+func (c *membersThresholdCond) RenderWithVotes(ballot Ballot) string {
+	s := ""
+	s += ufmt.Sprintf("to meet the condition, %g%% of members must vote yes\n\n", c.threshold*100)
+	s += ufmt.Sprintf("Yes: %d/%d = %g%%\n\n", c.totalYes(ballot), c.membersCountFn(), c.yesRatio(ballot)*100)
+	return s
+}
+
+var _ Condition = (*membersThresholdCond)(nil)
+
+func (c *membersThresholdCond) yesRatio(ballot Ballot) float64 {
+	return float64(c.totalYes(ballot)) / float64(c.membersCountFn())
+}
+
+func (c *membersThresholdCond) totalYes(ballot Ballot) uint64 {
+	totalYes := uint64(0)
+	ballot.Iterate(func(voter string, vote Vote) bool {
+		if vote == VoteYes && c.isMemberFn(voter) {
+			totalYes += 1
+		}
+		return false
+	})
+	return totalYes
+}

--- a/examples/gno.land/p/samcrew/daocond/cond_or.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_or.gno
@@ -1,0 +1,56 @@
+package daocond
+
+import (
+	"math"
+	"strings"
+)
+
+type orCond struct {
+	conditions []Condition
+}
+
+func Or(conditions ...Condition) Condition {
+	if len(conditions) < 2 {
+		panic("at least two conditions are required")
+	}
+	return &orCond{conditions: conditions}
+}
+
+// Eval implements Condition.
+func (c *orCond) Eval(ballot Ballot) bool {
+	for _, condition := range c.conditions {
+		if condition.Eval(ballot) {
+			return true
+		}
+	}
+	return false
+}
+
+// Signal implements Condition.
+func (c *orCond) Signal(ballot Ballot) float64 {
+	maxSignal := 0.0
+	for _, condition := range c.conditions {
+		maxSignal = math.Max(maxSignal, condition.Signal(ballot))
+	}
+	return maxSignal
+}
+
+// Render implements Condition.
+func (c *orCond) Render() string {
+	renders := []string{}
+	for _, condition := range c.conditions {
+		renders = append(renders, condition.Render())
+	}
+	return "[" + strings.Join(renders, " OR ") + "]"
+}
+
+// RenderWithVotes implements Condition.
+func (c *orCond) RenderWithVotes(ballot Ballot) string {
+	renders := []string{}
+	for _, condition := range c.conditions {
+		renders = append(renders, condition.RenderWithVotes(ballot))
+	}
+	return "[" + strings.Join(renders, " OR ") + "]"
+}
+
+var _ Condition = (*orCond)(nil)

--- a/examples/gno.land/p/samcrew/daocond/cond_role_count.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_role_count.gno
@@ -1,0 +1,67 @@
+package daocond
+
+import (
+	"errors"
+	"math"
+
+	"gno.land/p/demo/ufmt"
+)
+
+type roleCountCond struct {
+	hasRoleFn func(memberId string, role string) bool
+	count     uint64
+	role      string
+}
+
+func RoleCount(count uint64, role string, hasRoleFn func(memberId string, role string) bool) Condition {
+	if count == 0 {
+		panic(errors.New("count must be greater than 0"))
+	}
+	if role == "" {
+		panic(errors.New("role must not be empty"))
+	}
+	if hasRoleFn == nil {
+		panic(errors.New("nil hasRoleFn"))
+	}
+	return &roleCountCond{
+		count:     count,
+		hasRoleFn: hasRoleFn,
+		role:      role,
+	}
+}
+
+// Eval implements Condition.
+func (c *roleCountCond) Eval(ballot Ballot) bool {
+	return c.totalYes(ballot) >= c.count
+}
+
+// Signal implements Condition.
+func (c *roleCountCond) Signal(ballot Ballot) float64 {
+	return math.Min(float64(c.totalYes(ballot))/float64(c.count), 1)
+}
+
+// Render implements Condition.
+func (c *roleCountCond) Render() string {
+	return ufmt.Sprintf("%d %s", c.count, c.role)
+}
+
+// RenderWithVotes implements Condition.
+func (c *roleCountCond) RenderWithVotes(ballot Ballot) string {
+	s := ""
+	s += ufmt.Sprintf("to meet the condition, %d members with role %s must vote yes\n\n", c.count, c.role)
+	s += ufmt.Sprintf("Yes: %d/%d\n\n", c.totalYes(ballot), c.count)
+	return s
+}
+
+var _ Condition = (*roleCountCond)(nil)
+
+func (c *roleCountCond) totalYes(ballot Ballot) uint64 {
+	totalYes := uint64(0)
+	ballot.Iterate(func(voter string, vote Vote) bool {
+		if vote == VoteYes && c.hasRoleFn(voter, c.role) {
+			totalYes += 1
+		}
+		return false
+	})
+	return totalYes
+}

--- a/examples/gno.land/p/samcrew/daocond/cond_role_treshold.gno
+++ b/examples/gno.land/p/samcrew/daocond/cond_role_treshold.gno
@@ -1,0 +1,73 @@
+package daocond
+
+import (
+	"errors"
+	"math"
+
+	"gno.land/p/demo/ufmt"
+)
+
+type roleThresholdCond struct {
+	hasRoleFn        func(memberId string, role string) bool
+	usersRoleCountFn func(role string) uint32
+	threshold        float64
+	role             string
+}
+
+func RoleThreshold(threshold float64, role string, hasRoleFn func(memberId string, role string) bool, usersRoleCountFn func(role string) uint32) Condition {
+	if threshold <= 0 || threshold > 1 {
+		panic(errors.New("invalid threshold"))
+	}
+	if hasRoleFn == nil {
+		panic(errors.New("nil hasRoleFn"))
+	}
+	if usersRoleCountFn == nil {
+		panic(errors.New("nil usersRoleCountFn"))
+	}
+	return &roleThresholdCond{
+		threshold:        threshold,
+		hasRoleFn:        hasRoleFn,
+		usersRoleCountFn: usersRoleCountFn,
+		role:             role,
+	}
+}
+
+// Eval implements Condition.
+func (c *roleThresholdCond) Eval(ballot Ballot) bool {
+	return c.yesRatio(ballot) >= c.threshold
+}
+
+// Signal implements Condition.
+func (c *roleThresholdCond) Signal(ballot Ballot) float64 {
+	return math.Min(c.yesRatio(ballot)/c.threshold, 1)
+}
+
+// Render implements Condition.
+func (c *roleThresholdCond) Render() string {
+	return ufmt.Sprintf("%g%% of %s members", c.threshold*100, c.role)
+}
+
+// RenderWithVotes implements Condition.
+func (c *roleThresholdCond) RenderWithVotes(ballot Ballot) string {
+	s := ""
+	s += ufmt.Sprintf("To meet the condition, %g%% of %s members with role %s must vote yes\n\n", c.threshold*100, c.role)
+	s += ufmt.Sprintf("Yes: %d/%d = %g%%\n\n", c.totalYes(ballot), c.usersRoleCountFn(c.role), c.yesRatio(ballot)*100)
+	return s
+}
+
+var _ Condition = (*roleThresholdCond)(nil)
+
+func (c *roleThresholdCond) yesRatio(ballot Ballot) float64 {
+	return float64(c.totalYes(ballot)) / float64(c.usersRoleCountFn(c.role))
+}
+
+func (c *roleThresholdCond) totalYes(ballot Ballot) uint32 {
+	totalYes := uint32(0)
+	ballot.Iterate(func(voter string, vote Vote) bool {
+		if vote == VoteYes && c.hasRoleFn(voter, c.role) {
+			totalYes += 1
+		}
+		return false
+	})
+	return totalYes
+}

--- a/examples/gno.land/p/samcrew/daocond/daocond.gno
+++ b/examples/gno.land/p/samcrew/daocond/daocond.gno
@@ -1,0 +1,29 @@
+package daocond
+
+// We made conditions stateless to avoid complexity of handling events like (member added, member removed, role assigned, role removed, etc.)
+// This model should work pretty good for small DAOs with few voters.
+// In future, we should probably add a stateful model for large DAOs with many voters.
+
+type Condition interface {
+	Eval(ballot Ballot) bool
+	Signal(ballot Ballot) float64
+
+	Render() string
+	RenderWithVotes(ballot Ballot) string
+}
+
+type Ballot interface {
+	Vote(voter string, vote Vote)
+	Get(voter string) Vote
+	Total() int
+
+	Iterate(fn func(voter string, vote Vote) bool)
+}
+
+type Vote string
+
+const (
+	VoteYes     = "yes"
+	VoteNo      = "no"
+	VoteAbstain = "abstain"
+)

--- a/examples/gno.land/p/samcrew/daocond/daocond_test.gno
+++ b/examples/gno.land/p/samcrew/daocond/daocond_test.gno
@@ -1,0 +1,269 @@
+package daocond_test
+
+import (
+	"errors"
+	"testing"
+
+	"gno.land/p/demo/urequire"
+	"gno.land/p/samcrew/daocond"
+)
+
+func TestCondition(t *testing.T) {
+	dao := newMockDAO()
+
+	// leaf conditions
+	membersMajority := daocond.MembersThreshold(0.6, dao.isMember, dao.membersCount)
+	publicRelationships := daocond.RoleCount(1, "public-relationships", dao.hasRole)
+	financeOfficer := daocond.RoleCount(1, "finance-officer", dao.hasRole)
+
+	urequire.Equal(t, "60% of members", membersMajority.Render())
+	urequire.Equal(t, "1 public-relationships", publicRelationships.Render())
+	urequire.Equal(t, "1 finance-officer", financeOfficer.Render())
+
+	// ressource expressions
+	ressources := map[string]daocond.Condition{
+		"social.post":    daocond.And(publicRelationships, membersMajority),
+		"finance.invest": daocond.Or(financeOfficer, membersMajority),
+	}
+
+	urequire.Equal(t, "[1 public-relationships AND 60% of members]", ressources["social.post"].Render())
+	urequire.Equal(t, "[1 finance-officer OR 60% of members]", ressources["finance.invest"].Render())
+}
+
+func TestEval(t *testing.T) {
+	setups := []struct {
+		name  string
+		setup func(dao *mockDAO)
+	}{
+		{name: "basic", setup: func(dao *mockDAO) {
+			membersMajority := daocond.MembersThreshold(0.6, dao.isMember, dao.membersCount)
+			publicRelationships := daocond.RoleCount(1, "public-relationships", dao.hasRole)
+			financeOfficer := daocond.RoleCount(1, "finance-officer", dao.hasRole)
+			dao.resources = map[string]daocond.Condition{
+				"social.post":    daocond.And(publicRelationships, membersMajority),
+				"finance.invest": daocond.Or(financeOfficer, membersMajority),
+			}
+		}},
+	}
+
+	cases := []struct {
+		name     string
+		resource string
+		phases   []testPhase
+	}{
+		{
+			name:     "post with public-relationships",
+			resource: "social.post",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "yes",
+					"bob":   "yes",
+					"eve":   "no",
+				},
+				result: true,
+			}},
+		},
+		{
+			name:     "post without public-relationships",
+			resource: "social.post",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "yes",
+					"bob":   "no",
+					"eve":   "yes",
+				},
+				result: false,
+			}},
+		},
+		{
+			name:     "post after public-relationships changes",
+			resource: "social.post",
+			phases: []testPhase{
+				{
+					votes: map[string]daocond.Vote{
+						"alice": "yes",
+						"bob":   "yes",
+						"eve":   "no",
+					},
+					result: true,
+				},
+				{
+					changes: func(dao *mockDAO) {
+						dao.unassignRole("bob", "public-relationships")
+					},
+					result: false,
+				},
+				{
+					changes: func(dao *mockDAO) {
+						dao.assignRole("alice", "public-relationships")
+					},
+					result: true,
+				},
+			},
+		},
+		{
+			name:     "post public-relationships alone",
+			resource: "social.post",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "no",
+					"bob":   "yes",
+					"eve":   "no",
+				},
+				result: false,
+			}},
+		},
+		{
+			name:     "invest with finance officer",
+			resource: "finance.invest",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "yes",
+					"bob":   "no",
+					"eve":   "no",
+				},
+				result: true,
+			}},
+		},
+		{
+			name:     "invest without finance officer",
+			resource: "finance.invest",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "no",
+					"bob":   "yes",
+					"eve":   "yes",
+				},
+				result: true,
+			}},
+		},
+		{
+			name:     "invest alone",
+			resource: "finance.invest",
+			phases: []testPhase{{
+				votes: map[string]daocond.Vote{
+					"alice": "no",
+					"bob":   "no",
+					"eve":   "yes",
+				},
+				result: false,
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, s := range setups {
+			t.Run(tc.name+" "+s.name, func(t *testing.T) {
+				dao := newMockDAO()
+				s.setup(dao)
+
+				resource, ok := dao.resources[tc.resource]
+				urequire.True(t, ok)
+
+				ballot := daocond.NewBallot()
+				for _, phase := range tc.phases {
+					if phase.changes != nil {
+						phase.changes(dao)
+					}
+					if phase.votes != nil {
+						for memberId, vote := range phase.votes {
+							ballot.Vote(memberId, vote)
+						}
+					}
+					result := resource.Eval(ballot)
+					if phase.result != result {
+						println("State:", resource.RenderWithVotes(ballot))
+					}
+					urequire.Equal(t, phase.result, result)
+				}
+			})
+		}
+	}
+}
+
+type testPhase struct {
+	changes func(dao *mockDAO)
+	votes   map[string]daocond.Vote
+	result  bool
+}
+
+type mockDAO struct {
+	members   map[string][]string
+	roles     map[string][]string
+	resources map[string]daocond.Condition
+}
+
+func newMockDAO() *mockDAO {
+	return &mockDAO{
+		members: map[string][]string{
+			"alice": []string{"finance-officer"},
+			"bob":   []string{"public-relationships"},
+			"eve":   []string{},
+		},
+		roles: map[string][]string{
+			"finance-officer":      []string{"alice"},
+			"public-relationships": []string{"bob"},
+		}, // roles to users
+		resources: make(map[string]daocond.Condition),
+	}
+}
+
+func (m *mockDAO) assignRole(userId string, role string) {
+	roles, ok := m.members[userId]
+	if !ok {
+		panic(errors.New("unknown member"))
+	}
+	m.members[userId], ok = strsadd(roles, role)
+}
+
+func (m *mockDAO) unassignRole(userId string, role string) {
+	roles, ok := m.members[userId]
+	if !ok {
+		panic(errors.New("unknown member"))
+	}
+	m.members[userId], ok = strsrm(roles, role)
+}
+
+func (m *mockDAO) isMember(memberId string) bool {
+	_, ok := m.members[memberId]
+	return ok
+}
+
+func (m *mockDAO) membersCount() uint64 {
+	return uint64(len(m.members))
+}
+
+func (m *mockDAO) hasRole(memberId string, role string) bool {
+	roles, ok := m.members[memberId]
+	if !ok {
+		return false
+	}
+	for _, memberRole := range roles {
+		if memberRole == role {
+			return true
+		}
+	}
+	return false
+}
+
+func strsrm(strs []string, val string) ([]string, bool) {
+	removed := false
+	res := []string{}
+	for _, str := range strs {
+		if str == val {
+			removed = true
+			continue
+		}
+		res = append(res, str)
+	}
+	return res, removed
+}
+
+func strsadd(strs []string, val string) ([]string, bool) {
+	for _, str := range strs {
+		if str == val {
+			return strs, false
+		}
+	}
+	return append(strs, val), true
+}

--- a/examples/gno.land/p/samcrew/daocond/gnomod.toml
+++ b/examples/gno.land/p/samcrew/daocond/gnomod.toml
@@ -2,4 +2,4 @@ module = "gno.land/p/samcrew/daocond"
 gno = "0.9"
 
 [addpkg]
-creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"
+  creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/daocond/gnomod.toml
+++ b/examples/gno.land/p/samcrew/daocond/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/samcrew/daocond"
+gno = "0.9"
+
+[addpkg]
+creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/daokit/README.md
+++ b/examples/gno.land/p/samcrew/daokit/README.md
@@ -1,0 +1,354 @@
+# daokit
+
+# 1. Introduction
+
+A **Decentralized Autonomous Organization (DAO)** is a self-governing entity that operates through smart contracts, enabling transparent decision-making without centralized control.
+
+`daokit` is a gnolang package for creating complex DAO models. It introduces a new framework based on conditions, composed of :
+- `daokit` : Core package for building DAOs, proposals, and actions
+- `basedao` : Extension with membership and role management
+- `daocond`: Stateless condition engine for evaluating proposals
+
+# 2. What is `daokit` ?
+
+`daokit` provides a powerful condition and role-based system to build flexible and programmable DAOs.
+
+## Key Features:
+- Create proposals that include complex execution logic
+- Attach rules (conditions) to each resource
+- Assign roles to users to structure permissions and governance
+
+## 2.1 Key Concepts
+
+- **Proposal**: A request to execute a **resource**. Proposals are voted on and executed only if predefined **conditions** are met.
+- **Resource**: An executable action within the DAO. Each resource is governed by a **condition**.
+- **Condition**: A set of rules that determine whether a proposal can be executed.
+- **Role**: Labels that assign governance power or permissions to DAO members.
+
+**Example Use Case**: A DAO wants to create a proposal to spend money from its treasury.
+
+**Rules**:
+- `SpendMoney` is a resource with a condition requiring:
+	- 50% approval from the administration board
+	- Approval from the CFO
+
+**Outcome**:
+- Any user can propose to spend money
+- Only board and CFO votes are considered
+- The proposal executes only if the condition is satisfied
+
+# 3. Architecture
+
+DAOkit framework is composed of three packages:
+
+## 3.1 [daocond](/p/samcrew/daocond)
+
+`daocond` provides a stateless condition engine used to evaluate if a proposal should be executed.
+
+### 3.1.1 Interface
+```go
+type Condition interface {
+	// Eval checks if the condition is satisfied based on current votes.
+	Eval(ballot Ballot) bool
+	// Signal returns a value from 0.0 to 1.0 to indicate how close the condition is to being met.
+	Signal(ballot Ballot) float64
+
+	// Render returns a static human-readable representation of the condition.
+	Render() string
+	// RenderWithVotes returns a dynamic representation with vote context included.
+	RenderWithVotes(ballot Ballot) string
+}
+
+type Ballot interface {
+	// Vote allows a user to vote on a proposal.
+	Vote(voter string, vote Vote)
+	// Get returns the vote of a user.
+	Get(voter string) Vote
+	// Total returns the total number of votes.
+	Total() int
+	// Iterate iterates over all votes, similar as avl.Tree.Iterate.
+	Iterate(fn func(voter string, vote Vote) bool)
+}
+```
+
+### 3.1.2 Built-in Conditions
+`daocond` provides several built-in conditions to cover common governance scenarios.
+
+```go
+// MembersThreshold requires that a specified fraction of all DAO members approve the proposal.
+func MembersThreshold(threshold float64, isMemberFn func(memberId string) bool, membersCountFn func() uint64) Condition
+
+// RoleThreshold requires that a certain percentage of members holding a specific role approve.
+func RoleThreshold(threshold float64, role string, hasRoleFn func(memberId string, role string) bool, usersRoleCountFn func(role string) uint32) Condition
+
+// RoleCount requires a fixed minimum number of members holding a specific role to approve.
+func RoleCount(count uint64, role string, hasRoleFn func(memberId string, role string) bool) Condition
+```
+
+### 3.1.3 Logical Composition
+You can combine multiple conditions to create complex governance rules using logical operators:
+
+```go
+// And returns a condition that is satisfied only if *all* provided conditions are met.
+func And(conditions ...Condition) Condition
+// Or returns a condition that is satisfied if *any* one of the provided conditions is met.
+func Or(conditions ...Condition) Condition
+```
+
+**Example**:
+```go
+// Require both admin approval and at least one CFO
+cond := daocond.And(
+    daocond.RoleThreshold(0.5, "admin", hasRole, roleCount),
+    daocond.RoleCount(1, "CFO", hasRole),
+)
+```
+
+Conditions are stateless for flexibility and scalability.
+
+## 3.2 daokit
+
+`daokit` provides the core mechanics:
+
+### 3.2.1 Core Structure:
+It's the central component of a DAO, responsible for managing both available resources that can be executed and the proposals.
+```go
+type Core struct {
+	Resources *ResourcesStore
+	Proposals *ProposalsStore
+}
+```
+
+### 3.2.2 DAO Interface:
+The interface defines the external functions that users or other modules interact with. It abstracts the core governance flow: proposing, voting, and executing.
+```go
+type DAO interface {
+	Propose(req ProposalRequest) uint64
+	Vote(id uint64, vote daocond.Vote)
+	Execute(id uint64)
+}
+```
+> 📖 [Code Example of a Basic DAO](#4-code-example-of-a-basic-dao)
+
+### 3.2.3 Proposal Lifecycle
+
+Each proposal goes through the following states:
+
+1. **Open**: 
+- Initial state after proposal creation.
+- Accepts votes from eligible participants.
+
+2. **Passed**
+- Proposal has gathered enough valid votes to meet the condition.
+- Voting is **closed** and cannot be modified.
+- The proposal is now eligible for **execution**.
+
+3. **Executed**
+- Proposal action has been successfully carried out.
+- Final state — proposal can no longer be voted on or modified.
+
+
+## 3.3 [basedao](/p/samcrew/basedao)
+
+`basedao` extends `daokit` to handle members and roles management.
+It handles who can participate in a DAO and what permissions they have.
+
+### 3.3.1 Core Types
+```go
+type MembersStore struct {
+	Roles   *avl.Tree 
+	Members *avl.Tree 
+}
+```
+
+### 3.3.2 Initialize the DAO
+Create a `MembersStore` structure to initialize the DAO with predefined roles and members.
+
+```go
+roles := []basedao.RoleInfo{
+	{Name: "admin", Description: "Administrators"},
+	{Name: "finance", Description: "Handles treasury"},
+}
+
+members := []basedao.Member{
+	{Address: "g1abc...", Roles: []string{"admin"}},
+	{Address: "g1xyz...", Roles: []string{"finance"}},
+}
+
+store := basedao.NewMembersStore(roles, members)
+```
+
+### 3.3.3 Example Usage
+```go
+store := basedao.NewMembersStore(nil, nil)
+
+// Add a role and assign it
+store.AddRole(basedao.RoleInfo{Name: "moderator", Description: "Can moderate posts"})
+store.AddMember("g1alice...", []string{"moderator"})
+
+// Update role assignment
+store.AddRoleToMember("g1alice...", "editor")
+store.RemoveRoleFromMember("g1alice...", "moderator")
+
+// Inspect the state
+isMember := store.IsMember("g1alice...") // "Is Alice a member?"
+hasRole := store.HasRole("g1alice...", "editor") // "Is Alice an editor?"
+members := store.GetMembersJSON() // "All Members (JSON):"
+```
+
+### 3.3.4 Creating a DAO:
+
+```go
+func New(conf *Config) (daokit.DAO, *DAOPrivate)
+```
+
+#### 3.3.4.1 Key Structures:
+- `DAOPrivate`: Full access to internal DAO state
+- `daokit.DAO`: External interface for DAO interaction
+
+
+### 3.3.5 Configuration:
+```go
+type Config struct {
+	Name              string
+	Description       string
+	ImageURI          string
+	// Use `basedao.NewMembersStore(...)` to create members and roles.
+	Members           *MembersStore
+	// Set to `true` to disable built-in actions like add/remove member.
+	NoDefaultHandlers bool
+	// Default rule applied to all built-in DAO actions.
+	InitialCondition  daocond.Condition
+	// Optional helpers to store profile data (e.g., from `/r/demo/profile`).
+	SetProfileString  ProfileStringSetter
+	GetProfileString  ProfileStringGetter
+	// Set to `true` if you don’t want a "DAO Created" event to be emitted.
+	NoCreationEvent   bool
+}
+```
+
+# 4. Code Example of a Basic DAO
+
+```go
+package daokit_demo
+
+import (
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/demo/profile"
+)
+
+var (
+	DAO        daokit.DAO // External interface for DAO interaction
+	daoPrivate *basedao.DAOPrivate // Full access to internal DAO state
+)
+
+func init() {
+	initialRoles := []basedao.RoleInfo{
+		{Name: "admin", Description: "Admin is the superuser"},
+		{Name: "public-relationships", Description: "Responsible of communication with the public"},
+		{Name: "finance-officer", Description: "Responsible of funds management"},
+	}
+
+	initialMembers := []basedao.Member{
+		{Address: "g126...zlg", Roles: []string{"admin", "public-relationships"}},
+		{Address: "g1ld6...3jv", Roles: []string{"public-relationships"}},
+		{Address: "g1r69...0tth", Roles: []string{"finance-officer"}},
+		{Address: "g16jv...6e0r", Roles: []string{}},
+	}
+
+	memberStore := basedao.NewMembersStore(initialRoles, initialMembers)
+
+	membersMajority := daocond.MembersThreshold(0.6, memberStore.IsMember, memberStore.MembersCount)
+	publicRelationships := daocond.RoleCount(1, "public-relationships", memberStore.HasRole)
+	financeOfficer := daocond.RoleCount(1, "finance-officer", memberStore.HasRole)
+
+	// `and` and `or` use va_args so you can pass as many conditions as needed
+	adminCond := daocond.And(membersMajority, publicRelationships, financeOfficer)
+
+	DAO, daoPrivate = basedao.New(&basedao.Config{
+		Name:             "Demo DAOKIT DAO",
+		Description:      "This is a demo DAO built with DAOKIT",
+		Members:          memberStore,
+		InitialCondition: adminCond,
+		GetProfileString: profile.GetStringField,
+		SetProfileString: profile.SetStringField,
+	})
+}
+
+func Vote(proposalID uint64, vote daocond.Vote) {
+	DAO.Vote(proposalID, vote)
+}
+
+func Execute(proposalID uint64) {
+	DAO.Execute(proposalID)
+}
+
+func Render(path string) string {
+	return daoPrivate.Render(path)
+}
+```
+
+# 5. Create Custom Resources
+
+To add new behavior to your DAO — or to enable others to integrate your package into their own DAOs — define custom resources by implementing:
+
+```go
+type Action interface {
+	Type() string // return the type of the action. e.g.: "gno.land/p/samcrew/blog.NewPost"
+	String() string // return stringify content of the action
+}
+
+type ActionHandler interface {
+	Type() string // return the type of the action. e.g.: "gno.land/p/samcrew/blog"
+	Execute(action Action) // executes logic associated with the action
+}
+```
+This allows DAOs to execute arbitrary logic or interact with Gno packages through governance-approved decisions.
+
+## Steps to Add a Custom Resource:
+1. Define the path of the action, it should be unique 
+```go
+// XXX: pkg "/p/samcrew/blog" - does not exist, it's just an example
+const ActionNewPostKind = "gno.land/p/samcrew/blog.NewPost"
+```
+
+2. Create the structure type of the payload
+```go
+type ActionNewPost struct {
+	Title string
+	Content string
+}
+```
+
+3. Implement the action and handler
+```go
+func NewPostAction(title, content string) daokit.Action {
+	// def: daoKit.NewAction(kind: String, payload: interface{})
+	return daokit.NewAction(ActionNewPostKind, &ActionNewPost{
+		Title:   title,
+		Content: content,
+	})
+}
+
+func NewPostHandler(blog *Blog) daokit.ActionHandler {
+	// def: daoKit.NewActionHandler(kind: String, payload: func(interface{}))
+	return daokit.NewActionHandler(ActionNewPostKind, func(payload interface{}) {
+		action, ok := payload.(*ActionNewPost)
+		if !ok {
+			panic(errors.New("invalid action type"))
+		}
+		blog.NewPost(action.Title, action.Content)
+	})
+}
+```
+
+4. Register the resource
+```go
+resource := daokit.Resource{
+    Condition: daocond.NewRoleCount(1, "CEO", daoPrivate.Members.HasRole),
+    Handler: blog.NewPostHandler(blog),
+}
+daoPrivate.Core.Resources.Set(&resource)
+```

--- a/examples/gno.land/p/samcrew/daokit/actions.gno
+++ b/examples/gno.land/p/samcrew/daokit/actions.gno
@@ -1,0 +1,112 @@
+package daokit
+
+import (
+	"errors"
+
+	"gno.land/p/demo/ufmt"
+	"gno.land/p/moul/md"
+)
+
+type Action interface {
+	String() string
+	Type() string
+}
+
+type ActionHandler interface {
+	Execute(action Action)
+	Type() string
+}
+
+func NewAction(kind string, payload interface{}) Action {
+	return &genericAction{kind: kind, payload: payload}
+}
+
+type genericAction struct {
+	kind    string
+	payload interface{}
+}
+
+// String implements Action.
+func (g *genericAction) String() string {
+	return ufmt.Sprintf("%v", g.payload)
+}
+
+// Type implements Action.
+func (g *genericAction) Type() string {
+	return g.kind
+}
+
+func NewActionHandler(kind string, executor func(interface{})) ActionHandler {
+	return &genericActionHandler{kind: kind, executor: executor}
+}
+
+type genericActionHandler struct {
+	kind     string
+	executor func(payload interface{})
+}
+
+// Execute implements ActionHandler.
+func (g *genericActionHandler) Execute(iaction Action) {
+	action, ok := iaction.(*genericAction)
+	if !ok {
+		panic(errors.New("invalid action type"))
+	}
+	g.executor(action.payload)
+}
+
+// Instantiate implements ActionHandler.
+func (g *genericActionHandler) Instantiate() Action {
+	return &genericAction{
+		kind: g.kind,
+	}
+}
+
+// Type implements ActionHandler.
+func (g *genericActionHandler) Type() string {
+	return g.kind
+}
+
+const ActionExecuteLambdaKind = "gno.land/p/samcrew/daokit.ExecuteLambda"
+
+func NewExecuteLambdaHandler() ActionHandler {
+	return NewActionHandler(ActionExecuteLambdaKind, func(i interface{}) {
+		cb, ok := i.(func())
+		if !ok {
+			panic(errors.New("invalid action type"))
+		}
+		cb()
+	})
+}
+
+func NewExecuteLambdaAction(cb func()) Action {
+	return NewAction(ActionExecuteLambdaKind, cb)
+}
+
+const ActionInstantExecuteKind = "gno.land/p/samcrew/daokit.InstantExecute"
+
+type actionInstantExecute struct {
+	dao DAO
+	req ProposalRequest
+}
+
+func (a *actionInstantExecute) String() string {
+	// XXX: find a way to be explicit about the subdao
+	s := ""
+	s += md.Paragraph(md.Blockquote(a.req.Action.Type()))
+	s += md.Paragraph(a.req.Action.String())
+	return s
+}
+
+func NewInstantExecuteHandler() ActionHandler {
+	return NewActionHandler(ActionInstantExecuteKind, func(i interface{}) {
+		action, ok := i.(*actionInstantExecute)
+		if !ok {
+			panic(errors.New("invalid action type"))
+		}
+		InstantExecute(action.dao, action.req)
+	})
+}
+
+func NewInstantExecuteAction(dao DAO, req ProposalRequest) Action {
+	return NewAction(ActionInstantExecuteKind, &actionInstantExecute{dao: dao, req: req})
+}

--- a/examples/gno.land/p/samcrew/daokit/daokit.gno
+++ b/examples/gno.land/p/samcrew/daokit/daokit.gno
@@ -1,0 +1,85 @@
+package daokit
+
+import (
+	"time"
+
+	"gno.land/p/samcrew/daocond"
+)
+
+type DAO interface {
+	Propose(req ProposalRequest) uint64
+	Execute(id uint64)
+	Vote(id uint64, vote daocond.Vote)
+}
+
+func InstantExecute(d DAO, req ProposalRequest) uint64 {
+	id := d.Propose(req)
+	d.Vote(id, daocond.VoteYes)
+	d.Execute(id)
+	return id
+}
+
+type Core struct {
+	Resources *ResourcesStore
+	Proposals *ProposalsStore
+}
+
+func NewCore() *Core {
+	return &Core{
+		Resources: NewResourcesStore(),
+		Proposals: NewProposalsStore(),
+	}
+}
+
+func (d *Core) Vote(voterID string, proposalID uint64, vote daocond.Vote) {
+	proposal := d.Proposals.GetProposal(proposalID)
+	if proposal == nil {
+		panic("proposal not found")
+	}
+
+	if proposal.Status != ProposalStatusOpen {
+		panic("proposal is not open")
+	}
+
+	proposal.Ballot.Vote(voterID, daocond.Vote(vote))
+}
+
+func (d *Core) Execute(proposalID uint64) {
+	proposal := d.Proposals.GetProposal(proposalID)
+	if proposal == nil {
+		panic("proposal not found")
+	}
+
+	if proposal.Status != ProposalStatusOpen {
+		panic("proposal is not open")
+	}
+
+	if !proposal.Condition.Eval(proposal.Ballot) {
+		panic("proposal condition is not met")
+	}
+
+	proposal.UpdateStatus()
+	if proposal.Status != ProposalStatusPassed {
+		panic("proposal does not meet the condition(s) or is already closed/executed")
+	}
+
+	d.Resources.Get(proposal.Action.Type()).Handler.Execute(proposal.Action)
+	proposal.Status = ProposalStatusExecuted
+	proposal.ExecutedAt = time.Now()
+}
+
+func (d *Core) Propose(proposerID string, req ProposalRequest) uint64 {
+	actionType := req.Action.Type()
+
+	resource := d.Resources.Get(actionType)
+	if resource == nil {
+		panic("action type is not registered as a resource")
+	}
+
+	prop := d.Proposals.newProposal(proposerID, req, resource.Condition)
+	return uint64(prop.ID)
+}
+
+func (d *Core) ResourcesCount() int {
+	return d.Resources.Tree.Size()
+}

--- a/examples/gno.land/p/samcrew/daokit/daokit_test.gno
+++ b/examples/gno.land/p/samcrew/daokit/daokit_test.gno
@@ -1,0 +1,24 @@
+package daokit
+
+import (
+	"testing"
+
+	"gno.land/p/demo/testutils"
+)
+
+var (
+	alice = testutils.TestAddress("alice")
+	bob   = testutils.TestAddress("bob")
+	carol = testutils.TestAddress("carol")
+	dave  = testutils.TestAddress("dave")
+)
+
+func TestNewDAO(t *testing.T) {
+	testing.SetOriginCaller(alice)
+	dao := NewCore()
+
+	resourcesLen := dao.Resources.Tree.Size()
+	if resourcesLen != 0 { // There is 0 default resources
+		t.Errorf("Expected 0 resources, got %d", resourcesLen)
+	}
+}

--- a/examples/gno.land/p/samcrew/daokit/gnomod.toml
+++ b/examples/gno.land/p/samcrew/daokit/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/samcrew/daokit"
+gno = "0.9"
+
+[addpkg]
+creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/daokit/gnomod.toml
+++ b/examples/gno.land/p/samcrew/daokit/gnomod.toml
@@ -2,4 +2,4 @@ module = "gno.land/p/samcrew/daokit"
 gno = "0.9"
 
 [addpkg]
-creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"
+  creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/p/samcrew/daokit/proposals.gno
+++ b/examples/gno.land/p/samcrew/daokit/proposals.gno
@@ -1,0 +1,126 @@
+package daokit
+
+import (
+	"errors"
+	"std"
+	"time"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/json"
+	"gno.land/p/demo/seqid"
+	"gno.land/p/samcrew/daocond"
+)
+
+type ProposalStatus int
+
+const (
+	ProposalStatusOpen ProposalStatus = iota
+	ProposalStatusPassed
+	ProposalStatusExecuted
+)
+
+func (s ProposalStatus) String() string {
+	switch s {
+	case ProposalStatusOpen:
+		return "Open"
+	case ProposalStatusPassed:
+		return "Passed"
+	case ProposalStatusExecuted:
+		return "Executed"
+	default:
+		return "Unknown"
+	}
+}
+
+type Proposal struct {
+	ID            seqid.ID
+	Title         string
+	Description   string
+	CreatedAt     time.Time
+	CreatedHeight int64
+	ProposerID    string
+	Condition     daocond.Condition
+	Action        Action
+	Status        ProposalStatus
+	ExecutorID    string
+	ExecutedAt    time.Time
+	Ballot        daocond.Ballot
+}
+
+type ProposalsStore struct {
+	Tree  *avl.Tree // int -> Proposal
+	genID seqid.ID
+}
+
+type ProposalRequest struct {
+	Title       string
+	Description string
+	Action      Action
+}
+
+func NewProposalsStore() *ProposalsStore {
+	return &ProposalsStore{
+		Tree: avl.NewTree(),
+	}
+}
+
+func (p *ProposalsStore) newProposal(proposer string, req ProposalRequest, condition daocond.Condition) *Proposal {
+	id := p.genID.Next()
+	proposal := &Proposal{
+		ID:            id,
+		Title:         req.Title,
+		Description:   req.Description,
+		ProposerID:    proposer,
+		Status:        ProposalStatusOpen,
+		Action:        req.Action,
+		Condition:     condition,
+		Ballot:        daocond.NewBallot(),
+		CreatedAt:     time.Now(),
+		CreatedHeight: std.ChainHeight(),
+	}
+	p.Tree.Set(id.String(), proposal)
+	return proposal
+}
+
+func (p *ProposalsStore) GetProposal(id uint64) *Proposal {
+	value, ok := p.Tree.Get(seqid.ID(id).String())
+	if !ok {
+		return nil
+	}
+	proposal := value.(*Proposal)
+	return proposal
+}
+
+func (p *Proposal) UpdateStatus() {
+	conditionsAreMet := p.Condition.Eval(p.Ballot)
+	if p.Status == ProposalStatusOpen && conditionsAreMet {
+		p.Status = ProposalStatusPassed
+	}
+}
+
+func (p *ProposalsStore) GetProposalsJSON() string {
+	props := make([]*json.Node, 0, p.Tree.Size())
+	// XXX: pagination
+	p.Tree.Iterate("", "", func(key string, value interface{}) bool {
+		prop, ok := value.(*Proposal)
+		if !ok {
+			panic(errors.New("unexpected invalid proposal type"))
+		}
+		prop.UpdateStatus()
+		props = append(props, json.ObjectNode("", map[string]*json.Node{
+			"id":          json.NumberNode("", float64(prop.ID)),
+			"title":       json.StringNode("", prop.Title),
+			"description": json.StringNode("", prop.Description),
+			"proposer":    json.StringNode("", prop.ProposerID),
+			"status":      json.StringNode("", prop.Status.String()),
+			"startHeight": json.NumberNode("", float64(prop.CreatedHeight)),
+			"signal":      json.NumberNode("", prop.Condition.Signal(prop.Ballot)),
+		}))
+		return false
+	})
+	bz, err := json.Marshal(json.ArrayNode("", props))
+	if err != nil {
+		panic(err)
+	}
+	return string(bz)
+}

--- a/examples/gno.land/p/samcrew/daokit/resources.gno
+++ b/examples/gno.land/p/samcrew/daokit/resources.gno
@@ -1,0 +1,37 @@
+package daokit
+
+import (
+	"gno.land/p/demo/avl"
+	"gno.land/p/samcrew/daocond"
+)
+
+type ResourcesStore struct {
+	Tree *avl.Tree // string -> daocond.Condition
+}
+
+// XXX: should condition be a pointer?
+type Resource struct {
+	Handler     ActionHandler
+	Condition   daocond.Condition
+	DisplayName string
+	Description string
+}
+
+func NewResourcesStore() *ResourcesStore {
+	return &ResourcesStore{
+		Tree: avl.NewTree(),
+	}
+}
+
+func (r *ResourcesStore) Set(resource *Resource) {
+	r.Tree.Set(resource.Handler.Type(), resource)
+}
+
+func (r *ResourcesStore) Get(name string) *Resource {
+	value, ok := r.Tree.Get(name)
+	if !ok {
+		return nil
+	}
+	res := value.(*Resource)
+	return res
+}

--- a/examples/gno.land/r/samcrew/daodemo/daodemo.gno
+++ b/examples/gno.land/r/samcrew/daodemo/daodemo.gno
@@ -1,0 +1,64 @@
+package daodemo
+
+// This is the most basic example of a DAO using DAOKIT.
+// It is a simple DAO that has a single admin role and a single public-relationships role.
+// It is used to demonstrate the basic functionality of DAOKIT.
+
+import (
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/demo/profile"
+)
+
+var (
+	DAO        daokit.DAO
+	daoPrivate *basedao.DAOPrivate
+)
+
+// TODO: add a little bit more complexity to show daocond initialization
+func init() {
+	initialRoles := []basedao.RoleInfo{
+		{Name: "admin", Description: "Admin is the superuser"},
+		{Name: "public-relationships", Description: "Responsible of communication with the public"},
+		{Name: "finance-officer", Description: "Responsible of funds management"},
+	}
+
+	initialMembers := []basedao.Member{
+		{Address: "g126gx6p6d3da4ymef35ury6874j6kys044r7zlg", Roles: []string{"admin", "public-relationships"}},
+		{Address: "g1ld6uaykyugld4rnm63rcy7vju4zx23lufml3jv", Roles: []string{"public-relationships"}},
+		{Address: "g1r69l0vhp7tqle3a0rk8m8fulr8sjvj4h7n0tth", Roles: []string{"finance-officer"}},
+		{Address: "g16jv3rpz7mkt0gqulxas56se2js7v5vmc6n6e0r", Roles: []string{}},
+	}
+
+	// create the member store now to be able to use it in the condition
+	memberStore := basedao.NewMembersStore(initialRoles, initialMembers)
+
+	membersMajority := daocond.MembersThreshold(0.6, memberStore.IsMember, memberStore.MembersCount)
+	publicRelationships := daocond.RoleCount(1, "public-relationships", memberStore.HasRole)
+	financeOfficer := daocond.RoleCount(1, "finance-officer", memberStore.HasRole)
+
+	// and & or use va_args so you can pass as many conditions as you want
+	adminCond := daocond.And(membersMajority, publicRelationships, financeOfficer)
+
+	DAO, daoPrivate = basedao.New(&basedao.Config{
+		Name:             "Demo DAOKIT DAO",
+		Description:      "This is a demo DAO built with [DAOKIT](/p/samcrew/daokit)",
+		Members:          memberStore,
+		InitialCondition: adminCond,
+		GetProfileString: profile.GetStringField,
+		SetProfileString: profile.SetStringField,
+	})
+}
+
+func Vote(proposalID uint64, vote daocond.Vote) {
+	DAO.Vote(proposalID, vote)
+}
+
+func Execute(proposalID uint64) {
+	DAO.Execute(proposalID)
+}
+
+func Render(path string) string {
+	return daoPrivate.Render(path)
+}

--- a/examples/gno.land/r/samcrew/daodemo/daodemo_test.gno
+++ b/examples/gno.land/r/samcrew/daodemo/daodemo_test.gno
@@ -1,0 +1,28 @@
+package daodemo
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	membersCount := daoPrivate.Members.MembersCount()
+	if membersCount != 4 {
+		t.Fatalf("Expected 4 members, got %d", membersCount)
+	}
+
+	roles := daoPrivate.Members.GetRoles()
+	expectedRoles := []string{"admin", "public-relationships", "finance-officer"}
+	if len(roles) != len(expectedRoles) {
+		t.Fatalf("Expected %d roles, got %d", len(expectedRoles), len(roles))
+	}
+	for _, role := range roles {
+		err := true
+		for _, expectedRole := range expectedRoles {
+			if role == expectedRole {
+				err = false
+				break
+			}
+		}
+		if err {
+			t.Fatalf("Expected roles %v, got %v", expectedRoles, roles)
+		}
+	}
+}

--- a/examples/gno.land/r/samcrew/daodemo/gnomod.toml
+++ b/examples/gno.land/r/samcrew/daodemo/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/r/samcrew/daodemo"
+gno = "0.9"
+
+[addpkg]
+creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/examples/gno.land/r/samcrew/daodemo/gnomod.toml
+++ b/examples/gno.land/r/samcrew/daodemo/gnomod.toml
@@ -2,4 +2,4 @@ module = "gno.land/r/samcrew/daodemo"
 gno = "0.9"
 
 [addpkg]
-creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"
+  creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"


### PR DESCRIPTION
Adds the samourai daokit in examples, there is a [documentation `README.md`](https://github.com/gnolang/gno/blob/7704a12bd09c53cd9cd77b4ad8a881fa4d77294b/examples/gno.land/p/samcrew/daokit/README.md) in `/p/samcrew/daokit`

tl;dr:
- `/p/samcrew/daocond`: conditions system to go beyond threshold voting systems in daos
- `/p/samcrew/daokit`: dao core responsible to tie conditions, resources and proposals together
- `/p/samcrew/basedao`: daokit extension that adds the concept of members and roles on top of daokit
- `/r/samcrew/daodemo`: demo dao realm using basedao

daokit has already been used in [production for zenao during the hyperhacktive film festival event](https://zenao.io/event/15)