### PR TITLE
fix(gnovm): detect unused expression statements at preprocess time

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2515,6 +2515,12 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 				evalStaticType(store, last, n)
 
 			// TRANS_LEAVE -----------------------
+			case *ExprStmt:
+				if _, ok := n.X.(*CallExpr); !ok {
+					panic(fmt.Sprintf("invalid operation: %s is not used", n.X.String()))
+				}
+
+			// TRANS_LEAVE -----------------------
 			case *AssignStmt:
 				n.AssertCompatible(store, last)
 				if n.Op == ASSIGN {

--- a/gnovm/tests/files/expr_stmt0.gno
+++ b/gnovm/tests/files/expr_stmt0.gno
@@ -1,0 +1,13 @@
+package main
+
+func main() {
+	const c1 = 1 < 8
+	main()
+	1
+}
+
+// Error:
+// main/expr_stmt0.gno:6:2-3: invalid operation: (const (1 <untyped> bigint)) is not used
+
+// TypeCheckError:
+// main/expr_stmt0.gno:6:2: 1 (untyped int constant) is not used

--- a/gnovm/tests/files/expr_stmt1.gno
+++ b/gnovm/tests/files/expr_stmt1.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	x := 5
+	x
+}
+
+// Error:
+// main/expr_stmt1.gno:5:2-3: invalid operation: x<VPBlock(1,0)> is not used
+
+// TypeCheckError:
+// main/expr_stmt1.gno:5:2: x (variable of type int) is not used

--- a/gnovm/tests/files/expr_stmt2.gno
+++ b/gnovm/tests/files/expr_stmt2.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	x := 5
+	x + 1
+}
+
+// Error:
+// main/expr_stmt2.gno:5:2-7: invalid operation: x<VPBlock(1,0)> + (const (1 int)) is not used
+
+// TypeCheckError:
+// main/expr_stmt2.gno:5:2: x + 1 (value of type int) is not used


### PR DESCRIPTION
## Description
closes #3426

Gno was not detecting unused expression statements at preprocess time, unlike Go. This allowed invalid statements like bare `1` or `x + 1` to pass the preprocessor and reach the VM, where they could trigger runtime panics or OOM crashes (e.g. when combined with infinite recursion).

This PR adds a check in the `TRANS_LEAVE` phase of the preprocessor for `*ExprStmt` nodes. Only call expressions (`f()`, `obj.Method()`) are valid as expression statements. All other expressions now produce a preprocess-time error: `invalid operation: X is not used`

> Note: channel receive operations (`<-ch`) are also valid expression statements per the Go spec, but are omitted here as Gno does not support channels.

---

## Changes

* `gnovm/pkg/gnolang/preprocess.go`: add `*ExprStmt` case in `TRANS_LEAVE`
* `gnovm/tests/files/expr_stmt0.gno`: literal as statement (original issue example)
* `gnovm/tests/files/expr_stmt1.gno`: variable reference as statement
* `gnovm/tests/files/expr_stmt2.gno`: binary expression as statement
