### PR TITLE
fix(fmt): handle nil keys in maps to avoid GnoVM crash during Printf

### DIFF
--- a/gnovm/tests/files/map38.gno
+++ b/gnovm/tests/files/map38.gno
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	mp := map[any]int{nil: 1, 1: 1}
+	fmt.Printf("%v", mp)
+}
+
+// Output:
+// map[<nil>:1 1:1]

--- a/gnovm/tests/stdlibs/fmt/print.go
+++ b/gnovm/tests/stdlibs/fmt/print.go
@@ -179,7 +179,7 @@ func (m mapKV) Less(i, j int) bool {
 }
 
 func compareKeys(ki, kj gnolang.TypedValue) bool {
-	if ki.T.Kind() != kj.T.Kind() {
+	if ki.T == nil || kj.T == nil || ki.T.Kind() != kj.T.Kind() {
 		return false
 	}
 	switch ki.T.Kind() {


### PR DESCRIPTION
closes: #4652 