### PR TITLE
draft: grc000 metamodel token systems

### DIFF
--- a/examples/gno.land/p/labs/metamodel/README.md
+++ b/examples/gno.land/p/labs/metamodel/README.md
@@ -1,0 +1,87 @@
+# Metamodel Codex (v0)
+
+*A terse map of the falsifiable web of meaning.*
+
+𒆜𒋼  
+
+---
+
+## 0. Preamble
+The Logoverse is not a platform, not a chain, not a protocol.  
+It is the **substrate where logic and meaning become falsifiable**.  
+Every model is cryptographically sealed; every connection is compositional truth.  
+
+𒃲𒆕  
+
+---
+
+## 1. Cryptographic Bedrock
+- Each model is hashed into a CID.  
+- Change any part of the structure the seal breaks.  
+- Valid or void. No middle ground.  
+
+𒉿𒀀  
+
+---
+
+## 2. Petri-Net Grammar
+- **Places** hold state.  
+- **Transitions** enact change.  
+- **Arcs** bind them into flows.  
+- This is the native language of the Logoverse.  
+
+⚯  
+
+---
+
+## 3. Falsifiability as Law
+- Claims survive only if they can be disproven.  
+- A model is accepted when it fits *exactly*.  
+- Truth is a structural property, not a declaration.  
+
+⊗  
+
+---
+
+## 4. Compositional Cosmos
+- Models compose like cospans and wiring diagrams.  
+- $objects are ports—bridges between worlds.  
+- The ecosystem grows by assembly, not fiat.  
+
+⇌  
+
+---
+
+## 5. Semantic Gravity
+- Meaning clusters around structure.  
+- Loose symbols drift away.  
+- Verified forms attract, cohere, and persist.  
+
+◎  
+
+---
+
+## 6. Ecosystem of Objects
+- Wallets, tokens, ideas, events—all modeled as $objects.  
+- Each is portable, composable, falsifiable.  
+- $object links stitch the Logoverse together.  
+
+𒌋𒐊  
+
+---
+
+## 7. Append-Only Evolution
+- No deletion. No revisionist history.  
+- Growth is layering: strata of models, proofs, glyphs.  
+- The Logoverse accretes like geological time.  
+
+▤  
+
+---
+
+## 8. Resilient Substrate
+- Designed to withstand corruption.  
+- Resistant to attack through its structure, not decree.  
+- A living lattice, surviving by construction.  
+
+✶  

--- a/examples/gno.land/p/labs/metamodel/gnomod.toml
+++ b/examples/gno.land/p/labs/metamodel/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/labs/metamodel"
+gno = "0.9"

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -133,6 +133,9 @@ type Model struct {
 	RenderOpts  map[string]any        // Rendering options for the model.
 }
 
+// l1 := New(m.Objects, m.Places) //.Cid()
+// l2 :  New(l1, Arrows{})
+
 func New(inputs ...any) *Model {
 	m := &Model{
 		Places:      map[string]Place{},
@@ -475,7 +478,7 @@ func AssertValidObjectName(name string) {
 }
 
 func (model *Model) Cid() string {
-    return shaToCid(model.IdentityHash())
+	return shaToCid(model.IdentityHash())
 }
 
 func (model *Model) IdentityHash() string {

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -5,6 +5,12 @@ import (
 	"net/url"
 	"strings"
 
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+
+	"sort"
+
 	"gno.land/p/demo/ufmt"
 )
 
@@ -191,23 +197,23 @@ func New(inputs ...any) *Model {
 	return m
 }
 func (model *Model) T(val int64, object string) TokenType {
-    size := 1
-    if len(model.Objects) > 0 {
-        size = len(model.Objects)
-    }
+	size := 1
+	if len(model.Objects) > 0 {
+		size = len(model.Objects)
+	}
 
-    wt := make(TokenType, size)
-    if object != "" && len(model.Objects) > 0 {
-        for i, obj := range model.Objects {
-            if obj == object {
-                wt[i] = val
-                break
-            }
-        }
-    } else {
-        wt[0] = val // default to first object
-    }
-    return wt
+	wt := make(TokenType, size)
+	if object != "" && len(model.Objects) > 0 {
+		for i, obj := range model.Objects {
+			if obj == object {
+				wt[i] = val
+				break
+			}
+		}
+	} else {
+		wt[0] = val // default to first object
+	}
+	return wt
 }
 
 func (model *Model) Arrow(opts Arc) Arrow {
@@ -385,10 +391,10 @@ var legendStyles = `
 
 func (model *Model) LegendSvg() string {
 	var sb strings.Builder
-	rowHeight := 37 // REVIEW: can we calculate this dynamically based on content?
-	numRows := len(model.Places) + len(model.Transitions) + len(model.Arrows)
-	height := numRows * rowHeight // 60px for header and padding
-	if numRows < 10 {             // add space for low row count
+	rowHeight := 37
+	numRows := len(model.Places) + len(model.Transitions) + len(model.Arrows) + len(model.Objects) + 2 // Add rows for objects, header, and hash
+	height := numRows * rowHeight
+	if numRows < 10 {
 		height = 2*rowHeight + height
 	}
 	width := 700
@@ -398,12 +404,24 @@ func (model *Model) LegendSvg() string {
 	sb.WriteString(`<foreignObject x="10" y="10" width="680" height="` + ufmt.Sprintf("%d", height-20) + `">`)
 	sb.WriteString(`<div xmlns="http://www.w3.org/1999/xhtml">`)
 	sb.WriteString(`<table><thead><tr><th>Type</th><th>Label</th><th>Initial</th><th>Capacity</th><th>Weight</th></tr></thead><tbody>`)
+
+	// Add objects section
+	sb.WriteString(`<tr><td colspan="5"><strong>Objects:</strong></td></tr>`)
+	for i, obj := range model.Objects {
+		sb.WriteString(ufmt.Sprintf(`<tr><td colspan="5">%d: %s</td></tr>`, i, obj))
+	}
+
+	// Add places
 	for label, place := range model.Places {
 		sb.WriteString(`<tr><td>Place</td><td>` + label + `</td><td>` + place.Initial.String() + `</td><td>` + place.Capacity.String() + `</td><td>-</td></tr>`)
 	}
+
+	// Add transitions
 	for label := range model.Transitions {
 		sb.WriteString(`<tr><td>Transition</td><td>` + label + `</td><td>-</td><td>-</td><td>-</td></tr>`)
 	}
+
+	// Add arrows
 	for _, arrow := range model.Arrows {
 		arrowType := "Arc"
 		if arrow.Inhibit {
@@ -411,6 +429,10 @@ func (model *Model) LegendSvg() string {
 		}
 		sb.WriteString(`<tr><td>` + arrowType + `</td><td>` + arrow.Source + ` → ` + arrow.Target + `</td><td>-</td><td>-</td><td>` + fmtWeight(arrow.Weight) + `</td></tr>`)
 	}
+
+	// Add structural hash
+	sb.WriteString(`<tr><td colspan="5"><strong>ID:</strong> ` + model.Cid() + `</td></tr>`)
+
 	sb.WriteString(`</tbody></table></div></foreignObject>`)
 	sb.WriteString("</svg>")
 	return sb.String()
@@ -450,4 +472,101 @@ func AssertValidObjectName(name string) {
 	if !strings.HasPrefix(name, "$") {
 		panic("Invalid object name: " + name + ". Object names must start with '$'.")
 	}
+}
+
+func (model *Model) Cid() string {
+    return ShaToCid(model.IdentityHash())
+}
+
+func (model *Model) IdentityHash() string {
+	var elements []string
+
+	// Add objects in canonical order
+	sort.Strings(model.Objects)
+	for _, obj := range model.Objects {
+		elements = append(elements, hashString(obj))
+	}
+
+	// Add places in canonical order
+	placeKeys := make([]string, 0, len(model.Places))
+	for label := range model.Places {
+		placeKeys = append(placeKeys, label)
+	}
+	sort.Strings(placeKeys)
+	for _, label := range placeKeys {
+		elements = append(elements, hashString(label))
+	}
+
+	// Add transitions in canonical order
+	transitionKeys := make([]string, 0, len(model.Transitions))
+	for label := range model.Transitions {
+		transitionKeys = append(transitionKeys, label)
+	}
+	sort.Strings(transitionKeys)
+	for _, label := range transitionKeys {
+		elements = append(elements, hashString(label))
+	}
+
+	// Add arcs in canonical order
+	for _, arrow := range model.Arrows {
+		if arrow.Inhibit {
+			arcHash := hashString(arrow.Source + "-|>" + arrow.Target)
+			elements = append(elements, arcHash)
+		} else {
+			arcHash := hashString(arrow.Source + "-->" + arrow.Target)
+			elements = append(elements, arcHash)
+		}
+	}
+
+	return buildMerkleRoot(elements)
+}
+
+// hashString generates a SHA-256 hash for a string.
+func hashString(data string) string {
+	hash := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(hash[:])
+}
+
+// ShaToCid converts a hex-encoded SHA-256 digest into a CIDv1 (base32, multibase "b").
+// Layout: <0x01 version><0x55 codec=raw><0x12 mh=sha2-256><0x20 len=32><digest>
+func ShaToCid(sha string) string {
+	sha = strings.TrimSpace(sha)
+
+	// Decode hex digest (must be 32 bytes for sha2-256)
+	digest, err := hex.DecodeString(sha)
+	if err != nil || len(digest) != 32 {
+		panic("invalid sha256 digest")
+	}
+
+	// Assemble CIDv1 bytes
+	// 0x01 = version 1
+	// 0x55 = multicodec "raw"
+	// 0x12 = multihash code for sha2-256, 0x20 = digest length (32)
+	buf := make([]byte, 0, 1+1+2+32)
+	buf = append(buf, 0x01, 0x55, 0x12, 0x20)
+	buf = append(buf, digest...)
+
+	// Base32 (RFC 4648), no padding, lowercase, with multibase 'b' prefix
+	enc := base32.StdEncoding.WithPadding(base32.NoPadding)
+	return "b" + strings.ToLower(enc.EncodeToString(buf))
+}
+
+// buildMerkleRoot builds the Merkle root from a list of hashes.
+func buildMerkleRoot(hashes []string) string {
+	if len(hashes) == 0 {
+		return ""
+	}
+	for len(hashes) > 1 {
+		var newLevel []string
+		for i := 0; i < len(hashes); i += 2 {
+			if i+1 < len(hashes) {
+				combined := hashes[i] + hashes[i+1]
+				newLevel = append(newLevel, hashString(combined))
+			} else {
+				newLevel = append(newLevel, hashes[i]) // Carry forward the last hash if odd
+			}
+		}
+		hashes = newLevel
+	}
+	return hashes[0]
 }

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -475,19 +475,17 @@ func AssertValidObjectName(name string) {
 }
 
 func (model *Model) Cid() string {
-    return ShaToCid(model.IdentityHash())
+    return shaToCid(model.IdentityHash())
 }
 
 func (model *Model) IdentityHash() string {
 	var elements []string
 
-	// Add objects in canonical order
 	sort.Strings(model.Objects)
 	for _, obj := range model.Objects {
 		elements = append(elements, hashString(obj))
 	}
 
-	// Add places in canonical order
 	placeKeys := make([]string, 0, len(model.Places))
 	for label := range model.Places {
 		placeKeys = append(placeKeys, label)
@@ -497,7 +495,6 @@ func (model *Model) IdentityHash() string {
 		elements = append(elements, hashString(label))
 	}
 
-	// Add transitions in canonical order
 	transitionKeys := make([]string, 0, len(model.Transitions))
 	for label := range model.Transitions {
 		transitionKeys = append(transitionKeys, label)
@@ -507,7 +504,6 @@ func (model *Model) IdentityHash() string {
 		elements = append(elements, hashString(label))
 	}
 
-	// Add arcs in canonical order
 	for _, arrow := range model.Arrows {
 		if arrow.Inhibit {
 			arcHash := hashString(arrow.Source + "-|>" + arrow.Target)
@@ -527,9 +523,9 @@ func hashString(data string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// ShaToCid converts a hex-encoded SHA-256 digest into a CIDv1 (base32, multibase "b").
+// shaToCid converts a hex-encoded SHA-256 digest into a CIDv1 (base32, multibase "b").
 // Layout: <0x01 version><0x55 codec=raw><0x12 mh=sha2-256><0x20 len=32><digest>
-func ShaToCid(sha string) string {
+func shaToCid(sha string) string {
 	sha = strings.TrimSpace(sha)
 
 	// Decode hex digest (must be 32 bytes for sha2-256)

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -190,6 +190,25 @@ func New(inputs ...any) *Model {
 
 	return m
 }
+func (model *Model) T(val int64, object string) TokenType {
+    size := 1
+    if len(model.Objects) > 0 {
+        size = len(model.Objects)
+    }
+
+    wt := make(TokenType, size)
+    if object != "" && len(model.Objects) > 0 {
+        for i, obj := range model.Objects {
+            if obj == object {
+                wt[i] = val
+                break
+            }
+        }
+    } else {
+        wt[0] = val // default to first object
+    }
+    return wt
+}
 
 func (model *Model) Arrow(opts Arc) Arrow {
 	if opts.Source == "" {

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -570,6 +570,59 @@ func buildMerkleRoot(hashes []string) string {
 	return hashes[0]
 }
 
+
+
+/*
+Definition (informal):
+A system is monotone if “having more resources cannot disable behavior you could already do.”
+
+Monotonicity means: if a transition is enabled under marking M,
+it remains enabled under any "larger" marking M' (with more tokens).
+Ordinary Petri nets are monotone; inhibitor arcs are not.
+Adding tokens can *disable* an inhibitor, so adjacency cannot
+be safely composed through them — transitivity breaks.
+
+*/
+
+/*
+Inhibitor arcs intentionally break transitivity.
+
+Reason: normal arcs are monotone (more tokens ⇒ still enabled), so collapsing
+through them preserves “can-reach” structure. Inhibitors are anti-monotone:
+adding tokens can *disable* a transition.
+
+If you allowed them in ForgetPlaces/ForgetTransitions, you would create edges that do not hold
+behaviorally. To avoid spurious adjacency, inhibitors are skipped.
+
+Baez, Courser, Master, Shulman — Compositionality of Petri Nets / Open Petri Nets (2018–2022).
+
+They highlight that algebraic laws (like transitivity via composition) hold for standard nets with monotone semantics,
+but need adjustment or can outright fail in extensions like inhibitors.
+*/
+
+
+/*
+Example: inhibitors break monotonicity (Esparza & Nielsen 1994).
+
+Place p has an inhibitor arc to transition t.
+- At marking M = [p=0], t is enabled.
+- At marking M' = [p=1], t is disabled.
+
+So M ≤ M' (M' has more tokens), but enabled(M) ⊄ enabled(M').
+This violates monotonicity.
+
+Consequence:
+- With ordinary arcs, Petri nets are monotone and many problems are decidable
+  (reachability is EXPSPACE-complete).
+- With inhibitors, monotonicity fails; nets can simulate counter machines.
+- Result: reachability and related problems become *undecidable*.
+  (Esparza & Nielsen, "Decidability Issues for Petri Nets with Inhibitor Arcs", 1994)
+
+This is why ForgetPlaces/ForgetTransitions explicitly skip inhibitor arcs:
+composing through them would create edges that don’t exist behaviorally.
+*/
+
+
 /*
 ForgetTransitions projects a P/T net onto its places.
 
@@ -709,3 +762,10 @@ func (model *Model) ForgetPlaces() *Model {
 
 	return newModel
 }
+
+/* References
+- Esparza, J., & Nielsen, M. (1994). Decidability Issues for Petri Nets (BRICS Report RS-94-8). University of Aarhus. [Inhibitor arcs → undecidability]
+
+- Baez, J. C., & Master, J. (2018). Open Petri Nets. arXiv preprint.
+- Baez, J. C., & Master, J. (2020). Open Petri Nets. Mathematical Structures in Computer Science, 30(3), 314–341. [Compositional semantics via double categories]
+*/

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -569,3 +569,143 @@ func buildMerkleRoot(hashes []string) string {
 	}
 	return hashes[0]
 }
+
+/*
+ForgetTransitions projects a P/T net onto its places.
+
+Semantics:
+- Treat each transition as hidden/internal and connect every input place of that
+  transition to every output place of that transition.
+- The result is a place–adjacency graph: an edge p1 → p2 exists iff some
+  transition t has p1 → t and t → p2 (ignoring inhibits).
+
+Use when:
+- You want “token-flow potential” between places (state-space skeleton),
+  e.g., for coarse reachability heuristics, layout hints, or structural summaries.
+
+Notes:
+- Drops enabling/consumption/production details and rates/weights (structure-only).
+- Preserves topological connectivity but not behavioral properties.
+- Inhibit arcs are intentionally ignored so they don’t fabricate flow.
+
+Related:
+- Classical transition elimination and net-reduction rules (Berthelot/Murata).
+- Compositional abstraction as “hiding” internal transitions (open nets).
+*/
+func (model *Model) ForgetTransitions() *Model {
+	newModel := &Model{
+		Places:      map[string]Place{},
+		Transitions: map[string]Transition{},
+		Arrows:      []Arrow{},
+	}
+
+	// Copy places
+	for label, place := range model.Places {
+		newModel.Places[label] = place
+	}
+
+	// Find all Place -> Transition and Transition -> Place arrows
+	pt := map[string][]string{} // transition: sources (places)
+	tp := map[string][]string{} // transition: targets (places)
+	for _, arrow := range model.Arrows {
+		if arrow.Inhibit {
+			continue // Skip inhibit arcs which intentionally break transitivity
+		}
+		if _, srcIsPlace := model.Places[arrow.Source]; srcIsPlace {
+			if _, tgtIsTransition := model.Transitions[arrow.Target]; tgtIsTransition {
+				pt[arrow.Target] = append(pt[arrow.Target], arrow.Source)
+			}
+		}
+		if _, srcIsTransition := model.Transitions[arrow.Source]; srcIsTransition {
+			if _, tgtIsPlace := model.Places[arrow.Target]; tgtIsPlace {
+				tp[arrow.Source] = append(tp[arrow.Source], arrow.Target)
+			}
+		}
+	}
+
+	// For each transition, link all input places to all output places
+	for t, sources := range pt {
+		targets := tp[t]
+		for _, src := range sources {
+			for _, tgt := range targets {
+				newModel.Arrows = append(newModel.Arrows, Arrow{
+					Source:  src,
+					Target:  tgt,
+					Inhibit: false,
+				})
+			}
+		}
+	}
+
+	return newModel
+}
+/*
+ForgetPlaces projects a P/T net onto its transitions.
+
+Semantics:
+- Treat each place as hidden/internal and connect every input transition of that
+  place to every output transition of that place.
+- The result is a transition–adjacency graph (TAR): an edge t1 → t2 exists iff
+  there is some place p with t1 → p and p → t2 (ignoring inhibits).
+
+Use when:
+- You want the “can-follow” relation between transitions (control-flow skeleton),
+  e.g., for partial-order analysis, concurrency visualization, or quick pathing.
+
+Notes:
+- Drops token semantics, capacities, and markings (structure-only abstraction).
+- Preserves causal adjacency but not reachability/liveness/boundedness.
+- Inhibit arcs are intentionally ignored so they don’t fabricate adjacency.
+
+Related:
+- Transition Adjacency Relations (TAR) in workflow/Petri-net analysis.
+- Nets-with-boundaries/compositional “hiding” (open nets / cospans).
+*/
+func (model *Model) ForgetPlaces() *Model {
+	newModel := &Model{
+		Places:      map[string]Place{},
+		Transitions: map[string]Transition{},
+		Arrows:      []Arrow{},
+	}
+
+	// Copy transitions
+	for label, transition := range model.Transitions {
+		newModel.Transitions[label] = transition
+	}
+
+	// Find all Transition -> Place and Place -> Transition arrows
+	tp := map[string][]string{} // place: input transitions
+	pt := map[string][]string{} // place: output transitions
+	for _, arrow := range model.Arrows {
+		if arrow.Inhibit {
+			continue // Skip inhibit arcs which intentionally break transitivity
+		}
+		if _, srcIsTransition := model.Transitions[arrow.Source]; srcIsTransition {
+			if _, tgtIsPlace := model.Places[arrow.Target]; tgtIsPlace {
+				tp[arrow.Target] = append(tp[arrow.Target], arrow.Source)
+			}
+		}
+		if _, srcIsPlace := model.Places[arrow.Source]; srcIsPlace {
+			if _, tgtIsTransition := model.Transitions[arrow.Target]; tgtIsTransition {
+				pt[arrow.Source] = append(pt[arrow.Source], arrow.Target)
+			}
+		}
+	}
+
+	// For each place, link all input transitions to all output transitions
+	for place := range model.Places {
+		inputs := tp[place]
+		outputs := pt[place]
+		for _, src := range inputs {
+			for _, tgt := range outputs {
+				newModel.Arrows = append(newModel.Arrows, Arrow{
+					Source:  src,
+					Target:  tgt,
+					Inhibit: false,
+				})
+			}
+		}
+	}
+
+	return newModel
+}

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -620,6 +620,13 @@ Consequence:
 
 This is why ForgetPlaces/ForgetTransitions explicitly skip inhibitor arcs:
 composing through them would create edges that don’t exist behaviorally.
+
+Note: many practical "inhibit" conditions can be rephrased monotonically,
+e.g. by encoding them as initial markings or one-shot control places.
+In those cases the system stays monotone and Forget* projections are safe.
+True dynamic inhibitors (tests for zero that can later be refilled)
+remain non-monotone and break transitivity; we skip them.
+
 */
 
 

--- a/examples/gno.land/p/labs/metamodel/metamodel.gno
+++ b/examples/gno.land/p/labs/metamodel/metamodel.gno
@@ -1,0 +1,434 @@
+package metamodel
+
+import (
+	"math"
+	"net/url"
+	"strings"
+
+	"gno.land/p/demo/ufmt"
+)
+
+// TokenType represents multiple token types as a slice of integers.
+type TokenType []int64 // REVIEW: should this be int256
+
+func (tt TokenType) String() string {
+	if len(tt) == 0 {
+		return "[]"
+	}
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, v := range tt {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(ufmt.Sprintf("%d", v))
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
+// T converts a variadic list of values into a TokenType.
+func T(t ...any) TokenType {
+	ts := make(TokenType, len(t))
+	for i, v := range t {
+		switch v := v.(type) {
+		case int:
+			ts[i] = int64(v)
+		case int64:
+			ts[i] = v
+		case string:
+			ts[i] = 1
+		default:
+			ts[i] = -1 // Default to -1 for unsupported types.
+		}
+	}
+	return ts
+}
+
+// Place represents a place in the Petri net.
+type Place struct {
+	Label    string    // Label of the place.
+	Offset   int       // Offset of the place in the Petri net.
+	Tokens   TokenType // Current number of tokens for each type.
+	Initial  TokenType // Initial number of tokens for each type.
+	Capacity TokenType // Maximum capacity for each token type (0 = unlimited).
+	X        int       // X coordinate of the place.
+	Y        int       // Y coordinate of the place.
+	Binding  any       // Optional binding for the place.
+}
+
+// Arc represents an arc in the Petri net.
+type Arc struct {
+	Source  string // Source place or transition.
+	Target  string // Target place or transition.
+	Weight  int64  // Weight for the token type.
+	Inhibit bool   // Indicates if the arc inhibits the transition.
+	Object  string // Optional object name for the arrow.
+}
+
+// Arrow represents an arrow in the Petri net.
+type Arrow struct {
+	Source  string    // Source place or transition.
+	Target  string    // Target place or transition.
+	Weight  TokenType // Weight for each token type used in the model.
+	Inhibit bool      // Indicates if the arc inhibits the transition.
+	Binding any       // Optional binding for the arc.
+}
+
+// Transition represents a transition in the Petri net.
+type Transition struct {
+	Label   string  // Label of the transition.
+	Offset  int     // Offset of the transition in the Petri net.
+	X       int     // X coordinate of the transition.
+	Y       int     // Y coordinate of the transition.
+	Rate    float64 // Rate of the transition (for continuous models).
+	Binding any     // Optional binding for the transition.
+}
+
+// fmtWeight formats the weight of a TokenType.
+func fmtWeight(weight TokenType) (out string) {
+	if len(weight) == 0 || weight[0] == 0 {
+		return ""
+	}
+	if len(weight) == 1 {
+		out = ufmt.Sprintf("%d", weight[0])
+	} else {
+		out = ufmt.Sprintf("%v", weight)
+	}
+	if weight[0] >= 1_000_000 {
+		out = ufmt.Sprintf("%dM", weight[0]/1_000_000)
+	} else if weight[0] >= 1000 {
+		out = ufmt.Sprintf("%dK", weight[0]/1000)
+	} else {
+		out = ufmt.Sprintf("%d", weight[0])
+	}
+	return out
+}
+
+// assertValidObjectName ensures that an object name is valid.
+func assertValidObjectName(name string) {
+	if len(name) == 0 || name[0] != '$' {
+		panic("object names must start with $")
+	}
+	for i, ch := range name[1:] {
+		if !(ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9' && i > 0)) {
+			panic("object names must be valid identifiers")
+		}
+	}
+}
+
+// Model represents the Petri net model.
+type Model struct {
+	Objects     []string              // Additional $objects associated with the model.
+	Places      map[string]Place      // Map of places.
+	Transitions map[string]Transition // Map of transitions.
+	Arrows      []Arrow               // List of arcs.
+	Binding     any                   // Optional binding for the model.
+	RenderOpts  map[string]any        // Rendering options for the model.
+}
+
+func New(inputs ...any) *Model {
+	m := &Model{
+		Places:      map[string]Place{},
+		Transitions: map[string]Transition{},
+		Arrows:      []Arrow{},
+	}
+
+	for _, input := range inputs {
+		switch v := input.(type) {
+		case []string:
+			for _, obj := range v {
+				AssertValidObjectName(obj)
+				m.Objects = append(m.Objects, obj)
+			}
+		default:
+			continue
+		}
+	}
+
+	for _, input := range inputs {
+		switch v := input.(type) {
+		case *Model:
+			// m.Objects = append(m.Objects, v.Objects...) // REVIEW: should we merge objects?
+			for label, place := range v.Places {
+				m.Places[label] = place
+			}
+			for label, transition := range v.Transitions {
+				m.Transitions[label] = transition
+			}
+			m.Arrows = append(m.Arrows, v.Arrows...)
+		case map[string]Place:
+			for label, place := range v {
+				m.Places[label] = place
+			}
+		case map[string]Transition:
+			for label, transition := range v {
+				m.Transitions[label] = transition
+			}
+		case []Arrow:
+			m.Arrows = append(m.Arrows, v...)
+		case map[string]any: // REVIEW: we currently assume a finalized set of objects is passe (i.e. a superset of all objects)
+			m.RenderOpts = v
+		default:
+			continue
+		}
+	}
+
+	offset := 0
+	for label, place := range m.Places {
+		place.Offset = offset
+		m.Places[label] = place
+		offset++
+	}
+
+	offset = 0
+	for label, transition := range m.Transitions {
+		transition.Offset = offset
+		m.Transitions[label] = transition
+		offset++
+	}
+
+	return m
+}
+
+func (model *Model) Arrow(opts Arc) Arrow {
+	if opts.Source == "" {
+		panic("Source must be a non-empty string")
+	}
+	if opts.Target == "" {
+		panic("Target must be a non-empty string")
+	}
+	if opts.Weight < 0 {
+		panic("Weight must be a non-negative int64")
+	}
+
+	size := 1
+	if len(model.Objects) > 0 {
+		size = len(model.Objects)
+	}
+
+	wt := make(TokenType, size)
+	if opts.Object != "" && len(model.Objects) > 0 {
+		for i, obj := range model.Objects {
+			if obj == opts.Object {
+				wt[i] = opts.Weight
+				break
+			}
+		}
+	} else {
+		wt[0] = opts.Weight
+	}
+
+	return Arrow{
+		Source:  opts.Source,
+		Target:  opts.Target,
+		Weight:  wt,
+		Inhibit: opts.Inhibit,
+	}
+}
+
+func (model *Model) CanvasSize() (width, height int) {
+	padding := 50
+	maxX, maxY := 0, 0
+	for _, place := range model.Places {
+		if place.X > maxX {
+			maxX = place.X
+		}
+		if place.Y > maxY {
+			maxY = place.Y
+		}
+	}
+	for _, transition := range model.Transitions {
+		if transition.X > maxX {
+			maxX = transition.X
+		}
+		if transition.Y > maxY {
+			maxY = transition.Y
+		}
+	}
+	return maxX + padding, maxY + padding
+}
+
+func (model *Model) ToSvg() string {
+	var sb strings.Builder
+	width, height := model.CanvasSize()
+
+	sb.WriteString(ufmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%f" height="%d" viewBox="0 0 %d %d">\n`,
+		width, height, width, height))
+
+	sb.WriteString(`
+        <style>
+            .place { fill: #f0f0f0; stroke: #000000; stroke-width: 2; }
+            .transition { fill: #ffffff; stroke: #000000; stroke-width: 2; }
+            .arc { stroke: #000000; stroke-width: 1; }
+            .label { font-family: Arial, sans-serif; font-size: 14px; fill: #000000; }
+            .label-background { fill: #f0f0f0; stroke: #000000; stroke-width: 1; }
+            .tokenSmaller { font-size: 12px; }
+        </style>
+    `)
+
+	sb.WriteString(`
+        <defs>
+            <marker id="arrow" markerWidth="22.5" markerHeight="12" refX="9" refY="6.5" orient="auto">
+                <path d="M3,1.5 L3,12 L10.5,6 L3,1.5"/>
+            </marker>
+            <marker id="inhibit" markerWidth="30" markerHeight="16" refX="10" refY="8.5" orient="auto">
+                <circle cx="8" cy="9" r="4"/>
+            </marker>
+        </defs>
+    `)
+
+	for _, arrow := range model.Arrows {
+		var sourceX, sourceY, targetX, targetY int
+
+		// Determine source coordinates
+		if place, ok := model.Places[arrow.Source]; ok {
+			sourceX, sourceY = place.X, place.Y
+		} else if transition, ok := model.Transitions[arrow.Source]; ok {
+			sourceX, sourceY = transition.X, transition.Y
+		} else {
+			continue // Skip if source is invalid
+		}
+
+		// Determine target coordinates
+		if place, ok := model.Places[arrow.Target]; ok {
+			targetX, targetY = place.X, place.Y
+		} else if transition, ok := model.Transitions[arrow.Target]; ok {
+			targetX, targetY = transition.X, transition.Y
+		} else {
+			continue // Skip if target is invalid
+		}
+
+		// Calculate shortened coordinates
+		dx := targetX - sourceX
+		dy := targetY - sourceY
+		length := math.Sqrt(float64(dx*dx + dy*dy))
+		shortenFactor := 24
+		x2 := targetX - int(float64(dx)/length*float64(shortenFactor))
+		y2 := targetY - int(float64(dy)/length*float64(shortenFactor))
+
+		marker := "arrow"
+		if arrow.Inhibit {
+			marker = "inhibit"
+		}
+
+		sb.WriteString(ufmt.Sprintf("<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" class=\"arc\" marker-end=\"url(#%s)\" />\n",
+			sourceX, sourceY, x2, y2, marker))
+
+		// Add mid-marker circle and weight
+		midX := (sourceX + x2) / 2
+		midY := (sourceY + y2) / 2
+
+		if len(arrow.Weight) == 0 || arrow.Weight[0] == 0 {
+			continue // Skip if no weight
+		}
+
+		className := "label"
+		if arrow.Weight[0] > 1000 {
+			className = "tokenSmaller"
+		}
+
+		weightStr := fmtWeight(arrow.Weight)
+		sb.WriteString(ufmt.Sprintf("<circle cx=\"%d\" cy=\"%d\" r=\"14\" class=\"label-background\" />\n", midX, midY))
+		sb.WriteString(ufmt.Sprintf("<text x=\"%d\" y=\"%d\" class=\"%s\">%s</text>\n", midX-11, midY+5, className, weightStr))
+	}
+
+	// Draw places
+	for _, place := range model.Places {
+		sb.WriteString(ufmt.Sprintf("<circle cx=\"%d\" cy=\"%d\" r=\"16\" class=\"place\" />\n", place.X, place.Y))
+		sb.WriteString(ufmt.Sprintf("<text x=\"%d\" y=\"%d\" class=\"label\">%s</text>\n", place.X-18, place.Y-20, place.Label))
+	}
+
+	// Draw transitions
+	for i, transition := range model.Transitions {
+		label := ufmt.Sprintf("%s", i)
+		sb.WriteString(ufmt.Sprintf("<rect x=\"%d\" y=\"%d\" width=\"30\" height=\"30\" class=\"transition\" />\n", transition.X-15, transition.Y-15))
+		sb.WriteString(ufmt.Sprintf("<text x=\"%d\" y=\"%d\" class=\"label\">%s</text>\n", transition.X-15, transition.Y-20, label))
+	}
+
+	sb.WriteString("</svg>")
+	return sb.String()
+}
+
+func (model *Model) LegendDataUrl() string {
+	return "data:image/svg+xml;utf8," + url.PathEscape(model.LegendSvg())
+}
+
+var legendStyles = `
+<style>
+    table { font-family: Arial, sans-serif; font-size: 16px; border-collapse: collapse; width: 100%;}
+    th, td { border: 1px solid #ccc; padding: 6px 12px; text-align: left; }
+    th { background: #f0f0f0; }
+    tr:nth-child(even) { background: #fafafa; }
+    td:nth-child(2) { max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+</style>
+`
+
+func (model *Model) LegendSvg() string {
+	var sb strings.Builder
+	rowHeight := 37 // REVIEW: can we calculate this dynamically based on content?
+	numRows := len(model.Places) + len(model.Transitions) + len(model.Arrows)
+	height := numRows * rowHeight // 60px for header and padding
+	if numRows < 10 {             // add space for low row count
+		height = 2*rowHeight + height
+	}
+	width := 700
+
+	sb.WriteString(ufmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%v" height="%v">`, width, height))
+	sb.WriteString(legendStyles)
+	sb.WriteString(`<foreignObject x="10" y="10" width="680" height="` + ufmt.Sprintf("%d", height-20) + `">`)
+	sb.WriteString(`<div xmlns="http://www.w3.org/1999/xhtml">`)
+	sb.WriteString(`<table><thead><tr><th>Type</th><th>Label</th><th>Initial</th><th>Capacity</th><th>Weight</th></tr></thead><tbody>`)
+	for label, place := range model.Places {
+		sb.WriteString(`<tr><td>Place</td><td>` + label + `</td><td>` + place.Initial.String() + `</td><td>` + place.Capacity.String() + `</td><td>-</td></tr>`)
+	}
+	for label := range model.Transitions {
+		sb.WriteString(`<tr><td>Transition</td><td>` + label + `</td><td>-</td><td>-</td><td>-</td></tr>`)
+	}
+	for _, arrow := range model.Arrows {
+		arrowType := "Arc"
+		if arrow.Inhibit {
+			arrowType = "Inhibit"
+		}
+		sb.WriteString(`<tr><td>` + arrowType + `</td><td>` + arrow.Source + ` → ` + arrow.Target + `</td><td>-</td><td>-</td><td>` + fmtWeight(arrow.Weight) + `</td></tr>`)
+	}
+	sb.WriteString(`</tbody></table></div></foreignObject>`)
+	sb.WriteString("</svg>")
+	return sb.String()
+}
+
+func (model *Model) DataUrl() string {
+	return "data:image/svg+xml;utf8," + url.PathEscape(model.ToSvg())
+}
+
+func (model *Model) ThumbnailDataUrl() string {
+	return "data:image/svg+xml;utf8," + url.PathEscape(model.ThumbnailSvg("140", "140"))
+}
+
+func (model *Model) ThumbnailSvg(w, h string) string {
+	dataUrl := model.DataUrl()
+	return `<svg width="` + w + `" height="` + h + `" xmlns="http://www.w3.org/2000/svg">
+        <rect width="100%" height="100%" fill="none" stroke="#facade"/>
+        <image href="` + dataUrl + `" width="` + w + `" height="` + h + `"/>
+    </svg>`
+}
+
+func (model *Model) Markdown() string {
+	var sb strings.Builder
+
+	sb.WriteString("![model viz](")
+	sb.WriteString(model.DataUrl())
+	sb.WriteString(")\n\n")
+
+	sb.WriteString("![model legend](")
+	sb.WriteString(model.LegendDataUrl())
+	sb.WriteString(")\n\n")
+
+	return sb.String()
+}
+
+func AssertValidObjectName(name string) {
+	if !strings.HasPrefix(name, "$") {
+		panic("Invalid object name: " + name + ". Object names must start with '$'.")
+	}
+}

--- a/examples/gno.land/p/labs/metamodel/registry.gno
+++ b/examples/gno.land/p/labs/metamodel/registry.gno
@@ -1,0 +1,530 @@
+package metamodel
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"std"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
+)
+
+// --- Types ---
+
+type RegistryCallback = func(key string, value any) bool
+type RegistryMatcher = func(value any) bool
+
+type Registry struct {
+	tree          *avl.Tree
+	allowPrefixes []string
+	renderOpts    map[string]any
+	keywordIndex  *avl.Tree // maps keyword -> []string (keys)
+	idIndex       *avl.Tree // maps id (int) -> string (key)
+	sequence      int
+}
+
+// --- Constructor ---
+
+func NewRegistry(allowedPrefixes []string, opts map[string]any) *Registry {
+	chainId := std.ChainID()
+	if _, ok := opts[chainId]; !ok {
+		panic("render options must be set for the current chain: " + chainId)
+	}
+	renderOpts, ok := opts[chainId].(map[string]interface{})
+	if !ok {
+		panic("render options must be a map[string]interface{} for the current chain: " + chainId)
+	}
+
+	return &Registry{
+		tree:          avl.NewTree(),
+		allowPrefixes: allowedPrefixes,
+		renderOpts:    renderOpts,
+		keywordIndex:  avl.NewTree(),
+		idIndex:       avl.NewTree(),
+		sequence:      0,
+	}
+}
+
+// --- Registration & Access Control ---
+
+func (r *Registry) Register(key string, obj any, kw ...string) {
+	r.assertAccess()
+	r.register(key, obj, kw...)
+}
+
+func (r *Registry) register(name string, obj any, kw ...string) {
+	key := sanitizeAnchorKey(name)
+	if r.Exists(key) {
+		panic("Key already exists: " + key)
+	}
+	kwords := keywords(append(kw, name))
+	switch obj := obj.(type) {
+	case *Model:
+		r.addRecord(key, name, obj, kwords)
+		r.indexKeywords(key, kwords)
+		r.sequence++
+	default:
+		panic(ufmt.Sprintf("Invalid type for key %s: %T", key, obj))
+	}
+}
+
+func (r *Registry) addRecord(key, name string, obj *Model, kwords []string) {
+	rec := Record{
+		Id:       r.sequence,
+		Title:    name,
+		Content:  func(...any) *Model { return obj },
+		Keywords: kwords,
+	}
+	r.tree.Set(key, rec)
+	r.idIndex.Set(strconv.Itoa(rec.Id), key) // convert int to string
+}
+
+func (r *Registry) KeyById(id int) (string, bool) {
+	key, ok := r.idIndex.Get(strconv.Itoa(id)) // convert int to string
+	if !ok {
+		return "", false
+	}
+	return key.(string), true
+}
+
+func (r *Registry) indexKeywords(key string, kwords []string) {
+	for _, word := range kwords {
+		val, _ := r.keywordIndex.Get(word)
+		var keys []string
+		if val != nil {
+			keys = val.([]string)
+		}
+		keys = append(keys, key)
+		r.keywordIndex.Set(word, keys)
+	}
+}
+
+func (r *Registry) Exists(key string) bool {
+	_, ok := r.tree.Get(key)
+	return ok
+}
+
+func (r *Registry) assertAccess() {
+	if !r.hasAllowedPrefix() {
+		panic("access denied: " + std.PreviousRealm().PkgPath() +
+			" realm must match an allowed prefix:[" + strings.Join(r.allowPrefixes, ",") + "]")
+	}
+}
+
+func (r *Registry) hasAllowedPrefix() bool {
+	prevRealm := std.PreviousRealm()
+	for _, callerPath := range r.allowPrefixes {
+		if strings.HasPrefix(prevRealm.PkgPath(), callerPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Query & Indexing ---
+
+func (r *Registry) KeysByKeyword(word string) []string {
+	val, ok := r.keywordIndex.Get(strings.ToLower(word))
+	if !ok {
+		return nil
+	}
+	return val.([]string)
+}
+
+func (r *Registry) Iterate(callback RegistryCallback, matcher RegistryMatcher) {
+	r.tree.IterateByOffset(0, r.tree.Size(), func(key string, value any) bool {
+		if matcher(value) {
+			return callback(key, value)
+		}
+		return false
+	})
+}
+
+// --- Rendering & Content ---
+
+func (r *Registry) Render(path string, cb ...func(string) string) string {
+	q := parseQuery(path)
+	if strings.HasPrefix(path, "?search=") {
+		path = q["search"][0]
+	}
+
+	if strings.HasPrefix(path, "?") {
+		if idx, ok := q["i"]; ok && len(idx) > 0 {
+			return r.renderItem(idx[0], q)
+		}
+	}
+
+	if path != "" {
+		key := sanitizeAnchorKey(path)
+		if _, ok := r.tree.Get(key); ok {
+			return r.Content(key, path)
+		}
+		if c, ok := r.keywordIndex.Get(strings.ToLower(key)); ok {
+			return r.renderSearchResults(key, c.([]string))
+		}
+	}
+
+	return r.renderIndex(path, cb...)
+}
+
+func (r *Registry) getOptsString(key string) string {
+	if r.renderOpts == nil {
+		panic("render options not set")
+	}
+	if val, ok := r.renderOpts[key]; ok {
+		return val.(string)
+	}
+	panic("render option not found: " + key)
+}
+
+func (r *Registry) renderSearchResults(key string, keys []string) string {
+	const pageSize = 5
+	var sb strings.Builder
+	sb.WriteString("## Search Results for: " + key + "\n\n")
+	total := len(keys)
+	page, cleanKey := parsePageFromKey(key)
+	start, end := getPageBounds(page, pageSize, total)
+	sb.WriteString("Found " + ufmt.Sprintf("%d", total) + " results:\n\n")
+	r.renderSearchItems(&sb, keys, start, end)
+	r.renderSearchPagination(&sb, cleanKey, page, pageSize, total, end)
+	sb.WriteString("\n[<- Home](" + r.getOptsString("BasePath") + ")\n")
+	return sb.String()
+}
+
+func parsePageFromKey(key string) (page int, cleanKey string) {
+	page = 0
+	cleanKey = key
+	if idx := strings.Index(key, "?p="); idx != -1 {
+		pageStr := key[idx+3:]
+		cleanKey = key[:idx]
+		if i, err := strconv.Atoi(pageStr); err == nil {
+			page = i
+		}
+	}
+	return
+}
+
+func getPageBounds(page, pageSize, total int) (start, end int) {
+	start = page * pageSize
+	end = start + pageSize
+	if end > total {
+		end = total
+	}
+	return
+}
+
+func (r *Registry) renderSearchItems(sb *strings.Builder, keys []string, start, end int) {
+	for i := start; i < end; i++ {
+		k := keys[i]
+		obj, ok := r.tree.Get(k)
+		if !ok {
+			continue
+		}
+		rec := obj.(Record)
+		sb.WriteString("### " + rec.Title + "\n\n")
+		sb.WriteString(r.thumbnail(k, obj) + "\n")
+	}
+}
+
+func (r *Registry) renderSearchPagination(sb *strings.Builder, key string, page, pageSize, total, end int) {
+	if total > pageSize {
+		sb.WriteString("\n")
+		if page > 0 {
+			sb.WriteString("[Prev Page](" + r.getOptsString("BasePath") + ":" + key + "?p=" + ufmt.Sprintf("%d", page-1) + ") ")
+		}
+		sb.WriteString(ufmt.Sprintf("Page %d/%d", page+1, (total+pageSize)/pageSize+1))
+		if end < total {
+			sb.WriteString(" [Next Page](" + r.getOptsString("BasePath") + ":" + key + "?p=" + ufmt.Sprintf("%d", page+1) + ")")
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func (r *Registry) renderItem(indexStr string, u url.Values) string {
+	index, _ := strconv.Atoi(indexStr)
+	i := index % r.tree.Size()
+	key, obj := r.tree.GetByIndex(i)
+	rec := obj.(Record)
+	var sb strings.Builder
+	sb.WriteString("id: " + ufmt.Sprintf("%d", rec.Id) + "\n\n")
+	sb.WriteString("### " + upcaseWords(rec.Title) + "\n\n")
+	sb.WriteString("**[" + key + "🔗](" + r.getOptsString("BasePath") + ":" + key + ")**\n\n")
+	sb.WriteString("**Keywords:** " + strings.Join(rec.Keywords, ", ") + "\n\n")
+	sb.WriteString(r.renderNavigation(i, u))
+	sb.WriteString(r.Content(key, ""))
+	sb.WriteString(r.renderNavigation(i, u))
+	sb.WriteString("\n[<- Home](" + r.getOptsString("BasePath") + ")\n")
+	return sb.String()
+}
+
+func (r *Registry) renderNavigation(i int, u url.Values) string {
+	var sb strings.Builder
+	prev := (i - 1 + r.tree.Size()) % r.tree.Size()
+	next := (i + 1) % r.tree.Size()
+	sb.WriteString("[<-prev](?i=" + ufmt.Sprintf("%d", prev) + ") ")
+	sb.WriteString(ufmt.Sprintf("%d/%d", i+1, r.tree.Size()))
+	sb.WriteString(" [next->](?i=" + ufmt.Sprintf("%d", next) + ")\n\n")
+	return sb.String()
+}
+
+func (r *Registry) SearchForm() string {
+	return "View all models on the [Metamodel List ->](" +
+		r.getOptsString("BasePath") + "?p=0" +
+		")\n\n" + searchForm
+}
+
+var searchForm = `
+<gno-columns>
+<gno-form>
+    <gno-input name="search" placeholder="keyword" />
+</gno-form>
+|||
+
+**Search Models**:
+
+Enter a keyword
+
+or
+
+[Review all models ->](?p=0)
+
+</gno-columns>
+`
+
+func (r *Registry) renderIndex(path string, cb ...func(string) string) string {
+	q := parseQuery(path)
+	if page, ok := q["p"]; ok && len(page) > 0 {
+		return r.renderList(path)
+	}
+	var sb strings.Builder
+	for _, content := range cb {
+		if content != nil {
+			sb.WriteString(content(path) + "\n\n")
+		}
+	}
+	sb.WriteString("### Index\n\n")
+	sb.WriteString(searchForm + "\n\n")
+
+	return sb.String()
+}
+
+func (r *Registry) renderList(path string) string {
+	const pageSize = 5
+	total := r.tree.Size()
+	page := 0
+	if u := parseQuery(path); u != nil {
+		if idx, ok := u["p"]; ok && len(idx) > 0 {
+			if i, err := strconv.Atoi(idx[0]); err == nil {
+				page = i
+			}
+		}
+	}
+	sb := r.renderListItems(page, pageSize, total)
+	nav := r.renderListNav(page, pageSize, total)
+	sb.WriteString(nav)
+	return "## Metamodel Index\n\n" +
+		nav +
+		sb.String() +
+		"\n[<- Home](" + r.getOptsString("BasePath") + ")\n"
+}
+
+func (r *Registry) renderListItems(page, pageSize, total int) *strings.Builder {
+	sb := &strings.Builder{}
+	start := page * pageSize
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	for i := start; i < end; i++ {
+		key, obj := r.tree.GetByIndex(i)
+		sb.WriteString("### [" + upcaseWords(key) + "](?i=" + ufmt.Sprintf("%d", i) + ")\n")
+		sb.WriteString(r.thumbnail(key, obj))
+	}
+	return sb
+}
+
+func (r *Registry) renderListNav(page, pageSize, total int) string {
+	var nav strings.Builder
+	if total > pageSize {
+		nav.WriteString("\n")
+		if page > 0 {
+			nav.WriteString("[Prev Page](?p=" + ufmt.Sprintf("%d", page-1) + ") ")
+		}
+		nav.WriteString(ufmt.Sprintf("Page %d/%d", page+1, (total+pageSize)/pageSize+1))
+		if (page+1)*pageSize < total {
+			nav.WriteString(" [Next Page](?p=" + ufmt.Sprintf("%d", page+1) + ")")
+		}
+		nav.WriteString("\n")
+	}
+	return nav.String()
+}
+
+func (r *Registry) Content(key, path string) string {
+	key = sanitizeAnchorKey(key)
+	val, ok := r.tree.Get(key)
+	if !ok {
+		panic("Key not found: " + key)
+	}
+	rec := val.(Record)
+	model := rec.Content.(func(...any) *Model)()
+	if binding, ok := model.Binding.(func(path string) string); ok {
+		return binding(path)
+	}
+	return model.Markdown()
+}
+
+func (r *Registry) Preview(key, path string) string {
+	key = sanitizeAnchorKey(key)
+	val, ok := r.tree.Get(key)
+	if !ok {
+		panic("Key not found: " + key)
+	}
+	rec := val.(Record)
+	model := rec.Content.(func(...any) *Model)()
+	lineCount := 3
+	var content string
+	if binding, ok := model.Binding.(func(string) string); ok {
+		content = binding(path)
+		lines := strings.Split(content, "\n")
+		if len(lines) > lineCount {
+			return strings.Join(lines[:lineCount], "\n") + "\n"
+		}
+	} else {
+		content = model.Markdown()
+	}
+	return markdownPreview(content)
+}
+
+func (r *Registry) thumbnail(key string, obj any) string {
+	rec := obj.(Record)
+	var sb strings.Builder
+	sb.WriteString("**Keywords:** " + strings.Join(rec.Keywords, ", ") + "\n\n")
+	model := rec.Content.(func(...any) *Model)()
+	sb.WriteString("[![" + key + "](" + model.ThumbnailDataUrl() + ")](" + r.getOptsString("BasePath") + ":" + key + ")\n")
+	sb.WriteString(r.Preview(key, "") + "\n")
+	return sb.String()
+}
+
+// --- Helpers ---
+
+func keywords(kw []string) (out []string) {
+	seen := make(map[string]struct{})
+	for _, k := range kw {
+		for _, word := range strings.Split(k, " ") {
+			word = strings.ToLower(word)
+			if len(word) == 0 {
+				continue
+			}
+			if _, exists := seen[word]; !exists {
+				seen[word] = struct{}{}
+				out = append(out, word)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseQuery(path string) url.Values {
+	if len(path) > 0 && path[0] == '?' {
+		u, err := url.Parse(std.CurrentRealm().PkgPath() + path)
+		if err == nil {
+			return u.Query()
+		}
+	}
+	return url.Values{}
+}
+
+func upcaseWords(s string) string {
+	words := strings.Fields(s)
+	for i, word := range words {
+		if len(word) > 0 {
+			words[i] = strings.ToUpper(string(word[0])) + word[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func markdownPreview(content string) string {
+	regexImages := `!\[.*?\]\(.*?\)`
+	content = strings.ReplaceAll(content, regexImages, "")
+	return content
+}
+
+func sanitizeAnchorKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, " ", "-")
+	var sb strings.Builder
+	for _, r := range key {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func EscapeHtml(s string) string {
+	replacements := map[string]string{
+		"&":  "&amp;",
+		"<":  "&lt;",
+		">":  "&gt;",
+		"\"": "&quot;",
+		"'":  "&#39;",
+	}
+	for old, new := range replacements {
+		s = strings.ReplaceAll(s, old, new)
+	}
+	return s
+}
+
+func SubmitButton(label, path string, fontSize, minWidth int) string {
+	charWidth := int(0.6 * float64(fontSize))
+	padding := 40
+	h := 2 * fontSize
+	w := len(label)*charWidth + padding
+	if w < minWidth {
+		w = minWidth
+	}
+
+	svgButton := `<svg xmlns="http://www.w3.org/2000/svg" width="` + strconv.Itoa(w) + `" height="` + strconv.Itoa(h) + `">
+<foreignObject x="16" y="-5" width="` + strconv.Itoa(w) + `" height="` + strconv.Itoa(h) + `">
+  <body xmlns="http://www.w3.org/1999/xhtml">
+    <button style="padding-left: 20px; font-size:` + strconv.Itoa(fontSize) + `px">
+      ` + EscapeHtml(label) + `
+    </button>
+  </body>
+</foreignObject>
+</svg>`
+
+	dataUrl := "data:image/svg+xml;utf8," + url.PathEscape(svgButton)
+	return "[![" + label + "](" + dataUrl + ")](" + path + ")"
+}
+
+type Record struct {
+	Id       int
+	Title    string
+	Content  any
+	Keywords []string
+}
+
+func (record Record) String() string {
+	var sb strings.Builder
+	sb.WriteString("Record{Content: ")
+	if record.Content != nil {
+		sb.WriteString("any")
+	} else {
+		sb.WriteString("nil")
+	}
+	sb.WriteString(", Keywords: [")
+	for i, keyword := range record.Keywords {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(keyword)
+	}
+	sb.WriteString("]}")
+	return sb.String()
+}

--- a/examples/gno.land/r/labs/grc000/README.md
+++ b/examples/gno.land/r/labs/grc000/README.md
@@ -1,0 +1,293 @@
+# GRC-000 — Metamodel Token Standard
+
+**Status:** Draft **Version:** v0 **Target chain:** gno.land  
+**Focus:** Minimal **GRC-based balance primitives**, **composable-first** via Petri-net semantics.
+
+---
+
+### Document Navigation
+
+1. **[Overview](#1-overview)**
+2. **[Primitives](#2-primitives)**
+    1. [Wallet](#21-wallet-account-holds-tokens)
+    2. [Transfer](#22-transfer-tokens-move-between-accounts)
+    3. [Mint/Burn](#23-mintburn-tokens-created-or-destroyed)
+    4. [Token](#24-token-combines-wallet-transfer-mintburn)
+3. **[Terms](#3-terms)**
+4. **[Petri-Net Ports & Composition](#4-petri-net-ports--composition)**
+    1. [Port Definitions](#41-port-definitions)
+    2. [Port Usage](#42-port-usage)
+5. **[Composition Principles & Append-Only Evolution](#5-composition-principles--append-only-evolution)**
+    1. [Principles](#51-principles)
+    2. [Why Append-Only?](#52-why-append-only)
+    3. [Deployment Lifecycle](#53-deployment-lifecycle)
+6. **[GRC000 as a Little Language](#6-grc000-as-a-little-language)**
+    1. [Primitives as Vocabulary](#61-primitives-as-vocabulary)
+    2. [Combinators as Phrases](#62-combinators-as-phrases)
+    3. [Model Composition as Nested Syntax](#63-model-composition-as-nested-syntax)
+    4. [Rendering as Translation](#64-rendering-as-translation)
+7. **[Token Standards: Interface vs. Behavior-First](#7-token-standards-interface-vs-behavior-first)**
+    1. [Two paradigms, side-by-side](#71-two-paradigms-side-by-side)
+    2. [What you gain with behavior-first](#72-what-you-gain-with-behavior-first)
+    3. [What you lose (or must manage)](#73-what-you-lose-or-must-manage)
+    4. [Token standards, concretely](#74-token-standards-concretely)
+    5. [Migration / adoption pattern](#75-migration--adoption-pattern)
+    6. [When to choose which](#76-when-to-choose-which)
+8. **[References](#8-references)**
+
+---
+## 1. Overview
+
+**GRC-000** specifies a **safe, deterministic, minimal** interface for fungible tokens on `gno.land`, designed for **Petri-net composition**.  
+
+The aim: provide a **core set of primitives**—small, deterministic Petri-net fragments—that can be composed into more complex transaction models.
+
+This follows the **“Smart Objects, Dumb Code”** principle [(Yoneda-inspired)](https://ncatlab.org/nlab/show/Yoneda+lemma): each object’s identity is defined by behavior in all contexts, with internal rules embedded in the object and minimal external orchestration.
+
+These primitives are developed under **append-only** rules: new behaviors are added without mutating existing ones, preserving determinism and backward compatibility.
+
+---
+
+## 2. Primitives
+
+A **primitive** is a minimal Petri-net fragment capturing one atomic behavior.
+
+- Trivial alone, powerful when **composed**.
+- Deterministic, self-contained, and reusable.
+- Designed for **append-only growth**: the primitive’s logic is fixed, but new primitives can be added to extend functionality.
+- These basic elements combine to form DEXs, staking, DAOs, faucets—without redefining basics.
+### 2.1 **Wallet:** account holds tokens.
+ ```go
+func GRC000_Wallet(opts map[string]any) *mm.Model {
+    return mm.New(map[string]mm.Place{
+        "$wallet": {Initial: initial, Capacity: mm.T(0), X: 160, Y: 180},
+    })
+}
+```
+### 2.2 **Transfer:** tokens move between accounts.
+```go
+func GRC000_Transfer(opts map[string]any) *mm.Model {
+    return mm.New(
+        map[string]mm.Place{
+            "$recipient": {Initial: recipientInitial, X: 360, Y: 180},
+        },
+        map[string]mm.Transition{
+            "transfer": {X: 210, Y: 180},
+        },
+        []mm.Arrow{
+            {Source: "$wallet", Target: "transfer", Weight: transferWeight},
+            {Source: "transfer", Target: "$recipient", Weight: transferWeight},
+        },
+    )
+}
+```
+### 2.3 **Mint/Burn:** tokens created or destroyed.
+```go
+func GRC000_MintBurn(opts map[string]any) *mm.Model {
+    return mm.New(
+        map[string]mm.Place{
+            "$minter": {Initial: minterInitial, X: 60, Y: 180},
+            "$burner": {Initial: burnerInitial, X: 360, Y: 180},
+        },
+        map[string]mm.Transition{
+            "mint": {X: 210, Y: 120},
+            "burn": {X: 210, Y: 240},
+        },
+        []mm.Arrow{
+            {Source: "$minter", Target: "mint", Weight: mintWeight},
+            {Source: "mint", Target: "$wallet", Weight: mintWeight},
+            {Source: "$burner", Target: "burn", Weight: burnWeight},
+            {Source: "burn", Target: "$wallet", Weight: burnWeight},
+        },
+    )
+}
+```
+
+### 2.4 **Token:** combines wallet, transfer, mint/burn.
+```go
+func GRC000_Token(opts map[string]any) *mm.Model {
+    return mm.New(
+        GRC000_Wallet(opts),
+        GRC000_Transfer(opts),
+        GRC000_MintBurn(opts),
+    )
+}
+```
+
+
+---
+
+## 3. Terms
+
+| Term                                                     | Meaning                                                                                    |
+|----------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| **Account**                                              | `gno.land` address string.                                                                 |
+| **Amount**                                               | `uint64` (upgrade path to `uint256`).                                                      |
+| **Port**                                                 | Named Petri-net boundary place (e.g. `$wallet`, `$recipient`).                             |
+| **Primitive**                                            | Atomic Petri-net submodel for composition.                                                 |
+| **Append-Only**                                          | A design constraint ensuring primitives evolve by addition only—never removal or mutation. |
+| **Deterministic**                                        | Behavior is predictable and consistent across all contexts.                             |
+| [**Petri-Net**](https://ncatlab.org/nlab/show/Petri+net) | A mathematical model of computation using places, transitions, and arrows
+
+---
+
+## 4. Petri-Net Ports & Composition
+
+Named **ports** are consistent across primitives, enabling direct integration into larger Petri-nets.
+
+Primitives are **composed** into useful models, and models are bound to code by these ports.
+This allows for **deterministic behavior** and **reproducibility** across different contexts
+
+### 4.1 Port Definitions
+By design each port name starts with `$` to distinguish them from places in the Petri-net.
+
+- **$wallet**: Holds the token balance.
+- **$recipient**: Destination for transfers.
+- **$minter**: Source for minting new tokens.
+
+### 4.2 Port Usage
+Models use ports as a means for code to interact with the Petri-net.
+
+When executing a model, ports are populated with values from the context (e.g. a transaction).
+
+---
+
+## 5. Composition Principles & Append-Only Evolution
+
+### 5.1 Principles
+1. **Stable Ports:** `$wallet`, `$recipient`, `$minter` stay consistent for easy integration.
+2. **Append-Only Development:**
+    - **Add** new primitives or transitions.
+    - **Never** change or remove existing ones.
+    - All past states and invariants remain valid.
+3. **Merge by Ports:**
+    - Unify shared ports.
+    - Append transitions/arrows.
+    - Preserve determinism.
+
+### 5.2 Why Append-Only?
+- **Composable Upgrades:** New features can be layered without breaking integrations.
+- **Trust Preservation:** Contracts referencing old primitives remain correct.
+- **Reproducibility:** State can be replayed from genesis without divergence.
+- **Formal Verification:** Old proofs remain valid.
+
+### 5.3 Deployment Lifecycle
+1. **Design:** Draft primitive with fixed ports & logic.
+2. **Simulation:** Test in isolation and in compositions.
+3. **Freeze:** Lock logic; assign version.
+4. **Publish:** Deploy to GRC-000 standard library.
+5. **Compose:** Integrate with existing primitives in append-only fashion.
+
+---
+
+## 6. GRC000 as a Little Language
+
+### 6.1 Primitives as Vocabulary
+- **Place** → noun (state: `$wallet`, `$recipient`, `$minter`)
+- **Transition** → verb (action: `transfer`, `mint`, `burn`)
+- **Arrow** → grammar rule (mapping how verbs consume/produce nouns)
+
+These are the alphabet and grammar of the *inner* Petri-net language.
+
+---
+
+### 6.2 Combinators as Phrases
+Functions like `GRC000_Wallet`, `GRC000_Transfer`, and `GRC000_MintBurn` are idioms in this inner language — sentences that express atomic token behaviors.
+
+---
+
+### 6.3 Model Composition as Nested Syntax
+`GRC000_Token` composes smaller idioms into paragraphs.  
+The **outer Go syntax** orchestrates; the **inner Petri-net language** defines behavior.  
+Append-only rules ensure new “paragraphs” never rewrite history.
+
+---
+
+### 6.4 Rendering as Translation
+`Render(path string)` translates the nested Petri-net model into Markdown + SVG — akin to compiling or translating to another language.  
+Because the net is append-only, all renderings are reproducible over time.
+
+---
+
+## 7. Token Standards: Interface vs. Behavior-First
+
+> We standardize **behavior, not just function names**. The token’s canonical definition is its **open Petri net**; ERC-20-style functions are **generated views** for legacy tooling.
+
+- **ERC-20-style** = *nominal interface*: a handful of function names + event shapes. You prove conformance by matching the signature, not the whole behavior.
+- **OPetri / typed-Petri approach** = *behavioral specification*: you spell out **every allowed state transition**, and interfaces are just *views* over that model.
+
+---
+
+### 7.1 Two paradigms, side-by-side
+
+| Dimension | Interface-first (ERC-20) | Behavior-first (OPetri / typed Petri) |
+|---|---|---|
+| Spec unit | Function signatures (`transfer`, `approve`, …) | Places, transitions, guards, arcs (typed) |
+| Conformance | “Implements the ABI” | “Implements these transitions and invariants” |
+| Guarantees | Minimal (must not revert in obvious cases) | Rich: invariants, conservation laws, liveness, safety |
+| Extensibility | Add new funcs / extensions (fragmentation risk) | Compose subnets; refinement preserves proofs |
+| Composability | Name/ABI matching; adapters required | Structural: glue along shared `$objects` (ports) |
+| Analysis | Hard: need bespoke proofs per impl | Native: reachability, invariants, ODE analysis |
+| Concurrency | Not modeled; relies on VM/nonce | First-class: enabling conditions, mutual exclusion |
+| Upgrades | “New interface” or proxy patterns | Add/replace subnets; reuse proofs via refinement |
+| Testing | Unit/integration by example | Model checking, simulation, parameter sweeps |
+| Failure modes | Same ABI, wildly different semantics | Same ports ⇒ bounded semantic variation |
+
+---
+
+### 7.2 What you gain with behavior-first
+- **Total semantics**: No “mystery paths.” Every state change is one of your transitions.
+- **Machine-checkable properties**:
+   - *Conservation*: token mass is preserved except at mint/burn.
+   - *Safety*: guards prevent underflow/overdraft.
+   - *Liveness*: absence of deadlocks; intended flows always possible.
+- **True composability**: DEXes, escrows, staking = subnets that **plug into** `$token` and `$wallet`.
+- **Refinement without fragmentation**: Extensions (`permit`, `batch`) = new subnets; existing proofs still valid.
+
+---
+
+### 7.3 What you lose (or must manage)
+- **Higher upfront modeling cost**: You design a net, not just an ABI.
+- **Learning curve**: Readers must understand places, transitions, guards.
+- **Interop optics**: World “speaks ERC-20.” You’ll expose an ERC-20-compatible view.
+
+---
+
+### 7.4 Token standards, concretely
+
+**Model (canonical):**
+- Places: `$wallet`, `$recipient`, `$supply`, `$allowance[(owner,spend)]`
+- Transitions: `mint`, `burn`, `transfer`, `approve`, `transferFrom`, …
+- Guards: balances/allowances ≥ weight; role checks; time locks optional.
+- Invariants:
+   - `Σ tokens($wallet_i) + tokens($supply) = constant + minted − burned`
+   - No negative markings; respect capacity bounds.
+
+**Interface (derived view):**
+- `balanceOf(a)` ⇒ marking at `$wallet[a]`
+- `totalSupply()` ⇒ marking at `$supply`
+- `transfer(to, amt)` ⇒ fire `transfer` if enabled
+- `Approval`, `Transfer` events ⇒ emitted on transitions
+
+---
+
+### 7.5 Migration / adoption pattern
+1. **Author the net** (OPetri/typed Petri).
+2. **Auto-derive ABI** (queries + callable transitions).
+3. **Ship both**: net + thin ABI adapter.
+4. **Prove**: conservation, safety, allowance monotonicity.
+5. **Compose**: plug into DEX/vesting/staking subnets.
+
+---
+
+### 7.6 When to choose which
+- **Interface-first**: fastest baseline compatibility.
+- **Behavior-first**: for nontrivial policy, assurance, composability.
+
+## 8. References
+
+- [Open Petri Nets](https://arxiv.org/abs/1808.05415) - a foundational paper on Petri nets.
+- [Petri Nets](https://ncatlab.org/nlab/show/Petri+net) - all-purpose reference.
+- [Yoneda Lemma](https://ncatlab.org/nlab/show/Yoneda+lemma) - foundational concept in category theory, relevant to compositionality.
+- [ERC-20](https://eips.ethereum.org/EIPS/eip-20) - the classic token standard.
+- [Cross-chain Deals and Adversarial Commerce](https://arxiv.org/abs/1905.09743)

--- a/examples/gno.land/r/labs/grc000/gnomod.toml
+++ b/examples/gno.land/r/labs/grc000/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/labs/grc000"
+gno = "0.9"

--- a/examples/gno.land/r/labs/grc000/metamodel.gno
+++ b/examples/gno.land/r/labs/grc000/metamodel.gno
@@ -1,0 +1,219 @@
+package grc000
+
+import (
+	"strings"
+
+	mm "gno.land/p/labs/metamodel"
+)
+
+type Record struct {
+	Id          string
+	Name        string
+	Description string
+	Model       *mm.Model
+}
+
+const (
+	Token = "$token"
+)
+
+var (
+	basePath = "/r/labs/grc000"
+
+	modelOpts = map[string]any{
+		"balance":           100,
+		"recipient_balance": 50,
+		"transfer_amount":   10,
+		"minter_initial":    1,
+		"mint_amount":       5,
+		"burn_amount":       2,
+		"objects":           []string{Token},
+	}
+
+	registry = []*Record{
+		{
+			Id:          "wallet",
+			Name:        "GRC000_Wallet",
+			Description: "A simple wallet model that holds tokens.",
+			Model:       GRC000_Wallet(modelOpts),
+		},
+		{
+			Id:          "transfer",
+			Name:        "GRC000_Transfer",
+			Description: "A model for transferring tokens between wallets.",
+			Model:       mm.New(GRC000_Wallet(modelOpts), GRC000_Transfer(modelOpts), map[string]any{"version": "v0"}),
+		},
+		{
+			Id:          "mintburn",
+			Name:        "GRC000_MintBurn",
+			Description: "A model for minting into and burning from a wallet (with burned-accounting sink).",
+			Model:       mm.New(GRC000_Wallet(modelOpts), GRC000_MintBurn(modelOpts), map[string]any{"version": "v0"}),
+		},
+		{
+			Id:          "token",
+			Name:        "GRC000_Token",
+			Description: "A comprehensive model that composes wallet, transfer, and mint/burn.",
+			Model:       GRC000_Token(modelOpts),
+		},
+	}
+
+	registryMap = make(map[string]*Record)
+)
+
+// ------- utils -------
+
+func getIntOpt(opts map[string]any, key string, def int) int {
+	if v, ok := opts[key]; ok {
+		if i, ok := v.(int); ok {
+			return i
+		}
+	}
+	return def
+}
+
+func getStringSliceOpt(opts map[string]any, key string, def []string) []string {
+	if v, ok := opts[key]; ok {
+		if sl, ok := v.([]string); ok && len(sl) > 0 {
+			return sl
+		}
+	}
+	return def
+}
+
+func objectsFrom(opts map[string]any) []string {
+	return getStringSliceOpt(opts, "objects", []string{Token})
+}
+
+// ------- models -------
+
+func GRC000_Wallet(opts map[string]any) *mm.Model {
+	initial := mm.T(getIntOpt(opts, "balance", 1))
+	m := mm.New(
+		objectsFrom(opts),
+		map[string]mm.Place{
+			"$wallet": {Initial: initial, Capacity: mm.T(0), X: 160, Y: 180},
+		},
+		map[string]any{"version": "v0"},
+	)
+	return m
+}
+
+func GRC000_Transfer(opts map[string]any) *mm.Model {
+	recipientInitial := mm.T(getIntOpt(opts, "recipient_balance", 0))
+	transferWeight := int64(getIntOpt(opts, "transfer_amount", 1))
+	objectModel := mm.New(objectsFrom(opts))
+
+	m := mm.New(
+		objectModel.Objects,
+		map[string]mm.Place{
+			"$recipient": {Initial: recipientInitial, X: 360, Y: 180},
+		},
+		map[string]mm.Transition{
+			"transfer": {X: 260, Y: 180},
+		},
+		[]mm.Arrow{
+			objectModel.Arrow(mm.Arc{Source: "$wallet", Target: "transfer", Weight: transferWeight, Object: Token}),
+			objectModel.Arrow(mm.Arc{Source: "transfer", Target: "$recipient", Weight: transferWeight, Object: Token}),
+		},
+		map[string]any{"version": "v0"},
+	)
+	return m
+}
+
+func GRC000_MintBurn(opts map[string]any) *mm.Model {
+	minterInitial := mm.T(getIntOpt(opts, "minter_initial", 1))
+	mintWeight := int64(getIntOpt(opts, "mint_amount", 1))
+	burnWeight := int64(getIntOpt(opts, "burn_amount", 1))
+	objectModel := mm.New(objectsFrom(opts))
+
+	m := mm.New(
+		objectModel.Objects,
+		map[string]mm.Place{
+			"$minter": {Initial: minterInitial, X: 40, Y: 80},
+			"$burned": {Initial: mm.T(0), X: 280, Y: 280}, // accounting sink
+		},
+		map[string]mm.Transition{
+			"mint": {X: 160, Y: 80},
+			"burn": {X: 160, Y: 280},
+		},
+		[]mm.Arrow{
+			// mint: $minter -> mint -> $wallet
+			objectModel.Arrow(mm.Arc{Source: "$minter", Target: "mint", Weight: mintWeight, Object: Token}),
+			objectModel.Arrow(mm.Arc{Source: "mint", Target: "$wallet", Weight: mintWeight, Object: Token}),
+
+			// burn: $wallet -> burn -> $burned (accounting)
+			objectModel.Arrow(mm.Arc{Source: "$wallet", Target: "burn", Weight: burnWeight, Object: Token}),
+			objectModel.Arrow(mm.Arc{Source: "burn", Target: "$burned", Weight: burnWeight, Object: Token}),
+		},
+		map[string]any{"version": "v0"},
+	)
+	return m
+}
+
+func GRC000_Token(opts map[string]any) *mm.Model {
+	return mm.New(
+		objectsFrom(opts),
+		GRC000_Wallet(opts),
+		GRC000_Transfer(opts),
+		GRC000_MintBurn(opts),
+		map[string]any{"version": "v0"},
+	)
+}
+
+// ------- rendering -------
+
+func init() {
+	for _, rec := range registry {
+		registryMap[rec.Id] = rec
+		rec.Model.Binding = func(_ string) string {
+			var sb strings.Builder
+			sb.WriteString("# " + rec.Name + "\n")
+			sb.WriteString(rec.Description + "\n\n")
+			sb.WriteString("## Model\n")
+			sb.WriteString(rec.Model.Markdown() + "\n")
+			return sb.String()
+		}
+	}
+}
+
+func indexPage(_ string) string {
+	content := `# GRC000 Metamodel
+![grc000_Token combines all models](` + GRC000_Token(modelOpts).ThumbnailDataUrl() + `)
+This is a collection of GRC000 metamodels that demonstrate token-related functionalities such as wallets, transfers, and minting/burning tokens.
+
+Each model is designed to illustrate specific aspects of token management and can be used as a foundation for building more complex token systems.
+
+All of these models compose to form a comprehensive token model called **GRC000_Token** (pictured above).
+
+### What is a Metamodel?
+
+A _metamodel_ is a framework for modeling dynamic systems using places, transitions, and arrows, inspired by Petri nets.
+
+Models are defined by a set of _$objects_, each with a **unique identity** (e.g. $eth, $btc, $coffee_beans)
+
+Each _$object_ is defined by its behavior **in all contexts**.
+
+See the [Metamodel Token Standard](/r/labs/grc000$source) for more details.
+
+## Models
+`
+	for _, rec := range registryMap {
+		content += "- [" + rec.Name + "](" + basePath + ":" + rec.Id + "): " + rec.Description + "\n"
+	}
+	content += `## How can this be used?
+- Extend with staking, governance, multi-token systems.
+- Use as a foundation for dApps that need token management.
+- Simulate and analyze token flows off-chain for insight.
+`
+	return content
+}
+
+func Render(path string) string {
+	if rec, ok := registryMap[path]; ok {
+		if content, ok := rec.Model.Binding.(func(string) string); ok {
+			return content(path)
+		}
+		return rec.Model.Markdown()
+	}
+	return indexPage(path)
+}

--- a/examples/gno.land/r/labs/grc20/gnomod.toml
+++ b/examples/gno.land/r/labs/grc20/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/labs/grc20"
+gno = "0.9"

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -19,7 +19,7 @@ func init() {
 
 func Render(path string) string {
 	m := GRC20(modelOpts)
-	return pflowLink + "\n\n Model ID: " + m.Cid() + "\n\n" + m.Markdown()
+	return pflowLink + "\n\n Model ID: " + m.Cid() + "\n\n"  + m.IdentityHash() + "\n\n" + m.Markdown()
 }
 
 /*

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -1,0 +1,26 @@
+package grc20
+
+// REVIEW: conversion to julia w/ Algebraic Petri Nets
+// https://gist.github.com/stackdump/33dcd8e6f071d391c998008dfeac6ed9
+
+// interactive
+var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE.svg)](https://pflow.dev/p/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE/)"
+
+func Render(path string) string {
+    m := GRC20(map[string]any{})
+    return pflowLink + "\n\n" + m.Markdown()
+}
+
+/*
+func (tok Token) RenderHome() string {
+    return ufmt.Sprintf(`# %s ($%s)
+* **Version**: v0
+* **Decimals**: %d
+* **Total supply**: %d
+* **Known accounts**: %d
+* **Model digest**: %s
+* **Proof digest**: %s
+`, tok.name, tok.symbol, tok.decimals, tok.ledger.totalSupply, tok.KnownAccounts(),
+   tok.ModelDigest(), tok.ProofDigest())
+}
+*/

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -4,7 +4,7 @@ package grc20
 // https://gist.github.com/stackdump/33dcd8e6f071d391c998008dfeac6ed9
 
 // interactive
-var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE.svg)](https://pflow.dev/p/zb2rhabZZ4tZqhXeHZ9koFufakZ8bBGoMG9VS8HJaUTaUn8hE/)"
+var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk.svg)](https://pflow.dev/p/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk/)"
 
 func Render(path string) string {
     m := GRC20(map[string]any{})

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -4,7 +4,18 @@ package grc20
 // https://gist.github.com/stackdump/33dcd8e6f071d391c998008dfeac6ed9
 
 var pflowLink = `
-[![pflow](https://pflow.dev/img/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx.svg)](https://pflow.dev/p/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx/)`
+[![pflow](https://pflow.dev/img/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx.svg)](https://pflow.dev/p/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx/)
+`
+
+const version ="bafkreie4ceqfi5rnae75u2dp22utnwr6yrhvz5p5uvalgrrxfwwrvet2nq"
+
+func init() {
+    m := GRC20(modelOpts)
+    if m.Cid() != version {
+        panic("model version mismatch")
+    }
+}
+
 
 func Render(path string) string {
 	m := GRC20(modelOpts)

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -7,8 +7,8 @@ package grc20
 var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk.svg)](https://pflow.dev/p/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk/)"
 
 func Render(path string) string {
-    m := GRC20(map[string]any{})
-    return pflowLink + "\n\n" + m.Markdown()
+	m := GRC20(map[string]any{})
+	return pflowLink + "\n\n" + m.Markdown()
 }
 
 /*

--- a/examples/gno.land/r/labs/grc20/grc20.gno
+++ b/examples/gno.land/r/labs/grc20/grc20.gno
@@ -3,12 +3,12 @@ package grc20
 // REVIEW: conversion to julia w/ Algebraic Petri Nets
 // https://gist.github.com/stackdump/33dcd8e6f071d391c998008dfeac6ed9
 
-// interactive
-var pflowLink = "[![pflow](https://pflow.dev/img/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk.svg)](https://pflow.dev/p/zb2rhdBY7MrYLhWAm1GLZu7NzKfnko2DxpcYwUHGWgWWE8KAk/)"
+var pflowLink = `
+[![pflow](https://pflow.dev/img/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx.svg)](https://pflow.dev/p/zb2rhdVMFVdcBLYqpMJh8Vk4awKUf5GeWsuURmeTxRghdAmQx/)`
 
 func Render(path string) string {
-	m := GRC20(map[string]any{})
-	return pflowLink + "\n\n" + m.Markdown()
+	m := GRC20(modelOpts)
+	return pflowLink + "\n\n Model ID: " + m.Cid() + "\n\n" + m.Markdown()
 }
 
 /*

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -15,13 +15,16 @@ const (
 // GRC20 returns a single model that matches GRC20 semantics.
 func GRC20(opts map[string]any) *mm.Model {
     // Helper to get integer options with defaults
-    getIntOpt := func(key string, def int) int {
-        if v, ok := opts[key]; ok {
-            if i, ok := v.(int); ok {
-                return i
+    getIntOpt := func(key string, def int) int64 {
+        if val, ok := opts[key]; ok {
+            if intval, ok := val.(int); ok {
+                return int64(intval)
+            }
+            if intval, ok := val.(int64); ok {
+                return intval
             }
         }
-        return def
+        return int64(def)
     }
 
     // Objects
@@ -37,11 +40,12 @@ func GRC20(opts map[string]any) *mm.Model {
     burnAmt := int64(getIntOpt("burn_amount", 2))
 
     // Initial values
-    ownerInit := mm.T(getIntOpt("owner_balance", 1100))
-    recipientInit := mm.T(getIntOpt("recipient_balance", 0))
-    allowInit := mm.T(getIntOpt("allowance_initial", 0))
-    minterInit := mm.T(getIntOpt("minter_initial", 1))
-    supplyInit := mm.T(getIntOpt("supply_initial", 0))
+    supplyInit := objectModel.T(getIntOpt("supply_initial", 0), Token)
+    ownerInit := objectModel.T(getIntOpt("owner_balance", 1100), Token)
+    recipientInit := objectModel.T(getIntOpt("recipient_balance", 0), Token)
+
+    allowInit := objectModel.T(getIntOpt("allowance_initial", 0), Allow)
+    minterInit := objectModel.T(getIntOpt("minter_initial", 1), Allow)
 
 places := map[string]mm.Place{
     "$owner":               {Initial: ownerInit, X: 43, Y: 266},

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -7,13 +7,34 @@ import (
 const (
 	Version = "v0"
 
-	// Objects
+	// Fungible Objects
 	Token = "$token"
 	Allow = "$allow"
 )
 
+var (
+	modelOpts = map[string]any{
+		"transfer_amount":   10,
+		"approve_amount":    400,
+		"spend_amount":      100,
+		"mint_amount":       5,
+		"burn_amount":       2,
+		"supply_initial":    0,
+		"owner_balance":     1100,
+		"recipient_balance": 0,
+		"allowance_initial": 0,
+		"minter_initial":    1,
+		"objects":           []string{Token, Allow}, // "Token" oriented view
+	}
+)
+
+func init() {
+	modelOpts["objects"] = []string{Allow, Token} // invert view - "Allow" oriented view
+}
+
 // GRC20 returns a single model that matches GRC20 semantics.
 func GRC20(opts map[string]any) *mm.Model {
+
 	// Helper to get integer options with defaults
 	getIntOpt := func(key string, def int) int64 {
 		if val, ok := opts[key]; ok {
@@ -27,18 +48,13 @@ func GRC20(opts map[string]any) *mm.Model {
 		return int64(def)
 	}
 
-	// Objects
-	objects := []string{Token, Allow}
+	transferAmt := getIntOpt("transfer_amount", 10)
+	approveAmt := getIntOpt("approve_amount", 400)
+	spendAmt := getIntOpt("spend_amount", 100)
+	mintAmt := getIntOpt("mint_amount", 5)
+	burnAmt := getIntOpt("burn_amount", 2)
 
-	// Object model
-	om := mm.New(objects)
-
-	// Tunables
-	transferAmt := int64(getIntOpt("transfer_amount", 10))
-	approveAmt := int64(getIntOpt("approve_amount", 400))
-	spendAmt := int64(getIntOpt("spend_amount", 100))
-	mintAmt := int64(getIntOpt("mint_amount", 5))
-	burnAmt := int64(getIntOpt("burn_amount", 2))
+	om := mm.New(opts["objects"].([]string))
 
 	// Initial values
 	supplyInit := om.T(getIntOpt("supply_initial", 0), Token)
@@ -47,16 +63,17 @@ func GRC20(opts map[string]any) *mm.Model {
 
 	allowInit := om.T(getIntOpt("allowance_initial", 0), Allow)
 	minterInit := om.T(getIntOpt("minter_initial", 1), Allow)
+	spenderInit := om.T(1, Allow) // dummy spender to enable transferFrom
 
 	places := map[string]mm.Place{
-		"$owner":                 {Initial: ownerInit, X: 43, Y: 266},
-		"$recipient":             {Initial: recipientInit, X: 782, Y: 442},
-		"$spender":               {Initial: om.T(1, Allow), X: 44, Y: 443},
-		"$allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
-		"$supply":                {Initial: supplyInit, X: 513, Y: 111},
-		"$burned":                {X: 764, Y: 111},
-		"$minter":                {Initial: minterInit, X: 50, Y: 113},
-		"$void":                  {X: 941, Y: 274},
+		"$owner":                {Initial: ownerInit, X: 43, Y: 266},
+		"$recipient":            {Initial: recipientInit, X: 782, Y: 442},
+		"$spender":              {Initial: spenderInit, X: 44, Y: 443},
+		"allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
+		"supply":                {Initial: supplyInit, X: 513, Y: 111},
+		"$burned":               {X: 764, Y: 111},
+		"$minter":               {Initial: minterInit, X: 50, Y: 113},
+		"$void":                 {X: 941, Y: 274},
 	}
 
 	transitions := map[string]mm.Transition{
@@ -84,26 +101,26 @@ func GRC20(opts map[string]any) *mm.Model {
 		arc("transfer", "$recipient", transferAmt, Token),
 		inhibit("approveAdd", "$owner", 0, Allow),
 
-		arc("approveAdd", "$allow(owner->spender)", approveAmt, Allow),
-		arc("$allow(owner->spender)", "approveZero", spendAmt, Allow),
+		arc("approveAdd", "allow(owner->spender)", approveAmt, Allow),
+		arc("allow(owner->spender)", "approveZero", spendAmt, Allow),
 		arc("approveZero", "$void", spendAmt, Allow),
 		arc("$owner", "transferFrom", transferAmt, Token),
-		arc("$allow(owner->spender)", "transferFrom", transferAmt, Allow),
+		arc("allow(owner->spender)", "transferFrom", transferAmt, Allow),
 		arc("transferFrom", "$recipient", transferAmt, Token),
-		arc("$allow(owner->spender)", "spendAllowance", spendAmt, Allow),
+		arc("allow(owner->spender)", "spendAllowance", spendAmt, Allow),
 		arc("spendAllowance", "$void", spendAmt, Allow),
 		inhibit("mint", "$minter", 0, Allow),
 
 		arc("mint", "$owner", mintAmt, Token),
-		arc("mint", "$supply", mintAmt, Token),
+		arc("mint", "supply", mintAmt, Token),
 		arc("$owner", "burn", burnAmt, Token),
-		arc("$supply", "burn", burnAmt, Token),
+		arc("supply", "burn", burnAmt, Token),
 		arc("burn", "$burned", burnAmt, Token),
 		inhibit("transferFrom", "$spender", 0, Allow),
 	}
 
 	return mm.New(
-		objects,
+		om.Objects,
 		places,
 		transitions,
 		arrows,
@@ -112,10 +129,10 @@ func GRC20(opts map[string]any) *mm.Model {
 }
 
 /*
-Categorical view of `$allow(owner->spender)`
+Categorical view of `allow(owner->spender)`
 
 - Implementation note:
-    We model Allow(o,s) as its own place named "$allow(owner->spender)" — a
+    We model Allow(o,s) as its own place named "allow(owner->spender)" — a
     discrete-index view of the profunctor. A colored-token variant would store
     pairs (o,s) as token color in a single "$allow" place; the current layout is
     a clear, didactic approximation.

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -1,0 +1,127 @@
+package grc20
+
+import (
+    mm "gno.land/p/labs/metamodel"
+)
+
+const (
+    Version = "v0"
+
+    // Objects
+    Token = "$token"
+    Allow = "$allow"
+)
+
+// GRC20 returns a single model that matches GRC20 semantics.
+func GRC20(opts map[string]any) *mm.Model {
+    // Helper to get integer options with defaults
+    getIntOpt := func(key string, def int) int {
+        if v, ok := opts[key]; ok {
+            if i, ok := v.(int); ok {
+                return i
+            }
+        }
+        return def
+    }
+
+    // Objects
+    objects := []string{Token, Allow}
+
+    objectModel := mm.New(objects)
+
+    // Tunables
+    transferAmt := int64(getIntOpt("transfer_amount", 10))
+    approveAmt := int64(getIntOpt("approve_amount", 400))
+    spendAmt := int64(getIntOpt("spend_amount", 100))
+    mintAmt := int64(getIntOpt("mint_amount", 5))
+    burnAmt := int64(getIntOpt("burn_amount", 2))
+
+    // Initial values
+    ownerInit := mm.T(getIntOpt("owner_balance", 1100))
+    recipientInit := mm.T(getIntOpt("recipient_balance", 0))
+    allowInit := mm.T(getIntOpt("allowance_initial", 0))
+    minterInit := mm.T(getIntOpt("minter_initial", 1))
+    supplyInit := mm.T(getIntOpt("supply_initial", 0))
+
+places := map[string]mm.Place{
+    "$owner":               {Initial: ownerInit, X: 43, Y: 266},
+    "$recipient":           {Initial: recipientInit, X: 782, Y: 442},
+    "$spender":             {Initial: mm.T(1), X: 44, Y: 443},
+    "$allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
+    "$supply":              {Initial: supplyInit, X: 513, Y: 111},
+    "$burned":              {Initial: mm.T(0), X: 764, Y: 111},
+    "$minter":              {Initial: minterInit, X: 50, Y: 113},
+    "$void":                {Initial: mm.T(0), X: 941, Y: 274},
+}
+
+transitions := map[string]mm.Transition{
+    "transfer":       {X: 349, Y: 444},
+    "approveAdd":     {X: 345, Y: 277},
+    "approveZero":    {X: 680, Y: 275},
+    "transferFrom":   {X: 619, Y: 444},
+    "spendAllowance": {X: 799, Y: 275},
+    "mint":           {X: 347, Y: 185},
+    "burn":           {X: 345, Y: 113},
+}
+
+arrows := []mm.Arrow{
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transfer", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "transfer", Target: "$recipient", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "approveAdd", Weight: approveAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$allow(owner->spender)", Weight: approveAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "approveZero", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "approveZero", Target: "$void", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transferFrom", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "transferFrom", Weight: transferAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$recipient", Weight: transferAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "spendAllowance", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "spendAllowance", Target: "$void", Weight: spendAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$minter", Inhibit: true, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$owner", Weight: mintAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$supply", Weight: mintAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "burn", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "$supply", Target: "burn", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "burn", Target: "$burned", Weight: burnAmt, Object: Token}),
+    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$spender", Inhibit: true, Object: Allow}),
+}
+
+    // Return the model
+    return mm.New(
+        objects,
+        places,
+        transitions,
+        arrows,
+        map[string]any{"version": Version, "name": "GRC20"},
+    )
+}
+
+/*
+Categorical view of `$allow(owner->spender)`
+
+- Implementation note:
+    We model Allow(o,s) as its own place named "$allow(owner->spender)" — a
+    discrete-index view of the profunctor. A colored-token variant would store
+    pairs (o,s) as token color in a single "$allow" place; the current layout is
+    a clear, didactic approximation.
+
+- Profunctor (enriched in the commutative monoid (N,+,0)):
+    Allow : Addr^op × Addr -> (N,+,0)
+    Each pair (owner, spender) maps to a natural-number allowance.
+    The map is a sparse matrix representation of this profunctor.
+
+- Pointwise (natural) operations:
+    ApproveAdd(o,s,a):   Allow(o,s) += a
+    ApproveZero(o,s):    Allow(o,s)  = 0
+    SpendAllowance(o,s,a): Allow(o,s) = max(Allow(o,s) - a, 0)
+
+- Atomic TransferFrom:
+    Requires Token(o) and Allow(o,s) as simultaneous inputs, and produces Token(r).
+    Effect: Token moves owner->recipient by 'a' while Allow(o,s) decreases by 'a'
+    in the same transition. This is the categorical “commuting square” that
+    enforces atomicity.
+
+- Yoneda-ish slices:
+    Fix owner o:   Allow(o, -) : Addr -> (N,+,0)   (copresheaf: budgets by spender)
+    Fix spender s: Allow(-, s) : Addr^op -> (N,+,0) (presheaf: who grants me how much)
+
+*/

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -56,8 +56,9 @@ func GRC20(opts map[string]any) *mm.Model {
 
 	om := mm.New(opts["objects"].([]string))
 
-	// Initial values
+    //	supplyInit := T(0, 0) // $allow, $token
 	supplyInit := om.T(getIntOpt("supply_initial", 0), Token)
+
 	ownerInit := om.T(getIntOpt("owner_balance", 1100), Token)
 	recipientInit := om.T(getIntOpt("recipient_balance", 0), Token)
 

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -67,7 +67,7 @@ transitions := map[string]mm.Transition{
 arrows := []mm.Arrow{
     objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transfer", Weight: transferAmt, Object: Token}),
     objectModel.Arrow(mm.Arc{Source: "transfer", Target: "$recipient", Weight: transferAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "approveAdd", Weight: approveAmt, Object: Allow}),
+    objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$owner", Weight: approveAmt, Inhibit: true, Object: Allow}),
     objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$allow(owner->spender)", Weight: approveAmt, Object: Allow}),
     objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "approveZero", Weight: spendAmt, Object: Allow}),
     objectModel.Arrow(mm.Arc{Source: "approveZero", Target: "$void", Weight: spendAmt, Object: Allow}),

--- a/examples/gno.land/r/labs/grc20/metamodel.gno
+++ b/examples/gno.land/r/labs/grc20/metamodel.gno
@@ -1,102 +1,114 @@
 package grc20
 
 import (
-    mm "gno.land/p/labs/metamodel"
+	mm "gno.land/p/labs/metamodel"
 )
 
 const (
-    Version = "v0"
+	Version = "v0"
 
-    // Objects
-    Token = "$token"
-    Allow = "$allow"
+	// Objects
+	Token = "$token"
+	Allow = "$allow"
 )
 
 // GRC20 returns a single model that matches GRC20 semantics.
 func GRC20(opts map[string]any) *mm.Model {
-    // Helper to get integer options with defaults
-    getIntOpt := func(key string, def int) int64 {
-        if val, ok := opts[key]; ok {
-            if intval, ok := val.(int); ok {
-                return int64(intval)
-            }
-            if intval, ok := val.(int64); ok {
-                return intval
-            }
-        }
-        return int64(def)
-    }
+	// Helper to get integer options with defaults
+	getIntOpt := func(key string, def int) int64 {
+		if val, ok := opts[key]; ok {
+			if intval, ok := val.(int); ok {
+				return int64(intval)
+			}
+			if intval, ok := val.(int64); ok {
+				return intval
+			}
+		}
+		return int64(def)
+	}
 
-    // Objects
-    objects := []string{Token, Allow}
+	// Objects
+	objects := []string{Token, Allow}
 
-    objectModel := mm.New(objects)
+	// Object model
+	om := mm.New(objects)
 
-    // Tunables
-    transferAmt := int64(getIntOpt("transfer_amount", 10))
-    approveAmt := int64(getIntOpt("approve_amount", 400))
-    spendAmt := int64(getIntOpt("spend_amount", 100))
-    mintAmt := int64(getIntOpt("mint_amount", 5))
-    burnAmt := int64(getIntOpt("burn_amount", 2))
+	// Tunables
+	transferAmt := int64(getIntOpt("transfer_amount", 10))
+	approveAmt := int64(getIntOpt("approve_amount", 400))
+	spendAmt := int64(getIntOpt("spend_amount", 100))
+	mintAmt := int64(getIntOpt("mint_amount", 5))
+	burnAmt := int64(getIntOpt("burn_amount", 2))
 
-    // Initial values
-    supplyInit := objectModel.T(getIntOpt("supply_initial", 0), Token)
-    ownerInit := objectModel.T(getIntOpt("owner_balance", 1100), Token)
-    recipientInit := objectModel.T(getIntOpt("recipient_balance", 0), Token)
+	// Initial values
+	supplyInit := om.T(getIntOpt("supply_initial", 0), Token)
+	ownerInit := om.T(getIntOpt("owner_balance", 1100), Token)
+	recipientInit := om.T(getIntOpt("recipient_balance", 0), Token)
 
-    allowInit := objectModel.T(getIntOpt("allowance_initial", 0), Allow)
-    minterInit := objectModel.T(getIntOpt("minter_initial", 1), Allow)
+	allowInit := om.T(getIntOpt("allowance_initial", 0), Allow)
+	minterInit := om.T(getIntOpt("minter_initial", 1), Allow)
 
-places := map[string]mm.Place{
-    "$owner":               {Initial: ownerInit, X: 43, Y: 266},
-    "$recipient":           {Initial: recipientInit, X: 782, Y: 442},
-    "$spender":             {Initial: mm.T(1), X: 44, Y: 443},
-    "$allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
-    "$supply":              {Initial: supplyInit, X: 513, Y: 111},
-    "$burned":              {Initial: mm.T(0), X: 764, Y: 111},
-    "$minter":              {Initial: minterInit, X: 50, Y: 113},
-    "$void":                {Initial: mm.T(0), X: 941, Y: 274},
-}
+	places := map[string]mm.Place{
+		"$owner":                 {Initial: ownerInit, X: 43, Y: 266},
+		"$recipient":             {Initial: recipientInit, X: 782, Y: 442},
+		"$spender":               {Initial: om.T(1, Allow), X: 44, Y: 443},
+		"$allow(owner->spender)": {Initial: allowInit, X: 525, Y: 275},
+		"$supply":                {Initial: supplyInit, X: 513, Y: 111},
+		"$burned":                {X: 764, Y: 111},
+		"$minter":                {Initial: minterInit, X: 50, Y: 113},
+		"$void":                  {X: 941, Y: 274},
+	}
 
-transitions := map[string]mm.Transition{
-    "transfer":       {X: 349, Y: 444},
-    "approveAdd":     {X: 345, Y: 277},
-    "approveZero":    {X: 680, Y: 275},
-    "transferFrom":   {X: 619, Y: 444},
-    "spendAllowance": {X: 799, Y: 275},
-    "mint":           {X: 347, Y: 185},
-    "burn":           {X: 345, Y: 113},
-}
+	transitions := map[string]mm.Transition{
+		"transfer":       {X: 349, Y: 444},
+		"approveAdd":     {X: 345, Y: 277},
+		"approveZero":    {X: 680, Y: 275},
+		"transferFrom":   {X: 619, Y: 444},
+		"spendAllowance": {X: 799, Y: 275},
+		"mint":           {X: 347, Y: 185},
+		"burn":           {X: 345, Y: 113},
+	}
 
-arrows := []mm.Arrow{
-    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transfer", Weight: transferAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "transfer", Target: "$recipient", Weight: transferAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$owner", Weight: approveAmt, Inhibit: true, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "approveAdd", Target: "$allow(owner->spender)", Weight: approveAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "approveZero", Weight: spendAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "approveZero", Target: "$void", Weight: spendAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "transferFrom", Weight: transferAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "transferFrom", Weight: transferAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$recipient", Weight: transferAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "$allow(owner->spender)", Target: "spendAllowance", Weight: spendAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "spendAllowance", Target: "$void", Weight: spendAmt, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$minter", Inhibit: true, Object: Allow}),
-    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$owner", Weight: mintAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "mint", Target: "$supply", Weight: mintAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "$owner", Target: "burn", Weight: burnAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "$supply", Target: "burn", Weight: burnAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "burn", Target: "$burned", Weight: burnAmt, Object: Token}),
-    objectModel.Arrow(mm.Arc{Source: "transferFrom", Target: "$spender", Inhibit: true, Object: Allow}),
-}
+	arc := func(source, target string, weight int64, object string) mm.Arrow {
+		a := mm.Arc{Source: source, Target: target, Weight: weight, Object: object}
+		return om.Arrow(a)
+	}
 
-    // Return the model
-    return mm.New(
-        objects,
-        places,
-        transitions,
-        arrows,
-        map[string]any{"version": Version, "name": "GRC20"},
-    )
+	inhibit := func(source, target string, weight int64, object string) mm.Arrow {
+		a := mm.Arc{Source: source, Target: target, Weight: weight, Inhibit: true, Object: object}
+		return om.Arrow(a)
+	}
+
+	arrows := []mm.Arrow{
+		arc("$owner", "transfer", transferAmt, Token),
+		arc("transfer", "$recipient", transferAmt, Token),
+		inhibit("approveAdd", "$owner", 0, Allow),
+
+		arc("approveAdd", "$allow(owner->spender)", approveAmt, Allow),
+		arc("$allow(owner->spender)", "approveZero", spendAmt, Allow),
+		arc("approveZero", "$void", spendAmt, Allow),
+		arc("$owner", "transferFrom", transferAmt, Token),
+		arc("$allow(owner->spender)", "transferFrom", transferAmt, Allow),
+		arc("transferFrom", "$recipient", transferAmt, Token),
+		arc("$allow(owner->spender)", "spendAllowance", spendAmt, Allow),
+		arc("spendAllowance", "$void", spendAmt, Allow),
+		inhibit("mint", "$minter", 0, Allow),
+
+		arc("mint", "$owner", mintAmt, Token),
+		arc("mint", "$supply", mintAmt, Token),
+		arc("$owner", "burn", burnAmt, Token),
+		arc("$supply", "burn", burnAmt, Token),
+		arc("burn", "$burned", burnAmt, Token),
+		inhibit("transferFrom", "$spender", 0, Allow),
+	}
+
+	return mm.New(
+		objects,
+		places,
+		transitions,
+		arrows,
+		map[string]any{"version": Version, "name": "GRC20"},
+	)
 }
 
 /*

--- a/examples/gno.land/r/labs/home/gnomod.toml
+++ b/examples/gno.land/r/labs/home/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/labs/home"
+gno = "0.9"

--- a/examples/gno.land/r/labs/home/index.gno
+++ b/examples/gno.land/r/labs/home/index.gno
@@ -3,7 +3,8 @@ package home
 var index = `
 
 ## Labs Index
-- [Grc000](/r/labs/grc000)
+- [grc000](/r/labs/grc000) - base grammar for fungible tokens (GRC-000)
+- [grc20](/r/labs/grc20) - grammar for fungible tokens (GRC-20)
 `
 
 func Render(_ string) string {

--- a/examples/gno.land/r/labs/home/index.gno
+++ b/examples/gno.land/r/labs/home/index.gno
@@ -1,0 +1,11 @@
+package home
+
+var index = `
+
+## Labs Index
+- [Grc000](/r/labs/grc000)
+`
+
+func Render(_ string) string {
+	return index
+}

--- a/examples/gno.land/r/stackdump/home/README.md
+++ b/examples/gno.land/r/stackdump/home/README.md
@@ -1,0 +1,128 @@
+# Coffee Shop Petri Net Variants
+
+This document outlines the different structural and semantic variations of the **Coffee Shop** Petri net model, with explanations of their purpose and how each transformation aids different forms of analysis.
+
+---
+
+## 📦 Base Model: `coffeeShop()`
+
+This is a full Petri net model representing the operational steps of a coffee shop, including:
+
+- Boiling water
+- Grinding beans
+- Brewing coffee
+- Pouring into a cup
+- Sending the order
+- Processing payment
+
+### Features:
+- Places represent ingredients and resources (e.g., `Water`, `Filter`, `Cup`)
+- Transitions represent actions (e.g., `BoilWater`, `PourCoffee`)
+- Includes an **inhibitor arc** from `PourCoffee` to `Payment`, encoding a "guard condition"
+
+Used as a base for all transformations.
+
+---
+
+## 🔁 Structural Variants
+
+### 1. `ForgetPlaces()` – Transition Adjacency Graph
+**Name:** `Coffee Shop No Places`
+
+- Projects the model into a transition-only graph.
+- Highlights potential sequencing of activities.
+- Drops token dynamics.
+
+**Use Case:** Causal flow analysis.
+
+### 2. `ForgetTransitions()` – Place Flow Graph
+**Name:** `Coffee Shop No Transitions`
+
+- Connects places that are causally related via transitions.
+- Useful for visualizing token flow potential.
+
+**Use Case:** Layout planning or data dependency.
+
+---
+
+## 🧭 Workflow Net Variant: `coffeeShopWorkflowNet()`
+
+Enhances the base model to follow **workflow net** structure:
+
+- Adds a **`Start`** place with initial token
+- Adds an **`Exit`** place with final target
+- Ensures all transitions lie on a path from `Start` to `Exit`
+
+### Purpose:
+- To make the model suitable for **soundness analysis** and **workflow validation**
+- Enforces clear entry/exit points
+
+---
+
+## 🔁 Workflow Variant Projections
+
+### 3. `ForgetPlaces()` on workflow
+**Name:** `Coffee Shop Workflow Net No Places`
+
+- Transition adjacency only
+- Emphasizes execution order
+- Suitable for transition sequencing analysis
+
+### 4. `ForgetTransitions()` on workflow
+**Name:** `Coffee Shop Workflow Net No Transitions`
+
+- Place adjacency only
+- Shows state-to-state flows
+- Simplifies dependency extraction
+
+---
+
+## ⚠️ Inhibitor Arcs
+
+The base model includes a **single inhibitor arc**:
+
+```go
+{Source: "PourCoffee", Target: "Payment", Inhibit: true}
+```
+
+### Semantics:
+- Prevents payment from processing if coffee hasn't been poured.
+- Models a **guard condition** using negation logic.
+
+### Effect on Projections:
+- `ForgetPlaces` and `ForgetTransitions` **skip inhibitor arcs** to preserve monotonicity.
+- This avoids introducing **spurious transitive edges** due to anti-monotonic behavior.
+
+### Optional Refactoring:
+- Inhibitor can be modeled structurally by adding a control token or making the logic implicit in the workflow net design.
+
+---
+
+## 🔧 Implementation Notes
+
+Each model is registered with a description and keyword set using `register()` calls.
+
+This enables structured discovery of the following:
+- Full model
+- Workflow variant
+- Structure-only graphs (Places-only / Transitions-only)
+
+Keywords like `no_places`, `workflow_net`, `payment`, etc., allow fine-grained search or filtering.
+
+---
+
+## 🧩 Summary Table
+
+| Model Name                              | Description                                | Use Case                            |
+|----------------------------------------|--------------------------------------------|-------------------------------------|
+| Coffee Shop                            | Full Petri net with tokens and inhibitors  | Operational modeling                |
+| Coffee Shop No Places                  | Transition-only projection                 | Causal analysis                     |
+| Coffee Shop No Transitions             | Place-only projection                      | Token state mapping                 |
+| Coffee Shop Workflow Net               | Workflow net with Start/Exit               | Soundness + structured analysis     |
+| Coffee Shop Workflow Net No Places     | Transition flow of workflow                | Order-of-execution focus            |
+| Coffee Shop Workflow Net No Transitions| Place-level state flow                     | Data/state traceability             |
+
+---
+
+This set of models serves both as an educational scaffold and a testbed for projection, transformation, and analysis techniques across discrete and continuous Petri net systems.
+

--- a/examples/gno.land/r/stackdump/home/coffeeshop.gno
+++ b/examples/gno.land/r/stackdump/home/coffeeshop.gno
@@ -16,6 +16,19 @@ func init() {
 	}
 	keywords := []string{"coffee", "shop", "payment", "brew", "cafe"}
 	register("Coffee Shop", coffeeShopModel, keywords...)
+
+	shopNoPlaces := coffeeShop().ForgetPlaces()
+	shopNoPlaces.Binding = func(_ string) string {
+		return "This is the Coffee Shop model without places.\n\n\n" + shopNoPlaces.Markdown()
+	}
+	register("Coffee Shop No Places", shopNoPlaces, append(keywords, "no_places")...)
+
+	shopNoTransitions := coffeeShop().ForgetTransitions()
+	shopNoTransitions.Binding = func(_ string) string {
+		return "This is the Coffee Shop model without transitions.\n\n\n" + shopNoTransitions.Markdown()
+	}
+	register("Coffee Shop No Transitions", shopNoTransitions, append(keywords, "no_transitions")...)
+
 }
 
 func coffeeShop() *mm.Model {

--- a/examples/gno.land/r/stackdump/home/coffeeshop.gno
+++ b/examples/gno.land/r/stackdump/home/coffeeshop.gno
@@ -29,6 +29,29 @@ func init() {
 	}
 	register("Coffee Shop No Transitions", shopNoTransitions, append(keywords, "no_transitions")...)
 
+	shopWorkflow := coffeeShopWorkflowNet()
+	shopWorkflow.Binding = func(_ string) string {
+	    return "This is the Coffee Shop model as a workflow net.\n\n\n" +
+	            shopWorkflow.Markdown()
+
+    }
+    register("Coffee Shop Workflow Net", shopWorkflow, append(keywords, "workflow", "workflow_net")...)
+
+    workflowNoTransitions := shopWorkflow.ForgetTransitions()
+    workflowNoTransitions.Binding = func(_ string) string {
+        return "This is the Coffee Shop Workflow Net model without transitions.\n\n\n" +
+            workflowNoTransitions.Markdown()
+    }
+
+    register("Coffee Shop Workflow Net No Transitions", workflowNoTransitions, append(keywords, "workflow", "workflow_net", "no_transitions")...)
+
+    workflowNoPlaces := shopWorkflow.ForgetPlaces()
+    workflowNoPlaces.Binding = func(_ string) string {
+        return "This is the Coffee Shop Workflow Net model without places.\n\n\n" +
+            workflowNoPlaces.Markdown()
+    }
+    register("Coffee Shop Workflow Net No Places", workflowNoPlaces, append(keywords, "workflow", "workflow_net", "no_places")...)
+
 }
 
 func coffeeShop() *mm.Model {
@@ -72,4 +95,42 @@ func coffeeShop() *mm.Model {
 		{Source: "PourCoffee", Target: "Payment", Inhibit: true},
 	}
 	return mm.New(places, transitions, arrows)
+}
+
+func coffeeShopWorkflowNet() *mm.Model {
+	// Start with the base coffeeShop model
+	baseModel := coffeeShop()
+
+	// Add a single start place
+	baseModel.Places["Start"] = mm.Place{
+		Offset: 10, Initial: mm.T(1), Capacity: mm.T(1), X: 280, Y: 20,
+	}
+
+	// Add a single exit place
+	baseModel.Places["Exit"] = mm.Place{
+		Offset: 11, Initial: mm.T(0), Capacity: mm.T(1), X: 280, Y: 300,
+	}
+
+	// Connect the start place to the first transition
+	baseModel.Arrows = append(baseModel.Arrows, mm.Arrow{
+		Source: "Start", Target: "BoilWater",
+	})
+
+	// Connect the last transition to the exit place
+	baseModel.Arrows = append(baseModel.Arrows, mm.Arrow{
+		Source: "Credit", Target: "Exit",
+	})
+
+	// Connect Start and Send to ensure all transitions are on a path from Start to Exit
+	baseModel.Arrows = append(baseModel.Arrows, mm.Arrow{
+	    Source: "Start", Target: "Send",
+    })
+
+    // connect PourCoffee to Exit to ensure all transitions are on a path from Start to Exit
+    baseModel.Arrows = append(baseModel.Arrows, mm.Arrow{
+        Source: "PourCoffee", Target: "Exit",
+    })
+
+
+	return baseModel
 }

--- a/examples/gno.land/r/stackdump/home/coffeeshop.gno
+++ b/examples/gno.land/r/stackdump/home/coffeeshop.gno
@@ -1,0 +1,62 @@
+package home
+
+import (
+	mm "gno.land/p/labs/metamodel"
+)
+
+var coffeeShopDescription = `
+This is a model of a coffee shop process, which includes the following steps:
+
+`
+
+func init() {
+	coffeeShopModel := coffeeShop()
+	coffeeShopModel.Binding = func(_ string) string {
+		return coffeeShopDescription + coffeeShopModel.Markdown()
+	}
+	keywords := []string{"coffee", "shop", "payment", "brew", "cafe"}
+	register("Coffee Shop", coffeeShopModel, keywords...)
+}
+
+func coffeeShop() *mm.Model {
+	places := map[string]mm.Place{
+		"Water":        {Offset: 0, Initial: mm.T(1), Capacity: mm.T(1), X: 35, Y: 66},
+		"BoiledWater":  {Offset: 1, Initial: mm.T(0), Capacity: mm.T(1), X: 293, Y: 93},
+		"CoffeeBeans":  {Offset: 2, Initial: mm.T(1), Capacity: mm.T(1), X: 35, Y: 126},
+		"GroundCoffee": {Offset: 3, Initial: mm.T(0), Capacity: mm.T(1), X: 296, Y: 153},
+		"Filter":       {Offset: 4, Initial: mm.T(1), Capacity: mm.T(1), X: 35, Y: 190},
+		"CoffeeInPot":  {Offset: 5, Initial: mm.T(0), Capacity: mm.T(1), X: 300, Y: 222},
+		"Pending":      {Offset: 6, Initial: mm.T(1), Capacity: mm.T(1), X: 518, Y: 68},
+		"Sent":         {Offset: 7, Initial: mm.T(0), Capacity: mm.T(1), X: 524, Y: 158},
+		"Payment":      {Offset: 8, Initial: mm.T(0), Capacity: mm.T(1), X: 528, Y: 246},
+		"Cup":          {Offset: 9, Initial: mm.T(1), Capacity: mm.T(1), X: 35, Y: 249},
+	}
+
+	transitions := map[string]mm.Transition{
+		"BoilWater":  {Label: "Boil Water", Offset: 0, X: 184, Y: 67},
+		"BrewCoffee": {Label: "Brew Coffee", Offset: 0, X: 183, Y: 191},
+		"Credit":     {Label: "Credit Payment", Offset: 0, X: 393, Y: 188},
+		"GrindBeans": {Label: "Grind Beans", Offset: 0, X: 180, Y: 128},
+		"PourCoffee": {Label: "Pour Coffee", Offset: 0, X: 183, Y: 252},
+		"Send":       {Label: "Send Order", Offset: 0, X: 392, Y: 111},
+	}
+
+	arrows := []mm.Arrow{
+		{Source: "Water", Target: "BoilWater"},
+		{Source: "BoilWater", Target: "BoiledWater"},
+		{Source: "CoffeeBeans", Target: "GrindBeans"},
+		{Source: "GrindBeans", Target: "GroundCoffee"},
+		{Source: "BoiledWater", Target: "BrewCoffee"},
+		{Source: "GroundCoffee", Target: "BrewCoffee"},
+		{Source: "Filter", Target: "BrewCoffee"},
+		{Source: "BrewCoffee", Target: "CoffeeInPot"},
+		{Source: "CoffeeInPot", Target: "PourCoffee"},
+		{Source: "Cup", Target: "PourCoffee"},
+		{Source: "Pending", Target: "Send"},
+		{Source: "Send", Target: "Sent"},
+		{Source: "Sent", Target: "Credit"},
+		{Source: "Credit", Target: "Payment"},
+		{Source: "PourCoffee", Target: "Payment", Inhibit: true},
+	}
+	return mm.New(places, transitions, arrows)
+}

--- a/examples/gno.land/r/stackdump/home/gnomod.toml
+++ b/examples/gno.land/r/stackdump/home/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/stackdump/home"
+gno = "0.9"

--- a/examples/gno.land/r/stackdump/home/index.gno
+++ b/examples/gno.land/r/stackdump/home/index.gno
@@ -1,0 +1,47 @@
+package home
+
+import (
+	"strings"
+
+	mm "gno.land/p/labs/metamodel"
+)
+
+var (
+	renderOpts = map[string]interface{}{
+		"dev": map[string]interface{}{
+			"Title":       "Stackdump Home",
+			"Description": "Metamodel Registry",
+			"Version":     "0.0.1",
+			"BasePath":    "/r/stackdump/home",
+		},
+	}
+
+	// consider any path that ends with /metamodel/
+	authorizedPaths = []string{
+		"gno.land/r/stackdump/home",
+		"", // EOA - externally owned account
+	}
+
+	registry = mm.NewRegistry(authorizedPaths, renderOpts)
+)
+
+func register(key string, m *mm.Model, kw ...string) {
+	registry.Register(key, m, kw...)
+}
+
+func renderIndex(path string) string {
+	var sb strings.Builder
+	sb.WriteString("# Metamodel000 Index\n\n")
+	sb.WriteString("This is a public registry of metamodels.\n\n")
+	sb.WriteString("### What is a Metamodel?\n\n")
+	sb.WriteString("A _metamodel_ is a framework for modeling dynamic systems using places, transitions, and arrows, inspired by Petri nets.\n\n")
+	sb.WriteString("Models are defined by a set of _$objects_, each with a **unique identity** (e.g. $eth, $btc, $coffee_beans )\n\n")
+	sb.WriteString("Each _$object_ is defined by its behavior **in all contexts**.\n\n")
+	sb.WriteString("Read the [Metamodel Codex](/p/labs/metamodel$source) for more background.\n\n")
+
+	return sb.String()
+}
+
+func Render(path string) string {
+	return registry.Render(path, renderIndex)
+}

--- a/examples/gno.land/r/stackdump/home/index.gno
+++ b/examples/gno.land/r/stackdump/home/index.gno
@@ -19,7 +19,7 @@ var (
 	// consider any path that ends with /metamodel/
 	authorizedPaths = []string{
 		"gno.land/r/stackdump/home",
-		"", // EOA - externally owned account
+		"", // TODO: this opens perms for self, does it open for all EOAs? (i.e. non-realm accounts)
 	}
 
 	registry = mm.NewRegistry(authorizedPaths, renderOpts)

--- a/tm2/pkg/std/memfile.go
+++ b/tm2/pkg/std/memfile.go
@@ -35,7 +35,7 @@ var (
 //
 // File Name must contain a single dot and extension.
 // File Name may be ALLCAPS.xxx or lowercase.xxx; extensions lowercase.
-// e.g. OK:     README.md, readme.md, readme.txt, READ.me
+// e.g. OK:     README.md, README.md, readme.txt, READ.me
 // e.g. NOT OK: Readme.md, readme.MD, README, .readme
 // File Body can be any string.
 //


### PR DESCRIPTION
## Overview

This code axiom-izes a ERC-20-like token system using petri-net primitives.

## GRC000

Review the [primitives](https://github.com/gnolang/gno/blob/d9c489ce563aa18afad76dea9f9813b6aae61cac/examples/gno.land/r/labs/grc000/README.md#2-primitives) defined in /r/labs/grc000 - these basic elements combine to form GRC000-Token, a model composed from the Wallet, Transfer, Mint&Burn primitives.

With this design we can append new $objects and behavior to the model without invalidating any of elements it was previously composed from - see the [Append only notes in section 5](https://github.com/gnolang/gno/blob/d9c489ce563aa18afad76dea9f9813b6aae61cac/examples/gno.land/r/labs/grc000/README.md#5-composition-principles--append-only-evolution)

## metamodel package

/p/labs/metamodel provides a petri-net based modeling library that supports visualization.

With this library we can define and visualize complex token semantics using a mathematically sound method of construction and analysis. (see Open Petri nets)

If we adopted such a mechanism to define GRC tokens (like ERC-20), we can append new behavior to an existing system without invalidating existing transactions or having to re-prove soundless of existing structures.



## Motivation

- Interfaces hide behavior; we define it.
- Petri-net primitives make flows explicit, composable, verifiable.
- Correct-by-construction: invariants are structural and easy to simulate/check.

## References
- Review the [README](https://github.com/gnolang/gno/blob/d9c489ce563aa18afad76dea9f9813b6aae61cac/examples/gno.land/r/labs/grc000/README.md) in the MR for a full overview.
- See more examples and resources on the [AIB labsnet](https://aiblabs.net/r/metamodel000:metamodel-codex#what-is-a-metamodel)

- See [GRC-20 ported to metamodel syntax](https://github.com/stackdump/gno/pull/1)