### PR TITLE
fix: remove testingSpecial test case for misc/genstd

### DIFF
--- a/misc/genstd/package_sort_test.go
+++ b/misc/genstd/package_sort_test.go
@@ -48,14 +48,6 @@ func Test_sortPackages(t *testing.T) {
 			},
 			output: []string{"b", "a"},
 		},
-		{
-			name: "testingSpecial",
-			pkgs: []*pkgData{
-				{importPath: "testing", imports: imports("fmt", "os", "b")},
-				{importPath: "b"},
-			},
-			output: []string{"b", "testing"},
-		},
 
 		{
 			name: "cyclical0",


### PR DESCRIPTION
This test for a condition which no longer applies; there are no more "special packages" to test for.