### PR TITLE
ci: fix examples.yml workflow by adding a `workflow_dispatch` input for debug

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,13 @@ on:
       # any change to gnovm code can make examples fail
       - gnovm/**
       - examples/**
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: Enable debug mode for gno test
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -34,7 +41,7 @@ jobs:
     name: Run gno test
     uses: ./.github/workflows/template_gnotest.yml
     with:
-      debug: env.ACTIONS_STEP_DEBUG == 'true'
+      debug: ${{ inputs.debug || false }}
       path: "examples"
       go-version: "1.23.x"
 


### PR DESCRIPTION
Fixes this error: https://github.com/gnolang/gno/actions/runs/17951688475?pr=4040
By:
- setting `debug` to `false` by default
- adding a `workflow_dispatch` event that can run this workflow with `debug` set to `true`