### PR TITLE
chore(vm/keeper): remove unnecessary XSS TODO comments in `QueryFile`

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1101,14 +1101,12 @@ func (vm *VMKeeper) QueryFile(ctx sdk.Context, filepath string) (res string, err
 	if filename != "" {
 		memFile := store.GetMemFile(dirpath, filename)
 		if memFile == nil {
-			// TODO: XSS protection
 			return "", errors.Wrapf(&InvalidFileError{}, "file %q is not available", filepath)
 		}
 		return memFile.Body, nil
 	} else {
 		memPkg := store.GetMemPackage(dirpath)
 		if memPkg == nil {
-			// TODO: XSS protection
 			return "", errors.Wrapf(&InvalidPackageError{}, "package %q is not available", dirpath)
 		}
 		for i, memfile := range memPkg.Files {


### PR DESCRIPTION
Close #5062

The TODO comments suggested XSS protection was needed for user-provided `filepath/dirpath` values in error messages. Tracing the consumers shows this is not exploitable: gnoweb replaces these errors with fixed sentinel errors before rendering, and Go's `html/template` auto-escapes all values.

ref:
- Go's `html/template` auto-escapes all interpolated values in the status page template (`components/views/status.html`).
- gnoweb's rpcClient.query() maps InvalidFileError and InvalidPackageError to fixed sentinel errors (`client.go:219,226`), discarding the original message before it reaches the HTTP layer.
- GetClientErrorStatusPage (`handler_http.go:709`) renders only hardcoded strings like "package not found" via StatusErrorComponent.
