### PR TITLE
chore(docs-linter): skip staging.gno.land URLs

### DIFF
--- a/misc/docs/tools/linter/urls.go
+++ b/misc/docs/tools/linter/urls.go
@@ -38,7 +38,9 @@ func extractUrls(fileContent []byte) []string {
 			if !strings.Contains(url, "localhost") &&
 				!strings.Contains(url, "127.0.0.1") &&
 				// placeholder for examples
-				!strings.Contains(url, "example.land") {
+				!strings.Contains(url, "example.land") &&
+				// deployment-specific hosts whose uptime is not a CI concern
+				!strings.Contains(url, "staging.gno.land") {
 				urls = append(urls, url)
 			}
 		}


### PR DESCRIPTION
## Summary

The docs linter does a live HTTP GET on every external URL it finds in `.md` files. `staging.gno.land` is a deployment-specific host whose uptime isn't a CI concern, but it's referenced in quite a few docs (`users/interact-with-gnokey.md`, `builders/*`, `resources/*`). When staging is down, every PR's `docs` check fails spuriously.

Example recent flake: https://github.com/gnolang/gno/actions/runs/24572499453/job/71849094914 — same PR passed on retry with no code changes.

## Fix

Add `staging.gno.land` to the existing extraction-time skip list alongside `localhost`, `127.0.0.1`, and `example.land` in `misc/docs/tools/linter/urls.go`.

## Test plan

- [ ] Verify CI docs check passes on this branch
- [ ] (Optional) Confirm `staging.gno.land` URLs in docs still render correctly for readers — they're links, not linted

## Alternatives considered

- **Retry with backoff on HTTP failure** — doesn't help if staging is down for minutes
- **Treat 503/network errors differently from 404** — more surgery; the real answer is "CI shouldn't depend on staging uptime at all"

## Future

Similar case could be made for `rpc.staging.gno.land` (appears alongside `staging.gno.land` in the same files). Didn't add it here to keep the diff minimal — happy to expand if preferred.