### PR TITLE
test(gno.land): restore exact-value checks in gas/storage txtars

### DIFF
--- a/gno.land/pkg/integration/testdata/atomicswap.txtar
+++ b/gno.land/pkg/integration/testdata/atomicswap.txtar
@@ -16,24 +16,29 @@ stdout 'coins.*:.*1010000000ugnot'
 # echo -n "secret" | sha256sum
 # This will produce a hashlock string like "2bb808d537b1da3e38bd30361aa85586dbbeacdd7126fef6a25ef97b5f27a25b".
 # Replace the hashlock argument in the command below with the generated hash.
+# Exact balances pinned. Invariants preserved:
+#   test2 after NewCoinSwap = 1010000000 - 12345 (escrow) - 680001 (gas) - 453000 (storage) = 1008854654
+#   test2 after Claim       = 1008854654  (unchanged — Claim moves escrow to test3, not from test2)
+#   test3 after NewCoinSwap = 1010000000  (unchanged)
+#   test3 after Claim       = 1010000000 + 12345 (escrow) - 700001 (gas) - 500 (storage) = 1009311844
 gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func NewCoinSwap -gas-fee 680001ugnot -send 12345ugnot -gas-wanted 6_800_000 -args $test3_user_addr -args '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' -broadcast -chainid=tendermint_test test2
 stdout '(1 int)'
 stdout ".*$test2_user_addr.*$test3_user_addr.*12345ugnot.*"
 stdout 'OK!'
-stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":\d+\}.*\]'
+stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":453000\}.*\]'
 
 gnokey query vm/qrender --data 'gno.land/r/demo/defi/atomicswap:'
 
 gnokey query auth/accounts/$test2_user_addr
-stdout 'coins.*:.*\d+ugnot'
+stdout 'coins.*:.*1008854654ugnot'
 gnokey query auth/accounts/$test3_user_addr
 stdout 'coins.*:.*1010000000ugnot'
 
 gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func Claim -gas-fee 700001ugnot -gas-wanted 7_000_000 -args '1' -args 'secret' -broadcast -chainid=tendermint_test test3
 stdout 'OK!'
-stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":\d+\}.*\]'
+stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":500\}.*\]'
 
 gnokey query auth/accounts/$test2_user_addr
-stdout 'coins.*:.*\d+ugnot'
+stdout 'coins.*:.*1008854654ugnot'
 gnokey query auth/accounts/$test3_user_addr
-stdout 'coins.*:.*\d+ugnot'
+stdout 'coins.*:.*1009311844ugnot'

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -9,38 +9,49 @@ gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "0"'
 stdout '"coins": "10000000000000ugnot"'
 
-# Tx add package -simulate only, estimate gas used and gas fee
+# Tx add package -simulate only, estimate gas used and gas fee.
+# gas-wanted/gas-fee on the simulate call are generous; simulate reports
+# the actual gas the real tx would consume.
 gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -broadcast -chainid tendermint_test -simulate only test1
-stdout 'GAS USED: +\d+'
-stdout 'INFO:       estimated gas usage: \d+, gas fee: \d+ugnot, current gas price: 1ugnot/1000gas'
+stdout 'GAS USED:\s+2814462'
+stdout 'INFO:       estimated gas usage: 2814462, gas fee: 2955ugnot, current gas price: 1ugnot/1000gas'
 
 ## No fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "0"'
 stdout '"coins": "10000000000000ugnot"'
 
-# Using a generous gas-wanted and gas-fee should ensure the transaction executes successfully.
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -broadcast -chainid tendermint_test test1
+# Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
+# This is the documented simulate->broadcast workflow; the values on this
+# line MUST match the simulate output above (modulo a small gas-wanted
+# headroom).
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_814_500 -gas-fee 2955ugnot -broadcast -chainid tendermint_test test1
 stdout 'OK'
+stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":206900\}.*\]'
 
-# Tx Call -simulate only, estimate gas used and gas fee
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -broadcast -chainid tendermint_test -simulate only test1
-stdout 'GAS USED: +\d+'
-stdout 'INFO:       estimated gas usage: \d+, gas fee: \d+ugnot, current gas price: 1ugnot/1000gas'
-
-## Fee was charged for addpkg, and the sequence number increased.
+## fee + storage deposit were charged; sequence number increased.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
-stdout '"coins": "\d+ugnot"'
+stdout '"coins": "9999999790145ugnot"'
 
-# Using a generous gas-wanted and gas-fee should ensure the transaction executes successfully.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -broadcast -chainid tendermint_test test1
+# Tx Call -simulate only, estimate gas used and gas fee.
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -broadcast -chainid tendermint_test -simulate only test1
+stdout 'GAS USED:\s+1269324'
+stdout 'INFO:       estimated gas usage: 1269324, gas fee: 1333ugnot, current gas price: 1ugnot/1000gas'
+
+## No additional fee was charged, and the sequence number did not change.
+gnokey query auth/accounts/$test1_user_addr
+stdout '"sequence": "1"'
+stdout '"coins": "9999999790145ugnot"'
+
+# Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_269_400 -gas-fee 1333ugnot -broadcast -chainid tendermint_test test1
 stdout 'OK'
 
 ## fee is charged and sequence number increased
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "2"'
-stdout '"coins": "\d+ugnot"'
+stdout '"coins": "9999999788812ugnot"'
 
 -- hello/gnomod.toml --
 module = "gno.land/r/hello"

--- a/gno.land/pkg/integration/testdata/restart_gas.txtar
+++ b/gno.land/pkg/integration/testdata/restart_gas.txtar
@@ -1,15 +1,24 @@
+# Pin exact gas for three equivalent-shape AddPkg txs straddling a node
+# restart. Any VM, store, or gas-model change that shifts these numbers
+# MUST update them here — this is the regression signal that the test's
+# name ("restart_gas") implies.
+#
+# `foo` (pre-restart, same content as bar but different pkgpath) and
+# `baz` (post-restart, same shape) should stay close; a large divergence
+# between them indicates restart-dependent gas, which is a bug.
+
 gnoland start
 
 gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED: +\d+'
+stdout 'GAS USED:\s+2831873'
 
 gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED: +\d+'
+stdout 'GAS USED:\s+2834202'
 
 gnoland restart
 
 gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED: +\d+'
+stdout 'GAS USED:\s+2834216'
 
 -- bar/gnomod.toml --
 module = "bar"

--- a/gno.land/pkg/integration/testdata/restart_gas.txtar
+++ b/gno.land/pkg/integration/testdata/restart_gas.txtar
@@ -10,15 +10,15 @@
 gnoland start
 
 gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2831873'
+stdout 'GAS USED:\s+2833876'
 
 gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2834202'
+stdout 'GAS USED:\s+2836205'
 
 gnoland restart
 
 gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2834216'
+stdout 'GAS USED:\s+2836219'
 
 -- bar/gnomod.toml --
 module = "bar"

--- a/gno.land/pkg/integration/testdata/storage_deposit.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit.txtar
@@ -3,15 +3,21 @@
 ## start a new node
 gnoland start
 
+# Exact values pinned to preserve the storage-pricing invariants:
+#   fee_delta  == bytes_delta * 100  (storage price = 100 ugnot/byte)
+#   STORAGE DELTA == bytes_delta
+#   STORAGE FEE   == fee_delta
+#   qstorage "storage/deposit" echoes the on-chain values
+#   TOTAL TX COST == gas-fee +/- STORAGE FEE/REFUND
 gnokey maketx addpkg -pkgdir $WORK/realm -pkgpath gno.land/r/foo -gas-fee 380001ugnot -gas-wanted 3_800_000 -max-deposit 900000ugnot -broadcast -chainid=tendermint_test test1
-stdout 'EVENTS:     \[{\"bytes_delta\":\d+,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":\d+},\"pkg_path\":\"gno.land/r/foo\"}\]'
-stdout 'STORAGE DELTA:  \d+ bytes'
-stdout 'STORAGE FEE:    \d+ugnot'
-stdout 'TOTAL TX COST:  \d+ugnot'
+stdout 'EVENTS:     \[{\"bytes_delta\":5009,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":500900},\"pkg_path\":\"gno.land/r/foo\"}\]'
+stdout 'STORAGE DELTA:  5009 bytes'
+stdout 'STORAGE FEE:    500900ugnot'
+stdout 'TOTAL TX COST:  880901ugnot'
 
 gnokey query vm/qstorage --data gno.land/r/foo
 
-stdout 'storage: \d+, deposit: \d+'
+stdout 'storage: 5009, deposit: 500900'
 
 ## Set an object with a smaller size. Exactly 2 bytes are released when we update the realm record from 'hello' to 'foo'.
 gnokey maketx call -pkgpath gno.land/r/foo -func NewFoo -args "foo"  -gas-fee 260001ugnot -gas-wanted 2_600_000  -broadcast -chainid=tendermint_test test1
@@ -19,38 +25,38 @@ stdout OK!
 stdout 'EVENTS:     \[{\"bytes_delta\":-2,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":200},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
 stdout 'STORAGE DELTA:  -2 bytes'
 stdout 'STORAGE REFUND: 200ugnot'
-stdout 'TOTAL TX COST:  \d+ugnot'
+stdout 'TOTAL TX COST:  259801ugnot'
 
 gnokey query vm/qstorage --data gno.land/r/foo
-stdout 'storage: \d+, deposit: \d+'
+stdout 'storage: 5007, deposit: 500700'
 
 
 ## remove an object
 
  gnokey maketx call -pkgpath gno.land/r/foo -func Clear -gas-fee 260001ugnot -gas-wanted 2_600_000  -broadcast -chainid=tendermint_test test1
  stdout OK!
- stdout 'EVENTS:     \[{\"bytes_delta\":-\d+,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":\d+},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
- stdout 'STORAGE DELTA:  -\d+ bytes'
- stdout 'STORAGE REFUND: \d+ugnot'
- stdout 'TOTAL TX COST:  \d+ugnot'
+ stdout 'EVENTS:     \[{\"bytes_delta\":-27,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":2700},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
+ stdout 'STORAGE DELTA:  -27 bytes'
+ stdout 'STORAGE REFUND: 2700ugnot'
+ stdout 'TOTAL TX COST:  257301ugnot'
 
  gnokey query vm/qstorage --data gno.land/r/foo
- stdout 'storage: \d+, deposit: \d+'
+ stdout 'storage: 4980, deposit: 498000'
 
 
  gnokey query auth/accounts/$test1_user_addr
- stdout '"coins": "\d+ugnot"'
+ stdout '"coins": "9999998601997ugnot"'
 
 ## test storage deposit for package gno.land/p/foo
 gnokey maketx addpkg -pkgdir $WORK/package -pkgpath gno.land/p/foo -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 500000ugnot -broadcast -chainid=tendermint_test test1
 stdout OK!
-stdout 'EVENTS:     \[{\"bytes_delta\":\d+,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":\d+},\"pkg_path\":\"gno.land/p/foo\"}\]'
-stdout 'STORAGE DELTA:  \d+ bytes'
-stdout 'STORAGE FEE:    \d+ugnot'
-stdout 'TOTAL TX COST:  \d+ugnot'
+stdout 'EVENTS:     \[{\"bytes_delta\":3019,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":301900},\"pkg_path\":\"gno.land/p/foo\"}\]'
+stdout 'STORAGE DELTA:  3019 bytes'
+stdout 'STORAGE FEE:    301900ugnot'
+stdout 'TOTAL TX COST:  671901ugnot'
 
 gnokey query vm/qstorage --data gno.land/p/foo
-stdout 'storage: \d+, deposit: \d+'
+stdout 'storage: 3019, deposit: 301900'
 
 -- realm/gnomod.toml --
 module = "gno.land/r/foo"


### PR DESCRIPTION
PR #5415 bulk-converted exact gas/fee/balance assertions to `\d+` to cut churn during the gas refactor, but in some files the exact values were the load-bearing invariant.

This PR pins exact values instead of using wildcards. It reflects gas changes introduced in #5415, but *doesn’t    
explain the rationale*. Documenting that context would make it clearer and help subsequent PRs track and reason about gas  changes more effectively.