### PR TITLE
fix: gno.land: validator set changes should be validated at tx level

### DIFF
--- a/misc/deployments/gnoland1/govdao-scripts/rm-validator.sh
+++ b/misc/deployments/gnoland1/govdao-scripts/rm-validator.sh
@@ -28,6 +28,11 @@ fi
 
 ADDR="$1"
 
+if [[ ! "$ADDR" =~ ^g1[a-z0-9]{38}$ ]]; then
+  echo "Error: invalid address '${ADDR}' — must be a full, scoped bech32 address (g1...)"
+  exit 1
+fi
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 


### PR DESCRIPTION
## Summary

gno.land: validator set changes should be validated at tx level — modified `misc/deployments/gnoland1/govdao-scripts/rm-validator.sh`.

Fixes #5488

## Changes

- misc/deployments/gnoland1/govdao-scripts/rm-validator.sh (+5 lines, 45 modified)

## Rationale

Applied fix for gno.land: validator set changes should be validated at tx level in `rm-validator.sh`, where the affected behavior originates.
