### PR TITLE
fix: Avoid nil pointer dereferences in faucet Github fetcher

### DIFF
--- a/contribs/gnofaucet/github/api.go
+++ b/contribs/gnofaucet/github/api.go
@@ -78,16 +78,25 @@ type PullRequestGapi struct {
 
 // Number implements PullRequest.
 func (p *PullRequestGapi) Number() int {
+	if p.pr.Number == nil {
+		return 0
+	}
 	return *p.pr.Number
 }
 
 // Author implements PullRequest.
 func (p *PullRequestGapi) Author() string {
+	if p.pr.User == nil || p.pr.User.Login == nil {
+		return ""
+	}
 	return *p.pr.User.Login
 }
 
 // CommitsCount implements PullRequest.
 func (p *PullRequestGapi) CommitsCount() int {
+	if p.pr.Commits == nil {
+		return 0
+	}
 	return *p.pr.Commits
 }
 
@@ -104,11 +113,17 @@ func (p *PullRequestGapi) Reviews() []Review {
 
 // State implements PullRequest.
 func (p *PullRequestGapi) State() string {
+	if p.pr.State == nil {
+		return ""
+	}
 	return *p.pr.State
 }
 
 // Title implements PullRequest.
 func (p *PullRequestGapi) Title() string {
+	if p.pr.Title == nil {
+		return ""
+	}
 	return *p.pr.Title
 }
 

--- a/contribs/gnofaucet/github/fetcher.go
+++ b/contribs/gnofaucet/github/fetcher.go
@@ -277,7 +277,21 @@ func (f *GHFetcher) iterateEvents(ctx context.Context, pipe redis.Pipeliner, org
 				continue
 			}
 
-			f.logger.Info("processing new event", "event", *ev.Type, "user", *ev.Actor.Login, "org", org, "repo", repo)
+			var eType, login string
+
+			if ev.Type != nil {
+				eType = *ev.Type
+			} else {
+				eType = "UNKNOWN"
+			}
+
+			if ev.Actor != nil && ev.Actor.Login != nil {
+				login = *ev.Actor.Login
+			} else {
+				login = "UNKNOWN"
+			}
+
+			f.logger.Info("processing new event", "event", eType, "user", login, "org", org, "repo", repo)
 
 			et, err := ev.ParsePayload()
 			if err != nil {
@@ -287,6 +301,10 @@ func (f *GHFetcher) iterateEvents(ctx context.Context, pipe redis.Pipeliner, org
 
 			switch pe := et.(type) {
 			case *github.IssuesEvent:
+				if pe.Action == nil {
+					continue
+				}
+
 				if *pe.Action != "opened" {
 					continue
 				}
@@ -303,6 +321,10 @@ func (f *GHFetcher) iterateEvents(ctx context.Context, pipe redis.Pipeliner, org
 					continue
 				}
 
+				if pr.Merged == nil {
+					continue
+				}
+
 				if !*pr.Merged {
 					continue
 				}
@@ -311,6 +333,10 @@ func (f *GHFetcher) iterateEvents(ctx context.Context, pipe redis.Pipeliner, org
 			case *github.PullRequestReviewEvent:
 				review := pe.Review
 				if review == nil {
+					continue
+				}
+
+				if review.State == nil {
 					continue
 				}
 


### PR DESCRIPTION
We got some unexpected empty fields. Covering all the cases where this might happen.