### PR TITLE
fix(consensus): implement `RemovePeer` cleanup

### DIFF
--- a/tm2/pkg/bft/consensus/reactor.go
+++ b/tm2/pkg/bft/consensus/reactor.go
@@ -183,17 +183,27 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.PeerConn) {
 	}
 }
 
-// RemovePeer is a noop.
+// RemovePeer cleans up the peer's consensus state to prevent memory leaks
+// and stale peer tracking. The per-peer gossip goroutines will terminate
+// on their own via the peer.IsRunning() check, but we must still clean up
+// the PeerState to break reference cycles and release resources promptly.
 func (conR *ConsensusReactor) RemovePeer(peer p2p.PeerConn, reason any) {
 	if !conR.IsRunning() {
 		return
 	}
-	// TODO
-	// ps, ok := peer.Get(PeerStateKey).(*PeerState)
-	// if !ok {
-	// 	panic(fmt.Sprintf("Peer %v has no state", peer))
-	// }
-	// ps.Disconnect()
+
+	ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+	if !ok {
+		return
+	}
+
+	// Signal the PeerState that this peer has been removed.
+	ps.Disconnect()
+
+	// Clear the peer state from the peer's data store to break
+	// the reference cycle (peer -> PeerState -> peer) and allow
+	// the PeerState to be garbage collected promptly.
+	peer.Set(types.PeerStateKey, nil)
 }
 
 // Receive implements Reactor
@@ -455,7 +465,7 @@ func (conR *ConsensusReactor) gossipDataRoutine(peer p2p.PeerConn, ps *PeerState
 OUTER_LOOP:
 	for {
 		// Manage disconnects from self or peer.
-		if !peer.IsRunning() || !conR.IsRunning() {
+		if ps.IsDisconnected() || !peer.IsRunning() || !conR.IsRunning() {
 			logger.Info("Stopping gossipDataRoutine for peer")
 			return
 		}
@@ -595,7 +605,7 @@ func (conR *ConsensusReactor) gossipVotesRoutine(peer p2p.PeerConn, ps *PeerStat
 OUTER_LOOP:
 	for {
 		// Manage disconnects from self or peer.
-		if !peer.IsRunning() || !conR.IsRunning() {
+		if ps.IsDisconnected() || !peer.IsRunning() || !conR.IsRunning() {
 			logger.Info("Stopping gossipVotesRoutine for peer")
 			return
 		}
@@ -719,7 +729,7 @@ func (conR *ConsensusReactor) queryMaj23Routine(peer p2p.PeerConn, ps *PeerState
 OUTER_LOOP:
 	for {
 		// Manage disconnects from self or peer.
-		if !peer.IsRunning() || !conR.IsRunning() {
+		if ps.IsDisconnected() || !peer.IsRunning() || !conR.IsRunning() {
 			logger.Info("Stopping queryMaj23Routine for peer")
 			return
 		}
@@ -884,6 +894,9 @@ type PeerState struct {
 	peer   p2p.PeerConn
 	logger *slog.Logger
 
+	closer   chan struct{} // closed when the peer is removed
+	closerMu sync.Once     // ensures closer is closed exactly once
+
 	mtx sync.Mutex // NOTE: Modify below using setters, never directly.
 	cstypes.PeerStateExposed
 }
@@ -893,6 +906,7 @@ func NewPeerState(peer p2p.PeerConn) *PeerState {
 	return &PeerState{
 		peer:   peer,
 		logger: log.NewNoopLogger(),
+		closer: make(chan struct{}),
 		PeerStateExposed: cstypes.PeerStateExposed{
 			PRS: cstypes.PeerRoundState{
 				Round:              -1,
@@ -910,6 +924,25 @@ func NewPeerState(peer p2p.PeerConn) *PeerState {
 func (ps *PeerState) SetLogger(logger *slog.Logger) *PeerState {
 	ps.logger = logger
 	return ps
+}
+
+// Disconnect signals that this peer has been removed. It is safe to call
+// multiple times. After Disconnect is called, IsDisconnected returns true
+// and the Closer channel is closed.
+func (ps *PeerState) Disconnect() {
+	ps.closerMu.Do(func() {
+		close(ps.closer)
+	})
+}
+
+// IsDisconnected returns true if the peer has been removed.
+func (ps *PeerState) IsDisconnected() bool {
+	select {
+	case <-ps.closer:
+		return true
+	default:
+		return false
+	}
 }
 
 // GetRoundState returns an shallow copy of the PeerRoundState.

--- a/tm2/pkg/bft/consensus/reactor_test.go
+++ b/tm2/pkg/bft/consensus/reactor_test.go
@@ -876,3 +876,52 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 		})
 	}
 }
+
+// -------------------------------------------------------------
+// PeerState disconnect tests
+
+func TestPeerStateDisconnect(t *testing.T) {
+	t.Parallel()
+
+	peer := p2pTesting.NewPeer(t)
+	ps := NewPeerState(peer).SetLogger(log.NewNoopLogger())
+
+	// Initially not disconnected
+	assert.False(t, ps.IsDisconnected())
+
+	// After Disconnect, IsDisconnected returns true
+	ps.Disconnect()
+	assert.True(t, ps.IsDisconnected())
+
+	// Calling Disconnect again should not panic
+	assert.NotPanics(t, func() {
+		ps.Disconnect()
+	})
+	assert.True(t, ps.IsDisconnected())
+}
+
+func TestRemovePeerCleansUpState(t *testing.T) {
+	t.Parallel()
+
+	N := 1
+	css, cleanup := randConsensusNet(N, "consensus_remove_peer_test", newMockTickerFunc(true), newCounter)
+	defer cleanup()
+	reactors, _, eventSwitches, p2pSwitches := startConsensusNet(t, css, N)
+	defer stopConsensusNet(log.NewTestingLogger(t), reactors, eventSwitches, p2pSwitches)
+
+	reactor := reactors[0]
+	peer := p2pTesting.NewPeer(t)
+
+	// InitPeer + AddPeer to set up PeerState
+	reactor.InitPeer(peer)
+	ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+	assert.True(t, ok)
+	assert.NotNil(t, ps)
+	assert.False(t, ps.IsDisconnected())
+
+	// RemovePeer should signal disconnect and clear the peer state key
+	reactor.RemovePeer(peer, "test removal")
+
+	assert.True(t, ps.IsDisconnected())
+	assert.Nil(t, peer.Get(types.PeerStateKey))
+}


### PR DESCRIPTION
`RemovePeer` was a noop. Implementation to disconnect the peer and clean up `PeerState`.