### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/gno.land/cmd/gnoland/config_get_test.go
+++ b/gno.land/cmd/gnoland/config_get_test.go
@@ -46,7 +46,6 @@ func verifyGetTestTableCommon(t *testing.T, testTable []testGetCase) {
 	t.Helper()
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/gno.land/cmd/gnoland/config_set_test.go
+++ b/gno.land/cmd/gnoland/config_set_test.go
@@ -45,7 +45,6 @@ func verifySetTestTableCommon(t *testing.T, testTable []testSetCase) {
 	t.Helper()
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/gno.land/cmd/gnoland/secrets_init_test.go
+++ b/gno.land/cmd/gnoland/secrets_init_test.go
@@ -153,7 +153,6 @@ func TestSecrets_Init_Single(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
@@ -210,7 +209,6 @@ func TestSecrets_Init_Single_Overwrite(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/gno.land/cmd/gnoland/secrets_verify_test.go
+++ b/gno.land/cmd/gnoland/secrets_verify_test.go
@@ -189,7 +189,6 @@ func TestSecrets_Verify_All_Missing(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/gno.land/pkg/gnoclient/client_test.go
+++ b/gno.land/pkg/gnoclient/client_test.go
@@ -390,7 +390,6 @@ func TestCallErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -590,7 +589,6 @@ func TestClient_Send_Errors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -956,7 +954,6 @@ func TestRunErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1155,7 +1152,6 @@ func TestAddPackageErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1271,7 +1267,6 @@ func TestBlockErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1312,7 +1307,6 @@ func TestBlockResultErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1342,7 +1336,6 @@ func TestLatestBlockHeightErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gno.land/pkg/gnoweb/components/layout_test.go
+++ b/gno.land/pkg/gnoweb/components/layout_test.go
@@ -158,7 +158,6 @@ func TestIsActive(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := isActive(tc.query, tc.label)
 			assert.Equal(t, tc.expected, result)
@@ -277,7 +276,6 @@ func TestViewModePredicates(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.wantExplorer, tc.mode.IsExplorer(), "IsExplorer")
 			assert.Equal(t, tc.wantRealm, tc.mode.IsRealm(), "IsRealm")

--- a/gno.land/pkg/gnoweb/components/view_test.go
+++ b/gno.land/pkg/gnoweb/components/view_test.go
@@ -247,7 +247,6 @@ func TestDirLinkType_LinkPrefix(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.linkType.LinkPrefix(tc.pkgPath)
 			assert.Equal(t, tc.expected, result)
@@ -293,7 +292,6 @@ func TestGetFullLinks(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := GetFullLinks(tc.files, tc.linkType, tc.pkgPath)
 			assert.Equal(t, tc.expected, result)

--- a/gno.land/pkg/gnoweb/handler_http_test.go
+++ b/gno.land/pkg/gnoweb/handler_http_test.go
@@ -263,7 +263,6 @@ func TestHTTPHandler_GetSourceDownload(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(strings.TrimPrefix(tc.Path, "/"), func(t *testing.T) {
 			t.Parallel()
 			t.Logf("input: %+v", tc)
@@ -397,7 +396,6 @@ func TestHTTPHandler_NewInvalidConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -557,7 +555,6 @@ func TestHTTPHandler_GetClientErrorStatusPage(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -680,7 +677,6 @@ func TestHTTPHandler_CreateUsernameFromBech32(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gno.land/pkg/integration/utils_test.go
+++ b/gno.land/pkg/integration/utils_test.go
@@ -32,7 +32,6 @@ func TestUnquote(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.Input, func(t *testing.T) {
 			t.Parallel()
 

--- a/gno.land/pkg/sdk/vm/msgs_test.go
+++ b/gno.land/pkg/sdk/vm/msgs_test.go
@@ -129,7 +129,6 @@ func TestMsgAddPackage_ValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -278,7 +277,6 @@ func TestMsgCall_ValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -400,7 +398,6 @@ func TestMsgRun_ValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gnovm/cmd/gno/tool_transpile_test.go
+++ b/gnovm/cmd/gno/tool_transpile_test.go
@@ -71,7 +71,6 @@ pkg/file.gno:60:20: ugly error`,
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gnovm/pkg/doc/dirs_test.go
+++ b/gnovm/pkg/doc/dirs_test.go
@@ -98,7 +98,6 @@ func TestDirs_findPackage(t *testing.T) {
 		{"", []bfsDir{}},
 	}
 	for _, tc := range tt {
-		tc := tc
 		t.Run("name_"+strings.ReplaceAll(tc.name, "/", "_"), func(t *testing.T) {
 			res := d.findPackage(tc.name)
 			assert.Equal(t, tc.res, res, "dirs returned should be the equal")
@@ -126,7 +125,6 @@ func TestDirs_findDir(t *testing.T) {
 		{"2xx", "/2xx", nil},
 	}
 	for _, tc := range tt {
-		tc := tc
 		t.Run(strings.ReplaceAll(tc.name, "/", "_"), func(t *testing.T) {
 			res := d.findDir(tc.in)
 			assert.Equal(t, tc.res, res, "dirs returned should be the equal")

--- a/gnovm/pkg/doc/doc_test.go
+++ b/gnovm/pkg/doc/doc_test.go
@@ -105,7 +105,6 @@ func TestResolveDocumentable(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Wd prefix mean test relative to local directory -
 			// mock change local dir by setting the fpAbs variable (see doc.go) to match
@@ -182,7 +181,6 @@ func TestDocument(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			buf.Reset()
 			err := tc.d.WriteDocumentation(buf, tc.opts)
@@ -236,7 +234,6 @@ func Test_parseArgParts(t *testing.T) {
 		{"errTooManyArgs", []string{"io", "Writer", "Write"}, nil},
 	}
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			p, ok := parseArgs(tc.args)
 			if ok {

--- a/gnovm/pkg/gnolang/gotypecheck_test.go
+++ b/gnovm/pkg/gnolang/gotypecheck_test.go
@@ -375,7 +375,6 @@ func TestTypeCheckMemPackage(t *testing.T) {
 	})
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gnovm/pkg/gnolang/mempackage_test.go
+++ b/gnovm/pkg/gnolang/mempackage_test.go
@@ -295,7 +295,6 @@ func TestMemPackage_Validate(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if tc.panicMsg != "" {

--- a/gnovm/pkg/gnolang/type_check_test.go
+++ b/gnovm/pkg/gnolang/type_check_test.go
@@ -41,7 +41,6 @@ func TestCheckAssignableTo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkAssignableTo(nil, tt.xt, tt.dt, tt.autoNative)

--- a/gnovm/pkg/repl/repl_test.go
+++ b/gnovm/pkg/repl/repl_test.go
@@ -233,7 +233,6 @@ var fixtures = []struct {
 
 func TestRepl(t *testing.T) {
 	for _, fix := range fixtures {
-		fix := fix
 		t.Run(fix.Name, func(t *testing.T) {
 			outbuf := new(bytes.Buffer)
 			errbuf := new(bytes.Buffer)

--- a/gnovm/pkg/transpiler/transpiler_test.go
+++ b/gnovm/pkg/transpiler/transpiler_test.go
@@ -410,7 +410,6 @@ func testfunc() {
 		},
 	}
 	for _, c := range cases {
-		c := c // scopelint
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			// "\n" is added for better test case readability, now trim it

--- a/tm2/pkg/amino/encoder_test.go
+++ b/tm2/pkg/amino/encoder_test.go
@@ -24,7 +24,6 @@ func TestUvarintSize(t *testing.T) {
 		{"64 bits", 1 << 63, 10},
 	}
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/blockchain/reactor_test.go
+++ b/tm2/pkg/bft/blockchain/reactor_test.go
@@ -308,7 +308,6 @@ func TestBcBlockRequestMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -332,7 +331,6 @@ func TestBcNoBlockResponseMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -356,7 +354,6 @@ func TestBcStatusRequestMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -380,7 +377,6 @@ func TestBcStatusResponseMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/consensus/reactor_test.go
+++ b/tm2/pkg/bft/consensus/reactor_test.go
@@ -572,7 +572,6 @@ func TestNewRoundStepMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -616,7 +615,6 @@ func TestNewValidBlockMessageValidateBasic(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
 			t.Parallel()
 
@@ -656,7 +654,6 @@ func TestProposalPOLMessageValidateBasic(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
 			t.Parallel()
 
@@ -693,7 +690,6 @@ func TestBlockPartMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -737,7 +733,6 @@ func TestHasVoteMessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -786,7 +781,6 @@ func TestVoteSetMaj23MessageValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -829,7 +823,6 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/consensus/replay_test.go
+++ b/tm2/pkg/bft/consensus/replay_test.go
@@ -153,7 +153,6 @@ func TestWALCrash(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		consensusReplayConfig, genesisFile := ResetConfig(fmt.Sprintf("%s_%d", t.Name(), i))
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/bft/rpc/client/batch_test.go
+++ b/tm2/pkg/bft/rpc/client/batch_test.go
@@ -475,7 +475,6 @@ func TestRPCBatch_Endpoints(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.method, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/bft/rpc/client/e2e_test.go
+++ b/tm2/pkg/bft/rpc/client/e2e_test.go
@@ -426,7 +426,6 @@ func TestRPCClient_E2E_Endpoints(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
@@ -438,7 +437,6 @@ func TestRPCClient_E2E_Endpoints(t *testing.T) {
 			)
 
 			for _, clientCase := range clientTable {
-				clientCase := clientCase
 
 				t.Run(clientCase.name, func(t *testing.T) {
 					t.Parallel()

--- a/tm2/pkg/bft/rpc/lib/client/http/client_test.go
+++ b/tm2/pkg/bft/rpc/lib/client/http/client_test.go
@@ -54,7 +54,6 @@ func TestClient_parseRemoteAddr(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.remoteAddr, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/bft/rpc/lib/server/handlers.go
+++ b/tm2/pkg/bft/rpc/lib/server/handlers.go
@@ -679,7 +679,6 @@ func (wsc *wsConnection) readRoutine() {
 			}
 
 			for _, request := range requests {
-				request := request
 
 				// A Notification is a Request object without an "id" member.
 				// The Server MUST NOT reply to a Notification, including those that are within a batch request.

--- a/tm2/pkg/bft/rpc/lib/types/types_test.go
+++ b/tm2/pkg/bft/rpc/lib/types/types_test.go
@@ -57,7 +57,6 @@ func TestJSONRPCID_Marshal_Unmarshal(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/bft/state/eventstore/types/config_test.go
+++ b/tm2/pkg/bft/state/eventstore/types/config_test.go
@@ -34,7 +34,6 @@ func TestConfig_GetParam(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/bft/state/execution_test.go
+++ b/tm2/pkg/bft/state/execution_test.go
@@ -169,7 +169,6 @@ func TestValidateValidatorUpdates(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -239,7 +238,6 @@ func TestUpdateValidators(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/store/store_test.go
+++ b/tm2/pkg/bft/store/store_test.go
@@ -88,7 +88,6 @@ func TestNewBlockStore(t *testing.T) {
 	}
 
 	for i, tt := range panicCausers {
-		tt := tt
 		// Expecting a panic here on trying to parse an invalid blockStore
 		_, _, panicErr := doFn(func() (any, error) {
 			db.Set(blockStoreKey, tt.data)
@@ -261,7 +260,6 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	}
 
 	for i, tuple := range tuples {
-		tuple := tuple
 		bs, db := freshBlockStore()
 		// SaveBlock
 		res, err, panicErr := doFn(func() (any, error) {

--- a/tm2/pkg/bft/types/block_test.go
+++ b/tm2/pkg/bft/types/block_test.go
@@ -56,8 +56,6 @@ func TestBlockValidateBasic(t *testing.T) {
 		}, true},
 	}
 	for i, tc := range testCases {
-		tc := tc
-		i := i
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -201,7 +199,6 @@ func TestCommitValidateBasic(t *testing.T) {
 		{"Incorrect round", func(com *Commit) { com.Precommits[0].Round = 100 }, true},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -390,7 +387,6 @@ func TestSignedHeaderValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -434,7 +430,6 @@ func TestBlockIDValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/types/evidence_test.go
+++ b/tm2/pkg/bft/types/evidence_test.go
@@ -157,7 +157,6 @@ func TestDuplicateVoteEvidenceValidation(t *testing.T) {
 		}, true},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/types/part_set_test.go
+++ b/tm2/pkg/bft/types/part_set_test.go
@@ -102,7 +102,6 @@ func TestPartSetHeaderValidateBasic(t *testing.T) {
 		{"Invalid Hash", func(psHeader *PartSetHeader) { psHeader.Hash = make([]byte, 1) }, true},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
@@ -136,7 +135,6 @@ func TestPartValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/types/proposal_test.go
+++ b/tm2/pkg/bft/types/proposal_test.go
@@ -135,7 +135,6 @@ func TestProposalValidateBasic(t *testing.T) {
 	blockID := makeBlockID(tmhash.Sum([]byte("blockhash")), math.MaxInt64, tmhash.Sum([]byte("partshash")))
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/types/vote_test.go
+++ b/tm2/pkg/bft/types/vote_test.go
@@ -209,7 +209,6 @@ func TestIsVoteTypeValid(t *testing.T) {
 	}
 
 	for _, tt := range tc {
-		tt := tt
 		t.Run(tt.name, func(st *testing.T) {
 			st.Parallel()
 
@@ -309,7 +308,6 @@ func TestVoteValidateBasic(t *testing.T) {
 		{"Too big Signature", func(v *Vote) { v.Signature = make([]byte, MaxSignatureSize+1) }, true},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/bft/wal/wal_test.go
+++ b/tm2/pkg/bft/wal/wal_test.go
@@ -50,7 +50,6 @@ func TestWALWriterReader(t *testing.T) {
 	b := new(bytes.Buffer)
 
 	for _, msg := range msgs {
-		msg := msg
 
 		b.Reset()
 

--- a/tm2/pkg/bitarray/bit_array_test.go
+++ b/tm2/pkg/bitarray/bit_array_test.go
@@ -249,7 +249,6 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/commands/commands_test.go
+++ b/tm2/pkg/commands/commands_test.go
@@ -217,7 +217,6 @@ func TestCommandParseAndRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -384,7 +383,6 @@ func TestCommand_AddSubCommands(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
@@ -494,7 +492,6 @@ FLAGS
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/crypto/keys/client/export_test.go
+++ b/tm2/pkg/crypto/keys/client/export_test.go
@@ -147,7 +147,6 @@ func TestExport_ExportKey(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/crypto/keys/client/import_test.go
+++ b/tm2/pkg/crypto/keys/client/import_test.go
@@ -85,7 +85,6 @@ func TestImport_ImportKey(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/crypto/merkle/rfc6962_test.go
+++ b/tm2/pkg/crypto/merkle/rfc6962_test.go
@@ -58,7 +58,6 @@ func TestRFC6962Hasher(t *testing.T) {
 			got:  innerHash([]byte("N123"), []byte("N456")),
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/crypto/merkle/simple_proof_test.go
+++ b/tm2/pkg/crypto/merkle/simple_proof_test.go
@@ -23,7 +23,6 @@ func TestSimpleProofValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/crypto/multisig/bitarray/compact_bit_array_test.go
+++ b/tm2/pkg/crypto/multisig/bitarray/compact_bit_array_test.go
@@ -75,7 +75,6 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			t.Parallel()
 
@@ -139,7 +138,6 @@ func TestCompactMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			t.Parallel()
 
@@ -178,8 +176,6 @@ func TestCompactBitArrayNumOfTrueBitsBefore(t *testing.T) {
 		{`"______________xx"`, []int{14, 15}, []int{0, 1}},
 	}
 	for tcIndex, tc := range testCases {
-		tc := tc
-		tcIndex := tcIndex
 		t.Run(tc.marshalledBA, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/crypto/secp256k1/secp256k1_internal_test.go
+++ b/tm2/pkg/crypto/secp256k1/secp256k1_internal_test.go
@@ -29,7 +29,6 @@ func Test_genPrivKey(t *testing.T) {
 		{"valid because 0 < 1 < N", validOne, false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/crypto/secp256k1/secp256k1_test.go
+++ b/tm2/pkg/crypto/secp256k1/secp256k1_test.go
@@ -107,7 +107,6 @@ func TestGenPrivKeySecp256k1(t *testing.T) {
 		{"another seed used in cosmos tests #3", []byte("")},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/flow/io_test.go
+++ b/tm2/pkg/flow/io_test.go
@@ -92,7 +92,6 @@ func TestReader(t *testing.T) {
 		{false, start, _300ms, 0, 20, 3, 0, 0, 67, 100, 0, 0, 0},
 	}
 	for i, s := range status {
-		s := s
 		if !statusesAreEqual(&s, &want[i]) {
 			t.Errorf("r.Status(%v)\nexpected: %v\ngot     : %v", i, want[i], s)
 		}
@@ -149,7 +148,6 @@ func TestWriter(t *testing.T) {
 		{true, start, _500ms, _100ms, 100, 5, 200, 200, 200, 200, 0, 0, 100000},
 	}
 	for i, s := range status {
-		s := s
 		if !statusesAreEqual(&s, &want[i]) {
 			t.Errorf("w.Status(%v)\nexpected: %v\ngot     : %v\n", i, want[i], s)
 		}

--- a/tm2/pkg/p2p/conn/secret_connection_test.go
+++ b/tm2/pkg/p2p/conn/secret_connection_test.go
@@ -119,7 +119,6 @@ func TestShareLowOrderPubkey(t *testing.T) {
 
 	// all blacklisted low order points:
 	for _, remLowOrderPubKey := range blacklist {
-		remLowOrderPubKey := remLowOrderPubKey
 		_, _ = async.Parallel(
 			func(_ int) (val any, err error, abort bool) {
 				_, err = shareEphPubKey(fooConn, locEphPub)
@@ -149,7 +148,6 @@ func TestComputeDHFailsOnLowOrder(t *testing.T) {
 
 	_, locPrivKey := genEphKeys()
 	for _, remLowOrderPubKey := range blacklist {
-		remLowOrderPubKey := remLowOrderPubKey
 		shared, err := computeDHSecret(&remLowOrderPubKey, locPrivKey)
 		_ = assert.Error(t, err) &&
 			assert.Equal(t, lowOrderPointError, err.Error())

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -620,7 +620,6 @@ func TestProcessPubKey(t *testing.T) {
 		{"pubkey doesn't match addr, simulate on", args{acc1, std.Signature{PubKey: priv2.PubKey()}, true}, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -662,7 +661,6 @@ func TestConsumeSignatureVerificationGas(t *testing.T) {
 		{"unknown key", args{store.NewInfiniteGasMeter(), nil, nil, params}, 0, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -740,7 +738,6 @@ func TestCountSubkeys(t *testing.T) {
 		{"multi level multikey", args{multiLevelMultiKey}, 11},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tm2/pkg/std/coin_test.go
+++ b/tm2/pkg/std/coin_test.go
@@ -628,7 +628,6 @@ func TestNewCoins(t *testing.T) {
 		{"panic on dups", []Coin{tenatom, tenatom}, Coins{}, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -685,7 +684,6 @@ func TestFindDup(t *testing.T) {
 		{"dup after first position", args{Coins{abc, def, def}}, 2},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -710,7 +708,6 @@ func TestMarshalJSONCoins(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/std/doc_test.go
+++ b/tm2/pkg/std/doc_test.go
@@ -35,7 +35,6 @@ func TestSignDoc_GetSignaturePayload(t *testing.T) {
 	}
 
 	for _, testCase := range testTable {
-		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/tm2/pkg/std/memfile_test.go
+++ b/tm2/pkg/std/memfile_test.go
@@ -143,7 +143,6 @@ func TestMemPackage_Validate(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := tc.mpkg.ValidateBasic()
@@ -335,7 +334,6 @@ func TestSplitFilepath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dirPath, filename := SplitFilepath(tt.filepath)

--- a/tm2/pkg/versionset/versionset.go
+++ b/tm2/pkg/versionset/versionset.go
@@ -61,11 +61,9 @@ func (pvs VersionSet) CompatibleWith(other VersionSet) (res VersionSet, err erro
 	type pvpair [2]*VersionInfo
 	name2Pair := map[string]*pvpair{}
 	for _, pv := range pvs {
-		pv := pv
 		name2Pair[pv.Name] = &pvpair{&pv, nil}
 	}
 	for _, pv := range other {
-		pv := pv
 		item, ok := name2Pair[pv.Name]
 		if ok {
 			item[1] = &pv


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore