### PR TITLE
fix(gnoweb): apply IsDangerousURL to angle-bracket autolinks

### DIFF
--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -87,34 +87,58 @@ func (*GnoLink) Kind() ast.NodeKind {
 // linkTransformer implements ASTTransformer
 type linkTransformer struct{}
 
-// Transform replaces ast.Link nodes with GnoLink nodes in two passes.
+// Transform replaces ast.Link and ast.AutoLink nodes with GnoLink nodes.
 func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
 	orig, ok := getUrlFromContext(pc)
 	if !ok {
 		return
 	}
 
-	// Traverse through the document and transform link nodes to GnoLink nodes.
+	source := reader.Source()
+
 	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
 
-		link, ok := node.(*ast.Link)
-		if !ok {
+		var (
+			gnoLink *GnoLink
+			rawDest []byte
+		)
+
+		switch n := node.(type) {
+		case *ast.Link:
+			// Wrap the existing link node directly.
+			gnoLink = &GnoLink{Link: n}
+			rawDest = n.Destination
+
+		case *ast.AutoLink:
+			// Build a synthetic ast.Link so the existing renderGnoLink handles
+			// IsDangerousURL, rel attributes, and icons for autolinks too.
+			rawURL := n.URL(source)
+			if n.AutoLinkType == ast.AutoLinkEmail {
+				rawDest = append([]byte("mailto:"), rawURL...)
+			} else {
+				rawDest = rawURL
+			}
+			link := ast.NewLink()
+			link.Destination = rawDest
+			labelNode := ast.NewString(n.Label(source))
+			labelNode.SetRaw(true)
+			link.AppendChild(link, labelNode)
+			gnoLink = &GnoLink{Link: link}
+
+		default:
 			return ast.WalkContinue, nil
 		}
 
-		// Create a new GnoLink node wrapping the original link.
-		gnoLink := &GnoLink{Link: link}
-
-		// Replace the original link with the GnoLink wrapper.
+		// Replace the original node with the GnoLink wrapper.
 		parent, next := node.Parent(), node.NextSibling()
 		parent.RemoveChild(parent, node)
 		parent.InsertBefore(parent, next, gnoLink)
 
 		// Parse destination URL and check for validity.
-		dest, err := url.Parse(string(link.Destination))
+		dest, err := url.Parse(string(rawDest))
 		if err != nil {
 			gnoLink.LinkType = GnoLinkTypeInvalid
 			return ast.WalkContinue, nil

--- a/gno.land/pkg/gnoweb/markdown/ext_links.go
+++ b/gno.land/pkg/gnoweb/markdown/ext_links.go
@@ -94,8 +94,6 @@ func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc pa
 		return
 	}
 
-	source := reader.Source()
-
 	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -115,6 +113,7 @@ func (t *linkTransformer) Transform(doc *ast.Document, reader text.Reader, pc pa
 		case *ast.AutoLink:
 			// Build a synthetic ast.Link so the existing renderGnoLink handles
 			// IsDangerousURL, rel attributes, and icons for autolinks too.
+			source := reader.Source()
 			rawURL := n.URL(source)
 			if n.AutoLinkType == ast.AutoLinkEmail {
 				rawDest = append([]byte("mailto:"), rawURL...)

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/autolink.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/autolink.md.txtar
@@ -5,10 +5,16 @@
 
 <javascript:alert(1)>
 
+<vbscript:alert(1)>
+
+<file:///etc/passwd>
+
 <data:text/html,%3Cb%3Ehi%3C/b%3E>
 
 -- output.html --
 <p><a href="https://example.com" rel="noopener nofollow ugc">https://example.com<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
 <p><a href="mailto:user@example.com" rel="noopener nofollow ugc">user@example.com<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
 <p><a href="" rel="noopener nofollow ugc">javascript:alert(1)<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
+<p><a href="" rel="noopener nofollow ugc">vbscript:alert(1)<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
+<p><a href="">file:///etc/passwd<span class="link-internal tooltip" data-tooltip-target="info" data-tooltip="Cross package link" title="Cross package link"><svg class="c-icon"><use href="#ico-internal-link"></use></svg></span></a></p>
 <p><a href="" rel="noopener nofollow ugc">data:text/html,%3Cb%3Ehi%3C/b%3E<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>

--- a/gno.land/pkg/gnoweb/markdown/golden/ext_link/autolink.md.txtar
+++ b/gno.land/pkg/gnoweb/markdown/golden/ext_link/autolink.md.txtar
@@ -1,0 +1,14 @@
+-- input.md --
+<https://example.com>
+
+<user@example.com>
+
+<javascript:alert(1)>
+
+<data:text/html,%3Cb%3Ehi%3C/b%3E>
+
+-- output.html --
+<p><a href="https://example.com" rel="noopener nofollow ugc">https://example.com<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
+<p><a href="mailto:user@example.com" rel="noopener nofollow ugc">user@example.com<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
+<p><a href="" rel="noopener nofollow ugc">javascript:alert(1)<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>
+<p><a href="" rel="noopener nofollow ugc">data:text/html,%3Cb%3Ehi%3C/b%3E<span class="link-external tooltip" data-tooltip-target="info" data-tooltip="External link" title="External link"><svg class="c-icon"><use href="#ico-external-link"></use></svg></span></a></p>


### PR DESCRIPTION
Goldmark's default autolink renderer only applies URLEscape+EscapeHTML
to <scheme:payload> autolinks, preserving javascript:, vbscript:, and
data: schemes. The existing linkTransformer only walked *ast.Link nodes,
so *ast.AutoLink nodes bypassed IsDangerousURL entirely.

Extend linkTransformer.Transform to also handle *ast.AutoLink nodes:
build a synthetic ast.Link (email autolinks get a mailto: prefix) with
an ast.NewString label child, then wrap it in a GnoLink exactly like a
regular link. renderGnoLink already calls IsDangerousURL before writing
the href, so dangerous schemes now produce href="" for both link forms.
Safe autolinks also gain rel="noopener nofollow ugc" and the external
link icon, matching the treatment of regular [text](url) links.

Adds a golden test covering https:, email, javascript:, and data: autolinks.

