### PR TITLE
WIP feat(crypto): raw-sign and raw-verify for gnokey; stdlibs/crypto/secp256k1

### DIFF
--- a/gno.land/pkg/keyscli/root.go
+++ b/gno.land/pkg/keyscli/root.go
@@ -1,4 +1,3 @@
-// Dedicated to my love, Lexi.
 package keyscli
 
 import (
@@ -47,6 +46,8 @@ func NewRootCmd(io commands.IO, base client.BaseOptions) *commands.Command {
 		client.NewListCmd(cfg, io),
 		client.NewSignCmd(cfg, io),
 		client.NewVerifyCmd(cfg, io),
+		client.NewRawSignCmd(cfg, io),
+		client.NewRawVerifyCmd(cfg, io),
 		client.NewQueryCmd(cfg, io),
 		client.NewBroadcastCmd(cfg, io),
 		client.NewMultisignCmd(cfg, io),

--- a/gnovm/stdlibs/crypto/secp256k1/secp256k1.gno
+++ b/gnovm/stdlibs/crypto/secp256k1/secp256k1.gno
@@ -1,0 +1,8 @@
+package secp256k1
+
+// Verify returns true if the signature is valid for the message and public key.
+func Verify(publicKey []byte, message []byte, signature []byte) bool {
+	return verify(publicKey, message, signature)
+}
+
+func verify(publicKey []byte, message []byte, signature []byte) bool // injected

--- a/gnovm/stdlibs/crypto/secp256k1/secp256k1.go
+++ b/gnovm/stdlibs/crypto/secp256k1/secp256k1.go
@@ -1,0 +1,18 @@
+package secp256k1
+
+import (
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto/secp256k1"
+)
+
+func X_verify(publicKey []byte, message []byte, signature []byte) bool {
+	if len(publicKey) != 33 {
+		panic(fmt.Sprintf(
+			"invalid public key length: expected 33, got %d",
+			len(publicKey)))
+	}
+	pub := secp256k1.PubKeySecp256k1{}
+	copy(pub[:], publicKey)
+	return pub.VerifyBytes(message, signature)
+}

--- a/gnovm/stdlibs/generated.go
+++ b/gnovm/stdlibs/generated.go
@@ -12,6 +12,7 @@ import (
 	libs_chain_params "github.com/gnolang/gno/gnovm/stdlibs/chain/params"
 	libs_chain_runtime "github.com/gnolang/gno/gnovm/stdlibs/chain/runtime"
 	libs_crypto_ed25519 "github.com/gnolang/gno/gnovm/stdlibs/crypto/ed25519"
+	libs_crypto_secp256k1 "github.com/gnolang/gno/gnovm/stdlibs/crypto/secp256k1"
 	libs_crypto_sha256 "github.com/gnolang/gno/gnovm/stdlibs/crypto/sha256"
 	libs_math "github.com/gnolang/gno/gnovm/stdlibs/math"
 	libs_runtime "github.com/gnolang/gno/gnovm/stdlibs/runtime"
@@ -769,6 +770,48 @@ var nativeFuncs = [...]NativeFunc{
 		},
 	},
 	{
+		"crypto/secp256k1",
+		"verify",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  []byte
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  []byte
+				rp2 = reflect.ValueOf(&p2).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+
+			r0 := libs_crypto_secp256k1.X_verify(p0, p1, p2)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+		},
+	},
+	{
 		"crypto/sha256",
 		"sum256",
 		[]gno.FieldTypeExpr{
@@ -1345,6 +1388,7 @@ var initOrder = [...]string{
 	"crypto/chacha20",
 	"crypto/chacha20/rand",
 	"crypto/ed25519",
+	"crypto/secp256k1",
 	"crypto/sha256",
 	"crypto/subtle",
 	"encoding",

--- a/tm2/pkg/crypto/keys/client/raw_sign.go
+++ b/tm2/pkg/crypto/keys/client/raw_sign.go
@@ -1,0 +1,195 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type RawSignCfg struct {
+	RootCfg *BaseCfg
+
+	PlainPath      string
+	PlainEncoding  string
+	OutputDocument string
+}
+
+func NewRawSignCmd(rootCfg *BaseCfg, io commands.IO) *commands.Command {
+	cfg := &RawSignCfg{
+		RootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "raw-sign",
+			ShortUsage: "raw-sign [flags] <key-name or address>",
+			ShortHelp:  "(UNSAFE) signs the given raw bytes. This command is for advanced users. Use the 'sign' command instead to sign transactions",
+		},
+		cfg,
+		func(_ context.Context, args []string) error {
+			return execRawSign(cfg, args, io)
+		},
+	)
+}
+
+func (c *RawSignCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.PlainPath,
+		"plain-path",
+		"",
+		"path to the plaintext file to sign",
+	)
+
+	fs.StringVar(
+		&c.PlainEncoding,
+		"plain-encoding",
+		"json",
+		"encoding of plaintext file: 'json' or 'hex'",
+	)
+
+	fs.StringVar(
+		&c.OutputDocument,
+		"output-document",
+		"",
+		"the signature json document to save. If empty, outputs the signature in the terminal",
+	)
+}
+
+func execRawSign(cfg *RawSignCfg, args []string, io commands.IO) error {
+	// Make sure the key name is provided
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	// saveSignature saves the given signature to the given path (Amino-encoded JSON)
+	saveSignature := func(signature *std.Signature, path string) error {
+		// Encode the signature
+		encodedSig, err := amino.MarshalJSON(signature)
+		if err != nil {
+			return fmt.Errorf("unable to marshal signature to JSON, %w", err)
+		}
+
+		// Save the signature
+		if err := os.WriteFile(path, encodedSig, 0o644); err != nil {
+			return fmt.Errorf("unable to write signature to %s, %w", path, err)
+		}
+
+		io.Printf("\nSignature generated and successfully saved to %s\n", path)
+
+		return nil
+	}
+
+	// Load the keybase
+	kb, err := keys.NewKeyBaseFromDir(cfg.RootCfg.Home)
+	if err != nil {
+		return fmt.Errorf("unable to load keybase, %w", err)
+	}
+
+	// Fetch the key info from the keybase
+	info, err := kb.GetByNameOrAddress(args[0])
+	if err != nil {
+		return fmt.Errorf("unable to get key from keybase, %w", err)
+	}
+
+	// Get the plaintext bytes
+	plainBytes, err := os.ReadFile(cfg.PlainPath)
+	if err != nil {
+		return fmt.Errorf("unable to read transaction file")
+	}
+
+	// Make sure there is something to actually sign
+	if len(plainBytes) == 0 {
+		return errInvalidTxFile
+	}
+
+	var signBytes []byte
+	if cfg.PlainEncoding == "json" {
+		// Make sure plainBytes is valid JSON
+		var plain any
+		if err := json.Unmarshal(plainBytes, &plain); err != nil {
+			return fmt.Errorf("plaintext is not valid JSON %w", err)
+		}
+		// Bytes to sign are the JSON bytes.
+		signBytes = plainBytes
+	} else if cfg.PlainEncoding == "hex" {
+		decoded, err := hex.DecodeString(string(plainBytes))
+		if err != nil {
+			return fmt.Errorf("plaintext is not valid HEX %w", err)
+		}
+		signBytes = decoded
+	} else {
+		panic("unrecognized plain-encoding; expected 'json' or 'hex'")
+	}
+
+	var password string
+
+	// Check if we need to get a decryption password.
+	// This is only required for local keys
+	if info.GetType() != keys.TypeLedger {
+		// Get the keybase decryption password
+		prompt := "Enter password to decrypt key"
+		if cfg.RootCfg.Quiet {
+			prompt = "" // No prompt
+		}
+
+		password, err = io.GetPassword(
+			prompt,
+			cfg.RootCfg.InsecurePasswordStdin,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to get decryption key, %w", err)
+		}
+	}
+
+	// Prepare the signature ops
+	kOpts := keyOpts{
+		keyName:     args[0],
+		decryptPass: password,
+	}
+
+	// Generate the signature
+	signature, err := generateRawSignature(signBytes, kb, kOpts)
+	if err != nil {
+		return fmt.Errorf("unable to sign transaction, %w", err)
+	}
+
+	if cfg.OutputDocument == "" {
+		io.Printf("signature hex: %X\n", signature.Signature)
+	} else {
+		// Don't save the signature in-place, separate it
+		return saveSignature(signature, cfg.OutputDocument)
+	}
+
+	return nil
+}
+
+// generateRawSignature generates a signature for the given sign bytes.
+func generateRawSignature(
+	signBytes []byte,
+	kb keys.Keybase,
+	keyOpts keyOpts,
+) (*std.Signature, error) {
+
+	// Sign the bytes.
+	sig, pub, err := kb.Sign(
+		keyOpts.keyName,
+		keyOpts.decryptPass,
+		signBytes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sign transaction bytes, %w", err)
+	}
+
+	return &std.Signature{
+		PubKey:    pub,
+		Signature: sig,
+	}, nil
+}

--- a/tm2/pkg/crypto/keys/client/raw_sign.go
+++ b/tm2/pkg/crypto/keys/client/raw_sign.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/commands"
@@ -118,7 +119,7 @@ func execRawSign(cfg *RawSignCfg, args []string, io commands.IO) error {
 			return fmt.Errorf("plaintext is not valid JSON %w", err)
 		}
 		// Bytes to sign are the JSON bytes.
-		signBytes = plainBytes
+		signBytes = []byte(strings.TrimSpace(string(plainBytes)))
 	} else if cfg.PlainEncoding == "hex" {
 		decoded, err := hex.DecodeString(string(plainBytes))
 		if err != nil {

--- a/tm2/pkg/crypto/keys/client/raw_verify.go
+++ b/tm2/pkg/crypto/keys/client/raw_verify.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+)
+
+type RawVerifyCfg struct {
+	RootCfg *BaseCfg
+
+	SigPath       string
+	PlainPath     string
+	PlainEncoding string
+}
+
+func NewRawVerifyCmd(rootCfg *BaseCfg, io commands.IO) *commands.Command {
+	cfg := &RawVerifyCfg{
+		RootCfg: rootCfg,
+	}
+
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "raw-verify",
+			ShortUsage: "raw-verify [flags] <key-name or address>",
+			ShortHelp:  "verifies the signature against raw plaintext bytes",
+			LongHelp:   "Verifies a signature (expressed as a HEX string) of raw plaintext bytes (expressed as HEX bytes or JSON bytes) with pubkey identified by <key-name or address> in your local keybase. This is for advanced users. If you want to verify a signature against a transaction it is better to use 'verify' instead.",
+		},
+		cfg,
+		func(ctx context.Context, args []string) error {
+			return execRawVerify(ctx, cfg, args, io)
+		},
+	)
+}
+
+func (c *RawVerifyCfg) RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(
+		&c.PlainPath,
+		"plain-path",
+		"",
+		"path of plaintext file to verify",
+	)
+	fs.StringVar(
+		&c.PlainEncoding,
+		"plain-encoding",
+		"json",
+		"encoding of plaintext file: 'json' or 'hex'",
+	)
+	fs.StringVar(
+		&c.SigPath,
+		"sig-path",
+		"",
+		"path of signature file of HEX bytes",
+	)
+}
+
+func execRawVerify(ctx context.Context, cfg *RawVerifyCfg, args []string, io commands.IO) error {
+	var (
+		kb  keys.Keybase
+		err error
+	)
+
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	// Fetch the key info from the keybase.
+	kb, err = keys.NewKeyBaseFromDir(cfg.RootCfg.Home)
+	if err != nil {
+		return err
+	}
+
+	info, err := kb.GetByNameOrAddress(args[0])
+	if err != nil {
+		return fmt.Errorf("unable to get key from keybase, %w", err)
+	}
+
+	// Get the plaintext bytes
+	plainBytes, err := os.ReadFile(cfg.PlainPath)
+	if err != nil {
+		return fmt.Errorf("unable to read transaction file")
+	}
+	if len(plainBytes) == 0 {
+		return errInvalidTxFile
+	}
+
+	// Decode sign (plaintext) bytes from plainBytes
+	var signBytes []byte
+	if cfg.PlainEncoding == "json" {
+		// Make sure plainBytes is valid JSON
+		var plain any
+		if err := json.Unmarshal(plainBytes, &plain); err != nil {
+			return fmt.Errorf("plaintext is not valid JSON %w", err)
+		}
+		// Bytes to verify are the JSON bytes.
+		signBytes = plainBytes
+	} else if cfg.PlainEncoding == "hex" {
+		decoded, err := hex.DecodeString(string(plainBytes))
+		if err != nil {
+			return fmt.Errorf("plaintext is not valid HEX %w", err)
+		}
+		signBytes = decoded
+	} else {
+		panic("unrecognized plain-encoding; expected 'json' or 'hex'")
+	}
+
+	// Get the signature bytes
+	sigRawBytes, err := os.ReadFile(cfg.SigPath)
+	if err != nil {
+		return fmt.Errorf("unable to read signature file")
+	}
+	sigRawBytes = []byte(strings.TrimSpace(string(sigRawBytes)))
+	if len(sigRawBytes) == 0 {
+		return fmt.Errorf("no signature found in the signature file")
+	}
+
+	// Decode signature bytes
+	sigBytes, err := hex.DecodeString(string(sigRawBytes))
+	if err != nil {
+		return fmt.Errorf("signature is not valid HEX %w", err)
+	}
+
+	// Verify signature against sign bytes
+	if err = kb.Verify(info.GetName(), signBytes, sigBytes); err != nil {
+		return fmt.Errorf("unable to verify signature: %w", err)
+	}
+
+	if !cfg.RootCfg.BaseOptions.Quiet {
+		io.Printf(
+			"Valid signature!\nSigning Address: %s\nPublic key: %s\nSignature: %s\n",
+			info.GetAddress(),
+			info.GetPubKey().String(),
+			base64.StdEncoding.EncodeToString(sigBytes),
+		)
+	}
+
+	return nil
+}

--- a/tm2/pkg/crypto/keys/client/raw_verify.go
+++ b/tm2/pkg/crypto/keys/client/raw_verify.go
@@ -101,7 +101,7 @@ func execRawVerify(ctx context.Context, cfg *RawVerifyCfg, args []string, io com
 			return fmt.Errorf("plaintext is not valid JSON %w", err)
 		}
 		// Bytes to verify are the JSON bytes.
-		signBytes = plainBytes
+		signBytes = []byte(strings.TrimSpace(string(plainBytes)))
 	} else if cfg.PlainEncoding == "hex" {
 		decoded, err := hex.DecodeString(string(plainBytes))
 		if err != nil {

--- a/tm2/pkg/crypto/keys/client/root.go
+++ b/tm2/pkg/crypto/keys/client/root.go
@@ -46,6 +46,8 @@ func NewRootCmdWithBaseConfig(io commands.IO, base BaseOptions) *commands.Comman
 		NewRotateCmd(cfg, io),
 		NewSignCmd(cfg, io),
 		NewVerifyCmd(cfg, io),
+		NewRawSignCmd(cfg, io),
+		NewRawVerifyCmd(cfg, io),
 		NewQueryCmd(cfg, io),
 		NewBroadcastCmd(cfg, io),
 		NewMakeTxCmd(cfg, io),

--- a/tm2/pkg/crypto/keys/client/verify.go
+++ b/tm2/pkg/crypto/keys/client/verify.go
@@ -37,7 +37,7 @@ func NewVerifyCmd(rootCfg *BaseCfg, io commands.IO) *commands.Command {
 			Name:       "verify",
 			ShortUsage: "verify [flags] <key-name or address>",
 			ShortHelp:  "verifies the transaction signature",
-			LongHelp:   "Verifies a signature of a <Amino JSON format transaction> against <key-name or address> in your local keybase. The sign bytes are derived from the tx using --chain-id, --account-number, and --account-sequence; these must match the values used when the signature was created. If --account-number, --account-sequence or --chain-id are not set, the command queries the chain (via --remote) to fill them; if the query fails, default values are used. Provide the signature via --sigpath; otherwise the first signature in the tx (tx.Signatures[0]) is used.",
+			LongHelp:   "Verifies a signature of a <Amino JSON format transaction> with pubkey identified by <key-name or address> in your local keybase. The sign bytes are derived from the tx using --chain-id, --account-number, and --account-sequence; these must match the values used when the signature was created. If --account-number, --account-sequence or --chain-id are not set, the command queries the chain (via --remote) to fill them; if the query fails, default values are used. Provide the signature via --sigpath; otherwise the first signature in the tx (tx.Signatures[0]) is used.",
 		},
 		cfg,
 		func(ctx context.Context, args []string) error {


### PR DESCRIPTION
Adding raw secp256k1 signing from gnokey and corresponding Gno side verification.
this will allow for more interesting gno apps where signatures are passed in as function args.
This is for a prototype I'm working on for (github) oauth oracles. --> better boards moderation as an example.
