### PR TITLE
fix(gnovm): survive partial mempackage writes on restart

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -241,6 +241,21 @@ func (m *Machine) SetActivePackage(pv *PackageValue) {
 func (m *Machine) PreprocessAllFilesAndSaveBlockNodes() {
 	ch := m.Store.IterMemPackage()
 	for mpkg := range ch {
+		// AddMemPackage writes the path index (baseStore / pebble) and the
+		// package body (iavlStore) in two separate Set calls. If the process
+		// is SIGKILLed between them (OOM, container stop, OrbStack restart),
+		// the index can point at a path whose body is absent, and
+		// GetMemPackage then returns nil. ParseMemPackage(nil) would SIGSEGV
+		// on `nil.Type.(MemPackageType)` (offset 0x38) and the node cannot
+		// boot. Skip with a warning so an operator can still reach a working
+		// node; the real fix is atomic index+body writes in AddMemPackage.
+		if mpkg == nil {
+			fmt.Fprintln(m.Output,
+				"WARNING: IterMemPackage returned nil — index points at a "+
+					"package whose body is not persisted (likely a prior "+
+					"crash mid-AddMemPackage). Skipping.")
+			continue
+		}
 		mpkg = MPFProd.FilterMemPackage(mpkg)
 		fset := m.ParseMemPackage(mpkg)
 		pn := NewPackageNode(Name(mpkg.Name), mpkg.Path, fset)

--- a/gnovm/pkg/gnolang/machine_test.go
+++ b/gnovm/pkg/gnolang/machine_test.go
@@ -1,6 +1,7 @@
 package gnolang
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -146,4 +147,35 @@ func TestMachineString(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestPreprocessAllFilesAndSaveBlockNodes_SkipsNilMemPackage simulates a
+// partial AddMemPackage write: the baseStore index entry exists but the
+// iavlStore body is missing. Without the defensive nil-skip the Machine
+// SIGSEGVs on `nil.Type.(MemPackageType)` inside ParseMemPackage, crash-
+// looping the node. With the skip, the loop logs a warning and continues
+// so the node boots and an operator can repair the store.
+func TestPreprocessAllFilesAndSaveBlockNodes_SkipsNilMemPackage(t *testing.T) {
+	d1, d2 := memdb.NewMemDB(), memdb.NewMemDB()
+	baseStore := dbadapter.StoreConstructor(d1, stypes.StoreOptions{})
+	iavlStore := dbadapter.StoreConstructor(d2, stypes.StoreOptions{})
+	store := NewStore(nil, baseStore, iavlStore)
+
+	// Forge: counter=1, index slot points at a path with no iavlStore body.
+	// IterMemPackage hits GetMemPackage("missing/path") → nil and yields
+	// nil on the channel — exactly the case PR-B must survive.
+	baseStore.Set(nil, []byte(backendPackageIndexCtrKey()), []byte("1"))
+	baseStore.Set(nil, []byte(backendPackageIndexKey(1)), []byte("missing/path"))
+
+	var out bytes.Buffer
+	m := NewMachine("test", store)
+	m.Output = &out
+
+	require.NotPanics(t, func() {
+		m.PreprocessAllFilesAndSaveBlockNodes()
+	}, "must survive nil MemPackage from a partial AddMemPackage")
+
+	logged := out.String()
+	assert.Contains(t, logged, "WARNING:")
+	assert.Contains(t, logged, "IterMemPackage returned nil")
 }


### PR DESCRIPTION
Split out from #5597 (review-only stack) for atomic review.

## What changes

Defensive nil-skip in `Machine.PreprocessAllFilesAndSaveBlockNodes`. If `IterMemPackage` ever yields a nil `*std.MemPackage` (because the producer-side baseStore index points at a path with no iavlStore body — see [sister PR](https://github.com/gnolang/gno/pulls?q=is%3Apr+author%3Amoul+gnovm+store+body-first)), the loop logs a warning and continues instead of SIGSEGVing inside `ParseMemPackage` on `mpkg.Type.(MemPackageType)`.

15 lines added in `gnovm/pkg/gnolang/machine.go`. No behavior change unless the store is in an inconsistent state — in which case the node now boots and an operator can repair, instead of crash-looping.

## Why this is independent from the producer-side fix

The producer-side fix (body-first ordering, sister PR) closes most of the SIGKILL window but cross-substore WAL flush ordering can still surface inconsistencies. This consumer-side skip is belt-and-braces — useful even after the producer fix lands, and useful immediately on master where the producer fix isn't in yet.

## Tests

The cherry-pick is verbatim from #5597's \`rc2-master\` layer and ships without new tests in the original commit (it's a defensive guard, not a behavior change). Happy to add a focused machine-side test that injects a nil-yielding store mock if reviewers want one — say the word.

## Context

One slice of the test13 hardfork-readiness stack at #5597, specifically the \`rc2-master\` layer's \`fix(gnovm)\` commit. A dedicated ADR will follow.

cc @aeddi (original author, cherry-pick preserved).

Co-authored from #5597.