### PR TITLE
fix(tm2): reject block parts with mismatched proofs in AddPart

### DIFF
--- a/tm2/pkg/bft/types/part_set.go
+++ b/tm2/pkg/bft/types/part_set.go
@@ -209,6 +209,17 @@ func (ps *PartSet) AddPart(part *Part) (bool, error) {
 		return false, nil
 	}
 
+	// Verify proof metadata matches what we expect.
+	// Proof.Verify uses Proof.Index internally, so a Byzantine peer could send
+	// a Part with part.Index != part.Proof.Index and pass the merkle check
+	// while storing bytes at the wrong position.
+	if part.Proof.Index != part.Index {
+		return false, ErrPartSetInvalidProof
+	}
+	if part.Proof.Total != ps.total {
+		return false, ErrPartSetInvalidProof
+	}
+
 	// Check hash proof
 	if part.Proof.Verify(ps.Hash(), part.Bytes) != nil {
 		return false, ErrPartSetInvalidProof

--- a/tm2/pkg/bft/types/part_set_test.go
+++ b/tm2/pkg/bft/types/part_set_test.go
@@ -89,6 +89,53 @@ func TestWrongProof(t *testing.T) {
 	}
 }
 
+// TestAddPartSwappedIndex is a regression test for a Byzantine attack where a
+// peer sends a Part with part.Index != part.Proof.Index.  Because
+// SimpleProof.Verify uses Proof.Index internally, the merkle check passes even
+// though the bytes would be stored at the wrong slot, making the assembled
+// block undecodable.  AddPart must reject such parts before the merkle check.
+func TestAddPartSwappedIndex(t *testing.T) {
+	t.Parallel()
+
+	data := random.RandBytes(testPartSize * 3)
+	legitSet := NewPartSetFromData(data, testPartSize)
+	require.Equal(t, 3, legitSet.Total())
+
+	part0 := legitSet.GetPart(0)
+	part1 := legitSet.GetPart(1)
+
+	victimSet := NewPartSetFromHeader(legitSet.Header())
+
+	// Byzantine: send part1's proof+bytes but claim Index=0.
+	added, err := victimSet.AddPart(&Part{Index: 0, Bytes: part1.Bytes, Proof: part1.Proof})
+	assert.False(t, added)
+	assert.ErrorIs(t, err, ErrPartSetInvalidProof)
+
+	// Byzantine: send part0's proof+bytes but claim Index=1.
+	added, err = victimSet.AddPart(&Part{Index: 1, Bytes: part0.Bytes, Proof: part0.Proof})
+	assert.False(t, added)
+	assert.ErrorIs(t, err, ErrPartSetInvalidProof)
+}
+
+// TestAddPartWrongTotal checks that a Part whose proof carries a different
+// total than the PartSet is rejected.
+func TestAddPartWrongTotal(t *testing.T) {
+	t.Parallel()
+
+	data := random.RandBytes(testPartSize * 3)
+	legitSet := NewPartSetFromData(data, testPartSize)
+	require.Equal(t, 3, legitSet.Total())
+
+	part := legitSet.GetPart(0)
+	victimSet := NewPartSetFromHeader(legitSet.Header())
+
+	// Tamper the proof total.
+	part.Proof.Total = legitSet.Total() + 1
+	added, err := victimSet.AddPart(part)
+	assert.False(t, added)
+	assert.ErrorIs(t, err, ErrPartSetInvalidProof)
+}
+
 func TestPartSetHeaderValidateBasic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
PartSet.AddPart was missing two checks before calling Proof.Verify:
- part.Index == part.Proof.Index
- part.Proof.Total == ps.total

SimpleProof.Verify uses Proof.Index internally when computing the root hash, so a Byzantine peer could gossip a Part with a swapped Index while keeping the original Proof intact. The merkle check would pass, the part would be stored at the wrong position, and IsComplete() would return true with scrambled data — making the assembled block undecodable and causing every consensus round to time out.

Add the two guard checks before the merkle verification and add regression tests for both the index-swap and wrong-total cases.