### PR TITLE
feat: ledger implementation in gnokms

### DIFF
--- a/contribs/gnokms/README.md
+++ b/contribs/gnokms/README.md
@@ -2,7 +2,7 @@
 
 `gnokms` is a simple Key Management System (KMS) designed to securely manage signing keys for [gnoland](../../gno.land/cmd/gnoland) (TM2) validator nodes. Rather than storing a key in plain text on disk, a validator can run a `gnokms` server in a separate process or on a separate machine, delegating the responsibility of securely storing the signing key and using it for remote signing.
 
-`gnokms` also aims to provide several backends, including a local [gnokey](../../gno.land/cmd/gnokey) instance, a remote HSM, or a cloud-based KMS service.
+`gnokms` also aims to provide several backends, including a local [gnokey](../../gno.land/cmd/gnokey) instance, a Ledger Tendermint validator app (a local HSM‑class device), a remote HSM, or a cloud-based KMS service.
 
 Both TCP and Unix domain socket connections are supported for communication between the validator and the `gnokms` server. TCP connections are encrypted and can be mutually authenticated using Ed25519 keypairs and an authorized keys whitelist on both sides.
 
@@ -36,7 +36,7 @@ Both TCP and Unix domain socket connections are supported for communication betw
 
 ### Using `gnokms` with a gnoland validator
 
-**Note:** The only supported backend for now is [gnokey](../../gno.land/cmd/gnokey), so the following instructions will use it.
+### Using `gnokms` with gnokey
 
 1. Generate a signing key using [gnokey](../../gno.land/cmd/gnokey) if you do not already have one.
 2. Start a `gnokms` server with the [gnokey](../../gno.land/cmd/gnokey) backend using:
@@ -53,6 +53,24 @@ $ gnokms gnokey '<key_name>' -listener '<listen_address>'
 $ gnoland config set consensus.priv_validator.remote_signer.server_address '<gnokms_server_address>'
 Updated configuration saved at gnoland-data/config/config.toml
 ```
+
+### Using `gnokms` with Ledger Tendermint validator app
+
+1. Open the Tendermint Validator app on your Ledger device.
+   - Only Ledger Nano S Plus is supported.
+   - The Ledger Nano X does not support sideloading developer apps, so the Tendermint Validator app cannot be installed on it.
+   - Disable the PIN lock on the Ledger device.
+   - The first signature requires manual confirmation on the Ledger (it displays the height and round to initialize the validator state). Subsequent signatures proceed without user action.
+2. Start a `gnokms` server with the Ledger backend using:
+
+```shell
+$ gnokms ledger -listener '<listen_address>'
+# <listen_address> is the address on which the server should listen (e.g., 'tcp://127.0.0.1:26659' or 'unix:///tmp/gnokms.sock').
+```
+
+The Tendermint validator app uses the fixed BIP44 path `44'/118'/0'/0/0` and does not accept overrides.
+
+**Note:** Ledger support requires CGO-enabled builds and the Ledger HID dependencies (for example, `CGO_ENABLED=1` with the required system libraries installed).
 
 ### Genesis
 

--- a/contribs/gnokms/README.md
+++ b/contribs/gnokms/README.md
@@ -56,9 +56,9 @@ Updated configuration saved at gnoland-data/config/config.toml
 
 ### Using `gnokms` with Ledger Tendermint validator app
 
-1. Open the Tendermint Validator app on your Ledger device.
+1. Open the [tm-ledger-validator app](https://github.com/gnoverse/tm-ledger-validator) on your Ledger device.
    - Only Ledger Nano S Plus is supported.
-   - The Ledger Nano X does not support sideloading developer apps, so the Tendermint Validator app cannot be installed on it.
+   - The Ledger Nano X does not support sideloading developer apps, so the tm-ledger-validator app cannot be installed on it.
    - Disable the PIN lock on the Ledger device.
    - The first signature requires manual confirmation on the Ledger (it displays the height and round to initialize the validator state). Subsequent signatures proceed without user action.
 2. Start a `gnokms` server with the Ledger backend using:

--- a/contribs/gnokms/go.mod
+++ b/contribs/gnokms/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/gnolang/gno v0.0.0-00010101000000-000000000000
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.11.1
+	github.com/zondax/hid v0.9.2
+	github.com/zondax/ledger-go v1.0.1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.48.0
@@ -38,8 +40,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/zondax/golem v0.27.0 // indirect
-	github.com/zondax/hid v0.9.2 // indirect
-	github.com/zondax/ledger-go v1.0.1 // indirect
 	go.uber.org/zap/exp v0.3.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/contribs/gnokms/internal/gnokey/gnokey_signer.go
+++ b/contribs/gnokms/internal/gnokey/gnokey_signer.go
@@ -75,9 +75,8 @@ func newGnokeySigner(
 
 			break
 		}
-		// TODO: suggest to use `gnokms ledger` when it will be implemented.
-	// case keys.TypeLedger: // Ledger is not supported
-	// 	return nil, fmt.Errorf("unsupported key type: use 'gnokms ledger' for ledger keys")
+	case keys.TypeLedger:
+		return nil, fmt.Errorf("unsupported key type: use 'gnokms ledger' for ledger keys")
 	default: // Offline and Multi types are not supported.
 		return nil, fmt.Errorf("unsupported key type: %s", info.GetType())
 	}

--- a/contribs/gnokms/internal/ledger/ledger.go
+++ b/contribs/gnokms/internal/ledger/ledger.go
@@ -1,0 +1,51 @@
+// Package ledger implements a remote signer server using a Ledger Tendermint
+// validator app as backend.
+package ledger
+
+import (
+	"context"
+	"flag"
+
+	"github.com/gnolang/gno/contribs/gnokms/internal/common"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+)
+
+type ledgerFlags struct {
+	common.ServerFlags
+}
+
+// NewLedgerCmd creates the gnokms ledger subcommand.
+func NewLedgerCmd(io commands.IO) *commands.Command {
+	ledgerFlags := &ledgerFlags{}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "ledger",
+			ShortUsage: "ledger [flags]",
+			ShortHelp:  "uses a Ledger Tendermint validator app as a remote signer",
+			LongHelp:   "Runs a gnokms remote signer server using a Ledger Tendermint validator app as backend.",
+		},
+		ledgerFlags,
+		func(ctx context.Context, args []string) error {
+			return execLedger(ctx, args, ledgerFlags, io)
+		},
+	)
+}
+
+func (f *ledgerFlags) RegisterFlags(fs *flag.FlagSet) {
+	f.ServerFlags.RegisterFlags(fs)
+}
+
+func execLedger(ctx context.Context, args []string, ledgerFlags *ledgerFlags, io commands.IO) error {
+	if len(args) != 0 {
+		io.ErrPrintln("error: unexpected arguments\n")
+		return flag.ErrHelp
+	}
+
+	ledgerSigner, err := newLedgerSigner()
+	if err != nil {
+		return err
+	}
+
+	return common.RunSignerServer(ctx, &ledgerFlags.ServerFlags, ledgerSigner, io)
+}

--- a/contribs/gnokms/internal/ledger/ledger_device.go
+++ b/contribs/gnokms/internal/ledger/ledger_device.go
@@ -25,14 +25,14 @@ func requiredLedgerVersion() ledgerAppVersion {
 	return ledgerAppVersion{AppMode: 0, Major: 0, Minor: 5, Patch: 0}
 }
 
-func (v ledgerAppVersion) meetsMinimum(min ledgerAppVersion) bool {
-	if v.Major != min.Major {
-		return v.Major > min.Major
+func (v ledgerAppVersion) meetsMinimum(minimum ledgerAppVersion) bool {
+	if v.Major != minimum.Major {
+		return v.Major > minimum.Major
 	}
-	if v.Minor != min.Minor {
-		return v.Minor > min.Minor
+	if v.Minor != minimum.Minor {
+		return v.Minor > minimum.Minor
 	}
-	return v.Patch >= min.Patch
+	return v.Patch >= minimum.Patch
 }
 
 type tendermintLedger struct {

--- a/contribs/gnokms/internal/ledger/ledger_device.go
+++ b/contribs/gnokms/internal/ledger/ledger_device.go
@@ -1,0 +1,98 @@
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/zondax/hid"
+	ledger_go "github.com/zondax/ledger-go"
+)
+
+const (
+	ledgerCLA           = 0x56
+	ledgerINSGetVersion = 0x00
+)
+
+type ledgerAppVersion struct {
+	AppMode byte
+	Major   byte
+	Minor   byte
+	Patch   byte
+}
+
+func requiredLedgerVersion() ledgerAppVersion {
+	return ledgerAppVersion{AppMode: 0, Major: 0, Minor: 5, Patch: 0}
+}
+
+func (v ledgerAppVersion) meetsMinimum(min ledgerAppVersion) bool {
+	if v.Major != min.Major {
+		return v.Major > min.Major
+	}
+	if v.Minor != min.Minor {
+		return v.Minor > min.Minor
+	}
+	return v.Patch >= min.Patch
+}
+
+type tendermintLedger struct {
+	api ledger_go.LedgerDevice
+}
+
+func openTendermintLedger() (*tendermintLedger, error) {
+	if !hid.Supported() {
+		return nil, errors.New("ledger support is not enabled, try building with CGO_ENABLED=1")
+	}
+
+	ledgerAdmin := ledger_go.NewLedgerAdmin()
+	ledgerAPI, err := ledgerAdmin.Connect(0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tendermintLedger{api: ledgerAPI}, nil
+}
+
+func (ledger *tendermintLedger) Close() error {
+	return ledger.api.Close()
+}
+
+func (ledger *tendermintLedger) getVersion() (*ledgerAppVersion, error) {
+	message := []byte{ledgerCLA, ledgerINSGetVersion, 0, 0, 0}
+	response, err := ledger.api.Exchange(message)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response) < 4 {
+		return nil, errors.New("invalid response")
+	}
+
+	return &ledgerAppVersion{
+		AppMode: response[0],
+		Major:   response[1],
+		Minor:   response[2],
+		Patch:   response[3],
+	}, nil
+}
+
+func validateLedgerApp(ledger *tendermintLedger) error {
+	version, err := ledger.getVersion()
+	if err != nil {
+		if strings.Contains(err.Error(), "APDU_CODE_CLA_NOT_SUPPORTED") {
+			return errors.New("are you sure the Tendermint Validator app is open?")
+		}
+		return err
+	}
+
+	if !version.meetsMinimum(requiredLedgerVersion()) {
+		req := requiredLedgerVersion()
+		return fmt.Errorf(
+			"ledger app version %d.%d.%d is below required %d.%d.%d",
+			version.Major, version.Minor, version.Patch,
+			req.Major, req.Minor, req.Patch,
+		)
+	}
+
+	return nil
+}

--- a/contribs/gnokms/internal/ledger/ledger_device_test.go
+++ b/contribs/gnokms/internal/ledger/ledger_device_test.go
@@ -1,0 +1,81 @@
+package ledger
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	var gotCommand []byte
+	device := &mockLedgerDevice{
+		exchange: func(command []byte) ([]byte, error) {
+			gotCommand = append([]byte(nil), command...)
+			return []byte{0x00, 0x01, 0x02, 0x03}, nil
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	version, err := ledger.getVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(gotCommand) != 5 {
+		t.Fatalf("unexpected command length: %d", len(gotCommand))
+	}
+	if gotCommand[0] != ledgerCLA || gotCommand[1] != ledgerINSGetVersion || gotCommand[2] != 0 || gotCommand[3] != 0 || gotCommand[4] != 0 {
+		t.Fatalf("unexpected command: %x", gotCommand)
+	}
+
+	if version.AppMode != 0x00 || version.Major != 0x01 || version.Minor != 0x02 || version.Patch != 0x03 {
+		t.Fatalf("unexpected version: %+v", version)
+	}
+}
+
+func TestGetVersionInvalidResponse(t *testing.T) {
+	device := &mockLedgerDevice{
+		exchange: func([]byte) ([]byte, error) {
+			return []byte{0x00, 0x01, 0x02}, nil
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	if _, err := ledger.getVersion(); err == nil {
+		t.Fatalf("expected error for short response")
+	}
+}
+
+func TestValidateLedgerAppCLANotSupported(t *testing.T) {
+	device := &mockLedgerDevice{
+		exchange: func([]byte) ([]byte, error) {
+			return nil, errors.New("[APDU_CODE_CLA_NOT_SUPPORTED] Class not supported")
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	err := validateLedgerApp(ledger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "Tendermint Validator app is open") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidateLedgerAppVersionTooLow(t *testing.T) {
+	device := &mockLedgerDevice{
+		exchange: func([]byte) ([]byte, error) {
+			return []byte{0x00, 0x00, 0x04, 0x00}, nil
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	err := validateLedgerApp(ledger)
+	if err == nil {
+		t.Fatalf("expected version error")
+	}
+	if !strings.Contains(err.Error(), "below required") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}

--- a/contribs/gnokms/internal/ledger/ledger_mock_test.go
+++ b/contribs/gnokms/internal/ledger/ledger_mock_test.go
@@ -1,0 +1,20 @@
+package ledger
+
+type mockLedgerDevice struct {
+	exchange func([]byte) ([]byte, error)
+	calls    [][]byte
+}
+
+func (m *mockLedgerDevice) Exchange(command []byte) ([]byte, error) {
+	if m.exchange == nil {
+		return nil, nil
+	}
+	cmdCopy := make([]byte, len(command))
+	copy(cmdCopy, command)
+	m.calls = append(m.calls, cmdCopy)
+	return m.exchange(command)
+}
+
+func (m *mockLedgerDevice) Close() error {
+	return nil
+}

--- a/contribs/gnokms/internal/ledger/ledger_signer.go
+++ b/contribs/gnokms/internal/ledger/ledger_signer.go
@@ -1,0 +1,141 @@
+// Inspired by https://github.com/cosmos/ledger-cosmos-go/blob/9e3c918a05e0f84ce4205215d71c731f23888ec9/validator_app.go
+
+package ledger
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+)
+
+const (
+	ledgerINSPublicKeyED25519 = 0x01
+	ledgerINSSignED25519      = 0x02
+	ledgerMessageChunkSize    = 32 // needded for macOS HID IO issues
+)
+
+func (ledger *tendermintLedger) signED25519(message []byte) ([]byte, error) {
+	if len(message) == 0 {
+		return nil, errors.New("sign bytes are empty")
+	}
+
+	var packetIndex byte = 1
+	packetCount := byte(math.Ceil(float64(len(message)) / float64(ledgerMessageChunkSize)))
+
+	var finalResponse []byte
+
+	for packetIndex <= packetCount {
+		chunk := ledgerMessageChunkSize
+		if len(message) < ledgerMessageChunkSize {
+			chunk = len(message)
+		}
+
+		header := []byte{
+			ledgerCLA,
+			ledgerINSSignED25519,
+			packetIndex,
+			packetCount,
+			byte(chunk),
+		}
+
+		apduMessage := append(header, message[:chunk]...)
+
+		response, err := ledger.api.Exchange(apduMessage)
+		if err != nil {
+			return nil, formatLedgerError(err, response)
+		}
+
+		finalResponse = response
+		message = message[chunk:]
+		packetIndex++
+	}
+
+	return finalResponse, nil
+}
+
+func (ledger *tendermintLedger) getPublicKeyED25519() ([]byte, error) {
+	message := []byte{ledgerCLA, ledgerINSPublicKeyED25519, 0, 0, 0}
+	return ledger.api.Exchange(message)
+}
+
+func formatLedgerError(err error, response []byte) error {
+	if len(response) == 1 {
+		return fmt.Errorf("ledger rejected sign bytes (parse error code: 0x%02x): %w", response[0], err)
+	}
+
+	return err
+}
+
+// ledgerSigner is a gnokms signer backed by the Ledger Tendermint validator app.
+type ledgerSigner struct {
+	ledger *tendermintLedger
+	pubKey ed25519.PubKeyEd25519
+	mu     sync.Mutex
+}
+
+// ledgerSigner type implements types.Signer.
+var _ types.Signer = (*ledgerSigner)(nil)
+
+// PubKey implements types.Signer.
+func (ls *ledgerSigner) PubKey() crypto.PubKey {
+	return ls.pubKey
+}
+
+// Sign implements types.Signer.
+func (ls *ledgerSigner) Sign(signBytes []byte) ([]byte, error) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	signature, err := ls.ledger.signED25519(signBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(signature) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("unexpected ledger signature length: %d", len(signature))
+	}
+
+	return signature, nil
+}
+
+// Close implements types.Signer.
+func (ls *ledgerSigner) Close() error {
+	return ls.ledger.Close()
+}
+
+// newLedgerSigner initializes a new ledger signer using the Tendermint validator app.
+func newLedgerSigner() (*ledgerSigner, error) {
+	ledger, err := openTendermintLedger()
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to Ledger Tendermint validator app: %w", err)
+	}
+
+	if err := validateLedgerApp(ledger); err != nil {
+		_ = ledger.Close()
+		return nil, err
+	}
+
+	pubKeyBytes, err := ledger.getPublicKeyED25519()
+	if err != nil {
+		_ = ledger.Close()
+		return nil, fmt.Errorf("unable to fetch ledger public key: %w", err)
+	}
+
+	if len(pubKeyBytes) != ed25519.PubKeyEd25519Size {
+		_ = ledger.Close()
+		return nil, fmt.Errorf("unexpected ledger public key length: %d", len(pubKeyBytes))
+	}
+
+	var pubKey ed25519.PubKeyEd25519
+	copy(pubKey[:], pubKeyBytes)
+
+	return &ledgerSigner{
+		ledger: ledger,
+		pubKey: pubKey,
+	}, nil
+}

--- a/contribs/gnokms/internal/ledger/ledger_signer_test.go
+++ b/contribs/gnokms/internal/ledger/ledger_signer_test.go
@@ -1,0 +1,115 @@
+package ledger
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+)
+
+func TestSignED25519Empty(t *testing.T) {
+	ledger := &tendermintLedger{api: &mockLedgerDevice{}}
+	if _, err := ledger.signED25519(nil); err == nil {
+		t.Fatalf("expected error for empty sign bytes")
+	}
+}
+
+func TestSignED25519Chunking(t *testing.T) {
+	message := make([]byte, ledgerMessageChunkSize+8)
+	for i := range message {
+		message[i] = byte(i)
+	}
+
+	signature := make([]byte, ed25519.SignatureSize)
+	device := &mockLedgerDevice{}
+	device.exchange = func([]byte) ([]byte, error) {
+		if len(device.calls) == 2 {
+			return signature, nil
+		}
+		return []byte{0x00}, nil
+	}
+
+	ledger := &tendermintLedger{api: device}
+	resp, err := ledger.signED25519(message)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp) != ed25519.SignatureSize {
+		t.Fatalf("unexpected signature length: %d", len(resp))
+	}
+
+	if len(device.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(device.calls))
+	}
+
+	first := device.calls[0]
+	if len(first) != 5+ledgerMessageChunkSize {
+		t.Fatalf("unexpected first call length: %d", len(first))
+	}
+	if first[0] != ledgerCLA || first[1] != ledgerINSSignED25519 || first[2] != 1 || first[3] != 2 {
+		t.Fatalf("unexpected header for first call: %x", first[:5])
+	}
+
+	second := device.calls[1]
+	if second[2] != 2 || second[3] != 2 {
+		t.Fatalf("unexpected header for second call: %x", second[:5])
+	}
+	if second[4] != 8 {
+		t.Fatalf("unexpected chunk length: %d", second[4])
+	}
+}
+
+func TestSignED25519ExchangeError(t *testing.T) {
+	device := &mockLedgerDevice{
+		exchange: func([]byte) ([]byte, error) {
+			return []byte{0x42}, errors.New("boom")
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	_, err := ledger.signED25519([]byte{0x01})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "0x42") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPublicKeyHeaders(t *testing.T) {
+	expected := make([]byte, ed25519.PubKeyEd25519Size)
+	for i := range expected {
+		expected[i] = byte(i)
+	}
+
+	device := &mockLedgerDevice{
+		exchange: func(command []byte) ([]byte, error) {
+			return expected, nil
+		},
+	}
+	ledger := &tendermintLedger{api: device}
+
+	pubKeyBytes, err := ledger.getPublicKeyED25519()
+	if err != nil {
+		t.Fatalf("unexpected pubkey error: %v", err)
+	}
+
+	if len(pubKeyBytes) != ed25519.PubKeyEd25519Size {
+		t.Fatalf("unexpected pubkey length: %d", len(pubKeyBytes))
+	}
+	for i := range expected {
+		if pubKeyBytes[i] != expected[i] {
+			t.Fatalf("unexpected pubkey byte at %d: %x", i, pubKeyBytes[i])
+		}
+	}
+
+	if len(device.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(device.calls))
+	}
+
+	pubKeyCmd := device.calls[0]
+	if len(pubKeyCmd) != 5 || pubKeyCmd[0] != ledgerCLA || pubKeyCmd[1] != ledgerINSPublicKeyED25519 {
+		t.Fatalf("unexpected pubkey command: %x", pubKeyCmd)
+	}
+}

--- a/contribs/gnokms/main.go
+++ b/contribs/gnokms/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gnolang/gno/contribs/gnokms/internal/auth"
 	"github.com/gnolang/gno/contribs/gnokms/internal/gnokey"
+	"github.com/gnolang/gno/contribs/gnokms/internal/ledger"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
 
@@ -24,6 +25,7 @@ func main() {
 	cmd.AddSubCommands(
 		auth.NewAuthCmd(io),
 		gnokey.NewGnokeyCmd(io),
+		ledger.NewLedgerCmd(io),
 	)
 
 	cmd.Execute(context.Background(), os.Args[1:])


### PR DESCRIPTION
fixes https://github.com/gnolang/gno/issues/3235

Adds a new **Ledger backend** to `gnokms` via a `gnokms ledger` subcommand, allowing a gnoland validator to use the **[tm-ledger-validator app](https://github.com/gnoverse/tm-ledger-validator)** as a remote-signing device.
Introduces an `internal/ledger` implementation with:
- device detection (with CGO/HID requirements)
- ledger app version checks
- implements gnokms signer server
- checks for CGO/HID requirements

Note: the Ledger [tm-ledger-validator app](https://github.com/gnoverse/tm-ledger-validator) hardcodes the BIP44 path, first-sign confirmation, CGO/HID requirements, supported devices), and adjusts the gnokey backend error message to point Ledger users to `gnokms ledger`.

## Prerequisites

- Ledger Nano S Plus only.
- Ledger Nano X: not supported until the [tm-ledger-validator app](https://github.com/gnoverse/tm-ledger-validator) is not available in the Ledger Wallet store.
- You must have the [tm-ledger-validator app](https://github.com/gnoverse/tm-ledger-validator) installed and opened on the Ledger.
- Disable the PIN lock on the device.

## Setup

Please follow this [guide](https://gnops.io/articles/guides/gnokms/).

## Start gnokms for ledger

```shell
gnokms ledger -listener 'tcp://127.0.0.1:26659'
# or
gnokms ledger -listener 'unix:///tmp/gnokms.sock'
```

Then start the validator that uses gnokms.

First signature requires manual confirmation on the Ledger (initializes validator state); subsequent signatures will not require interaction.

## Testing

To validate the new Ledger backend end-to-end, I created a **Docker Compose** setup that simulates a small **4-validator cluster**, where **only one validator** uses `gnokms` with the **Ledger backend** and the other three run with non-Ledger signing.

On first startup, the Ledger **requires an initial state/signing initialization** that needs **manual user approval**. While `gnokms` is blocked waiting for this interaction, the Ledger-backed validator **misses signing** some blocks/consensus messages (as expected). Once the approval is performed on the device, `gnokms` unblocks and the validator **resumes signing**, successfully participating in consensus and signing new blocks continuously.

Works on a Linux and macOS machine.
