### PR TITLE
feat: add TransferOwnershipByPrevious for cross-realm owner flows

### DIFF
--- a/examples/gno.land/p/nt/ownable/ownable.gno
+++ b/examples/gno.land/p/nt/ownable/ownable.gno
@@ -43,6 +43,20 @@ func (o *Ownable) TransferOwnership(newOwner address) error {
 		return ErrUnauthorized
 	}
 
+	return o.transferOwnership(newOwner)
+}
+
+// TransferOwnershipByPrevious transfers ownership of the Ownable struct
+// when ownership is asserted against the previous realm.
+func (o *Ownable) TransferOwnershipByPrevious(newOwner address) error {
+	if !o.OwnedByPrevious() {
+		return ErrUnauthorized
+	}
+
+	return o.transferOwnership(newOwner)
+}
+
+func (o *Ownable) transferOwnership(newOwner address) error {
 	if !newOwner.IsValid() {
 		return ErrInvalidAddress
 	}

--- a/examples/gno.land/p/nt/ownable/ownable_test.gno
+++ b/examples/gno.land/p/nt/ownable/ownable_test.gno
@@ -76,13 +76,59 @@ func TestTransferOwnershipUnauthorized(t *testing.T) {
 
 	// Set realm to an unauthorized user bob.
 	testing.SetRealm(testing.NewUserRealm(bob))
-	// current is gno.land/r/test/test so of course errors.
+	// owner is alice, so bob is unauthorized.
 	uassert.ErrorContains(t, o.TransferOwnership(bob), ErrUnauthorized.Error())
 	uassert.ErrorContains(t, o.DropOwnershipByCurrent(), ErrUnauthorized.Error())
 	// Reset realm to alice.
 	testing.SetRealm(testing.NewUserRealm(alice))
 	uassert.NoError(t, o.TransferOwnership(alice))
 	uassert.NoError(t, o.DropOwnershipByCurrent())
+}
+
+func TestTransferOwnershipByPrevious(t *testing.T) {
+	var o *Ownable
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		o = NewWithOrigin() // owned by alice
+	})
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		err := o.TransferOwnershipByPrevious(bob)
+		urequire.NoError(t, err)
+	})
+
+	got := o.Owner()
+	uassert.Equal(t, got, bob)
+}
+
+func TestTransferOwnershipByPreviousUnauthorized(t *testing.T) {
+	var o *Ownable
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		o = NewWithOrigin() // owned by alice
+	})
+
+	testing.SetRealm(testing.NewUserRealm(bob))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		uassert.ErrorContains(t, o.TransferOwnershipByPrevious(bob), ErrUnauthorized.Error())
+	})
+}
+
+func TestTransferOwnershipByPreviousInvalidAddress(t *testing.T) {
+	var o *Ownable
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		o = NewWithOrigin() // owned by alice
+	})
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	crossThrough(testing.NewCodeRealm("gno.land/r/test/test"), func() {
+		uassert.ErrorContains(t, o.TransferOwnershipByPrevious(""), ErrInvalidAddress.Error())
+	})
 }
 
 func TestOwnedByCurrent(t *testing.T) {


### PR DESCRIPTION
This PR adds `TransferOwnershipByPrevious(newOwner address)` to `gno.land/p/nt/ownable`.

Today `TransferOwnership` authorizes with `OwnedByCurrent()`. That works when the owner is the current realm, but it fails in a common realm-admin pattern where access is checked against the external caller (PreviousRealm()), e.g. public func X(cur realm, ...) entrypoints called by users.

TransferOwnershipByPrevious fixes that mismatch by authorizing with OwnedByPrevious() while keeping the same validation and event emission behavior as TransferOwnership.

## What changed

- Added TransferOwnershipByPrevious(newOwner address) error in examples/gno.land/p/nt/ownable/ownable.gno.
- Added tests.

## How to use
Use TransferOwnershipByPrevious in public realm methods where owner auth is based on the caller crossing into the realm:

```
func TransferOwnership(cur realm, newOwner address) {
  err := owner.TransferOwnershipByPrevious(newOwner)
    if err != nil {
          panic(err)
    }
}
```

Use existing TransferOwnership when ownership should be tied to CurrentRealm().