### PR TITLE
ci(dependabot-tidy): use pr's head rather than merge ref

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -3,9 +3,9 @@ name: Dependabot Tidy Go Mods
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - '**/go.mod'
-      - '**/go.sum'
+      - ".github/workflows/**"
+      - "**/go.mod"
+      - "**/go.sum"
 
 jobs:
   tidy_go_mods:
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
I think that the PR was failing because the `/merge` ref was being fetched instead of the `/head`; [here's the difference](https://stackoverflow.com/a/63595981).

Combined with a change to git-auto-commit's behaviour, this lead to the action failing in recent dependabot PR's: https://github.com/gnolang/gno/actions/runs/17126910679/job/48580715672?pr=4654