### PR TITLE
fix(gnovm): don't panic on read index nil map

### DIFF
--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -14,13 +14,17 @@ func (m *Machine) doOpIndex1() {
 	ro := m.IsReadonly(xv)
 	switch ct := baseOf(xv.T).(type) {
 	case *MapType:
-		mv := xv.V.(*MapValue)
-		vv, exists := mv.GetValueForKey(m.Store, iv)
-		if exists {
-			*xv = vv // reuse as result
-		} else {
-			vt := ct.Value
+		vt := ct.Value
+		if xv.V == nil { // uninitialized map
 			*xv = defaultTypedValue(m.Alloc, vt) // reuse as result
+		} else {
+			mv := xv.V.(*MapValue)
+			vv, exists := mv.GetValueForKey(m.Store, iv)
+			if exists {
+				*xv = vv // reuse as result
+			} else {
+				*xv = defaultTypedValue(m.Alloc, vt) // reuse as result
+			}
 		}
 	default:
 		// NOTE: nilRealm is OK, not setting a map (w/ new key).

--- a/gnovm/tests/files/map45.gno
+++ b/gnovm/tests/files/map45.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	var m map[string]int
+	v := m["hello"]
+	println(v)
+}
+
+// Output:
+// 0


### PR DESCRIPTION
Reading from a nil map is valid in Go and just returns the zero value, but in Gno it panicked because the VM tried to cast the map value to *MapValue without checking for nil first. This adds a nil check before the cast so it returns the zero value instead, matching Go's behavior.