### PR TITLE
feat(markdown): SVG extension

### DIFF
--- a/examples/gno.land/p/demo/svg/svg.gno
+++ b/examples/gno.land/p/demo/svg/svg.gno
@@ -40,8 +40,11 @@ func (c *Canvas) WithViewBox(x, y, width, height int) *Canvas {
 
 // Render renders your canvas
 func (c Canvas) Render(alt string) string {
-	base64SVG := base64.StdEncoding.EncodeToString([]byte(c.String()))
-	return ufmt.Sprintf("![%s](data:image/svg+xml;base64,%s)", alt, base64SVG)
+	var s strings.Builder
+	ufmt.Fprintln(&s, "<gno-svg>")
+	ufmt.Fprintln(&s, c.String())
+	ufmt.Fprintln(&s, "</gno-svg>")
+	return s.String()
 }
 
 func (c Canvas) String() string {

--- a/gno.land/pkg/gnoweb/markdown/ext.go
+++ b/gno.land/pkg/gnoweb/markdown/ext.go
@@ -80,6 +80,9 @@ func (e *GnoExtension) Extend(m goldmark.Markdown) {
 	// Add mentions extension
 	ExtMention.Extend(m)
 
+	// Add svg extension
+	ExtSvg.Extend(m)
+
 	// If set, setup images filter
 	if e.cfg.imgValidatorFunc != nil {
 		ExtImageValidator.Extend(m, e.cfg.imgValidatorFunc)

--- a/gno.land/pkg/gnoweb/markdown/ext_svg.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_svg.go
@@ -39,13 +39,7 @@ func NewSvgNode() ast.Node {
 type svgBlockParser struct {
 }
 
-var svgInfoKey = parser.NewContextKey()
-
 var defaultSVGParser = &svgBlockParser{}
-
-type svgData struct {
-	node ast.Node
-}
 
 // NewSVGParser returns a new BlockParser that parses SVG blocks.
 func NewSVGParser() parser.BlockParser {
@@ -102,13 +96,10 @@ func (b *svgBlockParser) CanInterruptParagraph() bool {
 }
 
 func (b *svgBlockParser) CanAcceptIndentedLine() bool {
-	return true // Accept indented lines to prevent other parsers from taking them
+	return true
 }
 
 // svgRenderer renders the Svg node.
-// When entering the Svg node, it displays the opening <svg> tag
-// and when exiting (after rendering the child inputs),
-// it displays the submit button and </svg>.
 type svgRenderer struct{}
 
 // NewSvgRenderer creates a new instance of svgRenderer

--- a/gno.land/pkg/gnoweb/markdown/ext_svg.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_svg.go
@@ -1,0 +1,202 @@
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+type svgNode struct {
+	ast.BaseBlock
+}
+
+var KindGnoSvg = ast.NewNodeKind("GnoSVG")
+
+func (n *svgNode) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+	return
+}
+
+func (n *svgNode) Kind() ast.NodeKind {
+	return KindGnoSvg
+}
+
+func NewSvgNode() ast.Node {
+	return &svgNode{}
+}
+
+type svgBlockParser struct {
+}
+
+var svgInfoKey = parser.NewContextKey()
+
+var defaultSVGParser = &svgBlockParser{}
+
+// NewFencedCodeBlockParser returns a new BlockParser that
+// parses fenced code blocks.
+func NewSVGParser() parser.BlockParser {
+	return defaultSVGParser
+}
+
+type svgData struct {
+	char   byte
+	indent int
+	length int
+	node   ast.Node
+}
+
+// var svgBlockInfoKey = NewContextKey()
+
+func (b *svgBlockParser) Trigger() []byte {
+	return []byte{'<'}
+}
+
+func (b *svgBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, _ := reader.PeekLine()
+	line = util.TrimRightSpace(util.TrimLeftSpace(line))
+	toks, err := ParseHTMLTokens(bytes.NewReader(line))
+	if err != nil || len(toks) != 1 {
+		return nil, parser.NoChildren
+	}
+
+	tok := toks[0]
+	if tok.Data != "gno-svg" {
+		return nil, parser.NoChildren
+	}
+
+	// if pos < 0 || (line[pos] != '`' && line[pos] != '~') {
+	// 	return nil, parser.NoChildren
+	// }
+	// findent := pos
+	// fenceChar := line[pos]
+	// i := pos
+	// for ; i < len(line) && line[i] == fenceChar; i++ {
+	// }
+	// oFenceLength := i - pos
+	// if oFenceLength < 3 {
+	// 	return nil, parser.NoChildren
+	// }
+
+	node := NewSvgNode()
+	// pc.Set(svgInfoKey, &svgData{fenceChar, findent, oFenceLength, node})
+	return node, parser.NoChildren
+}
+
+func (b *svgBlockParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	line, segment := reader.PeekLine()
+	closeLine := util.TrimRightSpace(util.TrimLeftSpace(line))
+	if "</gno-svg>" == string(closeLine) {
+		reader.AdvanceLine()
+		return parser.Close
+	}
+
+	// w, pos := util.IndentWidth(line, reader.LineOffset())
+	// if w < 4 {
+	// 	i := pos
+	// 	for ; i < len(line) && line[i] == fdata.char; i++ {
+	// 	}
+	// 	length := i - pos
+	// 	if length >= fdata.length && util.IsBlank(line[i:]) {
+	// 		newline := 1
+	// 		if line[len(line)-1] != '\n' {
+	// 			newline = 0
+	// 		}
+	// 		reader.Advance(segment.Stop - segment.Start - newline + segment.Padding)
+	// 		return parser.Close
+	// 	}
+	// }
+
+	pos, padding := util.IndentPosition(line, reader.LineOffset(), segment.Padding)
+	if pos < 0 {
+		pos = util.FirstNonSpacePosition(line)
+		if pos < 0 {
+			pos = 0
+		}
+		padding = 0
+	}
+
+	seg := text.NewSegmentPadding(segment.Start+pos, segment.Stop, padding)
+	// if code block line starts with a tab, keep a tab as it is.
+	if padding != 0 {
+		preserveLeadingTabInCodeBlock(&seg, reader, 0)
+	}
+	seg.ForceNewline = true // EOF as newline
+	node.Lines().Append(seg)
+	reader.AdvanceLine()
+	return parser.Continue | parser.NoChildren
+}
+
+func (b *svgBlockParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {}
+
+func (b *svgBlockParser) CanInterruptParagraph() bool {
+	return true
+}
+
+func (b *svgBlockParser) CanAcceptIndentedLine() bool {
+	return false
+}
+
+// svgRenderer renders the Svg node.
+// When entering the Svg node, it displays the opening <svg> tag
+// and when exiting (after rendering the child inputs),
+// it displays the submit button and </svg>.
+type svgRenderer struct{}
+
+// NewSvgRenderer creates a new instance of svgRenderer
+func NewSvgRenderer() *svgRenderer {
+	return &svgRenderer{}
+}
+
+// RegisterFuncs registers the render function for the Svg node
+func (r *svgRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindGnoSvg, r.render)
+}
+
+// render renders the Svg node
+func (r *svgRenderer) render(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	fmt.Fprintln(w, "</mysvg>")
+	l := node.Lines().Len()
+	for i := 0; i < l; i++ {
+		line := node.Lines().At(i)
+		w.Write(line.Value(source))
+	}
+
+	fmt.Fprintln(w, "</mysvg>")
+	return ast.WalkContinue, nil
+}
+
+type svgExtension struct{}
+
+// Extend adds parsing and rendering options for the Form node
+func (e *svgExtension) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithBlockParsers(util.Prioritized(NewSVGParser(), 500)),
+	)
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(util.Prioritized(NewSvgRenderer(), 500)),
+	)
+
+}
+
+var ExtSvg = &svgExtension{}
+
+func preserveLeadingTabInCodeBlock(segment *text.Segment, reader text.Reader, indent int) {
+	offsetWithPadding := reader.LineOffset() + indent
+	sl, ss := reader.Position()
+	reader.SetPosition(sl, text.NewSegment(ss.Start-1, ss.Stop))
+	if offsetWithPadding == reader.LineOffset() {
+		segment.Padding = 0
+		segment.Start--
+	}
+	reader.SetPosition(sl, ss)
+}

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
@@ -1,0 +1,10 @@
+-- input.md --
+
+<gno-svg>
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="blue" />
+</svg>
+</gno-svg>
+
+
+-- output.html --

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
@@ -8,7 +8,4 @@
 
 
 -- output.html --
-<object type="image/svg+xml"><svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
-<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="blue" />
-</svg>
-</object>
+<object type="image/svg+xml" data="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgcj0iNDAiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMyIgZmlsbD0iYmx1ZSIgLz4KPC9zdmc+Cg=="></object>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_svg/draft.md.txtar
@@ -8,3 +8,7 @@
 
 
 -- output.html --
+<object type="image/svg+xml"><svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="blue" />
+</svg>
+</object>


### PR DESCRIPTION
This is a draft PR aimed at improving SVG handling by creating a dedicated Markdown extension. It will specifically enable the handling of links within the SVG. Unfortunately, in it's current state it alsoallows JavaScript injection, which is a no go for now.

following and closing #4479 