### PR TITLE
fix(ci): use local checkout for Docker bake source

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -68,10 +68,10 @@ jobs:
           labels: |
             org.opencontainers.image.authors=Gno Core Team
 
-      # Using Github Context. Overriding context with an explicit `set` is required
       - name: Bake build and push
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
+          source: . # use checked-out code, not git URL at GITHUB_SHA
           files: |
             misc/deployments/bake/docker-bake.hcl
             cwd://${{ steps.meta.outputs.bake-file-tags }}


### PR DESCRIPTION
The `docker/bake-action` defaults to fetching source from git at `GITHUB_SHA`, ignoring the local checkout. When triggered via `workflow_dispatch` from `master` with a chain tag input, this causes the image to be built from master code instead of the tag.

Add `source: .` to make the bake action use the checked-out code (the correct tag ref) as the build context.

similar issue: https://github.com/docker/bake-action/issues/301