### PR TITLE
chore(contribs/tx-archive): register chain stdlib amino types

### DIFF
--- a/contribs/tx-archive/backup/backup.go
+++ b/contribs/tx-archive/backup/backup.go
@@ -7,7 +7,8 @@ import (
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
-	_ "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	_ "github.com/gnolang/gno/gno.land/pkg/sdk/vm" // amino types
+	_ "github.com/gnolang/gno/gnovm/stdlibs/chain" // amino types
 
 	"github.com/gnolang/gno/contribs/tx-archive/backup/client"
 	"github.com/gnolang/gno/contribs/tx-archive/backup/writer"

--- a/contribs/tx-archive/restore/client/http/http.go
+++ b/contribs/tx-archive/restore/client/http/http.go
@@ -9,7 +9,8 @@ import (
 	rpcClient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"
 
-	_ "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	_ "github.com/gnolang/gno/gno.land/pkg/sdk/vm" // amino types
+	_ "github.com/gnolang/gno/gnovm/stdlibs/chain" // amino types
 )
 
 // Client is the TM2 HTTP client


### PR DESCRIPTION
Backport of the relevant code change from [gnolang/tx-archive@de762ac](https://github.com/gnolang/tx-archive/commit/de762ac5c0ed8e921614f97eaec3c99a97d81160).

That commit updated tx-archive for newer Gno API signatures. Most of it (`context.Background()` on `Status` / `BlockResults` / `BroadcastTxSync`) is already applied in the in-tree copy; the only missing piece is a blank import of \`gnovm/stdlibs/chain\` so amino can decode events emitted by chain-stdlib syscalls. Added to both \`backup/backup.go\` and \`restore/client/http/http.go\`.

Companion to the ongoing \`contribs/tx-archive\` sync:
- https://github.com/gnolang/tx-archive/pull/72 — archives the standalone repo
- https://github.com/gnolang/gno/pull/5533 — adds hardfork replay metadata fields
- https://github.com/gnolang/gno/pull/5486 — glue PR using the updated tx-archive

## AI disclosure

Prepared with assistance from Claude Code.