### PR TITLE
chore(ci): Introducing self-hosted runners leveraging persistent BuildKit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,11 @@ docs/
 .github/
 *.md
 
+# Excluded to make Docker build cache stable across CI checkouts.
+.git
+.gitignore
+.gitattributes
+
 # Copied from .gitignore
 
 # Editor Leftovers

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,11 @@ docs/
 .github/
 *.md
 
+# Excluded to make Docker build cache stable across CI checkouts.
+.git
+.gitignore
+.gitattributes
+
 # Copied from .gitignore
 
 # Editor Leftovers

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
-    - benchmarks
+    - gnolang-self-runner-large
+    - gnolang-self-runner-xlarge

--- a/.github/workflows/release-bench-history.yml
+++ b/.github/workflows/release-bench-history.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   benchmarks:
     if: ${{ github.repository == 'gnolang/gno' }}
-    runs-on: [ self-hosted, Linux, X64, benchmarks ]
+    runs-on: gnolang-self-runner-xlarge
     permissions:
       deployments: write # to deploy GitHub pages website
       contents: write # to update benchmark data in gh-benchmarks branch
@@ -60,7 +60,7 @@ jobs:
           alert-threshold: "120%"
           fail-on-alert: false
           comment-on-alert: true
-          alert-comment-cc-users: "@ajnavarro,@thehowl,@zivkovicmilos"
+          alert-comment-cc-users: "@ajnavarro,@thehowl"
           # Enable Job Summary for PRs
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -81,7 +81,7 @@ jobs:
         env:
           BUILD_VERSION: ${{ steps.build_version.outputs.version }}
         with:
-          source: .
+          source: . # use checked-out code, not git URL at GITHUB_SHA
           files: |
             misc/deployments/bake/docker-bake.hcl
             cwd://${{ steps.meta.outputs.bake-file-tags }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   bake:
+    runs-on: gnolang-self-runner-xlarge
     strategy:
       matrix:
         image: [gnoland,gnokey,gnoweb,gno,gnofaucet,gnodev,gnocontribs]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write # kept in case type=gha is re-enabled; not required by type=registry
@@ -49,6 +49,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        # remove this if GH runner is used
+        with:
+          driver: remote
+          endpoint: tcp://buildkit:1234
 
       - name: Resolve image tag
         id: resolve_tag

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -24,13 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write # for GHA cache (docker buildx cache-to/from=type=gha)
+      actions: write # kept in case type=gha is re-enabled; not required by type=registry
       packages: write # to push images to ghcr.io
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Compute build version
+        id: build_version
+        run: |
+          V=$(git describe --tags --exact-match 2>/dev/null \
+              || echo "$(git rev-parse --abbrev-ref HEAD).$(git rev-list --count HEAD)+$(git rev-parse --short HEAD)")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -70,15 +78,21 @@ jobs:
 
       - name: Bake build and push
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
+        env:
+          BUILD_VERSION: ${{ steps.build_version.outputs.version }}
         with:
-          source: . # use checked-out code, not git URL at GITHUB_SHA
+          source: .
           files: |
             misc/deployments/bake/docker-bake.hcl
             cwd://${{ steps.meta.outputs.bake-file-tags }}
             cwd://${{ steps.meta.outputs.bake-file-labels }}
           push: true
           targets: ${{ matrix.image }}
+          # type=registry is used instead of type=gha because GHA cache blob
+          # entries are global (not scoped). When matrix jobs export concurrently,
+          # they race on the shared blob namespace, corrupting each other's cache.
+          # type=registry gives each image a fully independent OCI cache manifest.
           set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}/cache:${{ matrix.image }}
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}/cache:${{ matrix.image }},mode=max
             *.context=.

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -24,13 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write # for GHA cache (docker buildx cache-to/from=type=gha)
+      actions: write # kept in case type=gha is re-enabled; not required by type=registry
       packages: write # to push images to ghcr.io
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Compute build version
+        id: build_version
+        run: |
+          V=$(git describe --tags --exact-match 2>/dev/null \
+              || echo "$(git rev-parse --abbrev-ref HEAD).$(git rev-list --count HEAD)+$(git rev-parse --short HEAD)")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -70,15 +78,21 @@ jobs:
 
       - name: Bake build and push
         uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+        env:
+          BUILD_VERSION: ${{ steps.build_version.outputs.version }}
         with:
-          source: . # use checked-out code, not git URL at GITHUB_SHA
+          source: .
           files: |
             misc/deployments/bake/docker-bake.hcl
             cwd://${{ steps.meta.outputs.bake-file-tags }}
             cwd://${{ steps.meta.outputs.bake-file-labels }}
           push: true
           targets: ${{ matrix.image }}
+          # type=registry is used instead of type=gha because GHA cache blob
+          # entries are global (not scoped). When matrix jobs export concurrently,
+          # they race on the shared blob namespace, corrupting each other's cache.
+          # type=registry gives each image a fully independent OCI cache manifest.
           set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}/cache:${{ matrix.image }}
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}/cache:${{ matrix.image }},mode=max
             *.context=.

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   bake:
+    runs-on: gnolang-self-runner-xlarge
     strategy:
       matrix:
         image: [gnoland,gnokey,gnoweb,gno,gnofaucet,gnodev,gnocontribs]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write # kept in case type=gha is re-enabled; not required by type=registry
@@ -48,7 +48,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        # remove this if GH runner is used
+        with:
+          driver: remote
+          endpoint: tcp://buildkit:1234
 
       - name: Resolve image tag
         id: resolve_tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,65 +3,70 @@ FROM        golang:1.24-alpine AS setup-gnocore
 ENV         GNOROOT="/gnoroot"
 ENV         CGO_ENABLED=0 GOOS=linux
 WORKDIR     /gnoroot
+# git is kept for `go mod download` fallback when a module isn't served via the Go proxy
 RUN         apk add --no-cache git
-RUN         go env -w GOMODCACHE=/root/.cache/go-build
 # Mod files
 COPY        go.mod go.sum ./
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
             --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
             go mod download -x
 COPY        . ./
-# Compute build version from git and write to a file for use in build stages
-RUN         { git describe --tags --exact-match 2>/dev/null \
-            || echo "$(git rev-parse --abbrev-ref HEAD).$(git rev-list --count HEAD)+$(git rev-parse --short HEAD)"; \
-            } > /gnoroot/build_version
+# BUILD_VERSION referes to the current git build version use in build stages
+# it is declared late so that a version change (new tag / commit)
+# only invalidates this layer and below excluding expensive layers above.
+ARG         BUILD_VERSION=dev
+RUN         echo "${BUILD_VERSION}" > /gnoroot/build_version
 
 # build gnocore
 FROM        setup-gnocore AS build-gnocore
+ARG         TARGETPLATFORM
 # Gnoland
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnoland ./gno.land/cmd/gnoland
 # Gnokey
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnokey ./gno.land/cmd/gnokey
 # Gnoweb
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnoweb ./gno.land/cmd/gnoweb
 # Gno
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gno ./gnovm/cmd/gno
 
 # Gnofaucet build
 FROM        setup-gnocore AS build-gnofaucet
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnofaucet
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=faucet-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=faucet-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=faucet \
-            --mount=type=cache,target=/root/.cache/go-build,id=faucet-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnofaucet .
 
 # Gnodev build
 FROM        setup-gnocore AS build-gnodev
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnodev
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnodev-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnodev-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnodev-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnodev-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build \
             -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
             -o /gnoroot/build/gnodev .
 
 # Gnobro build
 FROM        setup-gnocore AS build-gnobro
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnobro
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnobro-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnobro-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build \
             -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
             -o /gnoroot/build/gnobro .
@@ -69,31 +74,33 @@ RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnobro-modcache \
 # Gnocontribs
 ## Gnogenesis
 FROM        setup-gnocore AS build-contribs
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnogenesis
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=contribs_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=contribs_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=contribs_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=contribs_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnogenesis .
 ## GnoKMS
 WORKDIR     /gnoroot/contribs/gnokms
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=kms_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=kms_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=kms_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=kms_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnokms .
 
 # Misc build
 FROM        setup-gnocore AS build-misc
+ARG         TARGETPLATFORM
 ## Staging
 WORKDIR     /gnoroot/misc/loop
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=pl-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=pl-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=pl-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=pl-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/portalloopd ./cmd
 
 # Base image
@@ -139,7 +146,7 @@ ENTRYPOINT  ["/usr/bin/gnofaucet"]
 # Gnodev image
 ## ghcr.io/gnolang/gno/gnodev
 FROM        base AS gnodev
-COPY        --from=build-gnodev /gnoroot/build/gnodev                       /usr/bin/gnodev
+COPY        --from=build-gnodev  /gnoroot/build/gnodev                          /usr/bin/gnodev
 COPY        --from=build-gnocore /gnoroot/examples                              /gnoroot/examples
 COPY        --from=build-gnocore /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gnocore /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
@@ -160,12 +167,12 @@ ENTRYPOINT  ["/usr/bin/gno"]
 # Gno Contribs [ Gnobro, Gnogenesis, GnoKMS ]
 ## ghcr.io/gnolang/gnocontribs
 FROM        base AS gnocontribs
-COPY        --from=build-gnobro /gnoroot/build/gnobro                           /usr/bin/gnobro
+COPY        --from=build-gnobro   /gnoroot/build/gnobro                           /usr/bin/gnobro
 COPY        --from=build-contribs /gnoroot/build/gnogenesis                     /usr/bin/gnogenesis
-COPY        --from=build-contribs /gnoroot/build/gnokms                          /usr/bin/gnokms
-COPY        --from=build-gnocore /gnoroot/examples                              /gnoroot/examples
-COPY        --from=build-gnocore /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
-COPY        --from=build-gnocore /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
+COPY        --from=build-contribs /gnoroot/build/gnokms                         /usr/bin/gnokms
+COPY        --from=build-gnocore  /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gnocore  /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
+COPY        --from=build-gnocore  /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE     22
 ENTRYPOINT [ "/bin/sh", "-c" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,65 +3,70 @@ FROM        golang:1.25-alpine AS setup-gnocore
 ENV         GNOROOT="/gnoroot"
 ENV         CGO_ENABLED=0 GOOS=linux
 WORKDIR     /gnoroot
+# git is kept for `go mod download` fallback when a module isn't served via the Go proxy
 RUN         apk add --no-cache git
-RUN         go env -w GOMODCACHE=/root/.cache/go-build
 # Mod files
 COPY        go.mod go.sum ./
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
             --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
             go mod download -x
 COPY        . ./
-# Compute build version from git and write to a file for use in build stages
-RUN         { git describe --tags --exact-match 2>/dev/null \
-            || echo "$(git rev-parse --abbrev-ref HEAD).$(git rev-list --count HEAD)+$(git rev-parse --short HEAD)"; \
-            } > /gnoroot/build_version
+# BUILD_VERSION referes to the current git build version use in build stages
+# it is declared late so that a version change (new tag / commit)
+# only invalidates this layer and below excluding expensive layers above.
+ARG         BUILD_VERSION=dev
+RUN         echo "${BUILD_VERSION}" > /gnoroot/build_version
 
 # build gnocore
 FROM        setup-gnocore AS build-gnocore
+ARG         TARGETPLATFORM
 # Gnoland
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnoland ./gno.land/cmd/gnoland
 # Gnokey
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnokey ./gno.land/cmd/gnokey
 # Gnoweb
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gnoweb ./gno.land/cmd/gnoweb
 # Gno
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gomodcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o ./build/gno ./gnovm/cmd/gno
 
 # Gnofaucet build
 FROM        setup-gnocore AS build-gnofaucet
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnofaucet
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=faucet-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=faucet-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=faucet \
-            --mount=type=cache,target=/root/.cache/go-build,id=faucet-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnofaucet .
 
 # Gnodev build
 FROM        setup-gnocore AS build-gnodev
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnodev
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnodev-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnodev-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnodev-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnodev-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build \
             -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
             -o /gnoroot/build/gnodev .
 
 # Gnobro build
 FROM        setup-gnocore AS build-gnobro
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnobro
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnobro-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=gnobro-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build \
             -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
             -o /gnoroot/build/gnobro .
@@ -69,31 +74,33 @@ RUN         --mount=type=cache,target=/go/pkg/mod/,id=gnobro-modcache \
 # Gnocontribs
 ## Gnogenesis
 FROM        setup-gnocore AS build-contribs
+ARG         TARGETPLATFORM
 WORKDIR     /gnoroot/contribs/gnogenesis
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=contribs_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=contribs_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=contribs_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=contribs_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnogenesis .
 ## GnoKMS
 WORKDIR     /gnoroot/contribs/gnokms
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=kms_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=kms_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=kms_modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=kms_buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/gnokms .
 
 # Misc build
 FROM        setup-gnocore AS build-misc
+ARG         TARGETPLATFORM
 ## Staging
 WORKDIR     /gnoroot/misc/loop
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=pl-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=pl-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go mod download -x
-RUN         --mount=type=cache,target=/go/pkg/mod/,id=pl-modcache \
-            --mount=type=cache,target=/root/.cache/go-build,id=pl-buildcache \
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
             go build -ldflags "-w -s -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" -o /gnoroot/build/portalloopd ./cmd
 
 # Base image
@@ -139,7 +146,7 @@ ENTRYPOINT  ["/usr/bin/gnofaucet"]
 # Gnodev image
 ## ghcr.io/gnolang/gno/gnodev
 FROM        base AS gnodev
-COPY        --from=build-gnodev /gnoroot/build/gnodev                       /usr/bin/gnodev
+COPY        --from=build-gnodev  /gnoroot/build/gnodev                          /usr/bin/gnodev
 COPY        --from=build-gnocore /gnoroot/examples                              /gnoroot/examples
 COPY        --from=build-gnocore /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
 COPY        --from=build-gnocore /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
@@ -160,12 +167,12 @@ ENTRYPOINT  ["/usr/bin/gno"]
 # Gno Contribs [ Gnobro, Gnogenesis, GnoKMS ]
 ## ghcr.io/gnolang/gnocontribs
 FROM        base AS gnocontribs
-COPY        --from=build-gnobro /gnoroot/build/gnobro                           /usr/bin/gnobro
+COPY        --from=build-gnobro   /gnoroot/build/gnobro                           /usr/bin/gnobro
 COPY        --from=build-contribs /gnoroot/build/gnogenesis                     /usr/bin/gnogenesis
-COPY        --from=build-contribs /gnoroot/build/gnokms                          /usr/bin/gnokms
-COPY        --from=build-gnocore /gnoroot/examples                              /gnoroot/examples
-COPY        --from=build-gnocore /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
-COPY        --from=build-gnocore /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
+COPY        --from=build-contribs /gnoroot/build/gnokms                         /usr/bin/gnokms
+COPY        --from=build-gnocore  /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gnocore  /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
+COPY        --from=build-gnocore  /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE     22
 ENTRYPOINT [ "/bin/sh", "-c" ]
 

--- a/misc/deployments/bake/docker-bake.hcl
+++ b/misc/deployments/bake/docker-bake.hcl
@@ -6,6 +6,11 @@ variable "PROJECT_NAME" {
   default = "gno"
 }
 
+# computed by the caller and forwarded as a build arg.
+variable "BUILD_VERSION" {
+  default = "dev"
+}
+
 #########################################
 ################ GROUPS #################
 #########################################
@@ -52,10 +57,13 @@ target "common" {
     "type=sbom",
   ]
   context = "../../../"
+  args = {
+    BUILD_VERSION = "${BUILD_VERSION}"
+  }
   platforms = [
     "linux/amd64",
     "linux/arm64"
-  ] 
+  ]
   output = ["type=image"] # ,push=true -> Pushes to registry
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the Docker caching PR. Points the release workflows at self-hosted ARC runners (`gnolang-self-runner-xlarge`) and routes `docker/setup-buildx-action` to a long-lived BuildKit daemon via its remote TCP endpoint.

## Why

Previous PR fixed layer caching (`type=registry`) so it survives between runs on ephemeral runners. But the BuildKit **mount cache** (`--mount=type=cache` for Go mod cache and build cache) only lives inside the BuildKit daemon's state — on ephemeral runners it's thrown away at the end of each job.

With a persistent BuildKit on the cluster, those mount caches now survive across runs. Effect: even when a layer change forces a recompile, Go's on-disk build cache is hot — only changed packages get recompiled, unchanged ones are reused from the cache mount.

## Changes

- `release-docker.yml`: `runs-on` → `gnolang-self-runner-xlarge`, add `driver: remote` + `endpoint: tcp://buildkit:1234` to buildx setup.
- `release-bench-history.yml`: `runs-on` → `gnolang-self-runner-xlarge` (label swap only).

## Infra

The persistent BuildKit daemon is deployed separately. The workflow only needs the TCP endpoint everything else is on the self-hosted runners infra side.

## Test plan

- [ ] Run 1 (cold): trigger workflow, confirm it completes on `gnolang-self-runner-xlarge` and pushes to ghcr.io
- [ ] Run 2 (workflow_dispatch, no change): all layers `CACHED`, build completes in seconds
- [ ] Run 3 (small `.go` change): `go mod download` CACHED, changed binary recompiles with hot Go build cache (should be noticeably faster than a cold `go build`)
