### PR TITLE
test(gno.land/pkg/integration): in testscript, convert a gnokey panic to an error

### DIFF
--- a/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
@@ -72,6 +72,9 @@ stdout 'OK!'
 ! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/guigui123/two -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test admin
 stderr 'is not authorized to deploy packages to namespace'
 
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/random!name/mypkg -gas-fee 1000000ugnot -gas-wanted 550000 -broadcast -chainid=tendermint_test gui
+stderr 'but got "gno.land/r/random!name/mypkg"'
+
 -- gnomod.toml --
 module = "gno.land/r/mypkg"
 gno = "0.9"

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -453,6 +453,21 @@ func gnokeyCmd(nodes *NodesManager) func(ts *testscript.TestScript, neg bool, ar
 
 		args = append(defaultArgs, args...)
 
+		defer func() {
+			if r := recover(); r != nil {
+				switch val := r.(type) {
+				case error:
+					err = val
+				case string:
+					err = fmt.Errorf("error: %s", val)
+				default:
+					err = fmt.Errorf("unknown error: %#v", val)
+				}
+
+				tsValidateError(ts, "gnokey", neg, err)
+			}
+		}()
+
 		err = cmd.ParseAndRun(context.Background(), args)
 		tsValidateError(ts, "gnokey", neg, err)
 	}


### PR DESCRIPTION
Consider the following txtar test (included in this PR):
```
! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/random!name/mypkg -gas-fee 1000000ugnot -gas-wanted 550000 -broadcast -chainid=tendermint_test gui
```
gnokey actually [panics in `Validate`](https://github.com/gnolang/gno/blob/ef3c685f3c22674e16810f9d488cb6d5d01e02f3/gnovm/pkg/gnolang/mempackage.go#L564) for the bad package name "random!name". (This check is done before sending the transaction.) The txtar `! gnokey` command only checks for an expected error, not a panic. This PR updates `gnokeyCmd` with a `defer` and `recover` to convert a panic to an error and to call `tsValidateError`. Now the test checks the expected error. (The logic for converting a panic to an error is the same [used in `gnodev`](https://github.com/gnolang/gno/blob/ef3c685f3c22674e16810f9d488cb6d5d01e02f3/contribs/gnodev/pkg/dev/node.go#L587-L602).)