### PR TITLE
feat(tm2/rpc): readyness probe

### DIFF
--- a/contribs/gnogenesis/integration_test.go
+++ b/contribs/gnogenesis/integration_test.go
@@ -168,7 +168,7 @@ func Render(_ string) string { return "bar" }
 	cli, err := client.NewHTTPClient(address)
 	require.NoError(t, err)
 
-	s, err := cli.Status(ctx)
+	s, err := cli.Status(ctx, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, s.NodeInfo.Network, chainid)

--- a/contribs/gnohealth/internal/timestamp/timestamp.go
+++ b/contribs/gnohealth/internal/timestamp/timestamp.go
@@ -128,7 +128,7 @@ func execTimestamp(cfg *timestampCfg, io commands.IO) error {
 
 		case <-ticker.C:
 			// Fetch the latest block number from the chain
-			status, err := client.Status(context.Background())
+			status, err := client.Status(context.Background(), nil)
 			if err != nil {
 				return fmt.Errorf("unable to fetch latest block number: %w", err)
 			}

--- a/contribs/tx-archive/backup/client/rpc/rpc.go
+++ b/contribs/tx-archive/backup/client/rpc/rpc.go
@@ -48,7 +48,7 @@ func NewWSClient(remote string) (*Client, error) {
 }
 
 func (c *Client) GetLatestBlockNumber() (uint64, error) {
-	status, err := c.client.Status(context.Background())
+	status, err := c.client.Status(context.Background(), nil)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"unable to fetch latest block number, %w",

--- a/gno.land/pkg/gnoclient/client_queries.go
+++ b/gno.land/pkg/gnoclient/client_queries.go
@@ -171,7 +171,7 @@ func (c *Client) LatestBlockHeight() (int64, error) {
 		return 0, ErrMissingRPCClient
 	}
 
-	status, err := c.RPCClient.Status(context.Background())
+	status, err := c.RPCClient.Status(context.Background(), nil)
 	if err != nil {
 		return 0, fmt.Errorf("block number query failed: %w", err)
 	}

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -1226,7 +1226,7 @@ func TestLatestBlockHeight(t *testing.T) {
 	client := &Client{
 		Signer: &mockSigner{},
 		RPCClient: &mockRPCClient{
-			status: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+			status: func(ctx context.Context, heightGte *int64) (*ctypes.ResultStatus, error) {
 				return &ctypes.ResultStatus{
 					SyncInfo: ctypes.SyncInfo{
 						LatestBlockHeight: latestHeight,

--- a/gno.land/pkg/gnoclient/mock_test.go
+++ b/gno.land/pkg/gnoclient/mock_test.go
@@ -117,7 +117,7 @@ type (
 	mockBlockResults         func(ctx context.Context, height *int64) (*ctypes.ResultBlockResults, error)
 	mockCommit               func(ctx context.Context, height *int64) (*ctypes.ResultCommit, error)
 	mockValidators           func(ctx context.Context, height *int64) (*ctypes.ResultValidators, error)
-	mockStatus               func(ctx context.Context) (*ctypes.ResultStatus, error)
+	mockStatus               func(ctx context.Context, heightGte *int64) (*ctypes.ResultStatus, error)
 	mockUnconfirmedTxs       func(ctx context.Context, limit int) (*ctypes.ResultUnconfirmedTxs, error)
 	mockNumUnconfirmedTxs    func(ctx context.Context) (*ctypes.ResultUnconfirmedTxs, error)
 	mockTx                   func(ctx context.Context, hash []byte) (*ctypes.ResultTx, error)
@@ -266,9 +266,9 @@ func (m *mockRPCClient) Validators(ctx context.Context, height *int64) (*ctypes.
 	return nil, nil
 }
 
-func (m *mockRPCClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (m *mockRPCClient) Status(ctx context.Context, heightGte *int64) (*ctypes.ResultStatus, error) {
 	if m.status != nil {
-		return m.status(ctx)
+		return m.status(ctx, heightGte)
 	}
 	return nil, nil
 }

--- a/gno.land/pkg/gnoweb/status.go
+++ b/gno.land/pkg/gnoweb/status.go
@@ -128,7 +128,7 @@ func handlerReadyJSON(logger *slog.Logger, cli *client.RPCClient, domain string)
 
 // getChainID fetches the status endpoint and returns the "network" field
 func getChainID(ctx context.Context, cli *client.RPCClient) (string, error) {
-	status, err := cli.Status(ctx)
+	status, err := cli.Status(ctx, nil)
 	if err != nil {
 		return "", err
 	}

--- a/tm2/pkg/bft/rpc/client/client.go
+++ b/tm2/pkg/bft/rpc/client/client.go
@@ -107,13 +107,15 @@ func (c *RPCClient) NewBatch() *RPCBatch {
 	}
 }
 
-func (c *RPCClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (c *RPCClient) Status(ctx context.Context, heightGte *int64) (*ctypes.ResultStatus, error) {
 	return sendRequestCommon[ctypes.ResultStatus](
 		ctx,
 		c.requestTimeout,
 		c.caller,
 		statusMethod,
-		map[string]any{},
+		map[string]any{
+			"heightGte": heightGte,
+		},
 	)
 }
 

--- a/tm2/pkg/bft/rpc/client/client_test.go
+++ b/tm2/pkg/bft/rpc/client/client_test.go
@@ -122,7 +122,7 @@ func TestRPCClient_Status(t *testing.T) {
 		verifyFn = func(t *testing.T, params map[string]any) {
 			t.Helper()
 
-			assert.Len(t, params, 0)
+			assert.Len(t, params, 1)
 		}
 
 		mockClient = generateMockRequestClient(

--- a/tm2/pkg/bft/rpc/client/client_test.go
+++ b/tm2/pkg/bft/rpc/client/client_test.go
@@ -137,7 +137,7 @@ func TestRPCClient_Status(t *testing.T) {
 	c := NewRPCClient(mockClient)
 
 	// Get the status
-	status, err := c.Status(context.Background())
+	status, err := c.Status(context.Background(), nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedStatus, status)

--- a/tm2/pkg/bft/rpc/client/e2e_test.go
+++ b/tm2/pkg/bft/rpc/client/e2e_test.go
@@ -176,7 +176,7 @@ func TestRPCClient_E2E_Endpoints(t *testing.T) {
 				},
 			},
 			func(client *RPCClient, expectedResult any) {
-				status, err := client.Status(context.Background())
+				status, err := client.Status(context.Background(), nil)
 				require.NoError(t, err)
 
 				assert.Equal(t, expectedResult, status)

--- a/tm2/pkg/bft/rpc/client/local.go
+++ b/tm2/pkg/bft/rpc/client/local.go
@@ -51,8 +51,8 @@ func (c *Local) SetLogger(l *slog.Logger) {
 	c.Logger = l
 }
 
-func (c *Local) Status(_ context.Context) (*ctypes.ResultStatus, error) {
-	return core.Status(c.ctx)
+func (c *Local) Status(_ context.Context, heightGte *int64) (*ctypes.ResultStatus, error) {
+	return core.Status(c.ctx, heightGte)
 }
 
 func (c *Local) ABCIInfo(_ context.Context) (*ctypes.ResultABCIInfo, error) {

--- a/tm2/pkg/bft/rpc/client/types.go
+++ b/tm2/pkg/bft/rpc/client/types.go
@@ -68,7 +68,7 @@ type HistoryClient interface {
 
 // StatusClient provides access to general chain info.
 type StatusClient interface {
-	Status(ctx context.Context) (*ctypes.ResultStatus, error)
+	Status(ctx context.Context, heightGte *int64) (*ctypes.ResultStatus, error)
 }
 
 // NetworkClient is general info about the network state. May not be needed

--- a/tm2/pkg/bft/rpc/core/routes.go
+++ b/tm2/pkg/bft/rpc/core/routes.go
@@ -9,7 +9,7 @@ import (
 var Routes = map[string]*rpc.RPCFunc{
 	// info API
 	"health":               rpc.NewRPCFunc(Health, ""),
-	"status":               rpc.NewRPCFunc(Status, ""),
+	"status":               rpc.NewRPCFunc(Status, "heightGte"),
 	"net_info":             rpc.NewRPCFunc(NetInfo, ""),
 	"blockchain":           rpc.NewRPCFunc(BlockchainInfo, "minHeight,maxHeight"),
 	"genesis":              rpc.NewRPCFunc(Genesis, ""),

--- a/tm2/pkg/bft/rpc/core/status.go
+++ b/tm2/pkg/bft/rpc/core/status.go
@@ -17,7 +17,7 @@ import (
 // curl 'localhost:26657/status'
 // ```
 //
-// Additionaly, it has an optional `heightGte` parameter than will return a `409` if the latest chain height is less than it.
+// Additionally, it has an optional `heightGte` parameter than will return a `409` if the latest chain height is less than it.
 // This parameter is useful for readyness probes.
 //
 // ```shell

--- a/tm2/pkg/bft/rpc/core/status.go
+++ b/tm2/pkg/bft/rpc/core/status.go
@@ -17,6 +17,13 @@ import (
 // curl 'localhost:26657/status'
 // ```
 //
+// Additionaly, it has an optional `heightGte` parameter than will return a `409` if the latest chain height is less than it.
+// This parameter is useful for readyness probes.
+//
+// ```shell
+// curl 'localhost:26657/status?heightGte=1'
+// ```
+//
 // ```go
 // client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
 // err := client.Start()

--- a/tm2/pkg/bft/rpc/lib/types/types.go
+++ b/tm2/pkg/bft/rpc/lib/types/types.go
@@ -304,3 +304,21 @@ func (ctx *Context) Context() context.Context {
 	}
 	return context.Background()
 }
+
+// NewHTTPStatusError returns an error meant to be used in the rpc handlers to signal to the server
+// that it must answer with a specific http error code
+func NewHTTPStatusError(code int, message string) error {
+	return &HTTPStatusError{Code: code, Message: message}
+}
+
+// HTTPStatusError is an error meant to be returned in the rpc handlers to signal to the server
+// that it must answer with a specific http error code
+type HTTPStatusError struct {
+	Code    int
+	Message string
+}
+
+// Error implements error.
+func (h *HTTPStatusError) Error() string {
+	return fmt.Sprintf("%d: %s", h.Code, h.Message)
+}


### PR DESCRIPTION
Fixes #4686

This PR adds a new `heightGte` param to the `/status` endpoint that will return a `409 Conflict` http code if the chain latest height is less than `heightGte`

To do this, I added [a new error in the rpc types called `HTTPStatusError`](https://github.com/gnolang/gno/pull/4692/files#diff-669b91d5b3a01be790882c73d63e79f61bb22da6db82e982445939e417410e0eR308-R324) that is caught by the http handler and allows to emit a specific response code from the endpoints implementations.

Had to [modify `unreflectResult` logic](https://github.com/gnolang/gno/pull/4692/files#diff-424c6fdbace51795f33d280588e82f2eb8292bd108799f92c06edc6d9904c4b2R867-R870) because it was erasing the returned error type.

```bash
❯ curl -v 'http://127.0.0.1:26657/status?heightGte=10000'
*   Trying 127.0.0.1:26657...
* Connected to 127.0.0.1 (127.0.0.1) port 26657
> GET /status?heightGte=10000 HTTP/1.1
> Host: 127.0.0.1:26657
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 409 Conflict
< Content-Type: application/json
< Vary: Origin
< X-Server-Time: 1756726045
< Date: Mon, 01 Sep 2025 11:27:25 GMT
< Content-Length: 169
<
{
  "jsonrpc": "2.0",
  "id": "",
  "error": {
    "code": -32603,
    "message": "Internal error",
    "data": "409: latest height is 2, which is less than 10000"
  }
* Connection #0 to host 127.0.0.1 left intact
}
```

Note that in practice, due to https://github.com/gnolang/gno/issues/4696, it will just hang when it could respond with `409`