### PR TITLE
fix(github-bot): remove rule for docs directory

### DIFF
--- a/contribs/github-bot/internal/config/config.go
+++ b/contribs/github-bot/internal/config/config.go
@@ -40,23 +40,6 @@ func Config(gh *client.GitHub) ([]AutomaticCheck, []ManualCheck) {
 			Then: r.MaintainerCanModify(),
 		},
 		{
-			Description: "Changes to 'docs' folder must be reviewed/authored by at least one devrel and one tech-staff",
-			If: c.And(
-				c.BaseBranch("^master$"),
-				c.FileChanged(gh, "^docs/"),
-			),
-			Then: r.And(
-				r.Or(
-					r.AuthorInTeam(gh, "tech-staff"),
-					r.ReviewByTeamMembers(gh, "tech-staff", r.RequestIgnore).WithDesiredState(utils.ReviewStateApproved),
-				),
-				r.Or(
-					r.AuthorInTeam(gh, "devrels"),
-					r.ReviewByTeamMembers(gh, "devrels", r.RequestApply).WithDesiredState(utils.ReviewStateApproved),
-				),
-			),
-		},
-		{
 			Description: "Changes related to gnoweb must be reviewed by its codeowners",
 			If: c.And(
 				c.BaseBranch("^master$"),


### PR DESCRIPTION
There are no longer properly "devrels" in the team; the PR's relating to docs can just follow the normal approval process without this rule.