### PR TITLE
fix(node): ensure halt_height triggers clean process shutdown

### DIFF
--- a/tm2/pkg/bft/consensus/state.go
+++ b/tm2/pkg/bft/consensus/state.go
@@ -609,7 +609,7 @@ func (cs *ConsensusState) receiveRoutine(maxSteps int) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Check if this is an intentional halt-height shutdown.
-			if haltErr, ok := r.(types.ErrHaltHeightReached); ok {
+			if haltErr, ok := r.(types.HaltHeightReachedError); ok {
 				cs.Logger.Info("Halt height reached, shutting down",
 					"height", haltErr.Height)
 				onExit()

--- a/tm2/pkg/bft/consensus/state.go
+++ b/tm2/pkg/bft/consensus/state.go
@@ -608,6 +608,15 @@ func (cs *ConsensusState) receiveRoutine(maxSteps int) {
 
 	defer func() {
 		if r := recover(); r != nil {
+			// Check if this is an intentional halt-height shutdown.
+			if haltErr, ok := r.(types.ErrHaltHeightReached); ok {
+				cs.Logger.Info("Halt height reached, shutting down",
+					"height", haltErr.Height)
+				onExit()
+				osm.Kill()
+				return
+			}
+
 			// Log the panic if it's not due to the remote signer client being closed.
 			if err, ok := r.(error); !ok || !goerrors.Is(err, client.ErrClientAlreadyClosed) {
 				cs.Logger.Error("CONSENSUS FAILURE!!!", "err", r, "stack", string(debug.Stack()))

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -252,7 +252,18 @@ func createAndStartEventStoreService(
 
 func doHandshake(stateDB dbm.DB, state sm.State, blockStore sm.BlockStore,
 	genDoc *types.GenesisDoc, evsw events.EventSwitch, proxyApp appconn.AppConns, consensusLogger *slog.Logger,
-) error {
+) (retErr error) {
+	// Catch halt-height panics from BeginBlock during block replay.
+	defer func() {
+		if r := recover(); r != nil {
+			if haltErr, ok := r.(types.ErrHaltHeightReached); ok {
+				retErr = fmt.Errorf("halt height %d already reached, remove or increase halt_height in config before restarting", haltErr.Height)
+				return
+			}
+			panic(r)
+		}
+	}()
+
 	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc)
 	handshaker.SetLogger(consensusLogger)
 	handshaker.SetEventSwitch(evsw)

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -256,7 +256,7 @@ func doHandshake(stateDB dbm.DB, state sm.State, blockStore sm.BlockStore,
 	// Catch halt-height panics from BeginBlock during block replay.
 	defer func() {
 		if r := recover(); r != nil {
-			if haltErr, ok := r.(types.ErrHaltHeightReached); ok {
+			if haltErr, ok := r.(types.HaltHeightReachedError); ok {
 				retErr = fmt.Errorf("halt height %d already reached, remove or increase halt_height in config before restarting", haltErr.Height)
 				return
 			}

--- a/tm2/pkg/bft/types/errors.go
+++ b/tm2/pkg/bft/types/errors.go
@@ -39,3 +39,13 @@ func NewErrInvalidCommitPrecommits(expected, actual int) InvalidCommitPrecommits
 func (e InvalidCommitPrecommitsError) Error() string {
 	return fmt.Sprintf("Invalid commit -- wrong set size: %v vs %v", e.Expected, e.Actual)
 }
+
+// ErrHaltHeightReached is the panic value used when the configured halt height
+// has been reached and the node should shut down.
+type ErrHaltHeightReached struct {
+	Height uint64
+}
+
+func (e ErrHaltHeightReached) Error() string {
+	return fmt.Sprintf("halt height %d reached, node shutting down", e.Height)
+}

--- a/tm2/pkg/bft/types/errors.go
+++ b/tm2/pkg/bft/types/errors.go
@@ -40,12 +40,12 @@ func (e InvalidCommitPrecommitsError) Error() string {
 	return fmt.Sprintf("Invalid commit -- wrong set size: %v vs %v", e.Expected, e.Actual)
 }
 
-// ErrHaltHeightReached is the panic value used when the configured halt height
+// HaltHeightReachedError is the panic value used when the configured halt height
 // has been reached and the node should shut down.
-type ErrHaltHeightReached struct {
+type HaltHeightReachedError struct {
 	Height uint64
 }
 
-func (e ErrHaltHeightReached) Error() string {
+func (e HaltHeightReachedError) Error() string {
 	return fmt.Sprintf("halt height %d reached, node shutting down", e.Height)
 }

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -532,7 +532,7 @@ func (app *BaseApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseBeg
 	// We halt at the beginning of the block *after* haltHeight,
 	// so the block at haltHeight is fully committed.
 	if app.haltHeight > 0 && uint64(req.Header.GetHeight()) > app.haltHeight {
-		panic(bft.ErrHaltHeightReached{Height: app.haltHeight})
+		panic(bft.HaltHeightReachedError{Height: app.haltHeight})
 	}
 
 	// Initialize the DeliverTx state. If this is the first block, it should

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -532,7 +532,7 @@ func (app *BaseApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseBeg
 	// We halt at the beginning of the block *after* haltHeight,
 	// so the block at haltHeight is fully committed.
 	if app.haltHeight > 0 && uint64(req.Header.GetHeight()) > app.haltHeight {
-		panic(fmt.Sprintf("halt height %d reached, node shutting down", app.haltHeight))
+		panic(bft.ErrHaltHeightReached{Height: app.haltHeight})
 	}
 
 	// Initialize the DeliverTx state. If this is the first block, it should

--- a/tm2/pkg/sdk/baseapp_test.go
+++ b/tm2/pkg/sdk/baseapp_test.go
@@ -1301,7 +1301,7 @@ func TestHaltHeight(t *testing.T) {
 			header := &bft.Header{ChainID: "test-chain", Height: tt.blockHeight}
 			if tt.shouldPanic {
 				require.PanicsWithValue(t,
-					bft.ErrHaltHeightReached{Height: tt.haltHeight},
+					bft.HaltHeightReachedError{Height: tt.haltHeight},
 					func() {
 						app.BeginBlock(abci.RequestBeginBlock{Header: header})
 					},

--- a/tm2/pkg/sdk/baseapp_test.go
+++ b/tm2/pkg/sdk/baseapp_test.go
@@ -1300,9 +1300,12 @@ func TestHaltHeight(t *testing.T) {
 			// Process the target block.
 			header := &bft.Header{ChainID: "test-chain", Height: tt.blockHeight}
 			if tt.shouldPanic {
-				require.Panics(t, func() {
-					app.BeginBlock(abci.RequestBeginBlock{Header: header})
-				})
+				require.PanicsWithValue(t,
+					bft.ErrHaltHeightReached{Height: tt.haltHeight},
+					func() {
+						app.BeginBlock(abci.RequestBeginBlock{Header: header})
+					},
+				)
 			} else {
 				require.NotPanics(t, func() {
 					app.BeginBlock(abci.RequestBeginBlock{Header: header})


### PR DESCRIPTION
## fix(node): ensure halt_height triggers clean process shutdown

### Problem

PR #5334 added `halt_height` for coordinated chain upgrades. The intent was for the node to panic deterministically in `BeginBlock` when the halt height is exceeded, so the process exits and no extra blocks can be processed.

However, the panic is caught by the consensus `receiveRoutine`'s blanket `recover()` handler ([`consensus/state.go:612`](https://github.com/gnolang/gno/blob/3237d120e02775772b17bb4926e0a6992f380cba/tm2/pkg/bft/consensus/state.go#L612-L628)). This handler logs `CONSENSUS FAILURE!!!` and stops the WAL, but does not shut down the node process. The result is a zombie node: consensus was killed but P2P, RPC, and the main goroutine continue running indefinitely.

On **cold restart**, the behavior differs: the panic occurs during `Handshaker.replayBlock` on the main goroutine (no `recover()`), so the process does crash, but with an unrecovered panic and stack trace rather than a clean error message.

### Fix

**Typed error**: Replace the raw `panic(string)` in `BeginBlock` with `panic(types.HaltHeightReachedError{...})`, a new error type defined in `tm2/pkg/bft/types/errors.go` (alongside existing domain errors). This lets both the consensus and node packages distinguish halt-height panics from unexpected failures via direct type assertion on the `recover()` value.

**Warm halt** (consensus running, halt height reached during block production):
- The `receiveRoutine` recovery handler detects `HaltHeightReachedError`.
- Logs `INFO "Halt height reached, shutting down"` (not ERROR — this is expected behavior).
- Calls `osm.Kill()` which sends SIGTERM to the process, triggering the normal graceful shutdown path (`Node.OnStop` cleanup, context cancellation, etc.).
- Process exits with code 0.

**Cold restart** (halt height already exceeded when node starts):
- `doHandshake` in `node.go` catches the `HaltHeightReachedError` panic during block replay and converts it to an error.
- The error propagates normally through `NewNode` → `execStart`, which prints a clear message and exits.
- Process exits with code 1.

### Testing

Tested manually with a single-validator `gnoland start --lazy`:
- Set `halt_height = 3`, started node at height 3
- Node committed block 3, logged `INFO Halt height reached, shutting down`, shut down gracefully, **exit code 0**
- Restarted with same config: printed `halt height 3 already reached, remove or increase halt_height in config before restarting`, **exit code 1**
- Set `halt_height = 0`, restarted: chain resumed from height 5, producing blocks normally
