### PR TITLE
chore(github-bot): Explicit review/triage members

### DIFF
--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -98,7 +98,7 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			),
 			Then: r.
 				If(r.Or(
-					r.ReviewByAnyUser(gh, "jefft0", "leohhhn", "n0izn0iz", "notJoon", "omarsy", "wyhaines", "x1unix").WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByAnyUser(gh, "jefft0", "leohhhn", "n0izn0iz", "notJoon", "omarsy", "x1unix").WithDesiredState(utils.ReviewStateApproved),
 					r.ReviewByTeamMembers(gh, "tech-staff", r.RequestIgnore),
 					r.Draft(),
 				)).

--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -98,7 +98,15 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			),
 			Then: r.
 				If(r.Or(
-					r.ReviewByOrgMembers(gh).WithDesiredState(utils.ReviewStateApproved),
+					// Approved by member of the review/triage team
+					r.ReviewByUser(gh, "jefft0", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "leohhhn", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "n0izn0iz", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "notJoon", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "omarsy", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "wyhaines", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					r.ReviewByUser(gh, "x1unix", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
+					// Reviewed by a core dev
 					r.ReviewByTeamMembers(gh, "tech-staff", r.RequestIgnore),
 					r.Draft(),
 				)).

--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -98,15 +98,7 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			),
 			Then: r.
 				If(r.Or(
-					// Approved by member of the review/triage team
-					r.ReviewByUser(gh, "jefft0", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "leohhhn", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "n0izn0iz", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "notJoon", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "omarsy", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "wyhaines", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					r.ReviewByUser(gh, "x1unix", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-					// Reviewed by a core dev
+					r.ReviewByAnyUser(gh, "jefft0", "leohhhn", "n0izn0iz", "notJoon", "omarsy", "wyhaines", "x1unix").WithDesiredState(utils.ReviewStateApproved),
 					r.ReviewByTeamMembers(gh, "tech-staff", r.RequestIgnore),
 					r.Draft(),
 				)).


### PR DESCRIPTION
The github-bot should remove the `review/triage-pending` label if the PR is approved by a member of the review team. But it currently removes the label if any [member of the gnolang org](https://github.com/orgs/gnolang/people?query=role%3Amember) approves. This can falsely remove the label if a "random" person from the org approves. This PR adds the requirement `ReviewByAnyUser ` and uses it to list the review team members explicitly.