### PR TITLE
fix(gnovm): reset package state between test functions

### DIFF
--- a/examples/gno.land/r/archive/nir1218_evaluation_proposal/evaluation_test.gno
+++ b/examples/gno.land/r/archive/nir1218_evaluation_proposal/evaluation_test.gno
@@ -54,6 +54,9 @@ func TestEvaluationAddContribution(t *testing.T) {
 }
 
 func TestEvaluationUpdateContribution(t *testing.T) {
+	pr := NewPullRequest(id, name, description, status, category)
+	e.AddContribution(pr, address_XXX)
+
 	t.Run("", func(t *testing.T) {
 		status := "Negotiated"
 		ok := e.UpdateContribution(id, status)

--- a/examples/gno.land/r/demo/todolist/todolist_test.gno
+++ b/examples/gno.land/r/demo/todolist/todolist_test.gno
@@ -9,29 +9,26 @@ import (
 	"gno.land/p/nt/uassert/v0"
 )
 
-var (
-	node any
-	tdl  *todolist.TodoList
-)
+func setupTodoList(t *testing.T, title string) (int, *todolist.TodoList) {
+	t.Helper()
+	tlid, _ := NewTodoList(cross, title)
+	node, _ := todolistTree.Get(strconv.Itoa(tlid))
+	return tlid, node.(*todolist.TodoList)
+}
 
 func TestNewTodoList(t *testing.T) {
 	title := "My Todo List"
-	tlid, _ := NewTodoList(cross, title)
+	tlid, tdl := setupTodoList(t, title)
+
 	uassert.Equal(t, 1, tlid, "tlid does not match")
-
-	// get the todolist node from the tree
-	node, _ = todolistTree.Get(strconv.Itoa(tlid))
-	// convert the node to a TodoList struct
-	tdl = node.(*todolist.TodoList)
-
 	uassert.Equal(t, title, tdl.Title, "title does not match")
-	uassert.Equal(t, 1, tlid, "tlid does not match")
 	uassert.Equal(t, tdl.Owner.String(), runtime.OriginCaller().String(), "owner does not match")
 	uassert.Equal(t, 0, len(tdl.GetTasks()), "Expected no tasks in the todo list")
 }
 
 func TestAddTask(t *testing.T) {
-	AddTask(cross, 1, "Task 1")
+	tlid, tdl := setupTodoList(t, "My Todo List")
+	AddTask(cross, tlid, "Task 1")
 
 	tasks := tdl.GetTasks()
 	uassert.Equal(t, 1, len(tasks), "total task does not match")
@@ -40,21 +37,28 @@ func TestAddTask(t *testing.T) {
 }
 
 func TestToggleTaskStatus(t *testing.T) {
-	ToggleTaskStatus(cross, 1, 0)
+	tlid, tdl := setupTodoList(t, "My Todo List")
+	AddTask(cross, tlid, "Task 1")
+
+	ToggleTaskStatus(cross, tlid, 0)
 	task := tdl.GetTasks()[0]
 	uassert.True(t, task.Done, "Expected task to be done, but it is not marked as done")
 
-	ToggleTaskStatus(cross, 1, 0)
+	ToggleTaskStatus(cross, tlid, 0)
 	uassert.False(t, task.Done, "Expected task to be not done, but it is marked as done")
 }
 
 func TestRemoveTask(t *testing.T) {
-	RemoveTask(cross, 1, 0)
-	tasks := tdl.GetTasks()
-	uassert.Equal(t, 0, len(tasks), "Expected no tasks in the todo list")
+	tlid, tdl := setupTodoList(t, "My Todo List")
+	AddTask(cross, tlid, "Task 1")
+
+	RemoveTask(cross, tlid, 0)
+	uassert.Equal(t, 0, len(tdl.GetTasks()), "Expected no tasks in the todo list")
 }
 
 func TestRemoveTodoList(t *testing.T) {
-	RemoveTodoList(cross, 1)
-	uassert.Equal(t, 0, todolistTree.Size(), "Expected no tasks in the todo list")
+	tlid, _ := setupTodoList(t, "My Todo List")
+
+	RemoveTodoList(cross, tlid)
+	uassert.Equal(t, 0, todolistTree.Size(), "Expected no todolists after removal")
 }

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -188,45 +188,37 @@ func TestExecutorCreationRealm(cur realm, t *testing.T) {
 	urequire.Equal(t, true, contains(individualRendered, "This proposal tests executor creation realm tracking"))
 }
 
+func createMemberProposal(cur realm, nm1 address, portfolio string) dao.ProposalID {
+	testing.SetOriginCaller(m1)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao/v3/impl"))
+	req := NewAddMemberRequest(cur, nm1, memberstore.T2, portfolio)
+	testing.SetRealm(testing.NewUserRealm(m1))
+	return dao.MustCreateProposal(cross, req)
+}
+
 func TestProposalPagination(cur realm, t *testing.T) {
 	loadMembers()
 	portfolio := "### This is my portfolio:\n\n- THINGS"
-
-	testing.SetOriginCaller(m1)
-	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao/v3/impl"))
-
 	nm1 := testutils.TestAddress("nm1")
 
-	var pid dao.ProposalID
-
-	proposalRequest := NewAddMemberRequest(cur, nm1, memberstore.T2, portfolio)
+	// Build 8 proposals so the assertions below exercise both pages
+	// (page size 5, reverse): page 1 holds pids 7..3, page 2 holds 2..0.
+	// pid 1 uses a different title so the page 2 render assertion can
+	// distinguish it from the surrounding member proposals.
+	pid := createMemberProposal(cur, nm1, portfolio)
+	urequire.Equal(t, 0, int(pid))
 
 	testing.SetOriginCaller(m1)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/template/contract"))
+	executor := dao.NewSimpleExecutor(func(realm) error { return nil }, "Test executor from template")
 	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
+	pid = dao.MustCreateProposal(cross, dao.NewProposalRequest("Test Proposal", "This proposal tests pagination across two pages", executor))
+	urequire.Equal(t, 1, int(pid))
 
-	// TODO: tests keep the same vm state: https://github.com/gnolang/gno/issues/1982
-	urequire.Equal(t, 2, int(pid))
-
-	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
-	urequire.Equal(t, 3, int(pid))
-
-	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
-	urequire.Equal(t, 4, int(pid))
-
-	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
-	urequire.Equal(t, 5, int(pid))
-
-	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
-	urequire.Equal(t, 6, int(pid))
-
-	testing.SetRealm(testing.NewUserRealm(m1))
-	pid = dao.MustCreateProposal(cross, proposalRequest)
-	urequire.Equal(t, 7, int(pid))
+	for i := 2; i <= 7; i++ {
+		pid = createMemberProposal(cur, nm1, portfolio)
+		urequire.Equal(t, i, int(pid))
+	}
 
 	fmt.Println(dao.Render(""))
 	urequire.Equal(t, true, contains(dao.Render(""), "### [Prop #7 - New T2 Member Proposal](/r/gov/dao:7)"))
@@ -258,7 +250,7 @@ func TestUpgradeDaoImplementation(t *testing.T) {
 	testing.SetOriginCaller(m1)
 	testing.SetRealm(testing.NewUserRealm(m1))
 	pid := dao.MustCreateProposal(cross, preq)
-	urequire.Equal(t, int(pid), 8)
+	urequire.Equal(t, int(pid), 0)
 
 	// m1 votes yes because that member is interested on it
 	dao.MustVoteOnProposal(cross, dao.VoteRequest{
@@ -296,14 +288,15 @@ func TestUpgradeDaoImplementation(t *testing.T) {
 	// })
 	dao.MustVoteOnProposalSimple(cross, int64(pid), "YES")
 
-	urequire.Equal(t, true, contains(dao.Render("8"), "**Proposal is open for votes**"))
-	urequire.Equal(t, true, contains(dao.Render("8"), "68.42105263157895%"))
-	urequire.Equal(t, true, contains(dao.Render("8"), "0%"))
+	pidStr := pid.String()
+	urequire.Equal(t, true, contains(dao.Render(pidStr), "**Proposal is open for votes**"))
+	urequire.Equal(t, true, contains(dao.Render(pidStr), "68.42105263157895%"))
+	urequire.Equal(t, true, contains(dao.Render(pidStr), "0%"))
 
 	accepted := dao.ExecuteProposal(cross, dao.ProposalID(pid))
 	urequire.Equal(t, true, accepted)
-	urequire.Equal(t, true, contains(dao.Render("8"), "**PROPOSAL HAS BEEN ACCEPTED**"))
-	urequire.Equal(t, true, contains(dao.Render("8"), "YES PERCENT: 68.42105263157895%"))
+	urequire.Equal(t, true, contains(dao.Render(pidStr), "**PROPOSAL HAS BEEN ACCEPTED**"))
+	urequire.Equal(t, true, contains(dao.Render(pidStr), "YES PERCENT: 68.42105263157895%"))
 }
 
 func TestAbstainVote(cur realm, t *testing.T) {

--- a/examples/gno.land/r/leon/hor/hof_test.gno
+++ b/examples/gno.land/r/leon/hor/hof_test.gno
@@ -76,7 +76,15 @@ func TestRegister(t *testing.T) {
 	uassert.False(t, itemExists(t, rlmPath2))
 }
 
+func registerItem(t *testing.T, pkgpath string) {
+	t.Helper()
+	testing.SetRealm(testing.NewCodeRealm(pkgpath))
+	Register(cross, validTitle, validDesc)
+}
+
 func TestUpvote(t *testing.T) {
+	registerItem(t, rlmPath)
+
 	raw, _ := exhibition.items.Get(rlmPath)
 	item := raw.(*Item)
 
@@ -99,6 +107,8 @@ func TestUpvote(t *testing.T) {
 }
 
 func TestDownvote(t *testing.T) {
+	registerItem(t, rlmPath)
+
 	raw, _ := exhibition.items.Get(rlmPath)
 	item := raw.(*Item)
 
@@ -122,6 +132,8 @@ func TestDownvote(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	registerItem(t, rlmPath)
+
 	userRealm := testing.NewUserRealm(admin)
 	testing.SetRealm(userRealm)
 	testing.SetOriginCaller(admin)
@@ -129,9 +141,6 @@ func TestDelete(t *testing.T) {
 	uassert.AbortsWithMessage(t, ErrNoSuchItem.Error(), func() {
 		Delete(cross, "nonexistentpkgpath")
 	})
-
-	i, _ := exhibition.items.Get(rlmPath)
-	_ = i.(*Item).id
 
 	uassert.NotPanics(t, func() {
 		Delete(cross, rlmPath)

--- a/examples/gno.land/r/tests/vm/map_delete/map_delete_test.gno
+++ b/examples/gno.land/r/tests/vm/map_delete/map_delete_test.gno
@@ -9,11 +9,11 @@ func TestGetMap(t *testing.T) {
 }
 
 func TestDeleteMap(t *testing.T) {
+	if !GetMap(3) {
+		t.Fatal("precondition: key 3 should exist before delete")
+	}
 	DeleteMap(cross, 3)
-}
-
-func TestGetMapAfterDelete(t *testing.T) {
 	if GetMap(3) {
-		t.Error("Expected false, got ", GetMap(3))
+		t.Error("Expected false after delete, got true")
 	}
 }

--- a/gnovm/cmd/gno/testdata/test/init_and_isolation.txtar
+++ b/gnovm/cmd/gno/testdata/test/init_and_isolation.txtar
@@ -1,9 +1,4 @@
-mkdir $WORK/gnovm/tests
-symlink $WORK/gnovm/stdlibs -> $GNOROOT/gnovm/stdlibs
-symlink $WORK/gnovm/tests/stdlibs -> $GNOROOT/gnovm/tests/stdlibs
-env GNOROOT=$WORK
-
-gno test -v ./counter
+gno test -v .
 
 stderr '=== RUN   TestInitRan'
 stderr '--- PASS: TestInitRan'
@@ -12,12 +7,11 @@ stderr '--- PASS: TestStateResetBetweenTests_A'
 stderr '=== RUN   TestStateResetBetweenTests_B'
 stderr '--- PASS: TestStateResetBetweenTests_B'
 
--- gnowork.toml --
--- counter/gnomod.toml --
-module = "gno.land/p/demo/counter"
+-- gnomod.toml --
+module = "gno.test/p/integ/init_and_isolation"
 gno = "0.9"
 
--- counter/counter.gno --
+-- counter.gno --
 package counter
 
 var X int
@@ -26,7 +20,7 @@ func init() {
 	X = 42
 }
 
--- counter/counter_test.gno --
+-- counter_test.gno --
 package counter
 
 import "testing"

--- a/gnovm/cmd/gno/testdata/test/init_and_isolation.txtar
+++ b/gnovm/cmd/gno/testdata/test/init_and_isolation.txtar
@@ -1,0 +1,51 @@
+mkdir $WORK/gnovm/tests
+symlink $WORK/gnovm/stdlibs -> $GNOROOT/gnovm/stdlibs
+symlink $WORK/gnovm/tests/stdlibs -> $GNOROOT/gnovm/tests/stdlibs
+env GNOROOT=$WORK
+
+gno test -v ./counter
+
+stderr '=== RUN   TestInitRan'
+stderr '--- PASS: TestInitRan'
+stderr '=== RUN   TestStateResetBetweenTests_A'
+stderr '--- PASS: TestStateResetBetweenTests_A'
+stderr '=== RUN   TestStateResetBetweenTests_B'
+stderr '--- PASS: TestStateResetBetweenTests_B'
+
+-- gnowork.toml --
+-- counter/gnomod.toml --
+module = "gno.land/p/demo/counter"
+gno = "0.9"
+
+-- counter/counter.gno --
+package counter
+
+var X int
+
+func init() {
+	X = 42
+}
+
+-- counter/counter_test.gno --
+package counter
+
+import "testing"
+
+func TestInitRan(t *testing.T) {
+	if X != 42 {
+		t.Fatalf("init() did not run: X = %d, want 42", X)
+	}
+}
+
+func TestStateResetBetweenTests_A(t *testing.T) {
+	if X != 42 {
+		t.Fatalf("expected fresh state with X = 42, got %d", X)
+	}
+	X = 100
+}
+
+func TestStateResetBetweenTests_B(t *testing.T) {
+	if X != 42 {
+		t.Fatalf("state leaked from previous test: X = %d, want 42", X)
+	}
+}

--- a/gnovm/cmd/gno/testdata/test/issue_1982_increment.txtar
+++ b/gnovm/cmd/gno/testdata/test/issue_1982_increment.txtar
@@ -1,23 +1,17 @@
 # ref: https://github.com/gnolang/gno/issues/1982
 
-mkdir $WORK/gnovm/tests
-symlink $WORK/gnovm/stdlibs -> $GNOROOT/gnovm/stdlibs
-symlink $WORK/gnovm/tests/stdlibs -> $GNOROOT/gnovm/tests/stdlibs
-env GNOROOT=$WORK
-
-gno test -v ./counter
+gno test -v .
 
 stderr '=== RUN   TestIncrement1'
 stderr '--- PASS: TestIncrement1'
 stderr '=== RUN   TestIncrement2'
 stderr '--- PASS: TestIncrement2'
 
--- gnowork.toml --
--- counter/gnomod.toml --
-module = "gno.land/p/demo/counter"
+-- gnomod.toml --
+module = "gno.test/p/integ/issue_1982"
 gno = "0.9"
 
--- counter/counter.gno --
+-- counter.gno --
 package counter
 
 var count int
@@ -26,7 +20,7 @@ func Increment() {
 	count++
 }
 
--- counter/counter_test.gno --
+-- counter_test.gno --
 package counter
 
 import "testing"

--- a/gnovm/cmd/gno/testdata/test/issue_1982_increment.txtar
+++ b/gnovm/cmd/gno/testdata/test/issue_1982_increment.txtar
@@ -1,0 +1,46 @@
+# ref: https://github.com/gnolang/gno/issues/1982
+
+mkdir $WORK/gnovm/tests
+symlink $WORK/gnovm/stdlibs -> $GNOROOT/gnovm/stdlibs
+symlink $WORK/gnovm/tests/stdlibs -> $GNOROOT/gnovm/tests/stdlibs
+env GNOROOT=$WORK
+
+gno test -v ./counter
+
+stderr '=== RUN   TestIncrement1'
+stderr '--- PASS: TestIncrement1'
+stderr '=== RUN   TestIncrement2'
+stderr '--- PASS: TestIncrement2'
+
+-- gnowork.toml --
+-- counter/gnomod.toml --
+module = "gno.land/p/demo/counter"
+gno = "0.9"
+
+-- counter/counter.gno --
+package counter
+
+var count int
+
+func Increment() {
+	count++
+}
+
+-- counter/counter_test.gno --
+package counter
+
+import "testing"
+
+func TestIncrement1(t *testing.T) {
+	Increment()
+	if count != 1 {
+		t.Fail()
+	}
+}
+
+func TestIncrement2(t *testing.T) {
+	Increment()
+	if count != 1 {
+		t.Fail()
+	}
+}

--- a/gnovm/cmd/gno/testdata/test/realm_isolation.txtar
+++ b/gnovm/cmd/gno/testdata/test/realm_isolation.txtar
@@ -1,0 +1,58 @@
+gno test -v ./counter
+
+stderr '=== RUN   TestInitRan'
+stderr '--- PASS: TestInitRan'
+stderr '=== RUN   TestCrossingMutates_A'
+stderr '--- PASS: TestCrossingMutates_A'
+stderr '=== RUN   TestCrossingMutates_B'
+stderr '--- PASS: TestCrossingMutates_B'
+
+-- gnowork.toml --
+-- counter/gnomod.toml --
+module = "gno.land/r/demo/counter"
+gno = "0.9"
+
+-- counter/counter.gno --
+package counter
+
+var count int
+
+func init() {
+	count = 7
+}
+
+func Increment(cur realm) {
+	count++
+}
+
+func Get() int {
+	return count
+}
+
+-- counter/counter_test.gno --
+package counter
+
+import "testing"
+
+func TestInitRan(cur realm, t *testing.T) {
+	if Get() != 7 {
+		t.Fatalf("init() did not run in realm: count = %d, want 7", Get())
+	}
+}
+
+func TestCrossingMutates_A(cur realm, t *testing.T) {
+	if Get() != 7 {
+		t.Fatalf("expected fresh state (init=7), got %d", Get())
+	}
+	Increment(cross)
+	Increment(cross)
+	if Get() != 9 {
+		t.Fatalf("after 2 Increments, want 9, got %d", Get())
+	}
+}
+
+func TestCrossingMutates_B(cur realm, t *testing.T) {
+	if Get() != 7 {
+		t.Fatalf("state leaked from TestCrossingMutates_A: count = %d, want 7", Get())
+	}
+}

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -360,11 +360,7 @@ func (m *Machine) runMemPackage(mpkg *std.MemPackage, save, overrides, skipTestF
 		}
 	}
 	// run init functions
-	initUpdates := updates
-	if skipTestFileInits {
-		initUpdates = dropTestFileInitFuncs(updates)
-	}
-	m.runInitFromUpdates(pv, initUpdates)
+	m.runInitFromUpdates(pv, updates, skipTestFileInits)
 	// save again after init.
 	if save {
 		m.resavePackageValues(throwaway)
@@ -527,7 +523,7 @@ func (m *Machine) RunFiles(fns ...*FileNode) {
 			}
 		}
 	}
-	m.runInitFromUpdates(pv, updates)
+	m.runInitFromUpdates(pv, updates, false)
 	if rlm != nil {
 		rlm.FinalizeRealmTransaction(m.Store)
 	}
@@ -807,26 +803,8 @@ func (m *Machine) NewPackageInstance(pn *PackageNode) *PackageValue {
 	m.Store.SetCachePackage(pv)
 	m.SetActivePackage(pv)
 	m.instantiatePackageFiles(pn.FileSet.Files...)
-	m.runInitFromUpdates(pv, pv.GetBlock(m.Store).Values)
+	m.runInitFromUpdates(pv, pv.GetBlock(m.Store).Values, false)
 	return pv
-}
-
-// dropTestFileInitFuncs filters out init.* FuncValues declared in test
-// files so runInitFromUpdates skips them; all other entries (vars, funcs,
-// types, consts, and non-test init funcs) are preserved.
-func dropTestFileInitFuncs(updates []TypedValue) []TypedValue {
-	out := make([]TypedValue, 0, len(updates))
-	for _, tv := range updates {
-		if tv.IsDefined() && tv.T.Kind() == FuncKind && tv.V != nil {
-			if fv, ok := tv.V.(*FuncValue); ok &&
-				strings.HasPrefix(string(fv.Name), "init.") &&
-				IsTestFile(fv.FileName) {
-				continue
-			}
-		}
-		out = append(out, tv)
-	}
-	return out
 }
 
 // Run new init functions.
@@ -835,7 +813,10 @@ func dropTestFileInitFuncs(updates []TypedValue) []TypedValue {
 // multiple files belonging to the same package in
 // lexical file name order to a compiler."
 // If m.Realm is set `init(cur realm)` works too.
-func (m *Machine) runInitFromUpdates(pv *PackageValue, updates []TypedValue) {
+// When skipTestFileInits is true, init funcs declared in *_test.gno /
+// *_filetest.gno files are not executed; used by the test harness so
+// test-file inits don't mutate shared tgs state during the initial seed.
+func (m *Machine) runInitFromUpdates(pv *PackageValue, updates []TypedValue, skipTestFileInits bool) {
 	// Only for the init functions make the origin caller
 	// the package addr.
 	for _, tv := range updates {
@@ -844,13 +825,17 @@ func (m *Machine) runInitFromUpdates(pv *PackageValue, updates []TypedValue) {
 			if !ok {
 				continue // skip native functions.
 			}
-			if strings.HasPrefix(string(fv.Name), "init.") {
-				fb := pv.GetFileBlock(m.Store, fv.FileName)
-				m.PushBlock(fb)
-				maybeCrossing := m.Realm != nil
-				m.runFunc(StageAdd, fv.Name, maybeCrossing)
-				m.PopBlock()
+			if !strings.HasPrefix(string(fv.Name), "init.") {
+				continue
 			}
+			if skipTestFileInits && IsTestFile(fv.FileName) {
+				continue
+			}
+			fb := pv.GetFileBlock(m.Store, fv.FileName)
+			m.PushBlock(fb)
+			maybeCrossing := m.Realm != nil
+			m.runFunc(StageAdd, fv.Name, maybeCrossing)
+			m.PopBlock()
 		}
 	}
 }

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -283,7 +283,7 @@ func (m *Machine) RunMemPackage(mpkg *std.MemPackage, save bool) (*PackageNode, 
 			defer bm.FinishStore()
 		}
 	}
-	return m.runMemPackage(mpkg, save, false)
+	return m.runMemPackage(mpkg, save, false, false)
 }
 
 // RunMemPackageWithOverrides works as [RunMemPackage], however after parsing,
@@ -296,10 +296,21 @@ func (m *Machine) RunMemPackage(mpkg *std.MemPackage, save bool) (*PackageNode, 
 // NOTE: Does not validate the mpkg, except when saving validates a mpkg with
 // its type.
 func (m *Machine) RunMemPackageWithOverrides(mpkg *std.MemPackage, save bool) (*PackageNode, *PackageValue) {
-	return m.runMemPackage(mpkg, save, true)
+	return m.runMemPackage(mpkg, save, true, false)
 }
 
-func (m *Machine) runMemPackage(mpkg *std.MemPackage, save, overrides bool) (*PackageNode, *PackageValue) {
+// RunMemPackageSkipTestFileInits is like [RunMemPackageWithOverrides] but
+// does not execute init() functions declared in *_test.gno files when
+// loading the package. File parsing, preprocessing, and top-level var
+// declarations still run so that test-file symbols are available for
+// xxx_test integration test imports; only the init funcs are skipped.
+// Per-test machines that re-instantiate the package via
+// [Machine.NewPackageInstance] still run all inits on their fresh pv.
+func (m *Machine) RunMemPackageSkipTestFileInits(mpkg *std.MemPackage, save bool) (*PackageNode, *PackageValue) {
+	return m.runMemPackage(mpkg, save, true, true)
+}
+
+func (m *Machine) runMemPackage(mpkg *std.MemPackage, save, overrides, skipTestFileInits bool) (*PackageNode, *PackageValue) {
 	// validate mpkg.Type.
 	mptype := mpkg.Type.(MemPackageType)
 	if save && !mptype.IsStorable() {
@@ -349,7 +360,11 @@ func (m *Machine) runMemPackage(mpkg *std.MemPackage, save, overrides bool) (*Pa
 		}
 	}
 	// run init functions
-	m.runInitFromUpdates(pv, updates)
+	initUpdates := updates
+	if skipTestFileInits {
+		initUpdates = dropTestFileInitFuncs(updates)
+	}
+	m.runInitFromUpdates(pv, initUpdates)
 	// save again after init.
 	if save {
 		m.resavePackageValues(throwaway)
@@ -794,6 +809,24 @@ func (m *Machine) NewPackageInstance(pn *PackageNode) *PackageValue {
 	m.instantiatePackageFiles(pn.FileSet.Files...)
 	m.runInitFromUpdates(pv, pv.GetBlock(m.Store).Values)
 	return pv
+}
+
+// dropTestFileInitFuncs filters out init.* FuncValues declared in test
+// files so runInitFromUpdates skips them; all other entries (vars, funcs,
+// types, consts, and non-test init funcs) are preserved.
+func dropTestFileInitFuncs(updates []TypedValue) []TypedValue {
+	out := make([]TypedValue, 0, len(updates))
+	for _, tv := range updates {
+		if tv.IsDefined() && tv.T.Kind() == FuncKind && tv.V != nil {
+			if fv, ok := tv.V.(*FuncValue); ok &&
+				strings.HasPrefix(string(fv.Name), "init.") &&
+				IsTestFile(fv.FileName) {
+				continue
+			}
+		}
+		out = append(out, tv)
+	}
+	return out
 }
 
 // Run new init functions.

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -604,18 +604,9 @@ func (m *Machine) runFileDecls(withOverrides bool, fns ...*FileNode) []TypedValu
 	pb := pv.GetBlock(m.Store)
 	pn := pb.GetSource(m.Store).(*PackageNode)
 	fs := &FileSet{Files: fns}
-	fdeclared := map[Name]struct{}{}
 	if pn.FileSet == nil {
 		pn.FileSet = fs
 	} else {
-		// collect pre-existing declared names
-		for _, fn := range pn.FileSet.Files {
-			for _, decl := range fn.Decls {
-				for _, name := range decl.GetDeclNames() {
-					fdeclared[name] = struct{}{}
-				}
-			}
-		}
 		// add fns to pre-existing fileset.
 		pn.FileSet.AddFiles(fns...)
 	}
@@ -643,10 +634,27 @@ func (m *Machine) runFileDecls(withOverrides bool, fns ...*FileNode) []TypedValu
 		}
 		// After preprocessing, save blocknodes to store.
 		SaveBlockNodes(m.Store, fn)
-		// Make block for fn.
-		// Each file for each *PackageValue gets its own file *Block,
-		// with values copied over from each file's
-		// *FileNode.StaticBlock.
+	}
+
+	return m.instantiatePackageFiles(fns...)
+}
+
+// instantiatePackageFiles is the runtime-instantiation half of runFileDecls:
+// it allocates fresh file *Blocks on m.Package (values seeded from each
+// preprocessed FileNode.StaticBlock), calls PrepareNewValues, then runs
+// top-level non-Func declarations via Kahn's topological sort. Returns the
+// slice of new TypedValues to be consumed by runInitFromUpdates.
+//
+// NOTE: Preprocessing and pn.FileSet mutation are not performed here.
+// The caller must ensure fns are already in pn.FileSet and preprocessed.
+func (m *Machine) instantiatePackageFiles(fns ...*FileNode) []TypedValue {
+	pv := m.Package
+	pb := pv.GetBlock(m.Store)
+	pn := pb.GetSource(m.Store).(*PackageNode)
+
+	// Each file for each *PackageValue gets its own file *Block, with
+	// values copied over from each file's *FileNode.StaticBlock.
+	for _, fn := range fns {
 		fb := m.Alloc.NewBlock(fn, pb)
 		fb.Values = make([]TypedValue, len(fn.StaticBlock.Values))
 		copy(fb.Values, fn.StaticBlock.Values)
@@ -655,6 +663,27 @@ func (m *Machine) runFileDecls(withOverrides bool, fns ...*FileNode) []TypedValu
 
 	// Get new values across all files in package.
 	updates := pn.PrepareNewValues(m.Alloc, pv)
+
+	// Names declared in files from pn.FileSet that are not in fns are
+	// treated as pre-satisfied external dependencies by the sort below.
+	// For incremental file addition (runFileDecls), this is the set of
+	// previously-declared names. For fresh instantiation of a fully
+	// preprocessed pn (fns == pn.FileSet.Files), this is empty.
+	fnsSet := make(map[*FileNode]struct{}, len(fns))
+	for _, fn := range fns {
+		fnsSet[fn] = struct{}{}
+	}
+	fdeclared := map[Name]struct{}{}
+	for _, fn := range pn.FileSet.Files {
+		if _, ok := fnsSet[fn]; ok {
+			continue
+		}
+		for _, decl := range fn.Decls {
+			for _, name := range decl.GetDeclNames() {
+				fdeclared[name] = struct{}{}
+			}
+		}
+	}
 
 	// To initialize package variables, Go's spec says the following:
 	//    Within a package, package-level variable initialization proceeds
@@ -740,6 +769,31 @@ func (m *Machine) runFileDecls(withOverrides bool, fns ...*FileNode) []TypedValu
 	}
 
 	return updates
+}
+
+// instantiatePackageFiles performs runtime instantiation for the given
+// file nodes: it allocates a file *Block on m.Package for each fn (seeded
+// from fn.StaticBlock), calls PrepareNewValues, and runs top-level
+// non-Func declarations in dependency order (declaration order as tiebreak).
+// Returns the new TypedValues produced by PrepareNewValues, to be consumed
+// by runInitFromUpdates.
+//
+// fns must already be present in pn.FileSet and fully preprocessed; this
+// function does not preprocess or mutate pn.FileSet. Names declared in
+// pn.FileSet files outside of fns are treated as pre-satisfied dependencies.
+func (m *Machine) NewPackageInstance(pn *PackageNode) *PackageValue {
+	// pn.NewPackage calls pn.PrepareNewValues internally, populating
+	// pv.Block.Values with pn.Values (including init.* FuncValues). The
+	// second PrepareNewValues call inside instantiatePackageFiles is a
+	// no-op for an already-preprocessed pn (pvl == pnl returns nil), so
+	// runInitFromUpdates must be fed pv.Block.Values directly; otherwise
+	// init() funcs would never be scheduled.
+	pv := pn.NewPackage(m.Alloc)
+	m.Store.SetCachePackage(pv)
+	m.SetActivePackage(pv)
+	m.instantiatePackageFiles(pn.FileSet.Files...)
+	m.runInitFromUpdates(pv, pv.GetBlock(m.Store).Values)
+	return pv
 }
 
 // Run new init functions.

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -254,7 +254,13 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 	// If testing with only filetests, there will be no files.
 	tmpkg := gno.MPFTest.FilterMemPackage(mpkg)
 	if !tmpkg.IsEmptyOf(".gno") {
-		_, _ = m2.RunMemPackageWithOverrides(tmpkg, true)
+		// Skip test-file init() while seeding tgs: otherwise they would
+		// mutate shared imported-realm state (e.g. gov/dao.allowedDAOs
+		// via a test's InitWithUsers call), and every per-test inner
+		// transaction below would inherit that pollution. Each test
+		// still re-runs all inits on a fresh PackageValue via
+		// NewPackageInstance, against a clean tgs baseline.
+		_, _ = m2.RunMemPackageSkipTestFileInits(tmpkg, true)
 	}
 
 	// Eagerly load imports.
@@ -272,7 +278,7 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 	if len(tset.Files)+len(itset.Files) > 0 {
 		// Run test files in pkg.
 		if len(tset.Files) > 0 {
-			err := opts.runTestFiles(mpkg, tset, tgs)
+			err := opts.runTestFiles(mpkg, tset, tgs, tcw)
 			if err != nil {
 				errs = multierr.Append(errs, err)
 			}
@@ -293,7 +299,7 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 				Files: itfiles,
 			}
 
-			err := opts.runTestFiles(itmpkg, itset, tgs)
+			err := opts.runTestFiles(itmpkg, itset, tgs, tcw)
 			if err != nil {
 				errs = multierr.Append(errs, err)
 			}
@@ -354,6 +360,7 @@ func (opts *TestOptions) runTestFiles(
 	mpkg *std.MemPackage,
 	files *gno.FileSet,
 	tgs gno.TransactionStore,
+	baseStore storetypes.Store,
 ) (errs error) {
 	var m *gno.Machine
 	defer func() {
@@ -409,12 +416,15 @@ func (opts *TestOptions) runTestFiles(
 		// Each test runs in its own nested transaction off tgs, producing
 		// a fresh PackageValue (own Block and file blocks, re-run var
 		// decls and init() funcs) from the shared preprocessed pn. The
-		// inner txn's isolated cacheObjects (see
-		// defaultStore.BeginTransaction) plus the fresh pv ensure
-		// package-level globals start from zero for every test. Dropping
-		// the inner txn without calling Write() discards any state
-		// changes the test made.
-		innerTxn := tgs.BeginTransaction(nil, nil, nil, nil)
+		// inner txn's isolated cacheObjects plus the fresh pv ensure
+		// package-level globals start from zero for every test.
+		//
+		// The base/iavl stores are CacheWrap'd per test so that realm
+		// finalization writes (SetObject → baseStore.Set) do not
+		// propagate to tgs or sibling tests; dropping innerBase without
+		// calling Write() discards all persisted mutations.
+		innerBase := baseStore.CacheWrap()
+		innerTxn := tgs.BeginTransaction(innerBase, innerBase, nil, nil)
 
 		m = Machine(innerTxn, opts.WriterForStore(), mpkg.Path, opts.Debug, store.NewInfiniteGasMeter())
 		m.Alloc = alloc.Reset()

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -378,31 +378,47 @@ func (opts *TestOptions) runTestFiles(
 	// reset store ops, if any - we only need them for some filetests.
 	opts.TestStore.SetLogStoreOps(nil)
 
-	// Check if we already have the package - it may have been eagerly loaded.
+	// Derive the test-filtered mempackage so RunMemPackage below keeps
+	// *_test.gno files: MPUser/StdlibAll is demoted to Prod by
+	// AsRunnable() and strips tests unless pre-filtered with MPFTest
+	// (which produces an MPUser/StdlibTest type).
+	//
+	// NOTE: Integration mempackages are already runnable with their test
+	// files and must not be passed through MPFTest (which panics for
+	// MP*Integration).
+	tmpkg := mpkg
+	if mptype, ok := mpkg.Type.(gno.MemPackageType); ok && mptype.IsAll() {
+		tmpkg = gno.MPFTest.FilterMemPackage(mpkg)
+	}
+
+	// Eagerly load and preprocess the package once on tgs. This populates
+	// tgs.cacheNodes with the preprocessed PackageNode and its already-
+	// preprocessed FileNodes. Inner txns below see pn through the txlog
+	// overlay and create fresh PackageValues from it, avoiding re-parse
+	// and re-preprocess per test.
 	m = Machine(tgs, opts.WriterForStore(), mpkg.Path, opts.Debug, nil)
 	m.Alloc = alloc
 	if tgs.GetMemPackage(mpkg.Path) == nil {
-		m.RunMemPackage(mpkg, false)
+		m.RunMemPackage(tmpkg, false)
 	} else {
 		m.SetActivePackage(tgs.GetPackage(mpkg.Path, false))
 	}
-	pv := m.Package
-
-	// Load the test files into package and save.
-	// m.RunFiles(files.Files...)
+	pn := tgs.GetBlockNode(gno.PackageNodeLocation(mpkg.Path)).(*gno.PackageNode)
 
 	for _, tf := range tests {
-		// TODO(morgan): we could theoretically use wrapping on the baseStore
-		// and gno store to achieve per-test isolation. However, that requires
-		// some deeper changes, as ideally we'd:
-		// - Run the MemPackage independently (so it can also be run as a
-		//   consequence of an import)
-		// - Run the test files before this for loop (but persist it to store;
-		//   RunFiles doesn't do that currently)
-		// - Wrap here.
-		m = Machine(tgs, opts.WriterForStore(), mpkg.Path, opts.Debug, store.NewInfiniteGasMeter())
+		// Each test runs in its own nested transaction off tgs, producing
+		// a fresh PackageValue (own Block and file blocks, re-run var
+		// decls and init() funcs) from the shared preprocessed pn. The
+		// inner txn's isolated cacheObjects (see
+		// defaultStore.BeginTransaction) plus the fresh pv ensure
+		// package-level globals start from zero for every test. Dropping
+		// the inner txn without calling Write() discards any state
+		// changes the test made.
+		innerTxn := tgs.BeginTransaction(nil, nil, nil, nil)
+
+		m = Machine(innerTxn, opts.WriterForStore(), mpkg.Path, opts.Debug, store.NewInfiniteGasMeter())
 		m.Alloc = alloc.Reset()
-		m.SetActivePackage(pv)
+		pv := m.NewPackageInstance(pn)
 
 		testingpv := m.Store.GetPackage("testing", false)
 		testingtv := gno.TypedValue{T: &gno.PackageType{}, V: testingpv}


### PR DESCRIPTION
## Description

`gno test` previously shared a single `PackageValue` across every test function in a package, so mutation to package-level variables in one test leaked into the next. This PR runs each test against a freshly instantiated `PackageValue` created from the preprocessed `PackageNode`, inside its own nested transaction store. Package-level globals and `init()` side effects start from a clean slate for every test.

fixes #1982 

---

## Problem

The reproducer from the original issue:

```go
package counter

var count int

func Increment() { count++ }

func TestIncrement1(t *testing.T) {
    Increment()
    if count != 1 { t.Fail() }
}

func TestIncrement2(t *testing.T) {
    Increment()
    if count != 1 { t.Fail() }
}
```

Both tests assume `count` starts at `0`, so a single `Increment()` call should leave it at `1`. On master branch, `TestIncrement1` passes(count goes from 0 to 1), but `TestIncrement2` failed: `count` carries over as `1` from the first test, `Increment()` takes it to `2`.

Any test relying on a zero-initialized package global is fragile under the old behavior, with outcomes depending on which tests ran before it.

### Why it happeneds on master

[`runTestFiles`](https://github.com/gnolang/gno/blob/066f15a79e0c0889ff21b2899f666a926994ebd1/gnovm/pkg/test/test.go#L353) loaded the package once and reused the resulting `PackageValue` across every `tf` in the `tests` loop:

https://github.com/gnolang/gno/blob/066f15a79e0c0889ff21b2899f666a926994ebd1/gnovm/pkg/test/test.go#L391-L405

`pv.Block.Values` holds the mutable package-level variables. Even though each iteration creates a new machine, `SetActivePackage(pv)` attaches the same `pv`, so mutations from test N remain visible in test N+1. The pre-existing _TODO_ at that site already flagged this limitation, noting that a proper fix required a way to create a fresh `PackageValue` without re-parsing the source.

## Fix requirements
The fix needs three properties:

1. A fresh `PackageValue` for each test so package-level variables are re-initialized from their declarations and `init()` runs again.
2. A clean baseline to instantiate against. `*_test.gno` `init()` functions that mutate imported-realm state (e.g. a test file calling `dao.UpdateImpl` to set allow-lists) must not leak into the shared seed, or every test would inherit that pollution before it even starts.
3. Isolation at the store level so object mutations — both same-package globals and imported-realm state reached through crossing calls — do not bleed across tests either. This has to reach the `baseStore`, since realm finalization during a test writes through `SetObject` → `baseStore.Set` and would otherwise persist into sibling tests via the shared cache.

Naively re-running `RunMemPackage(mpkg, false)` per test satisfies (1) but re-parses and preprocesses every file on every test, which regresses performance significantly (see _Performance_ section below). The fix instead separates preprocessing from runtime instantiation: preprocess once, then hand the preprocessed `PackageNode` to each test to cheaply instantiate its own `PackageValue` inside a nested transaction.

## Solution

Two changes.

### 1. `gnovm/pkg/gnolang/machine.go`

Split `runFileDecls` into a preprocesses phase and a runtime instantiation phase. The instantiation half becomes `instantiatePackageFiles`, which:

- Allocates fresh file `*Block`s on `m.Package` with values copies from each preprocessed `FileNode.StaticBlock`.
- Calls `PrepareNewValues` to populate `pv.Block.Values`.
- Runs top-level non function declarations via the existing topological sort.

Meanwhile, `runFileDecls` keeps its existing behavior (preprocess + initantiate in one call) by delegating its second half to `instantiatePackageFiles`, so nothing outside the test runner sees a behavior change. A new public method `NewPackageInstance` produces a fresh `PackageValue` from an already processed `PackageNode`:

```go
// PATH: gnovm/pkg/gnolang/machine.go:L784
func (m *Machine) NewPackageInstance(pn *PackageNode) *PackageValue {
    pv := pn.NewPackage(m.Alloc)
    m.Store.SetCachePackage(pv)
    m.SetActivePackage(pv)
    m.instantiatePackageFiles(pn.FileSet.Files...)
    m.runInitFromUpdates(pv, pv.GetBlock(m.Store).Values)
    return pv
}
```

The explicit `pv.GetBlock(m.Store).Values` argument is load-bearing: `pn.NewPackage` already calls `PrepareNewValues` internally, so the second call inside `instantiatePacageFiles` sees `ppl == ppl` and returns `nil`. Feeding those `nil` updates to `runInitFromUpdates` would silently skip every `init()` function, so we pass the values that `pn.NewPackage` actually populated instead(related test: `init_and_isolation.txtar`).

### 2. `gnovm/pkg/test/test.go`

`runTestFiles` still preprocesses the package once, but now on the outer transaction store. The seed uses a new `RunMemPackageSkipTestFileInits` entry point so that `init()` functions in `*_test.gno` files are not executed against the shared `tgs`; file parsing, preprocessing, and top-level var declarations still run so that xxx_test integration imports continue to see test-file symbols. Each test then runs in its own nested transaction with a freshly instantiated `PackageValue` and a CacheWrap'd base store, so realm-finalization writes stay local to that test:

```go
tmpkg := mpkg
if mptype, ok := mpkg.Type.(gno.MemPackageType); ok && mptype.IsAll() {
    tmpkg = gno.MPFTest.FilterMemPackage(mpkg)
}

m2 = Machine(tgs, ...)
m2.RunMemPackageSkipTestFileInits(tmpkg, true) // preprocess once, skip test-file init()
pn := tgs.GetBlockNode(gno.PackageNodeLocation(mpkg.Path)).(*gno.PackageNode)

for _, tf := range tests {
    innerBase := baseStore.CacheWrap()
    innerTxn := tgs.BeginTransaction(innerBase, innerBase, nil, nil)
    m = Machine(innerTxn, ..., store.NewInfiniteGasMeter())
    m.Alloc = alloc.Reset()
    pv := m.NewPackageInstance(pn)
    // run tf...
}
```

`RunMemPackageSkipTestFileInits` threads a `skipTestFileInits` bool through to `runInitFromUpdates`, where init.* `FuncValue`s whose `FileName` matches `IsTestFile` are skipped inline alongside the existing init-detection check — no extra pass over `updates`, no duplicated predicate. `NewPackageInstance` and `RunFiles` call `runInitFromUpdates` with `skipTestFileInits=false`, so the per-test fresh `pv` still runs every `init()`, including test-file ones.

`innerBase := baseStore.CacheWrap()` gives each test its own overlay on top of `tgs`'s base store, so realm finalization writes performed during the test (e.g. an imported realm's block being persisted at a crossing-call boundary) stay on `innerBase`. Dropping `innerBase` between iterations — we never call `Write()` on it — discards those writes, which is what keeps mutations to imported realms from bleeding between tests.

The `tmpkg` filter handles a type system characteristic: `AsRunnable()` demotes `MPUser`/`StdlibAll` to `Prod`, which strips `*_test.gno` files unless the package is pre-filtered with `MPTest`, The `IsAll()` guard avoids passing integration types through `MPFTest`, which panics on them since they already carry their test files.

## How it works

Flow under the fix:

1. Outer transaction `tgs` runs `RunMemPackageSkipTestFileInits` once, parsing and preprocessing the package. Non-test `init()` functions run on `tgs` as usual; test-file `init()` functions are deliberately skipped so they cannot mutate imported-realm state in the shared seed. The preprocessed `PackageNode` lives in `tgs.cacheNodes`.
2. For each test, `tgs.BeginTransaction(innerBase, innerBase, ...)` returns `innerTxn`, a nested transaction with its own `cacheObjects` map for object writes and `innerBase = baseStore.CacheWrap()` layered on top of the outer base store so realm-finalization writes stay local. `cacheNodes` is shared via `txlog.Wrap`, so `innerTxn` sees the preprocessed `pn` without re-processing.
3. `m.NewPackageInstance(pn)` creates a fresh `PackageValue`:
    - `pn.NewPackage(m.Alloc)` allocates a new `pv.Block` and seeds `pv.Block.Values` from `pn.Values`, so the init function values are already in place.
    - `instantiatePackageFiles` creates fresh file blocks and runs top-level var declarations in dependency order, re-initializing every package global from its source expression.
    - `runInitFromUpdates(pv, pv.Block.Values)` schedules those `init()` functions — including test-file ones — for execution against the clean per-test pv.
4. The test runs against this fresh `pv` under `innerTxn`. Any mutations to package globals live in the new `pv.Block.Values`; any object writes go to `innerTxn.cacheObjects`, and realm finalizations that write through to the base store land on `innerBase` instead of `tgs`'s base.
5. When the test ends, `innerTxn` and `innerBase` are dropped without calling `Write()`, so both the `cacheObjects` overlay and the base-store overlay are discarded. The next iteration starts from scratch against `tgs`.

Under this flow, `TestIncrement1` starts with `count == 0`, increments it to `1`, and its mutation dies with `innerTxn`. `TestIncrement2` then starts from a fresh `pv` where `count == 0` again, and observes `count == 1` as expected.

## Performance

Re-running `RunMemPackage` per test regresses heavy packages by about 9x, because parse and preprocess repeat every test function. Splitting preprocess-once from instantiate per test brings the overhead down to a modest constant per test function.

Wall-clock measurement: `gno test .` on each package, median of 5 runs after warm-up run. `master` is 066f15a79, `branch` is this PR. Both binaries are built with identical flags and run against the same sources, and subtest counts were verified equal between them.

| package | test funcs | master | branch | ratio | absolute delta |
|---------|-----------:|-------:|-------:|------:|---------------:|
| `p/onbloc/uint256` | 39 | 0.53s | 0.60s | 1.13x | +70ms |
| `p/onbloc/int256` | 50 | 0.55s | 0.64s | 1.16x | +90ms |
| `p/onbloc/json` | 91 | 0.58s | 0.74s | 1.28x | +160ms |

The overhead is the cost of per-test `PackageValue` creation and re-running `init()`. Preprocessing happens once per package and is amortized across all tests. The measured overhead is consistent across the three packages -- roughly 1.7 to 1.8ms per test function -- so the cost scales with test function count rather than file size. Packages with expensive `init()` will see proportionally more.

## Known limitation

- Per-test `PackageValue` creation and `init()` re-execution is strictly more work than sharing a single `PackageValue` across tests. See the Performance section for measurements.
- This isolation is stricter than Go's go test, which shares package-level globals across tests in the same binary. The stricter semantics are what issue #1982 asks for, but anyone porting tests from Go should know the expectations differ.
- The design assumes `PackageNode` is immutable at runtime, which lets `tgs.cacheNodes` be shared across tests via `txlog.Wrap`. If a future change makes `PackageNode mutable`, this assumption needs to be revisited.
- The fix targets test isolation inside `runTestFiles`. Filetests and other entrypoints still use `runFileDecls` directly and keep their prior semantics; those paths already run each test against its own package state, so no change was needed.
- A handful of existing tests in `examples/gno.land/r/` (`sys/params`, `tests/vm/map_delete`, `demo/todolist`, `leon/hor`, `archive/nir1218_evaluation_proposal`, `gov/dao/v3/impl`) were written against the old leaky behavior — e.g. expecting an item created in one test to persist into the next, or hard-coding proposal IDs that assumed state carried over from prior tests. They are updated in this PR to set up their own preconditions; new tests added after this change should follow the same pattern.