### PR TITLE
feat: hardfork-replay improvements (BaseApp InitialHeight + PastChainIDs genesis-mode + --patch-realm)

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -457,6 +457,17 @@ func (cfg InitChainerConfig) loadAppState(ctx sdk.Context, appState any, reqInit
 			}
 		}
 
+		// Genesis-mode txs (no metadata or BlockHeight == 0) were signed with
+		// the original chain ID. During a hardfork (PastChainIDs is set), we
+		// need to verify their signatures against the original chain ID, not
+		// the new one. Use the first PastChainID as the signing context.
+		if (metadata == nil || metadata.BlockHeight == 0) && len(state.PastChainIDs) > 0 {
+			originalChainID := state.PastChainIDs[0]
+			ctxFn = func(ctx sdk.Context) sdk.Context {
+				return ctx.WithChainID(originalChainID)
+			}
+		}
+
 		// For historical txs with signer metadata, force-set account state
 		// so signature verification succeeds even if prior txs diverged.
 		// Uses pre-tx sequence — the value the signature was signed with.

--- a/misc/hardfork/genesis.go
+++ b/misc/hardfork/genesis.go
@@ -6,24 +6,40 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	bftypes "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
 type genesisCfg struct {
-	source         string
-	chainID        string
+	source          string
+	chainID         string
 	originalChainID string
-	haltHeight     int64
-	output         string
-	txsOutput      string
-	overlayDir     string
-	skipTxs        bool
-	noVerify       bool
+	haltHeight      int64
+	output          string
+	txsOutput       string
+	overlayDir      string
+	patchRealms     patchRealmList
+	skipTxs         bool
+	noVerify        bool
+}
+
+// patchRealmList accepts repeated --patch-realm flags. Each value is
+// "pkgpath=srcdir"; the tool rewrites the matching genesis-mode addpkg
+// tx's Package.Files with the contents of srcdir.
+type patchRealmList []string
+
+func (p *patchRealmList) String() string { return strings.Join(*p, ",") }
+func (p *patchRealmList) Set(v string) error {
+	*p = append(*p, v)
+	return nil
 }
 
 func newGenesisCmd(io commands.IO) *commands.Command {
@@ -70,6 +86,11 @@ func (c *genesisCfg) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.output, "output", "genesis.json", "output genesis file path")
 	fs.StringVar(&c.txsOutput, "txs-output", "", "also write extracted txs to this .jsonl file (optional)")
 	fs.StringVar(&c.overlayDir, "overlay-dir", "", "directory of overlay scripts to apply before tx replay (optional)")
+	fs.Var(&c.patchRealms, "patch-realm", "patch a genesis-mode addpkg tx in place: repeatable, PKGPATH=SRCDIR. "+
+		"Replaces Package.Files with the *.gno + gnomod.toml files found in SRCDIR. "+
+		"Source genesis on disk is NOT modified; the patch is applied in memory "+
+		"before writing the hardfork genesis. Use this to deliver realm upgrades "+
+		"as part of the fork (e.g. adding a new .gno file to an existing realm).")
 	fs.BoolVar(&c.skipTxs, "skip-txs", false, "skip tx export (only copy genesis structure — useful for quick preview)")
 	fs.BoolVar(&c.noVerify, "no-verify", false, "skip genesis verification after assembly")
 }
@@ -156,6 +177,25 @@ func execGenesis(ctx context.Context, cfg *genesisCfg, io commands.IO) error {
 	if err != nil {
 		return fmt.Errorf("building hardfork genesis: %w", err)
 	}
+
+	// Apply --patch-realm rewrites on genesis-mode addpkg txs (in-memory only).
+	for _, spec := range cfg.patchRealms {
+		parts := strings.SplitN(spec, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("--patch-realm needs PKGPATH=SRCDIR, got %q", spec)
+		}
+		pkgPath, srcDir := parts[0], parts[1]
+		n, err := patchGenesisModeAddPkg(appState, pkgPath, srcDir)
+		if err != nil {
+			return fmt.Errorf("patch %s: %w", pkgPath, err)
+		}
+		if n == 0 {
+			io.Printf("  WARNING: --patch-realm %s did not match any genesis-mode addpkg tx\n", pkgPath)
+		} else {
+			io.Printf("  patched %s from %s (%d tx rewritten)\n", pkgPath, srcDir, n)
+		}
+	}
+	newGenDoc.AppState = *appState
 
 	// Apply overlay if provided
 	if cfg.overlayDir != "" {
@@ -306,6 +346,111 @@ func baseGenesisModeTxs(appState *gnoland.GnoGenesisState) []gnoland.TxWithMetad
 		}
 	}
 	return out
+}
+
+// patchGenesisModeAddPkg rewrites every genesis-mode addpkg tx whose package
+// path matches `pkgPath` in-place — replacing its Package.Files slice with
+// the *.gno + gnomod.toml files read from `srcDir`.
+//
+// This is how realm upgrades ride along in a hardfork: instead of adding a
+// new tx (which would run with a different caller + account state and may
+// collide with existing state), we rewrite the tx that originally deployed
+// the realm so the forked chain initialises it with the new source.
+//
+// The source genesis on disk is NOT touched — this operates on the in-memory
+// GnoGenesisState that we assembled for the output.
+//
+// Returns the number of txs rewritten.
+func patchGenesisModeAddPkg(appState *gnoland.GnoGenesisState, pkgPath, srcDir string) (int, error) {
+	files, err := loadGnoPackageFiles(srcDir)
+	if err != nil {
+		return 0, fmt.Errorf("load %s: %w", srcDir, err)
+	}
+	if len(files) == 0 {
+		return 0, fmt.Errorf("no .gno/.toml files in %s", srcDir)
+	}
+
+	patched := 0
+	for i := range appState.Txs {
+		txm := &appState.Txs[i]
+		if txm.Metadata != nil && txm.Metadata.BlockHeight > 0 {
+			continue // historical tx, leave alone
+		}
+		for mi, msg := range txm.Tx.Msgs {
+			addpkg, ok := msg.(vm.MsgAddPackage)
+			if !ok {
+				continue
+			}
+			if addpkg.Package == nil || addpkg.Package.Path != pkgPath {
+				continue
+			}
+			addpkg.Package.Files = files
+			// Refresh package name in case a .gno's `package ...` declaration
+			// matters downstream.
+			for _, f := range files {
+				if strings.HasSuffix(f.Name, ".gno") {
+					if name := gnoPackageNameFromFileBody(f.Name, f.Body); name != "" {
+						addpkg.Package.Name = name
+					}
+					break
+				}
+			}
+			txm.Tx.Msgs[mi] = addpkg
+			patched++
+		}
+	}
+	return patched, nil
+}
+
+// loadGnoPackageFiles reads *.gno and gnomod.toml files from srcDir
+// (non-recursive) and returns them as ordered std.MemFile entries.
+// Skips _test.gno, _filetest.gno, and hidden files.
+func loadGnoPackageFiles(srcDir string) ([]*std.MemFile, error) {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, "_test.gno") || strings.HasSuffix(n, "_filetest.gno") {
+			continue
+		}
+		if strings.HasSuffix(n, ".gno") || n == "gnomod.toml" {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+
+	files := make([]*std.MemFile, 0, len(names))
+	for _, n := range names {
+		body, err := os.ReadFile(filepath.Join(srcDir, n))
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, &std.MemFile{Name: n, Body: string(body)})
+	}
+	return files, nil
+}
+
+// gnoPackageNameFromFileBody extracts `package NAME` from the top of a .gno
+// file. Returns "" if not found. (Intentionally lightweight — avoids pulling
+// in the gnovm parser.)
+func gnoPackageNameFromFileBody(_ string, body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		l := strings.TrimSpace(line)
+		if strings.HasPrefix(l, "package ") {
+			rest := strings.TrimPrefix(l, "package ")
+			if i := strings.IndexAny(rest, " \t/"); i >= 0 {
+				rest = rest[:i]
+			}
+			return rest
+		}
+	}
+	return ""
 }
 
 // applyOverlay runs overlay scripts from a directory against the genesis file.

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -301,10 +301,24 @@ func (app *BaseApp) getMaximumBlockGas() int64 {
 func (app *BaseApp) Info(req abci.RequestInfo) (res abci.ResponseInfo) {
 	lastCommitID := app.cms.LastCommitID()
 
-	// return res
 	res.Data = []byte(app.Name())
 	res.LastBlockHeight = lastCommitID.Version
 	res.LastBlockAppHash = lastCommitID.Hash
+
+	// When InitialHeight > 1 (chain upgrades), the multistore version counter
+	// starts from 0 and auto-increments, so it may be lower than the actual
+	// block height. Use the persisted header height when available.
+	if app.baseKey != nil {
+		baseStore := app.cms.GetStore(app.baseKey)
+		if baseStore != nil {
+			if headerBz := baseStore.Get(mainLastHeaderKey); headerBz != nil {
+				var header bft.Header
+				if err := amino.Unmarshal(headerBz, &header); err == nil && header.Height > res.LastBlockHeight {
+					res.LastBlockHeight = header.Height
+				}
+			}
+		}
+	}
 	return
 }
 
@@ -511,8 +525,24 @@ func (app *BaseApp) validateHeight(req abci.RequestBeginBlock) error {
 	// When prevHeight == 0 the app has no committed blocks yet. The first block
 	// may arrive at any height >= 1, including InitialHeight > 1 for chains
 	// that replay historical transactions during genesis.
-	if prevHeight != 0 && req.Header.GetHeight() != prevHeight+1 {
-		return fmt.Errorf("invalid height: %d; expected: %d", req.Header.GetHeight(), prevHeight+1)
+	if prevHeight == 0 {
+		return nil
+	}
+
+	// Normal sequential check: next block should be prevHeight+1.
+	// However, with InitialHeight > 1, the multistore version counter starts
+	// from 0 and auto-increments, so prevHeight (store version) can be less
+	// than the actual block height. In that case, we allow the jump as long as
+	// the height is increasing.
+	expected := prevHeight + 1
+	actual := req.Header.GetHeight()
+	if actual != expected && actual > prevHeight {
+		// Allow height jump — this happens when InitialHeight > 1 causes the
+		// store version to lag behind the block height.
+		return nil
+	}
+	if actual != expected {
+		return fmt.Errorf("invalid height: %d; expected: %d", actual, expected)
 	}
 
 	return nil


### PR DESCRIPTION
Three tightly-related improvements that fell out of end-to-end-testing the hardfork-replay mechanism on the full gnoland1 chain (see [#5486](https://github.com/gnolang/gno/pull/5486)). Each is a standalone commit; happy to split into separate PRs if reviewers prefer.

## 1. \`fix(tm2/sdk): BaseApp validateHeight + Info handle InitialHeight > 1\`

Two separate issues hit chains whose genesis sets \`InitialHeight > 1\`:

- \`validateHeight\` compared \`req.Header.Height\` against the multistore version counter (which auto-increments from 0). With \`InitialHeight > 1\` the store version lags block height — first block arrives at e.g. 101 while store is at version 0, second at 102 while store is at 1 — so \`expected 2, got 102\` panicked. Fix: when the store version lags, accept the jump as long as height is monotonic.
- \`Info()\` returned the multistore version as \`LastBlockHeight\`. On restart the handshaker saw \`appHeight=1\` but \`storeHeight=102\` and tried to replay from height 2. Fix: when the persisted header records a higher block height, return that instead.

## 2. \`feat(gnoland): genesis-mode txs use PastChainIDs[0] for sig verify\`

During a hardfork replay, genesis-mode txs (metadata == nil or BlockHeight == 0) were originally signed with the source chain's chain-id. Historical txs (BlockHeight > 0) already get \`PastChainIDs\`-based chain-id override in \`loadAppState\`; this extends the same treatment to genesis-mode txs by using the first \`PastChainIDs\` entry when a hardfork is in progress.

In practice this still needs \`--skip-genesis-sig-verification\` for gnogenesis-produced addpkg txs (where \`msg.Creator ≠ signing key\` — the pubkey-address check rejects those regardless of chain-id). But for genesis-mode txs where the signer IS the creator, this makes the signature verify against the correct chain-id without any skip flag.

## 3. \`feat(hardfork): --patch-realm flag\`

Repeatable \`--patch-realm PKGPATH=SRCDIR\` flag on \`hardfork genesis\`. Rewrites the genesis-mode addpkg tx for \`PKGPATH\` in-place, replacing \`Package.Files\` with the \`*.gno\` + \`gnomod.toml\` files from \`SRCDIR\`. Source genesis on disk stays untouched — patch lives only in the in-memory \`GnoGenesisState\` used for the output.

Motivation: you cannot re-addpkg to the same path post-deploy (unauthorized), and you cannot add a new \`.gno\` file to an existing realm via a call, so the only way to land a code change on an existing realm during a hardfork is to rewrite the addpkg tx that originally deployed it.

Combined with [#5368](https://github.com/gnolang/gno/pull/5368) (which adds \`halt.gno\` to \`r/sys/params\`), the hf-glue testbed boots a fork of gnoland1 where \`r/sys/params\` ships the new \`NewSetHaltRequest\` code out of the box:

\`\`\`
$ curl ... vm/qfile gno.land/r/sys/params
→ fee_collector.gno, gnomod.toml, halt.gno, params.gno, unlock.gno
\`\`\`

## End-to-end validation

All three land together in [#5486](https://github.com/gnolang/gno/pull/5486) (hf-glue testbed). Running \`make fetch && make init && make up\` against \`rpc.gno.land\` / halt @ 704052 produces a 192 MB hardfork genesis that replays with **0 / 2715 tx failures** and boots a live \`gnoland-1\` node with \`r/sys/params\` carrying the patched source.

Dependencies:
- Stacks on #5511 (this PR's base): needs \`PastChainIDs\`, \`SignerInfo\`, \`InitialHeight\` genesis-doc field
- Pairs with [#5533](https://github.com/gnolang/gno/pull/5533) (\`contribs/tx-archive\` metadata + SignerInfo populator) for the replay-ready backups

## AI disclosure

Developed with assistance from Claude Code.