### PR TITLE
fix: tm2/Makefile: _test.flappy should set STABILITY_FILTER

### DIFF
--- a/tm2/Makefile
+++ b/tm2/Makefile
@@ -49,7 +49,7 @@ test: _test.pkg.amino _test.pkg.bft _test.pkg.db _test.pkg.others _test.flappy
 _test.flappy:
 	# flappy tests should work "sometimes" (at least once).
 	# TODO: support coverage for flappy tests.
-	TEST_STABILITY=flappy $(rundep) moul.io/testman test -test.v -timeout=20m -retry=10 -run ^TestFlappy \
+	STABILITY_FILTER=flappy $(rundep) moul.io/testman test -test.v -timeout=20m -retry=10 -run ^TestFlappy \
 		./pkg/bft/consensus ./pkg/bft/blockchain ./pkg/bft/mempool ./pkg/p2p ./pkg/bft/privval
 
 _test.pkg.others:;  go test $(GOTEST_FLAGS) `go list ./pkg/... | grep -Ev 'pkg/(amino|bft|db|iavl/benchmarks)(/|$$)'`


### PR DESCRIPTION
`make test` in the tm2 folder is supposed to run flappy tests with [`_test.flappy`](https://github.com/gnolang/gno/blob/1183ce490502ce1e8e5d7eabf889994fbea3e932/tm2/Makefile#L47). It sets [`TEST_STABILITY=flappy`](https://github.com/gnolang/gno/blob/1183ce490502ce1e8e5d7eabf889994fbea3e932/tm2/Makefile#L52) . This doesn't work because `FilterStability` expects [`STABILITY_FILTER`](https://github.com/gnolang/gno/blob/1183ce490502ce1e8e5d7eabf889994fbea3e932/tm2/pkg/testutils/flappy.go#L16). This changes the `Makefile` to set `STABILITY_FILTER`.

The CI checks don't run flappy tests. But now, running `make test` locally may fail. For example, [`TestFlappyBadBlockStopsPeer`](https://github.com/gnolang/gno/blob/1183ce490502ce1e8e5d7eabf889994fbea3e932/tm2/pkg/bft/blockchain/reactor_test.go#L198).

Related to "Deflap flappy tests" #202