### PR TITLE
chore: Add -skip-genesis-sig-verification to gnoland start examples

### DIFF
--- a/contribs/gnofaucet/README.md
+++ b/contribs/gnofaucet/README.md
@@ -4,7 +4,7 @@
 
 Make sure you have started gnoland
     
-    ../../gno.land/build/gnoland start -lazy
+    ../../gno.land/build/gnoland start -lazy -skip-genesis-sig-verification
 
 ## Step2:
 

--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -21,7 +21,7 @@ GOTEST_FLAGS ?= -v -p 1 -timeout=30m
 ########################################
 # Dev tools
 .PHONY: start.gnoland
-start.gnoland:; go run ./cmd/gnoland start -lazy
+start.gnoland:; go run ./cmd/gnoland start -lazy -skip-genesis-sig-verification
 
 .PHONY: start.gnoweb
 start.gnoweb:; go run ./cmd/gnoweb

--- a/gno.land/cmd/gnoland/README.md
+++ b/gno.land/cmd/gnoland/README.md
@@ -24,7 +24,7 @@ make install.gnoland
 ### Run gnoland
 
 ```bash
-gnoland start -lazy
+gnoland start -lazy -skip-genesis-sig-verification
 ```
 
 Once running, you can interact with it using:

--- a/misc/stress-test/stress-test-many-posts/README.md
+++ b/misc/stress-test/stress-test-many-posts/README.md
@@ -10,7 +10,7 @@ Start a local gno.land:
 ```
 cd gno/gno.land
 make install
-gnoland start -lazy
+gnoland start -lazy -skip-genesis-sig-verification
 ```
 
 Start gnoweb. In a separate terminal enter:
@@ -41,7 +41,7 @@ This utility adds 50 replies per transaction (as allowed by the maximum gas of 1
 * In a text editor, open `gnoland-data/config/config.toml`
 * Change `timeout_commit` to "1s"
 * Save and close the text editor.
-* Restart gno.land by entering `gnoland start -lazy`
+* Restart gno.land by entering `gnoland start -lazy -skip-genesis-sig-verification`
 * In the terminal where you started the test, restart it by entering `go run .`
 
 Now data is added 5 times faster. This can reduce adding a million replies from days to hours.


### PR DESCRIPTION
At the moment, `gnoland start -lazy` crashes, as described in issue https://github.com/gnolang/gno/issues/4476 . Until that is fixed, we update the examples to include `-skip-genesis-sig-verification` .

See also https://github.com/gnoverse/gnops/pull/32