### PR TITLE
fix(gnovm): correct multi-value var init circular dependency detection

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -151,10 +151,21 @@ func PredefineFileSet(store Store, pn *PackageNode, fset *FileSet) {
 					if iota_ != nil {
 						part.SetAttribute(ATTR_IOTA, iota_)
 					}
-					predefineRecursively(store, fn, part)
 					split[j] = part
 				}
+				// Replace in fn.Decls BEFORE predefining so that
+				// GetDeclFor finds individual split declarations
+				// instead of the original multi-value declaration,
+				// which would cause false circular dependency errors.
 				fn.Decls = append(fn.Decls[:i], append(split, fn.Decls[i+1:]...)...) //nolint:makezero
+				for _, part := range split {
+					if part.GetAttribute(ATTR_PREDEFINED) == true {
+						// May have been predefined as a dependency
+						// of a prior part in the split.
+						continue
+					}
+					predefineRecursively(store, fn, part)
+				}
 				i += len(vd.NameExprs) - 1
 				continue
 			} else {

--- a/gnovm/tests/files/assign39.gno
+++ b/gnovm/tests/files/assign39.gno
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	c, d := 3, 4
+	a, b := c, d
+	println(a, b)
+}
+
+// Output:
+// 3 4

--- a/gnovm/tests/files/var36.gno
+++ b/gnovm/tests/files/var36.gno
@@ -1,0 +1,14 @@
+package main
+
+var (
+	A, B = C, D
+	C    = B
+	D    = 3
+)
+
+func main() {
+	println(A, B, C)
+}
+
+// Output:
+// 3 3 3

--- a/gnovm/tests/files/var37.gno
+++ b/gnovm/tests/files/var37.gno
@@ -1,0 +1,14 @@
+package main
+
+// Multi-value init where second var depends on first var's dependency.
+var (
+	A, B = 1, C
+	C    = A
+)
+
+func main() {
+	println(A, B, C)
+}
+
+// Output:
+// 1 1 1

--- a/gnovm/tests/files/var38.gno
+++ b/gnovm/tests/files/var38.gno
@@ -1,0 +1,18 @@
+package main
+
+// True circular dependency with multi-value init should still be caught.
+var (
+	A, B = C, D
+	C    = A
+	D    = 3
+)
+
+func main() {
+	println(A, B, C)
+}
+
+// Error:
+// main/var38.gno:1:1-12:2: invalid recursive value: A -> C -> A
+
+// TypeCheckError:
+// main/var38.gno:5:2: initialization cycle for A; main/var38.gno:5:2: 	A refers to C; main/var38.gno:6:2: 	C refers to A


### PR DESCRIPTION
## Summary
- Fix false circular dependency error for valid multi-value `var` declarations like `var A, B = C, D`
- GnoVM was incorrectly reporting `invalid recursive value: A -> C -> A -> B -> C` for code that Go accepts

## Root Cause
In `PredefineFileSet()`, when splitting `var A, B = C, D` into individual declarations (`var A = C`, `var B = D`), the split declarations were written back to `fn.Decls` **after** all parts were predefined. This meant `GetDeclFor(B)` during dependency resolution found the original unsplit `var A, B = C, D` — which dragged in all names and all RHS values, creating a false cycle.

## Fix
Move the `fn.Decls` replacement to **before** calling `predefineRecursively`, so dependency resolution finds individual split declarations. Added an `ATTR_PREDEFINED` guard to skip parts already resolved as dependencies of earlier parts.

## Test plan
- [x] `var36.gno` — exact issue reproduction, outputs `3 3 3`
- [x] `var37.gno` — another valid intra-dependent case
- [x] `var38.gno` — true circular dependency still correctly rejected
- [x] `assign39.gno` — multi-value short declaration `:=`
- [x] Full `TestFiles` suite passes (no regressions)

Closes #5328