### PR TITLE
fix: Allow {amino,pkg} to be used as a dependency

### DIFF
--- a/tm2/pkg/amino/amino.go
+++ b/tm2/pkg/amino/amino.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -924,6 +925,9 @@ func GetCallersDirname() string {
 	dirname = filepath.Dir(filename)
 	if filename == "" || dirname == "" {
 		panic("could not derive caller's package directory")
+	}
+	if !path.IsAbs(dirname) {
+		dirname = "" // if relative, assume from module and return empty string
 	}
 	return dirname
 }

--- a/tm2/pkg/amino/pkg/pkg.go
+++ b/tm2/pkg/amino/pkg/pkg.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -402,6 +403,9 @@ func GetCallersDirname() string {
 	dirName = filepath.Dir(filename)
 	if filename == "" || dirName == "" {
 		panic("could not derive caller's package directory")
+	}
+	if !path.IsAbs(dirName) {
+		dirName = "" // if relative, assume from module and return empty string
 	}
 	return dirName
 }


### PR DESCRIPTION
When used as a dependency, GetCallersDirname() returns a relative path which breaks subsequent code. 

This change returns an empty string for CallerDirname when amino is imported as a dependency to a different project.