### PR TITLE
fix(tx-archive): correctly wrap error in rpc client

### DIFF
--- a/contribs/tx-archive/backup/client/rpc/rpc.go
+++ b/contribs/tx-archive/backup/client/rpc/rpc.go
@@ -110,7 +110,7 @@ func (c *Client) GetBlocks(ctx context.Context, from, to uint64) ([]*client.Bloc
 			for _, encodedTx := range blockRes.Block.Data.Txs {
 				var tx std.Tx
 
-				if unmarshalErr := amino.Unmarshal(encodedTx, &tx); unmarshalErr != nil {
+				if err := amino.Unmarshal(encodedTx, &tx); err != nil {
 					return nil, fmt.Errorf(
 						"unable to unmarshal amino tx, %w",
 						err,


### PR DESCRIPTION
This came up today, because tx-archive running on portal loop is not actually able to print the error message happening in this case:

	portalloopd  | time=2025-08-11T16:19:18.612Z level=INFO msg="Backup txs"
	portalloopd  | time=2025-08-11T16:19:18.932Z level=INFO msg="Unsetting read only mode"
	portalloopd  | unable to run loop: unable to execute backup, unable to fetch blocks, unable to unmarshal amino tx, %!w(<nil>)