### PR TITLE
feat(faucet): Expose IP rate limiting parameters and improve IP parsing

### DIFF
--- a/contribs/gnofaucet/captcha.go
+++ b/contribs/gnofaucet/captcha.go
@@ -63,12 +63,12 @@ func execCaptcha(ctx context.Context, cfg *captchaCfg, io commands.IO) error {
 	}
 
 	// Start the IP throttler
-	st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+	st := newIPThrottler(cfg.rootCfg.rateLimitInterval, cfg.rootCfg.rateLimitCleanTimeout)
 	st.start(ctx)
 
 	// Prepare the middlewares
 	httpMiddlewares := []func(http.Handler) http.Handler{
-		ipMiddleware(cfg.rootCfg.isBehindProxy, st),
+		ipMiddleware(logger, cfg.rootCfg.isBehindProxy, st),
 	}
 
 	rpcMiddlewares := []faucet.Middleware{

--- a/contribs/gnofaucet/github.go
+++ b/contribs/gnofaucet/github.go
@@ -147,7 +147,7 @@ func execGithub(ctx context.Context, cfg *githubCfg, io commands.IO) error {
 	cooldownLimiter := newRedisLimiter(cfg.cooldownPeriod, rdb, cfg.maxClaimableLimit)
 
 	// Start the IP throttler
-	st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+	st := newIPThrottler(cfg.rootCfg.rateLimitInterval, cfg.rootCfg.rateLimitCleanTimeout)
 	st.start(ctx)
 
 	rewarderCfg, err := parseRewarderConfig()
@@ -164,7 +164,7 @@ func execGithub(ctx context.Context, cfg *githubCfg, io commands.IO) error {
 
 	// Prepare the middlewares
 	httpMiddlewares := []func(http.Handler) http.Handler{
-		ipMiddleware(cfg.rootCfg.isBehindProxy, st),
+		ipMiddleware(logger, cfg.rootCfg.isBehindProxy, st),
 		gitHubUsernameMiddleware(clientID, clientSecret, defaultGHExchange, logger, rdb),
 	}
 

--- a/contribs/gnofaucet/middleware.go
+++ b/contribs/gnofaucet/middleware.go
@@ -23,7 +23,7 @@ type contextKey int
 const remoteIPContextKey contextKey = iota
 
 // ipMiddleware returns the IP verification middleware, using the given subnet throttler
-func ipMiddleware(behindProxy bool, st *ipThrottler) func(next http.Handler) http.Handler {
+func ipMiddleware(logger *slog.Logger, behindProxy bool, st *ipThrottler) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -41,9 +41,12 @@ func ipMiddleware(behindProxy bool, st *ipThrottler) func(next http.Handler) htt
 					return
 				}
 
-				// Check if the request is behind a proxy
+				// Check if the request is behind a proxy.
+				// X-Forwarded-For can contain a comma-separated list of IPs
+				// (e.g. "client, proxy1, proxy2"). Extract the first (client) IP.
 				if xff := r.Header.Get("X-Forwarded-For"); xff != "" && behindProxy {
-					host = xff
+					host, _, _ = strings.Cut(xff, ",")
+					host = strings.TrimSpace(host)
 				}
 
 				// If the host is empty or IPv6 loopback, set it to IPv4 loopback
@@ -74,6 +77,8 @@ func ipMiddleware(behindProxy bool, st *ipThrottler) func(next http.Handler) htt
 
 					return
 				}
+
+				logger.Debug("registered new request from IP", slog.String("ip", hostAddr.String()))
 
 				// Store the resolved IP in the context for use by RPC middlewares
 				ctx := context.WithValue(r.Context(), remoteIPContextKey, hostAddr.String())

--- a/contribs/gnofaucet/middleware_test.go
+++ b/contribs/gnofaucet/middleware_test.go
@@ -23,6 +23,76 @@ const (
 	hcaptchaTestResponse = "10000000-aaaa-bbbb-cccc-000000000001"
 )
 
+func TestIPMiddleware_XForwardedFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses first IP from multi-value header", func(t *testing.T) {
+		t.Parallel()
+
+		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+
+		var capturedIP string
+		handler := ipMiddleware(discardLogger, true, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "203.0.113.50", capturedIP)
+	})
+
+	t.Run("single IP in header", func(t *testing.T) {
+		t.Parallel()
+
+		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+
+		var capturedIP string
+		handler := ipMiddleware(discardLogger, true, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "203.0.113.50")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "203.0.113.50", capturedIP)
+	})
+
+	t.Run("uses RemoteAddr when not behind proxy", func(t *testing.T) {
+		t.Parallel()
+
+		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+
+		var capturedIP string
+		handler := ipMiddleware(discardLogger, false, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "203.0.113.50")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "10.0.0.1", capturedIP)
+	})
+}
+
 func TestCheckHcaptcha(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -57,6 +57,9 @@ type serveCfg struct {
 	remote        string
 	isBehindProxy bool
 	logLevel      string
+
+	rateLimitInterval     time.Duration
+	rateLimitCleanTimeout time.Duration
 }
 
 func newServeCmd() *commands.Command {
@@ -136,6 +139,20 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 		"info",
 		"log level (debug, info, warn, error)",
 	)
+
+	fs.DurationVar(
+		&c.rateLimitInterval,
+		"ratelimit-interval",
+		defaultRateLimitInterval,
+		"minimum interval between allowed requests from the same IP",
+	)
+
+	fs.DurationVar(
+		&c.rateLimitCleanTimeout,
+		"ratelimit-cleanup-timeout",
+		defaultCleanTimeout,
+		"how long an idle IP entry is kept before being removed",
+	)
 }
 
 // newLogger constructs a JSON structured logger at the configured level.
@@ -169,6 +186,14 @@ func serveFaucet(
 	logger *slog.Logger,
 	opts ...faucet.Option,
 ) error {
+	if cfg.rateLimitInterval <= 0 {
+		return errors.New("ratelimit-interval must be greater than zero")
+	}
+
+	if cfg.rateLimitCleanTimeout <= 0 {
+		return errors.New("ratelimit-cleanup-timeout must be greater than zero")
+	}
+
 	// Parse static gas values.
 	// It is worth noting that this is temporary,
 	// and will be removed once gas estimation is enabled


### PR DESCRIPTION
- Fix parsing of IPs on X-Forwarded-For (not a problem but it might be depending on production configuration)
- Expose IP throttling configuration params on captcha and github login faucets.
- Log on debug level all limited IPs