### PR TITLE
fix(tm2): potential nil `stores` map

### DIFF
--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -217,6 +217,7 @@ func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.M
 		storeOpts:    ms.storeOpts,
 		storesParams: ms.storesParams,
 		keysByName:   ms.keysByName,
+		stores:       make(map[types.StoreKey]types.CommitStore),
 	}
 	ims.storeOpts.Immutable = true
 	err := ims.LoadVersion(version)

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -101,6 +101,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 	if ver == 0 {
 		// Special logic for version 0 where there is no need to get commit
 		// information.
+		newStores := make(map[types.StoreKey]types.CommitStore)
 		for key, storeParams := range ms.storesParams {
 			store, err := ms.constructStore(storeParams)
 			if err != nil {
@@ -116,6 +117,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 			}
 			ms.stores[key] = store
 		}
+		ms.stores = newStores
 		ms.lastCommitID = types.CommitID{}
 		return nil
 	}
@@ -217,7 +219,6 @@ func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.M
 		storeOpts:    ms.storeOpts,
 		storesParams: ms.storesParams,
 		keysByName:   ms.keysByName,
-		stores:       make(map[types.StoreKey]types.CommitStore),
 	}
 	ims.storeOpts.Immutable = true
 	err := ims.LoadVersion(version)

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -115,7 +115,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 			if !store.LastCommitID().IsZero() {
 				return errors.New("failed to load Store: non-empty CommitID for zero state")
 			}
-			ms.stores[key] = store
+			newStores[key] = store
 		}
 		ms.stores = newStores
 		ms.lastCommitID = types.CommitID{}


### PR DESCRIPTION
Fix a potential `nil` map in `tm2` store 

Given the nature of the issue, its location, and the fact that no one has touched this part since 2021, I find it strange that we are only encountering the issue now. cc @zivkovicmilos 


### stack trace

 _provided for free by @mazzy89 ™_

#### node trace:
```
test7-gnodevx-gnoland-devx-sen-2-0 gnoland 2025-08-05T15:04:46.962Z     ERROR   Panic in RPC HTTP handler
....
goroutine 161612 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.StartHTTPServer.RecoverAndLogHandler.func1.1()
    /gnoroot/tm2/pkg/bft/rpc/lib/server/http_server.go:158 +0x53a
panic({0x105ba60?, 0x1499540?})
    /usr/local/go/src/runtime/panic.go:791 +0x132
github.com/gnolang/gno/tm2/pkg/store/rootmulti.(*multiStore).LoadVersion(0xc00130e258, 0x300000002?)
    /gnoroot/tm2/pkg/store/rootmulti/store.go:117 +0xc69
github.com/gnolang/gno/tm2/pkg/store/rootmulti.(*multiStore).MultiImmutableCacheWrapWithVersion(0xc00033f200, 0x0)
    /gnoroot/tm2/pkg/store/rootmulti/store.go:222 +0x10d
github.com/gnolang/gno/tm2/pkg/sdk.handleQueryCustom(0xc000512000, {0xc042d07960, 0xc00130e8a0?, _}, {{}, {0xc00d765d28, 0x18, 0x18}, {0xc044d0e706, 0xa}, ...})
    /gnoroot/tm2/pkg/sdk/baseapp.go:497 +0x18d
github.com/gnolang/gno/tm2/pkg/sdk.(*BaseApp).Query(0xc000512000, {{}, {0xc00d765d28, 0x18, 0x18}, {0xc044d0e706, 0xa}, 0x0, 0x0})
    /gnoroot/tm2/pkg/sdk/baseapp.go:406 +0x2a8
github.com/gnolang/gno/tm2/pkg/bft/abci/client.(*localClient).QuerySync(0xc016400c00?, {{}, {0xc00d765d28, 0x18, 0x18}, {0xc044d0e706, 0xa}, 0x0, 0x0})
    /gnoroot/tm2/pkg/bft/abci/client/local_client.go:180 +0x14b
github.com/gnolang/gno/tm2/pkg/bft/appconn.(*query).QuerySync(0x4929b7?, {{}, {0xc00d765d28, 0x18, 0x18}, {0xc044d0e706, 0xa}, 0x0, 0x0})
    /gnoroot/tm2/pkg/bft/appconn/app_conn.go:144 +0xdc
github.com/gnolang/gno/tm2/pkg/bft/rpc/core.ABCIQuery(0xc045fb40c0?, {0xc044d0e706, 0xa}, {0xc00d765d28, 0x18, 0x18}, 0x0?, 0x53?)
    /gnoroot/tm2/pkg/bft/rpc/core/abci.go:59 +0x132
reflect.Value.call({0x10810a0?, 0x1344f20?, 0x11bf600?}, {0x11c5c81, 0x4}, {0xc0456c9400, 0x5, 0x5?})
    /usr/local/go/src/reflect/value.go:584 +0xca6
reflect.Value.Call({0x10810a0?, 0x1344f20?, 0x5a?}, {0xc0456c9400?, 0x11bf600?, 0x10?})
    /usr/local/go/src/reflect/value.go:368 +0xb9
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.processRequest(0xc04583c3c0, {{0xc044d0e6b0, 0x3}, {0x14a1d00, 0xc045185030}, {0xc044d0e6b4, 0xa}, {0xc04648a480, 0x5a, 0x60}}, ...)
    /gnoroot/tm2/pkg/bft/rpc/lib/server/handlers.go:208 +0x411
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.RegisterRPCFuncs.makeJSONRPCHandler.func9({0x14aa2c0, 0xc0171e2750}, 0xc04583c3c0)
    /gnoroot/tm2/pkg/bft/rpc/lib/server/handlers.go:162 +0x475
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.RegisterRPCFuncs.handleInvalidJSONRPCPaths.func10({0x14aa2c0?, 0xc0171e2750?}, 0xc00130f908?)
    /gnoroot/tm2/pkg/bft/rpc/lib/server/handlers.go:232 +0x42
net/http.HandlerFunc.ServeHTTP(0xc0448562a0?, {0x14aa2c0?, 0xc0171e2750?}, 0x41072a?)
    /usr/local/go/src/net/http/server.go:2220 +0x29
net/http.(*ServeMux).ServeHTTP(0xc044b164e0?, {0x14aa2c0, 0xc0171e2750}, 0xc04583c3c0)
    /usr/local/go/src/net/http/server.go:2747 +0x1ca
github.com/gnolang/gno/tm2/pkg/bft/node.(*Node).startRPC.(*Cors).Handler.func6({0x14aa2c0, 0xc0171e2750}, 0xc04583c3c0)
    /root/.cache/go-build/github.com/rs/cors@v1.11.1/cors.go:289 +0x184
net/http.HandlerFunc.ServeHTTP(0x0?, {0x14aa2c0?, 0xc0171e2750?}, 0xc00130fa18?)
    /usr/local/go/src/net/http/server.go:2220 +0x29
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.maxBytesHandler.ServeHTTP({{0x149fce0?, 0xc044ab1b00?}, 0xd?}, {0x14aa2c0, 0xc0171e2750}, 0xc04583c3c0)
    /gnoroot/tm2/pkg/bft/rpc/lib/server/http_server.go:212 +0xfb
github.com/gnolang/gno/tm2/pkg/bft/rpc/lib/server.StartHTTPServer.RecoverAndLogHandler.func1({0x14aa1a0, 0xc044bbec40}, 0xc04583c3c0)
    /gnoroot/tm2/pkg/bft/rpc/lib/server/http_server.go:185 +0x1d4
net/http.HandlerFunc.ServeHTTP(0x410a45?, {0x14aa1a0?, 0xc044bbec40?}, 0xc044bbec01?)
    /usr/local/go/src/net/http/server.go:2220 +0x29
net/http.serverHandler.ServeHTTP({0x14a6838?}, {0x14aa1a0?, 0xc044bbec40?}, 0x6?)
    /usr/local/go/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc03b09e2d0, {0x14abf58, 0xc044b15a40})
    /usr/local/go/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 69
    /usr/local/go/src/net/http/server.go:3360 +0x485
```

#### gnoweb trace:
```
2025-08-05T15:04:06.290Z        ERROR   failed to render index component        {"error": "write tcp 192.168.4.9:80->192.168.4.1:38948: write: connection reset by peer"}
github.com/gnolang/gno/gno.land/pkg/gnoweb.(*HTTPHandler).Get
        /gnoroot/gno.land/pkg/gnoweb/handler_http.go:167
github.com/gnolang/gno/gno.land/pkg/gnoweb.(*HTTPHandler).ServeHTTP
        /gnoroot/gno.land/pkg/gnoweb/handler_http.go:99
github.com/gnolang/gno/gno.land/pkg/gnoweb.NewRouter.RedirectMiddleware.func4
        /gnoroot/gno.land/pkg/gnoweb/redirect.go:35
net/http.HandlerFunc.ServeHTTP
        /usr/local/go/src/net/http/server.go:2220
net/http.(*ServeMux).ServeHTTP
        /usr/local/go/src/net/http/server.go:2747
main.SecureHeadersMiddleware.func1
        /gnoroot/gno.land/cmd/gnoweb/main.go:356
net/http.HandlerFunc.ServeHTTP
        /usr/local/go/src/net/http/server.go:2220
net/http.serverHandler.ServeHTTP
        /usr/local/go/src/net/http/server.go:3210
net/http.(*conn).serve
        /usr/local/go/src/net/http/server.go:2092
```