### PR TITLE
fix(gnovm): use side-table for PkgID flags instead of stealing hash bits

### DIFF
--- a/gno.land/adr/gas_refactor.md
+++ b/gno.land/adr/gas_refactor.md
@@ -778,22 +778,29 @@ production-available metrics.
 - **IAVL tree internals**: unchanged (no gctx threading through tree/nodeDB).
 - **dbm.DB interface**: unchanged.
 
-## PkgID Flag Nibble
+## PkgID Classification Flags
 
-The first nibble (4 bits) of `PkgID.Hashlet` is reserved for package
-classification flags, set during `PkgIDFromPkgPath()`:
+Package classification flags (`IsStdlib`, `IsImmutable`, `IsInternal`)
+are stored in an in-memory side table (`pkgIDFlags sync.Map`) keyed by
+`PkgID`, populated lazily by `PkgIDFromPkgPath()`.
 
-- bit 0 (0x80): `IsStdlib` — standard library package
-- bit 1 (0x40): `IsImmutable` — stdlib or `/p/` package
-- bit 2 (0x20): `IsInternal` — internal package path
-- bit 3 (0x10): reserved (always 0)
+The full 160-bit SHA-256 truncated hash in `PkgID.Hashlet` is preserved
+unchanged — no bits are stolen for flags. This avoids:
+- consensus-breaking changes to stored PkgIDs,
+- hash collision risk from reduced entropy (160 → 156 bits),
+- migration complexity for existing on-chain data.
 
-The remaining 156 bits are the truncated SHA-256 hash. Methods:
-`PkgID.IsStdlibPkg()`, `PkgID.IsImmutablePkg()`, `PkgID.IsInternalPkg()`.
-O(1) bitwise checks, no map lookups or path string parsing.
+Methods: `PkgID.IsStdlibPkg()`, `PkgID.IsImmutablePkg()`,
+`PkgID.IsInternalPkg()`. Each performs a `sync.Map.Load` (~15-25ns,
+lock-free on read path). The call sites are in realm finalization
+and object loading — not inner loops — so the cost vs a bitwise check
+is negligible relative to the amino/store work already done there.
 
-These flags enable efficient runtime decisions about package mutability
-and stdlib caching without needing reverse mappings from hash to path.
+Unknown PkgIDs return `false` (conservative: skip no optimizations,
+do normal refcount logic). Every package path goes through
+`PkgIDFromPkgPath` during `GetPackage`/`AddMemPackage` before realm
+finalization can reference its objects, so the table is always
+populated before the flags are queried.
 
 ## Immutable Package Guard
 

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -84,50 +84,75 @@ func (pid PkgID) Bytes() []byte {
 // https://github.com/gnolang/gno/pull/3424#issuecomment-2564571785
 var pkgIDFromPkgPathCache sync.Map
 
+// pkgFlags encodes package classification flags for O(1) lookups.
+type pkgFlags uint8
+
+const (
+	flagStdlib    pkgFlags = 1 << 0 // standard library package
+	flagImmutable pkgFlags = 1 << 1 // stdlib or /p/ package
+	flagInternal  pkgFlags = 1 << 2 // internal package path
+)
+
+// pkgIDFlags maps PkgID to classification flags. Populated alongside
+// pkgIDFromPkgPathCache by PkgIDFromPkgPath. Lock-free reads via sync.Map.
+// Every package path goes through PkgIDFromPkgPath during GetPackage /
+// AddMemPackage before any realm finalization can reference its objects,
+// so the table is always populated before IsStdlibPkg / IsImmutablePkg
+// are called.
+var pkgIDFlags sync.Map // PkgID → pkgFlags
+
 // PkgIDFromPkgPath derives a PkgID from a package path.
-// The first nibble (4 bits) of the Hashlet is reserved for flags:
-//
-//	bit 0 (0x80): IsStdlib — standard library package
-//	bit 1 (0x40): IsImmutable — immutable package (stdlib or /p/)
-//	bit 2 (0x20): IsInternal — internal package path
-//	bit 3 (0x10): reserved (always 0)
-//
-// The remaining 156 bits are the truncated SHA-256 hash.
+// The full 160-bit hash is preserved (no bits are stolen for flags).
+// Package classification flags are stored in a separate side table
+// (pkgIDFlags) for O(1) lookups without modifying the hash.
 func PkgIDFromPkgPath(path string) PkgID {
 	if v, ok := pkgIDFromPkgPathCache.Load(path); ok {
 		return *v.(*PkgID)
 	}
 	pkgID := &PkgID{HashBytes([]byte(path))}
-	// Clear the first nibble, then set flag bits.
-	pkgID.Hashlet[0] &= 0x0F
+	// Compute classification flags from the path.
+	var flags pkgFlags
 	if IsStdlib(path) {
-		pkgID.Hashlet[0] |= 0x80
-	}
-	if IsStdlib(path) || IsPPackagePath(path) {
-		pkgID.Hashlet[0] |= 0x40
+		flags |= flagStdlib | flagImmutable
+	} else if IsPPackagePath(path) {
+		flags |= flagImmutable
 	}
 	if _, isInternal := IsInternalPath(path); isInternal {
-		pkgID.Hashlet[0] |= 0x20
+		flags |= flagInternal
 	}
 	actual, _ := pkgIDFromPkgPathCache.LoadOrStore(path, pkgID)
-	return *actual.(*PkgID)
+	result := *actual.(*PkgID)
+	pkgIDFlags.LoadOrStore(result, flags)
+	return result
 }
 
 // IsStdlibPkg returns true if this PkgID is for a standard library package.
+// Returns false for unknown PkgIDs (conservative: skip no optimizations).
 func (pid PkgID) IsStdlibPkg() bool {
-	return pid.Hashlet[0]&0x80 != 0
+	if v, ok := pkgIDFlags.Load(pid); ok {
+		return v.(pkgFlags)&flagStdlib != 0
+	}
+	return false
 }
 
 // IsImmutablePkg returns true if this PkgID is for an immutable package
 // (stdlib or /p/ package). Objects from immutable packages should not
 // have their refcounts or dirty flags modified during realm finalization.
+// Returns false for unknown PkgIDs (conservative: do normal refcount logic).
 func (pid PkgID) IsImmutablePkg() bool {
-	return pid.Hashlet[0]&0x40 != 0
+	if v, ok := pkgIDFlags.Load(pid); ok {
+		return v.(pkgFlags)&flagImmutable != 0
+	}
+	return false
 }
 
 // IsInternalPkg returns true if this PkgID is for an internal package path.
+// Returns false for unknown PkgIDs.
 func (pid PkgID) IsInternalPkg() bool {
-	return pid.Hashlet[0]&0x20 != 0
+	if v, ok := pkgIDFlags.Load(pid); ok {
+		return v.(pkgFlags)&flagInternal != 0
+	}
+	return false
 }
 
 // Returns the ObjectID of the PackageValue associated with path.

--- a/gnovm/tests/files/addressable_1b_err.gno
+++ b/gnovm/tests/files/addressable_1b_err.gno
@@ -5,4 +5,4 @@ func main() {
 }
 
 // TypeCheckError:
-// main/addressable_1b_err.gno:4:6: invalid operation: cannot slice [1]int{…} (value of type [1]int) (value not addressable)
+// main/addressable_1b_err.gno:4:6: cannot slice unaddressable value [1]int{…} (value of type [1]int)

--- a/gnovm/tests/files/addressable_1d_err.gno
+++ b/gnovm/tests/files/addressable_1d_err.gno
@@ -9,4 +9,4 @@ func getArr() [1]int {
 }
 
 // TypeCheckError:
-// main/addressable_1d_err.gno:4:6: invalid operation: cannot slice getArr() (value of type [1]int) (value not addressable)
+// main/addressable_1d_err.gno:4:6: cannot slice unaddressable value getArr() (value of type [1]int)

--- a/gnovm/tests/files/append11.gno
+++ b/gnovm/tests/files/append11.gno
@@ -19,11 +19,11 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](0)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](0)=
 //     @@ -1,5 +1,5 @@
 //      {
 //     -    "Data": "YWJjAAAAAAAAAA==",
 //     +    "Data": "YWJjZAAAAAAAAA==",
 //          "List": null,
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",

--- a/gnovm/tests/files/append11b.gno
+++ b/gnovm/tests/files/append11b.gno
@@ -21,7 +21,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](0)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](0)=
 //     @@ -23,6 +23,7 @@
 //                  }
 //              },

--- a/gnovm/tests/files/append11c.gno
+++ b/gnovm/tests/files/append11c.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:21](215)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:21](215)={
 //     "Fields": [
 //         {
 //             "N": "AQAAAAAAAAA=",
@@ -36,14 +36,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:21",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:21",
 //         "LastObjectSize": "215",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:22](215)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:22](215)={
 //     "Fields": [
 //         {
 //             "N": "AgAAAAAAAAA=",
@@ -54,14 +54,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:22",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:22",
 //         "LastObjectSize": "215",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:23](215)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:23](215)={
 //     "Fields": [
 //         {
 //             "N": "AwAAAAAAAAA=",
@@ -72,14 +72,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:23",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:23",
 //         "LastObjectSize": "215",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:24](215)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:24](215)={
 //     "Fields": [
 //         {
 //             "N": "BAAAAAAAAAA=",
@@ -90,22 +90,22 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:24",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:24",
 //         "LastObjectSize": "215",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](1)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4](1)=
 //     @@ -8,8 +8,8 @@
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "3d3f4fca85becfd2f6b8d815f84f4ff8aac359fb",
-//     -                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:18"
-//     +                "Hash": "53d69e66700d965f7148cf885d0259ec9ec5c3b7",
-//     +                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:21"
+//     -                "Hash": "b64e6d66625500a1a73ad3aa83bf64a19e5ef79c",
+//     -                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:18"
+//     +                "Hash": "a50095053b0560d6000a853698d2a70398b43ff0",
+//     +                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:21"
 //                  }
 //              },
 //              {
@@ -113,10 +113,10 @@ func main() {
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "d50b7a33776f6f1c1d757b8ea75a599c131be937",
-//     -                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:19"
-//     +                "Hash": "fa78b6ce0e48cfb542702f012c6bc6fce8be6c66",
-//     +                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:22"
+//     -                "Hash": "044a7cc5cdc8d198ee0de4c97b17542ba2bcc45d",
+//     -                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:19"
+//     +                "Hash": "4bd56d347d1de8616331e0c7e9d24f2e660b7506",
+//     +                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:22"
 //                  }
 //              },
 //              {
@@ -124,10 +124,10 @@ func main() {
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "70bca675775dd6dcc49de4f0ea7dfd06657aa8b9",
-//     -                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:20"
-//     +                "Hash": "8e34dadb02e73e22238ab3d889a518d1e66aa77a",
-//     +                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:23"
+//     -                "Hash": "c2c402289358af04b4bcc1263a34b23304591963",
+//     -                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:20"
+//     +                "Hash": "0fd141d953069d60bf97cb84881f33976f022e11",
+//     +                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:23"
 //                  }
 //              },
 //              {
@@ -135,23 +135,23 @@ func main() {
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "9c241ce5ac2a49e7c0268f64c07b42ad36cdc68f",
-//     -                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8"
-//     +                "Hash": "f1d8c67694bafee5f9aa1b2302e3a154ab25a352",
-//     +                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:24"
+//     -                "Hash": "6f563d96f793175f993169399dc7a9b7ff7f5682",
+//     -                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8"
+//     +                "Hash": "34ef9d7fdb562e442c9fef95bc3c06f7613b119b",
+//     +                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:24"
 //                  }
 //              },
 //              {
 //     @@ -115,7 +115,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //              "LastObjectSize": "1738",
 //     -        "ModTime": "17",
 //     +        "ModTime": "20",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:3",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:3",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:18](-215)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:19](-215)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:20](-215)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-214)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:18](-215)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:19](-215)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:20](-215)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-214)

--- a/gnovm/tests/files/assign_unnamed_type/more/realm_compositelit_filetest.gno
+++ b/gnovm/tests/files/assign_unnamed_type/more/realm_compositelit_filetest.gno
@@ -26,7 +26,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:8](227)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](227)={
 //     "Data": null,
 //     "List": [
 //         {
@@ -37,14 +37,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "LastObjectSize": "227",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:7](359)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](359)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -55,8 +55,8 @@ func main() {
 //                 "@type": "/gno.SliceValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "62dccdf4fcc8734f14d51a75d15c9b73fcc4774a",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "053ebe7d3e2087ff390f1c09b3f36cf0763f0967",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Length": "1",
 //                 "Maxcap": "1",
@@ -65,19 +65,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "LastObjectSize": "359",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:6](335)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6](335)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -87,19 +87,19 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "da06f52280bfcd95ecd76d4eb2f7969a4838ba60",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             "Hash": "96b285f2bb2340b0a4560f1df367e43ae41a688a",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](134)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "251",
 //     -        "ModTime": "0",
 //     +        "ModTime": "5",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,16 @@
@@ -111,8 +111,8 @@ func main() {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "Hash": "9ec2417f6a4e3a4ba3d58113a12c2e3959fc4e35",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//     +                "Hash": "95c2996b9deeee6cc3c5a2fc5550ecb24195f772",
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null

--- a/gnovm/tests/files/heap_item_value.gno
+++ b/gnovm/tests/files/heap_item_value.gno
@@ -15,7 +15,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:8](214)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](214)={
 //     "Fields": [
 //         {
 //             "N": "BAAAAAAAAAA=",
@@ -26,16 +26,16 @@ func main(cur realm,) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "LastObjectSize": "214",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:7](335)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](335)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //         "IsEscaped": true,
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
@@ -48,19 +48,19 @@ func main(cur realm,) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "a280d74394f8a508ba2efa2b960833f6ad7db04a",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//             "Hash": "624f026b2961f3570f2ec9cbc3330418955c4895",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](134)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "249",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,15 @@
@@ -72,21 +72,21 @@ func main(cur realm,) {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null
 //              }
 //          }
 //      }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](134)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "LastObjectSize": "249",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,15 @@
@@ -98,7 +98,7 @@ func main(cur realm,) {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null

--- a/gnovm/tests/files/heap_item_value_init.gno
+++ b/gnovm/tests/files/heap_item_value_init.gno
@@ -19,14 +19,14 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](134)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "LastObjectSize": "249",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,15 @@
@@ -38,23 +38,23 @@ func main(cur realm,) {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null
 //              }
 //          }
 //      }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](7)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "333",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },

--- a/gnovm/tests/files/invalid_labels0.gno
+++ b/gnovm/tests/files/invalid_labels0.gno
@@ -12,3 +12,6 @@ FirstLoop:
 
 // Error:
 // main/invalid_labels0.gno:9:3-18: cannot find branch label "FirstLoop"
+
+// TypeCheckError:
+// main/invalid_labels0.gno:9:9: invalid break label FirstLoop; main/invalid_labels0.gno:5:1: label FirstLoop declared and not used

--- a/gnovm/tests/files/map31.gno
+++ b/gnovm/tests/files/map31.gno
@@ -13,12 +13,12 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/mapkey"]
-// c[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](216)={
+// c[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](216)={
 //     "ObjectInfo": {
-//         "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
+//         "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
 //         "LastObjectSize": "216",
 //         "ModTime": "0",
-//         "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//         "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -29,7 +29,7 @@ func main() {
 //         }
 //     }
 // }
-// u[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
+// u[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
 //     @@ -1,11 +1,40 @@
 //      {
 //          "List": {
@@ -48,8 +48,8 @@ func main() {
 //     +                        "@type": "/gno.PointerValue",
 //     +                        "Base": {
 //     +                            "@type": "/gno.RefValue",
-//     +                            "Hash": "155b33746175a490e1a154d886189491a2e224fe",
-//     +                            "ObjectID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
+//     +                            "Hash": "707048547d382f3872ac35d41c3bfc2ac692d6ad",
+//     +                            "ObjectID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
 //     +                        },
 //     +                        "Index": "0",
 //     +                        "TV": null
@@ -66,10 +66,10 @@ func main() {
 //     +        ]
 //          },
 //          "ObjectInfo": {
-//              "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//              "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //              "LastObjectSize": "175",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
+//              "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/map31b.gno
+++ b/gnovm/tests/files/map31b.gno
@@ -13,7 +13,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/mapkey"]
-// u[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
+// u[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
 //     @@ -1,11 +1,39 @@
 //      {
 //          "List": {
@@ -32,7 +32,7 @@ func main() {
 //     +                        "@type": "/gno.PointerValue",
 //     +                        "Base": {
 //     +                            "@type": "/gno.RefValue",
-//     +                            "ObjectID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5"
+//     +                            "ObjectID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5"
 //     +                        },
 //     +                        "Index": "0",
 //     +                        "TV": null
@@ -49,23 +49,23 @@ func main() {
 //     +        ]
 //          },
 //          "ObjectInfo": {
-//              "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//              "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //              "LastObjectSize": "175",
 //     -        "ModTime": "0",
 //     +        "ModTime": "7",
-//              "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
+//              "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
 //              "RefCount": "1"
 //          }
-// u[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5](7)=
+// u[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5",
+//              "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:5",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "216",
 //     -        "ModTime": "0",
 //     +        "ModTime": "7",
-//              "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:2",
+//              "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:2",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },

--- a/gnovm/tests/files/map31c.gno
+++ b/gnovm/tests/files/map31c.gno
@@ -17,12 +17,12 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/mapkey"]
-// c[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](216)={
+// c[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](216)={
 //     "ObjectInfo": {
-//         "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
+//         "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
 //         "LastObjectSize": "216",
 //         "ModTime": "0",
-//         "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//         "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -33,7 +33,7 @@ func main() {
 //         }
 //     }
 // }
-// u[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
+// u[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](236)=
 //     @@ -1,11 +1,40 @@
 //      {
 //          "List": {
@@ -52,8 +52,8 @@ func main() {
 //     +                        "@type": "/gno.PointerValue",
 //     +                        "Base": {
 //     +                            "@type": "/gno.RefValue",
-//     +                            "Hash": "155b33746175a490e1a154d886189491a2e224fe",
-//     +                            "ObjectID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
+//     +                            "Hash": "707048547d382f3872ac35d41c3bfc2ac692d6ad",
+//     +                            "ObjectID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
 //     +                        },
 //     +                        "Index": "0",
 //     +                        "TV": null
@@ -70,10 +70,10 @@ func main() {
 //     +        ]
 //          },
 //          "ObjectInfo": {
-//              "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//              "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //              "LastObjectSize": "175",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
+//              "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/map32.gno
+++ b/gnovm/tests/files/map32.gno
@@ -29,7 +29,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/mapkey"]
-// c[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8](239)={
+// c[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8](239)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -43,14 +43,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8",
+//         "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8",
 //         "LastObjectSize": "239",
 //         "ModTime": "0",
-//         "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
+//         "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
 //         "RefCount": "1"
 //     }
 // }
-// c[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](373)={
+// c[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7](373)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -59,8 +59,8 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "e7c6b15cf175010b3d14d7a18e68808b5144bb39",
-//                 "ObjectID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8"
+//                 "Hash": "7bfb3c98655cc8320fb2b037dc18cdb19a2a184e",
+//                 "ObjectID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:8"
 //             }
 //         },
 //         {
@@ -72,14 +72,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
+//         "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7",
 //         "LastObjectSize": "373",
 //         "ModTime": "0",
-//         "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//         "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //         "RefCount": "1"
 //     }
 // }
-// u[0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](206)=
+// u[2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4](206)=
 //     @@ -1,11 +1,32 @@
 //      {
 //          "List": {
@@ -93,8 +93,8 @@ func main() {
 //     +                    },
 //     +                    "V": {
 //     +                        "@type": "/gno.RefValue",
-//     +                        "Hash": "019dd1c84943ce603928bf72d02a9c3fd785501d",
-//     +                        "ObjectID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
+//     +                        "Hash": "01bedfec06b1141920641ca7ff7e5d89b70fa1e8",
+//     +                        "ObjectID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:7"
 //     +                    }
 //     +                },
 //     +                "Value": {
@@ -108,10 +108,10 @@ func main() {
 //     +        ]
 //          },
 //          "ObjectInfo": {
-//              "ID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
+//              "ID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:4",
 //              "LastObjectSize": "175",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "0a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
+//              "OwnerID": "2a17fa0a22a6e119cfaf6e864b74063e0e4d464d:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/persist_native.gno
+++ b/gnovm/tests/files/persist_native.gno
@@ -14,4 +14,4 @@ func main() {
 // main/persist_native.gno:6:6-13: use of builtin println not in function call
 
 // TypeCheckError:
-// main/persist_native.gno:6:6: println (built-in) must be called; main/persist_native.gno:10:2: invalid operation: cannot call non-function a (variable of interface type any)
+// main/persist_native.gno:6:6: println (built-in) must be called; main/persist_native.gno:10:2: invalid operation: cannot call a (variable of interface type any): any is not a function

--- a/gnovm/tests/files/redeclaration_global5.gno
+++ b/gnovm/tests/files/redeclaration_global5.gno
@@ -16,4 +16,4 @@ func main() {
 // 	previous declaration at redeclaration_global5.gno:3:5
 
 // TypeCheckError:
-// main/redeclaration_global5.gno:5:6: time redeclared in this block; main/redeclaration_global5.gno:3:5: 	other declaration of time; main/redeclaration_global5.gno:10:7: invalid operation: cannot call non-function time (variable of type int)
+// main/redeclaration_global5.gno:5:6: time redeclared in this block; main/redeclaration_global5.gno:3:5: 	other declaration of time; main/redeclaration_global5.gno:10:7: invalid operation: cannot call time (variable of type int): int is not a function

--- a/gnovm/tests/files/storage/primitive.gno
+++ b/gnovm/tests/files/storage/primitive.gno
@@ -19,7 +19,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/xx"]
-// c[0ea84df38908f9569d0f552575606e6e6e7e22dd:9](253)={
+// c[aea84df38908f9569d0f552575606e6e6e7e22dd:9](253)={
 //     "Data": null,
 //     "List": [
 //         {
@@ -37,14 +37,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:9",
+//         "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:9",
 //         "LastObjectSize": "253",
 //         "ModTime": "0",
-//         "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:4",
+//         "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:4",
 //         "RefCount": "1"
 //     }
 // }
-// c[0ea84df38908f9569d0f552575606e6e6e7e22dd:10](303)={
+// c[aea84df38908f9569d0f552575606e6e6e7e22dd:10](303)={
 //     "Data": null,
 //     "List": [
 //         {
@@ -69,21 +69,21 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:10",
+//         "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:10",
 //         "LastObjectSize": "303",
 //         "ModTime": "0",
-//         "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:6",
+//         "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:6",
 //         "RefCount": "1"
 //     }
 // }
-// u[0ea84df38908f9569d0f552575606e6e6e7e22dd:3](5)=
+// u[aea84df38908f9569d0f552575606e6e6e7e22dd:3](5)=
 //     @@ -2,11 +2,12 @@
 //          "ObjectInfo": {
-//              "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:3",
+//              "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:3",
 //              "LastObjectSize": "217",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:2",
+//              "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:2",
 //              "RefCount": "1"
 //          },
 //          "Value": {
@@ -91,14 +91,14 @@ func main() {
 //              "T": {
 //                  "@type": "/gno.PrimitiveType",
 //                  "value": "64"
-// u[0ea84df38908f9569d0f552575606e6e6e7e22dd:4](137)=
+// u[aea84df38908f9569d0f552575606e6e6e7e22dd:4](137)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:4",
+//              "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:4",
 //              "LastObjectSize": "237",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:2",
+//              "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:2",
 //              "RefCount": "1"
 //          },
 //     @@ -14,6 +14,17 @@
@@ -110,8 +110,8 @@ func main() {
 //     +            "@type": "/gno.SliceValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "Hash": "d1bfe56cd0fa827877a05e18bb530523a5290dc5",
-//     +                "ObjectID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:9"
+//     +                "Hash": "e84e8bceb6edffed359aabd64d88ad4cdaae23c8",
+//     +                "ObjectID": "aea84df38908f9569d0f552575606e6e6e7e22dd:9"
 //     +            },
 //     +            "Length": "2",
 //     +            "Maxcap": "2",
@@ -119,14 +119,14 @@ func main() {
 //              }
 //          }
 //      }
-// u[0ea84df38908f9569d0f552575606e6e6e7e22dd:5](30)=
+// u[aea84df38908f9569d0f552575606e6e6e7e22dd:5](30)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:5",
+//              "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:5",
 //              "LastObjectSize": "216",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:2",
+//              "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:2",
 //              "RefCount": "1"
 //          },
 //     @@ -10,6 +10,10 @@
@@ -140,14 +140,14 @@ func main() {
 //              }
 //          }
 //      }
-// u[0ea84df38908f9569d0f552575606e6e6e7e22dd:6](138)=
+// u[aea84df38908f9569d0f552575606e6e6e7e22dd:6](138)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:6",
+//              "ID": "aea84df38908f9569d0f552575606e6e6e7e22dd:6",
 //              "LastObjectSize": "236",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:2",
+//              "OwnerID": "aea84df38908f9569d0f552575606e6e6e7e22dd:2",
 //              "RefCount": "1"
 //          },
 //     @@ -14,6 +14,17 @@
@@ -159,8 +159,8 @@ func main() {
 //     +            "@type": "/gno.SliceValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "Hash": "0b321de960853f22df9d4635edffd1990257bbfc",
-//     +                "ObjectID": "0ea84df38908f9569d0f552575606e6e6e7e22dd:10"
+//     +                "Hash": "af828a01b9823a07083d08cb1c69bbe1f87c0edb",
+//     +                "ObjectID": "aea84df38908f9569d0f552575606e6e6e7e22dd:10"
 //     +            },
 //     +            "Length": "2",
 //     +            "Maxcap": "2",

--- a/gnovm/tests/files/storage/reference1.gno
+++ b/gnovm/tests/files/storage/reference1.gno
@@ -21,7 +21,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:7](243)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:7](243)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -35,19 +35,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7",
 //         "LastObjectSize": "243",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:6",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:6",
 //         "RefCount": "1"
 //     }
 // }
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:6](338)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:6](338)={
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:6",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:6",
 //         "LastObjectSize": "338",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -57,19 +57,19 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "3a413fbf36d1191bf438c588d9f345b8ecf129b2",
-//             "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7"
+//             "Hash": "0ed9f1cbe4144466c3fe41bdd44ed7b36bdbd795",
+//             "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7"
 //         }
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](134)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](134)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "LastObjectSize": "254",
 //     -        "ModTime": "0",
 //     +        "ModTime": "5",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,16 @@
@@ -81,8 +81,8 @@ func main() {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "Hash": "4875f42d817632f78fe3ca47bfabeafbfbf22ee5",
-//     +                "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:6"
+//     +                "Hash": "fef33cce5674d9c304da5a11ff35a9e2de35e007",
+//     +                "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:6"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null

--- a/gnovm/tests/files/storage/struct1.gno
+++ b/gnovm/tests/files/storage/struct1.gno
@@ -21,7 +21,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:7](240)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:7](240)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -35,32 +35,32 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7",
 //         "LastObjectSize": "240",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "LastObjectSize": "338",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "fd590cdbcf4922e4763aa37b29bf43887cabf06f",
-//     -            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:4"
-//     +            "Hash": "bbca14191d9ff8f32abaf30b17c4d70d3258a5a0",
-//     +            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7"
+//     -            "Hash": "2054070e999df8e7cb3d1f1b92c7019aa996206d",
+//     -            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:4"
+//     +            "Hash": "38c8d7d3b202f3ff95c28b39fcfcf9f04114c5ec",
+//     +            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7"
 //              }
 //          }
 //      }
-// d[04f997a9ca158338c03cfc00686d77220a6cf62f:4](-214)
+// d[34f997a9ca158338c03cfc00686d77220a6cf62f:4](-214)

--- a/gnovm/tests/files/storage/struct1b.gno
+++ b/gnovm/tests/files/storage/struct1b.gno
@@ -21,7 +21,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:7](244)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:7](244)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -35,32 +35,32 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7",
 //         "LastObjectSize": "244",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "LastObjectSize": "338",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "fd590cdbcf4922e4763aa37b29bf43887cabf06f",
-//     -            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:4"
-//     +            "Hash": "959ac8265241c987e9b584a312c37a620809bcef",
-//     +            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7"
+//     -            "Hash": "2054070e999df8e7cb3d1f1b92c7019aa996206d",
+//     -            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:4"
+//     +            "Hash": "828319b9f2bc74534d09894634deb113649ba6b1",
+//     +            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7"
 //              }
 //          }
 //      }
-// d[04f997a9ca158338c03cfc00686d77220a6cf62f:4](-214)
+// d[34f997a9ca158338c03cfc00686d77220a6cf62f:4](-214)

--- a/gnovm/tests/files/storage/struct1c.gno
+++ b/gnovm/tests/files/storage/struct1c.gno
@@ -21,7 +21,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:7](244)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:7](244)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -35,32 +35,32 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7",
 //         "LastObjectSize": "244",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "LastObjectSize": "338",
 //     -        "ModTime": "0",
 //     +        "ModTime": "6",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "8c902f00b69bdbfd67032c4db79852ededc606f0",
-//     -            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:4"
-//     +            "Hash": "959ac8265241c987e9b584a312c37a620809bcef",
-//     +            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:7"
+//     -            "Hash": "ecc526355828cb48db9b977fd3f25539ceeaea83",
+//     -            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:4"
+//     +            "Hash": "828319b9f2bc74534d09894634deb113649ba6b1",
+//     +            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:7"
 //              }
 //          }
 //      }
-// d[04f997a9ca158338c03cfc00686d77220a6cf62f:4](-243)
+// d[34f997a9ca158338c03cfc00686d77220a6cf62f:4](-243)

--- a/gnovm/tests/files/storage/struct2.gno
+++ b/gnovm/tests/files/storage/struct2.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:8](240)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:8](240)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -37,23 +37,23 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:8",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:8",
 //         "LastObjectSize": "240",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](0)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](0)=
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "d0f1ba7ee33fbbbf66a1c14967ed5c48b66e1bca",
-//     -            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:4"
-//     +            "Hash": "8973bec246829f2dd6dde20fa21f72b45af4b956",
-//     +            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:8"
+//     -            "Hash": "cb71b821cefa1bb05605966f33f2d53001f59237",
+//     -            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:4"
+//     +            "Hash": "fb5d0d403090106fdcdd5778d01d657e038c00c8",
+//     +            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:8"
 //              }
 //          }
 //      }
-// d[04f997a9ca158338c03cfc00686d77220a6cf62f:4](-248)
+// d[34f997a9ca158338c03cfc00686d77220a6cf62f:4](-248)

--- a/gnovm/tests/files/storage/struct2b.gno
+++ b/gnovm/tests/files/storage/struct2b.gno
@@ -23,7 +23,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:4](-3)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:4](-3)=
 //     @@ -7,7 +7,7 @@
 //                  },
 //                  "V": {

--- a/gnovm/tests/files/storage/struct3.gno
+++ b/gnovm/tests/files/storage/struct3.gno
@@ -46,7 +46,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:14](6)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:14](6)=
 //     @@ -7,14 +7,14 @@
 //                  },
 //                  "V": {
@@ -57,14 +57,14 @@ func main() {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:14",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:14",
 //              "LastObjectSize": "240",
 //     -        "ModTime": "0",
 //     +        "ModTime": "16",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "RefCount": "1"
 //          }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:16](6)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:16](6)=
 //     @@ -7,14 +7,14 @@
 //                  },
 //                  "V": {
@@ -75,21 +75,21 @@ func main() {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:16",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:16",
 //              "LastObjectSize": "241",
 //     -        "ModTime": "0",
 //     +        "ModTime": "16",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:15",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:15",
 //              "RefCount": "1"
 //          }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:6](135)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:6](135)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:6",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:6",
 //              "LastObjectSize": "254",
 //     -        "ModTime": "0",
 //     +        "ModTime": "16",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,15 @@
@@ -101,23 +101,23 @@ func main() {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:15"
+//     +                "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:15"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null
 //              }
 //          }
 //      }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:15](7)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:15](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:15",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:15",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "340",
 //     -        "ModTime": "0",
 //     +        "ModTime": "16",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:5",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:5",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },
@@ -127,8 +127,8 @@ func main() {
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "bb4bcc7028604a7fbdc85dbe1e017703f6c8a528",
-//     +            "Hash": "985baca75e3f9c0249bcb63a65cfa9b0a3c8ac03",
-//                  "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:16"
+//     -            "Hash": "1350323698e83f991922ca1d7732a79d01f2161b",
+//     +            "Hash": "0a40968d10e2618a057f0c13a02df1150ad975f4",
+//                  "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:16"
 //              }
 //          }

--- a/gnovm/tests/files/storage/struct4.gno
+++ b/gnovm/tests/files/storage/struct4.gno
@@ -35,7 +35,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/storage"]
-// c[04f997a9ca158338c03cfc00686d77220a6cf62f:13](215)={
+// c[34f997a9ca158338c03cfc00686d77220a6cf62f:13](215)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -45,14 +45,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:13",
+//         "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:13",
 //         "LastObjectSize": "215",
 //         "ModTime": "0",
-//         "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//         "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:12](6)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:12](6)=
 //     @@ -7,14 +7,14 @@
 //                  },
 //                  "V": {
@@ -63,21 +63,21 @@ func main() {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:12",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:12",
 //              "LastObjectSize": "241",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:11",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:11",
 //              "RefCount": "1"
 //          }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:6](135)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:6](135)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:6",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:6",
 //              "LastObjectSize": "254",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,6 +13,15 @@
@@ -89,61 +89,61 @@ func main() {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:11"
+//     +                "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:11"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null
 //              }
 //          }
 //      }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:11](5)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:11](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:11",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:11",
 //              "LastObjectSize": "340",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:5",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:5",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "51c6fa6364690a448a418ec9a08004b1bb4c6769",
-//     +            "Hash": "496985af13c208547556c56c1148bcd7bda561ef",
-//                  "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:12"
+//     -            "Hash": "2b6a1dd38af88a40a05ffd55e77e7ea3b4b3a156",
+//     +            "Hash": "6c3ebd5509617364a76aada1372a2c3f2afa0dc4",
+//                  "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:12"
 //              }
 //          }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:3](0)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:3",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:3",
 //              "LastObjectSize": "344",
 //     -        "ModTime": "9",
 //     +        "ModTime": "12",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "04e1534ca648348a54ba752206271062e0c1496a",
-//     -            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:10"
-//     +            "Hash": "326d056615debb3591e04b2be40e3f29bcfb4701",
-//     +            "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:13"
+//     -            "Hash": "332e3d0f721fc783bbd5d5fec75baae6488cad5a",
+//     -            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:10"
+//     +            "Hash": "95a698670cebb93239a3707db3d217c4799691dd",
+//     +            "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:13"
 //              }
 //          }
 //      }
-// u[04f997a9ca158338c03cfc00686d77220a6cf62f:5](-130)=
+// u[34f997a9ca158338c03cfc00686d77220a6cf62f:5](-130)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "04f997a9ca158338c03cfc00686d77220a6cf62f:5",
+//              "ID": "34f997a9ca158338c03cfc00686d77220a6cf62f:5",
 //              "LastObjectSize": "389",
 //     -        "ModTime": "9",
 //     +        "ModTime": "12",
-//              "OwnerID": "04f997a9ca158338c03cfc00686d77220a6cf62f:2",
+//              "OwnerID": "34f997a9ca158338c03cfc00686d77220a6cf62f:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,16 +13,6 @@
@@ -155,12 +155,12 @@ func main() {
 //     -            "@type": "/gno.PointerValue",
 //     -            "Base": {
 //     -                "@type": "/gno.RefValue",
-//     -                "Hash": "1e9529eaabb65e7bdcac367f5fe455f6ef66f98c",
-//     -                "ObjectID": "04f997a9ca158338c03cfc00686d77220a6cf62f:11"
+//     -                "Hash": "62723026ca278547b47a2fc04d84860e71f18865",
+//     -                "ObjectID": "34f997a9ca158338c03cfc00686d77220a6cf62f:11"
 //     -            },
 //     -            "Index": "0",
 //     -            "TV": null
 //              }
 //          }
 //      }
-// d[04f997a9ca158338c03cfc00686d77220a6cf62f:10](-240)
+// d[34f997a9ca158338c03cfc00686d77220a6cf62f:10](-240)

--- a/gnovm/tests/files/struct63.gno
+++ b/gnovm/tests/files/struct63.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:11](216)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:11](216)={
 //     "Fields": [
 //         {
 //             "N": "AgAAAAAAAAA=",
@@ -36,14 +36,14 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:11",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:11",
 //         "LastObjectSize": "216",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](333)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](333)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -52,38 +52,38 @@ func main() {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "3eb2453a7fb8536b3ad3e3b9e837944addfd7a98",
-//                 "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:11"
+//                 "Hash": "9ecaaba55c8400d0a9b7f90804afeebeccd80a79",
+//                 "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:11"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
 //         "LastObjectSize": "333",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //         "RefCount": "1"
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5](6)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5](6)=
 //     @@ -7,15 +7,15 @@
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "1274a7ff3e8fe80d0f715689b512ed03897e1a01",
-//     -                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6"
-//     +                "Hash": "e156e889763b28f60647501965a3f2613d3b67cc",
-//     +                "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10"
+//     -                "Hash": "1fd36417177aea9a1c497135645769b1228a43ee",
+//     -                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6"
+//     +                "Hash": "4f2e1ce0434fbc3f3dd49c10c8823bed0c407ab4",
+//     +                "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10"
 //                  }
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //              "LastObjectSize": "331",
 //     -        "ModTime": "0",
 //     +        "ModTime": "9",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:4",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](-331)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-214)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](-331)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-214)

--- a/gnovm/tests/files/struct63b.gno
+++ b/gnovm/tests/files/struct63b.gno
@@ -26,7 +26,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16](216)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16](216)={
 //     "Fields": [
 //         {
 //             "N": "AgAAAAAAAAA=",
@@ -37,19 +37,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16",
 //         "LastObjectSize": "216",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15](336)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15](336)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
 //         "LastObjectSize": "336",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -59,12 +59,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "1dec28e121657267508856fefcbbcd7db14d7549",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16"
+//             "Hash": "db794299f99e46ec060ee261f9f37361d4cef0dd",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16"
 //         }
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](379)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](379)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -78,8 +78,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "2ad35f30ae1c285d1778656149738d281a39dd84",
-//                     "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15"
+//                     "Hash": "52a2e2a846b73df0011e5eafb283fedab896d379",
+//                     "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -87,19 +87,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "LastObjectSize": "379",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -109,33 +109,33 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d60bdce59d90096915591cbee7506e6798bde04d",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
+//             "Hash": "cd93c2158c8fa9ce8198d3dce7e316137edbd718",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
 //         }
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
 //     @@ -12,8 +12,8 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "fea65b1c3974e6eb29ccc3de96f30b47f5fe41c8",
-//     -                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
-//     +                    "Hash": "665b2ff7bc854d22d0c126ceb5b4d3a44045d54a",
-//     +                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
+//     -                    "Hash": "bd0670aa7dc0c1a702fe46f743714d7b9d0072a0",
+//     -                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
+//     +                    "Hash": "16cf9006fad01a557cf9881188d9c4f8a1e3d738",
+//     +                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -23,7 +23,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //              "LastObjectSize": "376",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](-334)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](-215)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](-334)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](-215)

--- a/gnovm/tests/files/struct63c.gno
+++ b/gnovm/tests/files/struct63c.gno
@@ -25,7 +25,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16](216)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16](216)={
 //     "Fields": [
 //         {
 //             "N": "AgAAAAAAAAA=",
@@ -36,19 +36,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16",
 //         "LastObjectSize": "216",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15](336)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15](336)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15",
 //         "LastObjectSize": "336",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -58,12 +58,12 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "1dec28e121657267508856fefcbbcd7db14d7549",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:16"
+//             "Hash": "db794299f99e46ec060ee261f9f37361d4cef0dd",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:16"
 //         }
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](379)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](379)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -77,8 +77,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "2ad35f30ae1c285d1778656149738d281a39dd84",
-//                     "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:15"
+//                     "Hash": "52a2e2a846b73df0011e5eafb283fedab896d379",
+//                     "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:15"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -86,19 +86,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "LastObjectSize": "379",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -108,33 +108,33 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d60bdce59d90096915591cbee7506e6798bde04d",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
+//             "Hash": "cd93c2158c8fa9ce8198d3dce7e316137edbd718",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
 //         }
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
 //     @@ -12,8 +12,8 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "fea65b1c3974e6eb29ccc3de96f30b47f5fe41c8",
-//     -                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
-//     +                    "Hash": "665b2ff7bc854d22d0c126ceb5b4d3a44045d54a",
-//     +                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
+//     -                    "Hash": "bd0670aa7dc0c1a702fe46f743714d7b9d0072a0",
+//     -                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
+//     +                    "Hash": "16cf9006fad01a557cf9881188d9c4f8a1e3d738",
+//     +                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -23,7 +23,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //              "LastObjectSize": "376",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](-334)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](-215)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](-334)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](-215)

--- a/gnovm/tests/files/struct63d.gno
+++ b/gnovm/tests/files/struct63d.gno
@@ -26,17 +26,17 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](5)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
 //              "LastObjectSize": "334",
 //     -        "ModTime": "0",
 //     +        "ModTime": "14",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8",
 //              "RefCount": "1"
 //          },
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](378)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](378)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -50,8 +50,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "9dd8facc548ca98b55fa87afd0dad23b1074fda4",
-//                     "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9"
+//                     "Hash": "6762ea9b9f3263aaf4a4a2c665ec38779a323eec",
+//                     "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -59,19 +59,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "LastObjectSize": "378",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -81,31 +81,31 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "5d2946fdd983d5a633a9caf417c769828193c278",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
+//             "Hash": "4d1ddbecab6e5585cbff3b0348668ee36077380b",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
 //         }
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
 //     @@ -12,8 +12,8 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "fea65b1c3974e6eb29ccc3de96f30b47f5fe41c8",
-//     -                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
-//     +                    "Hash": "58efd07df8536f0a82758135f5012fc916a2707f",
-//     +                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
+//     -                    "Hash": "bd0670aa7dc0c1a702fe46f743714d7b9d0072a0",
+//     -                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
+//     +                    "Hash": "c4855bdb25859f250a4405d0d7011ce16e4f7ea5",
+//     +                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -23,7 +23,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //              "LastObjectSize": "376",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)

--- a/gnovm/tests/files/struct63e.gno
+++ b/gnovm/tests/files/struct63e.gno
@@ -27,7 +27,7 @@ func main() {
 
 // Realm:
 // finalizerealm["gno.land/r/main"]
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](5)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10](5)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [
@@ -39,33 +39,33 @@ func main() {
 //                      "value": "32"
 //     @@ -11,7 +11,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10",
 //              "LastObjectSize": "215",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
 //              "RefCount": "1"
 //          }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](5)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9",
 //              "LastObjectSize": "334",
 //     -        "ModTime": "0",
 //     +        "ModTime": "14",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "f82b64740b75696af2804084c1c6553f542695af",
-//     +            "Hash": "9adf50a17d5ecd43f48caaaa607daaf8654e2c72",
-//                  "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:10"
+//     -            "Hash": "043b7f42946883ac4865fa928b4d0759526f93a0",
+//     +            "Hash": "da0638e6b41ce900f14472a51a23c875b39cb8ea",
+//                  "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:10"
 //              }
 //          }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](378)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14](378)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -79,8 +79,8 @@ func main() {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "f4783626fc250fa516e5f3ff76df78641f2f37b2",
-//                     "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:9"
+//                     "Hash": "0256fffe5b960c712e0aa07c2d941df8b0f6ea4d",
+//                     "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:9"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -88,19 +88,19 @@ func main() {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14",
 //         "LastObjectSize": "378",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
+// c[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13](335)={
 //     "ObjectInfo": {
-//         "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
+//         "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13",
 //         "LastObjectSize": "335",
 //         "ModTime": "0",
-//         "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//         "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -110,31 +110,31 @@ func main() {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "35c946879944ec292797680b43ec72253f2efc77",
-//             "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
+//             "Hash": "1318d80f0cf4c2705481ff8e0d5a5c980d7b8fda",
+//             "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:14"
 //         }
 //     }
 // }
-// u[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
+// u[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6](6)=
 //     @@ -12,8 +12,8 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "fea65b1c3974e6eb29ccc3de96f30b47f5fe41c8",
-//     -                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
-//     +                    "Hash": "d19c41893833f71d630976276bd1ebd6a53414f3",
-//     +                    "ObjectID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
+//     -                    "Hash": "bd0670aa7dc0c1a702fe46f743714d7b9d0072a0",
+//     -                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7"
+//     +                    "Hash": "d95d01838d669947293d9550db2a62274df4d487",
+//     +                    "ObjectID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:13"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -23,7 +23,7 @@
 //          "ObjectInfo": {
-//              "ID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
+//              "ID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:6",
 //              "LastObjectSize": "376",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "09b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
+//              "OwnerID": "f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:5",
 //              "RefCount": "1"
 //          }
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
-// d[09b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:7](-333)
+// d[f9b6b63cc3f789fda754d95769bbf99bf64c5cb4:8](-376)

--- a/gnovm/tests/files/types/slice_0.gno
+++ b/gnovm/tests/files/types/slice_0.gno
@@ -9,4 +9,4 @@ func main() {
 // main/slice_0.gno:5:6-12: cannot slice variable of type *[]int
 
 // TypeCheckError:
-// main/slice_0.gno:5:6: invalid operation: cannot slice p (variable of type *[]int)
+// main/slice_0.gno:5:6: cannot slice p (variable of type *[]int)

--- a/gnovm/tests/files/types/slice_2.gno
+++ b/gnovm/tests/files/types/slice_2.gno
@@ -6,7 +6,7 @@ func main() {
 }
 
 // TypeCheckError:
-// main/slice_2.gno:5:6: invalid operation: cannot slice p (variable of type *int)
+// main/slice_2.gno:5:6: cannot slice p (variable of type *int)
 
 // Error:
 // main/slice_2.gno:5:6-12: cannot slice variable of type *int

--- a/gnovm/tests/files/types/slice_3.gno
+++ b/gnovm/tests/files/types/slice_3.gno
@@ -6,7 +6,7 @@ func main() {
 }
 
 // TypeCheckError:
-// main/slice_3.gno:5:6: invalid operation: cannot slice p (variable of type int)
+// main/slice_3.gno:5:6: cannot slice p (variable of type int)
 
 // Error:
 // main/slice_3.gno:5:6-12: cannot slice variable of type int

--- a/gnovm/tests/files/types/slice_5.gno
+++ b/gnovm/tests/files/types/slice_5.gno
@@ -9,4 +9,4 @@ func main() {
 // main/slice_5.gno:5:6-12: cannot slice variable of type **[3]int
 
 // TypeCheckError:
-// main/slice_5.gno:5:6: invalid operation: cannot slice p (variable of type **[3]int)
+// main/slice_5.gno:5:6: cannot slice p (variable of type **[3]int)

--- a/gnovm/tests/files/zrealm0.gno
+++ b/gnovm/tests/files/zrealm0.gno
@@ -14,6 +14,7 @@ func main(cur realm) {
 // 1
 
 
+
 // The below tests that the realm's block (of 1 variable) changed.  The first
 // element image in the package (block) is for the "main" function, which
 // appears first because function declarations are defined in a file before
@@ -21,14 +22,14 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](31)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](31)=
 //     @@ -2,9 +2,15 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "190",
 //     -        "ModTime": "0",
 //     +        "ModTime": "5",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     -    "Value": {}

--- a/gnovm/tests/files/zrealm1.gno
+++ b/gnovm/tests/files/zrealm1.gno
@@ -25,7 +25,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:6](269)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:6](269)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -41,21 +41,21 @@ func main(cur realm,) {
 //         {}
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //         "LastObjectSize": "269",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](156)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](156)=
 //     @@ -2,9 +2,19 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "190",
 //     -        "ModTime": "0",
 //     +        "ModTime": "5",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     -    "Value": {}
@@ -66,8 +66,8 @@ func main(cur realm,) {
 //     +        },
 //     +        "V": {
 //     +            "@type": "/gno.RefValue",
-//     +            "Hash": "9b6e58b7899427bb12c0faab3866ee328b4537d0",
-//     +            "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//     +            "Hash": "860c81a9b1ccd2bc42fc95635a1e940c88b758d7",
+//     +            "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6"
 //     +        }
 //     +    }
 //      }

--- a/gnovm/tests/files/zrealm10.gno
+++ b/gnovm/tests/files/zrealm10.gno
@@ -23,7 +23,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [

--- a/gnovm/tests/files/zrealm11.gno
+++ b/gnovm/tests/files/zrealm11.gno
@@ -23,7 +23,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [

--- a/gnovm/tests/files/zrealm13.gno
+++ b/gnovm/tests/files/zrealm13.gno
@@ -34,7 +34,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-130)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-130)=
 //     @@ -8,16 +8,6 @@
 //                          "@type": "/gno.RefType",
 //                          "ID": "gno.land/r/test.B"
@@ -44,8 +44,8 @@ func main(cur realm,) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "Hash": "039c758da189de11bb723e68a3ef3f2f59bae535",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//     -                    "Hash": "f8ae23e792fe87be8116be6c00e66166c79eb9dc",
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -54,16 +54,16 @@ func main(cur realm,) {
 //              {
 //     @@ -43,7 +33,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "582",
 //     -        "ModTime": "10",
 //     +        "ModTime": "14",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -3,8 +3,8 @@
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "IsEscaped": true,
 //              "LastObjectSize": "340",
 //     -        "ModTime": "12",
@@ -73,5 +73,5 @@ func main(cur realm,) {
 //          },
 //          "Value": {
 //              "T": {
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:11](-335)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:12](-441)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](-335)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](-441)

--- a/gnovm/tests/files/zrealm14.gno
+++ b/gnovm/tests/files/zrealm14.gno
@@ -35,7 +35,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-260)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-260)=
 //     @@ -8,16 +8,6 @@
 //                          "@type": "/gno.RefType",
 //                          "ID": "gno.land/r/test.B"
@@ -45,8 +45,8 @@ func main(cur realm,) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "Hash": "039c758da189de11bb723e68a3ef3f2f59bae535",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//     -                    "Hash": "f8ae23e792fe87be8116be6c00e66166c79eb9dc",
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -62,8 +62,8 @@ func main(cur realm,) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "Hash": "054c315a527d298c5e5919d78ced1705080b6fc3",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13"
+//     -                    "Hash": "2c5828e175c865d2bc98e9577b36f757a2d73290",
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -71,16 +71,16 @@ func main(cur realm,) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "582",
 //     -        "ModTime": "10",
 //     +        "ModTime": "14",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -3,8 +3,8 @@
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "IsEscaped": true,
 //              "LastObjectSize": "340",
 //     -        "ModTime": "12",
@@ -90,7 +90,7 @@ func main(cur realm,) {
 //          },
 //          "Value": {
 //              "T": {
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:11](-335)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:12](-441)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:13](-335)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:14](-441)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](-335)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](-441)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:13](-335)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:14](-441)

--- a/gnovm/tests/files/zrealm15.gno
+++ b/gnovm/tests/files/zrealm15.gno
@@ -39,7 +39,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-260)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-260)=
 //     @@ -8,15 +8,6 @@
 //                          "@type": "/gno.RefType",
 //                          "ID": "gno.land/r/test.B"
@@ -49,7 +49,7 @@ func main(cur realm) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14"
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -65,7 +65,7 @@ func main(cur realm) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14"
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -73,14 +73,14 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "582",
 //     -        "ModTime": "11",
 //     +        "ModTime": "15",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:5](-130)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:5](-130)=
 //     @@ -7,22 +7,13 @@
 //                          "@type": "/gno.RefType",
 //                          "ID": "gno.land/r/test.S"
@@ -90,7 +90,7 @@ func main(cur realm) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -98,16 +98,16 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:5",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5",
 //              "LastObjectSize": "382",
 //     -        "ModTime": "11",
 //     +        "ModTime": "15",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:12](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](5)=
 //     @@ -3,8 +3,8 @@
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //              "IsEscaped": true,
 //              "LastObjectSize": "337",
 //     -        "ModTime": "0",
@@ -117,7 +117,7 @@ func main(cur realm) {
 //          },
 //          "Value": {
 //              "T": {
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -4,7 +4,7 @@
 //              "IsEscaped": true,
 //              "LastObjectSize": "340",
@@ -131,10 +131,10 @@ func main(cur realm) {
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "11139afc54f70ddb4300ec4f8dbfa084876353c0",
-//     +            "Hash": "90bf83c06410281c3afa2e7f3eab7f368d4de377",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:5"
+//     -            "Hash": "5a6cf861be95815fd06392b3ca3ad56791a0e4ad",
+//     +            "Hash": "d67f9b6cb17e76c98ab078685f042be9f21aec72",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:5"
 //              }
 //          }
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:14](-337)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:15](-579)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:14](-337)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:15](-579)

--- a/gnovm/tests/files/zrealm16.gno
+++ b/gnovm/tests/files/zrealm16.gno
@@ -35,43 +35,43 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:15](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:15](5)=
 //     @@ -12,7 +12,7 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4"
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4"
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -32,7 +32,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:15",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15",
 //              "LastObjectSize": "441",
 //     -        "ModTime": "0",
 //     +        "ModTime": "17",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](7)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "333",
 //     -        "ModTime": "0",
 //     +        "ModTime": "17",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:6",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },
 //          "Value": {
 //              "T": {
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -3,8 +3,8 @@
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "IsEscaped": true,
 //              "LastObjectSize": "340",
 //     -        "ModTime": "15",

--- a/gnovm/tests/files/zrealm2.gno
+++ b/gnovm/tests/files/zrealm2.gno
@@ -28,7 +28,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:8](265)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](265)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -44,32 +44,32 @@ func main(cur realm,) {
 //         {}
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "LastObjectSize": "265",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "346",
 //     -        "ModTime": "6",
 //     +        "ModTime": "7",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "3dbc356b081c2276e299d630d10731c70aadf6e4",
-//     -            "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
-//     +            "Hash": "f6643c8bbef5c459457a0f8359447367e731d930",
-//     +            "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     -            "Hash": "c1bfc6b3d7043721364563a780c15c757c10a49f",
+//     -            "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +            "Hash": "17c8ef092e704bbac8183328f9295793011c8364",
+//     +            "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //              }
 //          }
 //      }
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-265)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-265)

--- a/gnovm/tests/files/zrealm3.gno
+++ b/gnovm/tests/files/zrealm3.gno
@@ -25,7 +25,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:10](390)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](390)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -57,19 +57,19 @@ func main(cur realm,) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "LastObjectSize": "390",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:9](337)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](337)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "LastObjectSize": "337",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -79,31 +79,31 @@ func main(cur realm,) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "23d24aa0b5df1c2e38adde7e684a4bc2af3d19e6",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//             "Hash": "24da1ffa2b1135d506e4e79ad56ba790d5bb3d36",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "386",
 //     -        "ModTime": "6",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,8 +18,8 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "e8c07f1269c2f82666c0c8cac8fad9c98776dc0d",
-//     -                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
-//     +                "Hash": "07c6d63dc74da34ca1e7dea31877f38a9af49df5",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     -                "Hash": "4455e3128f9519966eef9b90a79804d55a8af527",
+//     -                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "Hash": "2b04facb318fac37e5180a0d55648e0b6a6be45d",
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                  },
 //                  "Index": "0",
 //                  "TV": null
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-336)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:8](-389)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-336)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](-389)

--- a/gnovm/tests/files/zrealm4.gno
+++ b/gnovm/tests/files/zrealm4.gno
@@ -23,7 +23,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](9)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](9)=
 //     @@ -17,7 +17,7 @@
 //                  },
 //                  "V": {
@@ -35,47 +35,47 @@ func main(cur realm) {
 //              {
 //     @@ -49,7 +49,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "LastObjectSize": "617",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "423",
 //     -        "ModTime": "6",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,7 +18,6 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "14081ad8498d444f42f2ec4fa8b1c6b46d043817",
-//                      "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                "Hash": "40d48fc9265c6f4f740db5f1debb3f465684ec64",
+//                      "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                  },
 //                  "Index": "0",
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "373",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "3b944e0ac2a76fef67c2fd3383dfb971447bdc42",
-//     +            "Hash": "27065c2150e292a23156e12f0c7441e7dad8f9d4",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     -            "Hash": "ff7d2f7d23827a0af50e33994bc896d1b1ab3ea8",
+//     +            "Hash": "6e91c2c1ddacaac0d8a29bbbfa6816187d7a491c",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //              }
 //          }

--- a/gnovm/tests/files/zrealm5.gno
+++ b/gnovm/tests/files/zrealm5.gno
@@ -23,7 +23,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:10](618)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](618)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -72,19 +72,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "LastObjectSize": "618",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:9](374)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](374)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "LastObjectSize": "374",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -94,12 +94,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "3a52a8ad68d61b5eac06aca00f259bdfd6ca3037",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//             "Hash": "e7ac59063098152f2e2a716cc34c412b5d3a1673",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](134)=
 //     @@ -21,7 +21,7 @@
 //                  }
 //              },
@@ -118,8 +118,8 @@ func main(cur realm) {
 //     +                "@type": "/gno.PointerValue",
 //     +                "Base": {
 //     +                    "@type": "/gno.RefValue",
-//     +                    "Hash": "0e553559c1e64c66cc5aed8c3ecfbefed2dc7cc6",
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     +                    "Hash": "41555745b5cd9c6d47815feeba96d49c7f496d8f",
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //     +                },
 //     +                "Index": "0",
 //     +                "TV": null
@@ -127,47 +127,47 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "LastObjectSize": "617",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "423",
 //     -        "ModTime": "6",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,7 +18,6 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "14081ad8498d444f42f2ec4fa8b1c6b46d043817",
-//                      "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                "Hash": "40d48fc9265c6f4f740db5f1debb3f465684ec64",
+//                      "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                  },
 //                  "Index": "0",
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "373",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "3b944e0ac2a76fef67c2fd3383dfb971447bdc42",
-//     +            "Hash": "d85ee2e77889a2ec8ebdad2cb37c46320bdcb3d6",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     -            "Hash": "ff7d2f7d23827a0af50e33994bc896d1b1ab3ea8",
+//     +            "Hash": "11a38567c9143650f0a5a0ed4415d7855d293465",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //              }
 //          }

--- a/gnovm/tests/files/zrealm6.gno
+++ b/gnovm/tests/files/zrealm6.gno
@@ -24,7 +24,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:12](619)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](619)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -73,19 +73,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "LastObjectSize": "619",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:11](376)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](376)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "LastObjectSize": "376",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -95,12 +95,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "0b03c33406de59b770551924eb13721df55fdcb7",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//             "Hash": "91f2170c41ea7cf788183f14f96b8d4831d1df24",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:10](135)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](135)=
 //     @@ -21,7 +21,7 @@
 //                  }
 //              },
@@ -119,8 +119,8 @@ func main(cur realm) {
 //     +                "@type": "/gno.PointerValue",
 //     +                "Base": {
 //     +                    "@type": "/gno.RefValue",
-//     +                    "Hash": "91b373de2d3931c4463cf684fa53f7eef4a4fb13",
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//     +                    "Hash": "3751cf502d18890818cbec892779f223ec922a76",
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //     +                },
 //     +                "Index": "0",
 //     +                "TV": null
@@ -128,14 +128,14 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //              "LastObjectSize": "618",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](5)=
 //     @@ -21,7 +21,7 @@
 //                  }
 //              },
@@ -149,72 +149,72 @@ func main(cur realm) {
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "0e553559c1e64c66cc5aed8c3ecfbefed2dc7cc6",
-//                          "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     -                    "Hash": "41555745b5cd9c6d47815feeba96d49c7f496d8f",
+//                          "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                      },
 //                      "Index": "0",
 //     @@ -59,7 +58,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "LastObjectSize": "746",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //              "LastObjectSize": "374",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "3a52a8ad68d61b5eac06aca00f259bdfd6ca3037",
-//     +            "Hash": "5ba216a6136ebe187f58a4ea40eea3fd052db28b",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//     -            "Hash": "e7ac59063098152f2e2a716cc34c412b5d3a1673",
+//     +            "Hash": "b6260109680974ecd99147c87b4137cd2fa298ba",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //              }
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "423",
 //     -        "ModTime": "6",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,7 +18,6 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "3211396eb117ccbc3987be770f1c4f2a005697b4",
-//                      "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                "Hash": "ebcf5fc65f39a27f06dffc28105573ee2801e029",
+//                      "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                  },
 //                  "Index": "0",
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "373",
 //     -        "ModTime": "0",
 //     +        "ModTime": "10",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "d761320968b39fc2416b68b2649daa62b2bd116b",
-//     +            "Hash": "bf444b64708fd4af72f705bce573a162dde2c4e2",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     -            "Hash": "8c2515bcec8460ec3500767ced671ec2d5c1c7f1",
+//     +            "Hash": "51374afaf0a43c6edceb494ad7f01742176d7adc",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //              }
 //          }

--- a/gnovm/tests/files/zrealm7.gno
+++ b/gnovm/tests/files/zrealm7.gno
@@ -25,7 +25,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:14](619)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:14](619)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -74,19 +74,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //         "LastObjectSize": "619",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:13](376)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:13](376)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "LastObjectSize": "376",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -96,12 +96,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "709eba3056a061a866f833d88fdc06c8dcfdfd82",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14"
+//             "Hash": "d23620f4afd5ea68c8dcea8c04faaa6500cd8043",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:12](135)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](135)=
 //     @@ -21,7 +21,7 @@
 //                  }
 //              },
@@ -120,8 +120,8 @@ func main(cur realm) {
 //     +                "@type": "/gno.PointerValue",
 //     +                "Base": {
 //     +                    "@type": "/gno.RefValue",
-//     +                    "Hash": "edf9c5a1ce4d6fcea83b33fbbb62ad0711f3940c",
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13"
+//     +                    "Hash": "7fb97d3c3f333fb057f757847918d9ab2f833e53",
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
 //     +                },
 //     +                "Index": "0",
 //     +                "TV": null
@@ -129,14 +129,14 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //              "LastObjectSize": "619",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:10](134)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](134)=
 //     @@ -21,19 +21,10 @@
 //                  }
 //              },
@@ -162,8 +162,8 @@ func main(cur realm) {
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "9640a0414ff5d70dc029395e44ffdccc3c59ab23",
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                    "Hash": "0e148c4450bf962fb89d22a996639de651c6883c",
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //     +                },
 //     +                "Index": "0",
 //     +                "TV": null
@@ -181,38 +181,38 @@ func main(cur realm) {
 //     +                "@type": "/gno.PointerValue",
 //     +                "Base": {
 //     +                    "@type": "/gno.RefValue",
-//                          "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//                          "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //                      },
 //                      "Index": "0",
 //     @@ -59,7 +67,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //              "LastObjectSize": "748",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:11](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //              "LastObjectSize": "376",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "9da2b11c167d64c5e217e53f3579ee8d972594be",
-//     +            "Hash": "ee406ec9441b8feeb4fc548c1df1f7ec190cb60c",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//     -            "Hash": "4a17484cc93c655365dd3aca8dd7b71f98efefc6",
+//     +            "Hash": "1d295e120e0cbb610d82348bc15353705f8a35a5",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //              }
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](-124)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](-124)=
 //     @@ -21,7 +21,7 @@
 //                  }
 //              },
@@ -231,8 +231,8 @@ func main(cur realm) {
 //     -                "@type": "/gno.PointerValue",
 //     -                "Base": {
 //     -                    "@type": "/gno.RefValue",
-//     -                    "Hash": "fe19367377a1146980353a3dcd0c3de3c2de21ed",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     -                    "Hash": "0bd1ff6277871be3d2bac181c94f26c6032d2291",
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //     -                },
 //     -                "Index": "0",
 //     -                "TV": null
@@ -240,69 +240,69 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "LastObjectSize": "746",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //              "LastObjectSize": "374",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "2e4e53cb297a58323ae4a6dc98facbbc1f07e765",
-//     +            "Hash": "773ba6efa3609387bbf7a956b462b397523453bf",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//     -            "Hash": "9845eae74d1efdd947798f875a2cf80bb0330c23",
+//     +            "Hash": "c62dd43790fc806feebd62f4a38d406c29957862",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //              }
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "373",
 //     -        "ModTime": "0",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          },
 //     @@ -13,7 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "e8a406fa3e95dfa7986ce2b867319aa193decd80",
-//     +            "Hash": "29144c4c505d5d0ba099ae9ce0158beb875f1ff9",
-//                  "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     -            "Hash": "53160861cb3a67720e3006f33bf518be43a13026",
+//     +            "Hash": "1059095280e98f907857fc5204f45e523eb27912",
+//                  "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //              }
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "423",
 //     -        "ModTime": "6",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,8 +18,8 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "2644d74bd7bdd3f9dec5bed61244ffdde5f2ac2b",
-//     -                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
-//     +                "Hash": "346c2acf9ad4fefa5cfffb3ff29185809329e5e7",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     -                "Hash": "705a0ee1755d5cad953de1bce15d8148c9848287",
+//     -                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "Hash": "a5d2eaa3e6656f96156b562408631e96d5eb7b3d",
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                  },
 //                  "Index": "0",
 //                  "TV": null

--- a/gnovm/tests/files/zrealm8.gno
+++ b/gnovm/tests/files/zrealm8.gno
@@ -23,7 +23,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [

--- a/gnovm/tests/files/zrealm9.gno
+++ b/gnovm/tests/files/zrealm9.gno
@@ -23,7 +23,7 @@ func main(cur realm,) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](0)=
 //     @@ -1,7 +1,6 @@
 //      {
 //          "Fields": [

--- a/gnovm/tests/files/zrealm_avl0.gno
+++ b/gnovm/tests/files/zrealm_avl0.gno
@@ -24,19 +24,19 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](6)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](6)=
 //     @@ -2,8 +2,8 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "341",
 //     -        "ModTime": "0",
-//     -        "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//     -        "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //     +        "ModTime": "10",
-//     +        "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//     +        "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //              "RefCount": "1"
 //          },
 //          "Value": {
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:12](547)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](547)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -91,19 +91,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "LastObjectSize": "547",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:11](344)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](344)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "LastObjectSize": "344",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -113,12 +113,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d89a4f41f3ed19bc57ce93b4a99a1afb308b8d56",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//             "Hash": "ba8f74f9e4ff38fda7f0f8276c9df963302187a5",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //         }
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:10](749)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](749)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -157,8 +157,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "44b12d4d6d199e7891ef2f767d2feedb3582de96",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//                     "Hash": "bbdf5e072ea46acc4b996da25294c103479e1292",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -176,8 +176,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "b66d1b196b2bc5a98fb8fc4eed58e095d8f49471",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//                     "Hash": "dd4824dfa78d29b338e6136f760c78ebe29ba7c0",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -185,19 +185,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "LastObjectSize": "749",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:9](342)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](342)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //         "LastObjectSize": "342",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -207,29 +207,29 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "15172b3190ceaef48ccddb466a59dc0abc3d3dd2",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//             "Hash": "2e69772661bbb2482b9d6e0fc748f3e4673f87a1",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "391",
 //     -        "ModTime": "6",
 //     +        "ModTime": "8",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,8 +18,8 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "f6f6fde72f1d8a2c89a1aca5c06faa5e023a4222",
-//     -                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
-//     +                "Hash": "475807f87052e23bbaaed5cfc5d25edda93dd80f",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//     -                "Hash": "37b9e1da4d17f7a74c2cf1c27c06ae34e98c0f62",
+//     -                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "Hash": "a33fa2e4dc2887f1b193d88d40c1b944d76f524f",
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                  },
 //                  "Index": "0",
 //                  "TV": null

--- a/gnovm/tests/files/zrealm_avl1.gno
+++ b/gnovm/tests/files/zrealm_avl1.gno
@@ -24,27 +24,27 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:9](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9",
 //              "LastObjectSize": "342",
 //     -        "ModTime": "0",
 //     +        "ModTime": "14",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "RefCount": "1"
 //          },
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:11](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](5)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //              "LastObjectSize": "343",
 //     -        "ModTime": "0",
 //     +        "ModTime": "16",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "RefCount": "1"
 //          },
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:18](547)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:18](547)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -99,19 +99,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:18",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:18",
 //         "LastObjectSize": "547",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:17",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:17",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:17](344)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:17](344)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:17",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:17",
 //         "LastObjectSize": "344",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:16",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:16",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -121,12 +121,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "a5c576224a45bf998a1615a1ad4a36461eb4ae2c",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:18"
+//             "Hash": "494dd1cefeadb3878247625ec2dc742d4552ea55",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:18"
 //         }
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:16](751)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:16](751)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -165,8 +165,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "c8eb30e3b741f6819783f27f268ff3be4f2114c6",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//                     "Hash": "593b7e177f7bf1a9ba3f54459d61cb71d7f33818",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -184,8 +184,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "b2af9e7d39ebcbca7bcd67ca5f866d910d1f856f",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:17"
+//                     "Hash": "4e55816f9d0d825472748878502cf34dcdb8fc34",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:17"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -193,19 +193,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:16",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:16",
 //         "LastObjectSize": "751",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:15",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:15](344)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:15](344)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:15",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15",
 //         "LastObjectSize": "344",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -215,12 +215,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "a5d2aaeebbe03ec8eb6b7b2fe1e9db18cff56cbd",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:16"
+//             "Hash": "30a95b143804abb609618a96f3d3a98f522005db",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:16"
 //         }
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:14](750)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:14](750)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -259,8 +259,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "0a284c9e375fd75b03b39c1c88e147d1d03d1f8b",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:9"
+//                     "Hash": "8d349248505492926533f590441c0411e79fedfb",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:9"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -278,8 +278,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "a7317c02c00a3ac9405ad742102983c1882be0cf",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:15"
+//                     "Hash": "b88a13d2a0d868ec45dab6c70cc15568e38ae7f5",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:15"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -287,19 +287,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14",
 //         "LastObjectSize": "750",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:13](343)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:13](343)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "LastObjectSize": "343",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -309,31 +309,31 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "657568c64c78b3b8fb43ff87a04e566c5fb18976",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:14"
+//             "Hash": "935ccbe226126eed948a25cb28d3656729da1861",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:14"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](1)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](1)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "391",
 //     -        "ModTime": "6",
 //     +        "ModTime": "12",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -18,8 +18,8 @@
 //                  "@type": "/gno.PointerValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "cc0558a352eaabba77a535a4f98beb9e85e854ea",
-//     -                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
-//     +                "Hash": "c1b319e0bf0c9fe8aa4dc101f4fb33bf33db9104",
-//     +                "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13"
+//     -                "Hash": "9c42dcd048c8bc60dc6c848948838ef6353a2fa4",
+//     -                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     +                "Hash": "04cf894f389c6d68d92bdd7262d9f9acc896c5e1",
+//     +                "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
 //                  },
 //                  "Index": "0",
 //                  "TV": null
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:7](-341)
-// d[08ada09dee16d791fd406d629fe29bb0ed084a30:8](-748)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](-341)
+// d[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](-748)

--- a/gnovm/tests/files/zrealm_avl2.gno
+++ b/gnovm/tests/files/zrealm_avl2.gno
@@ -23,19 +23,19 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:8](6)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:8](6)=
 //     @@ -2,8 +2,8 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8",
 //              "LastObjectSize": "341",
 //     -        "ModTime": "0",
-//     -        "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//     -        "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //     +        "ModTime": "11",
-//     +        "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//     +        "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //              "RefCount": "1"
 //          },
 //          "Value": {
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:13](547)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:13](547)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -90,19 +90,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13",
 //         "LastObjectSize": "547",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:12](344)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:12](344)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12",
 //         "LastObjectSize": "344",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -112,12 +112,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "f12372559c7846f4b035c6970b7cd62d4b1740c6",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:13"
+//             "Hash": "28ec6cc6d74185ca7bf2f597b583a79da3ba39e4",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:13"
 //         }
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:11](750)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:11](750)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -156,8 +156,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "81a22abf9449036700a2307934da1ebd4b0bea90",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//                     "Hash": "ebf68309751652f387df21fb07e44f5c2c4c4fe9",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -175,8 +175,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "508dd833fa0beceda7b1781ad8ad2d89820a31c7",
-//                     "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:12"
+//                     "Hash": "657cbf54eaaca2b2c9ab55f36ef0fb416f23d749",
+//                     "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:12"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -184,19 +184,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11",
 //         "LastObjectSize": "750",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[08ada09dee16d791fd406d629fe29bb0ed084a30:10](343)={
+// c[a8ada09dee16d791fd406d629fe29bb0ed084a30:10](343)={
 //     "ObjectInfo": {
-//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10",
+//         "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10",
 //         "LastObjectSize": "343",
 //         "ModTime": "0",
-//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//         "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -206,29 +206,29 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "d6f122b735bb8a199491f9b645e9ce8708d2c952",
-//             "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:11"
+//             "Hash": "06f7e40443d34026ac924c520a65012c6a93220f",
+//             "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:11"
 //         }
 //     }
 // }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:4](1)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:4](1)=
 //     @@ -12,8 +12,8 @@
 //                      "@type": "/gno.PointerValue",
 //                      "Base": {
 //                          "@type": "/gno.RefValue",
-//     -                    "Hash": "3e9df728b22ef4b60e7abb81593f72e936a948e9",
-//     -                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:8"
-//     +                    "Hash": "353a1ea31d40e8baab45cbf5104e066f22424ba5",
-//     +                    "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:10"
+//     -                    "Hash": "bc00562e7cb6bbb5a4ff56c8d8bcfbaa54e3a9b6",
+//     -                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:8"
+//     +                    "Hash": "3185ce8ec334cfc0ac0dcdc88be02236df2076dc",
+//     +                    "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:10"
 //                      },
 //                      "Index": "0",
 //                      "TV": null
 //     @@ -23,7 +23,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:4",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:4",
 //              "LastObjectSize": "389",
 //     -        "ModTime": "7",
 //     +        "ModTime": "9",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/zrealm_crossrealm21.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21.gno
@@ -22,14 +22,14 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
-// u[07e973c6aeab1f1cb747d0903cb1e4d369226376:7](214)=
+// u[a7e973c6aeab1f1cb747d0903cb1e4d369226376:7](214)=
 //     @@ -2,9 +2,27 @@
 //          "ObjectInfo": {
-//              "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:7",
+//              "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:7",
 //              "LastObjectSize": "190",
 //     -        "ModTime": "0",
 //     +        "ModTime": "43",
-//              "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:2",
+//              "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:2",
 //              "RefCount": "1"
 //          },
 //     -    "Value": {}
@@ -46,23 +46,23 @@ func main(cur realm) {
 //     +            "@type": "/gno.PointerValue",
 //     +            "Base": {
 //     +                "@type": "/gno.RefValue",
-//     +                "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:4"
+//     +                "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:4"
 //     +            },
 //     +            "Index": "0",
 //     +            "TV": null
 //     +        }
 //     +    }
 //      }
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:4](7)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:4](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:4",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:4",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "354",
 //     -        "ModTime": "0",
 //     +        "ModTime": "43",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:3",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:3",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },
@@ -71,7 +71,7 @@ func main(cur realm) {
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:5](5)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:5](5)=
 //     @@ -7,14 +7,14 @@
 //                  },
 //                  "V": {
@@ -82,11 +82,11 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:5",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:5",
 //              "LastObjectSize": "239",
 //     -        "ModTime": "0",
 //     +        "ModTime": "18",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:4",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:4",
 //              "RefCount": "1"
 //          }
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]

--- a/gnovm/tests/files/zrealm_crossrealm22.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22.gno
@@ -36,12 +36,12 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
-// c[07e973c6aeab1f1cb747d0903cb1e4d369226376:45](401)={
+// c[a7e973c6aeab1f1cb747d0903cb1e4d369226376:45](401)={
 //     "ObjectInfo": {
-//         "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:45",
+//         "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:45",
 //         "LastObjectSize": "401",
 //         "ModTime": "0",
-//         "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:44",
+//         "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:44",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -57,14 +57,14 @@ func main(cur realm) {
 //             "@type": "/gno.PointerValue",
 //             "Base": {
 //                 "@type": "/gno.RefValue",
-//                 "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:4"
+//                 "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:4"
 //             },
 //             "Index": "0",
 //             "TV": null
 //         }
 //     }
 // }
-// c[07e973c6aeab1f1cb747d0903cb1e4d369226376:44](507)={
+// c[a7e973c6aeab1f1cb747d0903cb1e4d369226376:44](507)={
 //     "Captures": [
 //         {
 //             "T": {
@@ -72,8 +72,8 @@ func main(cur realm) {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "b02b2ea1d9a9c5ce8204784ba0a51487cbaaad9f",
-//                 "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:45"
+//                 "Hash": "a6562a9a996376dec5e767104133bb606b17e7a3",
+//                 "ObjectID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:45"
 //             }
 //         }
 //     ],
@@ -85,10 +85,10 @@ func main(cur realm) {
 //     "NativeName": "",
 //     "NativePkg": "",
 //     "ObjectInfo": {
-//         "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:44",
+//         "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:44",
 //         "LastObjectSize": "507",
 //         "ModTime": "0",
-//         "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14",
+//         "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:14",
 //         "RefCount": "1"
 //     },
 //     "Parent": null,
@@ -128,14 +128,14 @@ func main(cur realm) {
 //         ]
 //     }
 // }
-// u[07e973c6aeab1f1cb747d0903cb1e4d369226376:14](112)=
+// u[a7e973c6aeab1f1cb747d0903cb1e4d369226376:14](112)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14",
+//              "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:14",
 //              "LastObjectSize": "253",
 //     -        "ModTime": "0",
 //     +        "ModTime": "43",
-//              "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:2",
+//              "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:2",
 //              "RefCount": "1"
 //          },
 //     @@ -10,6 +10,11 @@
@@ -145,21 +145,21 @@ func main(cur realm) {
 //     +        },
 //     +        "V": {
 //     +            "@type": "/gno.RefValue",
-//     +            "Hash": "02487deed45ffc9663e14adf1db13a3bec68d9ac",
-//     +            "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:44"
+//     +            "Hash": "f3a8297b2dfe5d38fda3019a51be0f8be9627b47",
+//     +            "ObjectID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:44"
 //              }
 //          }
 //      }
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:4](7)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:4](7)=
 //     @@ -1,10 +1,11 @@
 //      {
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:4",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:4",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "354",
 //     -        "ModTime": "0",
 //     +        "ModTime": "45",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:3",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:3",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },
@@ -168,7 +168,7 @@ func main(cur realm) {
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:5](5)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:5](5)=
 //     @@ -7,14 +7,14 @@
 //                  },
 //                  "V": {
@@ -179,17 +179,17 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:5",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:5",
 //              "LastObjectSize": "239",
 //     -        "ModTime": "0",
 //     +        "ModTime": "18",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:4",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:4",
 //              "RefCount": "1"
 //          }
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:5](0)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:5](0)=
 //     @@ -7,7 +7,7 @@
 //                  },
 //                  "V": {
@@ -200,46 +200,46 @@ func main(cur realm) {
 //              }
 //          ],
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
-// u[07e973c6aeab1f1cb747d0903cb1e4d369226376:14](-1)=
+// u[a7e973c6aeab1f1cb747d0903cb1e4d369226376:14](-1)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14",
+//              "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:14",
 //              "LastObjectSize": "365",
 //     -        "ModTime": "43",
 //     +        "ModTime": "45",
-//              "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:2",
+//              "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:2",
 //              "RefCount": "1"
 //          },
 //     @@ -13,8 +13,7 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "02487deed45ffc9663e14adf1db13a3bec68d9ac",
-//     -            "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:44"
-//     +            "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:7"
+//     -            "Hash": "f3a8297b2dfe5d38fda3019a51be0f8be9627b47",
+//     -            "ObjectID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:44"
+//     +            "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:7"
 //              }
 //          }
 //      }
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:7](7)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:7](7)=
 //     @@ -8,10 +8,11 @@
 //          "NativePkg": "",
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:7",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:7",
 //     +        "IsEscaped": true,
 //              "LastObjectSize": "377",
 //     -        "ModTime": "0",
 //     +        "ModTime": "45",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:6",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:6",
 //     -        "RefCount": "1"
 //     +        "RefCount": "2"
 //          },
 //          "Parent": null,
 //          "PkgPath": "gno.land/r/tests/vm/crossrealm_b",
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:4](0)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:4](0)=
 //     @@ -5,7 +5,7 @@
 //              "LastObjectSize": "361",
 //              "ModTime": "45",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:3",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:3",
 //     -        "RefCount": "2"
 //     +        "RefCount": "1"
 //          },
@@ -249,17 +249,17 @@ func main(cur realm) {
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "534961c4c33e00090c5b38e73cdddaa534514e00",
-//     +            "Hash": "5aef97fff6d6cee13dcfc7c35cd6eead9c972ebd",
-//                  "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:5"
+//     -            "Hash": "23c79341f8583900b8e4138982dda98181fc2d8c",
+//     +            "Hash": "6e0f68a9de37b3e945fe297f093b079c869a3a07",
+//                  "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:5"
 //              }
 //          }
-// d[07e973c6aeab1f1cb747d0903cb1e4d369226376:44](-507)
-// d[07e973c6aeab1f1cb747d0903cb1e4d369226376:45](-401)
+// d[a7e973c6aeab1f1cb747d0903cb1e4d369226376:44](-507)
+// d[a7e973c6aeab1f1cb747d0903cb1e4d369226376:45](-401)
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:5](0)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:5](0)=
 //     @@ -7,7 +7,7 @@
 //                  },
 //                  "V": {
@@ -270,7 +270,7 @@ func main(cur realm) {
 //              }
 //          ],
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
-// c[07e973c6aeab1f1cb747d0903cb1e4d369226376:46](380)={
+// c[a7e973c6aeab1f1cb747d0903cb1e4d369226376:46](380)={
 //     "Crossing": false,
 //     "FileName": "",
 //     "IsClosure": false,
@@ -279,10 +279,10 @@ func main(cur realm) {
 //     "NativeName": "",
 //     "NativePkg": "",
 //     "ObjectInfo": {
-//         "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:46",
+//         "ID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:46",
 //         "LastObjectSize": "380",
 //         "ModTime": "0",
-//         "OwnerID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14",
+//         "OwnerID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:14",
 //         "RefCount": "1"
 //     },
 //     "Parent": null,
@@ -322,22 +322,22 @@ func main(cur realm) {
 //         ]
 //     }
 // }
-// u[07e973c6aeab1f1cb747d0903cb1e4d369226376:14](1)=
+// u[a7e973c6aeab1f1cb747d0903cb1e4d369226376:14](1)=
 //     @@ -13,7 +13,8 @@
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:7"
-//     +            "Hash": "912e4467b046c4fc2e609146cc2e00ea8d8c0187",
-//     +            "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:46"
+//     -            "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:7"
+//     +            "Hash": "cf4b669212d7a060336ace4ecf29fb8c45b0a195",
+//     +            "ObjectID": "a7e973c6aeab1f1cb747d0903cb1e4d369226376:46"
 //              }
 //          }
 //      }
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:7](0)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:7](0)=
 //     @@ -12,7 +12,7 @@
 //              "LastObjectSize": "384",
 //              "ModTime": "45",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:6",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:6",
 //     -        "RefCount": "2"
 //     +        "RefCount": "1"
 //          },

--- a/gnovm/tests/files/zrealm_crossrealm25a.gno
+++ b/gnovm/tests/files/zrealm_crossrealm25a.gno
@@ -36,7 +36,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:19](0)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:19](0)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [
@@ -47,7 +47,7 @@ func main(cur realm) {
 //                      "@type": "/gno.PrimitiveType",
 //                      "value": "32"
 //     @@ -12,7 +12,7 @@
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:19",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:19",
 //              "IsEscaped": true,
 //              "LastObjectSize": "222",
 //     -        "ModTime": "7",

--- a/gnovm/tests/files/zrealm_crossrealm28.gno
+++ b/gnovm/tests/files/zrealm_crossrealm28.gno
@@ -31,14 +31,14 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/tests/vm/crossrealm_b"]
-// u[06279d1e03ecb38b84822f9caf584bd16913470d:13](-98)=
+// u[46279d1e03ecb38b84822f9caf584bd16913470d:13](-98)=
 //     @@ -2,20 +2,15 @@
 //          "ObjectInfo": {
-//              "ID": "06279d1e03ecb38b84822f9caf584bd16913470d:13",
+//              "ID": "46279d1e03ecb38b84822f9caf584bd16913470d:13",
 //              "LastObjectSize": "320",
 //     -        "ModTime": "18",
 //     +        "ModTime": "19",
-//              "OwnerID": "06279d1e03ecb38b84822f9caf584bd16913470d:2",
+//              "OwnerID": "46279d1e03ecb38b84822f9caf584bd16913470d:2",
 //              "RefCount": "1"
 //          },
 //          "Value": {
@@ -50,16 +50,16 @@ func main(cur realm) {
 //     -        },
 //     -        "V": {
 //     -            "@type": "/gno.RefValue",
-//     -            "Hash": "8b50fbe1097c0c1a442a7b9da3b4162702c78318",
-//     -            "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:19"
+//     -            "Hash": "3fa519e4001c6f5839834b18d33f97c7f94139c5",
+//     -            "ObjectID": "46279d1e03ecb38b84822f9caf584bd16913470d:19"
 //     +            "@type": "/gno.PrimitiveType",
 //     +            "value": "32"
 //              }
 //          }
 //      }
-// d[06279d1e03ecb38b84822f9caf584bd16913470d:19](-298)
+// d[46279d1e03ecb38b84822f9caf584bd16913470d:19](-298)
 // finalizerealm["gno.land/r/crossrealm"]
-// u[0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:8](5)=
+// u[dc8307f7bbe97fdb07b2d0fa6907b8d67517c02a:8](5)=
 //     @@ -1,7 +1,7 @@
 //      {
 //          "Fields": [
@@ -71,10 +71,10 @@ func main(cur realm) {
 //                      "value": "32"
 //     @@ -11,7 +11,7 @@
 //          "ObjectInfo": {
-//              "ID": "0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:8",
+//              "ID": "dc8307f7bbe97fdb07b2d0fa6907b8d67517c02a:8",
 //              "LastObjectSize": "214",
 //     -        "ModTime": "0",
 //     +        "ModTime": "8",
-//              "OwnerID": "0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:7",
+//              "OwnerID": "dc8307f7bbe97fdb07b2d0fa6907b8d67517c02a:7",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/zrealm_example.gno
+++ b/gnovm/tests/files/zrealm_example.gno
@@ -24,7 +24,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/example"]
-// c[0ffd45e074aa1b8df562907c95ad97526b7ca187:14](257)={
+// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:14](257)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -37,14 +37,14 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:14",
+//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:14",
 //         "LastObjectSize": "257",
 //         "ModTime": "0",
-//         "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:13",
+//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:13",
 //         "RefCount": "1"
 //     }
 // }
-// c[0ffd45e074aa1b8df562907c95ad97526b7ca187:13](485)={
+// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:13](485)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -73,25 +73,25 @@ func main(cur realm) {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "f29452900c9e9bf5475fd7e589f1bd8714958f3d",
-//                 "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:14"
+//                 "Hash": "850bf1e3c9734920700335f84e2f28ddab1e9058",
+//                 "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:14"
 //             }
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:13",
+//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:13",
 //         "LastObjectSize": "485",
 //         "ModTime": "0",
-//         "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:12",
+//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:12",
 //         "RefCount": "1"
 //     }
 // }
-// c[0ffd45e074aa1b8df562907c95ad97526b7ca187:12](346)={
+// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:12](346)={
 //     "ObjectInfo": {
-//         "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:12",
+//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:12",
 //         "LastObjectSize": "346",
 //         "ModTime": "0",
-//         "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:11",
+//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:11",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -101,12 +101,12 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "187c2d3f28c73395ee97bf19409147e94389ff96",
-//             "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:13"
+//             "Hash": "20a805520f530227446154829006cc5e8c3fdc47",
+//             "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:13"
 //         }
 //     }
 // }
-// c[0ffd45e074aa1b8df562907c95ad97526b7ca187:11](687)={
+// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:11](687)={
 //     "Fields": [
 //         {
 //             "T": {
@@ -130,8 +130,8 @@ func main(cur realm) {
 //                 "@type": "/gno.PointerValue",
 //                 "Base": {
 //                     "@type": "/gno.RefValue",
-//                     "Hash": "82b9b0210cb8614983737976800b64daad781994",
-//                     "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:12"
+//                     "Hash": "302d0f4deae57df754a27e38365639d7a681f06c",
+//                     "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:12"
 //                 },
 //                 "Index": "0",
 //                 "TV": null
@@ -170,19 +170,19 @@ func main(cur realm) {
 //         }
 //     ],
 //     "ObjectInfo": {
-//         "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:11",
+//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:11",
 //         "LastObjectSize": "687",
 //         "ModTime": "0",
-//         "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:10",
+//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
 //         "RefCount": "1"
 //     }
 // }
-// c[0ffd45e074aa1b8df562907c95ad97526b7ca187:10](343)={
+// c[1ffd45e074aa1b8df562907c95ad97526b7ca187:10](343)={
 //     "ObjectInfo": {
-//         "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:10",
+//         "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10",
 //         "LastObjectSize": "343",
 //         "ModTime": "0",
-//         "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:9",
+//         "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
 //         "RefCount": "1"
 //     },
 //     "Value": {
@@ -192,18 +192,18 @@ func main(cur realm) {
 //         },
 //         "V": {
 //             "@type": "/gno.RefValue",
-//             "Hash": "ac7d986ec6e1ed131a9838b1258062756c7c4078",
-//             "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:11"
+//             "Hash": "48a0105e2b1f7049139d1a99cede038aae3cee65",
+//             "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:11"
 //         }
 //     }
 // }
-// u[0ffd45e074aa1b8df562907c95ad97526b7ca187:8](5)=
+// u[1ffd45e074aa1b8df562907c95ad97526b7ca187:8](5)=
 //     @@ -17,11 +17,11 @@
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "0f0e314e82aa24001576643128a2ca8c88a694bc",
-//                      "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:9"
+//     -                "Hash": "913587fc42b7ee6e72e442d449d09f28553f5b87",
+//                      "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9"
 //                  }
 //              },
 //              {
@@ -213,14 +213,14 @@ func main(cur realm) {
 //                      "value": "32"
 //     @@ -31,7 +31,7 @@
 //          "ObjectInfo": {
-//              "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:8",
+//              "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
 //              "LastObjectSize": "449",
 //     -        "ModTime": "0",
 //     +        "ModTime": "9",
-//              "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:7",
+//              "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:7",
 //              "RefCount": "1"
 //          }
-// u[0ffd45e074aa1b8df562907c95ad97526b7ca187:9](135)=
+// u[1ffd45e074aa1b8df562907c95ad97526b7ca187:9](135)=
 //     @@ -7,13 +7,23 @@
 //                          "@type": "/gno.RefType",
 //                          "ID": "gno.land/p/nt/avl/v0.Node"
@@ -230,8 +230,8 @@ func main(cur realm) {
 //     +                "@type": "/gno.PointerValue",
 //     +                "Base": {
 //     +                    "@type": "/gno.RefValue",
-//     +                    "Hash": "0f72acf6f18bb025291bdefef9706e3917b96972",
-//     +                    "ObjectID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:10"
+//     +                    "Hash": "6bb6848713e71dcc69d5c7d8c0ccf0762af4ff6a",
+//     +                    "ObjectID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:10"
 //     +                },
 //     +                "Index": "0",
 //     +                "TV": null
@@ -239,10 +239,10 @@ func main(cur realm) {
 //              }
 //          ],
 //          "ObjectInfo": {
-//              "ID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:9",
+//              "ID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:9",
 //              "LastObjectSize": "255",
 //     -        "ModTime": "0",
 //     +        "ModTime": "9",
-//              "OwnerID": "0ffd45e074aa1b8df562907c95ad97526b7ca187:8",
+//              "OwnerID": "1ffd45e074aa1b8df562907c95ad97526b7ca187:8",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/zrealm_map4a.gno
+++ b/gnovm/tests/files/zrealm_map4a.gno
@@ -25,13 +25,13 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -44,7 +44,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "382",
 //     -        "ModTime": "0",
 //     +        "ModTime": "7",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/zrealm_natbind0.gno
+++ b/gnovm/tests/files/zrealm_natbind0.gno
@@ -26,7 +26,7 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](-1)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](-1)=
 //     @@ -17,15 +17,15 @@
 //                          "Tag": "",
 //                          "Type": {

--- a/gnovm/tests/files/zrealm_slice2.gno
+++ b/gnovm/tests/files/zrealm_slice2.gno
@@ -33,17 +33,17 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -1,10 +1,10 @@
 //      {
 //     -    "Data": "AQIDBAU=",
 //     +    "Data": "Y1hNBAU=",
 //          "List": null,
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "182",
 //     -        "ModTime": "0",
 //     +        "ModTime": "7",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          }

--- a/gnovm/tests/files/zrealm_slice3.gno
+++ b/gnovm/tests/files/zrealm_slice3.gno
@@ -28,37 +28,37 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:7](5)=
 //     @@ -1,10 +1,10 @@
 //      {
 //     -    "Data": "ChQAAAA=",
 //     +    "Data": "ChQeAAA=",
 //          "List": null,
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7",
 //              "LastObjectSize": "182",
 //     -        "ModTime": "0",
 //     +        "ModTime": "7",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "RefCount": "1"
 //          }
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](0)=
 //     @@ -2,7 +2,7 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "374",
 //     -        "ModTime": "6",
 //     +        "ModTime": "7",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     @@ -19,10 +19,10 @@
 //                  "@type": "/gno.SliceValue",
 //                  "Base": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "7c24e29e0ae181ccd5ecc72d4e83ca4845126d76",
-//     +                "Hash": "b2c0068d8bfc22a8a3339e62e4de77dbb4480536",
-//                      "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//     -                "Hash": "20ce1f21d3d663cac2590f91d38e5d900c6efd25",
+//     +                "Hash": "6912ee8ba7233d9d5653d4ecc89e00eadf330e34",
+//                      "ObjectID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:7"
 //                  },
 //     -            "Length": "2",
 //     +            "Length": "3",

--- a/gnovm/tests/files/zrealm_stdlib_ref.gno
+++ b/gnovm/tests/files/zrealm_stdlib_ref.gno
@@ -19,14 +19,14 @@ func main(cur realm) {
 
 // Realm:
 // finalizerealm["gno.land/r/test"]
-// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](199)=
+// u[a8ada09dee16d791fd406d629fe29bb0ed084a30:3](199)=
 //     @@ -2,9 +2,40 @@
 //          "ObjectInfo": {
-//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "ID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:3",
 //              "LastObjectSize": "190",
 //     -        "ModTime": "0",
 //     +        "ModTime": "5",
-//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "OwnerID": "a8ada09dee16d791fd406d629fe29bb0ed084a30:2",
 //              "RefCount": "1"
 //          },
 //     -    "Value": {}
@@ -58,8 +58,8 @@ func main(cur realm) {
 //     +        },
 //     +        "V": {
 //     +            "@type": "/gno.RefValue",
-//     +            "Hash": "44d7cf6f34ea458657b8b6a40aae82fe8602216a",
-//     +            "ObjectID": "c3ac87e8cb3cc9276228f74d38694a208cacb99b:869"
+//     +            "Hash": "aa2f3c8cd23e4e15c3eebc5463ee00c87348472d",
+//     +            "ObjectID": "53ac87e8cb3cc9276228f74d38694a208cacb99b:869"
 //     +        }
 //     +    }
 //      }


### PR DESCRIPTION
⚠️ this pull request destination branch is https://github.com/gnolang/gno/pull/5415

## Summary

- Replace the PkgID flag nibble approach (which steals 4 bits from the hash) with an in-memory `sync.Map` side table
- Preserves the full 160-bit SHA-256 truncated hash in `PkgID.Hashlet` — no bits are mangled
- Avoids a consensus-breaking change to stored PkgIDs and eliminates hash collision risk from reduced entropy

## Problem

`PkgIDFromPkgPath()` was clearing the top 4 bits of the hash (`Hashlet[0] &= 0x0F`) and replacing them with classification flags. This had three issues:

1. **Consensus-breaking** — existing on-chain PkgIDs were computed without nibble clearing, so new code produces different PkgIDs for the same path
2. **Collision risk** — effective hash space reduced from 160 to 156 bits; packages differing only in the top nibble would collide
3. **Migration burden** — all stored PkgIDs would need migration

## Solution

Store flags in a `pkgIDFlags sync.Map` (keyed by `PkgID`) populated lazily by `PkgIDFromPkgPath` alongside the existing `pkgIDFromPkgPathCache`. The API is unchanged — `PkgID.IsStdlibPkg()`, `IsImmutablePkg()`, `IsInternalPkg()` still work as methods on `PkgID`, but internally they do a `sync.Map.Load` (~15-25ns, lock-free) instead of a bitwise check (~1ns).

The 5 call sites are in realm finalization and object loading (not inner loops), where amino marshal/unmarshal and store I/O already dominate — the lookup cost is negligible.

Unknown PkgIDs return `false` (conservative default: do normal refcount logic, skip no optimizations). Every package path goes through `PkgIDFromPkgPath` during `GetPackage`/`AddMemPackage` before realm finalization can reference its objects, so the table is always populated before flags are queried.

## Changes

- `gnovm/pkg/gnolang/realm.go` — replace hash bit mangling with `pkgIDFlags sync.Map` side table
- `gno.land/adr/gas_refactor.md` — update "PkgID Flag Nibble" section to document the new approach
- `gnovm/tests/files/**` — regenerate 62 golden test outputs (PkgID hashes changed back to their unmangled values)

## Test plan

- [x] `go build ./gnovm/pkg/gnolang/` compiles
- [x] `go test ./gnovm/pkg/gnolang/ -run Files -test.short` passes (62 golden files regenerated via `-update-golden-tests`)

cc @jaekwon