### PR TITLE
fix(tm2): fix three CodeQL high-severity alerts

### DIFF
--- a/tm2/pkg/amino/tests/common.go
+++ b/tm2/pkg/amino/tests/common.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -299,6 +300,9 @@ func (am *AminoMarshalerInt5) UnmarshalAmino(repr string) error {
 	i, err := strconv.Atoi(repr)
 	if err != nil {
 		return err
+	}
+	if i < math.MinInt32 || i > math.MaxInt32 {
+		return fmt.Errorf("value %d overflows int32", i)
 	}
 	*am = AminoMarshalerInt5(i)
 	return nil

--- a/tm2/pkg/crypto/xsalsa20symmetric/symmetric.go
+++ b/tm2/pkg/crypto/xsalsa20symmetric/symmetric.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/overflow"
 )
 
 // TODO, make this into a struct that implements crypto.Symmetric.
@@ -27,7 +28,7 @@ func EncryptSymmetric(plaintext []byte, secret []byte) (ciphertext []byte) {
 	copy(nonceArr[:], nonce)
 	secretArr := [secretLen]byte{}
 	copy(secretArr[:], secret)
-	ciphertext = make([]byte, nonceLen+secretbox.Overhead+len(plaintext))
+	ciphertext = make([]byte, overflow.Addp(overflow.Addp(nonceLen, secretbox.Overhead), len(plaintext)))
 	copy(ciphertext, nonce)
 	secretbox.Seal(ciphertext[nonceLen:nonceLen], plaintext, &nonceArr, &secretArr)
 	return ciphertext

--- a/tm2/pkg/store/prefix/store.go
+++ b/tm2/pkg/store/prefix/store.go
@@ -3,6 +3,7 @@ package prefix
 import (
 	"bytes"
 
+	"github.com/gnolang/gno/tm2/pkg/overflow"
 	"github.com/gnolang/gno/tm2/pkg/store/cache"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
@@ -25,7 +26,7 @@ func New(parent types.Store, prefix []byte) Store {
 }
 
 func cloneAppend(bz []byte, tail []byte) (res []byte) {
-	res = make([]byte, len(bz)+len(tail))
+	res = make([]byte, overflow.Addp(len(bz), len(tail)))
 	copy(res, bz)
 	copy(res[len(bz):], tail)
 	return


### PR DESCRIPTION
Fixes the three high-severity CodeQL alerts currently failing on master ([run](https://github.com/gnolang/gno/runs/72497339833)).

## Changes

- **`tm2/pkg/amino/tests/common.go`**: `AminoMarshalerInt5.UnmarshalAmino` cast the result of `strconv.Atoi` (arch-dependent `int`) directly to `int32` without a bounds check. Added `math.MinInt32`/`math.MaxInt32` guard that returns an error on overflow.
- **`tm2/pkg/crypto/xsalsa20symmetric/symmetric.go`**: ciphertext allocation size `nonceLen+secretbox.Overhead+len(plaintext)` could overflow. Replaced with `overflow.Addp`.
- **`tm2/pkg/store/prefix/store.go`**: `cloneAppend` allocation size `len(bz)+len(tail)` could overflow. Replaced with `overflow.Addp`.

<details><summary>Contributors' checklist...</summary>

- [x] Added new tests, or not needed
- [x] Provided an example (e.g. screenshot) to aid review
- [x] Updated the documentation if needed
- [x] Updated the [changelog_pending.md](https://github.com/gnolang/gno/blob/master/docs/changelog_pending.md) if needed

</details>