### PR TITLE
feat(commondao): improve proposal states

### DIFF
--- a/examples/gno.land/p/nt/commondao/commondao.gno
+++ b/examples/gno.land/p/nt/commondao/commondao.gno
@@ -19,6 +19,7 @@ var (
 	ErrProposalNotFound     = errors.New("proposal not found")
 	ErrVotingDeadlineNotMet = errors.New("voting deadline not met")
 	ErrVotingDeadlinePassed = errors.New("voting deadline has passed")
+	ErrWithdrawalNotAllowed = errors.New("withdrawal not allowed for proposals with votes")
 )
 
 // CommonDAO defines a DAO.
@@ -165,6 +166,25 @@ func (dao CommonDAO) GetProposal(proposalID uint64) *Proposal {
 		return p
 	}
 	return dao.finishedProposals.Get(proposalID)
+}
+
+// Withdraw withdraws a proposal that has no votes.
+// Only proposals without votes can be withdrawed, and once
+// withdrawed they are considered finished.
+func (dao *CommonDAO) Withdraw(proposalID uint64) error {
+	p := dao.activeProposals.Get(proposalID)
+	if p == nil {
+		return ErrProposalNotFound
+	}
+
+	if p.VotingRecord().Size() > 0 {
+		return ErrWithdrawalNotAllowed
+	}
+
+	p.status = StatusWithdrawed
+	dao.activeProposals.Remove(p.id)
+	dao.finishedProposals.Add(p)
+	return nil
 }
 
 // Vote submits a new vote for a proposal.

--- a/examples/gno.land/p/nt/commondao/commondao.gno
+++ b/examples/gno.land/p/nt/commondao/commondao.gno
@@ -12,10 +12,10 @@ import (
 const PathSeparator = "/"
 
 var (
+	ErrExecutionNotAllowed  = errors.New("proposal must pass before execution")
 	ErrInvalidVoteChoice    = errors.New("invalid vote choice")
 	ErrNotMember            = errors.New("account is not a member of the DAO")
 	ErrOverflow             = errors.New("next ID overflows uint64")
-	ErrProposalFailed       = errors.New("proposal failed to pass")
 	ErrProposalNotFound     = errors.New("proposal not found")
 	ErrVotingDeadlineNotMet = errors.New("voting deadline not met")
 	ErrVotingDeadlinePassed = errors.New("voting deadline has passed")
@@ -218,27 +218,6 @@ func (dao *CommonDAO) Vote(member std.Address, proposalID uint64, c VoteChoice, 
 	return nil
 }
 
-// Tally counts votes and validates if a proposal passes.
-func (dao *CommonDAO) Tally(proposalID uint64) (passes bool, _ error) {
-	p := dao.activeProposals.Get(proposalID)
-	if p == nil {
-		return false, ErrProposalNotFound
-	}
-
-	if p.Status() != StatusActive {
-		return false, ErrStatusIsNotActive
-	}
-
-	if err := dao.checkProposalPasses(p); err != nil {
-		// Don't return an error if proposal failed to pass when tallying
-		if err == ErrProposalFailed {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 // Execute executes a proposal.
 //
 // By default active proposals can only be executed after their voting deadline passes.
@@ -249,23 +228,34 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 		return ErrProposalNotFound
 	}
 
-	if p.Status() != StatusActive {
-		return ErrStatusIsNotActive
+	// Proposal must be active or have passed to be executed
+	if p.status != StatusActive && p.status != StatusPassed {
+		return ErrExecutionNotAllowed
 	}
 
+	// Execution must be done after voting deadline
 	if !dao.disableVotingDeadlineCheck && !p.HasVotingDeadlinePassed() {
 		return ErrVotingDeadlineNotMet
 	}
 
-	// From this point any error results in a proposal failure and successful execution
+	// IMPORTANT, from this point on, any error is going to result
+	// in a proposal failure and execute will succeed.
+
+	// Validate proposal before execution
 	err := p.Validate()
 
+	// Tally votes and update proposal status to "passed" or "rejected"
 	if err == nil {
-		err = dao.checkProposalPasses(p)
+		members := NewMemberSet(dao.Members())
+		err = p.Tally(members)
+		if err == nil && p.Status() == StatusRejected {
+			// Don't try to execute proposal if it's been rejected
+			return nil
+		}
 	}
 
+	// Execute proposal only if it's executable
 	if err == nil {
-		// Execute proposal only if it's executable
 		if e, ok := p.Definition().(Executable); ok {
 			err = e.Execute(cross)
 		}
@@ -276,26 +266,12 @@ func (dao *CommonDAO) Execute(proposalID uint64) error {
 		p.status = StatusFailed
 		p.statusReason = err.Error()
 	} else {
-		p.status = StatusPassed
+		p.status = StatusExecuted
 	}
 
 	// Whichever the outcome of the validation, tallying
 	// and execution consider the proposal finished.
 	dao.activeProposals.Remove(p.id)
 	dao.finishedProposals.Add(p)
-	return nil
-}
-
-func (dao *CommonDAO) checkProposalPasses(p *Proposal) error {
-	record := p.VotingRecord().Readonly()
-	members := NewMemberSet(dao.Members())
-	passes, err := p.Definition().Tally(record, members)
-	if err != nil {
-		return err
-	}
-
-	if !passes {
-		return ErrProposalFailed
-	}
 	return nil
 }

--- a/examples/gno.land/p/nt/commondao/commondao_test.gno
+++ b/examples/gno.land/p/nt/commondao/commondao_test.gno
@@ -179,6 +179,61 @@ func TestCommonDAOPropose(t *testing.T) {
 	}
 }
 
+func TestCommonDAOWithdraw(t *testing.T) {
+	cases := []struct {
+		name       string
+		proposalID uint64
+		setup      func() *CommonDAO
+		err        error
+	}{
+		{
+			name:       "success",
+			proposalID: 1,
+			setup: func() *CommonDAO {
+				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
+				dao := New(WithMember(member))
+				dao.Propose(member, testPropDef{votingPeriod: time.Hour})
+				return dao
+			},
+		},
+		{
+			name:       "proposal not found",
+			proposalID: 404,
+			setup: func() *CommonDAO {
+				return New(WithMember("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"))
+			},
+			err: ErrProposalNotFound,
+		},
+		{
+			name:       "withdrawal not allowed",
+			proposalID: 1,
+			setup: func() *CommonDAO {
+				member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
+				dao := New(WithMember(member))
+				p, _ := dao.Propose(member, testPropDef{votingPeriod: time.Hour})
+				dao.Vote(member, p.ID(), ChoiceYes, "")
+				return dao
+			},
+			err: ErrWithdrawalNotAllowed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dao := tc.setup()
+
+			err := dao.Withdraw(tc.proposalID)
+
+			if tc.err != nil {
+				urequire.ErrorIs(t, err, tc.err)
+				return
+			}
+
+			urequire.NoError(t, err)
+		})
+	}
+}
+
 func TestCommonDAOVote(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/examples/gno.land/p/nt/commondao/commondao_test.gno
+++ b/examples/gno.land/p/nt/commondao/commondao_test.gno
@@ -340,78 +340,6 @@ func TestCommonDAOVote(t *testing.T) {
 	}
 }
 
-func TestCommonDAOTally(t *testing.T) {
-	errTest := errors.New("test")
-	member := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
-	cases := []struct {
-		name   string
-		setup  func(*CommonDAO) (proposalID uint64)
-		passes bool
-		err    error
-	}{
-		{
-			name: "pass",
-			setup: func(dao *CommonDAO) uint64 {
-				return dao.MustPropose(member, testPropDef{tallyResult: true}).ID()
-			},
-			passes: true,
-		},
-		{
-			name: "fail to pass",
-			setup: func(dao *CommonDAO) uint64 {
-				return dao.MustPropose(member, testPropDef{tallyResult: false}).ID()
-			},
-			passes: false,
-		},
-		{
-			name:  "proposal not found",
-			setup: func(*CommonDAO) uint64 { return 404 },
-			err:   ErrProposalNotFound,
-		},
-		{
-			name: "proposal status not active",
-			setup: func(dao *CommonDAO) uint64 {
-				p := dao.MustPropose(member, testPropDef{})
-				p.status = StatusPassed
-				return p.ID()
-			},
-			err: ErrStatusIsNotActive,
-		},
-		{
-			name: "proposal failed error",
-			setup: func(dao *CommonDAO) uint64 {
-				return dao.MustPropose(member, testPropDef{tallyErr: ErrProposalFailed}).ID()
-			},
-			passes: false,
-		},
-		{
-			name: "error",
-			setup: func(dao *CommonDAO) uint64 {
-				return dao.MustPropose(member, testPropDef{tallyErr: errTest}).ID()
-			},
-			err: errTest,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			dao := New(WithMember(member))
-			proposalID := tc.setup(dao)
-
-			passes, err := dao.Tally(proposalID)
-
-			if tc.err != nil {
-				uassert.ErrorIs(t, err, tc.err, "expect an error")
-				uassert.False(t, passes, "expect tally to fail")
-				return
-			}
-
-			uassert.NoError(t, err, "expect no error")
-			uassert.Equal(t, tc.passes, passes, "expect tally success value to match")
-		})
-	}
-}
-
 func TestCommonDAOExecute(t *testing.T) {
 	errTest := errors.New("test")
 	member := std.Address("g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn")
@@ -457,15 +385,15 @@ func TestCommonDAOExecute(t *testing.T) {
 			err:        ErrProposalNotFound,
 		},
 		{
-			name: "proposal not active",
+			name: "execution not allowed",
 			setup: func() *CommonDAO {
 				dao := New(WithMember(member))
 				p, _ := dao.Propose(member, testPropDef{})
-				p.status = StatusPassed
+				p.status = StatusExecuted
 				return dao
 			},
 			proposalID: 1,
-			err:        ErrStatusIsNotActive,
+			err:        ErrExecutionNotAllowed,
 		},
 		{
 			name: "voting deadline not met",
@@ -481,7 +409,10 @@ func TestCommonDAOExecute(t *testing.T) {
 			name: "validation error",
 			setup: func() *CommonDAO {
 				dao := New(WithMember(member))
-				dao.Propose(member, testPropDef{validationErr: errTest})
+				dao.Propose(member, testPropDef{
+					validationErr: errTest,
+					tallyResult:   true,
+				})
 				return dao
 			},
 			proposalID:   1,

--- a/examples/gno.land/p/nt/commondao/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/proposal.gno
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	StatusActive ProposalStatus = "active"
-	StatusFailed                = "failed"
-	StatusPassed                = "passed"
+	StatusActive     ProposalStatus = "active"
+	StatusFailed                    = "failed"
+	StatusPassed                    = "passed"
+	StatusWithdrawed                = "withdrawed"
 )
 
 const (

--- a/examples/gno.land/p/nt/commondao/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/proposal.gno
@@ -10,8 +10,10 @@ import (
 
 const (
 	StatusActive     ProposalStatus = "active"
-	StatusFailed                    = "failed"
 	StatusPassed                    = "passed"
+	StatusRejected                  = "rejected"
+	StatusExecuted                  = "executed"
+	StatusFailed                    = "failed"
 	StatusWithdrawed                = "withdrawed"
 )
 
@@ -245,6 +247,28 @@ func (p Proposal) Validate() error {
 // IsVoteChoiceValid checks if a vote choice is valid for the proposal.
 func (p Proposal) IsVoteChoiceValid(c VoteChoice) bool {
 	return p.voteChoices.Has(string(c))
+}
+
+// Tally counts votes and updates proposal status with the current outcome.
+// Proposal status is updated to "passed" when proposal is approved
+// or to "rejected" if proposal doesn't pass.
+func (p *Proposal) Tally(members MemberSet) error {
+	if p.status != StatusActive {
+		return ErrStatusIsNotActive
+	}
+
+	record := p.VotingRecord().Readonly()
+	passes, err := p.Definition().Tally(record, members)
+	if err != nil {
+		return err
+	}
+
+	if passes {
+		p.status = StatusPassed
+	} else {
+		p.status = StatusRejected
+	}
+	return nil
 }
 
 // IsQuorumReached checks if a participation quorum is reach.

--- a/examples/gno.land/p/nt/commondao/proposal_test.gno
+++ b/examples/gno.land/p/nt/commondao/proposal_test.gno
@@ -292,6 +292,67 @@ func TestIsQuorumReached(t *testing.T) {
 	}
 }
 
+func TestProposalTally(t *testing.T) {
+	errTest := errors.New("test")
+	creator := std.Address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	cases := []struct {
+		name   string
+		setup  func() *Proposal
+		status ProposalStatus
+		err    error
+	}{
+		{
+			name: "passed",
+			setup: func() *Proposal {
+				p, _ := NewProposal(1, creator, testPropDef{tallyResult: true})
+				return p
+			},
+			status: StatusPassed,
+		},
+		{
+			name: "rejected",
+			setup: func() *Proposal {
+				p, _ := NewProposal(1, creator, testPropDef{tallyResult: false})
+				return p
+			},
+			status: StatusRejected,
+		},
+		{
+			name: "proposal is not active",
+			setup: func() *Proposal {
+				p, _ := NewProposal(1, creator, testPropDef{tallyErr: errTest})
+				p.status = StatusFailed
+				return p
+			},
+			err: ErrStatusIsNotActive,
+		},
+		{
+			name: "tally error",
+			setup: func() *Proposal {
+				p, _ := NewProposal(1, creator, testPropDef{tallyErr: errTest})
+				return p
+			},
+			err: errTest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := tc.setup()
+
+			err := p.Tally(MemberSet{})
+
+			if tc.err != nil {
+				urequire.ErrorIs(t, err, tc.err)
+				return
+			}
+
+			urequire.NoError(t, err)
+			urequire.Equal(t, string(tc.status), string(p.Status()))
+		})
+	}
+}
+
 func TestMustValidate(t *testing.T) {
 	uassert.NotPanics(t, func() {
 		MustValidate(testPropDef{})

--- a/examples/gno.land/p/nt/commondao/z_commondao_execute_0_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/z_commondao_execute_0_filetest.gno
@@ -40,4 +40,4 @@ func main() {
 
 // Output:
 // true
-// passed
+// executed

--- a/examples/gno.land/p/nt/commondao/z_commondao_execute_2_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/z_commondao_execute_2_filetest.gno
@@ -43,4 +43,4 @@ func main() {
 
 // Output:
 // true
-// passed
+// executed


### PR DESCRIPTION
This PR adds new proposal states to improve the workflow of proposals:
- **active**: Default state assigned upon creation, where users can vote or creator can withdraw proposal if there are no votes.
- **passed**: Proposal has been voted and it passes after counting votes.
- **rejected**: Proposal it's rejected after counting votes.
- **executed**: Proposal passed and has been executed.
- **failed**: Proposal passed but execution failed.
- **withdrawed**: Proposal was withdrawed by the creator, usually because proposal is not valid anymore or it has to be corrected.

This change moves tally to the *Proposal* type, which allows devs to tally proposals on render to calculate passed and rejected states, which can be useful in cases where there is no need to change proposal status using a TX, for example for proposals that met the deadline and didn't get enough votes, in that case it would be optional to send a TX to effectively change status to rejected.

PR also add support for withdrawing proposals when they have no votes.