### PR TITLE
fix(examples): Fix Adder realm Add function

### DIFF
--- a/examples/gno.land/r/docs/adder/adder.gno
+++ b/examples/gno.land/r/docs/adder/adder.gno
@@ -14,7 +14,7 @@ var (
 )
 
 // Add function to update the number and timestamp
-func Add(n int) {
+func Add(cur realm, n int) {
 	number += n
 	lastUpdate = time.Now()
 }

--- a/examples/gno.land/r/docs/adder/adder_test.gno
+++ b/examples/gno.land/r/docs/adder/adder_test.gno
@@ -20,10 +20,10 @@ Last Updated: Never
 	}
 
 	// Call Add with a value of 10
-	Add(10)
+	Add(cross, 10)
 
 	// Call Add again with a value of -5
-	Add(-5)
+	Add(cross, -5)
 
 	// Render after two Add calls
 	finalOutput := Render("")


### PR DESCRIPTION
### Why this PR

As a beginner on Gnoland, I first explored its usage by trying to call a function from the first realm in the `docs` folder, copying the command from GnoWeb. However, I ran into an error that caused me to lose some time.

### Description

The issue was simply that the `Add(n int)` function from the `Adder` realm wasn’t callable (even though it should be). So, as a first contribution in my Gnoland journey, I’d like to propose this fix (along with the necessary test update) to prevent future beginners from getting stuck on the same issue.

Since this is my first contribution to the project, feel free to let me know if I did anything wrong in this PR.
