### PR TITLE
chore: fix problematic comment

### DIFF
--- a/tm2/pkg/libtm/messages/collector_test.go
+++ b/tm2/pkg/libtm/messages/collector_test.go
@@ -58,7 +58,7 @@ func generatePrevoteMessages(
 	return messages
 }
 
-// generatePrevoteMessages generates dummy prevote messages
+// generatePrecommitMessages generates dummy precommit messages
 // for the given view and type
 func generatePrecommitMessages(
 	t *testing.T,


### PR DESCRIPTION
Updated the comment for `generatePrecommitMessages` to correctly state that it generates dummy precommit messages.