### PR TITLE
WIP feat(auth): multi-denomination gas fees

### DIFF
--- a/contribs/gnogenesis/internal/params/params_set.go
+++ b/contribs/gnogenesis/internal/params/params_set.go
@@ -157,13 +157,13 @@ func saveStringToValue(vals []string, dstValue reflect.Value) error {
 		}
 		dstValue.Set(reflect.ValueOf(addrs))
 
-	case std.GasPrice:
-		gas, err := std.ParseGasPrice(vals[0])
+	case []std.GasPrice:
+		gasPrices, err := std.ParseGasPrices(vals[0])
 		if err != nil {
-			return fmt.Errorf("unable to parse gas price %q: %w", vals[0], err)
+			return fmt.Errorf("unable to parse gas prices %q: %w", vals[0], err)
 		}
 
-		dstValue.Set(reflect.ValueOf(gas))
+		dstValue.Set(reflect.ValueOf(gasPrices))
 	case time.Duration:
 		d, err := time.ParseDuration(vals[0])
 		if err != nil {

--- a/contribs/gnogenesis/internal/params/params_set_test.go
+++ b/contribs/gnogenesis/internal/params/params_set_test.go
@@ -167,15 +167,15 @@ func TestParamsSetCmd(t *testing.T) {
 		assert.Equal(t, int64(4096), state.Auth.Params.MaxMemoBytes)
 	})
 
-	t.Run("set gas price field", func(t *testing.T) {
+	t.Run("set gas prices field", func(t *testing.T) {
 		t.Parallel()
 		tempGenesis, cleanup := testutils.NewTestFile(t)
 		t.Cleanup(cleanup)
 
 		genesis := common.DefaultGenesis()
 		appState := genesis.AppState.(gnoland.GnoGenesisState)
-		appState.Auth.Params.InitialGasPrice = std.GasPrice{
-			Gas: 10, Price: std.MustParseCoin("3ugnot"),
+		appState.Auth.Params.InitialGasPrices = []std.GasPrice{
+			{Gas: 10, Price: std.MustParseCoin("3ugnot")},
 		}
 		genesis.AppState = appState
 		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
@@ -186,18 +186,17 @@ func TestParamsSetCmd(t *testing.T) {
 		io := commands.NewTestIO()
 		cmd := newParamsSetCmd(cfg, io)
 
-		newGas := std.GasPrice{
-			Gas: 2000, Price: std.MustParseCoin("400ugnot"),
-		}
+		newGasPrices := "400ugnot/2000gas;200uphoton/1000gas"
 
-		args := []string{"auth.initial_gasprice", newGas.String()}
+		args := []string{"auth.initial_gasprices", newGasPrices}
 		err := cmd.ParseAndRun(context.Background(), args)
 		require.NoError(t, err)
 
 		updated, err := types.GenesisDocFromFile(tempGenesis.Name())
 		require.NoError(t, err)
 		state := updated.AppState.(gnoland.GnoGenesisState)
-		assert.Equal(t, newGas, state.Auth.Params.InitialGasPrice)
+		expected, _ := std.ParseGasPrices(newGasPrices)
+		assert.Equal(t, expected, state.Auth.Params.InitialGasPrices)
 	})
 
 	t.Run("invalid type", func(t *testing.T) {

--- a/gno.land/adr/adr-001-photon-gas-fees.md
+++ b/gno.land/adr/adr-001-photon-gas-fees.md
@@ -1,0 +1,60 @@
+# ADR-001: $PHOTON Gas Fees for gno.land Launch
+
+## Status
+
+Implemented
+
+## Context
+
+At gno.land launch, $GNOT will be non-transferrable. However, through ICS (Interchain Security) with atom.one, $PHOTON will be transferrable via IBC. Users who bridge $PHOTON to gno.land need a way to submit transactions without holding $GNOT.
+
+## Decision
+
+Use the tm2 multi-denomination gas fee support (see [tm2/adr/adr-001-multi-denom-gas-fees.md](../../tm2/adr/adr-001-multi-denom-gas-fees.md)) to accept $PHOTON as a gas fee token alongside $GNOT.
+
+### Genesis Configuration
+
+The default genesis gas prices are configured in `gno.land/pkg/gnoland/genesis.go`. For launch, this should include both ugnot and uphoton:
+```
+"1ugnot/1000gas;1uphoton/1000gas"
+```
+
+The `gnogenesis` CLI tool supports setting gas prices in the genesis file:
+```
+gnogenesis params set auth.initial_gasprices "1ugnot/1000gas;1uphoton/1000gas"
+```
+
+### Node Operator Requirements
+
+Node operators must configure `--min-gas-prices` to include all accepted denominations. For example:
+```
+--min-gas-prices "1ugnot/1000gas;1uphoton/1000gas"
+```
+
+Nodes that only configure ugnot will reject transactions paying in uphoton at the mempool level.
+
+### Limitations at Launch
+
+- **Gas fees**: $PHOTON holders can pay gas fees. This is what this ADR addresses.
+- **Storage deposits**: Realm deployment and package additions charge per-byte storage deposits in ugnot only. $PHOTON-only users cannot deploy realms until they acquire $GNOT.
+
+### Post-Launch: GnoSwap Integration
+
+After launch, whitelisting GnoSwap (Onbloc's AMM DEX) pool addresses and seeding $GNOT liquidity will allow $PHOTON holders to swap PHOTON for GNOT and become full gno.land users. This is outside the scope of this ADR.
+
+## Consequences
+
+### Positive
+
+- $PHOTON holders can submit transactions on gno.land at launch without needing $GNOT.
+- Additional IBC denominations can be added via governance without code changes.
+
+### Negative
+
+- $PHOTON-only users cannot deploy realms or add packages until they acquire $GNOT (via GnoSwap post-launch).
+- Node operators need to update their configuration to include uphoton in `--min-gas-prices`.
+
+## References
+
+- [tm2/adr/adr-001-multi-denom-gas-fees.md](../../tm2/adr/adr-001-multi-denom-gas-fees.md) — tm2 protocol-level multi-denom gas fee support
+- [GnoSwap](https://gnoswap.io) — planned PHOTON/GNOT swap venue post-launch

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -132,8 +132,8 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 		func(ctx sdk.Context, tx std.Tx, simulate bool) (
 			newCtx sdk.Context, res sdk.Result, abort bool,
 		) {
-			// Add last gas price in the context
-			ctx = ctx.WithValue(auth.GasPriceContextKey{}, gpk.LastGasPrice(ctx))
+			// Add last gas prices for all accepted fee denominations
+			ctx = ctx.WithValue(auth.GasPriceContextKey{}, gpk.LastGasPrices(ctx))
 			// Override auth params.
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
 
@@ -388,7 +388,7 @@ func (cfg InitChainerConfig) loadAppState(ctx sdk.Context, appState any) ([]abci
 
 	params := cfg.acck.GetParams(ctx)
 	ctx = ctx.WithValue(auth.AuthParamsContextKey{}, params)
-	auth.InitChainer(ctx, cfg.gpk, params.InitialGasPrice)
+	auth.InitChainer(ctx, cfg.gpk, params.InitialGasPrices)
 
 	// Replay genesis txs.
 	txResponses := make([]abci.ResponseDeliverTx, 0, len(state.Txs))
@@ -460,8 +460,8 @@ func EndBlocker(
 	req abci.RequestEndBlock,
 ) abci.ResponseEndBlock {
 	return func(ctx sdk.Context, _ abci.RequestEndBlock) abci.ResponseEndBlock {
-		// set the auth params value in the ctx.  The EndBlocker will use InitialGasPrice in
-		// the params to calculate the updated gas price.
+		// set the auth params value in the ctx.  The EndBlocker will use InitialGasPrices in
+		// the params to calculate the updated gas prices for each accepted fee denom.
 		if acck != nil {
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
 		}

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -1014,7 +1014,7 @@ func TestGasPriceUpdate(t *testing.T) {
 	replayBlock(t, baseApp, 8000, 4)
 	replayBlock(t, baseApp, 6000, 5)
 
-	key := []byte("gasPrice")
+	key := []byte("gasPrice:ugnot")
 	query := abci.RequestQuery{
 		Path: ".store/main/key",
 		Data: key,
@@ -1082,8 +1082,8 @@ func newGasPriceTestApp(t *testing.T) abci.Application {
 		func(ctx sdk.Context, tx std.Tx, simulate bool) (
 			newCtx sdk.Context, res sdk.Result, abort bool,
 		) {
-			// Add last gas price in the context
-			ctx = ctx.WithValue(auth.GasPriceContextKey{}, gpk.LastGasPrice(ctx))
+			// Add last gas prices for all accepted fee denominations
+			ctx = ctx.WithValue(auth.GasPriceContextKey{}, gpk.LastGasPrices(ctx))
 
 			// Override auth params.
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
@@ -1178,10 +1178,10 @@ func gnoGenesisState(t *testing.T) GnoGenesisState {
     "auth": {
       "params": {
         "gas_price_change_compressor": "8",
-        "initial_gasprice": {
+        "initial_gasprices": [{
           "gas": "1000",
           "price": "100ugnot"
-        },
+        }],
         "max_memo_bytes": "65536",
         "sig_verify_cost_ed25519": "590",
         "sig_verify_cost_secp256k1": "1000",

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
-const initGasPrice = "1ugnot/1000gas"
+const initGasPrices = "1ugnot/1000gas"
 
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) (Balances, error) {
@@ -245,11 +245,11 @@ func LoadPackage(mpkg *std.MemPackage, creator bft.Address, fee std.Fee, deposit
 
 func DefaultGenState() GnoGenesisState {
 	authGen := auth.DefaultGenesisState()
-	gp, err := std.ParseGasPrice(initGasPrice)
+	gps, err := std.ParseGasPrices(initGasPrices)
 	if err != nil {
 		panic(err)
 	}
-	authGen.Params.InitialGasPrice = gp
+	authGen.Params.InitialGasPrices = gps
 
 	gs := GnoGenesisState{
 		Balances: []Balance{},

--- a/gno.land/pkg/gnoland/mock_test.go
+++ b/gno.land/pkg/gnoland/mock_test.go
@@ -190,7 +190,7 @@ func (m *mockParamsKeeper) SetAny(ctx sdk.Context, key string, value any) {}
 
 type mockGasPriceKeeper struct{}
 
-func (m *mockGasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice    { return std.GasPrice{} }
+func (m *mockGasPriceKeeper) LastGasPrices(ctx sdk.Context) []std.GasPrice { return nil }
 func (m *mockGasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {}
 func (m *mockGasPriceKeeper) UpdateGasPrice(ctx sdk.Context)               {}
 

--- a/gno.land/pkg/integration/node_testing.go
+++ b/gno.land/pkg/integration/node_testing.go
@@ -105,7 +105,7 @@ func TestingMinimalNodeConfig(gnoroot string) *gnoland.InMemoryNodeConfig {
 func DefaultTestingGenesisConfig(gnoroot string, self crypto.PubKey, tmconfig *tmcfg.Config) *bft.GenesisDoc {
 	authGen := auth.DefaultGenesisState()
 	authGen.Params.UnrestrictedAddrs = []crypto.Address{crypto.MustAddressFromString(DefaultAccount_Address)}
-	authGen.Params.InitialGasPrice = std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	authGen.Params.InitialGasPrices = []std.GasPrice{{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}}
 	genState := gnoland.DefaultGenState()
 	genState.Balances = []gnoland.Balance{
 		{

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -198,7 +198,7 @@ func SetupGnolandTestscript(t *testing.T, p *testscript.Params) error {
 
 		genesis := gnoland.DefaultGenState()
 		genesis.Balances = LoadDefaultGenesisBalanceFile(t, gnoRootDir)
-		genesis.Auth.Params.InitialGasPrice = std.GasPrice{Gas: 0, Price: std.Coin{Amount: 0, Denom: "ugnot"}}
+		genesis.Auth.Params.InitialGasPrices = []std.GasPrice{{Gas: 0, Price: std.Coin{Amount: 0, Denom: "ugnot"}}}
 		genesis.Txs = []gnoland.TxWithMetadata{}
 		LoadDefaultGenesisParamFile(t, gnoRootDir, &genesis)
 

--- a/tm2/adr/adr-001-multi-denom-gas-fees.md
+++ b/tm2/adr/adr-001-multi-denom-gas-fees.md
@@ -1,0 +1,80 @@
+# ADR-001: Multi-Denomination Gas Fees
+
+## Status
+
+Implemented
+
+## Context
+
+The `auth` module's `GasPriceKeeper` supports only a single gas fee denomination. This limits chains built on tm2 to accepting fees in one token. Chains that accept multiple tokens via IBC or other mechanisms have no way to let users pay gas fees in those tokens.
+
+## Decision
+
+Extend the `auth` module to support multiple fee denominations. Each denomination has its own independently tracked and dynamically adjusted gas price.
+
+### Storage
+
+Gas prices are stored per-denom using a prefix key:
+```
+GasPriceKeyPrefix = "gasPrice:"   // e.g. "gasPrice:ugnot", "gasPrice:uphoton"
+```
+
+### Parameters
+
+`InitialGasPrices []std.GasPrice` replaces the former singular `InitialGasPrice`. This defines:
+- Which denominations are accepted for gas fees
+- The floor price for each denom (dynamic price cannot drop below this)
+
+Validation rejects duplicate denoms, empty denoms, and non-positive gas values.
+
+### GasPriceKeeper
+
+- `SetGasPrice(ctx, gp)`: Stores a gas price keyed by `gasPrice:<denom>`.
+- `LastGasPrices(ctx) []std.GasPrice`: Returns all tracked denoms via prefix iterator.
+- `UpdateGasPrice(ctx)`: Called in EndBlock. First seeds any new denoms from `InitialGasPrices` that aren't yet in the store, then adjusts each existing denom's price independently using the EIP-1559-inspired formula: `newPrice = lastPrice + lastPrice*(gasUsed - targetGas) / (targetGas * compressor)`.
+
+New denoms added to `InitialGasPrices` via governance are seeded before the `gasUsed > 0` guard, so they become active immediately on the next EndBlock regardless of whether the block has transactions.
+
+### Ante Handler
+
+`EnsureSufficientMempoolFees` finds the matching denom in the block gas prices slice and checks that the transaction's fee meets or exceeds it. Then checks the node's `minGasPrices` as before.
+
+Transactions must pass both the consensus-level block gas price (per-denom) and the node's local `minGasPrices` config. Node operators must configure `minGasPrices` for all accepted denoms.
+
+### Genesis
+
+`InitChainer` accepts `[]std.GasPrice` and seeds each into the `GasPriceKeeper` store.
+
+### Gas Price Format
+
+Gas prices use the existing multi-denom format supported by `std.ParseGasPrices`:
+```
+"1ugnot/1000gas;1uphoton/1000gas"
+```
+
+### Design Properties
+
+- **Independent price tracking**: Each denom has its own store entry and adjusts independently.
+- **Shared gas pressure**: All denoms see the same block gas usage signal. If a block is full, prices rise for all denoms regardless of which denom was used to pay. Block space is fungible.
+- **Governance-extensible**: New denominations can be added post-genesis by updating `InitialGasPrices`. The `GasPriceKeeper` automatically seeds new denoms on the next EndBlock.
+- **Denom removal**: Removing a denom from `InitialGasPrices` removes its price floor, allowing it to decay toward zero over time. The store entry persists. Full removal would require a `DeleteGasPrice` mechanism if needed in the future.
+
+## Consequences
+
+### Positive
+
+- Chains built on tm2 can accept gas fees in any number of denominations.
+- Each denom's price adjusts independently, preventing any single denom from being artificially cheap.
+- Minimal code change surface — the core formula and ante handler logic are preserved.
+
+### Negative
+
+- Node operators must configure `minGasPrices` for all accepted denominations.
+- All denoms share the same gas pressure signal, which could feel unintuitive.
+
+## References
+
+- [PR #2838: Dynamic gas price keeper](https://github.com/gnolang/gno/pull/2838) — original single-denom implementation
+- `std.ParseGasPrices` — existing multi-denom format parser
+- EIP-1559 — inspiration for the dynamic gas price adjustment formula
+- [gno.land/adr/adr-001-photon-gas-fees.md](../../gno.land/adr/adr-001-photon-gas-fees.md) — gno.land-specific application of this feature

--- a/tm2/pkg/sdk/auth/abci.go
+++ b/tm2/pkg/sdk/auth/abci.go
@@ -11,9 +11,10 @@ func EndBlocker(ctx sdk.Context, gk GasPriceKeeperI) {
 	gk.UpdateGasPrice(ctx)
 }
 
-// InitChainer is called in the InitChain(), it set the initial gas price in the
-// GasPriceKeeper store
-// for the next gas price
-func InitChainer(ctx sdk.Context, gk GasPriceKeeperI, gp std.GasPrice) {
-	gk.SetGasPrice(ctx, gp)
+// InitChainer is called in the InitChain(), it sets the initial gas prices
+// for all accepted fee denominations in the GasPriceKeeper store.
+func InitChainer(ctx sdk.Context, gk GasPriceKeeperI, gps []std.GasPrice) {
+	for _, gp := range gps {
+		gk.SetGasPrice(ctx, gp)
+	}
 }

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -339,7 +339,7 @@ func DeductFees(bk BankKeeperI, ctx sdk.Context, acc std.Account, collector cryp
 // consensus.
 func EnsureSufficientMempoolFees(ctx sdk.Context, fee std.Fee) sdk.Result {
 	minGasPrices := ctx.MinGasPrices()
-	blockGasPrice := ctx.Value(GasPriceContextKey{}).(std.GasPrice)
+	blockGasPrices := ctx.Value(GasPriceContextKey{}).([]std.GasPrice)
 	feeGasPrice := std.GasPrice{
 		Gas: fee.GasWanted,
 		Price: std.Coin{
@@ -347,21 +347,27 @@ func EnsureSufficientMempoolFees(ctx sdk.Context, fee std.Fee) sdk.Result {
 			Denom:  fee.GasFee.Denom,
 		},
 	}
-	// check the block gas price
-	if blockGasPrice.Price.IsValid() && !blockGasPrice.Price.IsZero() {
-		ok, err := feeGasPrice.IsGTE(blockGasPrice)
-		if err != nil {
-			return abciResult(std.ErrInsufficientFee(
-				err.Error(),
-			))
+	// check the block gas price for the fee's denom
+	for _, blockGasPrice := range blockGasPrices {
+		if blockGasPrice.Price.Denom != fee.GasFee.Denom {
+			continue
 		}
-		if !ok {
-			return abciResult(std.ErrInsufficientFee(
-				fmt.Sprintf(
-					"insufficient fees; got: {Gas-Wanted: %d, Gas-Fee %s}, fee required: %+v as block gas price", feeGasPrice.Gas, feeGasPrice.Price, blockGasPrice,
-				),
-			))
+		if blockGasPrice.Price.IsValid() && !blockGasPrice.Price.IsZero() {
+			ok, err := feeGasPrice.IsGTE(blockGasPrice)
+			if err != nil {
+				return abciResult(std.ErrInsufficientFee(
+					err.Error(),
+				))
+			}
+			if !ok {
+				return abciResult(std.ErrInsufficientFee(
+					fmt.Sprintf(
+						"insufficient fees; got: {Gas-Wanted: %d, Gas-Fee %s}, fee required: %+v as block gas price", feeGasPrice.Gas, feeGasPrice.Price, blockGasPrice,
+					),
+				))
+			}
 		}
+		break
 	}
 	// check min gas price set by the node.
 	if len(minGasPrices) == 0 {

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -813,7 +813,7 @@ func TestEnsureSufficientMempoolFees(t *testing.T) {
 		{std.NewFee(200000, std.NewCoin("atom", 5)), false},
 	}
 	// Do not set the block gas price
-	ctx = ctx.WithValue(GasPriceContextKey{}, std.GasPrice{})
+	ctx = ctx.WithValue(GasPriceContextKey{}, []std.GasPrice{})
 
 	for i, tc := range testCases {
 		res := EnsureSufficientMempoolFees(ctx, tc.input)
@@ -912,7 +912,7 @@ func TestEnsureBlockGasPrice(t *testing.T) {
 		ctx = ctx.WithMinGasPrices(
 			[]std.GasPrice{c.minGasPrice},
 		)
-		ctx = ctx.WithValue(GasPriceContextKey{}, c.blockGasPrice)
+		ctx = ctx.WithValue(GasPriceContextKey{}, []std.GasPrice{c.blockGasPrice})
 
 		res := EnsureSufficientMempoolFees(ctx, c.input)
 		require.Equal(
@@ -939,12 +939,12 @@ func TestInvalidUserFee(t *testing.T) {
 	ctx = ctx.WithMinGasPrices(
 		[]std.GasPrice{minGasPrice},
 	)
-	ctx = ctx.WithValue(GasPriceContextKey{}, blockGasPrice)
+	ctx = ctx.WithValue(GasPriceContextKey{}, []std.GasPrice{blockGasPrice})
 	res1 := EnsureSufficientMempoolFees(ctx, userFee1)
 	require.False(t, res1.IsOK())
 	assert.Contains(t, res1.Log, "GasPrice.Gas cannot be zero;")
 
 	res2 := EnsureSufficientMempoolFees(ctx, userFee2)
 	require.False(t, res2.IsOK())
-	assert.Contains(t, res2.Log, "Gas price denominations should be equal;")
+	assert.Contains(t, res2.Log, "insufficient fees")
 }

--- a/tm2/pkg/sdk/auth/consts.go
+++ b/tm2/pkg/sdk/auth/consts.go
@@ -16,8 +16,9 @@ const (
 
 	// AddressStoreKeyPrefix prefix for account-by-address store
 	AddressStoreKeyPrefix = "/a/"
-	// key for gas price
-	GasPriceKey = "gasPrice"
+	// prefix for per-denom gas price keys (e.g. "gasPrice:ugnot").
+	// See tm2/adr/adr-001-multi-denom-gas-fees.md.
+	GasPriceKeyPrefix = "gasPrice:"
 	// param key for global account number
 	GlobalAccountNumberKey = "globalAccountNumber"
 )

--- a/tm2/pkg/sdk/auth/handler.go
+++ b/tm2/pkg/sdk/auth/handler.go
@@ -79,11 +79,10 @@ func (ah authHandler) queryAccount(ctx sdk.Context, req abci.RequestQuery) (res 
 	return
 }
 
-// queryGasPrice fetch a gas price of the last block.
+// queryGasPrice fetches gas prices for all accepted denominations from the last block.
 func (ah authHandler) queryGasPrice(ctx sdk.Context, req abci.RequestQuery) (res abci.ResponseQuery) {
-	// get account from addr.
 	bz, err := amino.MarshalJSONIndent(
-		ah.gpKpr.LastGasPrice(ctx),
+		ah.gpKpr.LastGasPrices(ctx),
 		"", "  ")
 	if err != nil {
 		res = sdk.ABCIResponseQueryFromError(

--- a/tm2/pkg/sdk/auth/handler_test.go
+++ b/tm2/pkg/sdk/auth/handler_test.go
@@ -81,12 +81,13 @@ func TestQueryGasPrice(t *testing.T) {
 	}
 	env.gk.SetGasPrice(env.ctx, gp)
 
-	var gp2 std.GasPrice
+	var gps []std.GasPrice
 	res = h.Query(env.ctx, req)
 	require.Nil(t, res.Error)
 	require.NotNil(t, res)
-	require.NoError(t, amino.UnmarshalJSON(res.Data, &gp2))
-	require.True(t, gp == gp2)
+	require.NoError(t, amino.UnmarshalJSON(res.Data, &gps))
+	require.Len(t, gps, 1)
+	require.True(t, gp == gps[0])
 }
 
 func TestQuerierRouteNotFound(t *testing.T) {

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -177,16 +177,17 @@ type GasPriceKeeper struct {
 	key store.StoreKey
 }
 
-// GasPriceKeeper
-// The GasPriceKeeper stores the history of gas prices and calculates
-// new gas price with formula parameters
+// NewGasPriceKeeper creates a new GasPriceKeeper.
+// The GasPriceKeeper stores per-denom gas prices and adjusts them each block
+// based on gas usage. See tm2/adr/adr-001-multi-denom-gas-fees.md.
 func NewGasPriceKeeper(key store.StoreKey) GasPriceKeeper {
 	return GasPriceKeeper{
 		key: key,
 	}
 }
 
-// SetGasPrice is called in InitChainer to store initial gas price set in the genesis
+// SetGasPrice stores the gas price for a specific denomination.
+// The price is keyed by denom so multiple denominations can be tracked independently.
 func (gk GasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {
 	if (gp == std.GasPrice{}) {
 		return
@@ -196,14 +197,24 @@ func (gk GasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {
 	if err != nil {
 		panic(err)
 	}
-	stor.Set([]byte(GasPriceKey), bz)
+	stor.Set([]byte(GasPriceKeyPrefix+gp.Price.Denom), bz)
 }
 
-// We store the history. If the formula changes, we can replay blocks
-// and apply the formula to a specific block range. The new gas price is
-// calculated in EndBlock().
+// UpdateGasPrice adjusts gas prices for all tracked denominations based on
+// block gas usage. Each denom is adjusted independently using the same formula.
+// Called in EndBlock().
 func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 	params := ctx.Value(AuthParamsContextKey{}).(Params)
+
+	// Seed any new denoms from InitialGasPrices that aren't yet tracked.
+	// This handles denoms added via governance after genesis.
+	existing := gk.LastGasPrices(ctx)
+	for _, igp := range params.InitialGasPrices {
+		if findGasPrice(existing, igp.Price.Denom) == nil {
+			gk.SetGasPrice(ctx, igp)
+		}
+	}
+
 	gasUsed := ctx.BlockGasMeter().GasConsumed()
 
 	// Only update gas price if gas was consumed to avoid changing AppHash
@@ -213,14 +224,16 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 	}
 
 	maxBlockGas := ctx.ConsensusParams().Block.MaxGas
-	lgp := gk.LastGasPrice(ctx)
-	newGasPrice := gk.calcBlockGasPrice(lgp, gasUsed, maxBlockGas, params)
-	gk.SetGasPrice(ctx, newGasPrice)
-	logTelemetry(newGasPrice,
-		attribute.KeyValue{
-			Key:   "func",
-			Value: attribute.StringValue("UpdateGasPrice"),
-		})
+	for _, lgp := range gk.LastGasPrices(ctx) {
+		initGP := findInitialGasPrice(params.InitialGasPrices, lgp.Price.Denom)
+		newGasPrice := gk.calcBlockGasPrice(lgp, gasUsed, maxBlockGas, params, initGP)
+		gk.SetGasPrice(ctx, newGasPrice)
+		logTelemetry(newGasPrice,
+			attribute.KeyValue{
+				Key:   "func",
+				Value: attribute.StringValue("UpdateGasPrice"),
+			})
+	}
 }
 
 // calcBlockGasPrice calculates the minGasPrice for the txs to be included in the next block.
@@ -234,7 +247,7 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // instead of round down for the integer divisions, and in the second case, we should set a floor
 // as the target gas price. This is just a starting point. Down the line, the solution might not be even
 // representable by one simple formula
-func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
+func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params, initialGasPrice std.GasPrice) std.GasPrice {
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
 		return lastGasPrice
@@ -281,9 +294,9 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// XXX should we cap it with a max gas price?
 	} else { // gas used is less than the target
 		// decrease gas price down to initial gas price
-		initPriceInt := big.NewInt(params.InitialGasPrice.Price.Amount)
+		initPriceInt := big.NewInt(initialGasPrice.Price.Amount)
 		if lastPriceInt.Cmp(initPriceInt) == -1 {
-			return params.InitialGasPrice
+			return initialGasPrice
 		}
 		num.Sub(targetGasInt, gasUsedInt)
 		num.Mul(num, lastPriceInt)
@@ -311,25 +324,48 @@ func maxBig(x, y *big.Int) *big.Int {
 	return x
 }
 
-// It returns the gas price for the last block.
-func (gk GasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice {
+// LastGasPrices returns the gas prices for all tracked denominations from the last block.
+func (gk GasPriceKeeper) LastGasPrices(ctx sdk.Context) []std.GasPrice {
 	stor := ctx.Store(gk.key)
-	bz := stor.Get([]byte(GasPriceKey))
-	if bz == nil {
-		return std.GasPrice{}
-	}
+	iter := store.PrefixIterator(stor, []byte(GasPriceKeyPrefix))
+	defer iter.Close()
 
-	gp := std.GasPrice{}
-	err := amino.Unmarshal(bz, &gp)
-	if err != nil {
-		panic(err)
+	var prices []std.GasPrice
+	for ; iter.Valid(); iter.Next() {
+		var gp std.GasPrice
+		err := amino.Unmarshal(iter.Value(), &gp)
+		if err != nil {
+			panic(err)
+		}
+		logTelemetry(gp,
+			attribute.KeyValue{
+				Key:   "func",
+				Value: attribute.StringValue("LastGasPrices"),
+			})
+		prices = append(prices, gp)
 	}
-	logTelemetry(gp,
-		attribute.KeyValue{
-			Key:   "func",
-			Value: attribute.StringValue("LastGasPrice"),
-		})
-	return gp
+	return prices
+}
+
+// findInitialGasPrice returns the initial gas price for the given denom.
+// If not found, returns a zero GasPrice.
+func findInitialGasPrice(initPrices []std.GasPrice, denom string) std.GasPrice {
+	for _, gp := range initPrices {
+		if gp.Price.Denom == denom {
+			return gp
+		}
+	}
+	return std.GasPrice{}
+}
+
+// findGasPrice returns a pointer to the gas price for the given denom, or nil if not found.
+func findGasPrice(prices []std.GasPrice, denom string) *std.GasPrice {
+	for i := range prices {
+		if prices[i].Price.Denom == denom {
+			return &prices[i]
+		}
+	}
+	return nil
 }
 
 func logTelemetry(gp std.GasPrice, kv attribute.KeyValue) {

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -85,6 +85,37 @@ func TestAccountKeeperParams(t *testing.T) {
 	require.True(t, dp.Equals(dp2))
 }
 
+func TestParamsValidateInitialGasPrices(t *testing.T) {
+	valid := DefaultParams()
+	valid.InitialGasPrices = []std.GasPrice{
+		{Gas: 1000, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+		{Gas: 1000, Price: std.Coin{Denom: "uphoton", Amount: 5}},
+	}
+	require.NoError(t, valid.Validate())
+
+	// Duplicate denom
+	dup := DefaultParams()
+	dup.InitialGasPrices = []std.GasPrice{
+		{Gas: 1000, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+		{Gas: 1000, Price: std.Coin{Denom: "ugnot", Amount: 2}},
+	}
+	require.ErrorContains(t, dup.Validate(), "duplicate initial gas price denom")
+
+	// Empty denom
+	empty := DefaultParams()
+	empty.InitialGasPrices = []std.GasPrice{
+		{Gas: 1000, Price: std.Coin{Denom: "", Amount: 1}},
+	}
+	require.ErrorContains(t, empty.Validate(), "empty denom")
+
+	// Non-positive gas
+	badGas := DefaultParams()
+	badGas.InitialGasPrices = []std.GasPrice{
+		{Gas: 0, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+	}
+	require.ErrorContains(t, badGas.Validate(), "non-positive gas")
+}
+
 func TestGasPrice(t *testing.T) {
 	env := setupTestEnv()
 	gp := std.GasPrice{
@@ -95,8 +126,60 @@ func TestGasPrice(t *testing.T) {
 		},
 	}
 	env.gk.SetGasPrice(env.ctx, gp)
-	gp2 := env.gk.LastGasPrice(env.ctx)
-	require.True(t, gp == gp2)
+	gps := env.gk.LastGasPrices(env.ctx)
+	require.Len(t, gps, 1)
+	require.True(t, gp == gps[0])
+}
+
+func TestGasPriceMultiDenom(t *testing.T) {
+	env := setupTestEnv()
+	gpUgnot := std.GasPrice{
+		Gas:   1000,
+		Price: std.Coin{Denom: "ugnot", Amount: 1},
+	}
+	gpPhoton := std.GasPrice{
+		Gas:   1000,
+		Price: std.Coin{Denom: "uphoton", Amount: 5},
+	}
+	env.gk.SetGasPrice(env.ctx, gpUgnot)
+	env.gk.SetGasPrice(env.ctx, gpPhoton)
+
+	gps := env.gk.LastGasPrices(env.ctx)
+	require.Len(t, gps, 2)
+
+	// Verify both denoms are present (order from iterator is lexicographic by key)
+	denomMap := make(map[string]std.GasPrice)
+	for _, gp := range gps {
+		denomMap[gp.Price.Denom] = gp
+	}
+	require.Equal(t, gpUgnot, denomMap["ugnot"])
+	require.Equal(t, gpPhoton, denomMap["uphoton"])
+
+	// Update one denom independently
+	gpPhoton.Price.Amount = 8
+	env.gk.SetGasPrice(env.ctx, gpPhoton)
+
+	gps = env.gk.LastGasPrices(env.ctx)
+	require.Len(t, gps, 2)
+	denomMap = make(map[string]std.GasPrice)
+	for _, gp := range gps {
+		denomMap[gp.Price.Denom] = gp
+	}
+	require.Equal(t, int64(1), denomMap["ugnot"].Price.Amount, "ugnot should be unchanged")
+	require.Equal(t, int64(8), denomMap["uphoton"].Price.Amount, "uphoton should be updated")
+}
+
+func TestFindInitialGasPrice(t *testing.T) {
+	initPrices := []std.GasPrice{
+		{Gas: 1000, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+		{Gas: 1000, Price: std.Coin{Denom: "uphoton", Amount: 5}},
+	}
+	// Found
+	gp := findInitialGasPrice(initPrices, "uphoton")
+	require.Equal(t, int64(5), gp.Price.Amount)
+	// Not found returns zero
+	gp = findInitialGasPrice(initPrices, "uatom")
+	require.Equal(t, std.GasPrice{}, gp)
 }
 
 func TestMax(t *testing.T) {
@@ -142,6 +225,12 @@ func TestCalcBlockGasPrice(t *testing.T) {
 			Denom:  "atom",
 		},
 	}
+	initGasPrice := std.GasPrice{
+		Price: std.Coin{
+			Amount: 1,
+			Denom:  "atom",
+		},
+	}
 	gasUsed := int64(5000)
 	maxGas := int64(10000)
 	params := Params{
@@ -150,7 +239,7 @@ func TestCalcBlockGasPrice(t *testing.T) {
 	}
 
 	// Test with normal parameters
-	newGasPrice := gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params)
+	newGasPrice := gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params, initGasPrice)
 	expectedAmount := big.NewInt(100)
 	num := big.NewInt(gasUsed - maxGas*params.TargetGasRatio/100)
 	num.Mul(num, expectedAmount)
@@ -161,18 +250,18 @@ func TestCalcBlockGasPrice(t *testing.T) {
 
 	// Test with lastGasPrice amount as 0
 	lastGasPrice.Price.Amount = 0
-	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params)
+	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params, initGasPrice)
 	require.Equal(t, int64(0), newGasPrice.Price.Amount)
 
 	// Test with TargetGasRatio as 0 (should not change the last price)
 	params.TargetGasRatio = 0
-	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params)
+	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params, initGasPrice)
 	require.Equal(t, int64(0), newGasPrice.Price.Amount)
 
 	// Test with gasUsed as 0 (should not change the last price)
 	params.TargetGasRatio = 50
 	lastGasPrice.Price.Amount = 100
 	gasUsed = 0
-	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params)
+	newGasPrice = gk.calcBlockGasPrice(lastGasPrice, gasUsed, maxGas, params, initGasPrice)
 	require.Equal(t, int64(100), newGasPrice.Price.Amount)
 }

--- a/tm2/pkg/sdk/auth/params.go
+++ b/tm2/pkg/sdk/auth/params.go
@@ -35,7 +35,7 @@ type Params struct {
 	SigVerifyCostSecp256k1    int64            `json:"sig_verify_cost_secp256k1" yaml:"sig_verify_cost_secp256k1"`
 	GasPricesChangeCompressor int64            `json:"gas_price_change_compressor" yaml:"gas_price_change_compressor"`
 	TargetGasRatio            int64            `json:"target_gas_ratio" yaml:"target_gas_ratio"`
-	InitialGasPrice           std.GasPrice     `json:"initial_gasprice"`
+	InitialGasPrices          []std.GasPrice   `json:"initial_gasprices"` // see tm2/adr/adr-001-multi-denom-gas-fees.md
 	UnrestrictedAddrs         []crypto.Address `json:"unrestricted_addrs" yaml:"unrestricted_addrs"`
 	FeeCollector              crypto.Address   `json:"fee_collector" yaml:"fee_collector"`
 }
@@ -88,6 +88,7 @@ func (p Params) String() string {
 	fmt.Fprintf(sb, "SigVerifyCostSecp256k1: %d\n", p.SigVerifyCostSecp256k1)
 	fmt.Fprintf(sb, "GasPricesChangeCompressor: %d\n", p.GasPricesChangeCompressor)
 	fmt.Fprintf(sb, "TargetGasRatio: %d\n", p.TargetGasRatio)
+	fmt.Fprintf(sb, "InitialGasPrices: %v\n", p.InitialGasPrices)
 	fmt.Fprintf(sb, "FeeCollector: %s\n", p.FeeCollector.String())
 	return sb.String()
 }
@@ -116,6 +117,23 @@ func (p Params) Validate() error {
 	}
 	if p.FeeCollector.IsZero() {
 		return fmt.Errorf("invalid fee collector, cannot be empty")
+	}
+	// Validate InitialGasPrices: no duplicate denoms, positive gas and amounts.
+	seenDenoms := make(map[string]struct{}, len(p.InitialGasPrices))
+	for _, gp := range p.InitialGasPrices {
+		if gp.Price.Denom == "" {
+			return fmt.Errorf("initial gas price has empty denom")
+		}
+		if _, dup := seenDenoms[gp.Price.Denom]; dup {
+			return fmt.Errorf("duplicate initial gas price denom: %s", gp.Price.Denom)
+		}
+		seenDenoms[gp.Price.Denom] = struct{}{}
+		if gp.Gas <= 0 {
+			return fmt.Errorf("initial gas price for %s has non-positive gas: %d", gp.Price.Denom, gp.Gas)
+		}
+		if gp.Price.Amount < 0 {
+			return fmt.Errorf("initial gas price for %s has negative amount: %d", gp.Price.Denom, gp.Price.Amount)
+		}
 	}
 	return nil
 }

--- a/tm2/pkg/sdk/auth/params_test.go
+++ b/tm2/pkg/sdk/auth/params_test.go
@@ -118,11 +118,11 @@ func TestParamsString(t *testing.T) {
 		params Params
 		want   string
 	}{
-		{"blank params", Params{}, "Params: \nMaxMemoBytes: 0\nTxSigLimit: 0\nTxSizeCostPerByte: 0\nSigVerifyCostED25519: 0\nSigVerifyCostSecp256k1: 0\nGasPricesChangeCompressor: 0\nTargetGasRatio: 0\nFeeCollector: g1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqluuxe\n"},
+		{"blank params", Params{}, "Params: \nMaxMemoBytes: 0\nTxSigLimit: 0\nTxSizeCostPerByte: 0\nSigVerifyCostED25519: 0\nSigVerifyCostSecp256k1: 0\nGasPricesChangeCompressor: 0\nTargetGasRatio: 0\nInitialGasPrices: []\nFeeCollector: g1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqluuxe\n"},
 		{"some values", Params{
 			MaxMemoBytes:      1_000_000,
 			TxSizeCostPerByte: 8192,
-		}, "Params: \nMaxMemoBytes: 1000000\nTxSigLimit: 0\nTxSizeCostPerByte: 8192\nSigVerifyCostED25519: 0\nSigVerifyCostSecp256k1: 0\nGasPricesChangeCompressor: 0\nTargetGasRatio: 0\nFeeCollector: g1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqluuxe\n"},
+		}, "Params: \nMaxMemoBytes: 1000000\nTxSigLimit: 0\nTxSizeCostPerByte: 8192\nSigVerifyCostED25519: 0\nSigVerifyCostSecp256k1: 0\nGasPricesChangeCompressor: 0\nTargetGasRatio: 0\nInitialGasPrices: []\nFeeCollector: g1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqluuxe\n"},
 	}
 
 	for _, tt := range cases {

--- a/tm2/pkg/sdk/auth/types.go
+++ b/tm2/pkg/sdk/auth/types.go
@@ -26,7 +26,7 @@ type BankKeeperI interface {
 }
 
 type GasPriceKeeperI interface {
-	LastGasPrice(ctx sdk.Context) std.GasPrice
+	LastGasPrices(ctx sdk.Context) []std.GasPrice
 	SetGasPrice(ctx sdk.Context, gp std.GasPrice)
 	UpdateGasPrice(ctx sdk.Context)
 }


### PR DESCRIPTION
This is a branch for after launch to enable PHOTON holders to use Gno.land. 
More discussion and deliberation is needed, but this will allow people who do not yet own GNOT to use Gno.land. 

-------------

Allow transaction fees to be paid in any governance-accepted denomination, not just ugnot. Each denom has its own independently tracked and dynamically adjusted gas price stored per-denom in the GasPriceKeeper.

This enables $PHOTON holders to use gno.land at launch (when $GNOT is non-transferrable) by paying gas fees in uphoton.

Key changes:
- GasPriceKeeper stores per-denom gas prices (gasPrice:<denom>)
- InitialGasPrices param accepts []std.GasPrice for multiple denoms
- EnsureSufficientMempoolFees matches fee denom against block gas prices
- UpdateGasPrice adjusts each denom independently, seeds new denoms
- Params validation rejects duplicate/empty denoms

See tm2/adr/adr-001-multi-denom-gas-fees.md (protocol) See gno.land/adr/adr-001-photon-gas-fees.md (application)