### PR TITLE
fix(gnovm): allow xtest back-imports at genesis AddPkg

### DIFF
--- a/gno.land/adr/pr5500_xtest_genesis_handling.md
+++ b/gno.land/adr/pr5500_xtest_genesis_handling.md
@@ -1,0 +1,115 @@
+# ADR: Allow xtest back-import at genesis (#4530)
+
+## Context
+
+Issue [gnolang/gno#4530](https://github.com/gnolang/gno/issues/4530) shows two
+failure modes for a perfectly legal xtest topology — a package `importee_test`
+(package name `<importee>_test`, i.e. xtest / blackbox test) that imports
+`importer`, where `importer` in turn imports `importee`. This topology is
+allowed by Go because xtest is a separate compilation unit.
+
+Gno rejects it in two independent places during chain bootstrap:
+
+1. **`gnoland start --lazy`** fails with
+   `sorting packages: cycle detected: gno.land/r/issue/importee`.
+2. **`loadpkg` in txtar / genesis `AddPkg`** fails with
+   `importee_test.gno:7:2: could not import gno.land/r/issue/importer (unknown import path ...)`.
+
+Root causes, verified by code inspection:
+
+- `gnovm/pkg/packages/readpkglist.go` merges imports of all FileKinds
+  (`PackageSource`, `Test`, `XTest`, `Filetest`) into the single
+  `gnomod.Pkg.Imports` list used by `gnomod.PkgList.Sort()`. xtest/filetest
+  edges form legitimate back-dependencies that the DFS cycle-detector mistakes
+  for real cycles. `gno.land/pkg/gnoland/no_cycles_test.go` already documents
+  the correct model (xtest as its own graph node) and uses its own graph
+  builder, so the two paths are inconsistent today.
+
+- `gno.land/pkg/sdk/vm/keeper.go` calls `gno.TypeCheckMemPackage`, which runs
+  STEP 4 xtest and filetest passes unconditionally. At genesis the deploy
+  order is derived from prod imports only, so an xtest import may reference
+  a package not yet in the store and the Check fails with
+  `ImportNotFoundError`.
+
+## Decision
+
+Two surgical, non-consensus-breaking changes:
+
+1. **`gnovm/pkg/packages/readpkglist.go`**: exclude `FileKindXTest` and
+   `FileKindFiletest` from the import-merge used for deploy-order topological
+   sort. `FileKindPackageSource` and `FileKindTest` remain (internal
+   `_test.gno` files share the prod package, so they cannot form back-edges
+   without a Go-level cycle).
+
+2. **`gnovm/pkg/gnolang/gotypecheck.go`**: add a new opt-in
+   `TypeCheckOptions.SkipTestFileTypeCheck` field. When set, the root
+   `typeCheckMemPackage` call uses `wtests = &true`, which executes the prod
+   and prod+internal-test passes but skips the xtest and filetest Check
+   passes. All files are still fully parsed by `GoParseMemPackage`, so syntax
+   errors in test files remain reported.
+
+3. **`gno.land/pkg/sdk/vm/keeper.go`**: set `SkipTestFileTypeCheck = true`
+   **only** at genesis (`ctx.BlockHeight() == 0`). Post-genesis `AddPkg`
+   behavior is byte-identical to today, preserving live-chain replay apphash.
+
+## Alternatives considered
+
+- **Unconditional skip at keeper**: simpler, but flips post-genesis `AddPkg`
+  outcomes from reject→accept for any xtest with missing cross-package
+  imports, causing different state (pkg stored + events emitted) on
+  previously failing txs → different apphash on replay. Rejected.
+
+- **Two-pass genesis (deploy all prod first, then validate test files)**:
+  requires threading through the ABCI init-chainer and re-entering the VM
+  keeper with all packages already deployed. Over-scoped for a targeted fix.
+  Rejected.
+
+- **Break cycles in Sort() by detecting xtest-only back-edges**: replaces
+  a simple DFS with SCC analysis, and makes the sort-time and typecheck-time
+  views of the graph diverge silently. More invasive and less auditable than
+  narrowing the merge. Rejected.
+
+## Consequences
+
+- **Live chains (Betanet etc.)**: no consensus impact. Post-genesis `AddPkg`
+  remains strict; `ReadPkgListFromDir` is never invoked at runtime once
+  `genesis.json` is frozen.
+
+- **New chain genesis (re-generated from `examples/`)**: apphash may differ
+  from a pre-fix bootstrap if (a) an examples package has a xtest back-import
+  that previously tripped the bug (currently none known) or (b) the deploy
+  order differs because xtest/filetest edges were previously skewing the
+  topological sort. This is the intended outcome.
+
+- **Off-chain type-checking (`gno test`, `gno lint`, filetest runner, stdlib
+  init)**: unchanged. None of these callers set
+  `SkipTestFileTypeCheck`; the option defaults to false.
+
+- **Test files on chain**: a realm deployed at genesis can now ship a
+  syntactically-valid but type-incorrect xtest/filetest. Since the chain
+  never executes test files, the only observer is users running `gno test`
+  off-chain against the deployed package, where the error will surface
+  exactly as it does today. Acceptable trade-off.
+
+- **Internal `_test.gno` imports at genesis**: the prod+internal-test pass
+  still runs at genesis (only xtest and filetest are skipped), so an
+  internal test that imports a package not yet deployed will still fail.
+  Intentional: internal tests share the prod compilation unit, so Go rules
+  forbid back-imports anyway, and any cross-package dep of an internal test
+  is typically either a stdlib or already in prod imports. If this becomes
+  a real constraint for a future `examples/` package, the fix is to move
+  the offending imports into an xtest file.
+
+## Verification
+
+- `gno.land/pkg/integration/testdata/issue_4530.txtar` reproduces the issue
+  pre-fix and passes post-fix.
+- `TestVMKeeperAddPackage_XTestBackImport_Genesis` in
+  `gno.land/pkg/sdk/vm/keeper_test.go` pins both branches: reject at
+  Height>0, accept at Height=0.
+- `TestNoCycles` in `gno.land/pkg/gnoland/no_cycles_test.go` continues to
+  guard against genuine cycles.
+- `go test ./gno.land/pkg/integration/ -timeout 20m` passes end-to-end.
+
+Rename this ADR file to `pr<number>_xtest_genesis_handling.md` once the PR
+number is assigned.

--- a/gno.land/pkg/integration/testdata/issue_4530.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4530.txtar
@@ -1,0 +1,50 @@
+# Reproduction for https://github.com/gnolang/gno/issues/4530
+# `importee_test` (xtest) imports a package that itself imports `importee`,
+# which used to be flagged as a circular dependency.
+
+# Load packages from $WORK directory.
+loadpkg gno.land/r/issue/importee $WORK/importee
+loadpkg gno.land/r/issue/importer $WORK/importer
+
+# Start the node
+gnoland start
+stdout 'node started successfully'
+
+-- importer/gnomod.toml --
+module = "gno.land/r/issue/importer"
+gno = "0.9"
+
+-- importer/importer.gno --
+package importer
+
+import (
+	"gno.land/r/issue/importee"
+)
+
+func Function() {
+	importee.Function()
+}
+
+-- importee/gnomod.toml --
+module = "gno.land/r/issue/importee"
+gno = "0.9"
+
+-- importee/importee.gno --
+package importee
+
+func Function() {}
+
+-- importee/importee_test.gno --
+package importee_test
+
+import (
+	"testing"
+
+	"gno.land/r/issue/importee"
+	"gno.land/r/issue/importer"
+)
+
+func TestFunction(_ *testing.T) {
+	importee.Function()
+	importer.Function()
+}

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -554,7 +554,8 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 		Cache:      vm.getTypeCheckCache(ctx),
 	}
 	if ctx.BlockHeight() == 0 {
-		opts.Mode = gno.TCGenesisStrict // genesis time, waive blocking rules for importing draft packages.
+		opts.Mode = gno.TCGenesisStrict   // genesis time, waive blocking rules for importing draft packages.
+		opts.SkipTestFileTypeCheck = true // genesis time, xtest/filetest imports may not be deployed yet.
 	}
 	// Validate Gno syntax and type check.
 	_, err = gno.TypeCheckMemPackage(memPkg, opts)

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -1651,3 +1651,47 @@ func Hello(cur realm) string { return "hello" }`},
 	err := env.vmk.AddPackage(ctx, userMsg)
 	assert.NoError(t, err, "should allow deployment when CLA realm is not deployed (bootstrap)")
 }
+
+// Pins issue #4530: xtest back-import accepted at genesis, rejected post-genesis.
+func TestVMKeeperAddPackage_XTestBackImport_Genesis(t *testing.T) {
+	env := setupTestEnv()
+
+	addr := crypto.AddressFromPreimage([]byte("addr1"))
+	acc := env.acck.NewAccountWithAddress(env.ctx, addr)
+	env.acck.SetAccount(env.ctx, acc)
+	env.bankk.SetCoins(env.ctx, addr, initialBalance)
+
+	const pkgPath = "gno.land/r/test/importee"
+	files := []*std.MemFile{
+		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
+		{Name: "importee.gno", Body: `package importee
+
+func Function() {}`},
+		{Name: "importee_test.gno", Body: `package importee_test
+
+import (
+	"testing"
+
+	"gno.land/r/test/importee"
+	"gno.land/r/test/importer"
+)
+
+func TestFunction(_ *testing.T) {
+	importee.Function()
+	importer.Function()
+}`},
+	}
+	msg := NewMsgAddPackage(addr, pkgPath, files)
+
+	// Post-genesis: reject (consensus preserved).
+	postCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	err := env.vmk.AddPackage(postCtx, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gno.land/r/test/importer")
+
+	// Genesis (Height=0): accept.
+	genesisHeader := &bft.Header{ChainID: "test-chain-id", Height: 0}
+	genesisCtx := env.vmk.MakeGnoTransactionStore(env.ctx.WithBlockHeader(genesisHeader))
+	err = env.vmk.AddPackage(genesisCtx, msg)
+	require.NoError(t, err)
+}

--- a/gnovm/pkg/gnolang/gotypecheck.go
+++ b/gnovm/pkg/gnolang/gotypecheck.go
@@ -165,6 +165,12 @@ type TypeCheckOptions struct {
 	// After TypeCheckMemPackage returns, it contains the file position
 	// information from the parsed package.
 	Fset *token.FileSet
+
+	// SkipTestFileTypeCheck, when enabled, skips the xtest and filetest type
+	// check passes. Syntax is still validated via GoParseMemPackage. Intended
+	// for callers where xtest imports may reference packages not yet
+	// available to the importer (e.g. on-chain AddPkg at genesis).
+	SkipTestFileTypeCheck bool
 }
 
 // TypeCheckMemPackage performs type validation and checking on the given
@@ -198,7 +204,12 @@ func TypeCheckMemPackage(mpkg *std.MemPackage, opts TypeCheckOptions) (
 	}
 	gimp.cfg.Importer = gimp
 
-	pkg, errs = gimp.typeCheckMemPackage(mpkg, nil)
+	var wtests *bool
+	if opts.SkipTestFileTypeCheck {
+		t := true
+		wtests = &t
+	}
+	pkg, errs = gimp.typeCheckMemPackage(mpkg, wtests)
 	return
 }
 

--- a/gnovm/pkg/packages/readpkglist.go
+++ b/gnovm/pkg/packages/readpkglist.go
@@ -59,11 +59,12 @@ func ReadPkgListFromDir(dir string, mptype gnolang.MemPackageType) (gnomod.PkgLi
 				// ignore imports on error
 				importsMap = nil
 			}
+
+			// exclude xtest/filetest(Issue #4530): their back-imports are legal in Go and
+			// would be flagged as false cycles by the topological sort
 			importsRaw := importsMap.Merge(
-				FileKindFiletest,
 				FileKindPackageSource,
 				FileKindTest,
-				FileKindXTest,
 			)
 
 			imports := make([]string, 0, len(importsRaw))


### PR DESCRIPTION
## Description

Fixes #4530

## Problem

Two independent issues cause incorrect dependency handling during package loading and genesis:

1. **Invalid dependency graph for topo-sort**

   `gnovm/pkg/packages/readpkglist.go` merges imports from all file kinds (`PackageSource`, `Test`, `XTest`, `Filetest`) before passing them to `gnomod.PkgList.Sort()`.

   However, `xtest` and `filetest` are compiled as separate units. Including them introduces artificial back-edges, which incorrectly trigger DFS cycle detection.

2. **Premature type-checking of test imports at genesis**

   `gno.land/pkg/sdk/vm/keeper.go` calls `TypeCheckMemPackage` on every `AddPkg`, which always includes `xtest` and `filetest`.

   Genesis deployment does not guarantee that test-only cross-package imports are available in the store before their referrer is deployed (deploy order is driven by production imports, and some paths — e.g. txtar `loadpkg` — bypass ordering entirely). As a result, test-only imports may reference packages not yet in the store, leading to `ImportNotFoundError`.

---

## Changes

* **Dependency graph fix**

  * `readpkglist.go`: exclude `FileKindXTest` and `FileKindFiletest` from topo-sort inputs.

* **Selective test type-checking**

  * `gotypecheck.go`: introduce `TypeCheckOptions.SkipTestFileTypeCheck`.

    * Skips `xtest` and `filetest` type-check passes (syntax parsing remains).

* **Genesis-specific behavior**

  * `keeper.go`: enable `SkipTestFileTypeCheck` only when `ctx.BlockHeight() == 0`.

* **Tests & validation**

  * `keeper_test.go`: add `TestVMKeeperAddPackage_XTestBackImport_Genesis`

    * verifies:

      * reject at height > 0
      * accept at height == 0
  * `testdata/issue_4530.txtar`: end-to-end reproduction

* **Documentation**

  * `gno.land/adr/pr5500_xtest_genesis_handling.md`: ADR

---

## Consensus Safety

`TypeCheckMemPackage` behavior changes **only when `SkipTestFileTypeCheck` is explicitly enabled**, and the **only caller** that enables this flag is the VM keeper during genesis (`BlockHeight == 0`). All other paths (`gno lint`, filetest runner, stdlib init, unit tests) remain unchanged, so post-genesis `AddPkg` is **byte-identical** and there is no impact on **app hash determinism or chain replay**.

The `readpkglist.go` change is similarly narrow: its output feeds only `PkgList.Sort()` for genesis ordering, and `ReadPkgListFromDir` is **not used at runtime** after `genesis.json` is finalized. Together this means **no impact on existing chains, including Betanet**.

---

## Alternatives Considered

The simpler option — enabling `SkipTestFileTypeCheck` unconditionally in the keeper — was rejected because it would flip post-genesis `AddPkg` outcomes for xtest back-imports from reject to accept, which changes state on previously failing transactions (a successful `AddPkg` writes a package and emits events, a failed one does not) and therefore diverges app hashes on replay. The `BlockHeight == 0` gate keeps the fix consensus-safe.

A two-pass genesis scheme (deploy all prod first, validate tests after) was considered but rejected as over-scoped: it would require threading state through the ABCI init-chainer and re-entering the VM keeper. SCC analysis in `PkgList.Sort()` to break xtest-only back-edges was also rejected because it makes the sort-time and type-check-time views of the dependency graph diverge silently, which is strictly more invasive than narrowing the merge list.

---

## Trade-offs

Two consequences are accepted and documented in the ADR.

First, a realm deployed at genesis can now ship an xtest or filetest with type errors. The chain never executes test files, so `gno test` off-chain surfaces the error exactly as it does today.

Second, the prod+internal-test pass still runs at genesis — only the xtest and filetest passes are skipped. An internal `_test.gno` file that imports a package not yet deployed will still fail. This is intentional: internal tests share the prod compilation unit, so Go rules forbid back-imports, and any cross-package dep of an internal test is typically either a stdlib import or already in prod imports. If a future `examples/` package genuinely hits this constraint, the fix is to move the offending imports into an xtest file.

---

## Behavior Change

On newly bootstrapped chains only:

* Deployment order may change for packages previously affected by `xtest/filetest` imports
* Valid dependency graphs that were previously rejected may now be accepted
