### PR TITLE
fix: In getLedgerDevice() error, mention CGO_ENABLED=1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/yuin/goldmark v1.7.8
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
+	github.com/zondax/hid v0.9.2
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0
@@ -88,7 +89,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect

--- a/tm2/pkg/crypto/keys/client/add_ledger.go
+++ b/tm2/pkg/crypto/keys/client/add_ledger.go
@@ -66,7 +66,7 @@ func execAddLedger(cfg *AddCfg, args []string, io commands.IO) error {
 		uint32(cfg.Index),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to create Ledger reference in keybase, %+w", err)
+		return fmt.Errorf("unable to create Ledger reference in keybase, %w", err)
 	}
 
 	// Print the information

--- a/tm2/pkg/crypto/keys/client/add_ledger.go
+++ b/tm2/pkg/crypto/keys/client/add_ledger.go
@@ -66,7 +66,7 @@ func execAddLedger(cfg *AddCfg, args []string, io commands.IO) error {
 		uint32(cfg.Index),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to create Ledger reference in keybase, %w", err)
+		return fmt.Errorf("unable to create Ledger reference in keybase, %+w", err)
 	}
 
 	// Print the information

--- a/tm2/pkg/crypto/ledger/ledger_secp256k1.go
+++ b/tm2/pkg/crypto/ledger/ledger_secp256k1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -179,7 +180,11 @@ func convertDERtoBER(signatureDER []byte) ([]byte, error) {
 func getLedgerDevice() (ledger.SECP256K1, error) {
 	device, err := ledger.Discover()
 	if err != nil {
-		return nil, errors.Wrap(err, "ledger nano S")
+		msg := "ledger nano S"
+		if strings.Contains(err.Error(), "LedgerHID device (idx 0) not found") {
+			msg += ". Try building with CGO_ENABLED=1"
+		}
+		return nil, errors.Wrap(err, msg)
 	}
 
 	return device, nil

--- a/tm2/pkg/crypto/ledger/ledger_secp256k1.go
+++ b/tm2/pkg/crypto/ledger/ledger_secp256k1.go
@@ -179,7 +179,7 @@ func convertDERtoBER(signatureDER []byte) ([]byte, error) {
 
 func getLedgerDevice() (ledger.SECP256K1, error) {
 	if !hid.Supported() {
-		return nil, fmt.Errorf("Ledger support is not enabled. Try building with CGO_ENABLED=1")
+		return nil, fmt.Errorf("ledger support is not enabled, try building with CGO_ENABLED=1")
 	}
 
 	device, err := ledger.Discover()

--- a/tm2/pkg/crypto/ledger/ledger_secp256k1.go
+++ b/tm2/pkg/crypto/ledger/ledger_secp256k1.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"strings"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/zondax/hid"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
@@ -178,13 +178,13 @@ func convertDERtoBER(signatureDER []byte) ([]byte, error) {
 }
 
 func getLedgerDevice() (ledger.SECP256K1, error) {
+	if !hid.Supported() {
+		return nil, fmt.Errorf("Ledger support is not enabled. Try building with CGO_ENABLED=1")
+	}
+
 	device, err := ledger.Discover()
 	if err != nil {
-		msg := "ledger nano S"
-		if strings.Contains(err.Error(), "LedgerHID device (idx 0) not found") {
-			msg += ". Try building with CGO_ENABLED=1"
-		}
-		return nil, errors.Wrap(err, msg)
+		return nil, errors.Wrap(err, "ledger nano S")
 	}
 
 	return device, nil


### PR DESCRIPTION
Resolves #2737

As [required by the HID library](https://github.com/Zondax/hid/blob/148be243caa49724e017c248dde643b0ada03742/README.md?plain=1#L31), the executable must be built with `CGO_ENABLED=1` in order to find the Ledger. We want to keep building without this flag by default so that the binary is deterministic. The HID library already has the [`Supported` function](https://github.com/Zondax/hid/blob/148be243caa49724e017c248dde643b0ada03742/hid_disabled.go#L15) which returns false if not built with cgo.

* In the `getLedgerDevice`, if not `Supported` then return an error message to try building with CGO_ENABLED=1

The error message looks like:
```
unable to create Ledger reference in keybase, ledger support is not enabled, try building with CGO_ENABLED=1
```

This PR is a minimal solution as an alternative to putting `CGO_ENABLED=1` in the [gnokey Makefile](https://github.com/gnolang/gno/blob/e3df2c9e0bb17ddc90f34db223ab6593b4f6ca8a/gno.land/Makefile#L48).