### PR TITLE
docs: fix remaining stale `std` package references

### DIFF
--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -41,7 +41,7 @@ and the [package README](../../examples/gno.land/p/nt/avl/v0/README.md) for tech
 
 ### Banker
 A Tendermint2 module that is natively embedded into the Gno language, via the
-`std` package. Used for manipulating Coins within Gno.
+`chain/banker` package. Used for manipulating Coins within Gno.
 
 ### Block
 A fundamental unit in a blockchain that contains a collection of validated

--- a/docs/resources/gno-packages.md
+++ b/docs/resources/gno-packages.md
@@ -89,7 +89,7 @@ Initially, all users are granted a default namespace with their address - a
 pseudo-anonymous (PA) namespace - to which the associated address can
 deploy. This namespace has the following format:
 ```
-gno.land/{p,r}/{std.Address}/**
+gno.land/{p,r}/{address}/**
 ```
 
 For example, for address `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`, all the

--- a/docs/users/interact-with-gnokey.md
+++ b/docs/users/interact-with-gnokey.md
@@ -1295,12 +1295,12 @@ data: {
     {
       "type": "",
       "name": "GetByAddr",
-      "signature": "func GetByAddr(address std.Address) Valoper",
+      "signature": "func GetByAddr(address address) Valoper",
       "doc": "GetByAddr fetches the valoper using the address, if present\n",
       "params": [
         {
           "Name": "address",
-          "Type": "std.Address"
+          "Type": "address"
         }
       ],
       "results": [
@@ -1329,7 +1329,7 @@ data: {
   "types": [
     {
       "name": "Valoper",
-      "signature": "type Valoper struct {\n\tName        string // the display name of the valoper\n\tMoniker     string // the moniker of the valoper\n\tDescription string // the description of the valoper\n\n\tAddress      std.Address // The bech32 gno address of the validator\n\tPubKey       string      // the bech32 public key of the validator\n\tP2PAddresses []string    // the publicly reachable P2P addresses of the validator\n\tActive       bool        // flag indicating if the valoper is active\n}",
+      "signature": "type Valoper struct {\n\tName        string // the display name of the valoper\n\tMoniker     string // the moniker of the valoper\n\tDescription string // the description of the valoper\n\n\tAddress      address // The bech32 gno address of the validator\n\tPubKey       string      // the bech32 public key of the validator\n\tP2PAddresses []string    // the publicly reachable P2P addresses of the validator\n\tActive       bool        // flag indicating if the valoper is active\n}",
       "doc": "Valoper represents a validator operator profile\n"
     }
   ]

--- a/examples/gno.land/p/leon/coinsort/coinsort.gno
+++ b/examples/gno.land/p/leon/coinsort/coinsort.gno
@@ -9,7 +9,7 @@
 //	coinsort.SortByBalance(coins)
 //
 //	// Custom order – largest balance first
-//	coinsort.SortBy(coins, func(a, b std.Coin) bool {
+//	coinsort.SortBy(coins, func(a, b chain.Coin) bool {
 //	    return a.Amount > b.Amount // descending
 //	})
 //

--- a/examples/gno.land/p/lou/blog/doc.gno
+++ b/examples/gno.land/p/lou/blog/doc.gno
@@ -24,7 +24,7 @@ Example:
 			title,
 			body,
 			publicationDate,
-			std.OriginCaller().String(),
+			runtime.OriginCaller().String(),
 			authorsField,
 			tagsField,
 		)

--- a/examples/gno.land/p/moul/addrset/addrset.gno
+++ b/examples/gno.land/p/moul/addrset/addrset.gno
@@ -9,7 +9,6 @@
 // Example usage:
 //
 //	import (
-//	    "std"
 //	    "gno.land/p/moul/addrset"
 //	)
 //

--- a/examples/gno.land/p/moul/debug/debug.gno
+++ b/examples/gno.land/p/moul/debug/debug.gno
@@ -49,11 +49,11 @@ func (d Debug) Render(path string) string {
 		table := mdtable.Table{
 			Headers: []string{"Key", "Value"},
 		}
-		table.Append([]string{"`std.CurrentRealm().PkgPath()`", string(runtime.CurrentRealm().PkgPath())})
-		table.Append([]string{"`std.CurrentRealm().Address()`", string(runtime.CurrentRealm().Address())})
-		table.Append([]string{"`std.PreviousRealm().PkgPath()`", string(runtime.PreviousRealm().PkgPath())})
-		table.Append([]string{"`std.PreviousRealm().Address()`", string(runtime.PreviousRealm().Address())})
-		table.Append([]string{"`std.ChainHeight()`", ufmt.Sprintf("%d", runtime.ChainHeight())})
+		table.Append([]string{"`runtime.CurrentRealm().PkgPath()`", string(runtime.CurrentRealm().PkgPath())})
+		table.Append([]string{"`runtime.CurrentRealm().Address()`", string(runtime.CurrentRealm().Address())})
+		table.Append([]string{"`runtime.PreviousRealm().PkgPath()`", string(runtime.PreviousRealm().PkgPath())})
+		table.Append([]string{"`runtime.PreviousRealm().Address()`", string(runtime.PreviousRealm().Address())})
+		table.Append([]string{"`runtime.ChainHeight()`", ufmt.Sprintf("%d", runtime.ChainHeight())})
 		table.Append([]string{"`time.Now().Format(time.RFC3339)`", time.Now().Format(time.RFC3339)})
 		content += table.String()
 	}

--- a/examples/gno.land/p/moul/debug/debug_test.gno
+++ b/examples/gno.land/p/moul/debug/debug_test.gno
@@ -28,11 +28,11 @@ func testPackage(t *testing.T) {
 ### Metadata
 | Key | Value |
 | --- | --- |
-| ±std.CurrentRealm().PkgPath()± | gno.land/r/test/test |
-| ±std.CurrentRealm().Address()± | g1z7fga7u94pdmamlvcrtvsfwxgsye0qv3rres7n |
-| ±std.PreviousRealm().PkgPath()± |  |
-| ±std.PreviousRealm().Address()± | g1user |
-| ±std.ChainHeight()± | 123 |
+| ±runtime.CurrentRealm().PkgPath()± | gno.land/r/test/test |
+| ±runtime.CurrentRealm().Address()± | g1z7fga7u94pdmamlvcrtvsfwxgsye0qv3rres7n |
+| ±runtime.PreviousRealm().PkgPath()± |  |
+| ±runtime.PreviousRealm().Address()± | g1user |
+| ±runtime.ChainHeight()± | 123 |
 | ±time.Now().Format(time.RFC3339)± | 2009-02-13T23:31:30Z |
 
 </details>
@@ -60,11 +60,11 @@ func testPackage(t *testing.T) {
 ### Metadata
 | Key | Value |
 | --- | --- |
-| ±std.CurrentRealm().PkgPath()± | gno.land/r/test/test |
-| ±std.CurrentRealm().Address()± | g1z7fga7u94pdmamlvcrtvsfwxgsye0qv3rres7n |
-| ±std.PreviousRealm().PkgPath()± |  |
-| ±std.PreviousRealm().Address()± | g1user |
-| ±std.ChainHeight()± | 123 |
+| ±runtime.CurrentRealm().PkgPath()± | gno.land/r/test/test |
+| ±runtime.CurrentRealm().Address()± | g1z7fga7u94pdmamlvcrtvsfwxgsye0qv3rres7n |
+| ±runtime.PreviousRealm().PkgPath()± |  |
+| ±runtime.PreviousRealm().Address()± | g1user |
+| ±runtime.ChainHeight()± | 123 |
 | ±time.Now().Format(time.RFC3339)± | 2009-02-13T23:31:30Z |
 
 </details>

--- a/examples/gno.land/p/n2p5/loci/loci.gno
+++ b/examples/gno.land/p/n2p5/loci/loci.gno
@@ -25,7 +25,7 @@ func New() *LociStore {
 	}
 }
 
-// Set stores a byte slice in the AVL tree using the `std.PreviousRealm().Address()`
+// Set stores a byte slice in the AVL tree using the `runtime.PreviousRealm().Address()`
 // string as the key.
 func (s *LociStore) Set(value []byte) {
 	key := string(runtime.PreviousRealm().Address())

--- a/examples/gno.land/p/nt/ownable/v0/ownable.gno
+++ b/examples/gno.land/p/nt/ownable/v0/ownable.gno
@@ -36,7 +36,7 @@ func NewWithOrigin() *Ownable {
 	origin := runtime.OriginCaller()
 	previous := runtime.PreviousRealm()
 	if origin != previous.Address() {
-		panic("NewWithOrigin() should be called from init() where std.PreviousRealm() is origin")
+		panic("NewWithOrigin() should be called from init() where runtime.PreviousRealm() is origin")
 	}
 	return &Ownable{
 		owner:    origin,

--- a/examples/gno.land/p/nt/testutils/v0/misc.gno
+++ b/examples/gno.land/p/nt/testutils/v0/misc.gno
@@ -1,6 +1,6 @@
 package testutils
 
-// For testing std.CallerAt().
+// WrapCall adds a frame to the call stack, for testing call stack depth.
 func WrapCall(fn func()) {
 	fn()
 }

--- a/examples/gno.land/p/nt/treasury/v0/banker_coins.gno
+++ b/examples/gno.land/p/nt/treasury/v0/banker_coins.gno
@@ -77,10 +77,10 @@ func NewCoinsBankerWithOwner(owner address, banker_ banker.Banker) (*CoinsBanker
 		return nil, ErrNoOwnerProvided
 	}
 
-	// NOTE: Should we add methods to std.Banker to check both its type and the
+	// NOTE: Should we add methods to banker.Banker to check both its type and the
 	// associated Realm for this kind of case?
 	// For example:
-	// if banker.Type() != std.BankerTypeRealmSend { panic("banker must be of type std.BankerTypeRealmSend") }
+	// if banker.Type() != banker.BankerTypeRealmSend { panic("banker must be of type banker.BankerTypeRealmSend") }
 	// if banker.Realm().Address() != owner { panic("banker must be owned by the given owner address") }
 	if banker_ == nil {
 		return nil, ErrNoStdBankerProvided

--- a/examples/gno.land/p/oxtekgrinder/ownable2step/ownable.gno
+++ b/examples/gno.land/p/oxtekgrinder/ownable2step/ownable.gno
@@ -26,7 +26,7 @@ func NewWithOrigin() *Ownable2Step {
 	origin := runtime.OriginCaller()
 	previous := runtime.PreviousRealm()
 	if origin != previous.Address() {
-		panic("NewWithOrigin() should be called from init() where std.PreviousRealm() is origin")
+		panic("NewWithOrigin() should be called from init() where runtime.PreviousRealm() is origin")
 	}
 	return &Ownable2Step{
 		owner: origin,

--- a/examples/gno.land/p/sys/genesis/consts.gno
+++ b/examples/gno.land/p/sys/genesis/consts.gno
@@ -27,7 +27,7 @@ var (
 	Domain = runtime.ChainDomain()
 
 	// XXX: TZ
-	// XXX: Supply = std.Coins{{"ugnot", std.NewBanker(std.BankerTypeReadonly).TotalSupply("ugnot")}}
+	// XXX: Supply = chain.Coins{{"ugnot", banker.NewBanker(banker.BankerTypeReadonly).TotalSupply("ugnot")}}
 )
 
 // Uptime returns the uptime of the chain.

--- a/examples/gno.land/r/docs/events/events.gno
+++ b/examples/gno.land/r/docs/events/events.gno
@@ -11,7 +11,7 @@ To emit an event, simply use the **Emit()** function found in the **std** packag
 This function takes in string arguments as follows:
 
 `
-	out += "```\nstd.Emit(\"EventName\", \"key1\", \"value1\", \"key2\", \"value2\")\n```\n"
+	out += "```\nruntime.Emit(\"EventName\", \"key1\", \"value1\", \"key2\", \"value2\")\n```\n"
 	out += "The function takes in a variadic number of key:value pairs after the event name.\n\n"
 	out += "Events are stored in block results, and can be listened to via the [tx-indexer](https://github.com/gnolang/tx-indexer).\n\n"
 

--- a/examples/gno.land/r/docs/txlink/txlink.gno
+++ b/examples/gno.land/r/docs/txlink/txlink.gno
@@ -47,7 +47,7 @@ Check out the links below.
 	// Basic call
 	out += "- [Say Hello](" + txlink.Call("Post", "text", "Hello from txlink!") + ") - A simple, static argument call\n"
 
-	// A link builder including some funds specified in the string format (std.Coin.String())
+	// A link builder including some funds specified in the string format (chain.Coin.String())
 	custom := txlink.NewLink("Post").
 		AddArgs("text", "Support this board with 1ugnot").
 		SetSend("1ugnot").

--- a/examples/gno.land/r/gnoland/coins/coins.gno
+++ b/examples/gno.land/r/gnoland/coins/coins.gno
@@ -52,7 +52,7 @@ func init() {
 
 	// Coin info
 	router.HandleFunc("supply/{denom}", func(res *mux.ResponseWriter, req *mux.Request) {
-		// banker := std.NewBanker(std.BankerTypeReadonly)
+		// banker := banker.NewBanker(banker.BankerTypeReadonly)
 		// res.Write(renderAddressBalance(banker, denom, denom))
 		res.Write("The total supply feature is coming soon.")
 	})

--- a/examples/gno.land/r/gnoland/pages/admin.gno
+++ b/examples/gno.land/r/gnoland/pages/admin.gno
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-	// adminAddr = std.OriginCaller() // FIXME: find a way to use this from the main's genesis.
+	// adminAddr = runtime.OriginCaller() // FIXME: find a way to use this from the main's genesis.
 	adminAddr = "g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh" // govdao t1 multisig
 }
 

--- a/examples/gno.land/r/morgan/chess/chess.gno
+++ b/examples/gno.land/r/morgan/chess/chess.gno
@@ -530,7 +530,7 @@ func checkErr(err error) {
 	}
 }
 
-// Replacement for OriginCall using std.PreviousRealm().
+// Replacement for OriginCall using runtime.PreviousRealm().
 func assertOriginCall() {
 	if !runtime.PreviousRealm().IsUser() {
 		panic("invalid non-origin call")

--- a/gnovm/stdlibs/chain/banker/banker.gno
+++ b/gnovm/stdlibs/chain/banker/banker.gno
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Realm functions can call std.NewBanker(options) to get
+// Realm functions can call banker.NewBanker(options) to get
 // a banker instance. Banker objects cannot be persisted,
 // but can be passed onto other functions to be transacted
 // on. A banker instance can be passed onto other realm

--- a/gnovm/tests/files/zrealm_crossrealm11.gno
+++ b/gnovm/tests/files/zrealm_crossrealm11.gno
@@ -44,7 +44,7 @@ func main(cur realm) {
 		callerFnCrossing func(realm) runtime.Realm
 	}{
 		{
-			callStackAdd: " -> std.PreviousRealm",
+			callStackAdd: " -> runtime.PreviousRealm",
 			callerFn:     runtime.PreviousRealm,
 		},
 		{
@@ -70,8 +70,8 @@ func main(cur realm) {
 	}
 
 	println("---") // needed to have space prefixes
-	printColumns("STACK", "std.PreviousRealm")
-	printColumns("-----", "------------------")
+	printColumns("STACK", "runtime.PreviousRealm")
+	printColumns("-----", "----------------------")
 
 	baseCallStack := "user1.gno !> r/crossrealm.main2"
 	for _, tt := range tests {
@@ -147,13 +147,13 @@ func printColumns(left, right string) {
 
 // Output:
 // ---
-//                                                                                                     STACK = std.PreviousRealm
-//                                                                                                     ----- = ------------------
-//                                                      user1.gno !> r/crossrealm.main2 -> std.PreviousRealm = user1.gno
-//                                 user1.gno !> r/crossrealm.main2 -> r/crossrealm.Exec -> std.PreviousRealm = user1.gno
-//                                 user1.gno !> r/crossrealm.main2 -> r/demo/tests.Exec -> std.PreviousRealm = user1.gno
-//                           user1.gno !> r/crossrealm.main2 !> r/demo/tests.ExecSwitch -> std.PreviousRealm = gno.land/r/crossrealm
-//                                 user1.gno !> r/crossrealm.main2 -> p/demo/tests.Exec -> std.PreviousRealm = user1.gno
+//                                                                                                     STACK = runtime.PreviousRealm
+//                                                                                                     ----- = ----------------------
+//                                                  user1.gno !> r/crossrealm.main2 -> runtime.PreviousRealm = user1.gno
+//                             user1.gno !> r/crossrealm.main2 -> r/crossrealm.Exec -> runtime.PreviousRealm = user1.gno
+//                             user1.gno !> r/crossrealm.main2 -> r/demo/tests.Exec -> runtime.PreviousRealm = user1.gno
+//                       user1.gno !> r/crossrealm.main2 !> r/demo/tests.ExecSwitch -> runtime.PreviousRealm = gno.land/r/crossrealm
+//                             user1.gno !> r/crossrealm.main2 -> p/demo/tests.Exec -> runtime.PreviousRealm = user1.gno
 //                                          user1.gno !> r/crossrealm.main2 -> r/crossrealm.getPreviousRealm = user1.gno
 //                     user1.gno !> r/crossrealm.main2 -> r/crossrealm.Exec -> r/crossrealm.getPreviousRealm = user1.gno
 //                     user1.gno !> r/crossrealm.main2 -> r/demo/tests.Exec -> r/crossrealm.getPreviousRealm = user1.gno


### PR DESCRIPTION
Update references to the old std package across docs, examples, and filetests following the std split into chain, chain/runtime, and chain/banker. Changes include comments, doc strings, panic messages, display labels, and expected test output.

Related: #5506 