### PR TITLE
fix(bptree): deep-dive: correctness, safety, and performance fixes

### DIFF
--- a/tm2/pkg/bptree/README.md
+++ b/tm2/pkg/bptree/README.md
@@ -34,17 +34,27 @@ The value 32 balances:
 
 ### Out-of-line values
 
-Leaf nodes store `key + SHA256(value)`, not the raw value. Values are
-stored separately in the DB, content-addressed by their SHA256 hash.
-This means:
+Leaf nodes store `key + SHA256(value) + ValueKey(12B)`, not the raw value.
+Values are stored separately in the DB under their ValueKey (a
+per-allocation `(version, nonce)` identifier), with the SHA256(value) kept
+in the leaf for Merkle proofs. This means:
 - **Smaller nodes**: leaf nodes are ~1.4KB regardless of value size
 - **Less COW amplification**: modifying one key copies only hash references, not sibling values
-- **Deduplication**: identical values stored once (content-addressed)
 - **Copy safety**: callers cannot corrupt stored values by mutating their byte slices
 
 Values are written directly to the DB (not via batch) so `Get` works
 before `SaveVersion`. Values are never garbage collected — dead values
-after pruning are harmless noise.
+after pruning are harmless noise. Eagerly-written values left behind by
+a crashed working session (process died before `SaveVersion` or
+`Rollback`) are cleaned up on the next `Load()` by scanning for
+ValueKeys with a version greater than the latest persisted version.
+
+**No content-addressed deduplication.** Two `Set` calls with identical
+values each get a fresh ValueKey and a separate DB entry — there is no
+hash-based lookup table. This keeps the design simple (no reference
+counting, no "unreferenced hash" cleanup) at the cost of storage
+overhead when identical values are common. If your workload has highly
+duplicated values, dedupe at the application layer before `Set`.
 
 ### Full SHA256 (32 bytes)
 

--- a/tm2/pkg/bptree/bptree_test.go
+++ b/tm2/pkg/bptree/bptree_test.go
@@ -698,6 +698,8 @@ func TestNodeSerialization_LeafBasic(t *testing.T) {
 	leaf.keys[1] = []byte("b")
 	leaf.valueHashes[0] = sha256.Sum256([]byte("val_a"))
 	leaf.valueHashes[1] = sha256.Sum256([]byte("val_b"))
+	leaf.valueKeys[0] = (&NodeKey{Version: 1, Nonce: 100}).GetKey()
+	leaf.valueKeys[1] = (&NodeKey{Version: 1, Nonce: 101}).GetKey()
 	leaf.RebuildMiniMerkle()
 	origHash := leaf.Hash()
 
@@ -787,6 +789,7 @@ func TestNodeSerialization_FullLeaf(t *testing.T) {
 	for i := 0; i < B; i++ {
 		leaf.keys[i] = []byte{byte(i)}
 		leaf.valueHashes[i] = sha256.Sum256([]byte{byte(i)})
+		leaf.valueKeys[i] = (&NodeKey{Version: 1, Nonce: uint32(200 + i)}).GetKey()
 	}
 	leaf.RebuildMiniMerkle()
 
@@ -835,6 +838,8 @@ func TestNodeSerialization_LongKeys(t *testing.T) {
 	leaf.keys[1] = []byte(strings.Repeat("y", 500))
 	leaf.valueHashes[0] = sha256.Sum256([]byte("a"))
 	leaf.valueHashes[1] = sha256.Sum256([]byte("b"))
+	leaf.valueKeys[0] = (&NodeKey{Version: 1, Nonce: 10}).GetKey()
+	leaf.valueKeys[1] = (&NodeKey{Version: 1, Nonce: 11}).GetKey()
 
 	var buf bytes.Buffer
 	if err := leaf.Serialize(&buf); err != nil {
@@ -1102,6 +1107,7 @@ func TestReadNode_TruncatedLeaf(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		leaf.keys[i] = []byte{byte(i * 10)}
 		leaf.valueHashes[i] = sha256.Sum256([]byte{byte(i)})
+		leaf.valueKeys[i] = (&NodeKey{Version: 1, Nonce: uint32(100 + i)}).GetKey()
 	}
 	var buf bytes.Buffer
 	if err := leaf.Serialize(&buf); err != nil {
@@ -1323,6 +1329,8 @@ func TestNodeSerialization_LeafGoldenBytes(t *testing.T) {
 	leaf.keys[1] = []byte("bb")
 	leaf.valueHashes[0] = sha256.Sum256([]byte("v0"))
 	leaf.valueHashes[1] = sha256.Sum256([]byte("v1"))
+	leaf.valueKeys[0] = (&NodeKey{Version: 1, Nonce: 2}).GetKey()
+	leaf.valueKeys[1] = (&NodeKey{Version: 1, Nonce: 3}).GetKey()
 
 	var buf bytes.Buffer
 	if err := leaf.Serialize(&buf); err != nil {

--- a/tm2/pkg/bptree/crash_recovery_test.go
+++ b/tm2/pkg/bptree/crash_recovery_test.go
@@ -1,0 +1,83 @@
+package bptree
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// TestLoad_CleansUpCrashedSessionValues simulates a crash between Set and
+// SaveVersion: SaveValue wrote eagerly to DB, sessionValues tracked the
+// vks in memory only, and then the process "died". A fresh MutableTree
+// constructed over the same DB must clean up the orphan values on Load()
+// rather than leaking them forever.
+func TestLoad_CleansUpCrashedSessionValues(t *testing.T) {
+	db := memdb.NewMemDB()
+
+	// First session: commit v1 cleanly.
+	t1 := NewMutableTreeWithDB(db, 100, NewNopLogger())
+	t1.Set([]byte("k_saved"), []byte("v_saved"))
+	if _, _, err := t1.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion(1): %v", err)
+	}
+	committed := countDBValues(db)
+	if committed != 1 {
+		t.Fatalf("setup: committed values = %d, want 1", committed)
+	}
+
+	// Second session: Set(s) without SaveVersion, then simulate a crash by
+	// abandoning the tree instance (GC'd without Rollback).
+	t2 := NewMutableTreeWithDB(db, 100, NewNopLogger())
+	if _, err := t2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	t2.Set([]byte("k_leak1"), []byte("v_leak1"))
+	t2.Set([]byte("k_leak2"), []byte("v_leak2"))
+	if leaked := countDBValues(db); leaked != committed+2 {
+		t.Fatalf("mid-session: values = %d, want %d", leaked, committed+2)
+	}
+	// Don't call SaveVersion or Rollback — simulate a crash.
+	t2 = nil //nolint:wastedassign // simulate process death
+	_ = t2
+
+	// Third session: fresh tree over the same DB, Load() must clean orphans.
+	t3 := NewMutableTreeWithDB(db, 100, NewNopLogger())
+	if _, err := t3.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	after := countDBValues(db)
+	if after != committed {
+		t.Fatalf("after recovery Load: values = %d, want %d (orphans not cleaned)", after, committed)
+	}
+
+	// Committed value still reads back.
+	if v, _ := t3.Get([]byte("k_saved")); string(v) != "v_saved" {
+		t.Fatalf("Get k_saved after recovery = %q, want v_saved", v)
+	}
+	// Leaked keys are not in the tree (never committed).
+	if v, _ := t3.Get([]byte("k_leak1")); v != nil {
+		t.Fatalf("Get k_leak1 = %q, want nil", v)
+	}
+}
+
+// TestLoad_CleanShutdownNoCleanup verifies cleanupCrashedSessionValues is
+// a no-op on a clean shutdown (nothing to clean, no spurious deletes).
+func TestLoad_CleanShutdownNoCleanup(t *testing.T) {
+	db := memdb.NewMemDB()
+	t1 := NewMutableTreeWithDB(db, 100, NewNopLogger())
+	for i := byte('a'); i <= byte('j'); i++ {
+		t1.Set([]byte{i}, []byte{i, i})
+	}
+	if _, _, err := t1.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion: %v", err)
+	}
+	committed := countDBValues(db)
+
+	t2 := NewMutableTreeWithDB(db, 100, NewNopLogger())
+	if _, err := t2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if after := countDBValues(db); after != committed {
+		t.Fatalf("Load deleted legitimate values: %d vs %d", after, committed)
+	}
+}

--- a/tm2/pkg/bptree/errors.go
+++ b/tm2/pkg/bptree/errors.go
@@ -12,4 +12,11 @@ var (
 	ErrEmptyTree           = errors.New("tree is empty")
 	ErrActiveReaders       = errors.New("version has active readers")
 	ErrEmptyKey            = errors.New("key must not be empty")
+	ErrKeyTooLong          = errors.New("key exceeds maximum size")
 )
+
+// MaxKeyLen caps how long a single key can be. Must stay at or below
+// maxReadBytesLen in node.go — if we ever accepted a key larger than the
+// read cap, the node would serialize successfully but fail to deserialize,
+// permanently wedging that version of the tree.
+const MaxKeyLen = 1 << 20 // 1 MiB

--- a/tm2/pkg/bptree/immutable_tree.go
+++ b/tm2/pkg/bptree/immutable_tree.go
@@ -6,10 +6,15 @@ type ValueResolver func(vk []byte) ([]byte, error)
 // ImmutableTree is a read-only snapshot of the tree at a specific version.
 // It is safe for concurrent reads. Created by MutableTree.GetImmutable()
 // (Phase 3) or by snapshotting the root after SaveVersion.
+//
+// When the snapshot is backed by a DB, ndb is non-nil. Iterators and exporters
+// created from it register as version readers (via ndb.incrVersionReaders) so
+// that PruneVersionsTo cannot delete nodes they still depend on.
 type ImmutableTree struct {
 	root          Node
 	version       int64
 	valueResolver ValueResolver // resolves valueKeys to raw values
+	ndb           *nodeDB       // set when the snapshot is backed by a DB
 }
 
 // NewImmutableTree creates an ImmutableTree from a root node and version.

--- a/tm2/pkg/bptree/import.go
+++ b/tm2/pkg/bptree/import.go
@@ -36,6 +36,12 @@ func (imp *Importer) Add(node *ExportNode) error {
 	switch {
 	case node.Height == 0:
 		// Leaf entry: compute value hash, allocate valueKey, save value, buffer.
+		if len(node.Key) == 0 {
+			return fmt.Errorf("import: empty leaf key")
+		}
+		if len(node.Key) > MaxKeyLen {
+			return fmt.Errorf("import: leaf key length %d exceeds MaxKeyLen %d", len(node.Key), MaxKeyLen)
+		}
 		valueHash := sha256.Sum256(node.Value)
 		vk := (&NodeKey{Version: imp.version, Nonce: imp.nextNonce}).GetKey()
 		imp.nextNonce++
@@ -90,6 +96,11 @@ func (imp *Importer) Add(node *ExportNode) error {
 		}
 		if len(node.SeparatorKeys) != int(node.NumKeys) {
 			return fmt.Errorf("import: inner marker has %d separator keys, expected %d", len(node.SeparatorKeys), node.NumKeys)
+		}
+		for i, sk := range node.SeparatorKeys {
+			if len(sk) > MaxKeyLen {
+				return fmt.Errorf("import: inner separator key %d length %d exceeds MaxKeyLen %d", i, len(sk), MaxKeyLen)
+			}
 		}
 
 		children := imp.stack[len(imp.stack)-numChildren:]

--- a/tm2/pkg/bptree/insert.go
+++ b/tm2/pkg/bptree/insert.go
@@ -13,7 +13,11 @@ type insertResult struct {
 // Returns the (possibly new) root, whether it was an update, and the old
 // valueKey if an existing key was overwritten (nil otherwise).
 func treeInsert(root Node, key []byte, valueHash Hash, valueKey []byte) (Node, bool, []byte) {
-	key = copyKey(key) // defensive copy — caller may reuse the slice
+	// The caller may reuse the key slice after this call returns. We need a
+	// defensive copy only when the key ends up *stored* — which happens
+	// exclusively on the "new-key insert" paths in leafInsert (not on
+	// updates, where the existing leaf.keys[pos] is reused). Defer the
+	// copy to those paths so update-heavy workloads skip the allocation.
 
 	// COW-clone the root
 	root = cloneNode(root)
@@ -65,7 +69,11 @@ func leafInsert(leaf *LeafNode, key []byte, valueHash Hash, valueKey []byte) ins
 		return insertResult{updated: true, oldValueKey: oldVK}
 	}
 
-	// Insert new key
+	// Insert new key. The key will be stored in the leaf (here or after
+	// split), so take the deferred defensive copy now — the caller may
+	// reuse the slice, and mutating it later would corrupt the tree.
+	storedKey := copyKey(key)
+
 	if int(leaf.numKeys) < B {
 		// Room in this leaf — shift right and insert
 		n := int(leaf.numKeys)
@@ -74,7 +82,7 @@ func leafInsert(leaf *LeafNode, key []byte, valueHash Hash, valueKey []byte) ins
 			leaf.valueHashes[i] = leaf.valueHashes[i-1]
 			leaf.valueKeys[i] = leaf.valueKeys[i-1]
 		}
-		leaf.keys[pos] = key
+		leaf.keys[pos] = storedKey
 		leaf.valueHashes[pos] = valueHash
 		leaf.valueKeys[pos] = valueKey
 		leaf.numKeys++
@@ -88,7 +96,7 @@ func leafInsert(leaf *LeafNode, key []byte, valueHash Hash, valueKey []byte) ins
 	allVK := make([][]byte, B+1)
 	// Copy existing keys, inserting new key at pos
 	copy(allKeys[:pos], leaf.keys[:pos])
-	allKeys[pos] = key
+	allKeys[pos] = storedKey
 	copy(allKeys[pos+1:], leaf.keys[pos:B])
 	copy(allVH[:pos], leaf.valueHashes[:pos])
 	allVH[pos] = valueHash

--- a/tm2/pkg/bptree/insert_update_alloc_test.go
+++ b/tm2/pkg/bptree/insert_update_alloc_test.go
@@ -1,0 +1,72 @@
+package bptree
+
+import (
+	"testing"
+)
+
+// TestTreeInsert_UpdateDoesNotCopyKey verifies that an update of an
+// existing key does not allocate a fresh copy of the key slice. The
+// previous treeInsert took a defensive copyKey unconditionally; for
+// update-heavy workloads that's one wasted 16+N-byte allocation per
+// Set. We only need the copy when the key is actually stored — i.e.,
+// on the new-insert and split paths in leafInsert.
+//
+// The update path still has other allocations (sha256.Sum256 internals
+// triggered by later hashing, map/slice growth elsewhere), but the
+// specific copyKey allocation is observable and worth guarding against
+// a regression: if someone reintroduces the unconditional copy in
+// treeInsert, the per-Set allocation count on the update path jumps
+// noticeably.
+func TestTreeInsert_UpdateDoesNotCopyKey(t *testing.T) {
+	tree := NewMutableTreeMem()
+	key := []byte("fixed-key-exercising-update-path")
+	// Initial insert (this one DOES copy; we're measuring updates only).
+	if _, err := tree.Set(key, []byte("v0")); err != nil {
+		t.Fatalf("initial Set: %v", err)
+	}
+
+	// Measure allocations during repeated updates of the same key.
+	updateVal := []byte("v1")
+	n := testing.AllocsPerRun(200, func() {
+		_, _ = tree.Set(key, updateVal)
+	})
+
+	// Before the fix, treeInsert did copyKey(key) unconditionally, adding
+	// ~1 allocation per update. The value path also allocates a ValueKey
+	// (sessionValues), so we can't assert 0; but we can assert the key
+	// copy is gone by bounding the total. With the fix, updates do a
+	// single valueKey allocation plus internal bookkeeping; the key copy
+	// is removed. A regression puts allocations back at ~1 higher per Set.
+	// Give a small safety margin for future internal tweaks.
+	const maxAllowed = 10
+	if n > maxAllowed {
+		t.Fatalf("update path allocates %f per Set; want <= %d (regression on key-copy elision)", n, maxAllowed)
+	}
+}
+
+// TestTreeInsert_NewKeyStillCopies verifies that new-insert paths still
+// defensively copy the key, so callers can reuse their input slice.
+func TestTreeInsert_NewKeyStillCopies(t *testing.T) {
+	tree := NewMutableTreeMem()
+
+	key := []byte("k")
+	if _, err := tree.Set(key, []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Mutate the caller's slice: the tree must have taken its own copy.
+	key[0] = 'X'
+
+	v, err := tree.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(v) != "v" {
+		t.Fatalf("Get after caller mutated key slice = %q, want v (the tree did not take a defensive copy)", v)
+	}
+
+	// And the mutated key is NOT in the tree.
+	if has, _ := tree.Has([]byte("X")); has {
+		t.Fatalf("mutated key was found in tree (should not be)")
+	}
+}

--- a/tm2/pkg/bptree/iterator.go
+++ b/tm2/pkg/bptree/iterator.go
@@ -321,12 +321,23 @@ func (it *Iterator) Close() error {
 
 // NewIteratorWithNDB creates an iterator over an immutable tree with value
 // resolution via the mutable tree's nodeDB. Used by the store wrapper.
+//
+// When the immutable tree carries a DB-backed ndb, the iterator registers as
+// a version reader on imm.version so that concurrent PruneVersionsTo cannot
+// delete nodes this iterator still walks. The reader is released on Close.
 func NewIteratorWithNDB(imm *ImmutableTree, start, end []byte, ascending bool, mtree *MutableTree) *Iterator {
-	var ndb *nodeDB
-	if mtree != nil {
+	// Prefer the immutable tree's own ndb (set by GetImmutable) so we can
+	// track the specific version being read. Fall back to the mutable tree's
+	// ndb only for value resolution (no version tracking in that case).
+	ndb := imm.ndb
+	var trackVersion int64
+	if ndb != nil {
+		trackVersion = imm.version
+		ndb.incrVersionReaders(trackVersion)
+	} else if mtree != nil {
 		ndb = mtree.ndb
 	}
-	itr := newIterator(imm.root, start, end, ascending, ndb, 0)
+	itr := newIterator(imm.root, start, end, ascending, ndb, trackVersion)
 	if ndb == nil && mtree != nil && mtree.memValues != nil {
 		itr.valueResolver = func(vk []byte) ([]byte, error) {
 			val, ok := mtree.memValues[string(vk)]
@@ -340,6 +351,9 @@ func NewIteratorWithNDB(imm *ImmutableTree, start, end []byte, ascending bool, m
 }
 
 // Iterator returns an iterator over [start, end) in the given direction.
+// MutableTree iterators walk the in-memory working tree and do not take a
+// version reader: the working tree is never pruned (pruning rejects
+// toVersion >= latest).
 func (t *MutableTree) Iterator(start, end []byte, ascending bool) (*Iterator, error) {
 	itr := newIterator(t.root, start, end, ascending, t.ndb, 0)
 	if t.ndb == nil && t.memValues != nil {
@@ -354,11 +368,19 @@ func (t *MutableTree) Iterator(start, end []byte, ascending bool) (*Iterator, er
 	return itr, nil
 }
 
-// ImmutableTree.Iterator returns an iterator. If a valueResolver is set,
-// the iterator resolves values via a wrapping ndb-like mechanism.
-// For DB-backed trees, use NewIteratorWithNDB instead.
+// ImmutableTree.Iterator returns an iterator over [start, end).
+//
+// When the immutable tree is DB-backed (t.ndb != nil), the iterator registers
+// as a version reader so concurrent pruning cannot delete the nodes it walks.
+// The reader is released on Close. For snapshot-only trees without an ndb,
+// values are resolved via t.valueResolver (no version tracking needed).
 func (t *ImmutableTree) Iterator(start, end []byte, ascending bool) (*Iterator, error) {
-	itr := newIterator(t.root, start, end, ascending, nil, 0)
+	var trackVersion int64
+	if t.ndb != nil {
+		trackVersion = t.version
+		t.ndb.incrVersionReaders(trackVersion)
+	}
+	itr := newIterator(t.root, start, end, ascending, t.ndb, trackVersion)
 	itr.valueResolver = t.valueResolver
 	return itr, nil
 }

--- a/tm2/pkg/bptree/key_len_test.go
+++ b/tm2/pkg/bptree/key_len_test.go
@@ -1,0 +1,55 @@
+package bptree
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// TestSet_RejectsKeyOverMax asserts Set enforces a MaxKeyLen cap. Without
+// it, a caller could write a key longer than readBytes's 1 MiB cap on the
+// read path; the node would serialize successfully but fail to deserialize
+// on the next Load, wedging the version permanently.
+func TestSet_RejectsKeyOverMax(t *testing.T) {
+	tree := NewMutableTreeMem()
+
+	// Just under the limit is fine.
+	ok := bytes.Repeat([]byte{'a'}, MaxKeyLen)
+	if _, err := tree.Set(ok, []byte("v")); err != nil {
+		t.Fatalf("Set at MaxKeyLen: %v", err)
+	}
+
+	// Over the limit is rejected.
+	tooBig := bytes.Repeat([]byte{'b'}, MaxKeyLen+1)
+	_, err := tree.Set(tooBig, []byte("v"))
+	if err == nil {
+		t.Fatalf("Set over MaxKeyLen should return ErrKeyTooLong")
+	}
+	if !errors.Is(err, ErrKeyTooLong) {
+		t.Fatalf("error should wrap ErrKeyTooLong, got %v", err)
+	}
+
+	// Tree state is unchanged by the rejected Set.
+	if has, _ := tree.Has(tooBig); has {
+		t.Fatalf("rejected Set should not be reflected in the tree")
+	}
+}
+
+// TestImport_RejectsKeyOverMax asserts the Importer also enforces
+// MaxKeyLen; an untrusted export stream must not poison a fresh tree.
+func TestImport_RejectsKeyOverMax(t *testing.T) {
+	tree := NewMutableTreeMem()
+	imp, err := tree.Import(1)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	err = imp.Add(&ExportNode{
+		Height: 0,
+		Key:    bytes.Repeat([]byte{'x'}, MaxKeyLen+1),
+		Value:  []byte("v"),
+	})
+	if err == nil {
+		t.Fatalf("Importer.Add should reject key over MaxKeyLen")
+	}
+}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -434,6 +434,7 @@ func (t *MutableTree) GetImmutable(version int64) (*ImmutableTree, error) {
 		return nil, err
 	}
 	imm := NewImmutableTree(root, version)
+	imm.ndb = t.ndb
 	imm.valueResolver = func(vk []byte) ([]byte, error) {
 		return t.ndb.GetValue(vk)
 	}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -243,7 +243,36 @@ func (t *MutableTree) SaveVersion() ([]byte, int64, error) {
 		if existingEmpty != newEmpty || !bytes.Equal(existingHash, newHash) {
 			return nil, 0, fmt.Errorf("version %d already exists with a different hash", version)
 		}
-		// Same hash — idempotent save, skip
+
+		// Same hash — idempotent save (typical scenario: deterministic replay
+		// of an already-committed block). The working tree carries non-empty
+		// session state: Set/Remove during replay allocated fresh ValueKeys
+		// and eagerly wrote their values to the DB.
+		//
+		// In a deterministic replay those ValueKeys COLLIDE with the
+		// persisted ones (same version, same allocation order, same nonces),
+		// so SaveValue simply overwrote the live entries with the same
+		// content. The working tree and the persisted tree reference the
+		// same vks — identical state.
+		//
+		// We MUST NOT call DeleteValueDirect on sessionValues in that case:
+		// those vks are the live ones. That's exactly what Rollback would
+		// have done if we left sessionValues intact, which is the bug this
+		// guard was added for. Simply clear the session counters so a
+		// subsequent Rollback is a no-op on the DB.
+		//
+		// Caveat: if the replay's allocation order DIVERGES from the
+		// original (e.g., transient writes that cancel out), session vks
+		// don't collide and their DB entries become genuine duplicates.
+		// Detecting that reliably would require comparing every session vk
+		// against every leaf in the persisted tree, which is prohibitive.
+		// Those duplicates leak in the DB, but they're unreferenced and
+		// harmless — aligning with the rest of the design (values are never
+		// GC'd; see README).
+		t.sessionValues = t.sessionValues[:0]
+		t.versionOrphans = t.versionOrphans[:0]
+		t.nextValueNonce = 0
+
 		t.version = version
 		t.lastSaved = t.root
 		return newHash, version, nil

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -224,7 +224,14 @@ func (t *MutableTree) SaveVersion() ([]byte, int64, error) {
 
 	// If this version already exists, verify the hash matches.
 	// This prevents accidentally overwriting a version with different data.
-	if t.ndb.VersionExists(version) {
+	// Use the error-propagating variant: a DB error here must NOT be
+	// misinterpreted as "does not exist" (which would lead us to overwrite
+	// the existing version with unverified new data).
+	exists, err := t.ndb.versionExistsE(version)
+	if err != nil {
+		return nil, 0, fmt.Errorf("checking version %d existence: %w", version, err)
+	}
+	if exists {
 		existingNK, existingHash, err := t.ndb.GetRoot(version)
 		if err != nil {
 			return nil, 0, err

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -73,6 +73,9 @@ func (t *MutableTree) Set(key, value []byte) (updated bool, err error) {
 	if len(key) == 0 {
 		return false, ErrEmptyKey
 	}
+	if len(key) > MaxKeyLen {
+		return false, fmt.Errorf("%w: %d > %d", ErrKeyTooLong, len(key), MaxKeyLen)
+	}
 	if value == nil {
 		return false, fmt.Errorf("value must not be nil")
 	}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -383,6 +383,13 @@ func (t *MutableTree) saveNode(node Node, version int64) error {
 }
 
 // Load loads the latest version from the DB.
+//
+// As a side effect, cleans up any value entries left behind by a working
+// session that crashed before SaveVersion or Rollback (SaveValue writes
+// eagerly so Get works pre-commit; without this cleanup those values
+// leak forever — sessionValues is in-memory only). Orphans form a
+// contiguous suffix of the value keyspace above latestVersion, so the
+// scan cost is O(leaked-values), zero on a clean shutdown.
 func (t *MutableTree) Load() (int64, error) {
 	if t.ndb == nil {
 		return 0, nil
@@ -391,6 +398,9 @@ func (t *MutableTree) Load() (int64, error) {
 		return 0, err
 	}
 	latest := t.ndb.getLatestVersion()
+	if err := t.ndb.cleanupCrashedSessionValues(latest); err != nil {
+		return 0, fmt.Errorf("cleanup crashed-session values: %w", err)
+	}
 	if latest == 0 {
 		return 0, nil
 	}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -299,33 +299,47 @@ func (t *MutableTree) SaveVersion() ([]byte, int64, error) {
 }
 
 // saveNode recursively assigns NodeKeys and saves dirty nodes.
+//
+// Only in-memory child references (inner.childNodes[i]) are traversed: an
+// unloaded child (childNodes[i] == nil) cannot have been mutated in this
+// session, so its serialized reference (inner.children[i]) and its cached
+// hash (inner.childHashes[i]) are still correct. Calling getChild here —
+// which would force-load every sibling from DB just to early-return on
+// "already has a NodeKey" — would cause O(B) wasted reads per COW'd inner.
+// For a path-length-H insert with branching B, that's H*(B-1) unnecessary
+// DB reads per SaveVersion, mostly cache-missing at blockchain scale.
 func (t *MutableTree) saveNode(node Node, version int64) error {
 	if node.GetNodeKey() != nil {
 		return nil // already saved
 	}
 
-	// For inner nodes, save children first (bottom-up)
+	// For inner nodes, save dirty children first (bottom-up).
 	if inner, ok := node.(*InnerNode); ok {
 		for i := 0; i < inner.NumChildren(); i++ {
-			child := inner.getChild(i)
-			if child != nil {
-				if err := t.saveNode(child, version); err != nil {
-					return err
-				}
-				// Update child reference and hash after save
-				inner.children[i] = child.GetNodeKey().GetKey()
-				inner.childHashes[i] = child.Hash()
+			child := inner.childNodes[i]
+			if child == nil {
+				// Unloaded and therefore unchanged: children[i] (NodeKey ref)
+				// and childHashes[i] are authoritative from the prior load.
+				continue
 			}
+			if err := t.saveNode(child, version); err != nil {
+				return err
+			}
+			// Update child reference and hash after save. For clean children
+			// whose saveNode call early-returned, these assignments are
+			// redundant but harmless (same NodeKey, same hash).
+			inner.children[i] = child.GetNodeKey().GetKey()
+			inner.childHashes[i] = child.Hash()
 		}
 		inner.RebuildMiniMerkle()
 	}
 
-	// Rebuild leaf mini merkle (may already be done, but ensure correctness)
+	// Rebuild leaf mini merkle (may already be done, but ensure correctness).
 	if leaf, ok := node.(*LeafNode); ok {
 		leaf.RebuildMiniMerkle()
 	}
 
-	// Assign NodeKey
+	// Assign NodeKey.
 	nk := t.ndb.NextNodeKey(version)
 	node.SetNodeKey(nk)
 

--- a/tm2/pkg/bptree/node.go
+++ b/tm2/pkg/bptree/node.go
@@ -173,8 +173,16 @@ func (n *InnerNode) Serialize(w io.Writer) error {
 			return err
 		}
 	}
-	// children (numKeys+1 NodeKey refs)
+	// children (numKeys+1 NodeKey refs). saveNode must have wired these up
+	// before calling Serialize; a nil here would silently truncate the
+	// payload and shift every subsequent read during deserialization.
 	for i := 0; i < nc; i++ {
+		if n.children[i] == nil {
+			return fmt.Errorf("InnerNode.Serialize: nil child ref at index %d (numChildren=%d)", i, nc)
+		}
+		if len(n.children[i]) != NodeKeySize {
+			return fmt.Errorf("InnerNode.Serialize: child ref at index %d has wrong size %d (want %d)", i, len(n.children[i]), NodeKeySize)
+		}
 		if _, err := w.Write(n.children[i]); err != nil {
 			return err
 		}
@@ -206,15 +214,19 @@ func (n *LeafNode) Serialize(w io.Writer) error {
 		}
 	}
 	for i := 0; i < int(n.numKeys); i++ {
-		if n.valueKeys[i] != nil {
-			if _, err := w.Write(n.valueKeys[i]); err != nil {
-				return err
-			}
-		} else {
-			// Write zero-filled placeholder for missing valueKey
-			if _, err := w.Write(make([]byte, NodeKeySize)); err != nil {
-				return err
-			}
+		// Invariant: every occupied leaf slot has a non-nil valueKey (set by
+		// Set, leaf splits, redistributes, and import). A nil here means
+		// upstream code forgot to wire one up — on deserialization the
+		// round-tripped NodeKey would be {0,0}, which silently maps to
+		// "value not found" on every Get. Fail fast instead.
+		if n.valueKeys[i] == nil {
+			return fmt.Errorf("LeafNode.Serialize: nil valueKey at slot %d (numKeys=%d)", i, n.numKeys)
+		}
+		if len(n.valueKeys[i]) != NodeKeySize {
+			return fmt.Errorf("LeafNode.Serialize: valueKey at slot %d has wrong size %d (want %d)", i, len(n.valueKeys[i]), NodeKeySize)
+		}
+		if _, err := w.Write(n.valueKeys[i]); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/tm2/pkg/bptree/node.go
+++ b/tm2/pkg/bptree/node.go
@@ -221,19 +221,33 @@ func (n *LeafNode) Serialize(w io.Writer) error {
 }
 
 // ReadNode deserializes a node from bytes. Returns either *InnerNode or *LeafNode.
+// Returns an error if the payload has trailing bytes not consumed by the
+// type-specific decoder — a tight framing check that catches on-disk
+// corruption early instead of silently returning a truncated view.
 func ReadNode(nk *NodeKey, data []byte) (Node, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty node data")
 	}
 	r := bytes.NewReader(data[1:]) // skip type byte
+	var (
+		node Node
+		err  error
+	)
 	switch data[0] {
 	case TypeInner:
-		return readInnerNode(nk, r)
+		node, err = readInnerNode(nk, r)
 	case TypeLeaf:
-		return readLeafNode(nk, r)
+		node, err = readLeafNode(nk, r)
 	default:
 		return nil, fmt.Errorf("unknown node type: %d", data[0])
 	}
+	if err != nil {
+		return nil, err
+	}
+	if r.Len() != 0 {
+		return nil, fmt.Errorf("corrupt node data: %d trailing bytes after decode (type=%d)", r.Len(), data[0])
+	}
+	return node, nil
 }
 
 func readInnerNode(nk *NodeKey, r *bytes.Reader) (_ *InnerNode, err error) {

--- a/tm2/pkg/bptree/node_framing_test.go
+++ b/tm2/pkg/bptree/node_framing_test.go
@@ -1,0 +1,72 @@
+package bptree
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestReadNode_RejectsTrailingBytes verifies ReadNode fails cleanly on
+// payloads with extra bytes after the type-specific decode. Silently
+// ignoring trailing bytes would mask on-disk corruption as "successfully
+// decoded a truncated view".
+func TestReadNode_RejectsTrailingBytes(t *testing.T) {
+	// Serialize a valid leaf.
+	leaf := &LeafNode{miniTree: NewMiniMerkle()}
+	leaf.numKeys = 1
+	leaf.keys[0] = []byte("k")
+	leaf.valueHashes[0] = HashLeafSlot(leaf.keys[0], []byte("v"))
+	leaf.valueKeys[0] = (&NodeKey{Version: 1, Nonce: 1}).GetKey()
+
+	var buf bytes.Buffer
+	if err := leaf.Serialize(&buf); err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	clean := buf.Bytes()
+
+	// Clean round-trip succeeds.
+	if _, err := ReadNode(&NodeKey{Version: 1, Nonce: 2}, clean); err != nil {
+		t.Fatalf("ReadNode(clean): %v", err)
+	}
+
+	// Corrupt by appending garbage.
+	corrupt := append(append([]byte(nil), clean...), 0xAA, 0xBB, 0xCC)
+	_, err := ReadNode(&NodeKey{Version: 1, Nonce: 2}, corrupt)
+	if err == nil {
+		t.Fatalf("ReadNode(corrupt) succeeded; expected trailing-bytes error")
+	}
+	if !strings.Contains(err.Error(), "trailing bytes") {
+		t.Fatalf("error does not mention trailing bytes: %v", err)
+	}
+}
+
+// TestReadNode_RejectsTrailingBytes_Inner does the same for inner nodes.
+func TestReadNode_RejectsTrailingBytes_Inner(t *testing.T) {
+	inner := &InnerNode{miniTree: NewMiniMerkle()}
+	inner.numKeys = 1
+	inner.height = 1
+	inner.keys[0] = []byte("sep")
+	inner.children[0] = (&NodeKey{Version: 1, Nonce: 1}).GetKey()
+	inner.children[1] = (&NodeKey{Version: 1, Nonce: 2}).GetKey()
+	inner.childSizes[0] = 1
+	inner.childSizes[1] = 1
+
+	var buf bytes.Buffer
+	if err := inner.Serialize(&buf); err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	clean := buf.Bytes()
+
+	if _, err := ReadNode(&NodeKey{Version: 1, Nonce: 3}, clean); err != nil {
+		t.Fatalf("ReadNode(clean inner): %v", err)
+	}
+
+	corrupt := append(append([]byte(nil), clean...), 0x99)
+	_, err := ReadNode(&NodeKey{Version: 1, Nonce: 3}, corrupt)
+	if err == nil {
+		t.Fatalf("ReadNode(corrupt inner) succeeded; expected trailing-bytes error")
+	}
+	if !strings.Contains(err.Error(), "trailing bytes") {
+		t.Fatalf("error does not mention trailing bytes: %v", err)
+	}
+}

--- a/tm2/pkg/bptree/node_framing_test.go
+++ b/tm2/pkg/bptree/node_framing_test.go
@@ -40,6 +40,51 @@ func TestReadNode_RejectsTrailingBytes(t *testing.T) {
 	}
 }
 
+// TestLeafSerialize_RejectsNilValueKey asserts that Serialize fails fast
+// when a leaf slot is missing a ValueKey — the previous behavior of
+// writing 12 zero bytes produced a {version:0, nonce:0} NodeKey on
+// deserialization, which silently maps to "value not found" at read
+// time.
+func TestLeafSerialize_RejectsNilValueKey(t *testing.T) {
+	leaf := &LeafNode{miniTree: NewMiniMerkle()}
+	leaf.numKeys = 1
+	leaf.keys[0] = []byte("k")
+	leaf.valueHashes[0] = HashLeafSlot(leaf.keys[0], []byte("v"))
+	// leaf.valueKeys[0] deliberately left nil
+
+	var buf bytes.Buffer
+	err := leaf.Serialize(&buf)
+	if err == nil {
+		t.Fatalf("Serialize succeeded with nil valueKey; expected error")
+	}
+	if !strings.Contains(err.Error(), "nil valueKey") {
+		t.Fatalf("error does not mention nil valueKey: %v", err)
+	}
+}
+
+// TestInnerSerialize_RejectsNilChildRef asserts that Serialize fails fast
+// on a nil child ref. A nil would write zero bytes and shift every
+// subsequent read during deserialization — catastrophic silent corruption.
+func TestInnerSerialize_RejectsNilChildRef(t *testing.T) {
+	inner := &InnerNode{miniTree: NewMiniMerkle()}
+	inner.numKeys = 1
+	inner.height = 1
+	inner.keys[0] = []byte("sep")
+	inner.children[0] = (&NodeKey{Version: 1, Nonce: 1}).GetKey()
+	// inner.children[1] deliberately left nil
+	inner.childSizes[0] = 1
+	inner.childSizes[1] = 1
+
+	var buf bytes.Buffer
+	err := inner.Serialize(&buf)
+	if err == nil {
+		t.Fatalf("Serialize succeeded with nil child ref; expected error")
+	}
+	if !strings.Contains(err.Error(), "nil child ref") {
+		t.Fatalf("error does not mention nil child ref: %v", err)
+	}
+}
+
 // TestReadNode_RejectsTrailingBytes_Inner does the same for inner nodes.
 func TestReadNode_RejectsTrailingBytes_Inner(t *testing.T) {
 	inner := &InnerNode{miniTree: NewMiniMerkle()}

--- a/tm2/pkg/bptree/nodedb.go
+++ b/tm2/pkg/bptree/nodedb.go
@@ -362,6 +362,62 @@ func (ndb *nodeDB) AvailableVersions() []int {
 	return versions
 }
 
+// cleanupCrashedSessionValues deletes value entries whose ValueKey.Version
+// is greater than the latest persisted version. Those values were written
+// eagerly by a working session (SaveValue is non-batched so Get can work
+// before SaveVersion) that crashed or was killed before SaveVersion
+// committed — no saved tree references them.
+//
+// Cost: bounded by the number of orphans. Uses an iterator seeded at
+// PrefixVal||(latestVersion+1)||0..., which skips legitimate values
+// entirely — value keys sort lexicographically and version is the first
+// 8 big-endian bytes, so orphans form a contiguous suffix.
+//
+// Safe to call on every Load(): if the previous shutdown was clean,
+// sessionValues was cleared by SaveVersion/Rollback and no orphans exist,
+// so the iterator returns immediately.
+func (ndb *nodeDB) cleanupCrashedSessionValues(latestVersion int64) error {
+	start := make([]byte, 1+8)
+	start[0] = PrefixVal
+	// Use uint64 arithmetic to avoid overflow when latestVersion == MaxInt64.
+	nextV := uint64(latestVersion) + 1
+	binary.BigEndian.PutUint64(start[1:], nextV)
+	end := []byte{PrefixVal + 1}
+
+	itr, err := ndb.db.Iterator(start, end)
+	if err != nil {
+		return fmt.Errorf("scanning orphan values: %w", err)
+	}
+	defer itr.Close()
+
+	var toDelete [][]byte
+	for ; itr.Valid(); itr.Next() {
+		k := itr.Key()
+		kCopy := make([]byte, len(k))
+		copy(kCopy, k)
+		toDelete = append(toDelete, kCopy)
+	}
+	if err := itr.Error(); err != nil {
+		return fmt.Errorf("iterating orphan values: %w", err)
+	}
+	// The DB contract says no writes may happen during iteration on the
+	// same domain — collect keys first, delete after Close.
+	itr.Close()
+
+	for _, k := range toDelete {
+		if err := ndb.db.Delete(k); err != nil {
+			return fmt.Errorf("deleting orphan value %x: %w", k, err)
+		}
+	}
+	if len(toDelete) > 0 {
+		ndb.logger.Info("bptree: cleaned up crashed-session value leaks",
+			"count", len(toDelete),
+			"latestVersion", latestVersion,
+		)
+	}
+	return nil
+}
+
 // discoverVersions scans the DB for root references to find
 // the first and latest versions. Called during Load.
 func (ndb *nodeDB) discoverVersions() error {

--- a/tm2/pkg/bptree/nodedb.go
+++ b/tm2/pkg/bptree/nodedb.go
@@ -300,9 +300,32 @@ func (ndb *nodeDB) setFirstVersion(v int64) {
 }
 
 // VersionExists checks if a root reference exists for the given version.
+//
+// This boolean-returning form is retained for interface compatibility with
+// the store layer and is appropriate only for code paths that are robust to
+// a transient DB failure being reported as "does not exist" (e.g., test
+// helpers, informational queries). Underlying errors are logged at Error
+// level so the class of failure is observable.
+//
+// Internal callers that must distinguish "does not exist" from "DB error"
+// (notably SaveVersion, which treats non-existence as a go-ahead to write
+// potentially destructive new data under that version) MUST use
+// versionExistsE instead.
 func (ndb *nodeDB) VersionExists(version int64) bool {
-	has, _ := ndb.db.Has(rootDBKey(version))
+	has, err := ndb.db.Has(rootDBKey(version))
+	if err != nil {
+		ndb.logger.Error("bptree: VersionExists DB error", "version", version, "err", err)
+		return false
+	}
 	return has
+}
+
+// versionExistsE is the error-propagating variant of VersionExists. Use in
+// code paths where a DB failure must not be silently interpreted as "does
+// not exist" — specifically SaveVersion, where that misinterpretation would
+// overwrite an existing version with a fresh save under the same number.
+func (ndb *nodeDB) versionExistsE(version int64) (bool, error) {
+	return ndb.db.Has(rootDBKey(version))
 }
 
 // AvailableVersions returns all versions that have root references.

--- a/tm2/pkg/bptree/nodedb.go
+++ b/tm2/pkg/bptree/nodedb.go
@@ -162,12 +162,33 @@ func (ndb *nodeDB) SaveValue(value, vk []byte) error {
 }
 
 // GetValue loads a value by its ValueKey from the DB.
+//
+// If the stored value was empty ([]byte{}), this returns an empty non-nil
+// slice. If the ValueKey does not exist in the DB (corruption or an already
+// pruned value — neither of which should occur when called via the tree),
+// it returns a wrapped ErrKeyDoesNotExist so callers can distinguish
+// missing from empty. The DB-contract-level signal ("Get returns nil iff
+// key doesn't exist") is preserved but made explicit for the caller.
 func (ndb *nodeDB) GetValue(vk []byte) ([]byte, error) {
-	data, err := ndb.db.Get(valueDBKey(vk))
+	key := valueDBKey(vk)
+	data, err := ndb.db.Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("db get value: %w", err)
 	}
-	return data, nil
+	if data != nil {
+		return data, nil
+	}
+	// nil could mean "key missing" (corruption) or "stored value was empty"
+	// on a backend that doesn't normalize [] to an empty slice. Disambiguate
+	// with Has().
+	has, herr := ndb.db.Has(key)
+	if herr != nil {
+		return nil, fmt.Errorf("db has value: %w", herr)
+	}
+	if !has {
+		return nil, fmt.Errorf("%w: valueKey %x", ErrKeyDoesNotExist, vk)
+	}
+	return []byte{}, nil
 }
 
 // DeleteValue adds a value deletion to the batch (committed at prune time).

--- a/tm2/pkg/bptree/orphan_first_test.go
+++ b/tm2/pkg/bptree/orphan_first_test.go
@@ -1,0 +1,128 @@
+package bptree
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// TestOrphans_FirstVersionEmpty locks in the invariant that orphans[first]
+// is always empty (not written) for a freshly saved first version. The
+// pruning logic depends on this: pruneVersion only processes orphans[nextV]
+// values, not orphans[v] values — relying on orphans[first] being empty
+// because the first version has no prior state to displace.
+func TestOrphans_FirstVersionEmpty(t *testing.T) {
+	cases := []struct {
+		name           string
+		initialVersion uint64
+		setup          func(tree *MutableTree)
+	}{
+		{
+			name: "default initialVersion, no sets",
+			setup: func(_ *MutableTree) {},
+		},
+		{
+			name: "default initialVersion, with sets",
+			setup: func(tree *MutableTree) {
+				tree.Set([]byte("a"), []byte("1"))
+				tree.Set([]byte("b"), []byte("2"))
+				tree.Set([]byte("c"), []byte("3"))
+			},
+		},
+		{
+			name: "default initialVersion, set+remove+set",
+			setup: func(tree *MutableTree) {
+				tree.Set([]byte("a"), []byte("1"))
+				tree.Set([]byte("a"), []byte("2"))
+				tree.Remove([]byte("a"))
+				tree.Set([]byte("a"), []byte("3"))
+			},
+		},
+		{
+			name:           "initialVersion=100, with sets",
+			initialVersion: 100,
+			setup: func(tree *MutableTree) {
+				tree.Set([]byte("a"), []byte("1"))
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db := memdb.NewMemDB()
+			var tree *MutableTree
+			if c.initialVersion > 0 {
+				tree = NewMutableTreeWithDB(db, 100, NewNopLogger(),
+					InitialVersionOption(c.initialVersion))
+			} else {
+				tree = NewMutableTreeWithDB(db, 100, NewNopLogger())
+			}
+			c.setup(tree)
+			_, version, err := tree.SaveVersion()
+			if err != nil {
+				t.Fatalf("SaveVersion: %v", err)
+			}
+
+			orphans, err := tree.ndb.LoadOrphans(version)
+			if err != nil {
+				t.Fatalf("LoadOrphans(%d): %v", version, err)
+			}
+			if len(orphans) != 0 {
+				t.Fatalf("orphans[%d] has %d entries, want 0. Pruning assumes "+
+					"orphans[first] is empty since no prune consumes it; "+
+					"breaking this invariant leaks values.",
+					version, len(orphans))
+			}
+		})
+	}
+}
+
+// TestPrune_ConsumesOrphansOfFirstVersion defends the pruning change that
+// processes orphans[v] in addition to orphans[nextV]. We seed a non-empty
+// orphans[first] record directly (simulating a future regression where the
+// first-version-is-empty invariant breaks) and verify that PruneVersionsTo
+// deletes those values rather than leaking them.
+func TestPrune_ConsumesOrphansOfFirstVersion(t *testing.T) {
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 100, NewNopLogger())
+
+	// Create two real versions so we can prune v=1.
+	tree.Set([]byte("k1"), []byte("v1"))
+	if _, _, err := tree.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion(1): %v", err)
+	}
+	tree.Set([]byte("k2"), []byte("v2"))
+	if _, _, err := tree.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion(2): %v", err)
+	}
+
+	// Plant a synthetic value and a synthetic orphans[1] record that points
+	// at it. This represents the "some external initialization wrote
+	// orphans[first]" scenario the defensive code guards against.
+	planted := (&NodeKey{Version: 0, Nonce: 42}).GetKey()
+	if err := tree.ndb.SaveValue([]byte("PLANTED"), planted); err != nil {
+		t.Fatalf("SaveValue: %v", err)
+	}
+	if err := tree.ndb.SaveOrphans(1, [][]byte{planted}); err != nil {
+		t.Fatalf("SaveOrphans: %v", err)
+	}
+	if err := tree.ndb.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Sanity: the planted value is present.
+	if v, _ := tree.ndb.GetValue(planted); string(v) != "PLANTED" {
+		t.Fatalf("setup: planted value missing, got %q", v)
+	}
+
+	// Prune v=1. The fix must consume orphans[1] (not just orphans[2]).
+	if err := tree.DeleteVersionsTo(1); err != nil {
+		t.Fatalf("DeleteVersionsTo(1): %v", err)
+	}
+
+	// The planted value must be gone.
+	v, err := tree.ndb.GetValue(planted)
+	if err == nil && v != nil {
+		t.Fatalf("planted value not cleaned up by prune: still present as %q", v)
+	}
+}

--- a/tm2/pkg/bptree/prune.go
+++ b/tm2/pkg/bptree/prune.go
@@ -98,17 +98,33 @@ func (t *MutableTree) pruneVersion(v, nextV int64) error {
 		return err
 	}
 
-	// Process orphan list: delete values displaced when nextV was created
-	orphans, err := t.ndb.LoadOrphans(nextV)
-	if err != nil {
-		return fmt.Errorf("loading orphans for v%d: %w", nextV, err)
-	}
-	for _, vk := range orphans {
-		if err := t.ndb.DeleteValue(vk); err != nil {
-			return err
+	// Process orphan value lists:
+	//
+	// - orphans[nextV] lists values displaced WHEN nextV was created, i.e.,
+	//   values whose owning version is <=v. Pruning v means those values
+	//   should disappear.
+	//
+	// - orphans[v] lists values displaced when v was created (owners <v).
+	//   Those are normally consumed during pruneVersion(v-1, v), which runs
+	//   in the previous loop iteration and DeleteOrphans(v) at its end. For
+	//   the very first pruned version in a batch there is no such prior
+	//   iteration; without this guard, any values listed in orphans[first]
+	//   would leak. LoadOrphans returns an empty slice if the record was
+	//   already deleted, so for iterations where v > first the call is a
+	//   no-op (no batch bloat).
+	for _, version := range [2]int64{v, nextV} {
+		orphans, err := t.ndb.LoadOrphans(version)
+		if err != nil {
+			return fmt.Errorf("loading orphans for v%d: %w", version, err)
+		}
+		for _, vk := range orphans {
+			if err := t.ndb.DeleteValue(vk); err != nil {
+				return err
+			}
 		}
 	}
-	// Clean up orphan records for both versions
+
+	// Clean up orphan records for both versions.
 	if err := t.ndb.DeleteOrphans(nextV); err != nil {
 		return err
 	}

--- a/tm2/pkg/bptree/prune.go
+++ b/tm2/pkg/bptree/prune.go
@@ -24,6 +24,20 @@ func (t *MutableTree) PruneVersionsTo(toVersion int64) error {
 		}
 	}
 
+	// Flush cap in bytes. Commit whenever the pending batch grows past this
+	// bound so PruneVersionsTo's working memory is O(flushThreshold) rather
+	// than O(pruned-nodes-and-values), matching typical per-block usage but
+	// also bounding startup catch-up prunes of many versions.
+	//
+	// Intermediate commits are safe: pruning is idempotent. A crash after a
+	// partial commit means some root references are already deleted from
+	// the DB, so discoverVersions on the next startup recomputes the
+	// correct firstVersion and a retry re-processes only what's left.
+	flushThreshold := t.ndb.opts.FlushThreshold
+	if flushThreshold <= 0 {
+		flushThreshold = 4 * 1024 * 1024 // 4 MiB default
+	}
+
 	for v := first; v <= toVersion; v++ {
 		if !t.ndb.VersionExists(v) {
 			continue
@@ -47,6 +61,14 @@ func (t *MutableTree) PruneVersionsTo(toVersion int64) error {
 		}
 		if err := t.ndb.DeleteRoot(v); err != nil {
 			return err
+		}
+		// Flush if the batch has grown beyond the threshold. Ignore
+		// GetByteSize errors — fall back to the final Commit which will
+		// still flush everything; we just lose the intermediate bound.
+		if size, err := t.ndb.batch.GetByteSize(); err == nil && size >= flushThreshold {
+			if err := t.ndb.Commit(); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/tm2/pkg/bptree/prune.go
+++ b/tm2/pkg/bptree/prune.go
@@ -28,18 +28,22 @@ func (t *MutableTree) PruneVersionsTo(toVersion int64) error {
 		if !t.ndb.VersionExists(v) {
 			continue
 		}
+		// findNextVersion always returns a non-zero version here: we rejected
+		// toVersion >= latest above, so latest > v and findNextVersion will
+		// find at least `latest` as a successor. That is the only guarantee
+		// we need — a successor must exist for dual-tree-walk pruning to
+		// know which values (from orphan lists) can safely be deleted.
 		nextV := t.findNextVersion(v, latest)
 		if nextV == 0 {
-			// No next version — just delete root ref and nodes
-			if err := t.deleteAllNodesForVersion(v); err != nil {
-				return err
-			}
-		} else {
-			// Dual-tree-walk: find orphaned nodes in version v
-			// that are not referenced by version nextV.
-			if err := t.pruneVersion(v, nextV); err != nil {
-				return err
-			}
+			// Defensive: should not happen given the toVersion < latest
+			// check above. If it ever does, bail rather than silently
+			// deleting nodes without processing value-orphan lists (the
+			// old deleteAllNodesForVersion path walked nodes but left
+			// every leaf value referenced by v in the DB).
+			return fmt.Errorf("bptree: pruning v%d found no successor (invariant: toVersion=%d < latest=%d should guarantee one)", v, toVersion, latest)
+		}
+		if err := t.pruneVersion(v, nextV); err != nil {
+			return err
 		}
 		if err := t.ndb.DeleteRoot(v); err != nil {
 			return err
@@ -268,41 +272,3 @@ func (t *MutableTree) findCorrespondingChild(newNode, oldChild Node) Node {
 	}
 }
 
-// deleteAllNodesForVersion deletes the root node and all nodes reachable
-// from it. Used when there is no next version to compare against.
-func (t *MutableTree) deleteAllNodesForVersion(v int64) error {
-	nkBytes, _, err := t.ndb.GetRoot(v)
-	if err != nil || nkBytes == nil {
-		return err
-	}
-	root, err := t.ndb.GetNode(nkBytes)
-	if err != nil {
-		return fmt.Errorf("loading root node for v%d: %w", v, err)
-	}
-	return t.deleteSubtree(root)
-}
-
-// deleteSubtree recursively deletes a node and all its descendants.
-func (t *MutableTree) deleteSubtree(node Node) error {
-	nk := node.GetNodeKey()
-	if nk != nil {
-		if err := t.ndb.DeleteNode(nk.GetKey()); err != nil {
-			return err
-		}
-	}
-
-	if inner, ok := node.(*InnerNode); ok {
-		for i := 0; i < inner.NumChildren(); i++ {
-			if inner.children[i] != nil {
-				child, err := t.ndb.GetNode(inner.children[i])
-				if err != nil {
-					return fmt.Errorf("loading child %d in deleteSubtree: %w", i, err)
-				}
-				if err := t.deleteSubtree(child); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}

--- a/tm2/pkg/bptree/prune_flush_test.go
+++ b/tm2/pkg/bptree/prune_flush_test.go
@@ -1,0 +1,103 @@
+package bptree
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// batchCountingDB wraps a DB and counts calls to NewBatch, which tells us
+// how many times the pruner flushed its batch mid-run.
+type batchCountingDB struct {
+	dbm.DB
+	newBatchCalls uint64
+}
+
+func (c *batchCountingDB) NewBatch() dbm.Batch {
+	atomic.AddUint64(&c.newBatchCalls, 1)
+	return c.DB.NewBatch()
+}
+
+func (c *batchCountingDB) NewBatchWithSize(size int) dbm.Batch {
+	atomic.AddUint64(&c.newBatchCalls, 1)
+	return c.DB.NewBatchWithSize(size)
+}
+
+func (c *batchCountingDB) batches() uint64 { return atomic.LoadUint64(&c.newBatchCalls) }
+
+// TestPruneVersionsTo_FlushesBatchUnderThreshold verifies that pruning a
+// long run of versions does not accumulate an unbounded batch. With a
+// very low FlushThreshold, Commit should be called multiple times as the
+// loop progresses, rather than only once at the end.
+func TestPruneVersionsTo_FlushesBatchUnderThreshold(t *testing.T) {
+	cdb := &batchCountingDB{DB: memdb.NewMemDB()}
+	// Set an aggressively low threshold so we hit it within a few versions.
+	tree := NewMutableTreeWithDB(cdb, 100, NewNopLogger(),
+		FlushThresholdOption(128)) // 128 bytes
+
+	// Create many versions so the prune loop iterates enough to flush.
+	const numVersions = 20
+	for v := 0; v < numVersions; v++ {
+		for i := 0; i < 30; i++ {
+			tree.Set(fmt.Appendf(nil, "k%04d", i+v*30), fmt.Appendf(nil, "v%d_%d", v, i))
+		}
+		if _, _, err := tree.SaveVersion(); err != nil {
+			t.Fatalf("SaveVersion: %v", err)
+		}
+	}
+
+	// Baseline: batches created so far (one per SaveVersion Commit).
+	baseline := cdb.batches()
+
+	// Prune most versions (keep the latest).
+	if err := tree.DeleteVersionsTo(int64(numVersions - 1)); err != nil {
+		t.Fatalf("DeleteVersionsTo: %v", err)
+	}
+
+	flushes := cdb.batches() - baseline
+	if flushes < 2 {
+		t.Fatalf("prune only created %d batches — expected multiple flushes under a 128-byte threshold over %d versions",
+			flushes, numVersions-1)
+	}
+
+	// The latest version must still be readable and correct.
+	tree2 := NewMutableTreeWithDB(cdb, 100, NewNopLogger())
+	latestV, err := tree2.LoadVersion(int64(numVersions))
+	if err != nil {
+		t.Fatalf("LoadVersion: %v", err)
+	}
+	if latestV != int64(numVersions) {
+		t.Fatalf("loaded version = %d, want %d", latestV, numVersions)
+	}
+	if tree2.Size() != int64(numVersions*30) {
+		t.Fatalf("size after prune = %d, want %d", tree2.Size(), numVersions*30)
+	}
+}
+
+// TestPruneVersionsTo_ZeroFlushThresholdUsesDefault verifies that the
+// default/unset threshold does not degrade to per-version flushing (which
+// would be correct but slow).
+func TestPruneVersionsTo_ZeroFlushThresholdUsesDefault(t *testing.T) {
+	cdb := &batchCountingDB{DB: memdb.NewMemDB()}
+	tree := NewMutableTreeWithDB(cdb, 100, NewNopLogger()) // default threshold
+
+	for v := 0; v < 10; v++ {
+		tree.Set(fmt.Appendf(nil, "k%d", v), []byte("v"))
+		if _, _, err := tree.SaveVersion(); err != nil {
+			t.Fatalf("SaveVersion: %v", err)
+		}
+	}
+
+	baseline := cdb.batches()
+	if err := tree.DeleteVersionsTo(9); err != nil {
+		t.Fatalf("DeleteVersionsTo: %v", err)
+	}
+	flushes := cdb.batches() - baseline
+	// At the default 4 MiB threshold, a small prune should fit in one batch.
+	if flushes > 2 {
+		t.Fatalf("default threshold flushed %d times for a tiny prune; expected 1", flushes)
+	}
+}

--- a/tm2/pkg/bptree/prune_test.go
+++ b/tm2/pkg/bptree/prune_test.go
@@ -539,6 +539,104 @@ func TestRollback_CleansUpValues(t *testing.T) {
 	}
 }
 
+// TestSaveVersion_IdempotentReplayRollbackSafe exercises the "version
+// already exists with matching hash" path — typical of a deterministic
+// block replay after a crash. The working tree carries session state
+// (sessionValues, versionOrphans, nextValueNonce) accumulated from the
+// replay's Set/Remove calls. Before the fix, that state survived the
+// idempotent save; a subsequent Rollback would DeleteValueDirect each
+// session vk — which, in a deterministic replay, collide with the
+// persisted vks — and corrupt the live DB.
+func TestSaveVersion_IdempotentReplayRollbackSafe(t *testing.T) {
+	db := memdb.NewMemDB()
+
+	// Original save of V1.
+	orig := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+	orig.Set([]byte("k1"), []byte("v1"))
+	orig.Set([]byte("k2"), []byte("v2"))
+	hash1, _, err := orig.SaveVersion()
+	if err != nil {
+		t.Fatalf("SaveVersion(1): %v", err)
+	}
+	valuesAfterOriginalSave := countDBValues(db)
+	if valuesAfterOriginalSave != 2 {
+		t.Fatalf("setup: expected 2 values after original save, got %d", valuesAfterOriginalSave)
+	}
+
+	// Simulate crash + deterministic replay: fresh MutableTree on the same
+	// DB, same writes in the same order. Because nonces restart at 0 and
+	// allocation order is deterministic, replay's ValueKeys COLLIDE with
+	// the persisted ones — SaveValue overwrites the same DB entries.
+	replay := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+	replay.Set([]byte("k1"), []byte("v1"))
+	replay.Set([]byte("k2"), []byte("v2"))
+
+	hash1b, _, err := replay.SaveVersion()
+	if err != nil {
+		t.Fatalf("idempotent SaveVersion: %v", err)
+	}
+	if string(hash1) != string(hash1b) {
+		t.Fatalf("hash mismatch after idempotent save: %x vs %x", hash1, hash1b)
+	}
+	if got := countDBValues(db); got != 2 {
+		t.Fatalf("after idempotent save: %d values, want 2", got)
+	}
+
+	// Reads must still work.
+	if v, _ := replay.Get([]byte("k1")); string(v) != "v1" {
+		t.Fatalf("Get k1 after idempotent save = %q, want v1", v)
+	}
+
+	// Rollback must NOT corrupt the live DB. Before the fix, session state
+	// was never cleared on the idempotent path, so Rollback iterated
+	// sessionValues and called DeleteValueDirect on vks that collided with
+	// the persisted keys — wiping the live values from the DB.
+	replay.Rollback()
+	if got := countDBValues(db); got != 2 {
+		t.Fatalf("Rollback after idempotent save corrupted DB: %d values, want 2", got)
+	}
+	if v, _ := replay.Get([]byte("k1")); string(v) != "v1" {
+		t.Fatalf("Get k1 after rollback = %q, want v1 (live DB was not corrupted)", v)
+	}
+	if v, _ := replay.Get([]byte("k2")); string(v) != "v2" {
+		t.Fatalf("Get k2 after rollback = %q, want v2 (live DB was not corrupted)", v)
+	}
+}
+
+// TestSaveVersion_IdempotentEmptySessionNoOp verifies the trivial idempotent
+// path: calling SaveVersion twice in a row without any intervening Sets
+// produces the same hash and leaves the DB untouched. This protects the
+// session-clear logic from breaking the no-session case.
+func TestSaveVersion_IdempotentEmptySessionNoOp(t *testing.T) {
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 1000, NewNopLogger())
+
+	tree.Set([]byte("k"), []byte("v"))
+	hashA, versionA, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("first SaveVersion: %v", err)
+	}
+	valuesA := countDBValues(db)
+
+	// Forcibly re-enter the idempotent path: clear the version counter so
+	// WorkingVersion() again returns versionA, and re-save.
+	tree.version = versionA - 1
+	hashB, versionB, err := tree.SaveVersion()
+	if err != nil {
+		t.Fatalf("idempotent SaveVersion with empty session: %v", err)
+	}
+	if versionB != versionA {
+		t.Fatalf("version mismatch: %d vs %d", versionB, versionA)
+	}
+	if string(hashA) != string(hashB) {
+		t.Fatalf("hash mismatch: %x vs %x", hashA, hashB)
+	}
+	if countDBValues(db) != valuesA {
+		t.Fatalf("idempotent save with empty session changed DB: %d vs %d",
+			countDBValues(db), valuesA)
+	}
+}
+
 func TestPrune_DisjointKeysPreservesValues(t *testing.T) {
 	// Regression: pruning should NOT delete shared values
 	db := memdb.NewMemDB()

--- a/tm2/pkg/bptree/prune_test.go
+++ b/tm2/pkg/bptree/prune_test.go
@@ -128,6 +128,72 @@ func TestPrune_VersionReaders(t *testing.T) {
 	}
 }
 
+// TestPrune_IteratorBlocksPrune verifies that an open ImmutableTree iterator
+// on version V prevents PruneVersionsTo(V) from succeeding — and that closing
+// the iterator releases the hold. Regression test for a bug where iterators
+// never incremented versionReaders (the ctor hard-coded version=0), allowing
+// pruning to delete nodes mid-iteration.
+func TestPrune_IteratorBlocksPrune(t *testing.T) {
+	tree := newPruneTree(t)
+	for i := 0; i < 30; i++ {
+		tree.Set(fmt.Appendf(nil, "ir%03d", i), []byte("v"))
+	}
+	tree.SaveVersion()
+	tree.Set([]byte("ir_extra"), []byte("v"))
+	tree.SaveVersion()
+
+	// Open an iterator on v1 via the immutable snapshot's own Iterator.
+	imm, err := tree.GetImmutable(1)
+	if err != nil {
+		t.Fatalf("GetImmutable(1): %v", err)
+	}
+	itr, err := imm.Iterator(nil, nil, true)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+
+	// Pruning v1 should fail while the iterator is open.
+	if err := tree.DeleteVersionsTo(1); err == nil {
+		t.Fatalf("DeleteVersionsTo(1) should fail with an open iterator on v1")
+	}
+
+	// Close the iterator and retry.
+	if err := itr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := tree.DeleteVersionsTo(1); err != nil {
+		t.Fatalf("DeleteVersionsTo(1) after close: %v", err)
+	}
+}
+
+// TestPrune_StoreIteratorBlocksPrune verifies the same property through the
+// NewIteratorWithNDB entry point used by the store wrapper.
+func TestPrune_StoreIteratorBlocksPrune(t *testing.T) {
+	tree := newPruneTree(t)
+	for i := 0; i < 30; i++ {
+		tree.Set(fmt.Appendf(nil, "si%03d", i), []byte("v"))
+	}
+	tree.SaveVersion()
+	tree.Set([]byte("si_extra"), []byte("v"))
+	tree.SaveVersion()
+
+	imm, err := tree.GetImmutable(1)
+	if err != nil {
+		t.Fatalf("GetImmutable(1): %v", err)
+	}
+	itr := NewIteratorWithNDB(imm, nil, nil, true, tree)
+
+	if err := tree.DeleteVersionsTo(1); err == nil {
+		t.Fatalf("DeleteVersionsTo(1) should fail with an open NDB iterator on v1")
+	}
+	if err := itr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := tree.DeleteVersionsTo(1); err != nil {
+		t.Fatalf("DeleteVersionsTo(1) after close: %v", err)
+	}
+}
+
 func TestPrune_PreservesLatestState(t *testing.T) {
 	tree := newPruneTree(t)
 

--- a/tm2/pkg/bptree/remove.go
+++ b/tm2/pkg/bptree/remove.go
@@ -206,14 +206,17 @@ func redistributeRight(parent *InnerNode, idx int) {
 			r.childHashes[i] = r.childHashes[i-1]
 			r.childSizes[i] = r.childSizes[i-1]
 		}
-		// Demote separator, promote left's last key
-		r.keys[0] = parent.keys[idx]
+		// Demote separator to r, promote left's last key to parent. Use
+		// copyKey on both transfers for symmetry with the leaf case
+		// (redistributeRight / redistributeLeft both copy) and to keep
+		// keys stored in different nodes as independent slices.
+		r.keys[0] = copyKey(parent.keys[idx])
 		r.childNodes[0] = movedChild
 		r.children[0] = l.children[lastChildIdx]
 		r.childHashes[0] = l.childHashes[lastChildIdx]
 		r.childSizes[0] = movedSize
 		r.numKeys++
-		parent.keys[idx] = l.keys[lastKeyIdx]
+		parent.keys[idx] = copyKey(l.keys[lastKeyIdx])
 		l.keys[lastKeyIdx] = nil
 		l.childNodes[lastChildIdx] = nil
 		l.children[lastChildIdx] = nil
@@ -267,15 +270,18 @@ func redistributeLeft(parent *InnerNode, idx int) {
 		l := left.(*InnerNode)
 		movedSize := r.childSizes[0]
 		movedChild := r.childNodes[0]
-		// Demote separator to end of left, promote right's first key
-		l.keys[l.numKeys] = parent.keys[idx]
+		// Demote separator to end of left, promote right's first key.
+		// copyKey on both transfers for symmetry with the leaf branch
+		// (which already does this) and to keep keys stored in different
+		// nodes as independent slices.
+		l.keys[l.numKeys] = copyKey(parent.keys[idx])
 		lnc := l.NumChildren()
 		l.childNodes[lnc] = movedChild
 		l.children[lnc] = r.children[0]
 		l.childHashes[lnc] = r.childHashes[0]
 		l.childSizes[lnc] = movedSize
 		l.numKeys++
-		parent.keys[idx] = r.keys[0]
+		parent.keys[idx] = copyKey(r.keys[0])
 		// Shift right left (including childSizes)
 		rn := int(r.numKeys)
 		for i := 0; i < rn-1; i++ {

--- a/tm2/pkg/bptree/save_sibling_load_test.go
+++ b/tm2/pkg/bptree/save_sibling_load_test.go
@@ -1,0 +1,88 @@
+package bptree
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// countingDB wraps a DB and counts Get calls keyed by the first byte of the
+// requested key (the prefix: 'B' for nodes, 'V' for values, 'R' for roots,
+// 'O' for orphans, 'M' for meta).
+type countingDB struct {
+	dbm.DB
+	nodeGets uint64
+}
+
+func (c *countingDB) Get(key []byte) ([]byte, error) {
+	if len(key) > 0 && key[0] == PrefixNode {
+		atomic.AddUint64(&c.nodeGets, 1)
+	}
+	return c.DB.Get(key)
+}
+
+func (c *countingDB) nodeGetCount() uint64 { return atomic.LoadUint64(&c.nodeGets) }
+
+// TestSaveVersion_DoesNotForceLoadSiblings verifies that a Set on a tree with
+// many unloaded siblings does not cause SaveVersion to load those siblings
+// from the DB.
+//
+// Without the fix, saveNode called inner.getChild(i) for every i in every COW'd
+// inner node, which eagerly loaded every sibling. With ~30 unloaded siblings per
+// COW'd inner and a path length of ~2, that's ~60 extra DB reads per Set.
+// The fix iterates only in-memory childNodes, so no sibling loads occur.
+func TestSaveVersion_DoesNotForceLoadSiblings(t *testing.T) {
+	cdb := &countingDB{DB: memdb.NewMemDB()}
+	// Small cache so sibling loads actually hit the DB, not just the LRU.
+	tree := NewMutableTreeWithDB(cdb, 2, NewNopLogger())
+
+	// Fill enough keys to get a height>=1 tree with many leaves.
+	for i := 0; i < 500; i++ {
+		if _, err := tree.Set(fmt.Appendf(nil, "k%06d", i), []byte("v")); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+	}
+	if _, _, err := tree.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion v1: %v", err)
+	}
+
+	// Reload into a fresh tree so all children are unloaded.
+	tree2 := NewMutableTreeWithDB(cdb, 2, NewNopLogger())
+	if _, err := tree2.LoadVersion(1); err != nil {
+		t.Fatalf("LoadVersion: %v", err)
+	}
+	if tree2.Height() < 1 {
+		t.Fatalf("tree too shallow for sibling test: height=%d", tree2.Height())
+	}
+
+	// Do a single Set that loads ONE path (root→leaf). The COW path ends up
+	// in-memory; siblings along it are still serialized-only.
+	beforeGet := cdb.nodeGetCount()
+	if _, err := tree2.Set([]byte("k000100"), []byte("updated")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	afterSet := cdb.nodeGetCount()
+	setReads := afterSet - beforeGet
+
+	// Now SaveVersion. The fix's claim: no more sibling loads happen here.
+	if _, _, err := tree2.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion v2: %v", err)
+	}
+	saveReads := cdb.nodeGetCount() - afterSet
+
+	// Sanity: the Set itself loaded the path from root to leaf (1 leaf + inner
+	// nodes already root). Should be small.
+	if setReads > uint64(tree2.Height()+2) {
+		t.Fatalf("Set loaded %d nodes, expected <= %d (path length)", setReads, tree2.Height()+2)
+	}
+
+	// The fix's actual assertion: SaveVersion must NOT trigger sibling loads.
+	// Without the fix, saveNode would getChild(i) for every i in every COW'd
+	// inner, loading ~(B-1) = 31 siblings per level.
+	if saveReads != 0 {
+		t.Fatalf("SaveVersion loaded %d sibling nodes, want 0", saveReads)
+	}
+}

--- a/tm2/pkg/bptree/value_missing_test.go
+++ b/tm2/pkg/bptree/value_missing_test.go
@@ -1,0 +1,73 @@
+package bptree
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// TestGetValue_MissingValueReturnsError verifies that if the tree references
+// a ValueKey that is not present in the DB (corruption or a pruning bug),
+// GetValue returns a wrapped ErrKeyDoesNotExist rather than silently
+// returning (nil, nil). The silent form caused corruption to look like a
+// legitimate "empty value" to the caller.
+func TestGetValue_MissingValueReturnsError(t *testing.T) {
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 100, NewNopLogger())
+
+	if _, err := tree.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Capture the vk via tree lookup, then delete the value directly from DB
+	// to simulate corruption.
+	_, _, vk, found := treeLookup(tree.root, []byte("k"))
+	if !found {
+		t.Fatalf("setup: key not found")
+	}
+	if err := db.Delete(valueDBKey(vk)); err != nil {
+		t.Fatalf("delete value: %v", err)
+	}
+
+	_, err := tree.ndb.GetValue(vk)
+	if err == nil {
+		t.Fatalf("GetValue on missing vk should return error")
+	}
+	if !errors.Is(err, ErrKeyDoesNotExist) {
+		t.Fatalf("error should wrap ErrKeyDoesNotExist, got %v", err)
+	}
+}
+
+// TestGetValue_EmptyValueReturnsEmptySlice verifies that a stored empty
+// value is returned as a non-nil []byte{} — distinguishable from missing.
+// Previously, depending on the backend, empty values could round-trip as
+// nil, making them indistinguishable from "not found".
+func TestGetValue_EmptyValueReturnsEmptySlice(t *testing.T) {
+	db := memdb.NewMemDB()
+	tree := NewMutableTreeWithDB(db, 100, NewNopLogger())
+
+	if _, err := tree.Set([]byte("k"), []byte{}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	val, err := tree.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if val == nil {
+		t.Fatalf("Get on stored empty value should return non-nil, got nil")
+	}
+	if len(val) != 0 {
+		t.Fatalf("Get on stored empty value = %q, want empty", val)
+	}
+
+	// After SaveVersion: same contract.
+	if _, _, err := tree.SaveVersion(); err != nil {
+		t.Fatalf("SaveVersion: %v", err)
+	}
+	val, err = tree.Get([]byte("k"))
+	if err != nil || val == nil || len(val) != 0 {
+		t.Fatalf("Get after save: val=%q err=%v", val, err)
+	}
+}

--- a/tm2/pkg/bptree/version_exists_error_test.go
+++ b/tm2/pkg/bptree/version_exists_error_test.go
@@ -1,0 +1,52 @@
+package bptree
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// failingHasDB wraps a DB and forces Has() to return an error for all keys
+// whose first byte matches hasFailPrefix. Set Get/Set/Delete pass through.
+type failingHasDB struct {
+	dbm.DB
+	hasFailPrefix byte
+	hasFailErr    error
+}
+
+func (d *failingHasDB) Has(key []byte) (bool, error) {
+	if len(key) > 0 && key[0] == d.hasFailPrefix {
+		return false, d.hasFailErr
+	}
+	return d.DB.Has(key)
+}
+
+// TestSaveVersion_PropagatesVersionExistsError verifies that a DB error in
+// versionExistsE during SaveVersion is propagated to the caller. Before the
+// fix, SaveVersion called VersionExists which swallowed the error and
+// returned false — causing SaveVersion to proceed into the "fresh save"
+// branch and overwrite an existing version with new data.
+func TestSaveVersion_PropagatesVersionExistsError(t *testing.T) {
+	inner := memdb.NewMemDB()
+	wrapped := &failingHasDB{
+		DB:            inner,
+		hasFailPrefix: PrefixRoot,
+		hasFailErr:    errors.New("simulated root Has failure"),
+	}
+	tree := NewMutableTreeWithDB(wrapped, 100, NewNopLogger())
+
+	if _, err := tree.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	_, _, err := tree.SaveVersion()
+	if err == nil {
+		t.Fatalf("SaveVersion should have propagated the DB error")
+	}
+	if !strings.Contains(err.Error(), "simulated root Has failure") {
+		t.Fatalf("error does not wrap underlying cause: %v", err)
+	}
+}


### PR DESCRIPTION
Fifteen commits on `feat/alex/bp32tree-deep-dive`, one per finding, each with tests.

## Correctness / safety

- **Iterator version readers** (ccbbeb66b) — `newIterator` hard-coded `version=0`, so `incrVersionReaders` never fired. `PruneVersionsTo` could delete nodes a live iterator was walking. Iterators now register against `imm.version` and release on `Close`.
- **Idempotent `SaveVersion` leaked session state** (82eebc957) — on a deterministic replay hitting the "version already exists with same hash" path, `sessionValues` survived the early return. A subsequent `Rollback` then `DeleteValueDirect`'d vks that collided with live persisted entries, wiping real data. Now clears session counters on that branch.
- **`VersionExists` swallowed DB errors** (536f84a72) — a transient `Has` failure silently returned "does not exist", letting `SaveVersion` overwrite an existing version. Added `versionExistsE` that propagates the error; `SaveVersion` uses it.
- **`GetValue` couldn't distinguish missing from empty** (11cf2a24c) — returned `(nil, nil)` for both cases, masking corruption as empty values. Now disambiguates with `Has`; missing → wrapped `ErrKeyDoesNotExist`, empty → non-nil `[]byte{}`.
- **Crashed-session value leak** (388068894) — `SaveValue` writes eagerly, `sessionValues` is in-memory only, so a process crash before `SaveVersion`/`Rollback` leaked values permanently. `Load()` now scans the value keyspace above `latestVersion` (a contiguous suffix — zero cost on clean shutdown) and deletes the orphans.
- **`MaxKeyLen` cap on Set/Import** (5f091db7e) — read side capped length-prefixed fields at 1 MiB but the write side was unbounded. An oversized key would serialize but fail to deserialize, permanently wedging that version. `Set` and `Importer` now enforce the cap with `ErrKeyTooLong`.
- **Unreachable `deleteAllNodesForVersion` removed** (daaae1d45) — the `nextV == 0` branch never fired given the `toVersion < latest` guard, but if reached it deleted nodes without touching leaf values or orphan lists — a dormant value-leak timebomb. Removed; the branch now returns a loud error documenting the invariant.

## Fail-fast guards (corruption detection)

- **`ReadNode` trailing-bytes check** (c43bf6a4b) — corrupt payloads with extra bytes previously decoded as silently truncated nodes.
- **`Serialize` rejects nil `valueKey`/child-ref** (5387af584) — the leaf path wrote a 12-byte zero placeholder (round-tripped as `{v:0,n:0}` → silent "value not found"); the inner path wrote 0 bytes (shifting every subsequent read). Both now error.

## Performance / memory

- **`saveNode` force-loaded unchanged siblings** (b311fbb2e) — the big one. `inner.getChild(i)` fetched every sibling of every COW'd inner just to early-return on "already saved". At blockchain scale (100M leaves, H=6, B=32, ~100 mutations/block) that's ~18K unnecessary DB reads per block. Now walks `childNodes` directly; unloaded children are unchanged by construction.
- **`PruneVersionsTo` batch memory** (4dd84b894) — accumulated every delete across all pruned versions into a single batch. Wired the previously-unused `FlushThreshold` (default 4 MiB internal) so a startup catch-up prune of thousands of versions doesn't balloon RSS. Pruning is idempotent, so intermediate commits are safe.
- **Deferred `copyKey` on update path** (ee34a2dad) — `treeInsert` copied the key unconditionally, but updates don't store it. Moved the copy into the new-insert/split branches of `leafInsert`; update-heavy workloads skip the allocation.

## Defensive / hygiene

- **Orphans of first pruned version** (120238dda) — `pruneVersion` only consumed `orphans[nextV]`, assuming a prior iteration handled `orphans[v]`. For the first iteration there's no prior. `orphans[first]` is empty in practice (new invariant test `TestOrphans_FirstVersionEmpty` locks that in across default/`initialVersion`/churn cases), but the defensive consumption is free (`LoadOrphans` returns empty when the record is gone) and catches any future regression.
- **`redistributeLeft`/`Right` inner-case `copyKey`** (75a04d8f4) — leaf branches copied on separator transfer, inner branches didn't. Not an active bug (no code mutates key bytes), but the asymmetry was easy to break. Tightened to "every key in a different node is an independent slice."

## Docs

- **README dedup claim corrected** (675fe4425) — README claimed content-addressed value deduplication. The code allocates a fresh `ValueKey` on every `Set`; identical values produce separate DB entries. Replaced the bullet with an explicit "No content-addressed deduplication" note and added a reference to the new crash-recovery cleanup.

## Also verified (no code change)

- `walkAndPrune` visited-set — old-tree traversal visits each node at most once by construction; `newRoot` is only used for hash comparison, not deletion. Batch double-delete would be idempotent anyway.

## Tests

Every behavior-changing fix has a regression test. New test files in `tm2/pkg/bptree/`:

- `save_sibling_load_test.go`
- `value_missing_test.go`
- `version_exists_error_test.go`
- `orphan_first_test.go`
- `node_framing_test.go`
- `crash_recovery_test.go`
- `prune_flush_test.go`
- `key_len_test.go`
- `insert_update_alloc_test.go`

Pre-existing suites (`tm2/pkg/bptree`, `tm2/pkg/store/bptree`) remain green.

## Disclosure

AI-assisted review and implementation.
