### PR TITLE
fix(tm2): recover shutdown-time txDispatcher panic

### DIFF
--- a/tm2/pkg/bft/rpc/core/mempool.go
+++ b/tm2/pkg/bft/rpc/core/mempool.go
@@ -396,7 +396,24 @@ func newTxDispatcher(evsw events.EventSwitch) *txDispatcher {
 }
 
 func (td *txDispatcher) OnStart() error {
-	go td.listenRoutine()
+	go func() {
+		defer func() {
+			// listenRoutine panics when the subscription channel closes
+			// unexpectedly (programmer-error signal). During node shutdown
+			// the EventSwitch closes subscriptions from its own goroutine
+			// (see tm2/pkg/events/subscribe.go:55), which races td.Quit()
+			// — if it wins, the "unexpected" branch fires even though the
+			// dispatcher is about to stop anyway. Recover in that case so
+			// a normal shutdown doesn't crash the process (e.g. in-process
+			// integration tests). Otherwise, rethrow.
+			if r := recover(); r != nil {
+				if td.IsRunning() {
+					panic(r)
+				}
+			}
+		}()
+		td.listenRoutine()
+	}()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`txDispatcher.listenRoutine` panics with `txDispatcher subscription unexpectedly closed` on normal node shutdown, producing intermittent flakes in in-process integration tests ([example](https://github.com/gnolang/gno/actions/runs/24571730320/job/71846382817)).

The panic is **intentional** — it signals a programmer-error state (unexpected subscription closure). We want to keep it. What we *don't* want is for it to crash the process on a benign shutdown race.

## Root cause

- `EventSwitch` closes each subscription channel from its own goroutine when `evsw.Quit()` fires — see [tm2/pkg/events/subscribe.go:55-56](tm2/pkg/events/subscribe.go:55).
- `listenRoutine` has two exit conditions: `td.sub` closing or `td.Quit()` firing.
- On shutdown both fire. When the EventSwitch wins the race and closes `td.sub` first, `listenRoutine` hits the panic even though the dispatcher is about to stop anyway.

## Fix

Keep the panic. Wrap the goroutine with a `defer/recover` at its spawn site in `OnStart` that only swallows the panic when `td.IsRunning()` is already false — i.e. we're in the middle of stopping. In any other situation, rethrow so the original diagnostic is preserved.

```go
go func() {
    defer func() {
        if r := recover(); r != nil {
            if td.IsRunning() {
                panic(r) // genuinely unexpected — rethrow
            }
            // shutdown-time race — benign, swallow
        }
    }()
    td.listenRoutine()
}()
```

## Alternatives considered

- **Change `listenRoutine` to return cleanly on `!ok`.** Earlier version of this PR. Rejected per reviewer feedback: silently swallows a signal the author added on purpose.
- **Add the `recover()` in `gno.land/pkg/integration`.** Can't: Go's `recover()` only catches panics in the same goroutine. The integration harness doesn't own the dispatcher goroutine, so a recover there can't see this panic.
- **Stop the dispatcher before the EventSwitch in the shutdown sequence.** Correct in principle but requires reordering `node.Stop()` internals across several services; larger blast radius for a flaky-test fix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./tm2/pkg/bft/rpc/core/...` passes
- [ ] CI green on `gno.land/pkg/integration`

Reproducing the race deterministically in a unit test would require stubbing `evsw.Quit()` to fire before `td.Quit()`; low ROI for a targeted fix with an obvious root cause.

---

> Disclosure: this PR was prepared by an AI agent (Claude) working on @moul's behalf.