### PR TITLE
docs: Fix 2 errors on IsEphemeral and realm sequence

### DIFF
--- a/docs/resources/gno-stdlibs.md
+++ b/docs/resources/gno-stdlibs.md
@@ -301,13 +301,12 @@ if r.IsUserCall() {...}
 
 ### IsEphemeral
 
-Checks if the receiver realm is a user realm, given by a `MsgCall` transaction.
+Checks if the receiver realm is an ephemeral realm.
 
 ##### Usage
 ```go
 if r.IsUserCall() {...}
 ```
-
 ---
 
 ### CoinDenom

--- a/docs/resources/gno-stdlibs.md
+++ b/docs/resources/gno-stdlibs.md
@@ -305,7 +305,7 @@ Checks if the receiver realm is an ephemeral realm.
 
 ##### Usage
 ```go
-if r.IsUserCall() {...}
+if r.IsEphemeral() {...}
 ```
 ---
 

--- a/docs/resources/realms.md
+++ b/docs/resources/realms.md
@@ -150,7 +150,7 @@ Realm B:
 │         EOA         │   │       Realm A        │   │       Realm B       │
 │                     │   │                      │   │                     │
 │  addr:              │   │  addr:               │   │  addr:              │
-│  g1jg...sqf5        ├───►  g17m...8v2s         ├───►  g1rs...cm3v        │
+│  g1jg...sqf5        ├───►  g1dv...u2c6         ├───►  g1rs...cm3v        │
 │                     │   │                      │   │                     │
 │  pkgPath:           │   │  pkgPath:            │   │  pkgPath:           │
 │  ""                 │   │  gno.land/r/demo/a   │   │  gno.land/r/demo/b  │


### PR DESCRIPTION
Realm sequence addresses where not consistent in the examples
`IsEphemeral`'s documentation was the same as `IsUserCall`