### PR TITLE
Feat/bptree validation

### DIFF
--- a/tm2/pkg/bptree/errors.go
+++ b/tm2/pkg/bptree/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrNodeMissingNodeKey  = errors.New("node missing node key")
 	ErrEmptyTree           = errors.New("tree is empty")
 	ErrActiveReaders       = errors.New("version has active readers")
+	ErrVersionBeingPruned  = errors.New("version is being pruned")
 )

--- a/tm2/pkg/bptree/export.go
+++ b/tm2/pkg/bptree/export.go
@@ -29,7 +29,9 @@ func (t *ImmutableTree) Export(ndb *nodeDB) (*Exporter, error) {
 	}
 
 	if ndb != nil {
-		ndb.incrVersionReaders(t.version)
+		if err := ndb.incrVersionReaders(t.version); err != nil {
+			return nil, err
+		}
 	}
 
 	e := &Exporter{

--- a/tm2/pkg/bptree/insert.go
+++ b/tm2/pkg/bptree/insert.go
@@ -158,9 +158,13 @@ func innerInsert(inner *InnerNode, key []byte, valueHash Hash) insertResult {
 	allKeys[childIdx] = sr.separator
 	copy(allKeys[childIdx+1:], inner.keys[childIdx:B-1])
 
-	copy(allChildNodes[:childIdx+1], inner.childNodes[:childIdx+1])
+	for i := 0; i <= childIdx; i++ {
+		allChildNodes[i] = inner.getChild(i)
+	}
 	allChildNodes[childIdx+1] = sr.right
-	copy(allChildNodes[childIdx+2:], inner.childNodes[childIdx+1:B])
+	for i := childIdx + 1; i < B; i++ {
+		allChildNodes[i+1] = inner.getChild(i)
+	}
 
 	copy(allChildHashes[:childIdx+1], inner.childHashes[:childIdx+1])
 	allChildHashes[childIdx+1] = rightChildHash

--- a/tm2/pkg/bptree/iterator.go
+++ b/tm2/pkg/bptree/iterator.go
@@ -329,7 +329,11 @@ func NewIteratorWithNDB(imm *ImmutableTree, start, end []byte, ascending bool, m
 
 	version := imm.version
 	if ndb != nil && version > 0 {
-		ndb.incrVersionReaders(version)
+		if err := ndb.incrVersionReaders(version); err != nil {
+			// Version is being pruned here,
+			// return an exhausted iterator instead.
+			return &Iterator{start: start, end: end, ascending: ascending}
+		}
 	}
 
 	return newIterator(imm.root, start, end, ascending, ndb, version)

--- a/tm2/pkg/bptree/iterator.go
+++ b/tm2/pkg/bptree/iterator.go
@@ -318,12 +318,21 @@ func (it *Iterator) Close() error {
 
 // NewIteratorWithNDB creates an iterator over an immutable tree with value
 // resolution via the mutable tree's nodeDB. Used by the store wrapper.
+//
+// Registers as a version reader so that pruning cannot delete nodes while
+// the iterator is active.
 func NewIteratorWithNDB(imm *ImmutableTree, start, end []byte, ascending bool, mtree *MutableTree) *Iterator {
 	var ndb *nodeDB
 	if mtree != nil {
 		ndb = mtree.ndb
 	}
-	return newIterator(imm.root, start, end, ascending, ndb, 0)
+
+	version := imm.version
+	if ndb != nil && version > 0 {
+		ndb.incrVersionReaders(version)
+	}
+
+	return newIterator(imm.root, start, end, ascending, ndb, version)
 }
 
 // Iterator returns an iterator over [start, end) in the given direction.

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -314,12 +314,13 @@ func (t *MutableTree) LoadVersion(version int64) (int64, error) {
 	return version, nil
 }
 
-// LoadVersionForOverwriting loads a version and deletes all newer versions.
+// LoadVersionForOverwriting loads a version and deletes all newer versions,
+// including their node data.
 func (t *MutableTree) LoadVersionForOverwriting(version int64) error {
 	if t.ndb == nil {
 		return nil
 	}
-	// Remember the old latest version before LoadVersion overwrites it
+	// Capture latest before LoadVersion overwrites it.
 	oldLatest := t.ndb.getLatestVersion()
 
 	_, err := t.LoadVersion(version)
@@ -327,19 +328,9 @@ func (t *MutableTree) LoadVersionForOverwriting(version int64) error {
 		return err
 	}
 
-	// Delete all versions after the target, using the old latest as the upper bound
-	for v := version + 1; v <= oldLatest; v++ {
-		if t.ndb.VersionExists(v) {
-			if err := t.ndb.DeleteRoot(v); err != nil {
-				return err
-			}
-		}
-	}
-	if err := t.ndb.Commit(); err != nil {
-		return err
-	}
-	t.ndb.setLatestVersion(version)
-	return nil
+	// Temporarily restore so DeleteVersionsFrom sees the full range.
+	t.ndb.setLatestVersion(oldLatest)
+	return t.DeleteVersionsFrom(version + 1)
 }
 
 // loadNode loads a node from the DB. Children are loaded lazily via
@@ -401,18 +392,26 @@ func (t *MutableTree) DeleteVersionsTo(toVersion int64) error {
 	return t.PruneVersionsTo(toVersion)
 }
 
-// DeleteVersionsFrom deletes all versions >= fromVersion.
-// Stub for Phase 3.
+// DeleteVersionsFrom deletes all versions >= fromVersion, including
+// both root references and the underlying node data.
 func (t *MutableTree) DeleteVersionsFrom(fromVersion int64) error {
 	if t.ndb == nil {
 		return nil
 	}
 	latest := t.ndb.getLatestVersion()
+	if latest < fromVersion {
+		return nil
+	}
 	for v := fromVersion; v <= latest; v++ {
 		if t.ndb.hasVersionReaders(v) {
 			return fmt.Errorf("%w: version %d", ErrActiveReaders, v)
 		}
 	}
+	// Delete node data for all target versions via range scan.
+	if err := t.ndb.DeleteNodesFrom(fromVersion, latest); err != nil {
+		return err
+	}
+	// Delete root references.
 	for v := fromVersion; v <= latest; v++ {
 		if t.ndb.VersionExists(v) {
 			if err := t.ndb.DeleteRoot(v); err != nil {
@@ -423,9 +422,7 @@ func (t *MutableTree) DeleteVersionsFrom(fromVersion int64) error {
 	if err := t.ndb.Commit(); err != nil {
 		return err
 	}
-	if fromVersion <= latest {
-		t.ndb.setLatestVersion(fromVersion - 1)
-	}
+	t.ndb.setLatestVersion(fromVersion - 1)
 	return nil
 }
 

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -23,6 +23,11 @@ type MutableTree struct {
 	// In-memory value store for Phase 2 compat (no ndb).
 	// Maps SHA256(value) hex -> raw value bytes.
 	memValues map[Hash][]byte
+
+	// afterReaderCheck is a test-only hook called after the version reader
+	// check in PruneVersionsTo, before the actual deletion begins.
+	// Used to inject concurrent readers to reproduce TOCTOU races.
+	afterReaderCheck func()
 }
 
 // NewMutableTreeMem creates an in-memory MutableTree (no DB).
@@ -402,11 +407,10 @@ func (t *MutableTree) DeleteVersionsFrom(fromVersion int64) error {
 	if latest < fromVersion {
 		return nil
 	}
-	for v := fromVersion; v <= latest; v++ {
-		if t.ndb.hasVersionReaders(v) {
-			return fmt.Errorf("%w: version %d", ErrActiveReaders, v)
-		}
+	if err := t.ndb.beginPruning(fromVersion, latest); err != nil {
+		return err
 	}
+	defer t.ndb.endPruning()
 	// Delete node data for all target versions via range scan.
 	if err := t.ndb.DeleteNodesFrom(fromVersion, latest); err != nil {
 		return err

--- a/tm2/pkg/bptree/node.go
+++ b/tm2/pkg/bptree/node.go
@@ -229,6 +229,9 @@ func readInnerNode(nk *NodeKey, r *bytes.Reader) (_ *InnerNode, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading numKeys: %w", err)
 	}
+	if numKeys > B-1 {
+		return nil, fmt.Errorf("inner node numKeys %d exceeds max %d", numKeys, B-1)
+	}
 	n.numKeys = int16(numKeys)
 
 	n.size, err = binary.ReadVarint(r)
@@ -272,6 +275,9 @@ func readLeafNode(nk *NodeKey, r *bytes.Reader) (_ *LeafNode, err error) {
 	numKeys, err := binary.ReadUvarint(r)
 	if err != nil {
 		return nil, fmt.Errorf("reading numKeys: %w", err)
+	}
+	if numKeys > B {
+		return nil, fmt.Errorf("leaf node numKeys %d exceeds max %d", numKeys, B)
 	}
 	n.numKeys = int16(numKeys)
 
@@ -319,6 +325,9 @@ func readBytes(r *bytes.Reader) ([]byte, error) {
 	length, err := binary.ReadUvarint(r)
 	if err != nil {
 		return nil, err
+	}
+	if int(length) > r.Len() {
+		return nil, fmt.Errorf("readBytes: length %d exceeds remaining %d", length, r.Len())
 	}
 	b := make([]byte, length)
 	if _, err := io.ReadFull(r, b); err != nil {

--- a/tm2/pkg/bptree/node_test.go
+++ b/tm2/pkg/bptree/node_test.go
@@ -1,0 +1,53 @@
+package bptree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"runtime"
+	"testing"
+)
+
+func TestReadBytes_RejectsExcessiveLength(t *testing.T) {
+	const claimedSize = 8 << 20 // 8MB
+
+	var buf bytes.Buffer
+	var uvarintBuf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(uvarintBuf[:], uint64(claimedSize))
+	buf.Write(uvarintBuf[:n])
+
+	r := bytes.NewReader(buf.Bytes())
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	_, err := readBytes(r)
+	if err == nil {
+		t.Fatal("expected error due to length exceeding reader, got nil")
+	}
+
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	if allocated > 1<<20 {
+		t.Fatalf("unexpected large allocation: %d bytes (should be near zero)", allocated)
+	}
+}
+
+func TestReadBytes_ValidData(t *testing.T) {
+	payload := []byte("hello, bptree")
+
+	var buf bytes.Buffer
+	var uvarintBuf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(uvarintBuf[:], uint64(len(payload)))
+	buf.Write(uvarintBuf[:n])
+	buf.Write(payload)
+
+	r := bytes.NewReader(buf.Bytes())
+	got, err := readBytes(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+}

--- a/tm2/pkg/bptree/nodedb.go
+++ b/tm2/pkg/bptree/nodedb.go
@@ -24,6 +24,8 @@ type nodeDB struct {
 	latestVersion  int64
 	firstVersion   int64
 	versionReaders map[int64]uint32
+	pruningFrom    int64 // nonzero while pruning is in progress
+	pruningTo      int64
 
 	isCommitting bool
 	logger       Logger
@@ -287,10 +289,14 @@ func (ndb *nodeDB) discoverVersions() error {
 
 // --- Version readers ---
 
-func (ndb *nodeDB) incrVersionReaders(version int64) {
+func (ndb *nodeDB) incrVersionReaders(version int64) error {
 	ndb.mtx.Lock()
 	defer ndb.mtx.Unlock()
+	if ndb.pruningFrom > 0 && version >= ndb.pruningFrom && version <= ndb.pruningTo {
+		return fmt.Errorf("%w: version %d", ErrVersionBeingPruned, version)
+	}
 	ndb.versionReaders[version]++
+	return nil
 }
 
 func (ndb *nodeDB) decrVersionReaders(version int64) {
@@ -304,10 +310,27 @@ func (ndb *nodeDB) decrVersionReaders(version int64) {
 	}
 }
 
-func (ndb *nodeDB) hasVersionReaders(version int64) bool {
+// beginPruning atomically checks that no version in [first, toVersion] has
+// active readers, then marks the range as being pruned. While the range is
+// marked, incrVersionReaders rejects new readers on those versions.
+func (ndb *nodeDB) beginPruning(first, toVersion int64) error {
 	ndb.mtx.Lock()
 	defer ndb.mtx.Unlock()
-	return ndb.versionReaders[version] > 0
+	for v := first; v <= toVersion; v++ {
+		if ndb.versionReaders[v] > 0 {
+			return fmt.Errorf("%w: version %d", ErrActiveReaders, v)
+		}
+	}
+	ndb.pruningFrom = first
+	ndb.pruningTo = toVersion
+	return nil
+}
+
+func (ndb *nodeDB) endPruning() {
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
+	ndb.pruningFrom = 0
+	ndb.pruningTo = 0
 }
 
 // --- Commit coordination ---

--- a/tm2/pkg/bptree/nodedb.go
+++ b/tm2/pkg/bptree/nodedb.go
@@ -376,3 +376,34 @@ func (ndb *nodeDB) DeleteNode(nkBytes []byte) error {
 	}
 	return ndb.batch.Delete(nodeDBKey(nkBytes))
 }
+
+// DeleteNodesFrom deletes all node entries whose NodeKey.Version is in
+// [fromVersion, toVersion] using a DB range scan. This exploits the fact
+// that NodeKey serializes version as the first 8 big-endian bytes, so
+// lexicographic range covers exactly the target versions.
+func (ndb *nodeDB) DeleteNodesFrom(fromVersion, toVersion int64) error {
+	start := make([]byte, 1+8)
+	start[0] = PrefixNode
+	binary.BigEndian.PutUint64(start[1:], uint64(fromVersion))
+
+	end := make([]byte, 1+8)
+	end[0] = PrefixNode
+	binary.BigEndian.PutUint64(end[1:], uint64(toVersion+1))
+
+	itr, err := ndb.db.Iterator(start, end)
+	if err != nil {
+		return fmt.Errorf("DeleteNodesFrom iterator: %w", err)
+	}
+	defer itr.Close()
+
+	for ; itr.Valid(); itr.Next() {
+		key := itr.Key()
+		if ndb.nodeCache != nil && len(key) > 1 {
+			ndb.nodeCache.Remove(string(key[1:])) // strip PrefixNode
+		}
+		if err := ndb.batch.Delete(key); err != nil {
+			return err
+		}
+	}
+	return itr.Error()
+}

--- a/tm2/pkg/bptree/persistence_test.go
+++ b/tm2/pkg/bptree/persistence_test.go
@@ -535,6 +535,63 @@ func TestPersistence_LoadVersionForOverwriting(t *testing.T) {
 	}
 }
 
+func TestLoadVersionForOverwriting_CleansNodes(t *testing.T) {
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+
+	// V1: 30 keys
+	for i := 0; i < 30; i++ {
+		tree.Set(fmt.Appendf(nil, "ow_base%03d", i), []byte("v1"))
+	}
+	tree.SaveVersion()
+	nodesAfterV1 := countDBEntriesByPrefix(db, PrefixNode)
+
+	// V2: add 30 unique keys
+	for i := 30; i < 60; i++ {
+		tree.Set(fmt.Appendf(nil, "ow_new2_%03d", i), []byte("v2"))
+	}
+	tree.SaveVersion()
+
+	// V3: add 30 more unique keys
+	for i := 60; i < 90; i++ {
+		tree.Set(fmt.Appendf(nil, "ow_new3_%03d", i), []byte("v3"))
+	}
+	tree.SaveVersion()
+
+	nodesBeforeOverwrite := countDBEntriesByPrefix(db, PrefixNode)
+
+	err := tree.LoadVersionForOverwriting(1)
+	if err != nil {
+		t.Fatalf("LoadVersionForOverwriting(1): %v", err)
+	}
+
+	nodesAfterOverwrite := countDBEntriesByPrefix(db, PrefixNode)
+
+	if nodesAfterOverwrite >= nodesBeforeOverwrite {
+		t.Errorf("LoadVersionForOverwriting did not clean node data\n"+
+			"  nodes before: %d\n"+
+			"  nodes after:  %d (unchanged!)",
+			nodesBeforeOverwrite, nodesAfterOverwrite)
+	}
+
+	// Should be close to v1-only count
+	t.Logf("nodes: v1-only=%d, before=%d, after=%d", nodesAfterV1, nodesBeforeOverwrite, nodesAfterOverwrite)
+
+	// V1 must still be accessible
+	if tree.Version() != 1 {
+		t.Fatalf("version = %d, want 1", tree.Version())
+	}
+	for i := 0; i < 30; i++ {
+		val, err := tree.Get(fmt.Appendf(nil, "ow_base%03d", i))
+		if err != nil {
+			t.Fatalf("Get ow_base%03d: %v", i, err)
+		}
+		if !bytes.Equal(val, []byte("v1")) {
+			t.Fatalf("ow_base%03d: got %q, want 'v1'", i, val)
+		}
+	}
+}
+
 func TestPersistence_DeleteVersionsFrom(t *testing.T) {
 	tree := newTestTree(t)
 	for i := 0; i < 5; i++ {
@@ -553,6 +610,133 @@ func TestPersistence_DeleteVersionsFrom(t *testing.T) {
 	if tree.VersionExists(3) || tree.VersionExists(4) || tree.VersionExists(5) {
 		t.Fatalf("versions 3-5 should be deleted")
 	}
+}
+
+func TestDeleteVersionsFrom_CleansNodes(t *testing.T) {
+	// Scenario:
+	//  1. Create 3 versions, each adding unique keys so new nodes are created.
+	//  2. Record DB node count after all versions are saved.
+	//  3. Call DeleteVersionsFrom(2) to delete versions 2 and 3.
+	//  4. Verify root refs for v2, v3 are removed (this already works).
+	//  5. Verify node count decreased — this FAILS on current code, proving the leak.
+	//  6. Verify version 1 is still fully accessible.
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+
+	// Version 1: 50 keys (shared baseline)
+	for i := 0; i < 50; i++ {
+		tree.Set(fmt.Appendf(nil, "h3base%03d", i), []byte("v1"))
+	}
+	_, v1, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion v1: %v", err)
+	}
+	if v1 != 1 {
+		t.Fatalf("expected version 1, got %d", v1)
+	}
+
+	// Record node count after v1
+	nodesAfterV1 := countDBEntriesByPrefix(db, PrefixNode)
+
+	// Version 2: add 50 unique keys (creates new leaf + inner nodes)
+	for i := 50; i < 100; i++ {
+		tree.Set(fmt.Appendf(nil, "h3new2_%03d", i), []byte("v2"))
+	}
+	_, v2, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion v2: %v", err)
+	}
+	if v2 != 2 {
+		t.Fatalf("expected version 2, got %d", v2)
+	}
+
+	// Version 3: add 50 more unique keys
+	for i := 100; i < 150; i++ {
+		tree.Set(fmt.Appendf(nil, "h3new3_%03d", i), []byte("v3"))
+	}
+	_, v3, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion v3: %v", err)
+	}
+	if v3 != 3 {
+		t.Fatalf("expected version 3, got %d", v3)
+	}
+
+	nodesBeforeDelete := countDBEntriesByPrefix(db, PrefixNode)
+	rootsBeforeDelete := countDBEntriesByPrefix(db, PrefixRoot)
+
+	t.Logf("before DeleteVersionsFrom(2): nodes=%d roots=%d (v1-only nodes=%d)",
+		nodesBeforeDelete, rootsBeforeDelete, nodesAfterV1)
+
+	// Nodes added by v2 and v3 must be > 0
+	newNodes := nodesBeforeDelete - nodesAfterV1
+	if newNodes <= 0 {
+		t.Fatalf("expected new nodes from v2/v3, got %d", newNodes)
+	}
+
+	// --- Delete versions 2 and 3 ---
+	err = tree.DeleteVersionsFrom(2)
+	if err != nil {
+		t.Fatalf("DeleteVersionsFrom(2): %v", err)
+	}
+
+	// Root refs should be deleted
+	rootsAfterDelete := countDBEntriesByPrefix(db, PrefixRoot)
+	if rootsAfterDelete != 1 {
+		t.Fatalf("expected 1 root ref (v1 only), got %d", rootsAfterDelete)
+	}
+
+	// --- Key assertion: node count must decrease ---
+	nodesAfterDelete := countDBEntriesByPrefix(db, PrefixNode)
+
+	t.Logf("after DeleteVersionsFrom(2): nodes=%d (expected ~%d, got %d)",
+		nodesAfterDelete, nodesAfterV1, nodesAfterDelete)
+
+	// If DeleteVersionsFrom properly cleaned nodes, the count should be
+	// close to the v1-only count. At minimum, it must be less than before.
+	if nodesAfterDelete >= nodesBeforeDelete {
+		t.Errorf("H3 CONFIRMED: DeleteVersionsFrom did not clean node data\n"+
+			"  nodes before delete: %d\n"+
+			"  nodes after delete:  %d (unchanged!)\n"+
+			"  leaked nodes:        %d\n"+
+			"  This is a storage leak — nodes from deleted versions remain in DB.",
+			nodesBeforeDelete, nodesAfterDelete, nodesAfterDelete-nodesAfterV1)
+	}
+
+	// Version 1 must still be fully accessible
+	tree2 := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+	loadedV, err := tree2.LoadVersion(1)
+	if err != nil {
+		t.Fatalf("LoadVersion(1) after delete: %v", err)
+	}
+	if loadedV != 1 {
+		t.Fatalf("loaded version = %d, want 1", loadedV)
+	}
+	if tree2.Size() != 50 {
+		t.Fatalf("v1 size = %d, want 50", tree2.Size())
+	}
+	for i := 0; i < 50; i++ {
+		val, err := tree2.Get(fmt.Appendf(nil, "h3base%03d", i))
+		if err != nil {
+			t.Fatalf("Get h3base%03d: %v", i, err)
+		}
+		if !bytes.Equal(val, []byte("v1")) {
+			t.Fatalf("h3base%03d: got %q, want 'v1'", i, val)
+		}
+	}
+}
+
+// countDBEntriesByPrefix counts all DB entries with the given single-byte prefix.
+func countDBEntriesByPrefix(db *memdb.MemDB, prefix byte) int {
+	count := 0
+	start := []byte{prefix}
+	end := []byte{prefix + 1}
+	itr, _ := db.Iterator(start, end)
+	defer itr.Close()
+	for ; itr.Valid(); itr.Next() {
+		count++
+	}
+	return count
 }
 
 func TestPersistence_VersionReaders_BlockPruning(t *testing.T) {

--- a/tm2/pkg/bptree/persistence_test.go
+++ b/tm2/pkg/bptree/persistence_test.go
@@ -855,3 +855,123 @@ func TestPersistence_ExportImportHashMatch(t *testing.T) {
 		t.Logf("Export/Import produced different hash (different tree structure) — expected for B+ trees")
 	}
 }
+
+// findFullInnerNode recursively searches for an InnerNode with numKeys == B-1.
+// Returns the node and the key range it covers, or nil if none found.
+func findFullInnerNode(node Node) *InnerNode {
+	inner, ok := node.(*InnerNode)
+	if !ok {
+		return nil
+	}
+	if int(inner.numKeys) == B-1 {
+		return inner
+	}
+	for i := 0; i < inner.NumChildren(); i++ {
+		if inner.childNodes[i] != nil {
+			if found := findFullInnerNode(inner.childNodes[i]); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+// TestC4_InnerSplitWithLazyChildren reproduces the C4 bug:
+// When a DB-backed InnerNode is full (31 keys, 32 children) and a child
+// split propagates up, the inner split code copies childNodes directly
+// via copy(). Only the one child accessed via getChild() is loaded;
+// the remaining 30+ children are nil. nodeSize(nil) then panics.
+func TestC4_InnerSplitWithLazyChildren(t *testing.T) {
+	// Strategy: Insert sequential keys until a height-1 inner node has
+	// exactly B-1 = 31 keys (full). With B=32 and 90/10 leaf splits,
+	// each leaf split adds one separator to the parent inner node.
+	// After 31 leaf splits the inner node is full. We save at that point,
+	// reload (making all children lazy), then insert one more key to
+	// trigger a 32nd leaf split → inner split on the lazy-loaded node.
+	tree := newTestTree(t)
+
+	// Insert keys in batches, checking for a full inner node after each batch.
+	// With 90/10 splits, each ~30 sequential keys cause a leaf split.
+	// 31 leaf splits ≈ 930 keys, but tree structure varies.
+	var fullInnerKeys int
+	for i := 0; i < 2000; i++ {
+		tree.Set(fmt.Appendf(nil, "c4k%05d", i), fmt.Appendf(nil, "v%05d", i))
+
+		// Check every 30 keys (roughly one leaf split cycle)
+		if (i+1)%30 == 0 {
+			found := findFullInnerNode(tree.root)
+			if found != nil && found.height == 1 {
+				fullInnerKeys = i + 1
+				t.Logf("found full inner node (numKeys=%d, height=%d) after %d keys",
+					found.numKeys, found.height, fullInnerKeys)
+				break
+			}
+		}
+	}
+	if fullInnerKeys == 0 {
+		t.Fatalf("could not find a full inner node (numKeys=%d) in up to 2000 keys", B-1)
+	}
+
+	// Save to DB at this exact point
+	_, _, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion: %v", err)
+	}
+
+	// Reload from DB — all inner node childNodes become nil (lazy)
+	tree2 := NewMutableTreeWithDB(tree.ndb.db, 1000, NewNopLogger())
+	if _, err := tree2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Verify that loaded tree has lazy children
+	root2, ok := tree2.root.(*InnerNode)
+	if !ok {
+		t.Fatalf("root is not InnerNode after reload")
+	}
+	nilCount := 0
+	for i := 0; i < root2.NumChildren(); i++ {
+		if root2.childNodes[i] == nil {
+			nilCount++
+		}
+	}
+	if nilCount == 0 {
+		t.Fatalf("expected lazy children after Load")
+	}
+	t.Logf("reloaded root: numKeys=%d, nil children=%d/%d",
+		root2.numKeys, nilCount, root2.NumChildren())
+
+	// Insert enough keys to trigger a leaf split that propagates up to the
+	// full inner node. Since the full inner node was the one receiving
+	// sequential inserts, inserting more sequential keys will fill the
+	// rightmost leaf and trigger the split chain.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("C4 CONFIRMED: panic during insert on reloaded tree: %v\n"+
+				"inner split accessed nil childNodes (lazy-loaded children not materialized)", r)
+		}
+	}()
+
+	// Insert 100 more sequential keys — enough to trigger multiple leaf splits
+	for i := fullInnerKeys; i < fullInnerKeys+100; i++ {
+		tree2.Set(fmt.Appendf(nil, "c4k%05d", i), fmt.Appendf(nil, "v%05d", i))
+	}
+
+	// If we reach here without panic, verify data integrity
+	_, _, err = tree2.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion after insert: %v", err)
+	}
+
+	// All keys should be retrievable
+	for i := 0; i < fullInnerKeys+100; i++ {
+		val, err := tree2.Get(fmt.Appendf(nil, "c4k%05d", i))
+		if err != nil {
+			t.Fatalf("Get c4k%05d: %v", i, err)
+		}
+		if val == nil {
+			t.Fatalf("c4k%05d: value is nil", i)
+		}
+	}
+	t.Logf("all %d keys verified after reload + insert", fullInnerKeys+100)
+}

--- a/tm2/pkg/bptree/prune.go
+++ b/tm2/pkg/bptree/prune.go
@@ -17,11 +17,16 @@ func (t *MutableTree) PruneVersionsTo(toVersion int64) error {
 		return fmt.Errorf("cannot prune latest version %d", latest)
 	}
 
-	// Check for active readers
-	for v := first; v <= toVersion; v++ {
-		if t.ndb.hasVersionReaders(v) {
-			return fmt.Errorf("%w: version %d", ErrActiveReaders, v)
-		}
+	// Atomically check for active readers and mark the range as pruning.
+	// While marked, new readers on these versions are rejected.
+	if err := t.ndb.beginPruning(first, toVersion); err != nil {
+		return err
+	}
+	defer t.ndb.endPruning()
+
+	// Test-only hook: called after reader check, before deletion.
+	if t.afterReaderCheck != nil {
+		t.afterReaderCheck()
 	}
 
 	for v := first; v <= toVersion; v++ {

--- a/tm2/pkg/bptree/prune_test.go
+++ b/tm2/pkg/bptree/prune_test.go
@@ -334,6 +334,61 @@ func countDBNodes(db *memdb.MemDB) int {
 	return count
 }
 
+func TestPrune_IteratorBlocksPruning(t *testing.T) {
+	tree := newPruneTree(t)
+
+	// V1: insert keys
+	for i := 0; i < 50; i++ {
+		tree.Set(fmt.Appendf(nil, "it%03d", i), fmt.Appendf(nil, "val%03d", i))
+	}
+	tree.SaveVersion()
+
+	// V2: update some keys so V1 has unique nodes that pruning would delete
+	for i := 0; i < 20; i++ {
+		tree.Set(fmt.Appendf(nil, "it%03d", i), []byte("v2"))
+	}
+	tree.SaveVersion()
+
+	// Get an ImmutableTree for V1 and create an iterator (same path as store layer)
+	imm, err := tree.GetImmutable(1)
+	if err != nil {
+		t.Fatalf("GetImmutable(1): %v", err)
+	}
+	itr := NewIteratorWithNDB(imm, nil, nil, true, tree)
+	defer itr.Close()
+
+	if !itr.Valid() {
+		t.Fatalf("iterator should be valid")
+	}
+
+	// Pruning must fail — iterator is an active reader on V1
+	err = tree.DeleteVersionsTo(1)
+	if err == nil {
+		t.Fatalf("pruning should be blocked by active iterator")
+	}
+
+	// Iterator should still function normally while pruning is blocked
+	keysRead := 0
+	for itr.Valid() {
+		_ = itr.Key()
+		_ = itr.Value()
+		itr.Next()
+		keysRead++
+	}
+	if keysRead != 50 {
+		t.Fatalf("iterator read %d keys, want 50", keysRead)
+	}
+
+	// Close iterator — releases version reader
+	itr.Close()
+
+	// Pruning should now succeed
+	err = tree.DeleteVersionsTo(1)
+	if err != nil {
+		t.Fatalf("prune after iterator close should succeed: %v", err)
+	}
+}
+
 func TestPrune_EmptyVersions(t *testing.T) {
 	tree := newPruneTree(t)
 

--- a/tm2/pkg/bptree/prune_test.go
+++ b/tm2/pkg/bptree/prune_test.go
@@ -389,6 +389,62 @@ func TestPrune_IteratorBlocksPruning(t *testing.T) {
 	}
 }
 
+// TestPrune_TOCTOU_ReaderRejectedDuringPrune verifies that the TOCTOU gap
+// between version reader check and deletion is closed. The afterReaderCheck
+// hook fires after beginPruning marks the range but before deletion starts.
+// An iterator created in this window must be rejected (exhausted), proving
+// that new readers cannot slip in after the check.
+func TestPrune_TOCTOU_ReaderRejectedDuringPrune(t *testing.T) {
+	tree := newPruneTree(t)
+
+	// V1: insert keys
+	for i := 0; i < 50; i++ {
+		tree.Set(fmt.Appendf(nil, "tc%03d", i), fmt.Appendf(nil, "val%03d", i))
+	}
+	tree.SaveVersion()
+
+	// V2: update some keys so V1 has orphaned nodes
+	for i := 0; i < 20; i++ {
+		tree.Set(fmt.Appendf(nil, "tc%03d", i), []byte("v2"))
+	}
+	tree.SaveVersion()
+
+	// Try to create an iterator in the TOCTOU gap via the hook.
+	var itr *Iterator
+	tree.afterReaderCheck = func() {
+		// This runs after beginPruning marks versions [1,1] as pruning.
+		// incrVersionReaders should reject the registration.
+		imm, err := tree.GetImmutable(1)
+		if err != nil {
+			t.Errorf("GetImmutable(1) in hook: %v", err)
+			return
+		}
+		itr = NewIteratorWithNDB(imm, nil, nil, true, tree)
+	}
+
+	err := tree.DeleteVersionsTo(1)
+	tree.afterReaderCheck = nil
+
+	// Pruning should succeed — no real reader was registered.
+	if err != nil {
+		if itr != nil {
+			itr.Close()
+		}
+		t.Fatalf("pruning should succeed (no real reader): %v", err)
+	}
+
+	// The iterator created during pruning must be exhausted (not valid)
+	// because incrVersionReaders rejected the registration.
+	if itr == nil {
+		t.Fatalf("hook should have created an iterator")
+	}
+	defer itr.Close()
+
+	if itr.Valid() {
+		t.Fatalf("iterator should be exhausted — version was being pruned")
+	}
+}
+
 func TestPrune_EmptyVersions(t *testing.T) {
 	tree := newPruneTree(t)
 


### PR DESCRIPTION
## Bounds check on `readBytes` to prevent OOM from corrupted node data

fix: https://github.com/gnolang/gno/pull/5450/commits/c0ba7d74c4ece05a761cb33c522c56ae3f5c657c

`readBytes` in `node.go` reads a uvarint length from the byte stream and
immediately allocates a buffer of that size with `make([]byte, length)`. Since
the length comes from on-disk data that may be corrupted or maliciously
crafted, a bogus value like `1<<40` causes the Go runtime to OOM-kill the
process before `io.ReadFull` ever gets a chance to fail.

The fix adds a pre-allocation guard that compares the decoded length against
`r.Len()` (the bytes actually remaining in the reader). This is a tautological
bound — you can never need more bytes than the reader contains — so it has
zero false-positive risk and requires no arbitrary `MaxKeySize` constant.

Both `readInnerNode` and `readLeafNode` call `readBytes` for every key they
deserialize, so this single check protects the entire node deserialization
path.

_Note: This partially overlaps with issue no. 4 in PR #5442_

### Changes

| File | Change |
|------|--------|
| `node.go` | Add `length > r.Len()` guard in `readBytes` before `make` |

---

## `DeleteVersionsFrom` / `LoadVersionForOverwriting` leak node data

fix: https://github.com/gnolang/gno/pull/5450/commits/5068f67e855e370e16ae8b0608329df1364def79

`DeleteVersionsFrom` only deletes root references for each version but leaves
all the underlying node entries in the database. Every call leaks the full
node set of the deleted versions permanently.

The same bug exists in `LoadVersionForOverwriting`, which inlines a similar
delete loop.

### Root cause

`DeleteRoot` removes the 44-byte root reference (`R` prefix) but never touches
the node entries (`B` prefix). `DeleteVersionsTo` (the forward-pruning path)
has a separate dual-tree-walk that identifies and deletes orphaned nodes, but
`DeleteVersionsFrom` has no equivalent — it was a stub.

### Fix

Add `nodeDB.DeleteNodesFrom(fromVersion, toVersion)` that performs a
lexicographic range scan over the `B`-prefixed key space. NodeKeys encode the
version as the first 8 big-endian bytes, so the range `[prefix||from,
prefix||to+1)` covers exactly the target versions.

A node created at version V can only be referenced by version V or later.
When deleting all versions from `fromVersion` through `latest`, no surviving
version can reference these nodes, so the range delete is safe — no
shared-node analysis required.

`LoadVersionForOverwriting` is refactored to call `DeleteVersionsFrom`
instead of duplicating the delete loop, eliminating the same bug in a second
code path.

---

## `NewIteratorWithNDB` does not register as version reader

`NewIteratorWithNDB` — the iterator creation path used by the store layer for
querying historical versions — passes `version=0` to `newIterator`, skipping
version reader registration entirely. This means `PruneVersionsTo` cannot
detect an active iterator and may delete nodes the iterator is traversing.

In contrast, `Export()` correctly calls `ndb.incrVersionReaders(t.version)` and
is protected. The asymmetry was an oversight: the `Close()` path already had
the matching `decrVersionReaders` call guarded by `version > 0`, but no
creation path ever set a non-zero version for iterators.

### Root cause

All three iterator creation paths hardcode `version=0`:

- `NewIteratorWithNDB(imm, ..., mtree)` — passes `0` despite having
  `imm.version` available. This is the only path that needs fixing: it
  operates on a saved version's nodes via `ndb` and is a valid pruning target.
- `MutableTree.Iterator()` — operates on the working tree, not a saved
  version. Not a pruning target. `version=0` is correct.
- `ImmutableTree.Iterator()` — `ndb` is nil (in-memory only). No DB nodes to
  protect. `version=0` is correct.

Additionally, `PruneVersionsTo` has a TOCTOU race: the version reader check
loop and the deletion loop are in separate critical sections. Each
`hasVersionReaders` call locks and unlocks `ndb.mtx` individually, so a new
reader can register after the check passes but before deletion starts.

In the current gno architecture this is not reachable in practice —
`localClientCreator` shares a single `sync.Mutex` across the consensus,
query, and mempool ABCI connections, serializing `Commit` (pruning) with
`Query` (iteration). However, the race becomes exploitable if `AsyncPruning`
is ported from IAVL, if the tree is accessed outside the ABCI boundary, or if
a network-based ABCI client replaces `localClient`.

### Fix

Two changes that together close the race:

1. **Iterator registration**: In `NewIteratorWithNDB`, read
   `imm.version` and call `ndb.incrVersionReaders(version)` when
   `ndb != nil && version > 0`. The existing `Close()` logic decrements it.
  - fix: https://github.com/gnolang/gno/pull/5450/commits/667c28c5973434d9a1d79af92da9670402c204b3

2. **Atomic check-and-mark**: Replace the per-version `hasVersionReaders`
   loop with `ndb.beginPruning(first, toVersion)`, which atomically — under a
   single `ndb.mtx` hold — checks all versions for active readers and marks
   the range as pruning. `incrVersionReaders` rejects new readers on versions
   in the pruning range (`ErrVersionBeingPruned`). `defer ndb.endPruning()`
   clears the mark when pruning finishes.
  - fix: https://github.com/gnolang/gno/pull/5450/commits/d47f0b3b1d6a27472160b98c7a2780fd127fdf75

### Changes

| File | Change |
|------|--------|
| `iterator.go` | `NewIteratorWithNDB`: register `imm.version` as version reader; return exhausted iterator if version is being pruned |
| `nodedb.go` | `pruningFrom`/`pruningTo` fields; `beginPruning`/`endPruning` methods; `incrVersionReaders` returns error when version is in pruning range |
| `errors.go` | Add `ErrVersionBeingPruned` |
| `prune.go` | Replace reader check loop with `beginPruning`/`defer endPruning` |
| `mutable_tree.go` | `DeleteVersionsFrom`: same `beginPruning`/`endPruning` replacement; `afterReaderCheck` test hook |
| `export.go` | Propagate `incrVersionReaders` error |
| `prune_test.go` | `TestPrune_IteratorBlocksPruning`: iterator blocks pruning, succeeds after close |
| `prune_test.go` | `TestPrune_TOCTOU_ReaderRejectedDuringPrune`: reader injected in TOCTOU gap is rejected |

---

## Materialize lazy children before inner node split

fix: https://github.com/gnolang/gno/pull/5450/commits/3f3329a78c9b1a8501a36d7bb2070faf3eea3823

When a DB-backed `InnerNode` is full (31 keys, 32 children) and a child split
propagates up, the inner split code at `insert.go:161-163` copies
`inner.childNodes` directly via `copy()`. After `LoadVersion`, only the single
child accessed through `getChild(childIdx)` is materialized in memory — the
remaining 31 children stay `nil` (lazy). The subsequent `nodeSize(nil)` call
hits the `default` switch case and panics with `"unknown node type"`.

This is a deterministic crash on any DB-backed tree with ~990+ entries after a
node restart. The first block after restart calls `treeInsert` on a
lazy-loaded root. If the root (or any ancestor inner node on the insert path)
is full, the panic fires before `SaveVersion` has a chance to materialize the
tree into memory.

### Root cause

`innerInsert` calls `getChild(childIdx)` (line 104) to lazy-load the single
child being descended into, but the inner split path assumes all
`childNodes[i]` are populated:

```go
// insert.go:161-163 — copies nil entries verbatim
copy(allChildNodes[:childIdx+1], inner.childNodes[:childIdx+1])
allChildNodes[childIdx+1] = sr.right
copy(allChildNodes[childIdx+2:], inner.childNodes[childIdx+1:B])
```

In-memory tests never hit this because `NewMutableTreeMem()` trees have no DB
layer — all children are always resident. The lazy loading path is only
exercised via `NewMutableTreeWithDB` + `LoadVersion`, and no existing test
inserts enough keys after reload to trigger a split at a full inner node.

### Fix

Replace the three `copy()` calls with `getChild(i)` loops that force lazy
loading for each child before it enters the `allChildNodes` array:

```go
for i := 0; i <= childIdx; i++ {
    allChildNodes[i] = inner.getChild(i)
}
allChildNodes[childIdx+1] = sr.right
for i := childIdx + 1; i < B; i++ {
    allChildNodes[i+1] = inner.getChild(i)
}
```

`getChild` is the same method already used at line 104 for the single-child
case. It checks `childNodes[idx]`, falls through to `ndb.GetNode` if nil, and
caches the result. No new DB access pattern is introduced.

### Changes

| File | Change |
|------|--------|
| `insert.go` | Replace `copy(allChildNodes, inner.childNodes)` with `getChild(i)` loop to materialize lazy children before split |
| `persistence_test.go` | `TestC4_InnerSplitWithLazyChildren`: build tree to exact full-inner-node threshold (990 keys), save, reload with lazy children, insert to trigger inner split, assert no panic and all keys retrievable |
