### PR TITLE
fix(integration): store exec command

### DIFF
--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -158,6 +158,9 @@ func SetupGnolandTestscript(t *testing.T, p *testscript.Params) error {
 			env.Values[envKeyExecBin] = gnolandBin
 		}
 
+		// Store the resolved command kind so setupNode can read it later.
+		env.Values[envKeyExecCommand] = cmd
+
 		tmpdir, dbdir := t.TempDir(), t.TempDir()
 		gnoHomeDir := filepath.Join(tmpdir, "gno")
 


### PR DESCRIPTION
store correct `cmd` in  `envKeyExecCommand` in value exec key so setup integration is usable outside gno repo