### PR TITLE
fix: fix register default price

### DIFF
--- a/examples/gno.land/r/gnoland/users/v1/users.gno
+++ b/examples/gno.land/r/gnoland/users/v1/users.gno
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	registerPrice = int64(0)     // 0 GNOT
+	registerPrice = int64(1000000)     // 1 GNOT
 	latestUsers   = fifo.New(10) // Save the latest 10 users for rendering purposes
 	reUsername    = regexp.MustCompile(reValidUsername)
 )


### PR DESCRIPTION
This PR updates the registerPrice in users.gno from 0 to 1 GNOT (int64(1000000)).
This change ensures that registering a new username now requires a payment of 1 GNOT, instead of being free to avoid gas fee error.