### PR TITLE
chore(gnovm): set gnovm toolchain according to go.mod

### DIFF
--- a/examples/gno.land/r/sys/validators/v2/gnosdk.gno
+++ b/examples/gno.land/r/sys/validators/v2/gnosdk.gno
@@ -1,16 +1,29 @@
 package validators
 
 import (
+	"math"
+
 	"gno.land/p/sys/validators"
 )
 
-// GetChanges returns the validator changes stored on the realm, since the given block number.
-// This function is intended to be called by gno.land through the GnoSDK
-func GetChanges(from int64) []validators.Validator {
+// GetChanges returns the validator changes stored on the realm,
+// for blocks in the [from, to] range (inclusive on both ends).
+// If to >= math.MaxInt64, it is clamped to math.MaxInt64-1 to avoid overflow.
+// Panics if from > to (after clamping).
+// This function is intended to be called by gno.land through the GnoSDK.
+func GetChanges(from, to int64) []validators.Validator {
+	if to > math.MaxInt64-1 {
+		to = math.MaxInt64 - 1
+	}
+	if to < from {
+		panic("invalid range: from must be <= to")
+	}
+
 	valsetChanges := make([]validators.Validator, 0)
 
-	// Gather the changes from the specified block
-	changes.Iterate(getBlockID(from), "", func(_ string, value any) bool {
+	// Gather the changes in the [from, to] block range.
+	// AVL Iterate uses an exclusive end, so we pass to+1.
+	changes.Iterate(getBlockID(from), getBlockID(to+1), func(_ string, value any) bool {
 		chs := value.([]change)
 
 		for _, ch := range chs {

--- a/examples/gno.land/r/sys/validators/v2/validators_test.gno
+++ b/examples/gno.land/r/sys/validators/v2/validators_test.gno
@@ -2,9 +2,11 @@ package validators
 
 import (
 	"chain/runtime"
+	"math"
 	"testing"
 
 	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/poa/v0"
 	"gno.land/p/nt/testutils/v0"
 	"gno.land/p/nt/uassert/v0"
 	"gno.land/p/nt/ufmt/v0"
@@ -49,7 +51,7 @@ func TestValidators_AddRemove(t *testing.T) {
 
 	for i := initialHeight; i < initialHeight+int64(len(vals)); i++ {
 		// Make sure the changes are saved
-		chs := GetChanges(i)
+		chs := GetChanges(i, initialHeight+int64(len(vals)))
 
 		// We use the funky index calculation to make sure
 		// changes are properly handled for each block span
@@ -83,7 +85,7 @@ func TestValidators_AddRemove(t *testing.T) {
 
 	for i := initialRemoveHeight; i < initialRemoveHeight+int64(len(vals)); i++ {
 		// Make sure the changes are saved
-		chs := GetChanges(i)
+		chs := GetChanges(i, initialRemoveHeight+int64(len(vals)))
 
 		// We use the funky index calculation to make sure
 		// changes are properly handled for each block span
@@ -98,4 +100,73 @@ func TestValidators_AddRemove(t *testing.T) {
 			uassert.Equal(t, uint64(0), ch.VotingPower)
 		}
 	}
+}
+
+// TestGetChanges_BoundedRange verifies that GetChanges(from, to) correctly
+// returns only changes within the [from, to] block range.
+func TestGetChanges_BoundedRange(t *testing.T) {
+	changes = avl.NewTree()
+	vp = poa.NewPoA()
+
+	vals := generateTestValidators(3)
+
+	// Store additions at block h1
+	h1 := runtime.ChainHeight()
+	for _, val := range vals {
+		addValidator(val)
+	}
+	testing.SkipHeights(1)
+
+	// Store removals at block h2
+	h2 := runtime.ChainHeight()
+	for _, val := range vals {
+		removeValidator(val.Address)
+	}
+	testing.SkipHeights(1)
+
+	// Query spanning both blocks returns all changes
+	all := GetChanges(h1, h2)
+	uassert.Equal(t, 6, len(all))
+
+	// Query for h1 only returns additions
+	atH1 := GetChanges(h1, h1)
+	uassert.Equal(t, 3, len(atH1))
+	for i, ch := range atH1 {
+		uassert.Equal(t, vals[i].Address, ch.Address)
+		uassert.True(t, ch.VotingPower > 0)
+	}
+
+	// Query for h2 only returns removals
+	atH2 := GetChanges(h2, h2)
+	uassert.Equal(t, 3, len(atH2))
+	for i, ch := range atH2 {
+		uassert.Equal(t, vals[i].Address, ch.Address)
+		uassert.Equal(t, uint64(0), ch.VotingPower)
+	}
+
+	// Query beyond stored range returns empty
+	uassert.Equal(t, 0, len(GetChanges(h2+1, h2+1)))
+}
+
+func TestGetChanges_PanicsOnInvalidRange(t *testing.T) {
+	uassert.PanicsWithMessage(t, "invalid range: from must be <= to", func() {
+		GetChanges(10, 5)
+	})
+}
+
+func TestGetChanges_ClampsMaxInt64(t *testing.T) {
+	changes = avl.NewTree()
+
+	vals := generateTestValidators(1)
+
+	// Simulate a validator change at block math.MaxInt64-1 (the boundary value).
+	changes.Set(getBlockID(math.MaxInt64-1), []change{
+		{blockNum: math.MaxInt64 - 1, validator: vals[0]},
+	})
+
+	// Passing math.MaxInt64 as "to" means "get all updates from here onwards".
+	// The clamp (to = MaxInt64-1) must still include the boundary block.
+	result := GetChanges(math.MaxInt64-1, math.MaxInt64)
+	uassert.Equal(t, 1, len(result))
+	uassert.Equal(t, vals[0].Address, result[0].Address)
 }

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -475,11 +475,12 @@ func EndBlocker(
 			return abci.ResponseEndBlock{}
 		}
 
-		// Run the VM to get the updates from the chain
+		// Run the VM to get the validator changes for the last committed block.
+		lastHeight := app.LastBlockHeight()
 		response, err := vmk.QueryEval(
 			ctx,
 			valRealm,
-			fmt.Sprintf("%s(%d)", valChangesFn, app.LastBlockHeight()),
+			fmt.Sprintf("%s(%d,%d)", valChangesFn, lastHeight, lastHeight),
 		)
 		if err != nil {
 			app.Logger().Error("unable to call VM during EndBlocker", "err", err)

--- a/misc/deployments/gnoland1/README.md
+++ b/misc/deployments/gnoland1/README.md
@@ -2,6 +2,19 @@
 
 Basic, tested instructions for joining the `gnoland1` network as a validator. Advanced operators may adapt these steps to their own infrastructure (Docker, systemd, etc.) at their discretion.
 
+## Prerequisites
+
+The following tools must be installed before proceeding:
+
+- **Go** — required to build node binaries
+- **make**
+- **curl**
+- **jq**
+- **python3**
+- **gzip**
+
+Hardware: at least **16 GB RAM** is recommended. Node startup temporarily exceeds 8 GB during genesis execution. See also the [dedicated gnops article](https://gnops.io/articles/effective-gnops/validator-specs/).
+
 ## 1. Generate the Genesis
 
 Every validator must produce the same `genesis.json`. Run from this directory:
@@ -38,16 +51,22 @@ cp config.toml gnoland-data/config/config.toml
 grep -n TODO gnoland-data/config/config.toml   # shows what to change
 ```
 
+Fields to update:
+
+- `moniker` — human-readable name for your node, e.g. `"myorg-val-01"`
+- `external_address` — your public IP/host for P2P, e.g. `"tcp://1.2.3.4:26656"`
+- `service_instance_id` — telemetry identifier, e.g. `"myorg-val-01"`
+
 ## 4. Start the Node
 
 ```shell
 gnoland start \
-  --skip-genesis-sig-verification \
-  --genesis genesis.json \
-  --data-dir gnoland-data
+  --skip-genesis-sig-verification
 ```
 
 The `--skip-genesis-sig-verification` flag is required (known incompatibility between genesis signatures and custom package metadata).
+
+`config.toml` already includes a persistent peer, so the node will connect to the network automatically on startup — no extra peering configuration needed.
 
 ## 5. Verify & Join
 
@@ -59,5 +78,12 @@ The `--skip-genesis-sig-verification` flag is required (known incompatibility be
    ```
 
 2. Confirm your node is syncing — `latest_block_height` should be increasing and eventually match [the network RPC](https://rpc.betanet.gno.land/status).
-3. Make sure your RPC endpoint is publicly reachable: `http(s)://<your-host>:26657/status`
-4. Ping the team on the validators Signal group so we can add you via a GovDAO proposal.
+3. Make sure both your RPC port (`26657`) and P2P port (`26656`) are publicly reachable: `http(s)://<your-host>:26657/status`
+4. Get your validator key info to share with the team:
+
+   ```shell
+   gnoland secrets get -raw validator_key.address
+   gnoland secrets get -raw validator_key.pub_key
+   ```
+
+5. Ping the team on the validators Signal group so we can add you via a GovDAO proposal. Include your validator address and public key from the step above.


### PR DESCRIPTION
This avoids inconsistent typecheck errors in the filetest process caused by version mismatches.