### PR TITLE
fix(faucet): avoid IP spoofing

### DIFF
--- a/contribs/gnofaucet/captcha.go
+++ b/contribs/gnofaucet/captcha.go
@@ -68,7 +68,7 @@ func execCaptcha(ctx context.Context, cfg *captchaCfg, io commands.IO) error {
 
 	// Prepare the middlewares
 	httpMiddlewares := []func(http.Handler) http.Handler{
-		ipMiddleware(logger, cfg.rootCfg.isBehindProxy, st),
+		ipMiddleware(logger, cfg.rootCfg.trustedProxyCount, st),
 	}
 
 	rpcMiddlewares := []faucet.Middleware{

--- a/contribs/gnofaucet/github.go
+++ b/contribs/gnofaucet/github.go
@@ -164,7 +164,7 @@ func execGithub(ctx context.Context, cfg *githubCfg, io commands.IO) error {
 
 	// Prepare the middlewares
 	httpMiddlewares := []func(http.Handler) http.Handler{
-		ipMiddleware(logger, cfg.rootCfg.isBehindProxy, st),
+		ipMiddleware(logger, cfg.rootCfg.trustedProxyCount, st),
 		gitHubUsernameMiddleware(clientID, clientSecret, defaultGHExchange, logger, rdb),
 	}
 

--- a/contribs/gnofaucet/middleware.go
+++ b/contribs/gnofaucet/middleware.go
@@ -22,8 +22,14 @@ type contextKey int
 
 const remoteIPContextKey contextKey = iota
 
-// ipMiddleware returns the IP verification middleware, using the given subnet throttler
-func ipMiddleware(logger *slog.Logger, behindProxy bool, st *ipThrottler) func(next http.Handler) http.Handler {
+// ipMiddleware returns the IP verification middleware, using the given subnet throttler.
+//
+// trustedProxyCount is the number of trusted reverse proxies between the
+// internet and this server. When > 0 the client IP is selected from the
+// X-Forwarded-For header counting trustedProxyCount entries from the right,
+// which prevents spoofing of leftmost entries.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For
+func ipMiddleware(logger *slog.Logger, trustedProxyCount int, st *ipThrottler) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -41,12 +47,13 @@ func ipMiddleware(logger *slog.Logger, behindProxy bool, st *ipThrottler) func(n
 					return
 				}
 
-				// Check if the request is behind a proxy.
-				// X-Forwarded-For can contain a comma-separated list of IPs
-				// (e.g. "client, proxy1, proxy2"). Extract the first (client) IP.
-				if xff := r.Header.Get("X-Forwarded-For"); xff != "" && behindProxy {
-					host, _, _ = strings.Cut(xff, ",")
-					host = strings.TrimSpace(host)
+				// When behind trusted proxies, select the client IP from
+				// X-Forwarded-For by counting trustedProxyCount entries
+				// from the right. This ignores any spoofed leftmost entries.
+				if xff := r.Header.Get("X-Forwarded-For"); xff != "" && trustedProxyCount > 0 {
+					parts := strings.Split(xff, ",")
+					idx := max(len(parts)-trustedProxyCount, 0)
+					host = strings.TrimSpace(parts[idx])
 				}
 
 				// If the host is empty or IPv6 loopback, set it to IPv4 loopback

--- a/contribs/gnofaucet/middleware_test.go
+++ b/contribs/gnofaucet/middleware_test.go
@@ -26,70 +26,87 @@ const (
 func TestIPMiddleware_XForwardedFor(t *testing.T) {
 	t.Parallel()
 
-	t.Run("parses first IP from multi-value header", func(t *testing.T) {
-		t.Parallel()
+	// Helper to run ipMiddleware and return the captured IP and status code.
+	runMiddleware := func(t *testing.T, trustedProxyCount int, remoteAddr, xff string) (capturedIP string, statusCode int) {
+		t.Helper()
 
 		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
-
-		var capturedIP string
-		handler := ipMiddleware(discardLogger, true, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := ipMiddleware(discardLogger, trustedProxyCount, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
 			w.WriteHeader(http.StatusOK)
 		}))
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
-		req.RemoteAddr = "10.0.0.1:1234"
-		req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178")
+		req.RemoteAddr = remoteAddr
+		if xff != "" {
+			req.Header.Set("X-Forwarded-For", xff)
+		}
 
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "203.0.113.50", capturedIP)
+		return capturedIP, rr.Code
+	}
+
+	t.Run("count=0 uses RemoteAddr and ignores XFF", func(t *testing.T) {
+		t.Parallel()
+
+		ip, code := runMiddleware(t, 0, "10.0.0.1:1234", "203.0.113.50")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "10.0.0.1", ip)
 	})
 
-	t.Run("single IP in header", func(t *testing.T) {
+	t.Run("count=1 selects rightmost XFF entry (client IP)", func(t *testing.T) {
 		t.Parallel()
 
-		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
-
-		var capturedIP string
-		handler := ipMiddleware(discardLogger, true, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
-			w.WriteHeader(http.StatusOK)
-		}))
-
-		req := httptest.NewRequest(http.MethodPost, "/", nil)
-		req.RemoteAddr = "10.0.0.1:1234"
-		req.Header.Set("X-Forwarded-For", "203.0.113.50")
-
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "203.0.113.50", capturedIP)
+		// 1 proxy: proxy appends client IP → rightmost is client
+		ip, code := runMiddleware(t, 1, "10.0.0.1:1234", "203.0.113.50")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "203.0.113.50", ip)
 	})
 
-	t.Run("uses RemoteAddr when not behind proxy", func(t *testing.T) {
+	t.Run("count=1 ignores spoofed leftmost entries", func(t *testing.T) {
 		t.Parallel()
 
-		st := newIPThrottler(defaultRateLimitInterval, defaultCleanTimeout)
+		// Client spoofed "1.1.1.1", 1 proxy appended real client IP
+		ip, code := runMiddleware(t, 1, "10.0.0.1:1234", "1.1.1.1, 203.0.113.50")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "203.0.113.50", ip)
+	})
 
-		var capturedIP string
-		handler := ipMiddleware(discardLogger, false, st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			capturedIP, _ = r.Context().Value(remoteIPContextKey).(string)
-			w.WriteHeader(http.StatusOK)
-		}))
+	t.Run("count=2 skips one trusted proxy entry", func(t *testing.T) {
+		t.Parallel()
 
-		req := httptest.NewRequest(http.MethodPost, "/", nil)
-		req.RemoteAddr = "10.0.0.1:1234"
-		req.Header.Set("X-Forwarded-For", "203.0.113.50")
+		// 2 proxies: proxy1 appended client, proxy2 appended proxy1
+		// XFF: "spoofed, client, proxy1" → pick index len-2 = client
+		ip, code := runMiddleware(t, 2, "10.0.0.1:1234", "1.1.1.1, 203.0.113.50, 70.41.3.18")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "203.0.113.50", ip)
+	})
 
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
+	t.Run("count exceeds entries uses leftmost", func(t *testing.T) {
+		t.Parallel()
 
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "10.0.0.1", capturedIP)
+		// count=3 but only 2 entries: all from trusted proxies, leftmost is client
+		ip, code := runMiddleware(t, 3, "10.0.0.1:1234", "203.0.113.50, 70.41.3.18")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "203.0.113.50", ip)
+	})
+
+	t.Run("count>0 with empty XFF falls back to RemoteAddr", func(t *testing.T) {
+		t.Parallel()
+
+		ip, code := runMiddleware(t, 1, "10.0.0.1:1234", "")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "10.0.0.1", ip)
+	})
+
+	t.Run("handles whitespace in XFF entries", func(t *testing.T) {
+		t.Parallel()
+
+		ip, code := runMiddleware(t, 2, "10.0.0.1:1234", "  1.1.1.1 , 203.0.113.50 , 70.41.3.18 ")
+		assert.Equal(t, http.StatusOK, code)
+		assert.Equal(t, "203.0.113.50", ip)
 	})
 }
 

--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -54,9 +54,9 @@ type serveCfg struct {
 	maxSendAmount string
 	numAccounts   uint64
 
-	remote        string
-	isBehindProxy bool
-	logLevel      string
+	remote            string
+	trustedProxyCount int
+	logLevel          string
 
 	rateLimitInterval     time.Duration
 	rateLimitCleanTimeout time.Duration
@@ -126,11 +126,11 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 		"the static max send amount (native currency)",
 	)
 
-	fs.BoolVar(
-		&c.isBehindProxy,
-		"is-behind-proxy",
-		false,
-		"use X-Forwarded-For IP for throttling",
+	fs.IntVar(
+		&c.trustedProxyCount,
+		"trusted-proxy-count",
+		0,
+		"number of trusted reverse proxies between the internet and this server; client IP is selected from the right side of X-Forwarded-For (0 disables)",
 	)
 
 	fs.StringVar(


### PR DESCRIPTION
Changed --is-behind-proxy to --trusted-proxy-count to avoid spoofed IPs by the client.