### PR TITLE
fix(gnovm): validate addressability of & operand at preprocess stage

### DIFF
--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2335,6 +2335,11 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						"cannot take address of multi-value call (results: %s)",
 						tt.String()))
 				}
+				if !isAddressable(store, last, n.X) {
+					panic(fmt.Sprintf(
+						"invalid operation: cannot take address of %s (value of type %s)",
+						n.X.String(), xt.String()))
+				}
 				n.SetAttribute(ATTR_REF_ELEM_TYPE, xt)
 			// TRANS_LEAVE -----------------------
 			case *SelectorExpr:
@@ -4377,6 +4382,36 @@ func anyValue(t Type) TypedValue {
 func isConst(x Expr) bool {
 	_, ok := x.(*ConstExpr)
 	return ok
+}
+
+func isAddressable(store Store, last BlockNode, x Expr) bool {
+	switch cx := x.(type) {
+	case *NameExpr:
+		return true
+	case *StarExpr:
+		return true
+	case *CompositeLitExpr:
+		return true
+	case *IndexExpr:
+		xt := evalStaticTypeOf(store, last, cx.X)
+		if _, ok := baseOf(xt).(*MapType); ok {
+			return false
+		}
+		if _, ok := baseOf(xt).(*SliceType); ok {
+			return true
+		}
+		return isAddressable(store, last, cx.X)
+	case *SelectorExpr:
+		xt := evalStaticTypeOf(store, last, cx.X)
+		if _, ok := baseOf(xt).(*PointerType); ok {
+			return true
+		}
+		return isAddressable(store, last, cx.X)
+	case *TypeAssertExpr:
+		return false
+	default:
+		return false
+	}
 }
 
 func isConstType(x Expr) bool {

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -4386,29 +4386,21 @@ func isConst(x Expr) bool {
 
 func isAddressable(store Store, last BlockNode, x Expr) bool {
 	switch cx := x.(type) {
-	case *NameExpr:
-		return true
-	case *StarExpr:
-		return true
-	case *CompositeLitExpr:
+	case *NameExpr, *StarExpr, *CompositeLitExpr:
 		return true
 	case *IndexExpr:
-		xt := evalStaticTypeOf(store, last, cx.X)
-		if _, ok := baseOf(xt).(*MapType); ok {
+		switch evalStaticTypeOf(store, last, cx.X).Kind() {
+		case MapKind:
 			return false
-		}
-		if _, ok := baseOf(xt).(*SliceType); ok {
+		case SliceKind:
 			return true
 		}
 		return isAddressable(store, last, cx.X)
 	case *SelectorExpr:
-		xt := evalStaticTypeOf(store, last, cx.X)
-		if _, ok := baseOf(xt).(*PointerType); ok {
+		if evalStaticTypeOf(store, last, cx.X).Kind() == PointerKind {
 			return true
 		}
 		return isAddressable(store, last, cx.X)
-	case *TypeAssertExpr:
-		return false
 	default:
 		return false
 	}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2160,8 +2160,14 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					if t.Elem().Kind() != ArrayKind {
 						panic(fmt.Sprintf("cannot slice variable of type %v", t))
 					}
-				case SliceKind, ArrayKind, StringKind:
+				case SliceKind, StringKind:
 					// good.
+				case ArrayKind:
+					if !isAddressable(store, last, n.X) {
+						panic(fmt.Sprintf(
+							"invalid operation: %s (slice of unaddressable value)",
+							n.X.String()))
+					}
 				default:
 					panic(fmt.Sprintf("cannot slice variable of type %v", t))
 				}

--- a/gnovm/tests/files/addressable_10a_err.gno
+++ b/gnovm/tests/files/addressable_10a_err.gno
@@ -11,7 +11,7 @@ func getPtr() *S {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.CallExpr
+// main/addressable_10a_err.gno:4:10-19: invalid operation: cannot take address of getPtr<VPBlock(3,2)>() (value of type *main.S)
 
 // TypeCheckError:
 // main/addressable_10a_err.gno:4:11: invalid operation: cannot take address of getPtr() (value of type *S)

--- a/gnovm/tests/files/addressable_10b_err.gno
+++ b/gnovm/tests/files/addressable_10b_err.gno
@@ -9,7 +9,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.CallExpr
+// main/addressable_10b_err.gno:8:10-17: invalid operation: cannot take address of (const (new func(type{}) *main.S))(typeval{main.S}) (value of type *main.S)
 
 // TypeCheckError:
 // main/addressable_10b_err.gno:8:11: invalid operation: cannot take address of new(S) (value of type *S)

--- a/gnovm/tests/files/addressable_1c_rrr.gno
+++ b/gnovm/tests/files/addressable_1c_rrr.gno
@@ -11,3 +11,6 @@ func getArr() [1]int {
 
 // TypeCheckError:
 // main/addressable_1c_rrr.gno:4:7: invalid operation: cannot take address of getArr()[0] (value of type int)
+
+// Error:
+// main/addressable_1c_rrr.gno:4:6-18: invalid operation: cannot take address of getArr<VPBlock(3,1)>()[(const (0 int))] (value of type int)

--- a/gnovm/tests/files/addressable_1d_err.gno
+++ b/gnovm/tests/files/addressable_1d_err.gno
@@ -10,3 +10,6 @@ func getArr() [1]int {
 
 // TypeCheckError:
 // main/addressable_1d_err.gno:4:6: invalid operation: cannot slice getArr() (value of type [1]int) (value not addressable)
+
+// Error:
+// main/addressable_1d_err.gno:4:6-17: invalid operation: getArr<VPBlock(3,1)>() (slice of unaddressable value)

--- a/gnovm/tests/files/addressable_2a_err.gno
+++ b/gnovm/tests/files/addressable_2a_err.gno
@@ -5,7 +5,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.SliceExpr
+// main/addressable_2a_err.gno:4:6-18: invalid operation: cannot take address of (const-type []int){(const (1 int))}[:] (value of type []int)
 
 // TypeCheckError:
 // main/addressable_2a_err.gno:4:7: invalid operation: cannot take address of []int{…}[:] (value of type []int)

--- a/gnovm/tests/files/addressable_2b_err.gno
+++ b/gnovm/tests/files/addressable_2b_err.gno
@@ -9,7 +9,7 @@ func getSlice() []int {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.CallExpr
+// main/addressable_2b_err.gno:4:6-17: invalid operation: cannot take address of getSlice<VPBlock(3,1)>() (value of type []int)
 
 // TypeCheckError:
 // main/addressable_2b_err.gno:4:7: invalid operation: cannot take address of getSlice() (value of type []int)

--- a/gnovm/tests/files/addressable_3b_err.gno
+++ b/gnovm/tests/files/addressable_3b_err.gno
@@ -14,3 +14,6 @@ func getStruct() S {
 
 // TypeCheckError:
 // main/addressable_3b_err.gno:8:7: invalid operation: cannot take address of getStruct().i (value of type int)
+
+// Error:
+// main/addressable_3b_err.gno:8:6-20: invalid operation: cannot take address of getStruct<VPBlock(3,2)>().i (value of type int)

--- a/gnovm/tests/files/addressable_3c_err.gno
+++ b/gnovm/tests/files/addressable_3c_err.gno
@@ -15,3 +15,6 @@ func main() {
 
 // TypeCheckError:
 // main/addressable_3c_err.gno:13:7: invalid operation: cannot take address of makeT().Mp (value of type *int)
+
+// Error:
+// main/addressable_3c_err.gno:13:6-17: invalid operation: cannot take address of makeT<VPBlock(3,1)>().Mp (value of type *int)

--- a/gnovm/tests/files/addressable_3d_err.gno
+++ b/gnovm/tests/files/addressable_3d_err.gno
@@ -5,7 +5,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.RefExpr
+// main/addressable_3d_err.gno:4:6-20: invalid operation: cannot take address of &((const-type struct{}){}) (value of type *struct{})
 
 // TypeCheckError:
 // main/addressable_3d_err.gno:4:7: invalid operation: cannot take address of (&struct{}{}) (value of type *struct{})

--- a/gnovm/tests/files/addressable_5a_err.gno
+++ b/gnovm/tests/files/addressable_5a_err.gno
@@ -8,7 +8,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.ConstExpr
+// main/addressable_5a_err.gno:7:6-20: invalid operation: cannot take address of (const (255 <untyped> bigint)) (value of type <untyped> bigint)
 
 // TypeCheckError:
 // main/addressable_5a_err.gno:7:7: invalid operation: cannot take address of math.MaxUint8 (untyped int constant 255)

--- a/gnovm/tests/files/addressable_5b_err.gno
+++ b/gnovm/tests/files/addressable_5b_err.gno
@@ -8,7 +8,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.ConstExpr
+// main/addressable_5b_err.gno:7:6-32: invalid operation: cannot take address of (const (0 chain/banker.BankerType)) (value of type chain/banker.BankerType)
 
 // TypeCheckError:
 // main/addressable_5b_err.gno:7:7: invalid operation: cannot take address of banker.BankerTypeReadonly (constant 0 of uint8 type banker.BankerType)

--- a/gnovm/tests/files/addressable_5c_err.gno
+++ b/gnovm/tests/files/addressable_5c_err.gno
@@ -7,7 +7,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.ConstExpr
+// main/addressable_5c_err.gno:6:6-8: invalid operation: cannot take address of (const (1 <untyped> bigint)) (value of type <untyped> bigint)
 
 // TypeCheckError:
 // main/addressable_5c_err.gno:6:7: invalid operation: cannot take address of a (untyped int constant 1)

--- a/gnovm/tests/files/addressable_5d_err.gno
+++ b/gnovm/tests/files/addressable_5d_err.gno
@@ -7,7 +7,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.ConstExpr
+// main/addressable_5d_err.gno:6:6-8: invalid operation: cannot take address of (const (1 int)) (value of type int)
 
 // TypeCheckError:
 // main/addressable_5d_err.gno:6:7: invalid operation: cannot take address of a (constant 1 of type int)

--- a/gnovm/tests/files/addressable_6a_err.gno
+++ b/gnovm/tests/files/addressable_6a_err.gno
@@ -7,7 +7,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.TypeAssertExpr
+// main/addressable_6a_err.gno:6:10-18: invalid operation: cannot take address of i<VPBlock(1,0)>.((const-type int)) (value of type int)
 
 // TypeCheckError:
 // main/addressable_6a_err.gno:6:11: invalid operation: cannot take address of i.(int) (comma, ok expression of type int)

--- a/gnovm/tests/files/addressable_6b_err.gno
+++ b/gnovm/tests/files/addressable_6b_err.gno
@@ -10,8 +10,8 @@ func main() {
 	println(&i.(S).a)
 }
 
-// Output:
-// &(9 int)
-
 // TypeCheckError:
 // main/addressable_6b_err.gno:10:11: invalid operation: cannot take address of i.(S).a (value of type int)
+
+// Error:
+// main/addressable_6b_err.gno:10:10-18: invalid operation: cannot take address of i<VPBlock(1,0)>.(typeval{main.S}).a (value of type int)

--- a/gnovm/tests/files/addressable_6c_err.gno
+++ b/gnovm/tests/files/addressable_6c_err.gno
@@ -6,8 +6,8 @@ func main() {
 	println(&i.([1]int)[0])
 }
 
-// Output:
-// &(1 int)
-
 // TypeCheckError:
 // main/addressable_6c_err.gno:6:11: invalid operation: cannot take address of i.([1]int)[0] (value of type int)
+
+// Error:
+// main/addressable_6c_err.gno:6:10-24: invalid operation: cannot take address of i<VPBlock(1,0)>.([(const (1 int))](const-type int))[(const (0 int))] (value of type int)

--- a/gnovm/tests/files/addressable_6d_err.gno
+++ b/gnovm/tests/files/addressable_6d_err.gno
@@ -9,7 +9,7 @@ func getSlice() any {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.TypeAssertExpr
+// main/addressable_6d_err.gno:4:6-25: invalid operation: cannot take address of getSlice<VPBlock(3,1)>().([](const-type int)) (value of type []int)
 
 // TypeCheckError:
 // main/addressable_6d_err.gno:4:7: invalid operation: cannot take address of getSlice().([]int) (comma, ok expression of type []int)

--- a/gnovm/tests/files/addressable_6e_err.gno
+++ b/gnovm/tests/files/addressable_6e_err.gno
@@ -1,0 +1,14 @@
+package main
+
+type arr1 [1]int
+
+func main() {
+	var i interface{} = arr1{1}
+	_ = i.(arr1)[:]
+}
+
+// Error:
+// main/addressable_6e_err.gno:7:6-17: invalid operation: i<VPBlock(1,0)>.(typeval{main.arr1}) (slice of unaddressable value)
+
+// TypeCheckError:
+// main/addressable_6e_err.gno:7:6: invalid operation: cannot slice i.(arr1) (comma, ok expression of array type arr1) (value not addressable)

--- a/gnovm/tests/files/addressable_7b_err.gno
+++ b/gnovm/tests/files/addressable_7b_err.gno
@@ -5,7 +5,7 @@ func main() {
 }
 
 // Error:
-// main/addressable_7b_err.gno:4:2-16: RHS should not be &((const (9 int))) when len(Lhs) > len(Rhs)
+// main/addressable_7b_err.gno:4:9-16: invalid operation: cannot take address of (const (9 int)) (value of type int)
 
 // TypeCheckError:
 // main/addressable_7b_err.gno:4:10: invalid operation: cannot take address of int(9) (constant 9 of type int)

--- a/gnovm/tests/files/addressable_7c_err.gno
+++ b/gnovm/tests/files/addressable_7c_err.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	a, b := 1, 2
+	_ = &(a + b)
+}
+
+// Error:
+// main/addressable_7c_err.gno:5:6-14: invalid operation: cannot take address of a<VPBlock(1,0)> + b<VPBlock(1,1)> (value of type int)
+
+// TypeCheckError:
+// main/addressable_7c_err.gno:5:7: invalid operation: cannot take address of (a + b) (value of type int)

--- a/gnovm/tests/files/addressable_7d_err.gno
+++ b/gnovm/tests/files/addressable_7d_err.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	x := 1
+	_ = &(-x)
+}
+
+// Error:
+// main/addressable_7d_err.gno:5:6-11: invalid operation: cannot take address of -x<VPBlock(1,0)> (value of type int)
+
+// TypeCheckError:
+// main/addressable_7d_err.gno:5:7: invalid operation: cannot take address of (-x) (value of type int)

--- a/gnovm/tests/files/addressable_8a_err.gno
+++ b/gnovm/tests/files/addressable_8a_err.gno
@@ -5,7 +5,7 @@ func main() {
 }
 
 // Error:
-// illegal assignment X expression type *gnolang.FuncLitExpr
+// main/addressable_8a_err.gno:4:6-42: invalid operation: cannot take address of func func(){ (const (println func(...interface {})))((const ("Hello, World!" string))) } (value of type func())
 
 // TypeCheckError:
 // main/addressable_8a_err.gno:4:7: invalid operation: cannot take address of (func() literal) (value of type func())

--- a/gnovm/tests/files/addressable_9a_err.gno
+++ b/gnovm/tests/files/addressable_9a_err.gno
@@ -6,8 +6,8 @@ func main() {
 	println(&m[4])
 }
 
-// Output:
-// &(5 int)
-
 // TypeCheckError:
 // main/addressable_9a_err.gno:6:11: invalid operation: cannot take address of m[4] (map index expression of type int)
+
+// Error:
+// main/addressable_9a_err.gno:6:10-15: invalid operation: cannot take address of m<VPBlock(1,0)>[(const (4 int))] (value of type int)

--- a/gnovm/tests/files/addressable_9b_err.gno
+++ b/gnovm/tests/files/addressable_9b_err.gno
@@ -11,8 +11,8 @@ func main() {
 	println(&mmm[3][3].i)
 }
 
-// Output:
-// &(7 int)
-
 // TypeCheckError:
 // main/addressable_9b_err.gno:11:11: invalid operation: cannot take address of mmm[3][3].i (value of type int)
+
+// Error:
+// main/addressable_9b_err.gno:11:10-22: invalid operation: cannot take address of mmm<VPBlock(1,0)>[(const (3 int))][(const (3 int))].i (value of type int)

--- a/gnovm/tests/files/addressable_9c_err.gno
+++ b/gnovm/tests/files/addressable_9c_err.gno
@@ -1,0 +1,14 @@
+package main
+
+type S struct{ m map[string]int }
+
+func main() {
+	s := S{m: map[string]int{"a": 1}}
+	_ = &s.m["a"]
+}
+
+// Error:
+// main/addressable_9c_err.gno:7:6-15: invalid operation: cannot take address of s<VPBlock(1,0)>.m[(const ("a" string))] (value of type int)
+
+// TypeCheckError:
+// main/addressable_9c_err.gno:7:7: invalid operation: cannot take address of s.m["a"] (map index expression of type int)

--- a/gnovm/tests/files/addressable_9d_err.gno
+++ b/gnovm/tests/files/addressable_9d_err.gno
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	m := map[string][1]int{"k": {1}}
+	_ = m["k"][:]
+}
+
+// Error:
+// main/addressable_9d_err.gno:5:6-15: invalid operation: m<VPBlock(1,0)>[(const ("k" string))] (slice of unaddressable value)
+
+// TypeCheckError:
+// main/addressable_9d_err.gno:5:6: invalid operation: cannot slice m["k"] (map index expression of type [1]int) (value not addressable)


### PR DESCRIPTION
## Summary      
            
Closes #5586

Gno did not validate addressability of the `&` operand at the preprocess stage. Non-addressable expressions such as `&(a + b)`, `&(-x)`, or `&m["key"]` were silently accepted and either panicked at runtime or produced incorrect behavior. 

This PR adds an `isAddressable` check in the `RefExpr` `TRANS_LEAVE` handler, matching Go's addressability rules:                                                                                                                                                                                                                                      
  - **Addressable**: variables, pointer dereferences (`*p`), composite literals, slice index expressions, struct field selectors on addressable or pointer base
  - **Non-addressable**: map index expressions, type assertion results, binary/unary expressions, function call results, constants

## Changes                                                                                                                                                  
- `gnovm/pkg/gnolang/preprocess.go`: Add `isAddressable` helper and call it in `RefExpr` `TRANS_LEAVE`                                                                               
- `gnovm/tests/files/addressable_*.gno`: Update 20 existing test files — errors now caught at preprocess stage instead of runtime
- `gnovm/tests/files/addressable_7c_err.gno`: New test — `&(a + b)` (BinaryExpr)
- `gnovm/tests/files/addressable_7d_err.gno`: New test — `&(-x)` (UnaryExpr)
- `gnovm/tests/files/addressable_9c_err.gno`: New test — `&s.m["a"]` (map index through struct field)

## Test plan
`go test ./gnovm/pkg/gnolang/ -run TestFiles/addressable -test.short`  