### PR TITLE
chore(gno): fix `gno test` to update golden filetests in place

### DIFF
--- a/gnovm/cmd/gno/testdata/test/error_sync.txtar
+++ b/gnovm/cmd/gno/testdata/test/error_sync.txtar
@@ -8,9 +8,9 @@ gno test -update-golden-tests -v .
 ! stdout .+
 stderr '=== RUN   ./x_filetest.gno'
 
-cmp x_filetest.gno x_filetest.gno.golden
+cmp filetests/x_filetest.gno x_filetest.gno.golden
 
--- x_filetest.gno --
+-- filetests/x_filetest.gno --
 package main
 
 func main() {

--- a/gnovm/cmd/gno/testdata/test/output_sync.txtar
+++ b/gnovm/cmd/gno/testdata/test/output_sync.txtar
@@ -9,9 +9,9 @@ stderr '=== RUN   ./x_filetest.gno'
 stderr '--- PASS: ./x_filetest.gno \(elapsed: \d+\.\d\ds, gas: \d+\)'
 stderr 'ok      \. 	\d+\.\d\ds'
 
-cmp x_filetest.gno x_filetest.gno.golden
+cmp filetests/x_filetest.gno x_filetest.gno.golden
 
--- x_filetest.gno --
+-- filetests/x_filetest.gno --
 package main
 
 func main() {

--- a/gnovm/cmd/gno/testdata/test/realm_sync.txtar
+++ b/gnovm/cmd/gno/testdata/test/realm_sync.txtar
@@ -7,9 +7,9 @@ stderr '=== RUN   ./x_filetest.gno'
 stderr '--- PASS: ./x_filetest.gno \(elapsed: \d+\.\d\ds, gas: \d+\)'
 stderr 'ok      \. 	\d+\.\d\ds'
 
-cmp x_filetest.gno x_filetest.gno.golden
+cmp filetests/x_filetest.gno x_filetest.gno.golden
 
--- x_filetest.gno --
+-- filetests/x_filetest.gno --
 // PKGPATH: gno.land/r/xx
 package xx
 

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -305,7 +305,7 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 		filter := splitRegexp(opts.RunFlag)
 		for _, testFile := range ftfiles {
 			testFileName := testFile.Name
-			testFilePath := filepath.Join(fsDir, testFileName)
+			testFilePath := filepath.Join(fsDir, "filetests", testFileName)
 			// XXX consider this
 			testName := fsDir + "/" + testFileName
 			// testName := "file/" + testFileName


### PR DESCRIPTION
Fixes an issue where `-update-golden-tests=true` duplicates filetest in the package root, and the right behavior is to update them in place, inside the "filetests/" dir.