### PR TITLE
ci(stale): bump operations-per-run

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          # actions/stale's cache mechanism doesn't work if you have a non-trivial
+          # amount of other caches: https://github.com/actions/stale/issues/1136
+          # so, operations-per-run is large enough to hopefully process all
+          # of the open issues/pr's in the repo.
+          operations-per-run: 300
           exempt-all-milestones: true
           stale-pr-message: "This PR is stale because it has been open 3 months with no activity. Remove stale label or comment or this will be closed in 3 months."
           close-pr-message: "This PR was closed because it has been stalled for 3 months with no activity."


### PR DESCRIPTION
This issue has been brought up by @jefft0.

See, as an example, this workflow run of the `stale` action:

https://github.com/gnolang/gno/actions/runs/16869338469/job/47781086794

There is an open issue, with a fix available, on actions/stale: https://github.com/actions/stale/issues/1136 - however, it seems that Microsoft's funding for maintaining the core `actions` repositories has been lacking at best, so the maintainers haven't managed to get to it yet.

For now, this PR bumps the operations-per-run to 10x, to hopefully be able to process all of the issues during a single run.