### PR TITLE
feat(gnoweb): expose render link on realm directory views

### DIFF
--- a/gno.land/pkg/gnoweb/components/view_directory.go
+++ b/gno.land/pkg/gnoweb/components/view_directory.go
@@ -1,5 +1,7 @@
 package components
 
+import "strings"
+
 const DirectoryViewType ViewType = "dir-view"
 
 type DirData struct {
@@ -8,6 +10,8 @@ type DirData struct {
 	FilesLinks  FilesLinks
 	Mode        ViewMode
 	Readme      Component
+	IsRealm     bool
+	RenderURL   string
 }
 
 type DirLinkType int
@@ -51,11 +55,19 @@ func buildFilesLinks(files []string, linkType DirLinkType, pkgPath string) Files
 
 // DirectoryView creates a directory view
 func DirectoryView(pkgPath string, files []string, fileCounter int, linkType DirLinkType, mode ViewMode, readme ...Component) *View {
+	isRealm := strings.HasPrefix(pkgPath, "/r/")
+	renderURL := ""
+	if isRealm {
+		renderURL = strings.TrimSuffix(pkgPath, "/")
+	}
+
 	viewData := DirData{
 		PkgPath:     pkgPath,
 		FilesLinks:  buildFilesLinks(files, linkType, pkgPath),
 		FileCounter: fileCounter,
 		Mode:        mode,
+		IsRealm:     isRealm,
+		RenderURL:   renderURL,
 	}
 	if len(readme) > 0 {
 		viewData.Readme = readme[0]

--- a/gno.land/pkg/gnoweb/components/view_test.go
+++ b/gno.land/pkg/gnoweb/components/view_test.go
@@ -287,11 +287,11 @@ func TestHelpView(t *testing.T) {
 }
 
 func TestDirectoryView(t *testing.T) {
-	pkgPath := "example/path"
+	pkgPath := "/r/example/path"
 	files := []string{"file1.gno", "file2.gno"}
 	fileCounter := 2
 	linkType := DirLinkTypeSource
-	mode := ViewModePackage
+	mode := ViewModeRealm
 
 	view := DirectoryView(pkgPath, files, fileCounter, linkType, mode)
 
@@ -307,8 +307,23 @@ func TestDirectoryView(t *testing.T) {
 	assert.Equal(t, len(files), len(dirData.FilesLinks), "expected %d files, got %d", len(files), len(dirData.FilesLinks))
 	assert.Equal(t, fileCounter, dirData.FileCounter, "expected FileCounter %d, got %d", fileCounter, dirData.FileCounter)
 	assert.Equal(t, mode, dirData.Mode, "expected Mode %v, got %v", mode, dirData.Mode)
+	assert.True(t, dirData.IsRealm, "expected IsRealm to be true")
+	assert.Equal(t, pkgPath, dirData.RenderURL, "expected RenderURL %s, got %s", pkgPath, dirData.RenderURL)
 
 	assert.NoError(t, view.Render(io.Discard))
+}
+
+func TestDirectoryView_PackageHasNoRenderURL(t *testing.T) {
+	view := DirectoryView("/p/example/path", []string{"file1.gno"}, 1, DirLinkTypeSource, ViewModePackage)
+
+	templateComponent, ok := view.Component.(*TemplateComponent)
+	assert.True(t, ok, "expected TemplateComponent type in view.Component")
+
+	dirData, ok := templateComponent.data.(DirData)
+	assert.True(t, ok, "expected DirData type in component data")
+
+	assert.False(t, dirData.IsRealm, "expected IsRealm to be false")
+	assert.Empty(t, dirData.RenderURL, "expected RenderURL to be empty")
 }
 
 func TestDirLinkType_LinkPrefix(t *testing.T) {

--- a/gno.land/pkg/gnoweb/components/views/directory.html
+++ b/gno.land/pkg/gnoweb/components/views/directory.html
@@ -5,6 +5,9 @@
     <div class="header-info">
       <span>{{ if .Mode.IsExplorer }} Explorer · {{ .FileCounter }} Packages {{
         else }} Directory · {{ .FileCounter }} Files {{ end }}</span>
+      {{ if and .IsRealm (not .Mode.IsExplorer) }}
+      <a href="{{ .RenderURL }}" class="b-inline-btn">Render</a>
+      {{ end }}
     </div>
   </header>
 

--- a/gno.land/pkg/gnoweb/handler_http_test.go
+++ b/gno.land/pkg/gnoweb/handler_http_test.go
@@ -394,6 +394,67 @@ func TestHTTPHandler_RealmExplorerWithRender(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "Action")
 }
 
+func TestHTTPHandler_DirectoryViewRenderLink(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		requestPath string
+		pkg         *gnoweb.MockPackage
+		wantLink    string
+		wantRender  bool
+	}{
+		{
+			name:        "realm directory shows render link",
+			requestPath: "/r/demo/blog/",
+			pkg: &gnoweb.MockPackage{
+				Domain: "gno.land",
+				Path:   "/r/demo/blog",
+				Files: map[string]string{
+					"main.gno": "package blog",
+				},
+			},
+			wantLink:   `href="/r/demo/blog" class="b-inline-btn">Render</a>`,
+			wantRender: true,
+		},
+		{
+			name:        "pure package directory hides render link",
+			requestPath: "/p/demo/pkg/",
+			pkg: &gnoweb.MockPackage{
+				Domain: "gno.land",
+				Path:   "/p/demo/pkg",
+				Files: map[string]string{
+					"main.gno": "package pkg",
+				},
+			},
+			wantRender: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler, err := gnoweb.NewHTTPHandler(
+				slog.New(slog.NewTextHandler(&testingLogger{t}, nil)),
+				newTestHandlerConfig(t, gnoweb.NewMockClient(tc.pkg)),
+			)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, tc.requestPath, nil))
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			if tc.wantRender {
+				assert.Contains(t, rr.Body.String(), tc.wantLink)
+			} else {
+				assert.NotContains(t, rr.Body.String(), `class="b-inline-btn">Render</a>`)
+			}
+		})
+	}
+}
+
 // TestNewWebHandlerInvalidConfig ensures that NewWebHandler fails on invalid config.
 func TestHTTPHandler_NewInvalidConfig(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Directory view of a realm now displays a render link that redirects to the rendered content of the realm

Solves #5580

