### PR TITLE
Security: Path traversal in root resolver can escape configured root directory

### DIFF
--- a/contribs/gnodev/pkg/packages/resolver_root.go
+++ b/contribs/gnodev/pkg/packages/resolver_root.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type rootResolver struct {
@@ -25,8 +26,18 @@ func (r *rootResolver) Name() string {
 }
 
 func (r *rootResolver) Resolve(fset *token.FileSet, path string) (*Package, error) {
-	dir := filepath.Join(r.root, path)
-	_, err := os.Stat(dir)
+	clean := filepath.Clean(path)
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return nil, ErrResolverPackageNotFound
+	}
+
+	dir := filepath.Join(r.root, clean)
+	rel, err := filepath.Rel(r.root, dir)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, ErrResolverPackageNotFound
+	}
+
+	_, err = os.Stat(dir)
 	if err != nil {
 		return nil, ErrResolverPackageNotFound
 	}


### PR DESCRIPTION
## Summary

Security: Path traversal in root resolver can escape configured root directory

## Problem

**Severity**: `High` | **File**: `contribs/gnodev/pkg/packages/resolver_root.go:L27`

`Resolve` joins `r.root` with user-supplied `path` without validating traversal segments. Inputs like `../../...` can resolve outside the intended root, potentially allowing unauthorized filesystem reads when package paths are attacker-controlled.

## Solution

Clean and validate input paths before joining (e.g., `clean := filepath.Clean(path)`), reject absolute paths and any that begin with `..`, then verify final resolved path remains under `r.root` using `filepath.Rel` boundary checks.

## Changes

- `contribs/gnodev/pkg/packages/resolver_root.go` (modified)