### PR TITLE
docs: fix stale references, broken links, and minor inconsistencies

### DIFF
--- a/docs/builders/deploy-packages.md
+++ b/docs/builders/deploy-packages.md
@@ -107,14 +107,14 @@ TX HASH:    11fWJtYXQlyFcHY12HU1ECYs2GPo/e2z/Fdw6I8rwNs=
 
 ## Understanding Deployment Parameters
 
-- `--pkgpath` - The on-chain path where your code will be stored
-- `--pkgdir` - The local directory containing your code
-- `--send` - Amount of GNOT to send to the realm with the transaction (optional)
-- `--max-deposit` - Maximum GNOT to lock for on-chain storage (optional)
-- `--gas-fee` - The fee per unit of gas (typically 1 GNOT)
-- `--gas-wanted` - Maximum gas units for the transaction
-- `--remote` - The RPC endpoint for the network
-- `--chainid` - The ID of the blockchain network
+- `-pkgpath` - The on-chain path where your code will be stored
+- `-pkgdir` - The local directory containing your code
+- `-send` - Amount of GNOT to send to the realm with the transaction (optional)
+- `-max-deposit` - Maximum GNOT to lock for on-chain storage (optional)
+- `-gas-fee` - The fee per unit of gas (typically 1 GNOT)
+- `-gas-wanted` - Maximum gas units for the transaction
+- `-remote` - The RPC endpoint for the network
+- `-chainid` - The ID of the blockchain network
 
 For more details on gas fees and optimization strategies, see the [Gas Fees
 documentation](../resources/gas-fees.md).

--- a/docs/resources/gno-packages.md
+++ b/docs/resources/gno-packages.md
@@ -76,7 +76,7 @@ The components of these paths are:
 
 Two important facts about package paths:
 - The maximum length of a package path is `256` characters.
-- A realm's address is directly derived from its package path, by using [`chain.PackageAddress()`](./gno-stdlibs.md#derivepkgaddr)
+- A realm's address is directly derived from its package path, by using [`chain.PackageAddress()`](./gno-stdlibs.md#packageaddress)
 
 ## Namespaces
 

--- a/docs/resources/gno-testing.md
+++ b/docs/resources/gno-testing.md
@@ -30,8 +30,8 @@ gno mod init gno.land/r/<namespace>/counter
 Replace `<namespace>` with your username. In this example, we’ll use `example`.
 This command creates a file with the following content:
 
-```
-module gno.land/r/example/counter
+```toml
+module = "gno.land/r/example/counter"
 ```
 
 Then, in the same directory, create two files- `counter.gno` & `counter_test.gno`:

--- a/docs/resources/gnoland-networks.md
+++ b/docs/resources/gnoland-networks.md
@@ -151,7 +151,7 @@ These testnets are deprecated and currently serve as archives of previous progre
 
 ### Test10 (archive)
 
-Test9 is the testnet released on the 18th of December, 2025.
+Test10 is the testnet released on the 18th of December, 2025.
 
 ### Test9 (archive)
 

--- a/docs/users/discover-gnoland.md
+++ b/docs/users/discover-gnoland.md
@@ -25,9 +25,9 @@ you'll need a wallet:
 
 ### Useful Resources
 
-- [Staging network](https://staging.gno.land) - The main chain for exploring Gno.land
+- [Staging network](https://staging.gno.land) - A rolling development testnet running the latest code from master
 - [Faucet Hub](https://faucet.gno.land) - Get testnet tokens for experimenting
-- [Awesome Gno](https://github.com/gnolang/awesome-gno) - A curated list of tools, tutorials, and projects
+- [Awesome Gno](https://github.com/gnoverse/awesome-gno) - A curated list of tools, tutorials, and projects
 
 ## The Gno.land Ecosystem
 

--- a/docs/users/explore-with-gnoweb.md
+++ b/docs/users/explore-with-gnoweb.md
@@ -42,7 +42,7 @@ Let's break it down:
 
 ## Viewing Rendered Content
 
-Realms can implement a special `Render()` function that returns HTML-like content:
+Realms can implement a special `Render()` function that returns Markdown content:
 
 `gnoweb` is a minimalistic web server that serves as a unified frontend for all
 realms in Gno.land. It uses ABCI queries to get the latest state of a specific

--- a/docs/users/third-party-wallets.md
+++ b/docs/users/third-party-wallets.md
@@ -6,7 +6,7 @@ available third-party wallets that support Gno.land networks.
 
 ## GnoConnect Integration
 
-Gno.land uses GnoConnect, a protocol that allows external wallets to integrate
+Gno.land uses [GnoConnect](../resources/gnoconnect.md), a protocol that allows external wallets to integrate
 with gno-powered blockchains. This provides a standardized way for wallets to:
 
 - Connect to Gno.land networks


### PR DESCRIPTION
- Fix Test10 description copy-paste error (said "Test9")
- Fix Staging network described as "main chain" (it's a dev testnet)
- Fix Render() described as returning "HTML-like content" (it returns Markdown)
- Fix broken anchor link to PackageAddress in gno-packages.md
- Normalize flag prefixes to single dash in deploy-packages.md
- Standardize awesome-gno URL to gnoverse/awesome-gno (canonical after transfer)
- Add GnoConnect link in third-party-wallets.md
- Fix gnomod.toml example syntax in gno-testing.md (TOML requires `=` and quotes)