### PR TITLE
issue(gnovm): slices are returned unmodified by native binded functions

### DIFF
--- a/gnovm/stdlibs/generated.go
+++ b/gnovm/stdlibs/generated.go
@@ -565,6 +565,34 @@ var nativeFuncs = [...]NativeFunc{
 	},
 	{
 		"std",
+		"deleteSliceIndex",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("[]string")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("int")},
+		},
+		[]gno.FieldTypeExpr{},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  []string
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  int
+				rp1 = reflect.ValueOf(&p1).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+
+			libs_std.X_deleteSliceIndex(p0, p1)
+		},
+	},
+	{
+		"std",
 		"AssertOriginCall",
 		[]gno.FieldTypeExpr{},
 		[]gno.FieldTypeExpr{},

--- a/gnovm/stdlibs/std/map.gno
+++ b/gnovm/stdlibs/std/map.gno
@@ -1,0 +1,5 @@
+package std
+
+func DeleteSliceIndex(data []string, index int) { deleteSliceIndex(data,index) }
+
+func deleteSliceIndex(data []string, index int) // injected

--- a/gnovm/stdlibs/std/map.go
+++ b/gnovm/stdlibs/std/map.go
@@ -1,0 +1,5 @@
+package std
+
+func X_deleteSliceIndex(data []string, index int) {
+	data = append(data[:index], data[index+1:]...)
+}

--- a/gnovm/stdlibs/std/map_test.gno
+++ b/gnovm/stdlibs/std/map_test.gno
@@ -1,0 +1,15 @@
+package std
+
+import (
+	testing "testing/base"
+)
+func TestDeleteSliceIndex(t *testing.T) {
+	data := []string{"someKey","anotherKey"}
+	if len(data)!=2{
+		t.Errorf("unexpected number of arguments on slice expected %d got %d",2, len(data))
+	}
+	DeleteSliceIndex(data,0)
+	if len(data)!=1{
+		t.Errorf("unexpected number of arguments on slice expected %d got %d",1, len(data))
+	}
+}


### PR DESCRIPTION
This is just a test PR to illustrate issue #4628 