### PR TITLE
fix(gnofaucet): improve hCaptcha api compliance & observability

### DIFF
--- a/contribs/gnofaucet/captcha.go
+++ b/contribs/gnofaucet/captcha.go
@@ -23,7 +23,7 @@ func (c *captchaCfg) RegisterFlags(fs *flag.FlagSet) {
 		&c.captchaSecret,
 		"captcha-secret",
 		"",
-		"hcaptcha secret key (if empty, captcha are disabled)",
+		"hcaptcha secret key (required)",
 	)
 
 	fs.StringVar(
@@ -57,6 +57,11 @@ func execCaptcha(ctx context.Context, cfg *captchaCfg, io commands.IO) error {
 		return errCaptchaMissing
 	}
 
+	logger, err := cfg.rootCfg.newLogger(io)
+	if err != nil {
+		return err
+	}
+
 	// Start the IP throttler
 	st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
 	st.start(ctx)
@@ -67,13 +72,13 @@ func execCaptcha(ctx context.Context, cfg *captchaCfg, io commands.IO) error {
 	}
 
 	rpcMiddlewares := []faucet.Middleware{
-		captchaMiddleware(cfg.captchaSecret, cfg.captchaSitekey),
+		captchaMiddleware(cfg.captchaSecret, cfg.captchaSitekey, logger),
 	}
 
 	return serveFaucet(
 		ctx,
 		cfg.rootCfg,
-		io,
+		logger,
 		faucet.WithHTTPMiddlewares(httpMiddlewares),
 		faucet.WithMiddlewares(rpcMiddlewares),
 	)

--- a/contribs/gnofaucet/github.go
+++ b/contribs/gnofaucet/github.go
@@ -12,12 +12,10 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/gnolang/faucet"
-	"github.com/gnolang/gno/gno.land/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/google/go-github/v74/github"
 	"github.com/jferrl/go-githubauth"
 	"github.com/redis/go-redis/v9"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/oauth2"
 
 	igh "github.com/gnolang/gno/contribs/gnofaucet/github"
@@ -159,12 +157,10 @@ func execGithub(ctx context.Context, cfg *githubCfg, io commands.IO) error {
 
 	rr := igh.NewRedisRewarder(rdb, rewarderCfg)
 
-	logger := log.ZapLoggerToSlog(
-		log.NewZapJSONLogger(
-			io.Out(),
-			zapcore.DebugLevel,
-		),
-	)
+	logger, err := cfg.rootCfg.newLogger(io)
+	if err != nil {
+		return err
+	}
 
 	// Prepare the middlewares
 	httpMiddlewares := []func(http.Handler) http.Handler{
@@ -177,7 +173,7 @@ func execGithub(ctx context.Context, cfg *githubCfg, io commands.IO) error {
 	return serveFaucet(
 		ctx,
 		cfg.rootCfg,
-		io,
+		logger,
 		faucet.WithHTTPMiddlewares(httpMiddlewares),
 		faucet.WithMiddlewares(rpcMiddlewares),
 	)
@@ -215,12 +211,10 @@ func execGHFetcher(ctx context.Context, cfg *ghFetcherCfg, io commands.IO) error
 		return fmt.Errorf("unable to connect to redis, %w", err)
 	}
 
-	logger := log.ZapLoggerToSlog(
-		log.NewZapJSONLogger(
-			io.Out(),
-			zapcore.DebugLevel,
-		),
-	)
+	logger, err := cfg.rootCfg.newLogger(io)
+	if err != nil {
+		return err
+	}
 
 	appTokenSource, err := githubauth.NewApplicationTokenSource(appID, privKey)
 	if err != nil {

--- a/contribs/gnofaucet/middleware.go
+++ b/contribs/gnofaucet/middleware.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/netip"
@@ -85,7 +86,7 @@ func ipMiddleware(behindProxy bool, st *ipThrottler) func(next http.Handler) htt
 }
 
 // captchaMiddleware returns the captcha middleware, if any
-func captchaMiddleware(secret, sitekey string) faucet.Middleware {
+func captchaMiddleware(secret, sitekey string, logger *slog.Logger) faucet.Middleware {
 	return func(next faucet.HandlerFunc) faucet.HandlerFunc {
 		return func(ctx context.Context, req *spec.BaseJSONRequest) *spec.BaseJSONResponse {
 			// Parse the request meta to extract the captcha secret
@@ -106,7 +107,7 @@ func captchaMiddleware(secret, sitekey string) faucet.Middleware {
 			remoteIP, _ := ctx.Value(remoteIPContextKey).(string)
 
 			// Verify the captcha response
-			if err := checkHcaptcha(secret, strings.TrimSpace(meta.Captcha), remoteIP, sitekey); err != nil {
+			if err := checkHcaptcha(secret, strings.TrimSpace(meta.Captcha), remoteIP, sitekey, logger); err != nil {
 				return spec.NewJSONResponse(
 					req.ID,
 					nil,
@@ -121,7 +122,7 @@ func captchaMiddleware(secret, sitekey string) faucet.Middleware {
 }
 
 // checkHcaptcha checks the captcha challenge
-func checkHcaptcha(secret, response, remoteIP, sitekey string) error {
+func checkHcaptcha(secret, response, remoteIP, sitekey string, logger *slog.Logger) error {
 	// Create an HTTP client with a timeout
 	client := &http.Client{
 		Timeout: time.Second * 10,
@@ -137,6 +138,12 @@ func checkHcaptcha(secret, response, remoteIP, sitekey string) error {
 	if sitekey != "" {
 		form.Set("sitekey", sitekey)
 	}
+
+	logger.Debug("sending hcaptcha verification request",
+		slog.String("remoteip", remoteIP),
+		slog.Bool("secret_set", secret != ""),
+		slog.Bool("sitekey_set", sitekey != ""),
+	)
 
 	// Create the request
 	req, err := http.NewRequest(
@@ -167,6 +174,13 @@ func checkHcaptcha(secret, response, remoteIP, sitekey string) error {
 	if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return fmt.Errorf("failed to decode response, %w", err)
 	}
+
+	logger.Debug("received hcaptcha verification response",
+		slog.String("remoteip", remoteIP),
+		slog.Bool("success", body.Success),
+		slog.String("hostname", body.Hostname),
+		slog.Any("error_codes", body.ErrorCodes),
+	)
 
 	// Check if the hcaptcha verification was successful
 	if !body.Success {

--- a/contribs/gnofaucet/middleware_test.go
+++ b/contribs/gnofaucet/middleware_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// discardLogger is a no-op logger for use in tests.
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 // hCaptcha test credentials — always pass verification without a real browser.
 // See: https://docs.hcaptcha.com/#integration-testing-test-keys
@@ -52,7 +56,7 @@ func TestCheckHcaptcha(t *testing.T) {
 		siteVerifyURL = srv.URL
 		defer func() { siteVerifyURL = orig }()
 
-		require.NoError(t, checkHcaptcha("test-secret", "test-response", "", ""))
+		require.NoError(t, checkHcaptcha("test-secret", "test-response", "", "", discardLogger))
 	})
 
 	t.Run("success with remoteip and sitekey", func(t *testing.T) {
@@ -75,7 +79,7 @@ func TestCheckHcaptcha(t *testing.T) {
 		siteVerifyURL = srv.URL
 		defer func() { siteVerifyURL = orig }()
 
-		require.NoError(t, checkHcaptcha("test-secret", "test-response", "1.2.3.4", "test-sitekey"))
+		require.NoError(t, checkHcaptcha("test-secret", "test-response", "1.2.3.4", "test-sitekey", discardLogger))
 	})
 
 	t.Run("verification failure", func(t *testing.T) {
@@ -89,7 +93,7 @@ func TestCheckHcaptcha(t *testing.T) {
 		siteVerifyURL = srv.URL
 		defer func() { siteVerifyURL = orig }()
 
-		err := checkHcaptcha("test-secret", "bad-token", "", "")
+		err := checkHcaptcha("test-secret", "bad-token", "", "", discardLogger)
 		assert.Equal(t, errInvalidCaptcha, err)
 	})
 
@@ -103,7 +107,7 @@ func TestCheckHcaptcha(t *testing.T) {
 		siteVerifyURL = srv.URL
 		defer func() { siteVerifyURL = orig }()
 
-		err := checkHcaptcha("test-secret", "test-response", "", "")
+		err := checkHcaptcha("test-secret", "test-response", "", "", discardLogger)
 		assert.ErrorContains(t, err, "unexpected status code")
 	})
 
@@ -114,6 +118,6 @@ func TestCheckHcaptcha(t *testing.T) {
 			t.Skip("skipping network test in short mode")
 		}
 
-		require.NoError(t, checkHcaptcha(hcaptchaTestSecret, hcaptchaTestResponse, "", ""))
+		require.NoError(t, checkHcaptcha(hcaptchaTestSecret, hcaptchaTestResponse, "", "", discardLogger))
 	})
 }

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strconv"
 	"time"
@@ -55,6 +56,7 @@ type serveCfg struct {
 
 	remote        string
 	isBehindProxy bool
+	logLevel      string
 }
 
 func newServeCmd() *commands.Command {
@@ -127,6 +129,23 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 		false,
 		"use X-Forwarded-For IP for throttling",
 	)
+
+	fs.StringVar(
+		&c.logLevel,
+		"log-level",
+		"info",
+		"log level (debug, info, warn, error)",
+	)
+}
+
+// newLogger constructs a JSON structured logger at the configured level.
+func (c *serveCfg) newLogger(io commands.IO) (*slog.Logger, error) {
+	var level zapcore.Level
+	if err := level.UnmarshalText([]byte(c.logLevel)); err != nil {
+		return nil, fmt.Errorf("invalid log level %q: %w", c.logLevel, err)
+	}
+
+	return log.ZapLoggerToSlog(log.NewZapJSONLogger(io.Out(), level)), nil
 }
 
 // generateFaucetConfig generates the Faucet configuration
@@ -147,7 +166,7 @@ func (c *serveCfg) generateFaucetConfig() *config.Config {
 func serveFaucet(
 	ctx context.Context,
 	cfg *serveCfg,
-	io commands.IO,
+	logger *slog.Logger,
 	opts ...faucet.Option,
 ) error {
 	// Parse static gas values.
@@ -177,14 +196,6 @@ func serveFaucet(
 	if err != nil {
 		return fmt.Errorf("unable to create TM2 client, %w", err)
 	}
-
-	// Set up the logger
-	logger := log.ZapLoggerToSlog(
-		log.NewZapJSONLogger(
-			io.Out(),
-			zapcore.DebugLevel,
-		),
-	)
 
 	faucetOpts := []faucet.Option{
 		faucet.WithLogger(logger),


### PR DESCRIPTION
- Switch siteverify endpoint to the canonical `https://api.hcaptcha.com/siteverify`
- Send `remoteip` (recommended by hCaptcha docs) to improve fraud signal accuracy; the value is the already-validated client IP resolved by `ipMiddleware`, threaded through via request context
- Add optional `--captcha-sitekey` flag; when set, the sitekey is forwarded to hCaptcha's siteverify endpoint to prevent tokens issued for other sites from being accepted
- Add `--log-level` flag to the `serve` command (default `info`), replacing the previously hardcoded `debug` level across all subcommands; consolidate the three duplicate logger constructions into a single `newLogger` method on `serveCfg`
- Add structured `debug`-level logging around each hCaptcha verification call (request params and response fields including `error_codes`), observable in production by setting `--log-level debug`