### PR TITLE
chore: Re-add Gnosis.io disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ programming language, designed to build succinct and composable smart contracts.
 The first blockchain to use it is gno.land, a contribution-based chain, backed
 by a variation of the [Tendermint](./tm2) consensus engine.
 
+PLEASE NOTE: This is NOT the same project or token as the excellent Gnosis.io project.
+
 ## Getting Started
 
 Explore Gno through our comprehensive documentation:


### PR DESCRIPTION
Closes https://github.com/gnolang/gno/issues/2354

- Add the Gnosis.io disambiguation that was removed from README.md in the past