### PR TITLE
fix(tm2/amino): preserve nil_elements in genproto2

### DIFF
--- a/tm2/pkg/amino/genproto2/gen_unmarshal.go
+++ b/tm2/pkg/amino/genproto2/gen_unmarshal.go
@@ -585,16 +585,48 @@ func (ctx *P3Context2) writeUnpackedListUnmarshal(sb *strings.Builder, accessor 
 			fmt.Fprintf(sb, "%s\t%s", indent, storeElem("nil"))
 			fmt.Fprintf(sb, "%s}\n", indent)
 		} else if ertIsPointer {
-			fmt.Fprintf( // Amino never encodes nil pointers in unpacked lists — nil elements are
-				// skipped entirely. So 0x00 is always a valid length-prefix (empty message),
-				// not a nil marker. Just decode the element unconditionally.
-				sb, "%svar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
-			if writeImplicit {
-				ctx.writeImplicitStructDecode(sb, "ev", einfo, fopts, indent)
+			rt := einfo.ReprType.Type
+			isStructLike := rt.Kind() == reflect.Struct ||
+				rt == reflect.TypeOf(time.Duration(0)) ||
+				(isListType(rt) && rt.Elem().Kind() != reflect.Uint8)
+			if fopts.NilElements {
+				if writeImplicit || isStructLike {
+					fmt.Fprintf(sb, "%sfbz, n, err := amino.DecodeByteSlice(bz)\n", indent)
+					fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+					fmt.Fprintf(sb, "%sbz = bz[n:]\n", indent)
+					fmt.Fprintf(sb, "%sif len(fbz) == 0 {\n", indent)
+					fmt.Fprintf(sb, "%s\t%s", indent, storeElem("nil"))
+					fmt.Fprintf(sb, "%s} else {\n", indent)
+					fmt.Fprintf(sb, "%s\tvar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
+					if writeImplicit {
+						ctx.writeImplicitStructPayloadDecode(sb, "ev", einfo, fopts, indent+"\t", "fbz")
+					} else {
+						ctx.writeByteSliceElementPayloadDecode(sb, "ev", einfo, fopts, indent+"\t", "fbz")
+					}
+					fmt.Fprintf(sb, "%s\t%s", indent, storeElem("&ev"))
+					fmt.Fprintf(sb, "%s}\n", indent)
+				} else {
+					fmt.Fprintf(sb, "%sif len(bz) > 0 && bz[0] == 0x00 {\n", indent)
+					fmt.Fprintf(sb, "%s\tbz = bz[1:]\n", indent)
+					fmt.Fprintf(sb, "%s\t%s", indent, storeElem("nil"))
+					fmt.Fprintf(sb, "%s} else {\n", indent)
+					fmt.Fprintf(sb, "%s\tvar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
+					ctx.writeByteSliceElementDecode(sb, "ev", einfo, fopts, indent+"\t")
+					fmt.Fprintf(sb, "%s\t%s", indent, storeElem("&ev"))
+					fmt.Fprintf(sb, "%s}\n", indent)
+				}
 			} else {
-				ctx.writeByteSliceElementDecode(sb, "ev", einfo, fopts, indent)
+				fmt.Fprintf( // Amino never encodes nil pointers in unpacked lists unless
+					// amino:"nil_elements" is set. Without that tag, 0x00 is a valid
+					// length-prefix for an empty message, not a nil marker.
+					sb, "%svar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
+				if writeImplicit {
+					ctx.writeImplicitStructDecode(sb, "ev", einfo, fopts, indent)
+				} else {
+					ctx.writeByteSliceElementDecode(sb, "ev", einfo, fopts, indent)
+				}
+				fmt.Fprintf(sb, "%s%s", indent, storeElem("&ev"))
 			}
-			fmt.Fprintf(sb, "%s%s", indent, storeElem("&ev"))
 		} else {
 			fmt.Fprintf(sb, "%svar ev %s\n", indent, ctx.goTypeName(ert))
 			if writeImplicit {
@@ -618,21 +650,7 @@ func (ctx *P3Context2) writeByteSliceElementDecode(sb *strings.Builder, accessor
 		fmt.Fprintf(sb, "%sfbz, n, err := amino.DecodeByteSlice(bz)\n", indent)
 		fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 		fmt.Fprintf(sb, "%sbz = bz[n:]\n", indent)
-
-		switch {
-		case rt == reflect.TypeOf(time.Time{}):
-			fmt.Fprintf(sb, "%s%s, _, err = amino.DecodeTime(fbz)\n", indent, accessor)
-			fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
-		case rt == reflect.TypeOf(time.Duration(0)):
-			fmt.Fprintf(sb, "%s%s, _, err = amino.DecodeDuration(fbz)\n", indent, accessor)
-			fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
-		case isNestedList:
-			fmt.Fprintf(sb, "%sif err := cdc.Unmarshal(fbz, &%s); err != nil {\n%s\treturn err\n%s}\n",
-				indent, accessor, indent, indent)
-		default:
-			fmt.Fprintf(sb, "%sif err := %s.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {\n%s\treturn err\n%s}\n",
-				indent, accessor, indent, indent)
-		}
+		ctx.writeByteSliceElementPayloadDecode(sb, accessor, einfo, fopts, indent, "fbz")
 	} else if einfo.IsAminoMarshaler {
 		// AminoMarshaler element: decode repr, then UnmarshalAmino.
 		reprType := einfo.ReprType.Type
@@ -652,20 +670,54 @@ func (ctx *P3Context2) writeImplicitStructDecode(sb *strings.Builder, accessor s
 	fmt.Fprintf(sb, "%sibz, n, err := amino.DecodeByteSlice(bz)\n", indent)
 	fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
 	fmt.Fprintf(sb, "%sbz = bz[n:]\n", indent)
-	fmt.Fprintf(sb, "%sif len(ibz) > 0 {\n", indent)
+	ctx.writeImplicitStructPayloadDecode(sb, accessor, einfo, fopts, indent, "ibz")
+}
+
+func (ctx *P3Context2) writeByteSliceElementPayloadDecode(sb *strings.Builder, accessor string, einfo *amino.TypeInfo, fopts amino.FieldOptions, indent, srcVar string) {
+	rinfo := einfo.ReprType
+	rt := rinfo.Type
+
+	isNestedList := isListType(rt) && rt.Elem().Kind() != reflect.Uint8
+	switch {
+	case rt == reflect.TypeOf(time.Time{}):
+		fmt.Fprintf(sb, "%s%s, _, err = amino.DecodeTime(%s)\n", indent, accessor, srcVar)
+		fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	case rt == reflect.TypeOf(time.Duration(0)):
+		fmt.Fprintf(sb, "%s%s, _, err = amino.DecodeDuration(%s)\n", indent, accessor, srcVar)
+		fmt.Fprintf(sb, "%sif err != nil {\n%s\treturn err\n%s}\n", indent, indent, indent)
+	case isNestedList:
+		fmt.Fprintf(sb, "%sif err := cdc.Unmarshal(%s, &%s); err != nil {\n%s\treturn err\n%s}\n",
+			indent, srcVar, accessor, indent, indent)
+	case rt.Kind() == reflect.Struct:
+		fmt.Fprintf(sb, "%sif err := %s.UnmarshalBinary2(cdc, %s, anyDepth); err != nil {\n%s\treturn err\n%s}\n",
+			indent, accessor, srcVar, indent, indent)
+	case einfo.IsAminoMarshaler:
+		reprType := einfo.ReprType.Type
+		fmt.Fprintf(sb, "%svar rv %s\n", indent, ctx.goTypeName(reprType))
+		ctx.writePrimitiveDecodeFrom(sb, "rv", einfo.ReprType, fopts, indent, srcVar)
+		fmt.Fprintf(sb, "%sif err := %s.UnmarshalAmino(rv); err != nil {\n%s\treturn err\n%s}\n",
+			indent, accessor, indent, indent)
+	default:
+		ctx.writePrimitiveDecodeFrom(sb, accessor, einfo, fopts, indent, srcVar)
+	}
+}
+
+func (ctx *P3Context2) writeImplicitStructPayloadDecode(sb *strings.Builder, accessor string, einfo *amino.TypeInfo, fopts amino.FieldOptions, indent, srcVar string) {
+	fmt.Fprintf(sb, "%sif len(%s) > 0 {\n", indent, srcVar)
 	// Read field 1 key from ibz and validate it's the expected ByteLength wrapper.
-	fmt.Fprintf(sb, "%s\t_fnum, _typ3, _n, _err := amino.DecodeFieldNumberAndTyp3(ibz)\n", indent)
+	fmt.Fprintf(sb, "%s\t_fnum, _typ3, _n, _err := amino.DecodeFieldNumberAndTyp3(%s)\n", indent, srcVar)
 	fmt.Fprintf(sb, "%s\tif _err != nil {\n%s\t\treturn _err\n%s\t}\n", indent, indent, indent)
 	fmt.Fprintf(sb, "%s\tif _fnum != 1 || _typ3 != amino.Typ3ByteLength {\n", indent)
 	fmt.Fprintf(sb, "%s\t\treturn fmt.Errorf(\"implicit struct: expected field 1 ByteLength, got num=%%v typ=%%v\", _fnum, _typ3)\n", indent)
 	fmt.Fprintf(sb, "%s\t}\n", indent)
-	fmt.Fprintf(sb, "%s\tibz = ibz[_n:]\n", indent)
-	// Read inner ByteSlice (packed data).
-	fmt.Fprintf(sb, "%s\tfbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)\n", indent)
+	fmt.Fprintf(sb, "%s\t%s = %s[_n:]\n", indent, srcVar, srcVar)
+	// Read inner ByteSlice (packed data). Use a distinct variable name here:
+	// srcVar may already be named "fbz" in the caller.
+	fmt.Fprintf(sb, "%s\t_inner, _fbn, _err2 := amino.DecodeByteSlice(%s)\n", indent, srcVar)
 	fmt.Fprintf(sb, "%s\tif _err2 != nil {\n%s\t\treturn _err2\n%s\t}\n", indent, indent, indent)
 	// The implicit struct has only field 1 — reject anything past it.
-	fmt.Fprintf(sb, "%s\tif len(ibz)-_fbn > 0 {\n", indent)
-	fmt.Fprintf(sb, "%s\t\treturn fmt.Errorf(\"implicit struct: %%d trailing bytes after field 1\", len(ibz)-_fbn)\n", indent)
+	fmt.Fprintf(sb, "%s\tif len(%s)-_fbn > 0 {\n", indent, srcVar)
+	fmt.Fprintf(sb, "%s\t\treturn fmt.Errorf(\"implicit struct: %%d trailing bytes after field 1\", len(%s)-_fbn)\n", indent, srcVar)
 	fmt.Fprintf(sb, "%s\t}\n", indent)
 	// Decode elements from packed data.
 	innerEinfo := einfo.Elem
@@ -674,15 +726,15 @@ func (ctx *P3Context2) writeImplicitStructDecode(sb *strings.Builder, accessor s
 		for i := 0; i < length; i++ {
 			elemAccessor := fmt.Sprintf("%s[%d]", accessor, i)
 			fmt.Fprintf(sb, "%s\t{\n", indent)
-			ctx.writePrimitiveDecodeFrom(sb, elemAccessor, innerEinfo, fopts, indent+"\t\t", "fbz")
+			ctx.writePrimitiveDecodeFrom(sb, elemAccessor, innerEinfo, fopts, indent+"\t\t", "_inner")
 			fmt.Fprintf(sb, "%s\t}\n", indent)
 		}
 	} else {
 		// Slice: decode while data remains.
 		ert := einfo.Type.Elem()
-		fmt.Fprintf(sb, "%s\tfor len(fbz) > 0 {\n", indent)
+		fmt.Fprintf(sb, "%s\tfor len(_inner) > 0 {\n", indent)
 		fmt.Fprintf(sb, "%s\t\tvar _elem %s\n", indent, ctx.goTypeName(ert))
-		ctx.writePrimitiveDecodeFrom(sb, "_elem", innerEinfo, fopts, indent+"\t\t", "fbz")
+		ctx.writePrimitiveDecodeFrom(sb, "_elem", innerEinfo, fopts, indent+"\t\t", "_inner")
 		fmt.Fprintf(sb, "%s\t\t%s = append(%s, _elem)\n", indent, accessor, accessor)
 		fmt.Fprintf(sb, "%s\t}\n", indent)
 	}

--- a/tm2/pkg/amino/genproto2/gen_unmarshal.go
+++ b/tm2/pkg/amino/genproto2/gen_unmarshal.go
@@ -616,10 +616,10 @@ func (ctx *P3Context2) writeUnpackedListUnmarshal(sb *strings.Builder, accessor 
 					fmt.Fprintf(sb, "%s}\n", indent)
 				}
 			} else {
-				fmt.Fprintf( // Amino never encodes nil pointers in unpacked lists unless
-					// amino:"nil_elements" is set. Without that tag, 0x00 is a valid
-					// length-prefix for an empty message, not a nil marker.
-					sb, "%svar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
+				// For struct pointer elements without nil_elements, marshal errors on nil,
+				// so 0x00 on the wire is always a length-prefix for an empty message,
+				// not a nil marker.
+				fmt.Fprintf(sb, "%svar ev %s\n", indent, ctx.goTypeName(ert.Elem()))
 				if writeImplicit {
 					ctx.writeImplicitStructDecode(sb, "ev", einfo, fopts, indent)
 				} else {

--- a/tm2/pkg/amino/tests/pb3_gen.go
+++ b/tm2/pkg/amino/tests/pb3_gen.go
@@ -2156,7 +2156,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2164,19 +2164,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeVarint8(fbz)
+					v, n, err := amino.DecodeVarint8(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int8(v)
 				}
 				{
-					v, n, err := amino.DecodeVarint8(fbz)
+					v, n, err := amino.DecodeVarint8(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int8(v)
 				}
 			}
@@ -2214,7 +2214,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2222,19 +2222,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeVarint8(fbz)
+						v, n, err := amino.DecodeVarint8(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int8(v)
 					}
 					{
-						v, n, err := amino.DecodeVarint8(fbz)
+						v, n, err := amino.DecodeVarint8(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int8(v)
 					}
 				}
@@ -2263,7 +2263,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2271,19 +2271,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeVarint16(fbz)
+					v, n, err := amino.DecodeVarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int16(v)
 				}
 				{
-					v, n, err := amino.DecodeVarint16(fbz)
+					v, n, err := amino.DecodeVarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int16(v)
 				}
 			}
@@ -2321,7 +2321,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2329,19 +2329,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeVarint16(fbz)
+						v, n, err := amino.DecodeVarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int16(v)
 					}
 					{
-						v, n, err := amino.DecodeVarint16(fbz)
+						v, n, err := amino.DecodeVarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int16(v)
 					}
 				}
@@ -2370,7 +2370,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2378,19 +2378,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int32(v)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int32(v)
 				}
 			}
@@ -2428,7 +2428,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2436,19 +2436,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int32(v)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int32(v)
 					}
 				}
@@ -2477,7 +2477,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2485,19 +2485,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeInt32(fbz)
+					v, n, err := amino.DecodeInt32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int32(v)
 				}
 				{
-					v, n, err := amino.DecodeInt32(fbz)
+					v, n, err := amino.DecodeInt32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int32(v)
 				}
 			}
@@ -2535,7 +2535,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2543,19 +2543,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeInt32(fbz)
+						v, n, err := amino.DecodeInt32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int32(v)
 					}
 					{
-						v, n, err := amino.DecodeInt32(fbz)
+						v, n, err := amino.DecodeInt32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int32(v)
 					}
 				}
@@ -2584,7 +2584,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2592,19 +2592,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int64(v)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int64(v)
 				}
 			}
@@ -2642,7 +2642,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2650,19 +2650,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int64(v)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int64(v)
 					}
 				}
@@ -2691,7 +2691,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2699,19 +2699,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeInt64(fbz)
+					v, n, err := amino.DecodeInt64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int64(v)
 				}
 				{
-					v, n, err := amino.DecodeInt64(fbz)
+					v, n, err := amino.DecodeInt64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int64(v)
 				}
 			}
@@ -2749,7 +2749,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2757,19 +2757,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeInt64(fbz)
+						v, n, err := amino.DecodeInt64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int64(v)
 					}
 					{
-						v, n, err := amino.DecodeInt64(fbz)
+						v, n, err := amino.DecodeInt64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int64(v)
 					}
 				}
@@ -2798,7 +2798,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2806,19 +2806,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = int(v)
 				}
 				{
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = int(v)
 				}
 			}
@@ -2856,7 +2856,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -2864,19 +2864,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = int(v)
 					}
 					{
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = int(v)
 					}
 				}
@@ -2991,7 +2991,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -2999,19 +2999,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUvarint16(fbz)
+					v, n, err := amino.DecodeUvarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint16(v)
 				}
 				{
-					v, n, err := amino.DecodeUvarint16(fbz)
+					v, n, err := amino.DecodeUvarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint16(v)
 				}
 			}
@@ -3049,7 +3049,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3057,19 +3057,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUvarint16(fbz)
+						v, n, err := amino.DecodeUvarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint16(v)
 					}
 					{
-						v, n, err := amino.DecodeUvarint16(fbz)
+						v, n, err := amino.DecodeUvarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint16(v)
 					}
 				}
@@ -3098,7 +3098,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -3106,19 +3106,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint32(v)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint32(v)
 				}
 			}
@@ -3156,7 +3156,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3164,19 +3164,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint32(v)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint32(v)
 					}
 				}
@@ -3205,7 +3205,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -3213,19 +3213,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUint32(fbz)
+					v, n, err := amino.DecodeUint32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint32(v)
 				}
 				{
-					v, n, err := amino.DecodeUint32(fbz)
+					v, n, err := amino.DecodeUint32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint32(v)
 				}
 			}
@@ -3263,7 +3263,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3271,19 +3271,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUint32(fbz)
+						v, n, err := amino.DecodeUint32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint32(v)
 					}
 					{
-						v, n, err := amino.DecodeUint32(fbz)
+						v, n, err := amino.DecodeUint32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint32(v)
 					}
 				}
@@ -3312,7 +3312,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -3320,19 +3320,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint64(v)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint64(v)
 				}
 			}
@@ -3370,7 +3370,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3378,19 +3378,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint64(v)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint64(v)
 					}
 				}
@@ -3419,7 +3419,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -3427,19 +3427,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUint64(fbz)
+					v, n, err := amino.DecodeUint64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint64(v)
 				}
 				{
-					v, n, err := amino.DecodeUint64(fbz)
+					v, n, err := amino.DecodeUint64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint64(v)
 				}
 			}
@@ -3477,7 +3477,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3485,19 +3485,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUint64(fbz)
+						v, n, err := amino.DecodeUint64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint64(v)
 					}
 					{
-						v, n, err := amino.DecodeUint64(fbz)
+						v, n, err := amino.DecodeUint64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint64(v)
 					}
 				}
@@ -3526,7 +3526,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
@@ -3534,19 +3534,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[0] = uint(v)
 				}
 				{
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					ev[1] = uint(v)
 				}
 			}
@@ -3584,7 +3584,7 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
@@ -3592,19 +3592,19 @@ func (goo *ArraysArraysStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[0] = uint(v)
 					}
 					{
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						ev[1] = uint(v)
 					}
 				}
@@ -5255,20 +5255,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int8
-					v, n, err := amino.DecodeVarint8(fbz)
+					v, n, err := amino.DecodeVarint8(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int8(v)
 					ev = append(ev, _elem)
 				}
@@ -5303,20 +5303,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int8
-						v, n, err := amino.DecodeVarint8(fbz)
+						v, n, err := amino.DecodeVarint8(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int8(v)
 						ev = append(ev, _elem)
 					}
@@ -5342,20 +5342,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int16
-					v, n, err := amino.DecodeVarint16(fbz)
+					v, n, err := amino.DecodeVarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int16(v)
 					ev = append(ev, _elem)
 				}
@@ -5390,20 +5390,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int16
-						v, n, err := amino.DecodeVarint16(fbz)
+						v, n, err := amino.DecodeVarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int16(v)
 						ev = append(ev, _elem)
 					}
@@ -5429,20 +5429,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int32
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int32(v)
 					ev = append(ev, _elem)
 				}
@@ -5477,20 +5477,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int32
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int32(v)
 						ev = append(ev, _elem)
 					}
@@ -5516,20 +5516,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int32
-					v, n, err := amino.DecodeInt32(fbz)
+					v, n, err := amino.DecodeInt32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int32(v)
 					ev = append(ev, _elem)
 				}
@@ -5564,20 +5564,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int32
-						v, n, err := amino.DecodeInt32(fbz)
+						v, n, err := amino.DecodeInt32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int32(v)
 						ev = append(ev, _elem)
 					}
@@ -5603,20 +5603,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int64
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int64(v)
 					ev = append(ev, _elem)
 				}
@@ -5651,20 +5651,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int64
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int64(v)
 						ev = append(ev, _elem)
 					}
@@ -5690,20 +5690,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int64
-					v, n, err := amino.DecodeInt64(fbz)
+					v, n, err := amino.DecodeInt64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int64(v)
 					ev = append(ev, _elem)
 				}
@@ -5738,20 +5738,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int64
-						v, n, err := amino.DecodeInt64(fbz)
+						v, n, err := amino.DecodeInt64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int64(v)
 						ev = append(ev, _elem)
 					}
@@ -5777,20 +5777,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem int
-					v, n, err := amino.DecodeVarint(fbz)
+					v, n, err := amino.DecodeVarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = int(v)
 					ev = append(ev, _elem)
 				}
@@ -5825,20 +5825,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem int
-						v, n, err := amino.DecodeVarint(fbz)
+						v, n, err := amino.DecodeVarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = int(v)
 						ev = append(ev, _elem)
 					}
@@ -5950,20 +5950,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint16
-					v, n, err := amino.DecodeUvarint16(fbz)
+					v, n, err := amino.DecodeUvarint16(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint16(v)
 					ev = append(ev, _elem)
 				}
@@ -5998,20 +5998,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint16
-						v, n, err := amino.DecodeUvarint16(fbz)
+						v, n, err := amino.DecodeUvarint16(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint16(v)
 						ev = append(ev, _elem)
 					}
@@ -6037,20 +6037,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint32
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint32(v)
 					ev = append(ev, _elem)
 				}
@@ -6085,20 +6085,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint32
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint32(v)
 						ev = append(ev, _elem)
 					}
@@ -6124,20 +6124,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint32
-					v, n, err := amino.DecodeUint32(fbz)
+					v, n, err := amino.DecodeUint32(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint32(v)
 					ev = append(ev, _elem)
 				}
@@ -6172,20 +6172,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint32
-						v, n, err := amino.DecodeUint32(fbz)
+						v, n, err := amino.DecodeUint32(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint32(v)
 						ev = append(ev, _elem)
 					}
@@ -6211,20 +6211,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint64
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint64(v)
 					ev = append(ev, _elem)
 				}
@@ -6259,20 +6259,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint64
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint64(v)
 						ev = append(ev, _elem)
 					}
@@ -6298,20 +6298,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint64
-					v, n, err := amino.DecodeUint64(fbz)
+					v, n, err := amino.DecodeUint64(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint64(v)
 					ev = append(ev, _elem)
 				}
@@ -6346,20 +6346,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint64
-						v, n, err := amino.DecodeUint64(fbz)
+						v, n, err := amino.DecodeUint64(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint64(v)
 						ev = append(ev, _elem)
 					}
@@ -6385,20 +6385,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 					return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 				}
 				ibz = ibz[_n:]
-				fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+				_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 				if _err2 != nil {
 					return _err2
 				}
 				if len(ibz)-_fbn > 0 {
 					return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 				}
-				for len(fbz) > 0 {
+				for len(_inner) > 0 {
 					var _elem uint
-					v, n, err := amino.DecodeUvarint(fbz)
+					v, n, err := amino.DecodeUvarint(_inner)
 					if err != nil {
 						return err
 					}
-					fbz = fbz[n:]
+					_inner = _inner[n:]
 					_elem = uint(v)
 					ev = append(ev, _elem)
 				}
@@ -6433,20 +6433,20 @@ func (goo *SlicesSlicesStruct) UnmarshalBinary2(cdc *amino.Codec, bz []byte, any
 						return fmt.Errorf("implicit struct: expected field 1 ByteLength, got num=%v typ=%v", _fnum, _typ3)
 					}
 					ibz = ibz[_n:]
-					fbz, _fbn, _err2 := amino.DecodeByteSlice(ibz)
+					_inner, _fbn, _err2 := amino.DecodeByteSlice(ibz)
 					if _err2 != nil {
 						return _err2
 					}
 					if len(ibz)-_fbn > 0 {
 						return fmt.Errorf("implicit struct: %d trailing bytes after field 1", len(ibz)-_fbn)
 					}
-					for len(fbz) > 0 {
+					for len(_inner) > 0 {
 						var _elem uint
-						v, n, err := amino.DecodeUvarint(fbz)
+						v, n, err := amino.DecodeUvarint(_inner)
 						if err != nil {
 							return err
 						}
-						fbz = fbz[n:]
+						_inner = _inner[n:]
 						_elem = uint(v)
 						ev = append(ev, _elem)
 					}
@@ -15025,16 +15025,20 @@ func (goo *FuzzNilElements) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDep
 			if typ3 != amino.Typ3ByteLength {
 				return fmt.Errorf("field 1: expected typ3 %v, got %v", amino.Typ3ByteLength, typ3)
 			}
-			var ev FuzzFieldInfo
 			fbz, n, err := amino.DecodeByteSlice(bz)
 			if err != nil {
 				return err
 			}
 			bz = bz[n:]
-			if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-				return err
+			if len(fbz) == 0 {
+				goo.Entries = append(goo.Entries, nil)
+			} else {
+				var ev FuzzFieldInfo
+				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+					return err
+				}
+				goo.Entries = append(goo.Entries, &ev)
 			}
-			goo.Entries = append(goo.Entries, &ev)
 			for len(bz) > 0 {
 				var nextFnum uint32
 				var nextTyp3 amino.Typ3
@@ -15049,31 +15053,39 @@ func (goo *FuzzNilElements) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDep
 					return fmt.Errorf("field 1: expected typ3 %v, got %v", amino.Typ3ByteLength, nextTyp3)
 				}
 				bz = bz[n:]
-				var ev FuzzFieldInfo
 				fbz, n, err := amino.DecodeByteSlice(bz)
 				if err != nil {
 					return err
 				}
 				bz = bz[n:]
-				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-					return err
+				if len(fbz) == 0 {
+					goo.Entries = append(goo.Entries, nil)
+				} else {
+					var ev FuzzFieldInfo
+					if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+						return err
+					}
+					goo.Entries = append(goo.Entries, &ev)
 				}
-				goo.Entries = append(goo.Entries, &ev)
 			}
 		case 2:
 			if typ3 != amino.Typ3ByteLength {
 				return fmt.Errorf("field 2: expected typ3 %v, got %v", amino.Typ3ByteLength, typ3)
 			}
-			var ev GnoVMPos
 			fbz, n, err := amino.DecodeByteSlice(bz)
 			if err != nil {
 				return err
 			}
 			bz = bz[n:]
-			if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-				return err
+			if len(fbz) == 0 {
+				goo.Poses = append(goo.Poses, nil)
+			} else {
+				var ev GnoVMPos
+				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+					return err
+				}
+				goo.Poses = append(goo.Poses, &ev)
 			}
-			goo.Poses = append(goo.Poses, &ev)
 			for len(bz) > 0 {
 				var nextFnum uint32
 				var nextTyp3 amino.Typ3
@@ -15088,16 +15100,20 @@ func (goo *FuzzNilElements) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDep
 					return fmt.Errorf("field 2: expected typ3 %v, got %v", amino.Typ3ByteLength, nextTyp3)
 				}
 				bz = bz[n:]
-				var ev GnoVMPos
 				fbz, n, err := amino.DecodeByteSlice(bz)
 				if err != nil {
 					return err
 				}
 				bz = bz[n:]
-				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-					return err
+				if len(fbz) == 0 {
+					goo.Poses = append(goo.Poses, nil)
+				} else {
+					var ev GnoVMPos
+					if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+						return err
+					}
+					goo.Poses = append(goo.Poses, &ev)
 				}
-				goo.Poses = append(goo.Poses, &ev)
 			}
 		case 3:
 			if typ3 != amino.Typ3ByteLength {

--- a/tm2/pkg/amino/tests/pb3_test.go
+++ b/tm2/pkg/amino/tests/pb3_test.go
@@ -309,6 +309,27 @@ func TestRoundtripBinary2_PointerSlicesStruct(t *testing.T) {
 	compareEncoding(t, cdc, "PointerSlicesStruct", orig)
 }
 
+func TestRoundtripBinary2_FuzzNilElements(t *testing.T) {
+	cdc := amino.NewCodec()
+	cdc.RegisterPackage(Package)
+	cdc.Seal()
+
+	orig := FuzzNilElements{
+		Entries: []*FuzzFieldInfo{
+			{Name: "present", Embedded: true, Tag: "json:\"present\"", Index: 1},
+			nil,
+			{Name: "tail", Tag: "json:\"tail\"", Index: 2},
+		},
+		Poses: []*GnoVMPos{
+			{Line: 7, Column: 9},
+			nil,
+		},
+		Name: "nil-elements",
+	}
+
+	compareEncoding(t, cdc, "FuzzNilElements", orig)
+}
+
 func TestRoundtripBinary2_EmbeddedSt2(t *testing.T) {
 	cdc := amino.NewCodec()
 	cdc.RegisterPackage(Package)

--- a/tm2/pkg/bft/types/block_test.go
+++ b/tm2/pkg/bft/types/block_test.go
@@ -70,6 +70,50 @@ func TestBlockValidateBasic(t *testing.T) {
 	}
 }
 
+func TestBlockBinary2RoundTripPreservesNilLastCommitEntries(t *testing.T) {
+	t.Parallel()
+
+	height := int64(7)
+	lastBlockID := makeBlockIDRandom()
+	voteSet, _, privVals := randVoteSet(height-1, 0, PrecommitType, 4, 1)
+
+	for i := range 3 {
+		vote := &Vote{
+			ValidatorAddress: privVals[i].PubKey().Address(),
+			ValidatorIndex:   i,
+			Height:           height - 1,
+			Round:            0,
+			Type:             PrecommitType,
+			BlockID:          lastBlockID,
+			Timestamp:        tmtime.Now(),
+		}
+
+		signed, err := signAddVote(privVals[i], vote, voteSet)
+		require.NoError(t, err)
+		require.True(t, signed)
+	}
+
+	commit := voteSet.MakeCommit()
+	require.Len(t, commit.Precommits, 4)
+	require.Nil(t, commit.Precommits[3])
+
+	block := MakeBlock(height, nil, commit)
+	cdc := amino.NewCodec()
+	cdc.RegisterPackage(Package)
+	cdc.Seal()
+
+	bz, err := cdc.MarshalBinary2(block)
+	require.NoError(t, err)
+
+	var decoded Block
+	err = decoded.UnmarshalBinary2(cdc, bz, 0)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.LastCommit)
+	require.Len(t, decoded.LastCommit.Precommits, 4)
+	require.Nil(t, decoded.LastCommit.Precommits[3])
+	require.NoError(t, decoded.ValidateBasic())
+}
+
 func TestBlockHash(t *testing.T) {
 	t.Parallel()
 

--- a/tm2/pkg/bft/types/pb3_gen.go
+++ b/tm2/pkg/bft/types/pb3_gen.go
@@ -927,16 +927,20 @@ func (goo *Commit) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDepth int) e
 			if typ3 != amino.Typ3ByteLength {
 				return fmt.Errorf("field 2: expected typ3 %v, got %v", amino.Typ3ByteLength, typ3)
 			}
-			var ev CommitSig
 			fbz, n, err := amino.DecodeByteSlice(bz)
 			if err != nil {
 				return err
 			}
 			bz = bz[n:]
-			if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-				return err
+			if len(fbz) == 0 {
+				goo.Precommits = append(goo.Precommits, nil)
+			} else {
+				var ev CommitSig
+				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+					return err
+				}
+				goo.Precommits = append(goo.Precommits, &ev)
 			}
-			goo.Precommits = append(goo.Precommits, &ev)
 			for len(bz) > 0 {
 				var nextFnum uint32
 				var nextTyp3 amino.Typ3
@@ -951,16 +955,20 @@ func (goo *Commit) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDepth int) e
 					return fmt.Errorf("field 2: expected typ3 %v, got %v", amino.Typ3ByteLength, nextTyp3)
 				}
 				bz = bz[n:]
-				var ev CommitSig
 				fbz, n, err := amino.DecodeByteSlice(bz)
 				if err != nil {
 					return err
 				}
 				bz = bz[n:]
-				if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
-					return err
+				if len(fbz) == 0 {
+					goo.Precommits = append(goo.Precommits, nil)
+				} else {
+					var ev CommitSig
+					if err := ev.UnmarshalBinary2(cdc, fbz, anyDepth); err != nil {
+						return err
+					}
+					goo.Precommits = append(goo.Precommits, &ev)
 				}
-				goo.Precommits = append(goo.Precommits, &ev)
 			}
 		default:
 			return fmt.Errorf("unknown field number %d for Commit", fnum)


### PR DESCRIPTION
## Summary

Fix a genproto2 regression introduced by #5282 `e8aac7575f` (`feat(amino): add genproto2`).

After regenerating `pb3_gen.go` from master, `gnoland` consensus started failing deterministically because `types.Commit.Precommits` uses `amino:"nil_elements"`, and the generated genproto2 decoder did not preserve positional `nil` entries in unpacked pointer lists.

In the failing path:
- a commit with one missing validator precommit was marshaled with a zero-length `ByteLength` entry for that validator
- genproto2 unmarshal reconstructed that entry incorrectly
- the next proposal’s `LastCommit` then failed block validation with `wrong LastCommit`
- the proposer rejected its own block and the chain wedged

## Root Cause

Marshal was already correct: for unpacked pointer lists with `amino:"nil_elements"`, genproto2 encodes a `nil` element as an empty `ByteLength` value (`0x00`), matching the reflect codec.

The bug was in generated unmarshal: it did not turn that empty entry back into `nil`. Instead, it decoded it as a non-`nil` zero-value element.

For `types.Commit.Precommits`, that is consensus-critical because the list is positional. A missing precommit must remain `nil`; turning it into a zero-value `CommitSig` makes the reconstructed commit invalid, which is why the next proposal failed with `wrong LastCommit`.

The fix makes generated unmarshal match the reflect codec again: empty entries decode to `nil`, non-empty entries stay on the generated fast path, and `anyDepth` is preserved.

## Why This Fix

`Commit.Precommits` is positional and uses `amino:"nil_elements"`. Losing `nil` entries or changing their decode semantics is not just cosmetic; it changes the meaning of the commit.

The final implementation keeps genproto2 behavior aligned with the reflect codec while preserving the generated fast path and existing depth-guard semantics.