### PR TITLE
feat: total supply invariant check

### DIFF
--- a/contribs/gnodev/setup_node.go
+++ b/contribs/gnodev/setup_node.go
@@ -20,7 +20,7 @@ import (
 
 // extractDependenciesFromTxs extracts dependencies from transactions and adds them to the paths slice and config.BalancesList.
 func extractDependenciesFromTxs(nodeConfig *gnodev.NodeConfig, paths *[]string) {
-	var defaultPremineBalance = std.Coins{std.NewCoin(ugnot.Denom, 10e12)}
+	defaultPremineBalance := std.Coins{std.NewCoin(ugnot.Denom, 10e12)}
 
 	for _, tx := range nodeConfig.InitialTxs {
 		for _, msg := range tx.Tx.Msgs {

--- a/gno.land/pkg/gnoland/balance.go
+++ b/gno.land/pkg/gnoland/balance.go
@@ -163,3 +163,15 @@ func (bs Balances) LoadFromSheet(sheet io.Reader) error {
 
 	return nil
 }
+
+func TotalBalance(bals []Balance) std.Coins {
+	bm := NewBalances()
+	total := std.NewCoins()
+	for _, bal := range bals {
+		bm.Set(bal.Address, bal.Amount)
+	}
+	for _, v := range bm {
+		total = total.Add(v.Amount)
+	}
+	return total
+}

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -20,6 +20,7 @@ import (
 )
 
 const initGasPrice = "1ugnot/1000gas"
+const totalSupply = "1000000000000000ugnot" // 1 Billion gnot
 
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) (Balances, error) {
@@ -250,12 +251,13 @@ func DefaultGenState() GnoGenesisState {
 		panic(err)
 	}
 	authGen.Params.InitialGasPrice = gp
-
+	bankGen := bank.DefaultGenesisState()
+	bankGen.Params.TotalSupply = std.MustParseCoins(totalSupply)
 	gs := GnoGenesisState{
 		Balances: []Balance{},
 		Txs:      []TxWithMetadata{},
 		Auth:     authGen,
-		Bank:     bank.DefaultGenesisState(),
+		Bank:     bankGen,
 		VM:       vmm.DefaultGenesisState(),
 	}
 	return gs

--- a/gno.land/pkg/gnoland/test_common.go
+++ b/gno.land/pkg/gnoland/test_common.go
@@ -30,7 +30,7 @@ func setupTestEnv() testEnv {
 	ms.LoadLatestVersion()
 	prmk := params.NewParamsKeeper(authCapKey)
 	acck := auth.NewAccountKeeper(authCapKey, prmk.ForModule(auth.ModuleName), ProtoGnoAccount)
-	bankk := bank.NewBankKeeper(acck, prmk.ForModule(bank.ModuleName))
+	bankk := bank.NewBankKeeper(authCapKey, acck, prmk.ForModule(bank.ModuleName))
 	prmk.Register(auth.ModuleName, acck)
 	prmk.Register(bank.ModuleName, bankk)
 

--- a/gno.land/pkg/integration/testdata/total_supply.txtar
+++ b/gno.land/pkg/integration/testdata/total_supply.txtar
@@ -1,0 +1,7 @@
+# tests for total supply invariance.
+
+gnoland start
+
+## check the total supply
+gnokey query params/bank:p:total_supply
+stdout '25500000000000ugnot'

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -193,6 +193,7 @@ func SetupGnolandTestscript(t *testing.T, p *testscript.Params) error {
 
 		genesis := gnoland.DefaultGenState()
 		genesis.Balances = LoadDefaultGenesisBalanceFile(t, gnoRootDir)
+		genesis.Bank.Params.TotalSupply = gnoland.TotalBalance(genesis.Balances)
 		genesis.Auth.Params.InitialGasPrice = std.GasPrice{Gas: 0, Price: std.Coin{Amount: 0, Denom: "ugnot"}}
 		genesis.Txs = []gnoland.TxWithMetadata{}
 		LoadDefaultGenesisParamFile(t, gnoRootDir, &genesis)
@@ -293,6 +294,7 @@ func gnolandCmd(t *testing.T, nodesManager *NodesManager, gnoRootDir string) fun
 			genesis := cfg.Genesis.AppState.(gnoland.GnoGenesisState)
 			genesis.Txs = append(genesis.Txs, append(pkgsTxs, tsGenesis.Txs...)...)
 			genesis.Balances = append(genesis.Balances, tsGenesis.Balances...)
+			genesis.Bank.Params.TotalSupply = gnoland.TotalBalance(genesis.Balances)
 			if *lockTransfer {
 				genesis.Bank.Params.RestrictedDenoms = []string{"ugnot"}
 			}
@@ -484,6 +486,7 @@ func adduserCmd(nodesManager *NodesManager) func(ts *testscript.TestScript, neg 
 
 		genesis := ts.Value(envKeyGenesis).(*gnoland.GnoGenesisState)
 		genesis.Balances = append(genesis.Balances, balance)
+		genesis.Bank.Params.TotalSupply = gnoland.TotalBalance(genesis.Balances)
 	}
 }
 
@@ -529,6 +532,7 @@ func adduserfromCmd(nodesManager *NodesManager) func(ts *testscript.TestScript, 
 
 		genesis := ts.Value(envKeyGenesis).(*gnoland.GnoGenesisState)
 		genesis.Balances = append(genesis.Balances, balance)
+		genesis.Bank.Params.TotalSupply = gnoland.TotalBalance(genesis.Balances)
 
 		fmt.Fprintf(ts.Stdout(), "Added %s(%s) to genesis", args[0], balance.Address)
 	}

--- a/gno.land/pkg/sdk/vm/common_test.go
+++ b/gno.land/pkg/sdk/vm/common_test.go
@@ -51,7 +51,7 @@ func _setupTestEnv(cacheStdlibs bool) testEnv {
 
 	prmk := pm.NewParamsKeeper(iavlCapKey)
 	acck := authm.NewAccountKeeper(iavlCapKey, prmk.ForModule(authm.ModuleName), std.ProtoBaseAccount)
-	bankk := bankm.NewBankKeeper(acck, prmk.ForModule(bankm.ModuleName))
+	bankk := bankm.NewBankKeeper(iavlCapKey, acck, prmk.ForModule(bankm.ModuleName))
 	vmk := NewVMKeeper(baseCapKey, iavlCapKey, acck, bankk, prmk)
 
 	prmk.Register(authm.ModuleName, acck)

--- a/tm2/pkg/sdk/bank/abci.go
+++ b/tm2/pkg/sdk/bank/abci.go
@@ -1,0 +1,17 @@
+package bank
+
+import (
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+)
+
+// EndBlocker is called in the EndBlock(), it checks invariants
+func EndBlocker(ctx sdk.Context, bk BankKeeperI) {
+	bankk := bk.(BankKeeper)
+	invariant := BalanceChangeInvariant(bankk)
+	msg, stop := invariant(ctx)
+	if stop {
+		panic(fmt.Errorf("invariant broken: %s", msg))
+	}
+}

--- a/tm2/pkg/sdk/bank/common_test.go
+++ b/tm2/pkg/sdk/bank/common_test.go
@@ -34,7 +34,7 @@ func setupTestEnv() testEnv {
 
 	prmk := params.NewParamsKeeper(authCapKey)
 	acck := auth.NewAccountKeeper(authCapKey, prmk.ForModule(auth.ModuleName), std.ProtoBaseAccount)
-	bankk := NewBankKeeper(acck, prmk.ForModule(ModuleName))
+	bankk := NewBankKeeper(authCapKey, acck, prmk.ForModule(ModuleName))
 
 	prmk.Register(auth.ModuleName, acck)
 	prmk.Register(ModuleName, bankk)

--- a/tm2/pkg/sdk/bank/consts.go
+++ b/tm2/pkg/sdk/bank/consts.go
@@ -1,5 +1,10 @@
 package bank
 
 const (
-	ModuleName = "bank"
+	ModuleName     = "bank"
+	StoreKeyPrefix = "/bk/"
 )
+
+func storeKey(key string) []byte {
+	return append([]byte(StoreKeyPrefix), []byte(key)...)
+}

--- a/tm2/pkg/sdk/bank/invariants.go
+++ b/tm2/pkg/sdk/bank/invariants.go
@@ -3,8 +3,18 @@ package bank
 import (
 	"fmt"
 
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+const (
+	// BalanceIncKey is the key to stores the balances increase of each denom
+	balanceIncKey = "balanceIncrease"
+
+	// BalanceDecKey is the key to stores the balances decrease of each denom
+	balanceDecKey = "balanceDecrease"
 )
 
 // RegisterInvariants registers the bank module invariants
@@ -14,6 +24,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, acck auth.AccountKeeper) {
 }
 
 // NonnegativeBalanceInvariant checks that all accounts in the application have non-negative balances
+// We don't currently check this invariant, as iterating through all accounts is costly.
 func NonnegativeBalanceInvariant(acck auth.AccountKeeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var msg string
@@ -35,3 +46,61 @@ func NonnegativeBalanceInvariant(acck auth.AccountKeeper) sdk.Invariant {
 			fmt.Sprintf("amount of negative accounts found %d\n%s", count, msg)), broken
 	}
 }
+
+// This invariant should be only checked in genesis block, not on other blocks.
+// Since it iterate through all accounts. It is impractical in a production
+// environment due to execution costs
+func TotalSupplyInvariant(auth auth.AccountKeeperI, bank BankKeeperI) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		if ctx.BlockHeight() != 0 {
+			return "", false
+		}
+		supply := std.Coins{}
+		accts := auth.GetAllAccounts(ctx)
+		for _, acc := range accts {
+			coins := acc.GetCoins()
+			supply = supply.Add(coins)
+		}
+		totalSupply := bank.GetParams(ctx).TotalSupply
+		if !supply.IsEqual(totalSupply) {
+			return sdk.FormatInvariant(
+				ModuleName,
+				"total supply",
+				fmt.Sprintf("sum of accounts %v != total supply %v", supply, totalSupply),
+			), true
+		}
+
+		return "", false
+	}
+}
+
+// We check the changes in each block to ensure that the details of account balance changes
+// tally to zero. This is checked every block and combined to use togateher with
+// TotalSupplyInvariant checked in genesis block to ensure, total supply holds invariant
+// for every blocks
+func BalanceChangeInvariant(bank BankKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		store := ctx.Store(bank.key)
+		balanceInc := std.Coins{}
+		balanceDec := std.Coins{}
+		if bz := store.Get(storeKey(balanceIncKey)); bz != nil {
+			amino.MustUnmarshal(bz, &balanceInc)
+		}
+
+		if bz := store.Get(storeKey(balanceDecKey)); bz != nil {
+			amino.MustUnmarshal(bz, &balanceDec)
+		}
+
+		if balanceInc.Sub(balanceDec) != nil {
+			return sdk.FormatInvariant(
+				ModuleName,
+				"balance changes",
+				fmt.Sprintf("sum of balance increase %v != sum of balance increase %v in a block", balanceInc, balanceDec),
+			), true
+		}
+
+		return "", false
+	}
+}
+
+// XXX: We need to add invariant checks when implementing mint and burn functions.

--- a/tm2/pkg/sdk/bank/keeper_test.go
+++ b/tm2/pkg/sdk/bank/keeper_test.go
@@ -3,11 +3,12 @@ package bank
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeeper(t *testing.T) {
@@ -185,4 +186,216 @@ func TestSetRestrictedDenoms(t *testing.T) {
 	prmk.SetStrings(ctx, "bank:p:restricted_denoms", []string{})
 	params = bankk.GetParams(ctx)
 	require.Empty(t, params.RestrictedDenoms)
+}
+
+//nolint:tparallel // subtests share keeper/state; must run serially
+func TestTrackBalanceChange(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	addr1 := crypto.AddressFromPreimage([]byte("addr1"))
+	addr2 := crypto.AddressFromPreimage([]byte("addr2"))
+	acc1 := env.acck.NewAccountWithAddress(ctx, addr1)
+	acc2 := env.acck.NewAccountWithAddress(ctx, addr2)
+	balance1 := std.NewCoins(std.NewCoin("foo", 10), std.NewCoin("bar", 5), std.NewCoin("baz", 2), std.NewCoin("qux", 6))
+	balance2 := std.NewCoins(std.NewCoin("bar", 3), std.NewCoin("baz", 2))
+
+	// Track only foo and bar in TotalSupply (qux excluded on purpose)
+	params := env.bankk.GetParams(ctx)
+	params.TotalSupply = []std.Coin{
+		std.NewCoin("foo", 10),
+		std.NewCoin("bar", 10),
+		std.NewCoin("baz", 10),
+	}
+	env.bankk.SetParams(ctx, params)
+	// Test GetCoins/SetCoins
+	env.acck.SetAccount(ctx, acc1)
+	env.bankk.SetCoins(ctx, addr1, balance1)
+	env.acck.SetAccount(ctx, acc2)
+	env.bankk.SetCoins(ctx, addr2, balance2)
+
+	sendCoinsCases := []struct {
+		name    string
+		amt     std.Coins
+		wantInc std.Coins
+		wantDec std.Coins
+	}{
+		{
+			name:    "send: from addr1 to addr2 2foo, 1bar",
+			amt:     std.NewCoins(std.NewCoin("foo", 2), std.NewCoin("bar", 1)),
+			wantInc: std.NewCoins(std.NewCoin("foo", 2), std.NewCoin("bar", 1)),
+			wantDec: std.NewCoins(std.NewCoin("foo", 2), std.NewCoin("bar", 1)),
+		},
+		{
+			name:    "send: from addr1 to addr2 1qux and 1bar",
+			amt:     std.NewCoins(std.NewCoin("qux", 1), std.NewCoin("bar", 1)),
+			wantInc: std.NewCoins(std.NewCoin("foo", 2), std.NewCoin("bar", 2)),
+			wantDec: std.NewCoins(std.NewCoin("foo", 2), std.NewCoin("bar", 2)),
+		},
+		{
+			name:    "send: from addr1 to addr2 1foo, 1bar, 1baz 1qux",
+			amt:     std.NewCoins(std.NewCoin("foo", 1), std.NewCoin("bar", 1), std.NewCoin("baz", 1), std.NewCoin("qux", 1)),
+			wantInc: std.NewCoins(std.NewCoin("foo", 3), std.NewCoin("bar", 3), std.NewCoin("baz", 1)),
+			wantDec: std.NewCoins(std.NewCoin("foo", 3), std.NewCoin("bar", 3), std.NewCoin("baz", 1)),
+		},
+	}
+
+	// Run all steps and check cumulative counters
+	for _, tc := range sendCoinsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env.bankk.SetCoins(ctx, addr1, balance1)
+			env.bankk.SetCoins(ctx, addr2, balance2)
+
+			env.bankk.SendCoins(ctx, addr1, addr2, tc.amt)
+			inc, dec := readCounters(t, ctx, env.bankk)
+			assert.True(t, inc.IsEqual(tc.wantInc),
+				"inc mismatch: got=%v want=%v", inc.Sort(), tc.wantInc.Sort())
+			assert.True(t, dec.IsEqual(tc.wantDec),
+				"inc mismatch: got=%v want=%v", dec.Sort(), tc.wantDec.Sort())
+		})
+	}
+
+	t.Run("CheckTx: tracking skipped", func(t *testing.T) {
+		checkCtx := ctx.WithMode(sdk.RunTxModeCheck)
+		beforeInc, beforeDec := readCounters(t, ctx, env.bankk)
+
+		old1 := env.bankk.GetCoins(ctx, addr1)
+		new1 := old1.Add(std.NewCoins(std.NewCoin("foo", 1)))
+		// In CheckTx: should be NO-OP
+		env.bankk.trackBalanceChange(checkCtx, old1, new1)
+
+		afterInc, afterDec := readCounters(t, ctx, env.bankk)
+		if !afterInc.IsEqual(beforeInc) || !afterDec.IsEqual(beforeDec) {
+			t.Fatalf("counters changed during CheckTx; inc %v->%v dec %v->%v",
+				beforeInc, afterInc, beforeDec, afterDec)
+		}
+	})
+
+	inc, dec := readCounters(t, ctx, env.bankk)
+	assert.True(t, inc.IsEqual(dec),
+		"inc and dec mismatch: inc=%v dec=%v", inc.Sort(), dec.Sort())
+}
+func readCounters(t *testing.T, ctx sdk.Context, bank BankKeeper) (std.Coins, std.Coins) {
+	t.Helper()
+	store := ctx.Store(bank.key)
+
+	var inc, dec std.Coins
+	if bz := store.Get([]byte(balanceIncKey)); bz != nil {
+		amino.MustUnmarshal(bz, &inc)
+	}
+	if bz := store.Get([]byte(balanceDecKey)); bz != nil {
+		amino.MustUnmarshal(bz, &dec)
+	}
+	return inc, dec
+}
+
+func TestDiffCoins(t *testing.T) {
+	tests := []struct {
+		name    string
+		old     std.Coins
+		new     std.Coins
+		denoms  []string
+		wantInc std.Coins
+		wantDec std.Coins
+	}{
+		{
+			name:    "no changes (exact equal)",
+			old:     std.NewCoins(std.NewCoin("acoin", 10), std.NewCoin("bcoin", 5)),
+			new:     std.NewCoins(std.NewCoin("acoin", 10), std.NewCoin("bcoin", 5)),
+			denoms:  []string{"acoin", "bcoin"},
+			wantInc: std.NewCoins(),
+			wantDec: std.NewCoins(),
+		},
+		{
+			name:    "increase same denom",
+			old:     std.NewCoins(std.NewCoin("acoin", 10)),
+			new:     std.NewCoins(std.NewCoin("acoin", 15)),
+			denoms:  []string{"acoin"},
+			wantInc: std.NewCoins(std.NewCoin("acoin", 5)),
+			wantDec: std.NewCoins(),
+		},
+		{
+			name:    "decrease same denom",
+			old:     std.NewCoins(std.NewCoin("acoin", 10)),
+			new:     std.NewCoins(std.NewCoin("acoin", 6)),
+			denoms:  []string{"acoin"},
+			wantInc: std.NewCoins(),
+			wantDec: std.NewCoins(std.NewCoin("acoin", 4)),
+		},
+		{
+			name:    "denom only in old -> full decrease",
+			old:     std.NewCoins(std.NewCoin("ccoin", 7)),
+			new:     std.NewCoins(),
+			denoms:  []string{"ccoin"},
+			wantInc: std.NewCoins(),
+			wantDec: std.NewCoins(std.NewCoin("ccoin", 7)),
+		},
+		{
+			name:    "denom only in new -> full increase",
+			old:     std.NewCoins(),
+			new:     std.NewCoins(std.NewCoin("dcoin", 9)),
+			denoms:  []string{"dcoin"},
+			wantInc: std.NewCoins(std.NewCoin("dcoin", 9)),
+			wantDec: std.NewCoins(),
+		},
+		{
+			name:   "mixed increases/decreases + ignore non-total-supply denoms",
+			old:    std.NewCoins(std.NewCoin("acoin", 5), std.NewCoin("ccoin", 2), std.NewCoin("ecoin", 3)),
+			new:    std.NewCoins(std.NewCoin("acoin", 7), std.NewCoin("bcoin", 4), std.NewCoin("ecoin", 1), std.NewCoin("fcoin", 10)),
+			denoms: []string{"acoin", "ccoin", "ecoin", "fcoin"}, // "bcoin" is excluded -> ignored
+			// a: +2, c: -2, e: -2, f: +10
+			wantInc: std.NewCoins(std.NewCoin("acoin", 2), std.NewCoin("fcoin", 10)),
+			wantDec: std.NewCoins(std.NewCoin("ccoin", 2), std.NewCoin("ecoin", 2)),
+		},
+		{
+			name:   "unsorted inputs handled via Sort()",
+			old:    std.NewCoins(std.NewCoin("bcoin", 1), std.NewCoin("acoin", 2)),
+			new:    std.NewCoins(std.NewCoin("acoin", 3), std.NewCoin("bcoin", 1)),
+			denoms: []string{"acoin", "bcoin"},
+			// a: +1, b: 0
+			wantInc: std.NewCoins(std.NewCoin("acoin", 1)),
+			wantDec: std.NewCoins(),
+		},
+		{
+			name:   "tails: leftovers in old and new",
+			old:    std.NewCoins(std.NewCoin("acoin", 1), std.NewCoin("bcoin", 1), std.NewCoin("ccoin", 1)),
+			new:    std.NewCoins(std.NewCoin("acoin", 1), std.NewCoin("dcoin", 2)),
+			denoms: []string{"acoin", "bcoin", "ccoin", "dcoin"},
+			// dec: b:1,c:1 ; inc: d:2
+			wantInc: std.NewCoins(std.NewCoin("dcoin", 2)),
+			wantDec: std.NewCoins(std.NewCoin("bcoin", 1), std.NewCoin("ccoin", 1)),
+		},
+
+		{
+			name:    "ignored denoms not in denomSet",
+			old:     std.NewCoins(std.NewCoin("zcoin", 100)),
+			new:     std.NewCoins(std.NewCoin("zcoin", 1)),
+			denoms:  []string{"acoin", "bcoin"}, // z not tracked
+			wantInc: std.NewCoins(),
+			wantDec: std.NewCoins(),
+		},
+
+		{
+			name:    "redundant zero change (equal amounts) produces no inc/dec",
+			old:     std.NewCoins(std.NewCoin("ycoin", 5)),
+			new:     std.NewCoins(std.NewCoin("ycoin", 5)),
+			denoms:  []string{"ycoin"},
+			wantInc: std.NewCoins(),
+			wantDec: std.NewCoins(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inc, dec := diffCoins(tc.old, tc.new, toSet(tc.denoms))
+
+			assert.True(t, inc.IsEqual(tc.wantInc),
+				"inc mismatch: got=%v want=%v", inc.Sort(), tc.wantInc.Sort())
+
+			assert.True(t, dec.IsEqual(tc.wantDec),
+				"dec mismatch: got=%v want=%v", dec.Sort(), tc.wantDec.Sort())
+		})
+	}
 }

--- a/tm2/pkg/sdk/bank/params.go
+++ b/tm2/pkg/sdk/bank/params.go
@@ -10,21 +10,30 @@ import (
 
 type BankParamsContextKey struct{}
 
+// Default parameter values
+const (
+	//  Default 1M tokens, This should be overwritten by genesis parameters
+	TotalSupply = "1000000token"
+)
+
 // Params defines the parameters for the bank module.
 type Params struct {
-	RestrictedDenoms []string `json:"restricted_denoms" yaml:"restricted_denoms"`
+	RestrictedDenoms []string  `json:"restricted_denoms" yaml:"restricted_denoms"`
+	TotalSupply      std.Coins `json:"total_supply" yaml:"total_supply"`
 }
 
 // NewParams creates a new Params object
-func NewParams(restDenoms []string) Params {
+func NewParams(restDenoms []string, totalSupply std.Coins) Params {
 	return Params{
 		RestrictedDenoms: restDenoms,
+		TotalSupply:      totalSupply,
 	}
 }
 
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
-	return NewParams([]string{})
+	coins := std.MustParseCoins(TotalSupply)
+	return NewParams([]string{}, coins)
 }
 
 // String implements the stringer interface.
@@ -40,6 +49,11 @@ func (p *Params) Validate() error {
 		err := std.ValidateDenom(denom)
 		if err != nil {
 			return fmt.Errorf("invalid restricted denom: %s", denom)
+		}
+	}
+	for _, coin := range p.TotalSupply {
+		if !coin.IsValid() || coin.IsZero() {
+			return fmt.Errorf("invalid total supply: %s", coin.String())
 		}
 	}
 	return nil

--- a/tm2/pkg/std/coin_test.go
+++ b/tm2/pkg/std/coin_test.go
@@ -73,7 +73,7 @@ func TestCoinIsValid(t *testing.T) {
 
 func TestAddCoin(t *testing.T) {
 	t.Parallel()
-
+	empty := Coin{}
 	cases := []struct {
 		inputOne    Coin
 		inputTwo    Coin
@@ -83,6 +83,7 @@ func TestAddCoin(t *testing.T) {
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 1), NewCoin(testDenom1, 2), false},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 0), NewCoin(testDenom1, 1), false},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom2, 1), NewCoin(testDenom1, 1), true},
+		{NewCoin(testDenom1, 1), empty, empty, true},
 	}
 
 	for tcIndex, tc := range cases {
@@ -108,6 +109,7 @@ func TestSubCoin(t *testing.T) {
 		{NewCoin(testDenom1, 10), NewCoin(testDenom1, 1), NewCoin(testDenom1, 9), false},
 		{NewCoin(testDenom1, 5), NewCoin(testDenom1, 3), NewCoin(testDenom1, 2), false},
 		{NewCoin(testDenom1, 5), NewCoin(testDenom1, 0), NewCoin(testDenom1, 5), false},
+		{NewCoin(testDenom1, 5), NewCoin(testDenom1, 5), NewCoin(testDenom1, 0), false},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 5), Coin{}, true},
 	}
 
@@ -131,7 +133,7 @@ func TestSubCoin(t *testing.T) {
 
 func TestIsGTECoin(t *testing.T) {
 	t.Parallel()
-
+	empty := Coin{}
 	cases := []struct {
 		inputOne Coin
 		inputTwo Coin
@@ -141,6 +143,7 @@ func TestIsGTECoin(t *testing.T) {
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 1), true, false},
 		{NewCoin(testDenom1, 2), NewCoin(testDenom1, 1), true, false},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom2, 1), false, true},
+		{NewCoin(testDenom1, 1), empty, false, true},
 	}
 
 	for tcIndex, tc := range cases {
@@ -155,7 +158,7 @@ func TestIsGTECoin(t *testing.T) {
 
 func TestIsLTCoin(t *testing.T) {
 	t.Parallel()
-
+	empty := Coin{}
 	cases := []struct {
 		inputOne Coin
 		inputTwo Coin
@@ -168,6 +171,7 @@ func TestIsLTCoin(t *testing.T) {
 		{NewCoin(testDenom1, 1), NewCoin(testDenom2, 1), false, true},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 1), false, false},
 		{NewCoin(testDenom1, 1), NewCoin(testDenom1, 2), true, false},
+		{NewCoin(testDenom1, 1), empty, false, true},
 	}
 
 	for tcIndex, tc := range cases {
@@ -258,6 +262,7 @@ func TestAddCoins(t *testing.T) {
 		{Coins{{testDenom1, one}, {testDenom2, one}}, Coins{{testDenom1, one}, {testDenom2, one}}, Coins{{testDenom1, two}, {testDenom2, two}}},
 		{Coins{{testDenom1, zero}, {testDenom2, one}}, Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins{{testDenom2, one}}},
 		{Coins{{testDenom1, two}}, Coins{{testDenom2, zero}}, Coins{{testDenom1, two}}},
+		{Coins{{testDenom1, one}}, Coins{{testDenom2, two}}, Coins{{testDenom1, one}, {testDenom2, two}}},
 		{Coins{{testDenom1, one}}, Coins{{testDenom1, one}, {testDenom2, two}}, Coins{{testDenom1, two}, {testDenom2, two}}},
 		{Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins(nil)},
 	}
@@ -285,6 +290,8 @@ func TestSubCoins(t *testing.T) {
 		{Coins{{testDenom1, two}}, Coins{{testDenom1, one}, {testDenom2, two}}, Coins{{testDenom1, one}, {testDenom2, two}}, true},
 		{Coins{{testDenom1, two}}, Coins{{testDenom2, zero}}, Coins{{testDenom1, two}}, false},
 		{Coins{{testDenom1, one}}, Coins{{testDenom2, zero}}, Coins{{testDenom1, one}}, false},
+		{Coins{{testDenom1, one}}, Coins{{testDenom1, one}}, nil, false},
+		{Coins{{testDenom1, zero}}, Coins{{testDenom1, one}}, Coins{{testDenom1, one}}, true},
 		{Coins{{testDenom1, one}, {testDenom2, one}}, Coins{{testDenom1, one}}, Coins{{testDenom2, one}}, false},
 		{Coins{{testDenom1, one}, {testDenom2, one}}, Coins{{testDenom1, two}}, Coins{}, true},
 	}


### PR DESCRIPTION
## Total supply invariant

Checking the total-supply invariant is a safeguard against hacks and bugs that could “print” extra tokens by exploiting on-chain flaws. For each denom, the chain’s recorded total supply must exactly equal the sum of all account balances. Transfers don’t change supply. gnoland does not mint or burn tokens after genesis.

This invariant is critical for detecting accidental inflation/deflation caused by hacks, bugs, or faulty migrations—often surfacing as double credits.

### Background (Cosmos SDK crisis module)
Historically, the Cosmos SDK’s crisis module checked this in EndBlock by iterating all accounts and comparing the sum to totalSupply. If the invariant was broken, it panicked in EndBlock and halted the chain. Because a full scan each block is expensive, chains often ran it at intervals and allowed validators to submit a transaction to trigger a check. The crisis module is now deprecated and slated for removal.

### Why check every block
Most profitable attacks ultimately manifest as double-spend–like effects that inflate total supply, so block-level checks are valuable.

## Alternative Solution, this PR (lower overhead)

 - At genesis (or once at startup), iterate all accounts and verify the total-supply invariant to establish a correct baseline.

- For each transaction, the bank module tracks balance deltas across accounts, recording the total sum of increases and the total sum of decreases separately. 

- At the end of each block, the sum of increases must equal the sum of decreases for every denom (i.e., no net change when there is no minting or burning). If a mismatch is detected, the chain should panic and halt.

- This invariant is enforced for the denoms listed in bank.Params.TotalSupply, to protect the security of gno.land. Tokens issued by gnoVM contracts are ignored for now; contract authors are responsible for enforcing their own invariants within their programs. 

This approach preserves the total-supply invariant without the heavy cost of scanning all accounts in every block. In the future, we could implement mint and burn operations to handle contract-issued tokens and their removal.