### PR TITLE
feat(govdao): add script to set valoper registration fee to 0

### DIFF
--- a/misc/deployments/gnoland1/govdao-scripts/README.md
+++ b/misc/deployments/gnoland1/govdao-scripts/README.md
@@ -10,4 +10,5 @@ All scripts default to `GNOKEY_NAME=moul`, `CHAIN_ID=gnoland1`, and `REMOTE=http
 ./rm-validator.sh ADDR                       # remove a validator
 ./extend-govdao-t1.sh                       # add 6 T1 members to govDAO (one-time bootstrap)
 ./unrestrict-account.sh ADDR [ADDR...]      # allow address(es) to transfer ugnot
+./set-valoper-price-zero.sh                 # set r/gnops/valopers registration fee to 0
 ```

--- a/misc/deployments/gnoland1/govdao-scripts/set-valoper-price-zero.sh
+++ b/misc/deployments/gnoland1/govdao-scripts/set-valoper-price-zero.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Set the r/gnops/valopers registration fee to 0 via govDAO proposal.
+#
+# This removes the 20 GNOT barrier for valoper registration, allowing
+# anyone to register as a valoper without holding funds.
+#
+# Usage:
+#   ./set-valoper-price-zero.sh
+#
+# Environment:
+#   GNOKEY_NAME   - gnokey key name (default: moul)
+#   CHAIN_ID      - chain ID (default: gnoland1)
+#   REMOTE        - RPC endpoint (default: https://rpc.betanet.testnets.gno.land:443)
+#   GAS_WANTED    - gas limit (default: 10000000)
+#   GAS_FEE       - gas fee (default: 1000000ugnot)
+set -eo pipefail
+
+GNOKEY_NAME="${GNOKEY_NAME:-moul}"
+CHAIN_ID="${CHAIN_ID:-gnoland1}"
+REMOTE="${REMOTE:-https://rpc.betanet.testnets.gno.land:443}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/set_valoper_price_zero.gno" <<'GOEOF'
+package main
+
+import (
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+)
+
+func main() {
+	r := proposal.ProposeNewMinFeeProposalRequest(cross, 0)
+	pid := dao.MustCreateProposal(cross, r)
+	dao.MustVoteOnProposal(cross, dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.ExecuteProposal(cross, pid)
+}
+GOEOF
+
+echo "Setting valoper registration fee to 0..."
+echo "  Key: ${GNOKEY_NAME}"
+echo "  Chain: ${CHAIN_ID}"
+echo "  Remote: ${REMOTE}"
+echo ""
+
+gnokey maketx run \
+  -gas-wanted "$GAS_WANTED" \
+  -gas-fee "$GAS_FEE" \
+  -broadcast \
+  -chainid "$CHAIN_ID" \
+  -remote "$REMOTE" \
+  "$GNOKEY_NAME" \
+  "$TMPDIR/set_valoper_price_zero.gno"


### PR DESCRIPTION
## Summary

Adds a govDAO deployment script that sets the `r/gnops/valopers` registration fee to 0, removing the 20 GNOT barrier for valoper self-registration.

## Motivation

The valoper registry (`r/gnops/valopers`) currently requires a minimum fee of 20 GNOT to register. This blocks:
- Validators who don't hold GNOT from registering their profile
- The validator blog-post signup workflow
- Onboarding new validators before the hard fork

Setting the fee to 0 via GovDAO unblocks these workflows without any code change to the realm.

## Changes

- `misc/deployments/gnoland1/govdao-scripts/set-valoper-price-zero.sh` — new script that creates a GovDAO proposal using `proposal.ProposeNewMinFeeProposalRequest(0)`, votes YES, and executes it immediately
- `misc/deployments/gnoland1/govdao-scripts/README.md` — documents the new script

## Usage

```bash
# With defaults (key=moul, chain=gnoland1, remote=rpc.betanet.testnets.gno.land)
./set-valoper-price-zero.sh

# With custom env
GNOKEY_NAME=mykey CHAIN_ID=gnoland1 ./set-valoper-price-zero.sh
```

## Test plan

- [ ] Run on a local testnet to confirm proposal is created, voted on, and executed
- [ ] Verify `r/gnops/valopers` registration works with 0 fee after execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)