### PR TITLE
ci: skip PR title lint when source branch is master

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   pr-title:
+    if: github.head_ref != 'master'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
This causes the failing CI on master, because it is indentified as a pull request branch with PR https://github.com/gnolang/gno/pull/5295