### PR TITLE
feat(examples): add mictofun fluent markdown framework

### DIFF
--- a/examples/gno.land/p/demo/ui/mictofun/README.md
+++ b/examples/gno.land/p/demo/ui/mictofun/README.md
@@ -1,0 +1,108 @@
+# mictofun - Fluent Markdown Framework for Gno
+
+A powerful, chainable markdown generation library for gno.land smart contracts.
+
+## Features
+
+- **Fluent Chainable API** - Build documents with method chaining
+- **Component Composition** - Combine tables, alerts, and sections
+- **Table Builder** - Create tables with alignment support (Left, Center, Right)
+- **GitHub-style Alerts** - Note, Tip, Warning, Important, Caution callouts
+- **gno.land Integration** - UserLink, RealmLink, Columns helpers
+- **Layout Components** - Collapsible sections, centered content, badges
+
+## Quick Start
+
+```gno
+import "gno.land/p/demo/ui/mictofun"
+
+func Render(path string) string {
+    return mictofun.New().
+        H1("Welcome to My Realm").
+        P("This is a " + mictofun.Bold("powerful") + " markdown library.").
+        H2("Features").
+        Bullet("Fluent API", "Chainable methods", "Component composition").
+        HR().
+        P("Created by " + mictofun.UserLink("mictofun")).
+        String()
+}
+```
+
+## API Reference
+
+### Document Builder
+
+```gno
+doc := mictofun.New()          // Create new document
+doc.H1("Heading")              // Add heading (H1-H6)
+doc.P("Paragraph text")        // Add paragraph
+doc.Quote("Quoted text")       // Add blockquote
+doc.CodeBlock("code", "go")    // Add code block with language
+doc.HR()                       // Add horizontal rule
+doc.Bullet("a", "b", "c")      // Add bullet list
+doc.Numbered("1", "2", "3")    // Add numbered list
+doc.Todo(items, done)          // Add todo list
+doc.Img("alt", "url")          // Add image
+doc.String()                   // Get final markdown
+```
+
+### Inline Formatting (return string)
+
+```gno
+mictofun.Bold("text")          // **text**
+mictofun.Italic("text")        // *text*
+mictofun.Strike("text")        // ~~text~~
+mictofun.Code("text")          // `text`
+mictofun.Link("text", "url")   // [text](url)
+mictofun.Image("alt", "url")   // ![alt](url)
+mictofun.UserLink("name")      // [@name](/u/name)
+mictofun.RealmLink("path")     // [path](/path)
+```
+
+### Tables
+
+```gno
+table := mictofun.NewTable().
+    Headers("Name", "Amount", "Status").
+    SetAlign(mictofun.AlignLeft, mictofun.AlignRight, mictofun.AlignCenter).
+    Row("Alice", "$100", "✓").
+    Row("Bob", "$250", "Pending")
+
+doc.Add(table)
+```
+
+### Alerts (GitHub-style)
+
+```gno
+doc.Note("This is a note")
+doc.Tip("This is a tip")
+doc.Warning("This is a warning")
+doc.Important("This is important")
+doc.Caution("This is a caution")
+```
+
+Output:
+```markdown
+> [!NOTE]
+> This is a note
+```
+
+### Layout Components
+
+```gno
+doc.Collapsible("FAQ Title", "Answer content")
+doc.Cols("Column 1", "Column 2", "Column 3")
+doc.Center("Centered content")
+doc.Right("Right-aligned content")
+```
+
+## Testing
+
+```bash
+cd examples
+go run ../gnovm/cmd/gno test -v ./gno.land/p/demo/ui/mictofun/...
+```
+
+## License
+
+Same as gno.land project.

--- a/examples/gno.land/p/demo/ui/mictofun/alert.gno
+++ b/examples/gno.land/p/demo/ui/mictofun/alert.gno
@@ -1,0 +1,111 @@
+// Alert provides GitHub-style alert/callout components for markdown.
+//
+// These render as blockquotes with special markers that GitHub and
+// compatible markdown renderers display as colored callout boxes.
+//
+// Example usage:
+//
+//	doc := mictofun.New().
+//	    H1("Documentation").
+//	    AddRaw(mictofun.Note("This is important information.")).
+//	    AddRaw(mictofun.Warning("Be careful with this operation."))
+package mictofun
+
+import (
+	"strings"
+)
+
+// AlertType represents the type of alert/callout.
+type AlertType int
+
+const (
+	AlertNote AlertType = iota
+	AlertTip
+	AlertImportant
+	AlertWarning
+	AlertCaution
+)
+
+// alertTypeStrings maps AlertType to its markdown string.
+var alertTypeStrings = map[AlertType]string{
+	AlertNote:      "NOTE",
+	AlertTip:       "TIP",
+	AlertImportant: "IMPORTANT",
+	AlertWarning:   "WARNING",
+	AlertCaution:   "CAUTION",
+}
+
+// Alert creates a GitHub-style alert callout.
+//
+// Output format:
+//
+//	> [!NOTE]
+//	> Your content here
+func Alert(alertType AlertType, content string) string {
+	typeStr, ok := alertTypeStrings[alertType]
+	if !ok {
+		typeStr = "NOTE"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("> [!" + typeStr + "]\n")
+
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		sb.WriteString("> " + line + "\n")
+	}
+
+	return sb.String()
+}
+
+// Note creates a NOTE alert for general information.
+func Note(content string) string {
+	return Alert(AlertNote, content)
+}
+
+// Tip creates a TIP alert for helpful suggestions.
+func Tip(content string) string {
+	return Alert(AlertTip, content)
+}
+
+// Important creates an IMPORTANT alert for critical information.
+func Important(content string) string {
+	return Alert(AlertImportant, content)
+}
+
+// Warning creates a WARNING alert for potential issues.
+func Warning(content string) string {
+	return Alert(AlertWarning, content)
+}
+
+// Caution creates a CAUTION alert for dangerous actions.
+func Caution(content string) string {
+	return Alert(AlertCaution, content)
+}
+
+// Alert builder for method chaining on Doc
+
+// Note adds a NOTE alert to the document.
+func (d *Doc) Note(content string) *Doc {
+	return d.write(Note(content))
+}
+
+// Tip adds a TIP alert to the document.
+func (d *Doc) Tip(content string) *Doc {
+	return d.write(Tip(content))
+}
+
+// Important adds an IMPORTANT alert to the document.
+func (d *Doc) Important(content string) *Doc {
+	return d.write(Important(content))
+}
+
+// Warning adds a WARNING alert to the document.
+func (d *Doc) Warning(content string) *Doc {
+	return d.write(Warning(content))
+}
+
+// Caution adds a CAUTION alert to the document.
+func (d *Doc) Caution(content string) *Doc {
+	return d.write(Caution(content))
+}

--- a/examples/gno.land/p/demo/ui/mictofun/gnomod.toml
+++ b/examples/gno.land/p/demo/ui/mictofun/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/demo/ui/mictofun"
+gno = "0.9"

--- a/examples/gno.land/p/demo/ui/mictofun/md.gno
+++ b/examples/gno.land/p/demo/ui/mictofun/md.gno
@@ -1,0 +1,295 @@
+// Package mictofun provides a fluent, chainable API for generating Markdown content.
+//
+// Unlike other markdown libraries that use separate functions, mictofun uses method
+// chaining to create readable and composable markdown documents.
+//
+// Example usage:
+//
+//	import "gno.land/p/demo/ui/mictofun"
+//
+//	func Render(path string) string {
+//	    return mictofun.New().
+//	        H1("Welcome").
+//	        P("This is a " + mictofun.Bold("powerful") + " markdown library.").
+//	        H2("Features").
+//	        Bullet("Fluent API", "Chainable methods", "Component composition").
+//	        HR().
+//	        P("Created by " + mictofun.UserLink("mictofun")).
+//	        String()
+//	}
+package mictofun
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Doc is the main markdown document builder with fluent API.
+type Doc struct {
+	parts []string
+}
+
+// New creates a new markdown document builder.
+func New() *Doc {
+	return &Doc{
+		parts: make([]string, 0),
+	}
+}
+
+// String returns the final markdown string.
+func (d *Doc) String() string {
+	return strings.Join(d.parts, "\n")
+}
+
+// write appends content to the document.
+func (d *Doc) write(content string) *Doc {
+	d.parts = append(d.parts, content)
+	return d
+}
+
+// Add adds a component that implements fmt.Stringer interface.
+func (d *Doc) Add(component interface{ String() string }) *Doc {
+	return d.write(component.String())
+}
+
+// AddRaw adds raw markdown content directly.
+func (d *Doc) AddRaw(markdown string) *Doc {
+	return d.write(markdown)
+}
+
+// Ln adds one or more empty lines.
+func (d *Doc) Ln(count ...int) *Doc {
+	n := 1
+	if len(count) > 0 && count[0] > 0 {
+		n = count[0]
+	}
+	return d.write(strings.Repeat("\n", n))
+}
+
+// ============================================================================
+// HEADINGS
+// ============================================================================
+
+// H1 adds a level 1 heading.
+func (d *Doc) H1(text string) *Doc {
+	return d.write("# " + text + "\n")
+}
+
+// H2 adds a level 2 heading.
+func (d *Doc) H2(text string) *Doc {
+	return d.write("## " + text + "\n")
+}
+
+// H3 adds a level 3 heading.
+func (d *Doc) H3(text string) *Doc {
+	return d.write("### " + text + "\n")
+}
+
+// H4 adds a level 4 heading.
+func (d *Doc) H4(text string) *Doc {
+	return d.write("#### " + text + "\n")
+}
+
+// H5 adds a level 5 heading.
+func (d *Doc) H5(text string) *Doc {
+	return d.write("##### " + text + "\n")
+}
+
+// H6 adds a level 6 heading.
+func (d *Doc) H6(text string) *Doc {
+	return d.write("###### " + text + "\n")
+}
+
+// ============================================================================
+// TEXT FORMATTING (Inline helpers - return string for embedding)
+// ============================================================================
+
+// Bold returns bold formatted text.
+func Bold(text string) string {
+	return "**" + text + "**"
+}
+
+// Italic returns italic formatted text.
+func Italic(text string) string {
+	return "*" + text + "*"
+}
+
+// Strike returns strikethrough formatted text.
+func Strike(text string) string {
+	return "~~" + text + "~~"
+}
+
+// Code returns inline code formatted text.
+func Code(text string) string {
+	return "`" + strings.ReplaceAll(text, "`", "\\`") + "`"
+}
+
+// ============================================================================
+// PARAGRAPH & TEXT BLOCKS
+// ============================================================================
+
+// P adds a paragraph.
+func (d *Doc) P(text string) *Doc {
+	return d.write(text + "\n")
+}
+
+// Quote adds a blockquote. Handles multiline text.
+func (d *Doc) Quote(text string) *Doc {
+	lines := strings.Split(text, "\n")
+	var sb strings.Builder
+	for _, line := range lines {
+		sb.WriteString("> " + line + "\n")
+	}
+	return d.write(sb.String())
+}
+
+// CodeBlock adds a fenced code block with optional language.
+func (d *Doc) CodeBlock(content string, lang ...string) *Doc {
+	language := ""
+	if len(lang) > 0 {
+		language = lang[0]
+	}
+	escaped := strings.ReplaceAll(content, "```", "\\`\\`\\`")
+	return d.write("```" + language + "\n" + escaped + "\n```\n")
+}
+
+// HR adds a horizontal rule.
+func (d *Doc) HR() *Doc {
+	return d.write("\n---\n")
+}
+
+// ============================================================================
+// LISTS
+// ============================================================================
+
+// Bullet adds a bullet list from items.
+func (d *Doc) Bullet(items ...string) *Doc {
+	var sb strings.Builder
+	for _, item := range items {
+		lines := strings.Split(item, "\n")
+		sb.WriteString("- " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			sb.WriteString("  " + line + "\n")
+		}
+	}
+	return d.write(sb.String())
+}
+
+// Numbered adds a numbered list from items.
+func (d *Doc) Numbered(items ...string) *Doc {
+	var sb strings.Builder
+	for i, item := range items {
+		lines := strings.Split(item, "\n")
+		sb.WriteString(strconv.Itoa(i+1) + ". " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			sb.WriteString("   " + line + "\n")
+		}
+	}
+	return d.write(sb.String())
+}
+
+// Todo adds a todo list with checkboxes.
+func (d *Doc) Todo(items []string, done []bool) *Doc {
+	var sb strings.Builder
+	for i, item := range items {
+		checkbox := " "
+		if i < len(done) && done[i] {
+			checkbox = "x"
+		}
+		lines := strings.Split(item, "\n")
+		sb.WriteString("- [" + checkbox + "] " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			sb.WriteString("  " + line + "\n")
+		}
+	}
+	return d.write(sb.String())
+}
+
+// NestedBullet adds items with a prefix for nested lists.
+func (d *Doc) NestedBullet(prefix string, items ...string) *Doc {
+	var sb strings.Builder
+	for _, item := range items {
+		sb.WriteString(prefix + "- " + item + "\n")
+	}
+	return d.write(sb.String())
+}
+
+// ============================================================================
+// LINKS & IMAGES
+// ============================================================================
+
+// Link returns a markdown link.
+func Link(text, url string) string {
+	return "[" + EscapeText(text) + "](" + url + ")"
+}
+
+// Image returns a markdown image.
+func Image(alt, url string) string {
+	return "![" + EscapeText(alt) + "](" + url + ")"
+}
+
+// ImageWithLink returns an image wrapped in a link.
+func ImageWithLink(alt, imageURL, linkURL string) string {
+	return "[" + Image(alt, imageURL) + "](" + linkURL + ")"
+}
+
+// Img adds an image to the document.
+func (d *Doc) Img(alt, url string) *Doc {
+	return d.write(Image(alt, url) + "\n")
+}
+
+// ============================================================================
+// GNO.LAND SPECIFIC HELPERS
+// ============================================================================
+
+// UserLink returns a link to a gno.land user profile.
+// For usernames starting with "g1", displays the address.
+// For other usernames, adds @ prefix.
+func UserLink(user string) string {
+	if strings.HasPrefix(user, "g1") {
+		return "[" + EscapeText(user) + "](/u/" + user + ")"
+	}
+	return "[@" + EscapeText(user) + "](/u/" + user + ")"
+}
+
+// RealmLink returns a link to a gno.land realm.
+func RealmLink(path string, text ...string) string {
+	displayText := path
+	if len(text) > 0 {
+		displayText = text[0]
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return "[" + EscapeText(displayText) + "](" + path + ")"
+}
+
+// ============================================================================
+// UTILITIES
+// ============================================================================
+
+// EscapeText escapes special markdown characters in text.
+func EscapeText(text string) string {
+	replacer := strings.NewReplacer(
+		`*`, `\*`,
+		`_`, `\_`,
+		`[`, `\[`,
+		`]`, `\]`,
+		`(`, `\(`,
+		`)`, `\)`,
+		`~`, `\~`,
+		`>`, `\>`,
+		`|`, `\|`,
+		`-`, `\-`,
+		`+`, `\+`,
+		`.`, `\.`,
+		`!`, `\!`,
+		"`", "\\`",
+	)
+	return replacer.Replace(text)
+}
+
+// Footnote returns a footnote reference.
+func Footnote(ref, text string) string {
+	return "[" + EscapeText(ref) + "]: " + text
+}

--- a/examples/gno.land/p/demo/ui/mictofun/md_test.gno
+++ b/examples/gno.land/p/demo/ui/mictofun/md_test.gno
@@ -1,0 +1,367 @@
+package mictofun
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// DOCUMENT BUILDER TESTS
+// ============================================================================
+
+func TestNew(t *testing.T) {
+	doc := New()
+	if doc == nil {
+		t.Fatal("New() returned nil")
+	}
+	if doc.String() != "" {
+		t.Errorf("New document should be empty, got: %q", doc.String())
+	}
+}
+
+func TestHeadings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    func() string
+		expected string
+	}{
+		{"H1", func() string { return New().H1("Title").String() }, "# Title\n"},
+		{"H2", func() string { return New().H2("Title").String() }, "## Title\n"},
+		{"H3", func() string { return New().H3("Title").String() }, "### Title\n"},
+		{"H4", func() string { return New().H4("Title").String() }, "#### Title\n"},
+		{"H5", func() string { return New().H5("Title").String() }, "##### Title\n"},
+		{"H6", func() string { return New().H6("Title").String() }, "###### Title\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input()
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTextFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Bold", Bold("test"), "**test**"},
+		{"Italic", Italic("test"), "*test*"},
+		{"Strike", Strike("test"), "~~test~~"},
+		{"Code", Code("test"), "`test`"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.input != tt.expected {
+				t.Errorf("got %q, want %q", tt.input, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParagraph(t *testing.T) {
+	doc := New().P("Hello world").String()
+	expected := "Hello world\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestQuote(t *testing.T) {
+	doc := New().Quote("Hello\nWorld").String()
+	expected := "> Hello\n> World\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestCodeBlock(t *testing.T) {
+	doc := New().CodeBlock("fmt.Println()", "go").String()
+	expected := "```go\nfmt.Println()\n```\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestHR(t *testing.T) {
+	doc := New().HR().String()
+	expected := "\n---\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+// ============================================================================
+// LIST TESTS
+// ============================================================================
+
+func TestBulletList(t *testing.T) {
+	doc := New().Bullet("Item 1", "Item 2", "Item 3").String()
+	expected := "- Item 1\n- Item 2\n- Item 3\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestNumberedList(t *testing.T) {
+	doc := New().Numbered("First", "Second", "Third").String()
+	expected := "1. First\n2. Second\n3. Third\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestTodoList(t *testing.T) {
+	doc := New().Todo([]string{"Done", "Pending"}, []bool{true, false}).String()
+	expected := "- [x] Done\n- [ ] Pending\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+func TestMultilineBullet(t *testing.T) {
+	doc := New().Bullet("Line1\nLine2", "Single").String()
+	expected := "- Line1\n  Line2\n- Single\n"
+	if doc != expected {
+		t.Errorf("got %q, want %q", doc, expected)
+	}
+}
+
+// ============================================================================
+// LINK & IMAGE TESTS
+// ============================================================================
+
+func TestLink(t *testing.T) {
+	result := Link("Click here", "https://gno.land")
+	expected := "[Click here](https://gno.land)"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestImage(t *testing.T) {
+	result := Image("Logo", "https://gno.land/logo.png")
+	expected := "![Logo](https://gno.land/logo.png)"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestUserLink(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"moul", "[@moul](/u/moul)"},
+		{"g1abc123", "[g1abc123](/u/g1abc123)"},
+	}
+
+	for _, tt := range tests {
+		result := UserLink(tt.input)
+		if result != tt.expected {
+			t.Errorf("UserLink(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestRealmLink(t *testing.T) {
+	result := RealmLink("r/demo/foo", "Demo Realm")
+	expected := "[Demo Realm](/r/demo/foo)"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+// ============================================================================
+// TABLE TESTS
+// ============================================================================
+
+func TestBasicTable(t *testing.T) {
+	table := NewTable().
+		Headers("Name", "Age").
+		Row("Alice", "30").
+		Row("Bob", "25")
+
+	expected := "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |\n"
+	if table.String() != expected {
+		t.Errorf("got %q, want %q", table.String(), expected)
+	}
+}
+
+func TestTableAlignment(t *testing.T) {
+	table := NewTable().
+		Headers("Left", "Center", "Right").
+		SetAlign(AlignLeft, AlignCenter, AlignRight).
+		Row("L", "C", "R")
+
+	result := table.String()
+	if !containsString(result, ":---:") {
+		t.Error("Expected center alignment marker :---:")
+	}
+	if !containsString(result, "---:") {
+		t.Error("Expected right alignment marker ---:")
+	}
+}
+
+func TestEmptyTable(t *testing.T) {
+	table := NewTable()
+	if table.String() != "" {
+		t.Errorf("Empty table should return empty string, got %q", table.String())
+	}
+}
+
+func TestTableCellEscaping(t *testing.T) {
+	table := NewTable().
+		Headers("Data").
+		Row("Value with | pipe")
+
+	result := table.String()
+	if containsString(result, "| pipe |") {
+		t.Error("Pipe character should be escaped in table cells")
+	}
+}
+
+// ============================================================================
+// ALERT TESTS
+// ============================================================================
+
+func TestAlerts(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func(string) string
+		marker   string
+	}{
+		{"Note", Note, "[!NOTE]"},
+		{"Tip", Tip, "[!TIP]"},
+		{"Important", Important, "[!IMPORTANT]"},
+		{"Warning", Warning, "[!WARNING]"},
+		{"Caution", Caution, "[!CAUTION]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.fn("Test content")
+			if !containsString(result, tt.marker) {
+				t.Errorf("Expected %s marker in output", tt.marker)
+			}
+			if !containsString(result, "> Test content") {
+				t.Error("Expected content to be quoted")
+			}
+		})
+	}
+}
+
+func TestAlertMultiline(t *testing.T) {
+	result := Note("Line1\nLine2")
+	expected := "> [!NOTE]\n> Line1\n> Line2\n"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+// ============================================================================
+// SECTION TESTS
+// ============================================================================
+
+func TestCollapsible(t *testing.T) {
+	result := Collapsible("FAQ", "Some answer")
+	if !containsString(result, "<details>") {
+		t.Error("Expected <details> tag")
+	}
+	if !containsString(result, "<summary>FAQ</summary>") {
+		t.Error("Expected <summary> tag with title")
+	}
+	if !containsString(result, "Some answer") {
+		t.Error("Expected content in output")
+	}
+}
+
+func TestColumns(t *testing.T) {
+	result := Columns("Col1", "Col2")
+	if !containsString(result, "<gno-columns>") {
+		t.Error("Expected <gno-columns> tag")
+	}
+	if !containsString(result, "|||") {
+		t.Error("Expected column separator |||")
+	}
+}
+
+func TestCenter(t *testing.T) {
+	result := Center("Centered text")
+	if !containsString(result, `align="center"`) {
+		t.Error("Expected center alignment")
+	}
+}
+
+// ============================================================================
+// FLUENT CHAINING TEST
+// ============================================================================
+
+func TestFluentChaining(t *testing.T) {
+	doc := New().
+		H1("Welcome").
+		P("Hello " + Bold("world") + "!").
+		H2("Features").
+		Bullet("Fast", "Simple", "Powerful").
+		HR().
+		Note("This is a note.").
+		P("Footer")
+
+	result := doc.String()
+
+	checks := []string{
+		"# Welcome",
+		"**world**",
+		"## Features",
+		"- Fast",
+		"---",
+		"[!NOTE]",
+		"Footer",
+	}
+
+	for _, check := range checks {
+		if !containsString(result, check) {
+			t.Errorf("Expected %q in output", check)
+		}
+	}
+}
+
+func TestComponentComposition(t *testing.T) {
+	table := NewTable().
+		Headers("Name", "Value").
+		Row("Key", "123")
+
+	doc := New().
+		H1("Report").
+		Add(table).
+		P("End of report")
+
+	result := doc.String()
+
+	if !containsString(result, "# Report") {
+		t.Error("Expected heading in output")
+	}
+	if !containsString(result, "| Name | Value |") {
+		t.Error("Expected table in output")
+	}
+	if !containsString(result, "End of report") {
+		t.Error("Expected footer in output")
+	}
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+func containsString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/gno.land/p/demo/ui/mictofun/section.gno
+++ b/examples/gno.land/p/demo/ui/mictofun/section.gno
@@ -1,0 +1,153 @@
+// Section provides layout components like collapsible sections and columns.
+//
+// These use HTML tags that are supported by gno.land's markdown renderer.
+//
+// Example usage:
+//
+//	doc := mictofun.New().
+//	    H1("FAQ").
+//	    AddRaw(mictofun.Collapsible("What is Gno?", "Gno is a smart contract platform...")).
+//	    AddRaw(mictofun.Collapsible("How to get started?", "Check the docs at..."))
+package mictofun
+
+import (
+	"strings"
+)
+
+// Collapsible creates a collapsible/expandable section using HTML details tag.
+//
+// Output format:
+//
+//	<details><summary>Title</summary>
+//
+//	Content here
+//	</details>
+func Collapsible(title, content string) string {
+	return "<details><summary>" + EscapeText(title) + "</summary>\n\n" + content + "\n</details>\n"
+}
+
+// CollapsibleOpen creates a collapsible section that is open by default.
+func CollapsibleOpen(title, content string) string {
+	return "<details open><summary>" + EscapeText(title) + "</summary>\n\n" + content + "\n</details>\n"
+}
+
+// Collapsible adds a collapsible section to the document.
+func (d *Doc) Collapsible(title, content string) *Doc {
+	return d.write(Collapsible(title, content))
+}
+
+// CollapsibleOpen adds an open collapsible section to the document.
+func (d *Doc) CollapsibleOpen(title, content string) *Doc {
+	return d.write(CollapsibleOpen(title, content))
+}
+
+// ============================================================================
+// COLUMNS (gno.land specific)
+// ============================================================================
+
+// Columns creates a multi-column layout using gno.land's <gno-columns> tag.
+// Each string in cols represents content for one column.
+// Maximum 4 columns are supported per row.
+//
+// Output format:
+//
+//	<gno-columns>
+//	Column 1 content
+//	|||
+//	Column 2 content
+//	</gno-columns>
+func Columns(cols ...string) string {
+	if len(cols) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<gno-columns>\n")
+
+	for i, col := range cols {
+		if i > 0 {
+			sb.WriteString("|||\n")
+		}
+		sb.WriteString(col + "\n")
+	}
+
+	sb.WriteString("</gno-columns>\n")
+	return sb.String()
+}
+
+// ColumnsN splits content into rows of N columns each.
+// Useful for creating grid layouts with consistent column counts.
+func ColumnsN(content []string, colsPerRow int) string {
+	if len(content) == 0 || colsPerRow <= 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i := 0; i < len(content); i += colsPerRow {
+		end := i + colsPerRow
+		if end > len(content) {
+			end = len(content)
+		}
+		row := content[i:end]
+		sb.WriteString(Columns(row...))
+	}
+	return sb.String()
+}
+
+// Cols adds a multi-column layout to the document.
+func (d *Doc) Cols(cols ...string) *Doc {
+	return d.write(Columns(cols...))
+}
+
+// ============================================================================
+// BADGES & SHIELDS
+// ============================================================================
+
+// Badge creates a shields.io style badge.
+func Badge(label, message, color string) string {
+	url := "https://img.shields.io/badge/" + label + "-" + message + "-" + color
+	return Image(label+": "+message, url)
+}
+
+// BadgeLink creates a clickable badge.
+func BadgeLink(label, message, color, linkURL string) string {
+	badgeURL := "https://img.shields.io/badge/" + label + "-" + message + "-" + color
+	return ImageWithLink(label+": "+message, badgeURL, linkURL)
+}
+
+// ============================================================================
+// DIVIDERS & SPACING
+// ============================================================================
+
+// Spacer adds vertical spacing using line breaks.
+func Spacer(lines int) string {
+	if lines <= 0 {
+		lines = 1
+	}
+	return strings.Repeat("<br>\n", lines)
+}
+
+// Spacer adds vertical spacing to the document.
+func (d *Doc) Spacer(lines int) *Doc {
+	return d.write(Spacer(lines))
+}
+
+// Center creates centered text using HTML.
+func Center(content string) string {
+	return "<div align=\"center\">\n\n" + content + "\n\n</div>\n"
+}
+
+// Center adds centered content to the document.
+func (d *Doc) Center(content string) *Doc {
+	return d.write(Center(content))
+}
+
+// Right creates right-aligned text using HTML.
+func Right(content string) string {
+	return "<div align=\"right\">\n\n" + content + "\n\n</div>\n"
+}
+
+// Right adds right-aligned content to the document.
+func (d *Doc) Right(content string) *Doc {
+	return d.write(Right(content))
+}

--- a/examples/gno.land/p/demo/ui/mictofun/table.gno
+++ b/examples/gno.land/p/demo/ui/mictofun/table.gno
@@ -1,0 +1,149 @@
+// Table provides a fluent API for creating markdown tables with alignment support.
+//
+// Example usage:
+//
+//	table := mictofun.NewTable().
+//	    Headers("Name", "Amount", "Status").
+//	    SetAlign(mictofun.AlignLeft, mictofun.AlignRight, mictofun.AlignCenter).
+//	    Row("Alice", "$100", "✓").
+//	    Row("Bob", "$250", "Pending")
+//
+//	doc.Add(table)
+package mictofun
+
+import (
+	"strings"
+)
+
+// Align represents column alignment in tables.
+type Align int
+
+const (
+	AlignLeft Align = iota
+	AlignCenter
+	AlignRight
+)
+
+// Table is a fluent builder for creating markdown tables.
+type Table struct {
+	headers []string
+	aligns  []Align
+	rows    [][]string
+}
+
+// NewTable creates a new table builder.
+func NewTable() *Table {
+	return &Table{
+		headers: make([]string, 0),
+		aligns:  make([]Align, 0),
+		rows:    make([][]string, 0),
+	}
+}
+
+// Headers sets the table headers.
+func (t *Table) Headers(cols ...string) *Table {
+	t.headers = cols
+	return t
+}
+
+// SetAlign sets column alignments. Use AlignLeft, AlignCenter, or AlignRight constants.
+func (t *Table) SetAlign(aligns ...Align) *Table {
+	t.aligns = aligns
+	return t
+}
+
+// Row adds a single row to the table.
+func (t *Table) Row(cells ...string) *Table {
+	t.rows = append(t.rows, cells)
+	return t
+}
+
+// Rows adds multiple rows at once.
+func (t *Table) Rows(rows [][]string) *Table {
+	t.rows = append(t.rows, rows...)
+	return t
+}
+
+// String returns the markdown representation of the table.
+func (t *Table) String() string {
+	if len(t.headers) == 0 && len(t.rows) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	// Determine column count
+	colCount := len(t.headers)
+	if colCount == 0 && len(t.rows) > 0 {
+		colCount = len(t.rows[0])
+		t.headers = make([]string, colCount) // Empty headers
+	}
+
+	// Write header row
+	sb.WriteString("| ")
+	for i, h := range t.headers {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		sb.WriteString(escapeTableCell(h))
+	}
+	sb.WriteString(" |\n")
+
+	// Write separator row with alignment
+	sb.WriteString("|")
+	for i := 0; i < colCount; i++ {
+		align := AlignLeft
+		if i < len(t.aligns) {
+			align = t.aligns[i]
+		}
+		switch align {
+		case AlignCenter:
+			sb.WriteString(" :---: |")
+		case AlignRight:
+			sb.WriteString(" ---: |")
+		default:
+			sb.WriteString(" --- |")
+		}
+	}
+	sb.WriteString("\n")
+
+	// Write data rows
+	for _, row := range t.rows {
+		sb.WriteString("| ")
+		for i := 0; i < colCount; i++ {
+			if i > 0 {
+				sb.WriteString(" | ")
+			}
+			if i < len(row) {
+				sb.WriteString(escapeTableCell(row[i]))
+			}
+		}
+		sb.WriteString(" |\n")
+	}
+
+	return sb.String()
+}
+
+// escapeTableCell escapes pipe characters in table cells.
+func escapeTableCell(cell string) string {
+	return strings.ReplaceAll(cell, "|", "&#124;")
+}
+
+// TableFromData creates a table from a 2D string slice.
+// First row is used as headers.
+func TableFromData(data [][]string) *Table {
+	t := NewTable()
+	if len(data) == 0 {
+		return t
+	}
+	t.Headers(data[0]...)
+	if len(data) > 1 {
+		t.Rows(data[1:])
+	}
+	return t
+}
+
+// SimpleTable creates a quick table with headers and rows.
+func SimpleTable(headers []string, rows [][]string) string {
+	return NewTable().Headers(headers...).Rows(rows).String()
+}

--- a/examples/gno.land/r/demo/mictofun_example/gnomod.toml
+++ b/examples/gno.land/r/demo/mictofun_example/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/mictofun_example"
+gno = "0.9"

--- a/examples/gno.land/r/demo/mictofun_example/mictofun_example.gno
+++ b/examples/gno.land/r/demo/mictofun_example/mictofun_example.gno
@@ -1,0 +1,142 @@
+// Package mictofun_example demonstrates the mictofun markdown framework.
+//
+// This realm shows how to use all features of the mictofun library
+// including fluent API, tables, alerts, and layout components.
+package mictofun_example
+
+import (
+	"gno.land/p/demo/ui/mictofun"
+)
+
+func Render(path string) string {
+	switch path {
+	case "":
+		return renderHome()
+	case "tables":
+		return renderTables()
+	case "alerts":
+		return renderAlerts()
+	case "features":
+		return renderFeatures()
+	default:
+		return renderHome()
+	}
+}
+
+func renderHome() string {
+	// Create a feature table
+	features := mictofun.NewTable().
+		Headers("Feature", "Description", "Status").
+		SetAlign(mictofun.AlignLeft, mictofun.AlignLeft, mictofun.AlignCenter).
+		Row("Fluent API", "Method chaining for readable code", "✓").
+		Row("Tables", "With alignment support", "✓").
+		Row("Alerts", "GitHub-style callouts", "✓").
+		Row("Layouts", "Columns, collapsible sections", "✓")
+
+	return mictofun.New().
+		H1("mictofun - Fluent Markdown Framework").
+		P("A powerful, chainable markdown generation library for gno.land.").
+		Note("This realm demonstrates all features of the mictofun package.").
+		H2("Quick Example").
+		CodeBlock(`doc := mictofun.New().
+    H1("Hello World").
+    P("This is " + mictofun.Bold("amazing") + "!").
+    Bullet("Fast", "Simple", "Powerful").
+    String()`, "gno").
+		H2("Features").
+		Add(features).
+		H2("Navigation").
+		Bullet(
+			mictofun.Link("Tables Demo", "/r/demo/mictofun_example:tables"),
+			mictofun.Link("Alerts Demo", "/r/demo/mictofun_example:alerts"),
+			mictofun.Link("All Features", "/r/demo/mictofun_example:features"),
+		).
+		HR().
+		P("Created with " + mictofun.Bold("mictofun") + " | " + mictofun.Link("View Source", "https://github.com/gnolang/gno")).
+		String()
+}
+
+func renderTables() string {
+	// Basic table
+	basic := mictofun.NewTable().
+		Headers("ID", "Name", "Score").
+		Row("1", "Alice", "100").
+		Row("2", "Bob", "95").
+		Row("3", "Charlie", "87")
+
+	// Aligned table
+	aligned := mictofun.NewTable().
+		Headers("Left", "Center", "Right").
+		SetAlign(mictofun.AlignLeft, mictofun.AlignCenter, mictofun.AlignRight).
+		Row("Text", "Text", "Text").
+		Row("More", "More", "More")
+
+	return mictofun.New().
+		H1("Table Examples").
+		P(mictofun.Link("← Back to Home", "/r/demo/mictofun_example")).
+		H2("Basic Table").
+		Add(basic).
+		H2("Aligned Table").
+		P("Columns can be aligned left, center, or right:").
+		Add(aligned).
+		H2("Code").
+		CodeBlock(`table := mictofun.NewTable().
+    Headers("Name", "Value").
+    SetAlign(mictofun.AlignLeft, mictofun.AlignRight).
+    Row("Price", "$100").
+    Row("Quantity", "5")`, "gno").
+		String()
+}
+
+func renderAlerts() string {
+	return mictofun.New().
+		H1("Alert Examples").
+		P(mictofun.Link("← Back to Home", "/r/demo/mictofun_example")).
+		H2("Available Alert Types").
+		Note("This is a NOTE alert for general information.").
+		Tip("This is a TIP alert for helpful suggestions.").
+		Important("This is an IMPORTANT alert for critical information.").
+		Warning("This is a WARNING alert for potential issues.").
+		Caution("This is a CAUTION alert for dangerous actions.").
+		H2("Code").
+		CodeBlock(`doc := mictofun.New().
+    Note("General information").
+    Warning("Be careful!").
+    Tip("Pro tip here")`, "gno").
+		String()
+}
+
+func renderFeatures() string {
+	return mictofun.New().
+		H1("All Features Demo").
+		P(mictofun.Link("← Back to Home", "/r/demo/mictofun_example")).
+		H2("Text Formatting").
+		P("You can use " + mictofun.Bold("bold") + ", " + mictofun.Italic("italic") + ", and " + mictofun.Strike("strikethrough") + " text.").
+		P("Inline " + mictofun.Code("code") + " is also supported.").
+		H2("Lists").
+		H3("Bullet List").
+		Bullet("First item", "Second item", "Third item with\nmultiple lines").
+		H3("Numbered List").
+		Numbered("Step one", "Step two", "Step three").
+		H3("Todo List").
+		Todo([]string{"Completed task", "Pending task", "Another pending"}, []bool{true, false, false}).
+		H2("Blockquote").
+		Quote("This is a blockquote.\nIt can span multiple lines.").
+		H2("Code Block").
+		CodeBlock(`func main() {
+    fmt.Println("Hello, Gno!")
+}`, "go").
+		H2("Links").
+		Bullet(
+			mictofun.UserLink("moul")+" - User link with @",
+			mictofun.UserLink("g1abc123def456")+" - Address link",
+			mictofun.RealmLink("r/demo/wugnot", "Wrapped UGNOT")+" - Realm link",
+		).
+		H2("Collapsible Section").
+		Collapsible("Click to expand", "This content is hidden by default!\n\nYou can put any markdown content here.").
+		H2("Horizontal Rule").
+		P("Content above").
+		HR().
+		P("Content below").
+		String()
+}


### PR DESCRIPTION
## Description
Add mictofun - a fluent, chainable markdown framework for Gno.
Related to #2753
## Features
- Fluent chainable API
- Table builder with alignment
- GitHub-style alerts
- 30 tests passing