### PR TITLE
feat: rpc override in gnowork.toml

### DIFF
--- a/gnovm/pkg/packages/gnowork.go
+++ b/gnovm/pkg/packages/gnowork.go
@@ -15,6 +15,9 @@ type Gnowork struct {
 }
 
 func (gw *Gnowork) rpcOverrides() map[string]string {
+	if gw == nil {
+		return nil
+	}
 	res := map[string]string{}
 	for domainName, domain := range gw.Domains {
 		if domain.RPC == "" {

--- a/gnovm/pkg/packages/gnowork.go
+++ b/gnovm/pkg/packages/gnowork.go
@@ -1,0 +1,42 @@
+package packages
+
+import (
+	"os"
+
+	"github.com/pelletier/go-toml"
+)
+
+type GnoworkDomain struct {
+	RPC string
+}
+
+type Gnowork struct {
+	Domains map[string]GnoworkDomain
+}
+
+func (gw *Gnowork) rpcOverrides() map[string]string {
+	res := map[string]string{}
+	for domainName, domain := range gw.Domains {
+		if domain.RPC == "" {
+			continue
+		}
+		res[domainName] = domain.RPC
+	}
+	return res
+}
+
+func ParseGnowork(bz []byte) (*Gnowork, error) {
+	var res Gnowork
+	if err := toml.Unmarshal(bz, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func ReadGnowork(file string) (*Gnowork, error) {
+	bz, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGnowork(bz)
+}

--- a/gnovm/pkg/packages/gnowork.go
+++ b/gnovm/pkg/packages/gnowork.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pelletier/go-toml"
@@ -39,7 +40,11 @@ func ParseGnowork(bz []byte) (*Gnowork, error) {
 func ReadGnowork(file string) (*Gnowork, error) {
 	bz, err := os.ReadFile(file)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read gnowork file %q: %w", file, err)
 	}
-	return ParseGnowork(bz)
+	gw, err := ParseGnowork(bz)
+	if err != nil {
+		return nil, fmt.Errorf("parse gnowork file %q: %w", file, err)
+	}
+	return gw, nil
 }

--- a/gnovm/pkg/packages/gnowork_test.go
+++ b/gnovm/pkg/packages/gnowork_test.go
@@ -1,0 +1,98 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGnowork(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		overrides map[string]string
+		wantErr   bool
+	}{
+		{
+			name:      "empty",
+			body:      "",
+			overrides: map[string]string{},
+		},
+		{
+			name: "single domain override",
+			body: `[domains."gno.land"]
+rpc = "http://localhost:26657"`,
+			overrides: map[string]string{"gno.land": "http://localhost:26657"},
+		},
+		{
+			name: "multiple domains",
+			body: `[domains."gno.land"]
+rpc = "http://localhost:26657"
+
+[domains."example.com"]
+rpc = "http://localhost:8080"`,
+			overrides: map[string]string{
+				"gno.land":    "http://localhost:26657",
+				"example.com": "http://localhost:8080",
+			},
+		},
+		{
+			name: "empty rpc is skipped",
+			body: `[domains."gno.land"]
+rpc = ""`,
+			overrides: map[string]string{},
+		},
+		{
+			name:    "malformed toml",
+			body:    `[domains."gno.land"`,
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gw, err := ParseGnowork([]byte(c.body))
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.overrides, gw.rpcOverrides())
+		})
+	}
+}
+
+func TestGnoworkRPCOverridesNil(t *testing.T) {
+	// a nil *Gnowork (non-workspace context) must not panic and yields no overrides
+	var gw *Gnowork
+	require.Nil(t, gw.rpcOverrides())
+}
+
+func TestReadGnowork(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("valid file", func(t *testing.T) {
+		file := filepath.Join(dir, "gnowork.toml")
+		require.NoError(t, os.WriteFile(file, []byte(`[domains."gno.land"]
+rpc = "http://localhost:26657"`), 0o600))
+
+		gw, err := ReadGnowork(file)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"gno.land": "http://localhost:26657"}, gw.rpcOverrides())
+	})
+
+	t.Run("missing file wraps path", func(t *testing.T) {
+		file := filepath.Join(dir, "does-not-exist.toml")
+		_, err := ReadGnowork(file)
+		require.ErrorContains(t, err, file)
+	})
+
+	t.Run("malformed file wraps path", func(t *testing.T) {
+		file := filepath.Join(dir, "bad.toml")
+		require.NoError(t, os.WriteFile(file, []byte(`[domains."gno.land"`), 0o600))
+		_, err := ReadGnowork(file)
+		require.ErrorContains(t, err, file)
+	})
+}

--- a/gnovm/pkg/packages/load.go
+++ b/gnovm/pkg/packages/load.go
@@ -62,7 +62,7 @@ func Load(conf LoadConfig, patterns ...string) (PkgList, error) {
 		if cpf, ok := conf.Fetcher.(pkgdownload.RPCPackageFetcher); ok {
 			cpf.OverrideDomainsRPCs(rpcOverrides)
 		} else {
-			fmt.Fprintf(conf.Out, "gno: warning: ignored rpc overrides, fetcher has no support for it")
+			fmt.Fprintf(conf.Out, "gno: warning: ignored rpc overrides, fetcher has no support for it\n")
 		}
 	}
 

--- a/gnovm/pkg/packages/load.go
+++ b/gnovm/pkg/packages/load.go
@@ -56,14 +56,9 @@ func Load(conf LoadConfig, patterns ...string) (PkgList, error) {
 		return nil, err
 	}
 
-	// override rpcs if requested and possible
-	rpcOverrides := loaderCtx.Gnowork.rpcOverrides()
-	if len(rpcOverrides) != 0 {
-		if cpf, ok := conf.Fetcher.(pkgdownload.RPCPackageFetcher); ok {
-			cpf.OverrideDomainsRPCs(rpcOverrides)
-		} else {
-			fmt.Fprintf(conf.Out, "gno: warning: ignored rpc overrides, fetcher has no support for it\n")
-		}
+	// apply per-domain rpc overrides from gnowork.toml, if any
+	if err := applyRPCOverrides(conf.Fetcher, loaderCtx.Gnowork.rpcOverrides()); err != nil {
+		return nil, err
 	}
 
 	// sanity assert
@@ -163,6 +158,22 @@ func Load(conf LoadConfig, patterns ...string) (PkgList, error) {
 	}
 
 	return loaded, nil
+}
+
+// applyRPCOverrides pushes the per-domain rpc overrides declared in gnowork.toml
+// into the package fetcher. When overrides are requested but the configured
+// fetcher cannot honor them, it returns an error rather than silently fetching
+// package source from the default endpoints.
+func applyRPCOverrides(fetcher pkgdownload.PackageFetcher, overrides map[string]string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+	rpcFetcher, ok := fetcher.(pkgdownload.RPCPackageFetcher)
+	if !ok {
+		return fmt.Errorf("gnowork.toml requests rpc overrides but the configured package fetcher (%T) does not support them", fetcher)
+	}
+	rpcFetcher.OverrideDomainsRPCs(overrides)
+	return nil
 }
 
 type loaderContext struct {

--- a/gnovm/pkg/packages/load.go
+++ b/gnovm/pkg/packages/load.go
@@ -56,6 +56,16 @@ func Load(conf LoadConfig, patterns ...string) (PkgList, error) {
 		return nil, err
 	}
 
+	// override rpcs if requested and possible
+	rpcOverrides := loaderCtx.Gnowork.rpcOverrides()
+	if len(rpcOverrides) != 0 {
+		if cpf, ok := conf.Fetcher.(pkgdownload.RPCPackageFetcher); ok {
+			cpf.OverrideDomainsRPCs(rpcOverrides)
+		} else {
+			fmt.Fprintf(conf.Out, "gno: warning: ignored rpc overrides, fetcher has no support for it")
+		}
+	}
+
 	// sanity assert
 	if !filepath.IsAbs(loaderCtx.Root) {
 		panic(fmt.Errorf("context root should be absolute at this point, got %q", loaderCtx.Root))
@@ -158,6 +168,7 @@ func Load(conf LoadConfig, patterns ...string) (PkgList, error) {
 type loaderContext struct {
 	Root        string
 	IsWorkspace bool
+	Gnowork     *Gnowork
 }
 
 func findLoaderContext() (*loaderContext, error) {
@@ -176,7 +187,11 @@ func findLoaderContextFor(dir string) (*loaderContext, error) {
 		root, err := findWorkspaceRootDir(dir)
 		switch {
 		case err == nil:
-			return &loaderContext{Root: root, IsWorkspace: true}, nil
+			gnowork, err := ReadGnowork(filepath.Join(root, "gnowork.toml"))
+			if err != nil {
+				return nil, err
+			}
+			return &loaderContext{Root: root, IsWorkspace: true, Gnowork: gnowork}, nil
 		case errors.Is(err, ErrGnoworkNotFound):
 			// continue
 		default:

--- a/gnovm/pkg/packages/load_rpcoverrides_test.go
+++ b/gnovm/pkg/packages/load_rpcoverrides_test.go
@@ -1,0 +1,39 @@
+package packages
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRPCFetcher implements pkgdownload.RPCPackageFetcher and records what it received.
+type fakeRPCFetcher struct {
+	applied map[string]string
+}
+
+func (f *fakeRPCFetcher) FetchPackage(string) ([]*std.MemFile, error) { return nil, nil }
+func (f *fakeRPCFetcher) OverrideDomainsRPCs(m map[string]string)     { f.applied = m }
+
+// fakePlainFetcher implements only pkgdownload.PackageFetcher (no override support).
+type fakePlainFetcher struct{}
+
+func (fakePlainFetcher) FetchPackage(string) ([]*std.MemFile, error) { return nil, nil }
+
+func TestApplyRPCOverrides(t *testing.T) {
+	t.Run("no overrides is a no-op even for a plain fetcher", func(t *testing.T) {
+		require.NoError(t, applyRPCOverrides(fakePlainFetcher{}, nil))
+	})
+
+	t.Run("overrides are pushed into an rpc-capable fetcher", func(t *testing.T) {
+		f := &fakeRPCFetcher{}
+		overrides := map[string]string{"gno.land": "http://localhost:26657"}
+		require.NoError(t, applyRPCOverrides(f, overrides))
+		require.Equal(t, overrides, f.applied)
+	})
+
+	t.Run("overrides on an unsupported fetcher error instead of being dropped", func(t *testing.T) {
+		err := applyRPCOverrides(fakePlainFetcher{}, map[string]string{"gno.land": "http://localhost:26657"})
+		require.ErrorContains(t, err, "does not support")
+	})
+}

--- a/gnovm/pkg/packages/pkgdownload/pkgfetcher.go
+++ b/gnovm/pkg/packages/pkgdownload/pkgfetcher.go
@@ -10,6 +10,11 @@ type PackageFetcher interface {
 	FetchPackage(pkgPath string) ([]*std.MemFile, error)
 }
 
+type RPCPackageFetcher interface {
+	PackageFetcher
+	OverrideDomainsRPCs(map[string]string)
+}
+
 func NewNoopFetcher() PackageFetcher {
 	return &noopFetcher{}
 }

--- a/gnovm/pkg/packages/pkgdownload/rpcpkgfetcher/rpcpkgfetcher.go
+++ b/gnovm/pkg/packages/pkgdownload/rpcpkgfetcher/rpcpkgfetcher.go
@@ -25,7 +25,7 @@ func New(remoteOverrides map[string]string) pkgdownload.PackageFetcher {
 	}
 }
 
-// FetchPackage implements pkgdownload.PackageFetcher.
+// FetchPackage implements [pkgdownload.PackageFetcher].
 func (gpf *gnoPackageFetcher) FetchPackage(pkgPath string) ([]*std.MemFile, error) {
 	rpcURL, err := rpcURLFromPkgPath(pkgPath, gpf.remoteOverrides)
 	if err != nil {
@@ -57,19 +57,15 @@ func (gpf *gnoPackageFetcher) FetchPackage(pkgPath string) ([]*std.MemFile, erro
 	return res, nil
 }
 
-// OverrideDomainsRPCs implements pkgdownload.RPCPackageFetcher.
+// OverrideDomainsRPCs implements [pkgdownload.RPCPackageFetcher].
 func (gpf *gnoPackageFetcher) OverrideDomainsRPCs(values map[string]string) {
 	if len(values) == 0 {
 		return
 	}
 	if gpf.remoteOverrides == nil {
-		gpf.remoteOverrides = map[string]string{}
+		gpf.remoteOverrides = make(map[string]string, len(values))
 	}
 	for domain, rpc := range values {
-		if rpc == "" {
-			delete(gpf.remoteOverrides, domain)
-			continue
-		}
 		gpf.remoteOverrides[domain] = rpc
 	}
 }

--- a/gnovm/pkg/packages/pkgdownload/rpcpkgfetcher/rpcpkgfetcher_test.go
+++ b/gnovm/pkg/packages/pkgdownload/rpcpkgfetcher/rpcpkgfetcher_test.go
@@ -51,3 +51,32 @@ func TestRpcURLFromPkgPath(t *testing.T) {
 		})
 	}
 }
+
+func TestOverrideDomainsRPCs(t *testing.T) {
+	t.Run("populates a nil override map", func(t *testing.T) {
+		gpf := &gnoPackageFetcher{}
+		gpf.OverrideDomainsRPCs(map[string]string{"gno.land": "http://localhost:26657"})
+
+		res, err := rpcURLFromPkgPath("gno.land/p/nt/avl/v0", gpf.remoteOverrides)
+		require.NoError(t, err)
+		require.Equal(t, "http://localhost:26657", res)
+	})
+
+	t.Run("merges onto existing overrides", func(t *testing.T) {
+		gpf := &gnoPackageFetcher{remoteOverrides: map[string]string{"gno.land": "https://old:443"}}
+		gpf.OverrideDomainsRPCs(map[string]string{
+			"gno.land":    "http://localhost:26657",
+			"example.com": "http://localhost:8080",
+		})
+		require.Equal(t, map[string]string{
+			"gno.land":    "http://localhost:26657",
+			"example.com": "http://localhost:8080",
+		}, gpf.remoteOverrides)
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		gpf := &gnoPackageFetcher{}
+		gpf.OverrideDomainsRPCs(nil)
+		require.Nil(t, gpf.remoteOverrides)
+	})
+}


### PR DESCRIPTION
allow to override the rpc for each domain in `gnowork.toml`, example:

```toml
[domains."gno.land"]
rpc = "http://localhost:26657"
```

another idea is to use cli arguments but I think this one is better devx

workaround for #4739