### PR TITLE
fix(bank): add missing return after address parse error in `queryBalance`

### DIFF
--- a/tm2/pkg/sdk/bank/handler.go
+++ b/tm2/pkg/sdk/bank/handler.go
@@ -121,6 +121,7 @@ func (bh bankHandler) queryBalance(ctx sdk.Context, req abci.RequestQuery) (res 
 	if err != nil {
 		res = sdk.ABCIResponseQueryFromError(
 			std.ErrInvalidAddress("invalid query address " + b32addr))
+		return
 	}
 
 	// get coins from addr.

--- a/tm2/pkg/sdk/bank/handler_test.go
+++ b/tm2/pkg/sdk/bank/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
 	tu "github.com/gnolang/gno/tm2/pkg/sdk/testutils"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -52,6 +53,29 @@ func TestBalances(t *testing.T) {
 	require.NotNil(t, res)
 	require.NoError(t, amino.UnmarshalJSON(res.Data, &coins))
 	require.True(t, coins.AmountOf("foo") == 10)
+}
+
+func TestQueryBalanceInvalidAddress(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	h := NewHandler(env.bankk)
+
+	// Fund the zero address so we can detect the information leak.
+	zeroAddr := crypto.Address{} // all-zero address
+	acc := env.acck.NewAccountWithAddress(env.ctx, zeroAddr)
+	acc.SetCoins(std.NewCoins(std.NewCoin("secret", 999)))
+	env.acck.SetAccount(env.ctx, acc)
+
+	// Query with an invalid (non-bech32) address.
+	req := abci.RequestQuery{
+		Path: fmt.Sprintf("bank/%s/%s", QueryBalance, "notavalidaddress"),
+		Data: []byte{},
+	}
+	res := h.Query(env.ctx, req)
+
+	require.NotNil(t, res.Error, "invalid address should return an error")
+	require.Empty(t, res.Data, "invalid address should not return any balance data")
 }
 
 func TestQuerierRouteNotFound(t *testing.T) {


### PR DESCRIPTION
## Description

`queryBalance` is missing a `return` after handling an invalid address. This was introduced in 36fff1370, which refactored address parsing from `amino.UnmarshalJSON` to `crypto.AddressFromBech32`.

Without the `return`, execution falls through ro `GetConis` with a zero-address. The error response is silently overwritten with zero-address balance.

## Changes

- Add `return` after the address parsing error branch
- add test that funds the zero address and confirms an invalid address query returns an error