### PR TITLE
chore: add current Boards realm to homepage and update to test9

### DIFF
--- a/examples/gno.land/r/gnoland/home/home.gno
+++ b/examples/gno.land/r/gnoland/home/home.gno
@@ -133,7 +133,7 @@ All code in Gno.land is organized in packages, and each package lives at a uniqu
 
 Official realm packages developed by the Gno.land core team.
 
-[-> Browse](/r/gnoland)
+[Browse](/r/gnoland)
 
 |||
 
@@ -141,7 +141,7 @@ Official realm packages developed by the Gno.land core team.
 
 System-level realm packages used by the chain.
 
-[-> Browse](/r/sys)
+[Browse](/r/sys)
 
 |||
 
@@ -149,7 +149,7 @@ System-level realm packages used by the chain.
 
 Demo realm packages showcasing what’s possible.
 
-[-> Browse](/r/demo)
+[Browse](/r/demo)
 
 |||
 
@@ -157,7 +157,7 @@ Demo realm packages showcasing what’s possible.
 
 Pure packages for demo purposes.
 
-[-> Browse](/p/demo)
+[Browse](/p/demo)
 
 </gno-columns>
 

--- a/examples/gno.land/r/gnoland/home/home_filetest.gno
+++ b/examples/gno.land/r/gnoland/home/home_filetest.gno
@@ -104,7 +104,7 @@ func main() {
 //
 // Official realm packages developed by the Gno.land core team.
 //
-// [-> Browse](/r/gnoland)
+// [Browse](/r/gnoland)
 //
 // |||
 //
@@ -112,7 +112,7 @@ func main() {
 //
 // System-level realm packages used by the chain.
 //
-// [-> Browse](/r/sys)
+// [Browse](/r/sys)
 //
 // |||
 //
@@ -120,7 +120,7 @@ func main() {
 //
 // Demo realm packages showcasing what’s possible.
 //
-// [-> Browse](/r/demo)
+// [Browse](/r/demo)
 //
 // |||
 //
@@ -128,7 +128,7 @@ func main() {
 //
 // Pure packages for demo purposes.
 //
-// [-> Browse](/p/demo)
+// [Browse](/p/demo)
 //
 // </gno-columns>
 //


### PR DESCRIPTION
Added updates to include Open Boards on the homepage and Test 9 while removing test7 as it is a broken link. 