### PR TITLE
fix(tm2): add wait after stop in `crashWALandCheckLiveness`

### DIFF
--- a/tm2/pkg/bft/consensus/replay_test.go
+++ b/tm2/pkg/bft/consensus/replay_test.go
@@ -225,6 +225,7 @@ LOOP:
 
 			// stop consensus state and transactions sender (initFn)
 			cs.Stop()
+			cs.Wait()
 			cancel()
 
 			// if we reached the required height, exit

--- a/tm2/pkg/bft/consensus/replay_test.go
+++ b/tm2/pkg/bft/consensus/replay_test.go
@@ -232,8 +232,8 @@ LOOP:
 			if _, ok := err.(ReachedLastBlockHeightError); ok {
 				break LOOP
 			}
-		case <-time.After(10 * time.Second):
-			t.Fatal("WAL did not panic for 10 seconds (check the log)")
+		case <-time.After(30 * time.Second):
+			t.Fatal("WAL did not panic for 30 seconds (check the log)")
 		}
 	}
 }


### PR DESCRIPTION
## Description

closes #5394 

- add `cs.Wait()` after `cs.Stop()`

`ConsensusState.Stop()` signals shutdown via the quit channel but returns immediately. The `receiveRoutine` goroutine may still be running when the next crash loop iter starts. Without `Wait()`, coroutines from previous iterations accumulate, creating scheduling pressure that slows subsequent iterations enough to exceed the hardcoded 10s timeout.

Adding `Wait()` blocks until the goroutine exits, ensuring clean handoff between iterations.

### Reproduction


```go
// PATH: tm2/pkg/bft/consensus/replay_flaky_test.go
package consensus

import (
	"fmt"
	"io"
	"log/slog"
	"os"
	"runtime"
	"sync"
	"testing"
	"time"

	"github.com/stretchr/testify/require"

	"github.com/gnolang/gno/tm2/pkg/bft/abci/example/kvstore"
	cfg "github.com/gnolang/gno/tm2/pkg/bft/config"
	sm "github.com/gnolang/gno/tm2/pkg/bft/state"
	walm "github.com/gnolang/gno/tm2/pkg/bft/wal"
	"github.com/gnolang/gno/tm2/pkg/db/memdb"
	"github.com/gnolang/gno/tm2/pkg/log"
)

// delayedWAL wraps a WAL and adds artificial delay to writes, simulating
// the goroutine scheduling latency seen on loaded CI runners.
type delayedWAL struct {
	next     walm.WAL
	delay    time.Duration
	writesMu sync.Mutex
	writes   int
}

var _ walm.WAL = &delayedWAL{}

func (w *delayedWAL) SetLogger(logger *slog.Logger) { w.next.SetLogger(logger) }

func (w *delayedWAL) Write(m walm.WALMessage) error {
	w.writesMu.Lock()
	w.writes++
	w.writesMu.Unlock()
	time.Sleep(w.delay)
	return w.next.Write(m)
}

func (w *delayedWAL) WriteSync(m walm.WALMessage) error {
	w.writesMu.Lock()
	w.writes++
	w.writesMu.Unlock()
	time.Sleep(w.delay)
	return w.next.WriteSync(m)
}

func (w *delayedWAL) WriteMetaSync(m walm.MetaMessage) error {
	time.Sleep(w.delay)
	return w.next.WriteMetaSync(m)
}

func (w *delayedWAL) FlushAndSync() error { return w.next.FlushAndSync() }

func (w *delayedWAL) SearchForHeight(height int64, options *walm.WALSearchOptions) (io.ReadCloser, bool, error) {
	return w.next.SearchForHeight(height, options)
}

func (w *delayedWAL) Start() error { return w.next.Start() }
func (w *delayedWAL) Stop() error  { return w.next.Stop() }
func (w *delayedWAL) Wait()        { w.next.Wait() }

// TestWALCrashFlaky_SlowWALTimeout deterministically reproduces the timeout
// failure.
func TestWALCrashFlaky_SlowWALTimeout(t *testing.T) {
	t.Parallel()

	cases := []struct {
		name          string
		delay         time.Duration
		timeout       time.Duration
		expectTimeout bool
	}{
		{"no_delay", 0, 5 * time.Second, false},
		{"300ms_delay", 300 * time.Millisecond, 2 * time.Second, true},
	}

	for i, tc := range cases {
		t.Run(tc.name, func(t *testing.T) {
			t.Parallel()

			rc, gf := ResetConfig(fmt.Sprintf("WALCrashFlaky_slow_%d", i))
			defer os.RemoveAll(rc.RootDir)

			crashCh := make(chan error)
			cwal := &crashingWAL{crashCh: crashCh, lastBlockHeight: 1}

			var timedOut bool
			iter := 1
		LOOP:
			for {
				logger := log.NewTestingLogger(t)
				blockDB := memdb.NewMemDB()
				state, _ := sm.MakeGenesisStateFromFile(gf)
				privValidator := loadPrivValidator(rc)
				cs := newConsensusStateWithConfigAndBlockStore(rc, state, privValidator, kvstore.NewKVStoreApplication(), blockDB)
				cs.SetLogger(logger)

				walFile := cs.config.WalFile()
				os.Remove(walFile)
				csWal, err := cs.OpenWAL(walFile)
				require.NoError(t, err)

				// Stack: consensus → delayedWAL → crashingWAL → real WAL
				cwal.next = csWal
				cwal.msgIndex = 1
				dwal := &delayedWAL{next: cwal, delay: tc.delay}
				cs.wal = dwal

				err = cs.Start()
				require.NoError(t, err)
				iter++

				select {
				case err := <-crashCh:
					dwal.writesMu.Lock()
					writes := dwal.writes
					dwal.writesMu.Unlock()
					t.Logf("iteration %d: WAL crashed after %d writes (cumulative delay=%v): %v",
						iter, writes, time.Duration(writes)*tc.delay, err)
					cs.Stop()

					if _, ok := err.(ReachedLastBlockHeightError); ok {
						break LOOP
					}
				case <-time.After(tc.timeout):
					dwal.writesMu.Lock()
					writes := dwal.writes
					dwal.writesMu.Unlock()
					t.Logf("iteration %d: TIMEOUT — %d writes x %v = %v exceeded %v",
						iter, writes, tc.delay, time.Duration(writes)*tc.delay, tc.timeout)
					cs.Stop()
					timedOut = true
					break LOOP
				}
			}

			if timedOut != tc.expectTimeout {
				t.Errorf("expected timeout=%v but got timeout=%v", tc.expectTimeout, timedOut)
			}
		})
	}
}

// TestWALCrashFlaky_StopWithoutWaitGoroutineAccumulation validates the fix:
// adding cs.Wait() after cs.Stop() reduces peak goroutine count, which
// reduces scheduling pressure that causes the 10s timeout to be exceeded.
func TestWALCrashFlaky_StopWithoutWaitGoroutineAccumulation(t *testing.T) {
	t.Parallel()

	replayConfig, genesisFile := ResetConfig(fmt.Sprintf("%s_accum", t.Name()))
	defer os.RemoveAll(replayConfig.RootDir)

	const iterations = 20
	goroutinesBefore := runtime.NumGoroutine()

	// --- Stop without Wait
	var peakWithout int
	for i := range iterations {
		cs := makeConsensusStateForReplay(t, replayConfig, genesisFile)
		err := cs.Start()
		require.NoError(t, err)

		cs.Stop()
		// No cs.Wait()

		if g := runtime.NumGoroutine(); g > peakWithout {
			peakWithout = g
		}
		if i%5 == 4 {
			t.Logf("without_wait iteration %d: goroutines=%d", i, runtime.NumGoroutine())
		}
	}

	time.Sleep(500 * time.Millisecond)
	afterWithout := runtime.NumGoroutine()

	// --- Stop + Wait
	var peakWith int
	for i := range iterations {
		cs := makeConsensusStateForReplay(t, replayConfig, genesisFile)
		err := cs.Start()
		require.NoError(t, err)

		cs.Stop()
		cs.Wait()

		if g := runtime.NumGoroutine(); g > peakWith {
			peakWith = g
		}
		if i%5 == 4 {
			t.Logf("with_wait iteration %d: goroutines=%d", i, runtime.NumGoroutine())
		}
	}

	time.Sleep(500 * time.Millisecond)
	afterWith := runtime.NumGoroutine()

	t.Logf("before: %d goroutines", goroutinesBefore)
	t.Logf("without Wait(): peak=%d, final=%d", peakWithout, afterWithout)
	t.Logf("with    Wait(): peak=%d, final=%d", peakWith, afterWith)

	if peakWith >= peakWithout {
		t.Errorf("expected Wait() to reduce peak goroutines: without=%d, with=%d", peakWithout, peakWith)
	} else {
		t.Logf("CONFIRMED: Wait() reduces peak goroutines from %d to %d (%.0f%% reduction)",
			peakWithout, peakWith, float64(peakWithout-peakWith)/float64(peakWithout)*100)
	}
}

// makeConsensusStateForReplay creates a ConsensusState with WAL for replay
// testing. Uses newConsensusStateWithConfigAndBlockStore from common_test.go
// and loadPrivValidator from common_test.go.
func makeConsensusStateForReplay(t *testing.T, replayConfig *cfg.Config, genesisFile string) *ConsensusState {
	t.Helper()

	logger := log.NewTestingLogger(t)
	blockDB := memdb.NewMemDB()
	state, _ := sm.MakeGenesisStateFromFile(genesisFile)
	privValidator := loadPrivValidator(replayConfig)
	cs := newConsensusStateWithConfigAndBlockStore(replayConfig, state, privValidator, kvstore.NewKVStoreApplication(), blockDB)
	cs.SetLogger(logger)

	walFile := cs.config.WalFile()
	os.Remove(walFile)
	csWal, err := cs.OpenWAL(walFile)
	require.NoError(t, err)
	cs.wal = csWal

	return cs
}
```