### PR TITLE
docs: reformat CLA.md to 80 columns and fix markdown

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -2,78 +2,173 @@
 
 **Contributor License Agreement**
 
-This Agreement governs Contributions uploaded, published, or made available for execution on the Gno.land blockchain network (the "Network"), and the related software and repositories used to publish such Contributions.
+This Agreement governs Contributions uploaded, published, or made available
+for execution on the Gno.land blockchain network (the "Network"), and the
+related software and repositories used to publish such Contributions.
 
-The Network is stewarded by (i) GovDAO as the community governance body for Gno.land and (ii) NewTendermint, LLC ("NewTendermint") as the current core maintainer of the Network.
+The Network is stewarded by (i) GovDAO as the community governance body for
+Gno.land and (ii) NewTendermint, LLC ("NewTendermint") as the current core
+maintainer of the Network.
 
-**1\. Definitions**
+**1. Definitions**
 
-**"CLA Hash"** means the cryptographic hash of the canonical text of this Agreement published by the Network as an on-chain parameter.
+**"CLA Hash"** means the cryptographic hash of the canonical text of this
+Agreement published by the Network as an on-chain parameter.
 
-**"Contribution"** means (a) any code package, module, or documentation you submit for publication or execution on the Network, including via an on-chain package submission transaction (e.g. `MsgAddPackage`), (b) any inputs you provide in connection with submitting, running, or executing that package on the Network; and (c) any resulting or derived on-chain state produced from the foregoing ("Resulting State") but only to the extent you have rights in such inputs or Resulting State.
+**"Contribution"** means (a) any code package, module, or documentation you
+submit for publication or execution on the Network, including via an on-chain
+package submission transaction (e.g. `MsgAddPackage`), (b) any inputs you
+provide in connection with submitting, running, or executing that package on
+the Network; and (c) any resulting or derived on-chain state produced from the
+foregoing ("Resulting State") but only to the extent you have rights in such
+inputs or Resulting State.
 
-**"Contributor"** (also **"you"** or **"your"**) means the individual or legal entity who submits a Contribution. If you submit on behalf of an entity, you represent you have authority to bind that entity.
+**"Contributor"** (also **"you"** or **"your"**) means the individual or legal
+entity who submits a Contribution. If you submit on behalf of an entity, you
+represent you have authority to bind that entity.
 
-**"Network License"** means the GNO Network General Public License, version 6 (or any later version published by NewTendermint, LLC), including its Additional Terms on Strong Attribution, under which the Network's code is released.
+**"Network License"** means the GNO Network General Public License, version 6
+(or any later version published by NewTendermint, LLC), including its
+Additional Terms on Strong Attribution, under which the Network's code is
+released.
 
-"**Qualified Fork**" has the meaning set forth in the Gno.land Constitution and describes a fork's recognized status under Network governance. Nothing in this Agreement grants any right to use the Gno, Tendermint, or Gno.land names or marks, or to represent any fork as the official continuation of Gno.land, except as permitted under applicable NewTendermint policies. Where the Network License applies (for example, to code and other copyrightable works), Strong Attribution and other Network License requirements must be followed.
+**"Qualified Fork"** has the meaning set forth in the Gno.land Constitution
+and describes a fork's recognized status under Network governance. Nothing in
+this Agreement grants any right to use the Gno, Tendermint, or Gno.land names
+or marks, or to represent any fork as the official continuation of Gno.land,
+except as permitted under applicable NewTendermint policies. Where the Network
+License applies (for example, to code and other copyrightable works), Strong
+Attribution and other Network License requirements must be followed.
 
-**2\. Acceptance; Scope**
+**2. Acceptance; Scope**
 
-By submitting a Contribution for publication or execution on the Network, you agree to be bound by this Agreement.
+By submitting a Contribution for publication or execution on the Network, you
+agree to be bound by this Agreement.
 
-The Network publishes a canonical text of this Agreement and the corresponding CLA Hash. When you submit a Contribution via an on-chain package submission transaction that includes the CLA Hash (currently, `MsgAddPackage`), you agree that inclusion of the CLA Hash constitutes evidence that you accepted the Agreement text corresponding to that hash. Package submission transactions may be rejected by the Network if the included CLA Hash does not match the current canonical CLA Hash published by the Network.
+The Network publishes a canonical text of this Agreement and the corresponding
+CLA Hash. When you submit a Contribution via an on-chain package submission
+transaction that includes the CLA Hash (currently, `MsgAddPackage`), you agree
+that inclusion of the CLA Hash constitutes evidence that you accepted the
+Agreement text corresponding to that hash. Package submission transactions may
+be rejected by the Network if the included CLA Hash does not match the current
+canonical CLA Hash published by the Network.
 
-**Accept once per CLA Hash.** If you have previously accepted the Agreement text corresponding to a given CLA Hash, you do not need to accept it again for subsequent Contributions submitted under the same CLA Hash. You will be required to accept the Agreement again only if the canonical Agreement text changes and the CLA Hash changes. Interfaces and tooling may prompt you to confirm your submission under the current CLA Hash at the time of a package upload; any such confirmation is valid assent, but does not change the accept-once-per-CLA-Hash rule in this Section.
+**Accept once per CLA Hash.** If you have previously accepted the Agreement
+text corresponding to a given CLA Hash, you do not need to accept it again for
+subsequent Contributions submitted under the same CLA Hash. You will be
+required to accept the Agreement again only if the canonical Agreement text
+changes and the CLA Hash changes. Interfaces and tooling may prompt you to
+confirm your submission under the current CLA Hash at the time of a package
+upload; any such confirmation is valid assent, but does not change the
+accept-once-per-CLA-Hash rule in this Section.
 
-Other Network participants (including those submitting non-package transactions) are governed by the Network Interaction Terms referenced in the site footer.
+Other Network participants (including those submitting non-package
+transactions) are governed by the Network Interaction Terms referenced in the
+site footer.
 
-**3\. Copyright License Grant**
+**3. Copyright License Grant**
 
-You grant to NewTendermint, GovDAO (in its capacity as the Network's governance body), and all recipients of software distributed in connection with the Network and related repositories a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contribution, in whole or in part, in any media.
+You grant to NewTendermint, GovDAO (in its capacity as the Network's
+governance body), and all recipients of software distributed in connection with
+the Network and related repositories a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute your
+Contribution, in whole or in part, in any media.
 
-You agree that this license permits NewTendermint, GovDAO and Network participants to include your Contribution in the Network's software and related repositories, and to use, modify, and redistribute your Contribution under the Network License (GNO GPL v6 or later), including its Additional Terms on Strong Attribution. This Agreement does not transfer ownership of your Contribution.
+You agree that this license permits NewTendermint, GovDAO and Network
+participants to include your Contribution in the Network's software and related
+repositories, and to use, modify, and redistribute your Contribution under the
+Network License (GNO GPL v6 or later), including its Additional Terms on
+Strong Attribution. This Agreement does not transfer ownership of your
+Contribution.
 
-**4\. License Grant for Inputs and Resulting State**
+**4. License Grant for Inputs and Resulting State**
 
-To the extent you have rights in any non-code inputs you submit and any resulting or derived on-chain state produced from your Contribution, you grant NewTendermint, GovDAO, Network participants, and Qualified Forks a perpetual, worldwide, irrevocable, royalty-free license to store, reproduce, index, cache, mirror, archive, display, and use those inputs and resulting state as needed to operate, verify, maintain, improve and provide access to the Network and its history.
+To the extent you have rights in any non-code inputs you submit and any
+resulting or derived on-chain state produced from your Contribution, you grant
+NewTendermint, GovDAO, Network participants, and Qualified Forks a perpetual,
+worldwide, irrevocable, royalty-free license to store, reproduce, index, cache,
+mirror, archive, display, and use those inputs and resulting state as needed to
+operate, verify, maintain, improve and provide access to the Network and its
+history.
 
-**5\. Patent License**
+**5. Patent License**
 
-To the extent you own or control any patent claims that would be necessarily infringed by use of the code portion of your Contribution (alone or in combination with the Network), you grant to NewTendermint, GovDAO (in its capacity as the Network's governance body), and all recipients of the contributed code a perpetual, worldwide, royalty-free, non-exclusive, irrevocable patent license to make, have made, use, sell, offer for sale, import, and otherwise exploit that code under the Network License.
+To the extent you own or control any patent claims that would be necessarily
+infringed by use of the code portion of your Contribution (alone or in
+combination with the Network), you grant to NewTendermint, GovDAO (in its
+capacity as the Network's governance body), and all recipients of the
+contributed code a perpetual, worldwide, royalty-free, non-exclusive,
+irrevocable patent license to make, have made, use, sell, offer for sale,
+import, and otherwise exploit that code under the Network License.
 
-**6\. Contributor Representations and Warranties**
+**6. Contributor Representations and Warranties**
 
 You represent and warrant that:
 
-(a) **Authority; Rights.** Your Contribution (including any inputs you submit and any Resulting State to the extent you have rights in it) is your original work, or you have sufficient rights and authority to submit the Contribution and to grant the rights set forth in this Agreement and the Network License.
+(a) **Authority; Rights.** Your Contribution (including any inputs you submit
+and any Resulting State to the extent you have rights in it) is your original
+work, or you have sufficient rights and authority to submit the Contribution
+and to grant the rights set forth in this Agreement and the Network License.
 
-(b) **No Infringement.** To your knowledge, the Contribution does not infringe, misappropriate, or otherwise violate any third-party intellectual property or other rights.
+(b) **No Infringement.** To your knowledge, the Contribution does not
+infringe, misappropriate, or otherwise violate any third-party intellectual
+property or other rights.
 
-(c) **Employer and Third-Party Rights.** If you submit the Contribution in the course of employment or under any agreement that could grant another person or entity rights in the Contribution, you have obtained all permissions and consents necessary for you to make the Contribution and grant the rights in this Agreement (or such person or entity has waived any such rights).
+(c) **Employer and Third-Party Rights.** If you submit the Contribution in the
+course of employment or under any agreement that could grant another person or
+entity rights in the Contribution, you have obtained all permissions and
+consents necessary for you to make the Contribution and grant the rights in
+this Agreement (or such person or entity has waived any such rights).
 
-(d) **Third-Party Materials.** If your Contribution includes material owned by a third party, you represent and warrant that you have the right to submit it under the Network License and this Agreement, and that you have complied with any applicable notice or attribution requirements.
+(d) **Third-Party Materials.** If your Contribution includes material owned by
+a third party, you represent and warrant that you have the right to submit it
+under the Network License and this Agreement, and that you have complied with
+any applicable notice or attribution requirements.
 
-**7\. No Assignment of Ownership**
+**7. No Assignment of Ownership**
 
-Except for the rights granted under this Agreement and the Network License, you retain all right, title, and interest in and to your Contribution. Nothing in this Agreement transfers ownership of your Contribution to NewTendermint, GovDAO, or any other party.
+Except for the rights granted under this Agreement and the Network License, you
+retain all right, title, and interest in and to your Contribution. Nothing in
+this Agreement transfers ownership of your Contribution to NewTendermint,
+GovDAO, or any other party.
 
-**8\. Moral Rights**
+**8. Moral Rights**
 
-To the maximum extent permitted by applicable law, you waive and agree not to assert any moral rights (or similar rights) in your Contribution to the extent such rights would interfere with the licenses granted under this Agreement.
+To the maximum extent permitted by applicable law, you waive and agree not to
+assert any moral rights (or similar rights) in your Contribution to the extent
+such rights would interfere with the licenses granted under this Agreement.
 
-**9\. Disclaimer**
+**9. Disclaimer**
 
-YOUR CONTRIBUTION IS PROVIDED "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, TO THE MAXIMUM EXTENT PERMITTED BY LAW. YOU DISCLAIM ALL EXPRESS OR IMPLIED WARRANTIES, INCLUDING WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. UNLESS SEPARATELY AGREED IN WRITING, YOU HAVE NO OBLIGATION TO PROVIDE SUPPORT, UPDATES, OR BUG FIXES FOR YOUR CONTRIBUTION.
+YOUR CONTRIBUTION IS PROVIDED "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, TO THE MAXIMUM EXTENT PERMITTED BY LAW. YOU DISCLAIM ALL EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. UNLESS SEPARATELY AGREED IN
+WRITING, YOU HAVE NO OBLIGATION TO PROVIDE SUPPORT, UPDATES, OR BUG FIXES FOR
+YOUR CONTRIBUTION.
 
-**10\. Severability; Relationship to Network License**
+**10. Severability; Relationship to Network License**
 
-This Agreement supplements the Network License and is intended to be consistent with it. If any provision of this Agreement is held unenforceable, the remaining provisions will remain in full force and effect. To the extent of any conflict between this Agreement and the Network License, the Network License controls. Nothing in this Agreement limits any rights granted under the Network License.
+This Agreement supplements the Network License and is intended to be consistent
+with it. If any provision of this Agreement is held unenforceable, the
+remaining provisions will remain in full force and effect. To the extent of any
+conflict between this Agreement and the Network License, the Network License
+controls. Nothing in this Agreement limits any rights granted under the Network
+License.
 
-**11\. General Provisions.**
+**11. General Provisions**
 
-This Agreement is effective as of the date you first submit a Contribution to the Network. It applies to Contributions you submit after you accept this Agreement.
+This Agreement is effective as of the date you first submit a Contribution to
+the Network. It applies to Contributions you submit after you accept this
+Agreement.
 
-This Agreement may be amended by publishing an updated canonical text on the Network (resulting in a new CLA Hash) or by posting an updated version through official Network channels. Continued submission of Contributions after notice of an update constitutes acceptance of the updated Agreement for those subsequent Contributions.
+This Agreement may be amended by publishing an updated canonical text on the
+Network (resulting in a new CLA Hash) or by posting an updated version through
+official Network channels. Continued submission of Contributions after notice
+of an update constitutes acceptance of the updated Agreement for those
+subsequent Contributions.
 
-You agree that you are not an agent or legal partner of the Network or NewTendermint, and you sign this Agreement in your individual capacity (or on behalf of your employer if so authorized).
+You agree that you are not an agent or legal partner of the Network or
+NewTendermint, and you sign this Agreement in your individual capacity (or on
+behalf of your employer if so authorized).


### PR DESCRIPTION
## Summary
- Reformat CLA.md to 80-column line width for better readability
- Remove unnecessary backslash escapes on numbered headings (`1\.` → `1.`)
- Fix inconsistent bold/quote placement on "Qualified Fork" definition
- Remove trailing period on section 11 heading

## Test plan
- [x] Verify no lines exceed 80 columns
- [x] Verify rendered markdown looks identical (content-preserving reformat)