### PR TITLE
fix(examples): unreachable return in r/sys/users

### DIFF
--- a/examples/gno.land/r/sys/users/store.gno
+++ b/examples/gno.land/r/sys/users/store.gno
@@ -111,7 +111,6 @@ func (u *UserData) UpdateName(newName string) error {
 
 	// Validate caller
 	if !controllers.Has(std.CurrentRealm().Address()) {
-		panic(NewErrNotWhitelisted())
 		return NewErrNotWhitelisted()
 	}
 


### PR DESCRIPTION
There is a `panic` followed by a `return err` in the same branch, we could also change the func to panic-style but we shouldn't keep both.
Caught this thanks to gnopls :)