### PR TITLE
feat(events): add configurable initialTimeout to subscriptions

### DIFF
--- a/tm2/pkg/events/subscribe.go
+++ b/tm2/pkg/events/subscribe.go
@@ -7,46 +7,53 @@ import (
 )
 
 // Returns a synchronous event emitter.
-func Subscribe(evsw EventSwitch, listenerID string) <-chan Event {
+// You can specify initialTimeout to set the initial timeout for waiting for the event (default is 10s).
+func Subscribe(evsw EventSwitch, listenerID string, initialTimeout ...time.Duration) <-chan Event {
 	ch := make(chan Event) // synchronous
-	return SubscribeOn(evsw, listenerID, ch)
+	return SubscribeOn(evsw, listenerID, ch, initialTimeout...)
 }
 
 // Like Subscribe, but lets the caller construct a channel.  If the capacity of
 // the provided channel is 0, it will be called synchronously; otherwise, it
 // will drop when the capacity is reached and a select doesn't immediately
 // send.
-func SubscribeOn(evsw EventSwitch, listenerID string, ch chan Event) <-chan Event {
-	return SubscribeFilteredOn(evsw, listenerID, nil, ch)
+// You can specify initialTimeout to set the initial timeout for waiting for the event (default is 10s).
+func SubscribeOn(evsw EventSwitch, listenerID string, ch chan Event, initialTimeout ...time.Duration) <-chan Event {
+	return SubscribeFilteredOn(evsw, listenerID, nil, ch, initialTimeout...)
 }
 
-func SubscribeToEvent(evsw EventSwitch, listenerID string, protoevent Event) <-chan Event {
+func SubscribeToEvent(evsw EventSwitch, listenerID string, protoevent Event, initialTimeout ...time.Duration) <-chan Event {
 	ch := make(chan Event) // synchronous
-	return SubscribeToEventOn(evsw, listenerID, protoevent, ch)
+	return SubscribeToEventOn(evsw, listenerID, protoevent, ch, initialTimeout...)
 }
 
-func SubscribeToEventOn(evsw EventSwitch, listenerID string, protoevent Event, ch chan Event) <-chan Event {
+func SubscribeToEventOn(evsw EventSwitch, listenerID string, protoevent Event, ch chan Event, initialTimeout ...time.Duration) <-chan Event {
 	rt := reflect.TypeOf(protoevent)
 	return SubscribeFilteredOn(evsw, listenerID, func(event Event) bool {
 		return reflect.TypeOf(event) == rt
-	}, ch)
+	}, ch, initialTimeout...)
 }
 
 type EventFilter func(Event) bool
 
-func SubscribeFiltered(evsw EventSwitch, listenerID string, filter EventFilter) <-chan Event {
+func SubscribeFiltered(evsw EventSwitch, listenerID string, filter EventFilter, initialTimeout ...time.Duration) <-chan Event {
 	ch := make(chan Event)
-	return SubscribeFilteredOn(evsw, listenerID, filter, ch)
+	return SubscribeFilteredOn(evsw, listenerID, filter, ch, initialTimeout...)
 }
 
-func SubscribeFilteredOn(evsw EventSwitch, listenerID string, filter EventFilter, ch chan Event) <-chan Event {
+func SubscribeFilteredOn(evsw EventSwitch, listenerID string, filter EventFilter, ch chan Event, initialTimeout ...time.Duration) <-chan Event {
 	evsw.AddListener(listenerID, func(event Event) {
 		if filter != nil && !filter(event) {
 			return // filter
 		}
+
+		timeout := 10 * time.Second
+		if len(initialTimeout) > 0 && initialTimeout[0] > 0 {
+			timeout = initialTimeout[0]
+		}
+
 		// NOTE: This callback must not block for performance.
 		if cap(ch) == 0 {
-			timeout := 10 * time.Second
 		LOOP:
 			for {
 				select { // sync


### PR DESCRIPTION
This PR introduces a new optional initialTimeout parameter to subscription functions.

By default, timeout is 10s (backward compatibility preserved).

If specified, the subscriber uses the provided timeout as the initial value.

The timeout still doubles on each warning as before.

Why:
Previously, the timeout was hardcoded to 10s, which might not be suitable for all use cases. This change allows users to configure it without modifying library code.