### PR TITLE
fix(gnoweb): prevent XSS in realm markdown TOC entries

### DIFF
--- a/gno.land/pkg/gnoweb/components/template.go
+++ b/gno.land/pkg/gnoweb/components/template.go
@@ -17,14 +17,6 @@ var tmpl = template.New("web")
 
 func registerCommonFuncs(funcs template.FuncMap) {
 	// NOTE: this method does NOT escape HTML, use with caution
-	funcs["noescape_string"] = func(in string) template.HTML {
-		return template.HTML(in) //nolint:gosec
-	}
-	// NOTE: this method does NOT escape HTML, use with caution
-	funcs["noescape_bytes"] = func(in []byte) template.HTML {
-		return template.HTML(in) //nolint:gosec
-	}
-	// NOTE: this method does NOT escape HTML, use with caution
 	// Render Component element into raw html element
 	funcs["render"] = func(comp Component) (template.HTML, error) {
 		var buf bytes.Buffer

--- a/gno.land/pkg/gnoweb/components/ui/toc.html
+++ b/gno.land/pkg/gnoweb/components/ui/toc.html
@@ -22,7 +22,7 @@ UI - TOC Realm component
 {{ define "ui/toc_realm" }}
 <ul class="b-toc">{{- range .Items }}
   <li>
-    <a href="{{ .Anchor }}"> {{ .Title | noescape_bytes }}
+    <a href="{{ .Anchor }}"> {{ printf "%s" .Title }}
     </a>
     {{ if .Items }} {{ template "ui/toc_realm" . }} {{ end }}
   </li>

--- a/gno.land/pkg/gnoweb/components/view_test.go
+++ b/gno.land/pkg/gnoweb/components/view_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/gnolang/gno/gno.land/pkg/gnoweb/markdown"
 	"github.com/gnolang/gno/gnovm/pkg/doc"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSourceView(t *testing.T) {
@@ -166,6 +167,99 @@ func TestRealmView(t *testing.T) {
 	assert.Equal(t, content, realmViewParams.Article.ComponentContent, "expected component content to match")
 
 	assert.NoError(t, view.Render(io.Discard))
+}
+
+func TestRealmViewTOCXSSPrevention(t *testing.T) {
+	tests := []struct {
+		name           string
+		tocTitle       []byte
+		tocID          []byte
+		mustNotContain []string
+		mustContain    []string
+	}{
+		{
+			name:           "HTML entities in TOC title",
+			tocTitle:       []byte("&lt;script&gt;alert('XSS')&lt;/script&gt; Heading"),
+			tocID:          []byte("heading"),
+			mustNotContain: []string{"<script>alert", "<script>"},
+			mustContain:    []string{"&amp;lt;script&amp;gt;"},
+		},
+		{
+			name:           "Image tag with onerror via entities",
+			tocTitle:       []byte("&lt;img src=x onerror=alert(1)&gt;"),
+			tocID:          []byte("img"),
+			mustNotContain: []string{},
+			mustContain:    []string{"&amp;lt;img"},
+		},
+		{
+			name:           "SVG with onload via entities",
+			tocTitle:       []byte("&lt;svg onload=alert(1)&gt;"),
+			tocID:          []byte("svg"),
+			mustNotContain: []string{},
+			mustContain:    []string{"&amp;lt;svg"},
+		},
+		{
+			name:           "Numeric HTML entities",
+			tocTitle:       []byte("&#60;script&#62;alert(1)&#60;/script&#62;"),
+			tocID:          []byte("numeric"),
+			mustNotContain: []string{"<script"},
+			mustContain:    []string{"&amp;#60;script"},
+		},
+		{
+			name:           "Normal heading with ampersand",
+			tocTitle:       []byte("API & SDK"),
+			tocID:          []byte("api-sdk"),
+			mustNotContain: []string{},
+			mustContain:    []string{"API &amp; SDK"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a RealmView with potentially malicious TOC item
+			content := NewReaderComponent(strings.NewReader("test content"))
+			tocItems := &RealmTOCData{
+				Items: []*markdown.TocItem{
+					{Title: tt.tocTitle, ID: tt.tocID},
+				},
+			}
+			data := RealmData{
+				ComponentContent: content,
+				TocItems:         tocItems,
+			}
+
+			view := RealmView(data)
+
+			var buf strings.Builder
+			err := view.Render(&buf)
+			assert.NoError(t, err, "expected no error rendering view")
+
+			rendered := buf.String()
+
+			tocStart := strings.Index(rendered, `<ul class="b-toc">`)
+			tocEnd := strings.LastIndex(rendered, `</ul>`)
+			if tocStart == -1 || tocEnd == -1 {
+				t.Fatal("could not find TOC in rendered HTML")
+			}
+			tocHTML := rendered[tocStart : tocEnd+5]
+
+			for _, danger := range tt.mustNotContain {
+				if strings.Contains(tocHTML, danger) {
+					t.Errorf("Found unescaped dangerous pattern %q in TOC HTML.\n"+
+						"TOC HTML: %s",
+						danger, tocHTML)
+				}
+			}
+
+			for _, safe := range tt.mustContain {
+				if !strings.Contains(tocHTML, safe) {
+					t.Errorf("Expected escaped pattern %q not found in TOC HTML.\n"+
+						"Title: %s\nTOC HTML: %s",
+						safe, string(tt.tocTitle), tocHTML)
+				}
+			}
+		})
+	}
 }
 
 func TestHelpView(t *testing.T) {


### PR DESCRIPTION
Fixes a stored cross-site scripting vulnerability where HTML entities in markdown headings could be exploited to execute javascript in the browser when rendered in the ToC.