### PR TITLE
fix(gnoland): fix data races in integration test harness, add event collector test

### DIFF
--- a/gno.land/pkg/integration/process.go
+++ b/gno.land/pkg/integration/process.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/goleveldb"
 	"github.com/gnolang/gno/tm2/pkg/db/memdb"
-	"github.com/stretchr/testify/require"
 )
 
 const gracefulShutdown = time.Second * 5
@@ -331,9 +330,11 @@ func RunMain(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) err
 	return err
 }
 
-func runTestingNodeProcess(t TestingTS, ctx context.Context, pcfg ProcessConfig) NodeProcess {
+func runTestingNodeProcess(ctx context.Context, pcfg ProcessConfig) (NodeProcess, error) {
 	bin, err := os.Executable()
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	args := []string{
 		"-test.run=^$",
 		"-run-node-process",
@@ -343,10 +344,7 @@ func runTestingNodeProcess(t TestingTS, ctx context.Context, pcfg ProcessConfig)
 		args = append(args, "-test.gocoverdir="+pcfg.CoverDir)
 	}
 
-	node, err := RunNodeProcess(ctx, pcfg, bin, args...)
-	require.NoError(t, err)
-
-	return node
+	return RunNodeProcess(ctx, pcfg, bin, args...)
 }
 
 // initDatabase initializes the database based on the provided directory configuration.

--- a/gno.land/pkg/integration/process_test.go
+++ b/gno.land/pkg/integration/process_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), nodeMaxLifespan)
 	defer cancel()
 
 	if err := RunMain(ctx, os.Stdin, os.Stdout, os.Stderr); err != nil {
@@ -59,7 +59,7 @@ func TestNodeProcess(t *testing.T) {
 	}()
 
 	start := time.Now()
-	node := runTestingNodeProcess(t, ctx, ProcessConfig{
+	node, err := runTestingNodeProcess(ctx, ProcessConfig{
 		Stderr: &stdio, Stdout: &stdio,
 		Node: &ProcessNodeConfig{
 			Verbose:      true,
@@ -70,6 +70,7 @@ func TestNodeProcess(t *testing.T) {
 			Genesis:      NewMarshalableGenesisDoc(cfg.Genesis),
 		},
 	})
+	require.NoError(t, err)
 	t.Logf("time to start the node: %v", time.Since(start).String())
 
 	// Create a new HTTP client to interact with the integration node

--- a/gno.land/pkg/integration/race_off.go
+++ b/gno.land/pkg/integration/race_off.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package integration
+
+// raceEnabled is false when the binary is compiled without -race.
+const raceEnabled = false

--- a/gno.land/pkg/integration/race_on.go
+++ b/gno.land/pkg/integration/race_on.go
@@ -1,0 +1,6 @@
+//go:build race
+
+package integration
+
+// raceEnabled is true when the binary is compiled with -race.
+const raceEnabled = true

--- a/gno.land/pkg/integration/testdata/event_race.txtar
+++ b/gno.land/pkg/integration/testdata/event_race.txtar
@@ -1,13 +1,47 @@
-# Test: Verify event collector is exercised with real validator set changes.
+# Test: Event collector data race verification
 #
-# This test triggers actual ValidatorAdded events through the GovDAO proposal
-# flow, ensuring the collector's updateWith() and getEvents() are both called
-# during block processing.
+# PURPOSE:
+# Verify that the event collector (gno.land/pkg/gnoland/events.go) has no
+# data race between updateWith() and getEvents(). These two methods access
+# collector.events (a plain []T slice with no mutex), so if they ever ran
+# concurrently the Go race detector would catch it.
 #
-# The collector (gno.land/pkg/gnoland/events.go) stores events in a plain []T
-# slice. Both updateWith() (called from fireEvents after block commit) and
-# getEvents() (called from EndBlocker) run on the same consensus receiveRoutine
-# goroutine, so there is no data race by design.
+# WHY THERE IS NO RACE:
+# Both methods run on the single consensus receiveRoutine goroutine,
+# sequentially inside ApplyBlock():
+#
+#   ApplyBlock()                              (tm2/pkg/bft/state/execution.go:90)
+#   ├── execBlockOnProxyApp()                 (execution.go:95)
+#   │   └── EndBlockSync()                    (execution.go:265)
+#   │       └── app EndBlocker                (gno.land/pkg/gnoland/app.go:462)
+#   │           └── collector.getEvents()     ← READS + RESETS collector.events
+#   │
+#   └── fireEvents()                          (execution.go:151)
+#       └── evsw.FireEvent(EventTx)           (execution.go:427)
+#           └── collector.updateWith()        ← APPENDS to collector.events
+#
+# The EventSwitch fires listeners synchronously (events.go:106-107),
+# not in goroutines. So getEvents() always completes before the next
+# updateWith(). Events from block N are consumed by block N+1's EndBlocker.
+#
+# HOW THIS TEST EXERCISES THE COLLECTOR:
+# We trigger a real ValidatorAdded event through the GovDAO proposal flow:
+#   1. Register a valoper profile
+#   2. Create a GovDAO proposal to add it as a validator
+#   3. Vote YES and execute the proposal
+#   4. Execution calls r/sys/validators/v2.addValidator()
+#      which calls chain.Emit("ValidatorAdded")
+#   5. The validatorEventFilter matches the event, updateWith() stores it
+#   6. Next block's EndBlocker calls getEvents(), sees the event,
+#      and queries r/sys/validators/v2.GetChanges() for the actual update
+#
+# The [!race] guard ensures this test only runs with `go test -race`,
+# since the race detector is the whole point.
+#
+# Run: go test -race -v -run TestTestdata/event_race -timeout 300s ./gno.land/pkg/integration
+
+# Only run when compiled with -race; skip otherwise.
+[!race] skip 'requires -race build flag'
 
 loadpkg gno.land/r/gnops/valopers
 loadpkg gno.land/r/gnops/valopers/proposal
@@ -15,42 +49,54 @@ loadpkg gno.land/r/gov/dao
 
 gnoland start
 
-# Step 1: Initialize GovDAO with test1 as a member
+# Initialize GovDAO with test1 as a member (required for proposal voting)
 gnokey maketx run -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout 'OK!'
 
-# Step 2: Register a valoper
+# Register a valoper — this creates the on-chain profile that the proposal references
 gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 1000000ugnot -gas-wanted 30000000 -send 20000000ugnot -args myval -args "test validator" -args on-prem -args g1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
-# Step 3: Create a GovDAO proposal to add the valoper as a validator
-# This calls r/sys/validators/v2.NewPropRequest under the hood
+# Create a GovDAO proposal to add the valoper as a validator.
+# Under the hood: r/gnops/valopers/proposal.NewValidatorProposalRequest()
+# -> r/sys/validators/v2.NewPropRequest()
 gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_proposal.gno
 stdout 'OK!'
 
-# Step 4: Vote YES on the proposal
+# Vote YES — since test1 is the only GovDAO member, this passes immediately
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1000000ugnot -gas-wanted 10000000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
-# Step 5: Execute the proposal — this triggers:
-#   r/sys/validators/v2.addValidator()
-#     -> chain.Emit("ValidatorAdded")
-#     -> EventTx in DeliverTx response
-#     -> fireEvents() fires EventTx
-#     -> collector.updateWith() appends to collector.events
-#   Next block's EndBlocker:
-#     -> collector.getEvents() reads and resets collector.events
+# Execute the proposal — THIS IS THE KEY TRANSACTION.
+# It calls r/sys/validators/v2.addValidator() which emits:
+#   chain.Emit("ValidatorAdded")
+#
+# During this block's commit:
+#   1. DeliverTx runs the proposal execution, producing a GnoVM event
+#   2. EndBlockSync() calls app EndBlocker -> collector.getEvents()
+#      (returns empty — no events from *previous* block)
+#   3. fireEvents() fires EventTx containing the ValidatorAdded event
+#   4. collector.updateWith() stores validatorUpdate{} in collector.events
+#
+# During the NEXT block's commit:
+#   5. EndBlockSync() calls collector.getEvents() -> returns [validatorUpdate{}]
+#   6. EndBlocker queries r/sys/validators/v2.GetChanges() for the actual update
+#   7. The validator set change is applied
+#
+# If updateWith() (step 4) and getEvents() (step 2/5) could run concurrently,
+# the race detector would fire here. It doesn't — both are on receiveRoutine.
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 1000000ugnot -gas-wanted 20000000 -args 0 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
-# Step 6: Send follow-up queries to force subsequent blocks,
-# ensuring getEvents() is called after the validator event was collected.
+# Force a follow-up block to ensure getEvents() consumes the buffered event
 gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
 stdout 'myval'
 
-# Step 7: Verify the validator was actually added and valset changes recorded
+# Verify: the validator was added and the change was recorded.
+# This confirms the full event flow worked: Emit -> updateWith -> getEvents -> QueryEval
 gnokey query vm/qrender --data 'gno.land/r/sys/validators/v2:'
-stdout 'Valset changes'
+stdout 'Valset changes:'
+stdout 'g1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl \(1\)'
 
 -- run/init_govdao.gno --
 package main

--- a/gno.land/pkg/integration/testdata/event_race.txtar
+++ b/gno.land/pkg/integration/testdata/event_race.txtar
@@ -1,0 +1,75 @@
+# Test: Verify event collector is exercised with real validator set changes.
+#
+# This test triggers actual ValidatorAdded events through the GovDAO proposal
+# flow, ensuring the collector's updateWith() and getEvents() are both called
+# during block processing.
+#
+# The collector (gno.land/pkg/gnoland/events.go) stores events in a plain []T
+# slice. Both updateWith() (called from fireEvents after block commit) and
+# getEvents() (called from EndBlocker) run on the same consensus receiveRoutine
+# goroutine, so there is no data race by design.
+
+loadpkg gno.land/r/gnops/valopers
+loadpkg gno.land/r/gnops/valopers/proposal
+loadpkg gno.land/r/gov/dao
+
+gnoland start
+
+# Step 1: Initialize GovDAO with test1 as a member
+gnokey maketx run -gas-fee 100000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+stdout 'OK!'
+
+# Step 2: Register a valoper
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 1000000ugnot -gas-wanted 30000000 -send 20000000ugnot -args myval -args "test validator" -args on-prem -args g1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+# Step 3: Create a GovDAO proposal to add the valoper as a validator
+# This calls r/sys/validators/v2.NewPropRequest under the hood
+gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_proposal.gno
+stdout 'OK!'
+
+# Step 4: Vote YES on the proposal
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1000000ugnot -gas-wanted 10000000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+# Step 5: Execute the proposal — this triggers:
+#   r/sys/validators/v2.addValidator()
+#     -> chain.Emit("ValidatorAdded")
+#     -> EventTx in DeliverTx response
+#     -> fireEvents() fires EventTx
+#     -> collector.updateWith() appends to collector.events
+#   Next block's EndBlocker:
+#     -> collector.getEvents() reads and resets collector.events
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 1000000ugnot -gas-wanted 20000000 -args 0 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+# Step 6: Send follow-up queries to force subsequent blocks,
+# ensuring getEvents() is called after the validator event was collected.
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+stdout 'myval'
+
+# Step 7: Verify the validator was actually added and valset changes recorded
+gnokey query vm/qrender --data 'gno.land/r/sys/validators/v2:'
+stdout 'Valset changes'
+
+-- run/init_govdao.gno --
+package main
+
+import dao "gno.land/r/gov/dao/v3/init"
+
+func main() {
+	dao.InitWithUsers("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+}
+
+-- run/create_proposal.gno --
+package main
+
+import (
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+)
+
+func main() {
+	pr := proposal.NewValidatorProposalRequest(cross, address("g1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl"))
+	dao.MustCreateProposal(cross, pr)
+}

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -724,11 +724,37 @@ func (l *tsLogWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+// safeWriter is a thread-safe writer that buffers output.
+// It is used to capture node stderr without racing with
+// testscript's internal strings.Builder.
+type safeWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *safeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *safeWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
 func setupNode(ts *testscript.TestScript, ctx context.Context, cfg *ProcessNodeConfig) NodeProcess {
+	// Use thread-safe buffers for stdout and stderr to avoid racing
+	// with testscript's internal buffers. The node subprocess writes
+	// from background goroutines (waitForProcessReady stdout forwarder,
+	// node stderr) while the testscript main goroutine reads them
+	// via clearBuiltinStd/Logf.
+	var stdoutBuf, stderrBuf safeWriter
 	pcfg := ProcessConfig{
 		Node:   cfg,
-		Stdout: &tsLogWriter{ts},
-		Stderr: ts.Stderr(),
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
 	}
 
 	// Setup coverdir provided
@@ -742,6 +768,7 @@ func setupNode(ts *testscript.TestScript, ctx context.Context, cfg *ProcessNodeC
 	case commandKindInMemory:
 		nodep, err := RunInMemoryProcess(ctx, pcfg)
 		if err != nil {
+			fmt.Fprint(ts.Stderr(), stderrBuf.String())
 			ts.Fatalf("unable to start in memory node: %s", err)
 		}
 
@@ -752,12 +779,19 @@ func setupNode(ts *testscript.TestScript, ctx context.Context, cfg *ProcessNodeC
 			ts.Fatalf("unable to invoke testing process while not testing")
 		}
 
-		return runTestingNodeProcess(&testingTS{ts}, ctx, pcfg)
+		nodep, err := runTestingNodeProcess(ctx, pcfg)
+		if err != nil {
+			fmt.Fprint(ts.Stderr(), stderrBuf.String())
+			ts.Fatalf("unable to start testing node: %s", err)
+		}
+
+		return nodep
 
 	case commandKindBin:
 		bin := ts.Value(envKeyExecBin).(string)
 		nodep, err := RunNodeProcess(ctx, pcfg, bin)
 		if err != nil {
+			fmt.Fprint(ts.Stderr(), stderrBuf.String())
 			ts.Fatalf("unable to start process node: %s", err)
 		}
 

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -251,6 +251,19 @@ func SetupGnolandTestscript(t *testing.T, p *testscript.Params) error {
 		p.Cmds[cmd] = call
 	}
 
+	// Register custom conditions.
+	// [race] evaluates to true when the binary is compiled with -race.
+	origCondition := p.Condition
+	p.Condition = func(cond string) (bool, error) {
+		if cond == "race" {
+			return raceEnabled, nil
+		}
+		if origCondition != nil {
+			return origCondition(cond)
+		}
+		return false, fmt.Errorf("unknown condition %q", cond)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fix data races in integration test harness (stdout/stderr `strings.Builder` accessed from background goroutines) that blocked running txtar tests with `-race`.
- Add `event_race.txtar` integration test exercising the event collector end-to-end through real validator set changes via the GovDAO proposal flow.
- Introduce `[race]` testscript condition so individual txtar tests can be gated on `-race` compilation.

## Test plan
- [x] `go test -race -run TestTestdata/event_race ./gno.land/pkg/integration` passes (no data race)
- [x] `go test -run TestTestdata/event_race ./gno.land/pkg/integration` skips (via `[!race] skip`)
- [x] `go test -run TestTestdata/addpkg ./gno.land/pkg/integration` still passes (no regression)
- [x] `go test -race -run TestTestdata/addpkg ./gno.land/pkg/integration` passes (harness fix verified on other tests)