### PR TITLE
feat(gnoland): add version subcommand and fix RPC version

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -26,6 +26,8 @@ builds:
   - id: gnoland
     main: ./gno.land/cmd/gnoland
     binary: gnoland
+    ldflags:
+      - -X github.com/gnolang/gno/tm2/pkg/version.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
     goos:

--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -33,7 +33,7 @@ start.gnoweb:; go run ./cmd/gnoweb
 .PHONY: build
 build: build.gnoland build.gnokey build.gnoweb
 
-build.gnoland:;    go build -o build/gnoland   ./cmd/gnoland
+build.gnoland:;    go build $(GOBUILD_FLAGS) -o build/gnoland   ./cmd/gnoland
 build.gnoweb:;     go build -o build/gnoweb    ./cmd/gnoweb
 build.gnokey:;     go build $(GOBUILD_FLAGS) -o build/gnokey    ./cmd/gnokey
 
@@ -43,7 +43,7 @@ run.gnoweb:;       go run ./cmd/gnoweb
 .PHONY: install
 install: install.gnoland install.gnoweb install.gnokey
 
-install.gnoland:;    go install ./cmd/gnoland
+install.gnoland:;    go install $(GOBUILD_FLAGS) ./cmd/gnoland
 install.gnoweb:;     go install ./cmd/gnoweb
 install.gnokey:;     go install ./cmd/gnokey
 

--- a/gno.land/Makefile
+++ b/gno.land/Makefile
@@ -45,7 +45,7 @@ install: install.gnoland install.gnoweb install.gnokey
 
 install.gnoland:;    go install $(GOBUILD_FLAGS) ./cmd/gnoland
 install.gnoweb:;     go install ./cmd/gnoweb
-install.gnokey:;     go install ./cmd/gnokey
+install.gnokey:;     go install $(GOBUILD_FLAGS) ./cmd/gnokey
 
 .PHONY: dev.gnoweb generate.gnoweb
 dev.gnoweb:

--- a/gno.land/cmd/gnoland/root.go
+++ b/gno.land/cmd/gnoland/root.go
@@ -38,6 +38,7 @@ func newRootCmd(io commands.IO) *commands.Command {
 		newStartCmd(io),
 		newSecretsCmd(io),
 		newConfigCmd(io),
+		newVersionCmd(io),
 	)
 
 	return cmd

--- a/gno.land/cmd/gnoland/version.go
+++ b/gno.land/cmd/gnoland/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/version"
+)
+
+func newVersionCmd(io commands.IO) *commands.Command {
+	return commands.NewCommand(
+		commands.Metadata{
+			Name:       "version",
+			ShortUsage: "version",
+			ShortHelp:  "display the gnoland binary version",
+		},
+		nil,
+		func(_ context.Context, _ []string) error {
+			io.Println("gnoland version:", version.Version)
+			return nil
+		},
+	)
+}

--- a/gno.land/cmd/gnoland/version_test.go
+++ b/gno.land/cmd/gnoland/version_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCmd(t *testing.T) {
+	t.Parallel()
+
+	originalVersion := version.Version
+	t.Cleanup(func() {
+		version.Version = originalVersion
+	})
+
+	versionValues := []string{"develop", "master.42+abc1234", "v1.0.0"}
+
+	for _, v := range versionValues {
+		t.Run(v, func(t *testing.T) {
+			version.Version = v
+
+			mockOut := bytes.NewBufferString("")
+			io := commands.NewTestIO()
+			io.SetOut(commands.WriteNopCloser(mockOut))
+
+			cmd := newVersionCmd(io)
+			require.NoError(t, cmd.ParseAndRun(context.Background(), nil))
+
+			assert.Equal(t, "gnoland version: "+v+"\n", mockOut.String())
+		})
+	}
+}

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -925,6 +925,7 @@ func makeNodeInfo(
 		VersionSet: vset,
 		NetAddress: nil, // The shared address depends on the configuration
 		Network:    genDoc.ChainID,
+		Software:   "gnoland",
 		Version:    softwareVersion.Version,
 		Channels: []byte{
 			bcChannel,

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -38,6 +38,7 @@ import (
 	tmtime "github.com/gnolang/gno/tm2/pkg/bft/types/time"
 	"github.com/gnolang/gno/tm2/pkg/bft/version"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	softwareVersion "github.com/gnolang/gno/tm2/pkg/version"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 	"github.com/gnolang/gno/tm2/pkg/events"
@@ -924,7 +925,7 @@ func makeNodeInfo(
 		VersionSet: vset,
 		NetAddress: nil, // The shared address depends on the configuration
 		Network:    genDoc.ChainID,
-		Version:    version.Version,
+		Version:    softwareVersion.Version,
 		Channels: []byte{
 			bcChannel,
 			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,

--- a/tm2/pkg/bft/node/node_test.go
+++ b/tm2/pkg/bft/node/node_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/events"
 	"github.com/gnolang/gno/tm2/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/random"
+	softwareVersion "github.com/gnolang/gno/tm2/pkg/version"
 )
 
 func TestNodeStartStop(t *testing.T) {
@@ -158,6 +159,17 @@ func TestNodeSetAppVersion(t *testing.T) {
 	appVersion2, ok := n.nodeInfo.VersionSet.Get("app")
 	assert.True(t, ok)
 	assert.Equal(t, appVersion2.Version, appVersion)
+}
+
+func TestNodeSoftwareVersion(t *testing.T) {
+	config, genesisFile := cfg.ResetTestRoot("node_software_version_test")
+	defer os.RemoveAll(config.RootDir)
+
+	n, err := DefaultNewNode(config, genesisFile, events.NewEventSwitch(), log.NewTestingLogger(t))
+	require.NoError(t, err)
+
+	// NodeInfo.Version should reflect the software version, not the TM2 protocol version
+	assert.Equal(t, softwareVersion.Version, n.nodeInfo.Version)
 }
 
 func TestNodeSetPrivValTCP(t *testing.T) {

--- a/tm2/pkg/bft/node/node_test.go
+++ b/tm2/pkg/bft/node/node_test.go
@@ -170,6 +170,7 @@ func TestNodeSoftwareVersion(t *testing.T) {
 
 	// NodeInfo.Version should reflect the software version, not the TM2 protocol version
 	assert.Equal(t, softwareVersion.Version, n.nodeInfo.Version)
+	assert.Equal(t, "gnoland", n.nodeInfo.Software)
 }
 
 func TestNodeSetPrivValTCP(t *testing.T) {


### PR DESCRIPTION
**Edit:** I missed this PR https://github.com/gnolang/gno/commit/391938e8f4df67210a3bc10ca57d5e46977b1c79. I’m going to switch this one to draft while I resolve the conflicts and see if there’s anything worth keeping 

This PR:
- Add a `gnoland version` subcommand (mirrors `gnokey version` and `gno version`)
- Inject build version via ldflags for both `gnoland` and `gnokey` (Makefile + goreleaser)
- Fix `NodeInfo.Version` in RPC `/status` to report the actual software version instead of the TM2 protocol version

Before this PR, `NodeInfo.Version` (returned by the `/status` RPC endpoint) was set to the TM2 protocol version (`"v1.0.0-rc.0"`), which I suspect is an error/oversight. This should be the node version, not just the protocol version, which is already provided here:`NodeInfo.VersionSet["bft"]`.

Not fully sure about these two points, but they seemed like the right thing to do:
- `make install.gnokey` now uses `GOBUILD_FLAGS`, previously only `make build.gnokey` injected the version via ldflags. This seemed like an oversight so I fixed it.
- `NodeInfo.Software` is now set to `gnoland`, this field existed in the struct but was never populated.
