### PR TITLE
fix(gnovm): Support mixed key and unkeyed elements in a slice

### DIFF
--- a/gnovm/pkg/gnolang/bench_ops_test.go
+++ b/gnovm/pkg/gnolang/bench_ops_test.go
@@ -1229,49 +1229,6 @@ func BenchmarkOpUxor_BigInt_1024(b *testing.B) { benchOpUxor_BigInt(b, 1024) }
 func BenchmarkOpUxor_BigInt_4096(b *testing.B) { benchOpUxor_BigInt(b, 4096) }
 
 // ---------------------------------------------------------------------------
-// doOpSliceLit: PopExpr(CompositeLitExpr), pop N values, pop type, push slice.
-// Parameterized by element count.
-// ---------------------------------------------------------------------------
-
-func benchOpSliceLit(b *testing.B, n int) {
-	b.Helper()
-	m := benchMachine()
-	defer m.Release()
-
-	st := m.Alloc.NewType(&SliceType{Elt: IntType, Vrd: false})
-	elts := make([]KeyValueExpr, n)
-	for i := range n {
-		elts[i] = KeyValueExpr{Value: &ConstExpr{}}
-	}
-	litExpr := &CompositeLitExpr{Elts: elts}
-
-	bm.InitMeasure()
-	bm.BeginOpCode(bmSetup)
-	for range b.N {
-		m.PushValue(asValue(st))
-		for i := range n {
-			m.PushValue(TypedValue{T: IntType, N: i2n(int64(i))})
-		}
-		m.PushExpr(litExpr)
-		bm.SwitchOpCode(bmTarget)
-		m.doOpSliceLit()
-		bm.SwitchOpCode(bmSetup)
-		res := m.PeekValue(1)
-		sv := res.V.(*SliceValue)
-		if sv.Length != n {
-			b.Fatalf("expected len %d, got %d", n, sv.Length)
-		}
-		m.Values = m.Values[:0]
-	}
-	reportBenchops(b)
-}
-
-func BenchmarkOpSliceLit_1(b *testing.B)    { benchOpSliceLit(b, 1) }
-func BenchmarkOpSliceLit_10(b *testing.B)   { benchOpSliceLit(b, 10) }
-func BenchmarkOpSliceLit_100(b *testing.B)  { benchOpSliceLit(b, 100) }
-func BenchmarkOpSliceLit_1000(b *testing.B) { benchOpSliceLit(b, 1000) }
-
-// ---------------------------------------------------------------------------
 // doOpArrayLit: PopExpr(CompositeLitExpr), PopValues(N), peek type at bottom, push array.
 // Parameterized by element count.
 // ---------------------------------------------------------------------------
@@ -3569,18 +3526,20 @@ func BenchmarkOpConvert_StringToRunes_10(b *testing.B)   { benchOpConvert_String
 func BenchmarkOpConvert_StringToRunes_100(b *testing.B)  { benchOpConvert_StringToRunes(b, 100) }
 func BenchmarkOpConvert_StringToRunes_1000(b *testing.B) { benchOpConvert_StringToRunes(b, 1000) }
 
-// --- SliceLit2 sparse: maxVal amplification ---
+// ---------------------------------------------------------------------------
+// doOpSliceLit: PopExpr(CompositeLitExpr), PopValues(N), peek type, push slice.
+// Parameterized by element count (dense, no keys).
+// ---------------------------------------------------------------------------
 
-func benchOpSliceLit2_Sparse(b *testing.B, maxIdx int) {
+func benchOpSliceLit(b *testing.B, n int) {
 	b.Helper()
 	m := benchMachine()
 	defer m.Release()
 
-	st := &SliceType{Elt: IntType}
-	// Two keyed elements: index 0 and index maxIdx
-	elts := []KeyValueExpr{
-		{Key: &ConstExpr{}, Value: &ConstExpr{}},
-		{Key: &ConstExpr{}, Value: &ConstExpr{}},
+	st := m.Alloc.NewType(&SliceType{Elt: IntType, Vrd: false})
+	elts := make([]KeyValueExpr, n)
+	for i := range n {
+		elts[i] = KeyValueExpr{Value: &ConstExpr{}}
 	}
 	litExpr := &CompositeLitExpr{Elts: elts}
 
@@ -3588,14 +3547,53 @@ func benchOpSliceLit2_Sparse(b *testing.B, maxIdx int) {
 	bm.BeginOpCode(bmSetup)
 	for range b.N {
 		m.PushValue(asValue(st))
-		// Push key-value pairs: (0, 1) and (maxIdx, 2)
-		m.PushValue(TypedValue{T: IntType, N: i2n(0)})
+		for i := range n {
+			m.PushValue(TypedValue{T: IntType, N: i2n(int64(i))})
+		}
+		m.PushExpr(litExpr)
+		bm.SwitchOpCode(bmTarget)
+		m.doOpSliceLit()
+		bm.SwitchOpCode(bmSetup)
+		res := m.PeekValue(1)
+		sv := res.V.(*SliceValue)
+		if sv.Length != n {
+			b.Fatalf("expected len %d, got %d", n, sv.Length)
+		}
+		m.Values = m.Values[:0]
+	}
+	reportBenchops(b)
+}
+
+func BenchmarkOpSliceLit_1(b *testing.B)    { benchOpSliceLit(b, 1) }
+func BenchmarkOpSliceLit_10(b *testing.B)   { benchOpSliceLit(b, 10) }
+func BenchmarkOpSliceLit_100(b *testing.B)  { benchOpSliceLit(b, 100) }
+func BenchmarkOpSliceLit_1000(b *testing.B) { benchOpSliceLit(b, 1000) }
+
+// --- SliceLit sparse: maxVal amplification ---
+
+func benchOpSliceLit_Sparse(b *testing.B, maxIdx int) {
+	b.Helper()
+	m := benchMachine()
+	defer m.Release()
+
+	st := &SliceType{Elt: IntType}
+	// Two keyed elements: index 0 and index maxIdx (keys read from AST)
+	elts := []KeyValueExpr{
+		{Key: &ConstExpr{TypedValue: TypedValue{T: IntType, N: i2n(0)}}, Value: &ConstExpr{}},
+		{Key: &ConstExpr{TypedValue: TypedValue{T: IntType, N: i2n(int64(maxIdx))}}, Value: &ConstExpr{}},
+	}
+	litExpr := &CompositeLitExpr{Elts: elts}
+
+	bm.InitMeasure()
+	bm.BeginOpCode(bmSetup)
+	for range b.N {
+		m.PushValue(asValue(st))
+		// Push only values (keys are read from AST)
 		m.PushValue(TypedValue{T: IntType, N: i2n(1)})
-		m.PushValue(TypedValue{T: IntType, N: i2n(int64(maxIdx))})
 		m.PushValue(TypedValue{T: IntType, N: i2n(2)})
 		m.PushExpr(litExpr)
 		bm.SwitchOpCode(bmTarget)
-		m.doOpSliceLit2()
+		m.doOpSliceLit()
 		bm.SwitchOpCode(bmSetup)
 		res := m.PeekValue(1)
 		rsv := res.V.(*SliceValue)
@@ -3607,10 +3605,10 @@ func benchOpSliceLit2_Sparse(b *testing.B, maxIdx int) {
 	reportBenchops(b)
 }
 
-func BenchmarkOpSliceLit2_Sparse_10(b *testing.B)    { benchOpSliceLit2_Sparse(b, 9) }
-func BenchmarkOpSliceLit2_Sparse_100(b *testing.B)   { benchOpSliceLit2_Sparse(b, 99) }
-func BenchmarkOpSliceLit2_Sparse_1000(b *testing.B)  { benchOpSliceLit2_Sparse(b, 999) }
-func BenchmarkOpSliceLit2_Sparse_10000(b *testing.B) { benchOpSliceLit2_Sparse(b, 9999) }
+func BenchmarkOpSliceLit_Sparse_10(b *testing.B)    { benchOpSliceLit_Sparse(b, 9) }
+func BenchmarkOpSliceLit_Sparse_100(b *testing.B)   { benchOpSliceLit_Sparse(b, 99) }
+func BenchmarkOpSliceLit_Sparse_1000(b *testing.B)  { benchOpSliceLit_Sparse(b, 999) }
+func BenchmarkOpSliceLit_Sparse_10000(b *testing.B) { benchOpSliceLit_Sparse(b, 9999) }
 
 // --- ArrayLit uint8: NewDataArray (flat byte alloc) vs non-uint8 ---
 

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -1120,8 +1120,7 @@ const (
 	OpStaticTypeOf Op = 0x4A // static type of X
 	OpCompositeLit Op = 0x4B // X{???}
 	OpArrayLit     Op = 0x4C // [Len]{...}
-	OpSliceLit     Op = 0x4D // []{value,...}
-	OpSliceLit2    Op = 0x4E // []{key:value,...}
+	OpSliceLit     Op = 0x4E // []{...}
 	OpMapLit       Op = 0x4F // X{...}
 	OpStructLit    Op = 0x50 // X{...}
 	OpFuncLit      Op = 0x51 // func(T){Body}
@@ -1328,8 +1327,7 @@ const (
 	OpCPUStaticTypeOf    = 520 // XXX arbitrary
 	OpCPUCompositeLit    = 76
 	OpCPUArrayLit        = 292 // base from fit; per-element added in handler
-	OpCPUSliceLit        = 342 // base from fit; per-element added in handler
-	OpCPUSliceLit2       = 966 // base from fit; per-alloc-size added in handler
+	OpCPUSliceLit        = 966 // base from fit; per-alloc-size added in handler
 	OpCPUMapLit          = 536 // base; per-entry added in handler (fit base negative, clamped to ~536)
 	OpCPUStructLit       = 326 // base from fit; per-field added in handler (max of unnamed=307, named=326)
 	OpCPUFuncLit         = 269 // base from fit; per-capture added in handler
@@ -1387,8 +1385,7 @@ const (
 	OpCPUSlopeAssign          = 86  // per LHS variable (fit: 86.2)
 	OpCPUSlopeMapLit          = 335 // per map entry (fit: 335.0)
 	OpCPUSlopeArrayLit        = 52  // per element (max of int=52, uint8=9)
-	OpCPUSlopeSliceLit        = 28  // per element (fit: 28.5)
-	OpCPUSlopeSliceLit2       = 31  // per alloc size (fit: 31.4)
+	OpCPUSlopeSliceLit        = 31  // per alloc size (fit: 31.4)
 	OpCPUSlopeStructLit       = 51  // per field (max of unnamed=29, named=51)
 	OpCPUSlopeFuncLit         = 34  // per capture (fit: 34.0)
 	OpCPUSlopeCallParam       = 53  // per param in OpCall (fit: 52.5)
@@ -1699,9 +1696,6 @@ func (m *Machine) runOnce() (caught *Exception) {
 		case OpSliceLit:
 			m.incrCPU(OpCPUSliceLit)
 			m.doOpSliceLit()
-		case OpSliceLit2:
-			m.incrCPU(OpCPUSliceLit2)
-			m.doOpSliceLit2()
 		case OpFuncLit:
 			m.incrCPU(OpCPUFuncLit)
 			m.doOpFuncLit()

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -387,14 +387,10 @@ func (m *Machine) doOpCompositeLit() {
 		}
 	case *SliceType:
 		m.PushOp(OpSliceLit2)
-		// evaluate item values; also evaluate key if present
+		// evaluate item values only (keys are read from AST in doOpSliceLit2)
 		for i := len(x.Elts) - 1; 0 <= i; i-- {
 			m.PushExpr(x.Elts[i].Value)
 			m.PushOp(OpEval)
-			if x.Elts[i].Key != nil {
-				m.PushExpr(x.Elts[i].Key)
-				m.PushOp(OpEval)
-			}
 		}
 	case *MapType:
 		m.PushOp(OpMapLit)
@@ -505,66 +501,49 @@ func (m *Machine) doOpSliceLit() {
 
 func (m *Machine) doOpSliceLit2() {
 	x := m.PopExpr().(*CompositeLitExpr)
-	// count total stack items: key+value for keyed elements, value only for unkeyed.
-	total := len(x.Elts)
-	for _, elt := range x.Elts {
-		if elt.Key != nil {
-			total++
-		}
-	}
-	tvs := m.PopValues(total)
+	ne := len(x.Elts)
 	// peek slice type.
-	st := m.PeekValue(1).V.(TypeValue).Type
-	// first pass: calculate max index, tracking prev for unkeyed elements.
-	// maxVal and idx start at -1 so that an empty literal (e.g. []rune{})
-	// produces a zero-length slice instead of a one-element slice.
-	var maxVal int64 = -1
+	st := m.PeekValue(1 + ne).V.(TypeValue).Type
+	// first pass: compute length (max index + 1).
+	var maxIdx int64 = -1
 	var idx int64 = -1
-	pos := 0
 	for _, elt := range x.Elts {
-		if elt.Key != nil {
-			idx = tvs[pos].ConvertGetInt()
-			pos++
+		if kx := elt.Key; kx != nil {
+			idx = kx.(*ConstExpr).ConvertGetInt()
 		} else {
 			idx++
 		}
-		if idx > maxVal {
-			maxVal = idx
+		if idx > maxIdx {
+			maxIdx = idx
 		}
-		pos++ // skip value
 	}
-	m.incrCPU(OpCPUSlopeSliceLit2 * (maxVal + 1))
+	length := maxIdx + 1
+	m.incrCPU(OpCPUSlopeSliceLit2 * length)
 	// construct element buf slice.
-	// alloc before the underlying array constructed
-	baseArray := m.Alloc.NewListArray(int(maxVal + 1))
+	baseArray := m.Alloc.NewListArray(int(length))
 	es := baseArray.List
-
-	// second pass: fill values.
+	vs := m.PopValues(ne)
+	// second pass: fill values using AST keys.
 	idx = -1
-	pos = 0
-	for _, elt := range x.Elts {
-		if elt.Key != nil {
-			idx = tvs[pos].ConvertGetInt()
-			pos++
+	for i, elt := range x.Elts {
+		if kx := elt.Key; kx != nil {
+			idx = kx.(*ConstExpr).ConvertGetInt()
 		} else {
 			idx++
 		}
-		vtv := tvs[pos]
-		pos++
 		if es[idx].IsDefined() {
-			// slice index has already been assigned
 			panic(fmt.Sprintf("duplicate index %d in array or slice literal", idx))
 		}
-		es[idx] = vtv.Copy(m.Alloc)
+		es[idx] = vs[i].Copy(m.Alloc)
 	}
-	// fill in empty values.
+	// fill unset elements with zero values.
 	ste := st.Elem()
 	for i, etv := range es {
 		if etv.IsUndefined() {
 			es[i] = defaultTypedValue(m.Alloc, ste)
 		}
 	}
-	// construct and push value.
+	// pop type, push slice.
 	if debug {
 		if m.PopValue().V.(TypeValue).Type != st {
 			panic("should not happen")
@@ -572,7 +551,7 @@ func (m *Machine) doOpSliceLit2() {
 	} else {
 		m.PopValue()
 	}
-	sv := m.Alloc.NewSlice(baseArray, 0, int(maxVal+1), int(maxVal+1))
+	sv := m.Alloc.NewSlice(baseArray, 0, int(length), int(length))
 	m.PushValue(TypedValue{
 		T: st,
 		V: sv,

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -386,8 +386,8 @@ func (m *Machine) doOpCompositeLit() {
 			m.PushOp(OpEval)
 		}
 	case *SliceType:
-		m.PushOp(OpSliceLit2)
-		// evaluate item values only (keys are read from AST in doOpSliceLit2)
+		m.PushOp(OpSliceLit)
+		// evaluate item values only (keys are read from AST in doOpSliceLit)
 		for i := len(x.Elts) - 1; 0 <= i; i-- {
 			m.PushExpr(x.Elts[i].Value)
 			m.PushOp(OpEval)
@@ -474,32 +474,8 @@ func (m *Machine) doOpArrayLit() {
 	})
 }
 
-func (m *Machine) doOpSliceLit() {
-	x := m.PopExpr().(*CompositeLitExpr)
-	el := len(x.Elts)
-	m.incrCPU(OpCPUSlopeSliceLit * int64(el))
-	// peek slice type.
-	st := m.PeekValue(1 + el).V.(TypeValue).Type
-	// construct element buf slice.
-	baseArray := m.Alloc.NewListArray(el)
-	es := baseArray.List
-	m.PopCopyValues(es)
-	// construct and push value.
-	if debug {
-		if m.PopValue().V.(TypeValue).Type != st {
-			panic("should not happen")
-		}
-	} else {
-		m.PopValue()
-	}
-	sv := m.Alloc.NewSlice(baseArray, 0, el, el)
-	m.PushValue(TypedValue{
-		T: st,
-		V: sv,
-	})
-}
 
-func (m *Machine) doOpSliceLit2() {
+func (m *Machine) doOpSliceLit() {
 	x := m.PopExpr().(*CompositeLitExpr)
 	ne := len(x.Elts)
 	// peek slice type.
@@ -518,7 +494,7 @@ func (m *Machine) doOpSliceLit2() {
 		}
 	}
 	length := maxIdx + 1
-	m.incrCPU(OpCPUSlopeSliceLit2 * length)
+	m.incrCPU(OpCPUSlopeSliceLit * length)
 	// construct element buf slice.
 	baseArray := m.Alloc.NewListArray(int(length))
 	es := baseArray.List

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -386,26 +386,13 @@ func (m *Machine) doOpCompositeLit() {
 			m.PushOp(OpEval)
 		}
 	case *SliceType:
-		if len(x.Elts) > 0 && x.Elts[0].Key != nil {
-			m.PushOp(OpSliceLit2)
-			// evaluate item values
-			for i := len(x.Elts) - 1; 0 <= i; i-- {
-				if x.Elts[i].Key == nil {
-					panic("slice composite literal cannot mix keyed and unkeyed elements")
-				}
-				m.PushExpr(x.Elts[i].Value)
-				m.PushOp(OpEval)
+		m.PushOp(OpSliceLit2)
+		// evaluate item values; also evaluate key if present
+		for i := len(x.Elts) - 1; 0 <= i; i-- {
+			m.PushExpr(x.Elts[i].Value)
+			m.PushOp(OpEval)
+			if x.Elts[i].Key != nil {
 				m.PushExpr(x.Elts[i].Key)
-				m.PushOp(OpEval)
-			}
-		} else {
-			m.PushOp(OpSliceLit)
-			// evaluate item values
-			for i := len(x.Elts) - 1; 0 <= i; i-- {
-				if x.Elts[i].Key != nil {
-					panic("slice composite literal cannot mix keyed and unkeyed elements")
-				}
-				m.PushExpr(x.Elts[i].Value)
 				m.PushOp(OpEval)
 			}
 		}
@@ -518,18 +505,33 @@ func (m *Machine) doOpSliceLit() {
 
 func (m *Machine) doOpSliceLit2() {
 	x := m.PopExpr().(*CompositeLitExpr)
-	el := len(x.Elts)
-	tvs := m.PopValues(el * 2)
+	// count total stack items: key+value for keyed elements, value only for unkeyed.
+	total := len(x.Elts)
+	for _, elt := range x.Elts {
+		if elt.Key != nil {
+			total++
+		}
+	}
+	tvs := m.PopValues(total)
 	// peek slice type.
 	st := m.PeekValue(1).V.(TypeValue).Type
-	// calculate maximum index.
-	var maxVal int64
-	for i := range el {
-		itv := tvs[i*2+0]
-		idx := itv.ConvertGetInt()
+	// first pass: calculate max index, tracking prev for unkeyed elements.
+	// maxVal and idx start at -1 so that an empty literal (e.g. []rune{})
+	// produces a zero-length slice instead of a one-element slice.
+	var maxVal int64 = -1
+	var idx int64 = -1
+	pos := 0
+	for _, elt := range x.Elts {
+		if elt.Key != nil {
+			idx = tvs[pos].ConvertGetInt()
+			pos++
+		} else {
+			idx++
+		}
 		if idx > maxVal {
 			maxVal = idx
 		}
+		pos++ // skip value
 	}
 	m.incrCPU(OpCPUSlopeSliceLit2 * (maxVal + 1))
 	// construct element buf slice.
@@ -537,10 +539,18 @@ func (m *Machine) doOpSliceLit2() {
 	baseArray := m.Alloc.NewListArray(int(maxVal + 1))
 	es := baseArray.List
 
-	for i := range el {
-		itv := tvs[i*2+0]
-		vtv := tvs[i*2+1]
-		idx := itv.ConvertGetInt()
+	// second pass: fill values.
+	idx = -1
+	pos = 0
+	for _, elt := range x.Elts {
+		if elt.Key != nil {
+			idx = tvs[pos].ConvertGetInt()
+			pos++
+		} else {
+			idx++
+		}
+		vtv := tvs[pos]
+		pos++
 		if es[idx].IsDefined() {
 			// slice index has already been assigned
 			panic(fmt.Sprintf("duplicate index %d in array or slice literal", idx))

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -1237,7 +1237,7 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 							cx := evalConst(store, last, n)
 							return cx, TRANS_CONTINUE
 						}
-						panic("slice/array literals may not contain non-const keys")
+						return n, TRANS_CONTINUE
 					}
 				}
 				// specific and general cases
@@ -1485,14 +1485,6 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 				}
 			// TRANS_LEAVE -----------------------
 			case *CallExpr:
-				if ftype == TRANS_COMPOSITE_KEY {
-					clx := ns[len(ns)-1].(*CompositeLitExpr)
-					clt := evalStaticType(store, last, clx.Type)
-					switch baseOf(clt).(type) {
-					case *ArrayType, *SliceType:
-						panic("slice/array literals may not contain non-const keys")
-					}
-				}
 				// Func type evaluation.
 				nft := evalStaticTypeOf(store, last, n.Func)
 				switch bnft := baseOf(nft).(type) {
@@ -2237,16 +2229,28 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					}
 				case *ArrayType:
 					for i := range n.Elts {
-						if cx, ok := n.Elts[i].Key.(*ConstExpr); ok && cx.TypedValue.Sign() < 0 {
-							panic(fmt.Sprintf("invalid argument: index must not be negative: %v", cx.TypedValue))
+						if n.Elts[i].Key != nil {
+							cx, ok := n.Elts[i].Key.(*ConstExpr)
+							if !ok {
+								panic("slice/array literals may not contain non-const keys")
+							}
+							if cx.TypedValue.Sign() < 0 {
+								panic(fmt.Sprintf("invalid argument: index must not be negative: %v", cx.TypedValue))
+							}
 						}
 						convertType(store, last, n, &n.Elts[i].Key, IntType)
 						checkOrConvertType(store, last, n, &n.Elts[i].Value, cclt.Elt)
 					}
 				case *SliceType:
 					for i := range n.Elts {
-						if cx, ok := n.Elts[i].Key.(*ConstExpr); ok && cx.TypedValue.Sign() < 0 {
-							panic(fmt.Sprintf("invalid argument: index must not be negative: %v", cx.TypedValue))
+						if n.Elts[i].Key != nil {
+							cx, ok := n.Elts[i].Key.(*ConstExpr)
+							if !ok {
+								panic("slice/array literals may not contain non-const keys")
+							}
+							if cx.TypedValue.Sign() < 0 {
+								panic(fmt.Sprintf("invalid argument: index must not be negative: %v", cx.TypedValue))
+							}
 						}
 						convertType(store, last, n, &n.Elts[i].Key, IntType)
 						checkOrConvertType(store, last, n, &n.Elts[i].Value, cclt.Elt)

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -1485,6 +1485,14 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 				}
 			// TRANS_LEAVE -----------------------
 			case *CallExpr:
+				if ftype == TRANS_COMPOSITE_KEY {
+					clx := ns[len(ns)-1].(*CompositeLitExpr)
+					clt := evalStaticType(store, last, clx.Type)
+					switch baseOf(clt).(type) {
+					case *ArrayType, *SliceType:
+						panic("slice/array literals may not contain non-const keys")
+					}
+				}
 				// Func type evaluation.
 				nft := evalStaticTypeOf(store, last, n.Func)
 				switch bnft := baseOf(nft).(type) {

--- a/gnovm/pkg/gnolang/string_methods.go
+++ b/gnovm/pkg/gnolang/string_methods.go
@@ -118,8 +118,7 @@ func _() {
 	_ = x[OpStaticTypeOf-74]
 	_ = x[OpCompositeLit-75]
 	_ = x[OpArrayLit-76]
-	_ = x[OpSliceLit-77]
-	_ = x[OpSliceLit2-78]
+	_ = x[OpSliceLit-78]
 	_ = x[OpMapLit-79]
 	_ = x[OpStructLit-80]
 	_ = x[OpFuncLit-81]
@@ -161,7 +160,7 @@ func _() {
 	_ = x[OpVoid-255]
 }
 
-const _Op_name = "OpInvalidOpHaltOpNoopOpExecOpPrecallOpEnterCrossingOpCallOpCallNativeBodyOpDeferOpCallDeferNativeBodyOpGoOpSelectOpSwitchClauseOpSwitchClauseCaseOpTypeSwitchOpIfCondOpPopValueOpPopResultsOpPopBlockOpPopFrameAndResetOpPanic1OpPanic2OpReturnOpReturnAfterCopyOpReturnFromBlockOpReturnToBlockOpUposOpUnegOpUnotOpUxorOpUrecvOpLorOpLandOpEqlOpNeqOpLssOpLeqOpGtrOpGeqOpAddOpSubOpBorOpXorOpMulOpQuoOpRemOpShlOpShrOpBandOpBandnOpEvalOpBinary1OpIndex1OpIndex2OpSelectorOpSliceOpStarOpRefOpTypeAssert1OpTypeAssert2OpStaticTypeOfOpCompositeLitOpArrayLitOpSliceLitOpSliceLit2OpMapLitOpStructLitOpFuncLitOpConvertOpFieldTypeOpArrayTypeOpSliceTypeOpPointerTypeOpInterfaceTypeOpChanTypeOpFuncTypeOpMapTypeOpStructTypeOpAssignOpAddAssignOpSubAssignOpMulAssignOpQuoAssignOpRemAssignOpBandAssignOpBandnAssignOpBorAssignOpXorAssignOpShlAssignOpShrAssignOpDefineOpIncOpDecOpValueDeclOpTypeDeclOpStickyOpBodyOpForLoopOpRangeIterOpRangeIterStringOpRangeIterMapOpRangeIterArrayPtrOpReturnCallDefersOpVoid"
+const _Op_name = "OpInvalidOpHaltOpNoopOpExecOpPrecallOpEnterCrossingOpCallOpCallNativeBodyOpDeferOpCallDeferNativeBodyOpGoOpSelectOpSwitchClauseOpSwitchClauseCaseOpTypeSwitchOpIfCondOpPopValueOpPopResultsOpPopBlockOpPopFrameAndResetOpPanic1OpPanic2OpReturnOpReturnAfterCopyOpReturnFromBlockOpReturnToBlockOpUposOpUnegOpUnotOpUxorOpUrecvOpLorOpLandOpEqlOpNeqOpLssOpLeqOpGtrOpGeqOpAddOpSubOpBorOpXorOpMulOpQuoOpRemOpShlOpShrOpBandOpBandnOpEvalOpBinary1OpIndex1OpIndex2OpSelectorOpSliceOpStarOpRefOpTypeAssert1OpTypeAssert2OpStaticTypeOfOpCompositeLitOpArrayLitOpSliceLitOpMapLitOpStructLitOpFuncLitOpConvertOpFieldTypeOpArrayTypeOpSliceTypeOpPointerTypeOpInterfaceTypeOpChanTypeOpFuncTypeOpMapTypeOpStructTypeOpAssignOpAddAssignOpSubAssignOpMulAssignOpQuoAssignOpRemAssignOpBandAssignOpBandnAssignOpBorAssignOpXorAssignOpShlAssignOpShrAssignOpDefineOpIncOpDecOpValueDeclOpTypeDeclOpStickyOpBodyOpForLoopOpRangeIterOpRangeIterStringOpRangeIterMapOpRangeIterArrayPtrOpReturnCallDefersOpVoid"
 
 var _Op_map = map[Op]string{
 	0:   _Op_name[0:9],
@@ -227,47 +226,46 @@ var _Op_map = map[Op]string{
 	74:  _Op_name[503:517],
 	75:  _Op_name[517:531],
 	76:  _Op_name[531:541],
-	77:  _Op_name[541:551],
-	78:  _Op_name[551:562],
-	79:  _Op_name[562:570],
-	80:  _Op_name[570:581],
-	81:  _Op_name[581:590],
-	82:  _Op_name[590:599],
-	112: _Op_name[599:610],
-	113: _Op_name[610:621],
-	114: _Op_name[621:632],
-	115: _Op_name[632:645],
-	116: _Op_name[645:660],
-	117: _Op_name[660:670],
-	118: _Op_name[670:680],
-	119: _Op_name[680:689],
-	120: _Op_name[689:701],
-	128: _Op_name[701:709],
-	129: _Op_name[709:720],
-	130: _Op_name[720:731],
-	131: _Op_name[731:742],
-	132: _Op_name[742:753],
-	133: _Op_name[753:764],
-	134: _Op_name[764:776],
-	135: _Op_name[776:789],
-	136: _Op_name[789:800],
-	137: _Op_name[800:811],
-	138: _Op_name[811:822],
-	139: _Op_name[822:833],
-	140: _Op_name[833:841],
-	141: _Op_name[841:846],
-	142: _Op_name[846:851],
-	144: _Op_name[851:862],
-	145: _Op_name[862:872],
-	208: _Op_name[872:880],
-	209: _Op_name[880:886],
-	210: _Op_name[886:895],
-	211: _Op_name[895:906],
-	212: _Op_name[906:923],
-	213: _Op_name[923:937],
-	214: _Op_name[937:956],
-	215: _Op_name[956:974],
-	255: _Op_name[974:980],
+	78:  _Op_name[541:551],
+	79:  _Op_name[551:559],
+	80:  _Op_name[559:570],
+	81:  _Op_name[570:579],
+	82:  _Op_name[579:588],
+	112: _Op_name[588:599],
+	113: _Op_name[599:610],
+	114: _Op_name[610:621],
+	115: _Op_name[621:634],
+	116: _Op_name[634:649],
+	117: _Op_name[649:659],
+	118: _Op_name[659:669],
+	119: _Op_name[669:678],
+	120: _Op_name[678:690],
+	128: _Op_name[690:698],
+	129: _Op_name[698:709],
+	130: _Op_name[709:720],
+	131: _Op_name[720:731],
+	132: _Op_name[731:742],
+	133: _Op_name[742:753],
+	134: _Op_name[753:765],
+	135: _Op_name[765:778],
+	136: _Op_name[778:789],
+	137: _Op_name[789:800],
+	138: _Op_name[800:811],
+	139: _Op_name[811:822],
+	140: _Op_name[822:830],
+	141: _Op_name[830:835],
+	142: _Op_name[835:840],
+	144: _Op_name[840:851],
+	145: _Op_name[851:861],
+	208: _Op_name[861:869],
+	209: _Op_name[869:875],
+	210: _Op_name[875:884],
+	211: _Op_name[884:895],
+	212: _Op_name[895:912],
+	213: _Op_name[912:926],
+	214: _Op_name[926:945],
+	215: _Op_name[945:963],
+	255: _Op_name[963:969],
 }
 
 func (i Op) String() string {

--- a/gnovm/tests/files/composite15.gno
+++ b/gnovm/tests/files/composite15.gno
@@ -13,4 +13,4 @@ func main() {
 // main/composite15.gno:6:3: index a must be integer constant; main/composite15.gno:7:3: index c must be integer constant
 
 // Error:
-// main/composite15.gno:6:3-4: slice/array literals may not contain non-const keys
+// main/composite15.gno:5:7-8:3: slice/array literals may not contain non-const keys

--- a/gnovm/tests/files/composite16.gno
+++ b/gnovm/tests/files/composite16.gno
@@ -17,4 +17,4 @@ func main() {
 // main/composite16.gno:10:3: index x(1) must be integer constant; main/composite16.gno:11:3: index x(3) must be integer constant
 
 // Error:
-// main/composite16.gno:10:3-7: slice/array literals may not contain non-const keys
+// main/composite16.gno:9:7-12:3: slice/array literals may not contain non-const keys

--- a/gnovm/tests/files/composite16.gno
+++ b/gnovm/tests/files/composite16.gno
@@ -13,12 +13,8 @@ func main() {
 	println(x)
 }
 
-// Output:
-// 1
-// 2
-// 3
-// 4
-// slice[(0 int),(2 int),(0 int),(4 int)]
-
 // TypeCheckError:
 // main/composite16.gno:10:3: index x(1) must be integer constant; main/composite16.gno:11:3: index x(3) must be integer constant
+
+// Error:
+// main/composite16.gno:10:3-7: slice/array literals may not contain non-const keys

--- a/gnovm/tests/files/slice6.gno
+++ b/gnovm/tests/files/slice6.gno
@@ -1,4 +1,3 @@
-// slice4.gno
 package main
 
 func main() {

--- a/gnovm/tests/files/slice6.gno
+++ b/gnovm/tests/files/slice6.gno
@@ -1,0 +1,10 @@
+// slice4.gno
+package main
+
+func main() {
+	var x = []int{4: 14, 25, 1: 33, 34}
+	println(len(x), x[2])
+}
+
+// Output:
+// 6 34

--- a/gnovm/tests/files/slice7.gno
+++ b/gnovm/tests/files/slice7.gno
@@ -1,0 +1,20 @@
+package main
+
+func main() {
+	// unkeyed then keyed with gap
+	a := []int{10, 20, 5: 50}
+	println(len(a), a[0], a[1], a[2], a[5])
+
+	// explicit key 0 followed by unkeyed
+	b := []int{0: 100, 200, 300}
+	println(len(b), b[0], b[1], b[2])
+
+	// single keyed element with gap zero-fill
+	c := []int{3: 42}
+	println(len(c), c[0], c[1], c[2], c[3])
+}
+
+// Output:
+// 6 10 20 0 50
+// 3 100 200 300
+// 4 0 0 0 42

--- a/gnovm/tests/files/slice8.gno
+++ b/gnovm/tests/files/slice8.gno
@@ -1,0 +1,30 @@
+package main
+
+func main() {
+	// unkeyed elements followed by keyed element with large index
+	a := []int{1, 2, 3, 11: 123}
+	println(len(a), a[0], a[1], a[2], a[3], a[11])
+
+	// keyed then unkeyed continuation
+	b := []int{5: 50, 60, 70}
+	println(len(b), b[0], b[5], b[6], b[7])
+
+	// out-of-order keys
+	c := []int{2: 20, 0: 5, 1: 10}
+	println(len(c), c[0], c[1], c[2])
+
+	// empty slice literal
+	d := []int{}
+	println(len(d))
+
+	// string slice with gap
+	e := []string{"a", "b", 5: "f"}
+	println(len(e), e[0], e[1], e[2], e[5])
+}
+
+// Output:
+// 12 1 2 3 0 123
+// 8 0 50 60 70
+// 3 5 10 20
+// 0
+// 6 a b  f


### PR DESCRIPTION
## Description

closes #3464

GnoVM was panicking on mixed keyed/unkeyed slice composite literals (e.g. `[]int{4: 14, 25, 1: 33, 34}`), which is valid Go syntax. All slice literals are now routed through `OpSliceLit2`, which distinguishes keyed and unkeyed elements. Unkeyed elements automatically get the previous `index +1`. Also, `maxVal` and `idx` are initialized to -1 so that empty slice literals (e.g. `[]rune{}`) produce a zero-length slice correctly.