### PR TITLE
fix(gnovm): detect invalid interface implementation with name collision

### DIFF
--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -1050,6 +1050,8 @@ func (it *InterfaceType) VerifyImplementedBy(ot Type) error {
 			if dmtid != imtid {
 				return fmt.Errorf("wrong type for method %s", im.Name)
 			}
+		} else {
+			return fmt.Errorf("wrong type for method %s", im.Name)
 		}
 	}
 	return nil

--- a/gnovm/tests/files/types/assign_iface.gno
+++ b/gnovm/tests/files/types/assign_iface.gno
@@ -1,0 +1,20 @@
+package main
+
+type MyStruct struct {
+    doSomething int // only name matches the interface
+}
+
+type MyInterface interface {
+    doSomething(string) string
+}
+
+func main() {
+    var x MyInterface = MyStruct{}
+    println("ok", x == nil)
+}
+
+// Error:
+// main/assign_iface.gno:12:9-35: main.MyStruct does not implement main.MyInterface (wrong type for method doSomething)
+
+// TypeCheckError:
+// main/assign_iface.gno:12:25: cannot use MyStruct{} (value of struct type MyStruct) as MyInterface value in variable declaration: MyStruct does not implement MyInterface (MyStruct.doSomething is a field, not a method)


### PR DESCRIPTION
An struct containing a field matching an interface method name could be wrongly seen as implementing such interface.

The corresponding type check was performed only for functions. Now also catch non function types.

Fixes GHSA-v84r-rg57-8j33