### PR TITLE
fix(vm/keeper): ensure correct array lengths

### DIFF
--- a/gnovm/pkg/gnolang/op_exec.go
+++ b/gnovm/pkg/gnolang/op_exec.go
@@ -52,7 +52,9 @@ SelectStmt ->
 
 func (m *Machine) doOpExec(op Op) {
 	s := m.PeekStmt(1) // TODO: PeekStmt1()?
-	m.Lastline = s.GetLine()
+	if line := s.GetLine(); line != 0 {
+		m.Lastline = line
+	}
 	if debug {
 		debug.Printf("PEEK STMT: %v\n", s)
 		debug.Printf("%v\n", m)
@@ -146,6 +148,10 @@ func (m *Machine) doOpExec(op Op) {
 			var ll int
 			var dv *TypedValue
 			if op == OpRangeIterArrayPtr {
+				if xv.V == nil {
+					m.pushPanic(typedString("nil pointer dereference"))
+					return
+				}
 				dv = xv.V.(PointerValue).TV
 				*xv = *dv
 			} else {

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -102,6 +102,10 @@ func (m *Machine) doOpSlice() {
 	if xv.T.Kind() == PointerKind &&
 		xv.T.Elem().Kind() == ArrayKind {
 		// simply deref xv.
+		if xv.V == nil {
+			m.pushPanic(typedString("nil pointer dereference"))
+			return
+		}
 		*xv = xv.V.(PointerValue).Deref()
 		// check array also for ro.
 		if !ro {

--- a/gnovm/tests/files/ptr_array4.gno
+++ b/gnovm/tests/files/ptr_array4.gno
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	defer func() {
+		rec := recover()
+		if rec != nil {
+			println("recovered", rec)
+		}
+	}()
+	var p *[3]int
+	_ = p[0:1]
+}
+
+// Output:
+// recovered nil pointer dereference

--- a/gnovm/tests/files/ptr_array5.gno
+++ b/gnovm/tests/files/ptr_array5.gno
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+	defer func() {
+		rec := recover()
+		if rec != nil {
+			println("recovered", rec)
+		}
+	}()
+	var p *[3]int
+	for i, v := range p {
+		println(i, v)
+	}
+}
+
+// Output:
+// recovered nil pointer dereference


### PR DESCRIPTION
This PR fixes an incorrectness in the keeper which would accept any value size for array values. This would cause the GnoVM to have an array with a fixed size but with diverging results from `len()`, for loops and all such semantics.