### PR TITLE
fix(gnovm): register vm amino types in gno CLI

### DIFF
--- a/gnovm/cmd/gno/main.go
+++ b/gnovm/cmd/gno/main.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"runtime/pprof"
 
+	// Register vm amino types so the gno CLI can deserialize
+	// ABCI errors (e.g. InvalidPackageError) from chain RPC responses.
+	_ "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 )
 


### PR DESCRIPTION
Fix #4739 

## Summary

Since #4410, `QueryFile` returns typed errors (`InvalidPackageError`, `InvalidFileError`) instead of plain `fmt.Errorf`. These errors are amino-encoded in ABCI responses with `{"@type": "/vm.InvalidPackageError"}`.

The `gno` CLI (`gno mod download`, `gno test`) uses `rpcpkgfetcher` to fetch packages from chain RPC via `vm/qfile` ABCI queries. The CLI doesn't import `gno.land/pkg/sdk/vm`, so its amino codec can't deserialize these typed errors, failing with:

```
amino: unrecognized concrete type full name vm.InvalidPackageError
```

This makes `gno mod download` silently fail — no files are written to the module cache, and subsequent `gno test` runs fail with `no such file or directory`.

## Fix

Add a blank import of `gno.land/pkg/sdk/vm` in the `gno` CLI's `main.go` to register the amino types. The CLI can then properly deserialize and display the error:

```
qfile failed: invalid package
-- package "gno.land/p/foo" is not available
```

## How to reproduce

```bash
# Clear the module cache
mv  ~/.config/gno/pkg/mod ~/.config/gno/pkg/mod.bak

# Try to download packages from any chain running post-#4410
git clone git@github.com:allinbits/gno-realms
cd gno-realms
gno mod download -C <package-dir>
# Before fix: "amino: unrecognized concrete type full name vm.InvalidPackageError"
# After fix: "qfile failed: invalid package — package X is not available"
```