### PR TITLE
chore(staging): fix prefixes for staging backups for tx-export

### DIFF
--- a/misc/loop/docker-compose.yml
+++ b/misc/loop/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       - traefik.http.routers.gnoweb.rule=Host(`gno.land`) || Host(`www.gno.land`) || Host(`staging.gno.land`)
       - traefik.http.routers.gnoweb.tls=true
       - traefik.http.routers.gnoweb.tls.certresolver=le
+      # # secure headers
+      - traefik.http.routers.gnoweb.middlewares=secure-headers@file
       - com.centurylinklabs.watchtower.enable=true
 
   gnofaucet:

--- a/misc/loop/docker-compose.yml
+++ b/misc/loop/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - traefik.http.routers.gnoweb.rule=Host(`gno.land`) || Host(`www.gno.land`) || Host(`staging.gno.land`)
       - traefik.http.routers.gnoweb.tls=true
       - traefik.http.routers.gnoweb.tls.certresolver=le
-      # # secure headers
+      # Secure headers
       - traefik.http.routers.gnoweb.middlewares=secure-headers@file
       - com.centurylinklabs.watchtower.enable=true
 

--- a/misc/loop/scripts/pull-gh.sh
+++ b/misc/loop/scripts/pull-gh.sh
@@ -13,7 +13,7 @@ MASTER_BALANCES_FILE="balances.jsonl"
 # Clones the staging backups subdirectory, located in BACKUPS_REPO (tx-exports)
 pullGHBackups () {
   BACKUPS_REPO=https://github.com/gnolang/tx-exports.git
-  BACKUPS_REPO_PATH="portal-loop"
+  BACKUPS_REPO_PATH="staging.gno.land"
 
   # Clone just the root folder of the same name
   git clone --depth 1 --no-checkout $BACKUPS_REPO
@@ -35,8 +35,8 @@ cd $TMP_DIR || exit 1
 pullGHBackups
 
 # Combine the pulled backups into a single backup file
-TXS_BACKUPS_PREFIX="backup_portal_loop_txs_"
-BALANCES_BACKUP_NAME="backup_portal_loop_balances.jsonl"
+TXS_BACKUPS_PREFIX="backup_staging_txs_"
+BALANCES_BACKUP_NAME="backup_staging_balances.jsonl"
 
 find . -type f -name "${TXS_BACKUPS_PREFIX}*.jsonl" | sort | xargs cat > "temp_$MASTER_BACKUP_FILE"
 find . -type f -name "${BALANCES_BACKUP_NAME}" | sort | xargs cat > "temp_$MASTER_BALANCES_FILE"

--- a/misc/loop/traefik/gno.yml
+++ b/misc/loop/traefik/gno.yml
@@ -1,6 +1,25 @@
 ---
 http:
   middlewares:
+    secure-headers:
+      headers:
+        # CSP Headers
+        contentSecurityPolicy: "default-src 'self'; script-src 'self' https://sa.gno.services; style-src 'self'; img-src 'self' data: https://gnolang.github.io https://assets.gnoteam.com https://sa.gno.services https://imgur.com https://*.imgur.com https://*.github.io https://github.com https://*.githubusercontent.com https://imgflip.com https://*.imgflip.com https://ipfs.io https://cloudflare-ipfs.com; font-src 'self';"
+        # Vary: Origin
+        addVaryHeader: true
+        # X-XSS-Protection: 1; mode=block
+        browserXssFilter: true
+        # X-Content-Type-Options: nosniff
+        contentTypeNosniff: true
+        # X-Frame-Options: DENY
+        frameDeny: true
+        # Referrer-Policy: no-referrer
+        referrerPolicy: "no-referrer"
+        # HSTS Headers
+        forceSTSHeader: true
+        stsIncludeSubdomains: true
+        stsPreload: true
+        stsSeconds: 31536000
     ipwhitelist:
       ipWhiteList:
         sourceRange:


### PR DESCRIPTION
- Aligning names to `staging` from the previous `Portal Loop` naming.

See https://github.com/gnolang/tx-exports/pull/42

- adding secure headers to gnoweb in `misc/loop`
