### PR TITLE
feat(examples): remove readonly types from `commondao` package

### DIFF
--- a/examples/gno.land/p/nt/commondao/v0/exts/definition/definition.gno
+++ b/examples/gno.land/p/nt/commondao/v0/exts/definition/definition.gno
@@ -119,7 +119,7 @@ func (d Definition) Executor() commondao.ExecFunc {
 // Tally considers that proposals passes when more than half of members votes YES.
 func TallyByAbsoluteMajority(ctx commondao.VotingContext) (bool, error) {
 	// Check if a quorum of 51% has been met
-	if !commondao.IsQuorumReached(commondao.QuorumMoreThanHalf, ctx.VotingRecord, ctx.Members) {
+	if !commondao.IsQuorumReached(commondao.QuorumMoreThanHalf, &ctx.VotingRecord, ctx.Members) {
 		return false, commondao.ErrNoQuorum
 	}
 

--- a/examples/gno.land/p/nt/commondao/v0/exts/storage/member_storage.gno
+++ b/examples/gno.land/p/nt/commondao/v0/exts/storage/member_storage.gno
@@ -145,20 +145,28 @@ type groupMemberStorage struct {
 
 // Add adds a member to the storage.
 // Returns true if the member is added, or false if it already existed.
+// It panics when storage is sealed.
 func (s *groupMemberStorage) Add(member address) bool {
-	s.messages.Publish(msgMemberAdd, groupMemberUpdateData{
-		Group:  s.group,
-		Member: member,
-	})
-	return s.MemberStorage.Add(member)
+	added := s.MemberStorage.Add(member)
+	if added {
+		s.messages.Publish(msgMemberAdd, groupMemberUpdateData{
+			Group:  s.group,
+			Member: member,
+		})
+	}
+	return added
 }
 
 // Remove removes a member from the storage.
 // Returns true if member was removed, or false if it was not found.
+// It panics when storage is sealed.
 func (s *groupMemberStorage) Remove(member address) bool {
-	s.messages.Publish(msgMemberRemove, groupMemberUpdateData{
-		Group:  s.group,
-		Member: member,
-	})
-	return s.MemberStorage.Remove(member)
+	removed := s.MemberStorage.Remove(member)
+	if removed {
+		s.messages.Publish(msgMemberRemove, groupMemberUpdateData{
+			Group:  s.group,
+			Member: member,
+		})
+	}
+	return removed
 }

--- a/examples/gno.land/p/nt/commondao/v0/exts/storage/member_storage_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/exts/storage/member_storage_test.gno
@@ -11,10 +11,11 @@ import (
 
 func TestMemberStorageGroupingMemberAdd(t *testing.T) {
 	tests := []struct {
-		name   string
-		setup  func() commondao.MemberStorage
-		group  string
-		member address
+		name     string
+		setup    func() commondao.MemberStorage
+		group    string
+		member   address
+		panicMsg string
 	}{
 		{
 			name: "empty group",
@@ -51,6 +52,16 @@ func TestMemberStorageGroupingMemberAdd(t *testing.T) {
 			group:  "bar",
 			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
 		},
+		{
+			name: "sealed group",
+			setup: func() commondao.MemberStorage {
+				s := storage.NewMemberStorage()
+				s.Grouping().Add("foo")
+				return s.Seal().(commondao.MemberStorage)
+			},
+			group:    "foo",
+			panicMsg: "type is sealed so it can't be modified",
+		},
 	}
 
 	for _, tt := range tests {
@@ -60,20 +71,29 @@ func TestMemberStorageGroupingMemberAdd(t *testing.T) {
 			group, _ := s.Grouping().Get(tt.group)
 
 			// Act
-			group.Members().Add(tt.member)
+			fn := func() {
+				group.Members().Add(tt.member)
+			}
 
 			// Assert
-			urequire.True(t, s.Has(tt.member), "expect member to also be added to parent storage")
+			if tt.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tt.panicMsg, fn)
+				urequire.False(t, s.Has(tt.member), "expect member not to be added to storage")
+			} else {
+				urequire.NotPanics(t, fn)
+				urequire.True(t, s.Has(tt.member), "expect member to also be added to storage")
+			}
 		})
 	}
 }
 
 func TestMemberStorageGroupingMemberRemove(t *testing.T) {
 	tests := []struct {
-		name   string
-		setup  func() commondao.MemberStorage
-		group  string
-		member address
+		name     string
+		setup    func() commondao.MemberStorage
+		group    string
+		member   address
+		panicMsg string
 	}{
 		{
 			name: "one group one member",
@@ -113,6 +133,18 @@ func TestMemberStorageGroupingMemberRemove(t *testing.T) {
 			group:  "foo",
 			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
 		},
+		{
+			name: "sealed storage",
+			setup: func() commondao.MemberStorage {
+				s := storage.NewMemberStorage()
+				group, _ := s.Grouping().Add("foo")
+				group.Members().Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s.Seal().(commondao.MemberStorage)
+			},
+			group:    "foo",
+			member:   "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			panicMsg: "type is sealed so it can't be modified",
+		},
 	}
 
 	for _, tt := range tests {
@@ -122,10 +154,18 @@ func TestMemberStorageGroupingMemberRemove(t *testing.T) {
 			group, _ := s.Grouping().Get(tt.group)
 
 			// Act
-			group.Members().Remove(tt.member)
+			fn := func() {
+				group.Members().Remove(tt.member)
+			}
 
 			// Assert
-			urequire.False(t, s.Has(tt.member), "expect member to also be removed from parent storage")
+			if tt.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tt.panicMsg, fn)
+				urequire.True(t, s.Has(tt.member), "expect member not to be removed from storage")
+			} else {
+				urequire.NotPanics(t, fn)
+				urequire.False(t, s.Has(tt.member), "expect member to also be removed from storage")
+			}
 		})
 	}
 }

--- a/examples/gno.land/p/nt/commondao/v0/member_group.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_group.gno
@@ -7,6 +7,8 @@ import (
 
 // MemberGroup defines an interface for a group of members.
 type MemberGroup interface {
+	Sealable
+
 	// Name returns the name of the group.
 	Name() string
 
@@ -54,6 +56,19 @@ type memberGroup struct {
 	name    string
 	members MemberStorage
 	meta    any
+	sealed  bool
+}
+
+// Seal returns a sealed copy of the group.
+// No further changes are accepted on the returned copy once sealed.
+func (g memberGroup) Seal() Sealable {
+	g.sealed = true
+	return &g
+}
+
+// IsSealed checks if grouping is sealed.
+func (g memberGroup) IsSealed() bool {
+	return g.sealed
 }
 
 // Name returns the name of the group.
@@ -67,57 +82,25 @@ func (g memberGroup) Members() MemberStorage {
 }
 
 // SetMeta sets any metadata relevant to the group.
+// It panics when group is sealed.
 func (g *memberGroup) SetMeta(meta any) {
+	assertNotSealed(g)
 	g.meta = meta
 }
 
 // GetMeta returns the group metadata.
+// It panics when group is sealed and metadata is not sealable.
+// Metadata must implement `Sealable` interface to be exposed when group is sealed.
 func (g memberGroup) GetMeta() any {
-	return g.meta
-}
-
-// NewReadonlyMemberGroup creates a new readonly member group.
-func NewReadonlyMemberGroup(g MemberGroup) (*ReadonlyMemberGroup, error) {
-	if g == nil {
-		return nil, errors.New("member group is required")
+	if !g.sealed {
+		return g.meta
 	}
-	return &ReadonlyMemberGroup{g}, nil
-}
 
-// MustNewReadonlyMemberGroup creates a new readonly member group or panics on error.
-func MustNewReadonlyMemberGroup(g MemberGroup) *ReadonlyMemberGroup {
-	group, err := NewReadonlyMemberGroup(g)
-	if err != nil {
-		panic(err)
+	s, ok := g.meta.(Sealable)
+	if !ok {
+		// Don't return metadata when group is sealed and metadata
+		// is not sealable to avoid exposing data unintentionally.
+		panic("failed to get metadata, group is sealed and metadata is not sealable")
 	}
-	return group
-}
-
-// ReadonlyMemberGroup defines a readonly member group.
-type ReadonlyMemberGroup struct {
-	group MemberGroup
-}
-
-// Name returns the name of the group.
-func (g ReadonlyMemberGroup) Name() string {
-	if g.group == nil {
-		return ""
-	}
-	return g.group.Name()
-}
-
-// Members returns the members that belong to the group.
-func (g ReadonlyMemberGroup) Members() *ReadonlyMemberStorage {
-	if g.group == nil {
-		return nil
-	}
-	return MustNewReadonlyMemberStorage(g.group.Members())
-}
-
-// GetMeta returns the group metadata.
-func (g ReadonlyMemberGroup) GetMeta() any {
-	if g.group == nil {
-		return nil
-	}
-	return g.group.GetMeta()
+	return s.Seal()
 }

--- a/examples/gno.land/p/nt/commondao/v0/member_group.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_group.gno
@@ -78,6 +78,9 @@ func (g memberGroup) Name() string {
 
 // Members returns the members that belong to the group.
 func (g memberGroup) Members() MemberStorage {
+	if g.sealed {
+		return g.members.Seal().(MemberStorage)
+	}
 	return g.members
 }
 

--- a/examples/gno.land/p/nt/commondao/v0/member_group_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_group_test.gno
@@ -25,15 +25,121 @@ func TestMemberGroupNew(t *testing.T) {
 	uassert.Nil(t, g.GetMeta(), "expect default group meta to be nil")
 }
 
-func TestMemberGroupMeta(t *testing.T) {
-	g, err := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
-	urequire.NoError(t, err, "expect no error")
+func TestMemberGroupSetMeta(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantMeta any
+		setup    func() commondao.MemberGroup
+		panicMsg string
+	}{
+		{
+			name:     "ok",
+			wantMeta: 42,
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				return g
+			},
+		},
+		{
+			name:     "overwrite",
+			wantMeta: 42,
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				g.SetMeta(123)
+				return g
+			},
+		},
+		{
+			name:     "sealed group",
+			wantMeta: 1,
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				return g.Seal().(commondao.MemberGroup)
+			},
+			panicMsg: "type is sealed so it can't be modified",
+		},
+	}
 
-	g.SetMeta(42)
-	v := g.GetMeta()
-	urequire.NotEqual(t, nil, v, "expect metadata to be not nil")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			g := tc.setup()
 
-	meta, ok := v.(int)
-	urequire.True(t, ok, "expect meta type to be int")
-	uassert.Equal(t, 42, meta, "expect metadata to match")
+			// Act
+			fn := func() {
+				g.SetMeta(tc.wantMeta)
+			}
+
+			// Assert
+			if tc.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tc.panicMsg, fn)
+			} else {
+				urequire.NotPanics(t, fn)
+				uassert.True(t, g.GetMeta() == tc.wantMeta, "expect metadata to match")
+			}
+		})
+	}
 }
+
+func TestMemberGroupGetMeta(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantMeta any
+		setup    func() commondao.MemberGroup
+		panicMsg string
+	}{
+		{
+			name:     "ok",
+			wantMeta: 42,
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				g.SetMeta(42)
+				return g
+			},
+		},
+		{
+			name: "sealed group",
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				g.SetMeta(42)
+				return g.Seal().(commondao.MemberGroup)
+			},
+			panicMsg: "failed to get metadata, group is sealed and metadata is not sealable",
+		},
+		{
+			name:     "sealed group with sealable value",
+			wantMeta: sealableInt(-42), // Negative when sealed
+			setup: func() commondao.MemberGroup {
+				g, _ := commondao.NewMemberGroup("Test", commondao.NewMemberStorage())
+				g.SetMeta(sealableInt(42))
+				return g.Seal().(commondao.MemberGroup)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			var got any
+			g := tc.setup()
+
+			// Act
+			fn := func() {
+				got = g.GetMeta()
+			}
+
+			// Assert
+			if tc.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tc.panicMsg, fn)
+			} else {
+				urequire.NotPanics(t, fn)
+				uassert.True(t, got == tc.wantMeta, "expect metadata to match")
+			}
+		})
+	}
+}
+
+type sealableInt int
+
+func (i sealableInt) Seal() commondao.Sealable { return -i } // Negative when sealed
+func (sealableInt) IsSealed() bool             { return true }

--- a/examples/gno.land/p/nt/commondao/v0/member_grouping.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_grouping.gno
@@ -14,6 +14,8 @@ type (
 	// Member grouping can be used by implementations that require grouping users
 	// by roles or by tiers for example.
 	MemberGrouping interface {
+		Sealable
+
 		// Size returns the number of groups that grouping contains.
 		Size() int
 
@@ -50,6 +52,19 @@ func NewMemberGrouping(options ...MemberGroupingOption) MemberGrouping {
 type memberGrouping struct {
 	groups        avl.Tree // string(name) -> MemberGroup
 	createStorage func(group string) MemberStorage
+	sealed        bool
+}
+
+// Seal returns a sealed copy of the grouping.
+// No further changes are accepted on the returned copy once sealed.
+func (g memberGrouping) Seal() Sealable {
+	g.sealed = true
+	return &g
+}
+
+// IsSealed checks if grouping is sealed.
+func (g memberGrouping) IsSealed() bool {
+	return g.sealed
 }
 
 // Size returns the number of groups that grouping contains.
@@ -63,7 +78,10 @@ func (g memberGrouping) Has(name string) bool {
 }
 
 // Add adds an new member group if it doesn't exists.
+// It panics when grouping is sealed.
 func (g *memberGrouping) Add(name string) (MemberGroup, error) {
+	assertNotSealed(g)
+
 	if g.groups.Has(name) {
 		return nil, errors.New("member group already exists: " + name)
 	}
@@ -83,11 +101,13 @@ func (g memberGrouping) Get(name string) (_ MemberGroup, found bool) {
 	if !found {
 		return nil, false
 	}
-	return v.(MemberGroup), true
+	return g.maySealGroup(v.(MemberGroup)), true
 }
 
 // Delete deletes a member group.
+// It panics when grouping is sealed.
 func (g *memberGrouping) Delete(name string) error {
+	assertNotSealed(g)
 	g.groups.Remove(name)
 	return nil
 }
@@ -95,68 +115,13 @@ func (g *memberGrouping) Delete(name string) error {
 // IterateByOffset iterates all member groups.
 func (g memberGrouping) IterateByOffset(offset, count int, fn MemberGroupIterFn) bool {
 	return g.groups.IterateByOffset(offset, count, func(_ string, v any) bool {
-		return fn(v.(MemberGroup))
+		return fn(g.maySealGroup(v.(MemberGroup)))
 	})
 }
 
-// NewReadonlyMemberGrouping creates a new grouping if member.
-func NewReadonlyMemberGrouping(g MemberGrouping) (*ReadonlyMemberGrouping, error) {
-	if g == nil {
-		return nil, errors.New("member grouping is required")
+func (g memberGrouping) maySealGroup(mg MemberGroup) MemberGroup {
+	if g.sealed {
+		return mg.Seal().(MemberGroup)
 	}
-	return &ReadonlyMemberGrouping{g}, nil
-}
-
-// MustNewReadonlyMemberGrouping creates a new grouping if member or panics on error.
-func MustNewReadonlyMemberGrouping(g MemberGrouping) *ReadonlyMemberGrouping {
-	grouping, err := NewReadonlyMemberGrouping(g)
-	if err != nil {
-		panic(err)
-	}
-	return grouping
-}
-
-// ReadonlyMemberGrouping defines a type for storing multiple readonly member groups.
-type ReadonlyMemberGrouping struct {
-	grouping MemberGrouping
-}
-
-// Size returns the number of groups that grouping contains.
-func (g ReadonlyMemberGrouping) Size() int {
-	if g.grouping == nil {
-		return 0
-	}
-	return g.grouping.Size()
-}
-
-// Has checks if a group exists.
-func (g ReadonlyMemberGrouping) Has(name string) bool {
-	if g.grouping == nil {
-		return false
-	}
-	return g.grouping.Has(name)
-}
-
-// Get returns a member group.
-func (g ReadonlyMemberGrouping) Get(name string) (_ *ReadonlyMemberGroup, found bool) {
-	if g.grouping == nil {
-		return nil, false
-	}
-
-	group, found := g.grouping.Get(name)
-	if !found {
-		return nil, false
-	}
-	return MustNewReadonlyMemberGroup(group), true
-}
-
-// IterateByOffset iterates all member groups.
-func (g ReadonlyMemberGrouping) IterateByOffset(offset, count int, fn func(*ReadonlyMemberGroup) bool) bool {
-	if g.grouping == nil {
-		return false
-	}
-
-	return g.grouping.IterateByOffset(offset, count, func(group MemberGroup) bool {
-		return fn(MustNewReadonlyMemberGroup(group))
-	})
+	return mg
 }

--- a/examples/gno.land/p/nt/commondao/v0/member_grouping.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_grouping.gno
@@ -101,7 +101,7 @@ func (g memberGrouping) Get(name string) (_ MemberGroup, found bool) {
 	if !found {
 		return nil, false
 	}
-	return g.maySealGroup(v.(MemberGroup)), true
+	return g.trySealGroup(v.(MemberGroup)), true
 }
 
 // Delete deletes a member group.
@@ -115,13 +115,18 @@ func (g *memberGrouping) Delete(name string) error {
 // IterateByOffset iterates all member groups.
 func (g memberGrouping) IterateByOffset(offset, count int, fn MemberGroupIterFn) bool {
 	return g.groups.IterateByOffset(offset, count, func(_ string, v any) bool {
-		return fn(g.maySealGroup(v.(MemberGroup)))
+		return fn(g.trySealGroup(v.(MemberGroup)))
 	})
 }
 
-func (g memberGrouping) maySealGroup(mg MemberGroup) MemberGroup {
+func (g memberGrouping) trySealGroup(mg MemberGroup) MemberGroup {
 	if g.sealed {
-		return mg.Seal().(MemberGroup)
+		// A factory can be used to create custom member groups, so make sure
+		// that Seal() is actually returning a MemberGroup implementation.
+		mg, _ = mg.Seal().(MemberGroup)
+		if mg == nil {
+			panic("expected custom member group to return a sealed copy")
+		}
 	}
 	return mg
 }

--- a/examples/gno.land/p/nt/commondao/v0/member_grouping_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_grouping_test.gno
@@ -40,6 +40,15 @@ func TestMemberGroupingAdd(t *testing.T) {
 		_, err = g.Add(name)
 		uassert.ErrorContains(t, err, "member group already exists: Foo", "expect duplication error")
 	})
+
+	t.Run("sealed grouping", func(t *testing.T) {
+		g := commondao.NewMemberGrouping()
+		g = g.Seal().(commondao.MemberGrouping)
+
+		uassert.PanicsWithMessage(t, "type is sealed so it can't be modified", func() {
+			g.Add("Foo")
+		}, "expect panic")
+	})
 }
 
 func TestMemberGroupingGet(t *testing.T) {
@@ -62,36 +71,78 @@ func TestMemberGroupingGet(t *testing.T) {
 
 		urequire.False(t, found, "expect grouping group to be not found")
 	})
+
+	t.Run("sealed grouping", func(t *testing.T) {
+		name := "Foo"
+		g := commondao.NewMemberGrouping()
+		g.Add(name)
+		g = g.Seal().(commondao.MemberGrouping)
+
+		mg, found := g.Get(name)
+
+		urequire.True(t, found, "expect grouping group to be found")
+		urequire.True(t, mg != nil, "expect grouping group to be not nil")
+		uassert.True(t, mg.IsSealed(), "expect group to be sealed")
+	})
 }
 
 func TestMemberGroupingDelete(t *testing.T) {
-	name := "Foo"
-	g := commondao.NewMemberGrouping()
-	g.Add(name)
+	t.Run("success", func(t *testing.T) {
+		name := "Foo"
+		g := commondao.NewMemberGrouping()
+		g.Add(name)
 
-	err := g.Delete(name)
+		err := g.Delete(name)
 
-	urequire.NoError(t, err, "expect no error")
-	uassert.False(t, g.Has(name), "expect grouping group not to be found")
+		urequire.NoError(t, err, "expect no error")
+		uassert.False(t, g.Has(name), "expect grouping group not to be found")
+	})
+
+	t.Run("sealed grouping", func(t *testing.T) {
+		name := "Foo"
+		g := commondao.NewMemberGrouping()
+		g = g.Seal().(commondao.MemberGrouping)
+
+		uassert.PanicsWithMessage(t, "type is sealed so it can't be modified", func() {
+			g.Delete(name)
+		}, "expect panic")
+	})
 }
 
 func TestMemberGroupingIterate(t *testing.T) {
-	groups := []string{"Tier 1", "Tier 2", "Tier 3"}
-	g := commondao.NewMemberGrouping()
-	for _, name := range groups {
-		g.Add(name)
-	}
+	t.Run("success", func(t *testing.T) {
+		groups := []string{"Tier 1", "Tier 2", "Tier 3"}
+		g := commondao.NewMemberGrouping()
+		for _, name := range groups {
+			g.Add(name)
+		}
 
-	var i int
-	g.IterateByOffset(0, g.Size(), func(mg commondao.MemberGroup) bool {
-		urequire.True(t, mg != nil, "expect member group not to be nil")
-		urequire.Equal(t, groups[i], mg.Name(), "expect group to be iterated in order")
+		var i int
+		g.IterateByOffset(0, g.Size(), func(mg commondao.MemberGroup) bool {
+			urequire.True(t, mg != nil, "expect member group not to be nil")
+			urequire.Equal(t, groups[i], mg.Name(), "expect group to be iterated in order")
 
-		i++
-		return false
+			i++
+			return false
+		})
+
+		uassert.Equal(t, len(groups), i, "expect all groups to be iterated")
 	})
 
-	uassert.Equal(t, len(groups), i, "expect all groups to be iterated")
+	t.Run("sealed grouping", func(t *testing.T) {
+		groups := []string{"Tier 1", "Tier 2", "Tier 3"}
+		g := commondao.NewMemberGrouping()
+		for _, name := range groups {
+			g.Add(name)
+		}
+
+		g = g.Seal().(commondao.MemberGrouping)
+
+		g.IterateByOffset(0, g.Size(), func(mg commondao.MemberGroup) bool {
+			uassert.True(t, mg.IsSealed(), "expect group to be sealed")
+			return false
+		})
+	})
 }
 
 func TestMemberGroupingUseStorageFactory(t *testing.T) {

--- a/examples/gno.land/p/nt/commondao/v0/member_storage.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_storage.gno
@@ -116,6 +116,9 @@ func (s *memberStorage) Remove(member address) bool {
 
 // Grouping returns member groups.
 func (s memberStorage) Grouping() MemberGrouping {
+	if s.sealed && s.grouping != nil {
+		return s.grouping.Seal().(MemberGrouping)
+	}
 	return s.grouping
 }
 

--- a/examples/gno.land/p/nt/commondao/v0/member_storage.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_storage.gno
@@ -1,8 +1,6 @@
 package commondao
 
 import (
-	"errors"
-
 	"gno.land/p/moul/addrset"
 )
 
@@ -12,6 +10,8 @@ type (
 
 	// MemberStorage defines an interface for member storages.
 	MemberStorage interface {
+		Sealable
+
 		// Size returns the number of members in the storage.
 		Size() int
 
@@ -53,23 +53,38 @@ func NewMemberStorageWithGrouping(options ...MemberGroupingOption) MemberStorage
 }
 
 type memberStorage struct {
-	addrset.Set
-
+	members  addrset.Set
 	grouping MemberGrouping
+	sealed   bool
+}
+
+// Seal returns a sealed copy of the storage.
+// No further changes are accepted on the returned copy once sealed.
+func (s memberStorage) Seal() Sealable {
+	s.sealed = true
+	if s.grouping != nil {
+		s.grouping = s.grouping.Seal().(MemberGrouping)
+	}
+	return &s
+}
+
+// IsSealed checks if storage is sealed.
+func (s memberStorage) IsSealed() bool {
+	return s.sealed
 }
 
 // Size returns the number of members in the storage.
 // The result is the number of members within the base underlying storage,
 // grouped members are not included, they must be counted separately.
 func (s memberStorage) Size() int {
-	return s.Set.Size()
+	return s.members.Size()
 }
 
 // Has checks if a member exists in the storage.
 // Member is also searched within all defined member groups.
 func (s memberStorage) Has(member address) bool {
 	// Check underlying member address storage
-	if s.Set.Has(member) {
+	if s.members.Has(member) {
 		return true
 	}
 
@@ -83,6 +98,22 @@ func (s memberStorage) Has(member address) bool {
 	})
 }
 
+// Add adds a member to the storage.
+// Returns true if the member is added, or false if it already existed.
+// It panics when storage is sealed.
+func (s *memberStorage) Add(member address) bool {
+	assertNotSealed(s)
+	return s.members.Add(member)
+}
+
+// Remove removes a member from the storage.
+// Returns true if member was removed, or false if it was not found.
+// It panics when storage is sealed.
+func (s *memberStorage) Remove(member address) bool {
+	assertNotSealed(s)
+	return s.members.Remove(member)
+}
+
 // Grouping returns member groups.
 func (s memberStorage) Grouping() MemberGrouping {
 	return s.grouping
@@ -92,81 +123,22 @@ func (s memberStorage) Grouping() MemberGrouping {
 // The callback can return true to stop iteration.
 func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool {
 	var stopped bool
-	s.Set.IterateByOffset(offset, count, func(member address) bool {
+	s.members.IterateByOffset(offset, count, func(member address) bool {
 		stopped = fn(member)
 		return stopped
 	})
 	return stopped
 }
 
-// NewReadonlyMemberStorage creates a new readonly member storage.
-func NewReadonlyMemberStorage(s MemberStorage) (*ReadonlyMemberStorage, error) {
-	if s == nil {
-		return nil, errors.New("member storage is required")
-	}
-	return &ReadonlyMemberStorage{s}, nil
-}
-
-// MustNewReadonlyMemberStorage creates a new readonly member storage or panics on error.
-func MustNewReadonlyMemberStorage(s MemberStorage) *ReadonlyMemberStorage {
-	storage, err := NewReadonlyMemberStorage(s)
-	if err != nil {
-		panic(err)
-	}
-	return storage
-}
-
-// ReadonlyMemberStorage defines a readonly member storage.
-type ReadonlyMemberStorage struct {
-	storage MemberStorage
-}
-
-// Size returns the number of members in the storage.
-func (s ReadonlyMemberStorage) Size() int {
-	if s.storage == nil {
-		return 0
-	}
-	return s.storage.Size()
-}
-
-// Has checks if a member exists in the storage.
-func (s ReadonlyMemberStorage) Has(member address) bool {
-	if s.storage == nil {
-		return false
-	}
-	return s.storage.Has(member)
-}
-
-// Grouping returns member groups.
-func (s ReadonlyMemberStorage) Grouping() *ReadonlyMemberGrouping {
-	if s.storage == nil {
-		return nil
-	}
-
-	if g := s.storage.Grouping(); g != nil {
-		return MustNewReadonlyMemberGrouping(g)
-	}
-	return nil
-}
-
-// IterateByOffset iterates members starting at the given offset.
-// The callback can return true to stop iteration.
-func (s ReadonlyMemberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool {
-	if s.storage != nil {
-		return s.storage.IterateByOffset(offset, count, fn)
-	}
-	return false
-}
-
 // CountStorageMembers returns the total number of members in the storage.
 // It counts all members in each group and the ones without group.
-func CountStorageMembers(s *ReadonlyMemberStorage) int {
+func CountStorageMembers(s MemberStorage) int {
 	if s == nil {
 		return 0
 	}
 
 	c := s.Size()
-	s.Grouping().IterateByOffset(0, s.Grouping().Size(), func(g *ReadonlyMemberGroup) bool {
+	s.Grouping().IterateByOffset(0, s.Grouping().Size(), func(g MemberGroup) bool {
 		c += g.Members().Size()
 		return false
 	})

--- a/examples/gno.land/p/nt/commondao/v0/member_storage_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_storage_test.gno
@@ -149,6 +149,5 @@ func TestCountStorageMembers(t *testing.T) {
 
 	g.Members().Add("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // Add a member that exists in other group
 
-	s := commondao.MustNewReadonlyMemberStorage(storage)
-	uassert.Equal(t, 4, commondao.CountStorageMembers(s))
+	uassert.Equal(t, 4, commondao.CountStorageMembers(storage))
 }

--- a/examples/gno.land/p/nt/commondao/v0/member_storage_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/member_storage_test.gno
@@ -134,6 +134,151 @@ func TestMemberStorageHas(t *testing.T) {
 	}
 }
 
+func TestMemberStorageAdd(t *testing.T) {
+	cases := []struct {
+		name     string
+		member   address
+		want     bool
+		setup    func() commondao.MemberStorage
+		panicMsg string
+	}{
+		{
+			name:   "success",
+			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			want:   true,
+			setup: func() commondao.MemberStorage {
+				return commondao.NewMemberStorage()
+			},
+		},
+		{
+			name:   "existing member",
+			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			want:   false,
+			setup: func() commondao.MemberStorage {
+				s := commondao.NewMemberStorage()
+				s.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+		},
+		{
+			name:   "sealed storage",
+			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			setup: func() commondao.MemberStorage {
+				s := commondao.NewMemberStorage()
+				return s.Seal().(commondao.MemberStorage)
+			},
+			panicMsg: "type is sealed so it can't be modified",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			var got bool
+			storage := tc.setup()
+
+			// Act
+			fn := func() {
+				got = storage.Add(tc.member)
+			}
+
+			// Assert
+			if tc.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tc.panicMsg, fn)
+				urequire.False(t, storage.Has(tc.member), "expect member to be missing")
+			} else {
+				urequire.NotPanics(t, fn)
+				urequire.True(t, got == tc.want, "expect member to be added")
+				urequire.True(t, storage.Has(tc.member), "expect member to be found")
+			}
+		})
+	}
+}
+
+func TestMemberStorageRemove(t *testing.T) {
+	member := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	cases := []struct {
+		name     string
+		member   address
+		want     bool
+		setup    func() commondao.MemberStorage
+		panicMsg string
+	}{
+		{
+			name:   "success",
+			member: member,
+			want:   true,
+			setup: func() commondao.MemberStorage {
+				s := commondao.NewMemberStorage()
+				s.Add(member)
+				return s
+			},
+		},
+		{
+			name:   "member not found",
+			member: member,
+			want:   false,
+			setup: func() commondao.MemberStorage {
+				s := commondao.NewMemberStorage()
+				return s
+			},
+		},
+		{
+			name:   "sealed storage",
+			member: member,
+			setup: func() commondao.MemberStorage {
+				s := commondao.NewMemberStorage()
+				s.Add(member)
+				return s.Seal().(commondao.MemberStorage)
+			},
+			panicMsg: "type is sealed so it can't be modified",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			var got bool
+			storage := tc.setup()
+
+			// Act
+			fn := func() {
+				got = storage.Remove(tc.member)
+			}
+
+			// Assert
+			if tc.panicMsg != "" {
+				urequire.PanicsWithMessage(t, tc.panicMsg, fn)
+				urequire.True(t, storage.Has(tc.member), "expect member to be found")
+			} else {
+				urequire.NotPanics(t, fn)
+				urequire.True(t, got == tc.want, "expect member to be removed")
+				urequire.False(t, storage.Has(tc.member), "expect member to be missing")
+			}
+		})
+	}
+}
+
+func TestMemberStorageGrouping(t *testing.T) {
+	t.Run("with grouping", func(t *testing.T) {
+		storage := commondao.NewMemberStorageWithGrouping()
+		urequire.True(t, storage.Grouping() != nil, "expect a grouping to be returned")
+		uassert.False(t, storage.Grouping().IsSealed(), "expect a non sealed grouping")
+	})
+
+	t.Run("without grouping", func(t *testing.T) {
+		storage := commondao.NewMemberStorage()
+		urequire.True(t, storage.Grouping() == nil, "expect a grouping to be nil")
+	})
+
+	t.Run("sealed storage", func(t *testing.T) {
+		storage := commondao.NewMemberStorageWithGrouping()
+		storage = storage.Seal().(commondao.MemberStorage)
+		urequire.True(t, storage.Grouping() != nil, "expect a grouping to be returned")
+		uassert.True(t, storage.Grouping().IsSealed(), "expect a sealed grouping")
+	})
+}
+
 func TestCountStorageMembers(t *testing.T) {
 	storage := commondao.NewMemberStorageWithGrouping()
 	storage.Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")

--- a/examples/gno.land/p/nt/commondao/v0/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/v0/proposal.gno
@@ -281,7 +281,11 @@ func (p *Proposal) Tally(members MemberStorage) error {
 }
 
 // IsQuorumReached checks if a participation quorum is reach.
-func IsQuorumReached(quorum float64, r ReadonlyVotingRecord, members MemberStorage) bool {
+func IsQuorumReached(quorum float64, r *VotingRecord, members MemberStorage) bool {
+	if r == nil {
+		return false
+	}
+
 	if members.Size() <= 0 || quorum <= 0 {
 		return false
 	}

--- a/examples/gno.land/p/nt/commondao/v0/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/v0/proposal.gno
@@ -266,7 +266,7 @@ func (p *Proposal) Tally(members MemberStorage) error {
 		return ErrStatusIsNotActive
 	}
 
-	ctx := MustNewVotingContext(p.VotingRecord(), members)
+	ctx := MustNewVotingContext(p.VotingRecord(), members.Seal().(MemberStorage))
 	passes, err := p.Definition().Tally(ctx)
 	if err != nil {
 		return err
@@ -281,7 +281,7 @@ func (p *Proposal) Tally(members MemberStorage) error {
 }
 
 // IsQuorumReached checks if a participation quorum is reach.
-func IsQuorumReached(quorum float64, r ReadonlyVotingRecord, members ReadonlyMemberStorage) bool {
+func IsQuorumReached(quorum float64, r ReadonlyVotingRecord, members MemberStorage) bool {
 	if members.Size() <= 0 || quorum <= 0 {
 		return false
 	}

--- a/examples/gno.land/p/nt/commondao/v0/proposal.gno
+++ b/examples/gno.land/p/nt/commondao/v0/proposal.gno
@@ -266,7 +266,7 @@ func (p *Proposal) Tally(members MemberStorage) error {
 		return ErrStatusIsNotActive
 	}
 
-	ctx := MustNewVotingContext(p.VotingRecord(), members.Seal().(MemberStorage))
+	ctx := MustNewVotingContext(p.VotingRecord(), members)
 	passes, err := p.Definition().Tally(ctx)
 	if err != nil {
 		return err

--- a/examples/gno.land/p/nt/commondao/v0/proposal_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/proposal_test.gno
@@ -346,7 +346,7 @@ func TestIsQuorumReached(t *testing.T) {
 				record.AddVote(v)
 			}
 
-			success := commondao.IsQuorumReached(tc.quorum, record.Readonly(), members)
+			success := commondao.IsQuorumReached(tc.quorum, &record, members)
 
 			if tc.fail {
 				uassert.False(t, success, "expect quorum to fail")

--- a/examples/gno.land/p/nt/commondao/v0/proposal_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/proposal_test.gno
@@ -337,7 +337,6 @@ func TestIsQuorumReached(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			members := commondao.NewMemberStorage()
-			storage := commondao.MustNewReadonlyMemberStorage(members)
 			for _, m := range tc.members {
 				members.Add(m)
 			}
@@ -347,7 +346,7 @@ func TestIsQuorumReached(t *testing.T) {
 				record.AddVote(v)
 			}
 
-			success := commondao.IsQuorumReached(tc.quorum, record.Readonly(), *storage)
+			success := commondao.IsQuorumReached(tc.quorum, record.Readonly(), members)
 
 			if tc.fail {
 				uassert.False(t, success, "expect quorum to fail")

--- a/examples/gno.land/p/nt/commondao/v0/record.gno
+++ b/examples/gno.land/p/nt/commondao/v0/record.gno
@@ -65,12 +65,7 @@ func (r VotingRecord) Size() int {
 func (r VotingRecord) Iterate(offset, count int, reverse bool, fn VoteIterFn) bool {
 	cb := func(_ string, v any) bool {
 		vote := v.(Vote)
-		if r.sealed {
-			// Context will be nil if it's not sealable to avoid unintentional exposure
-			vote.Context, _ = vote.Context.(Sealable)
-		}
-
-		return fn(vote)
+		return fn(r.trySealVote(vote))
 	}
 
 	if reverse {
@@ -102,7 +97,7 @@ func (r VotingRecord) HasVoted(user address) bool {
 // GetVote returns a vote.
 func (r VotingRecord) GetVote(user address) (_ Vote, found bool) {
 	if v, found := r.votes.Get(user.String()); found {
-		return v.(Vote), true
+		return r.trySealVote(v.(Vote)), true
 	}
 	return Vote{}, false
 }
@@ -125,6 +120,14 @@ func (r *VotingRecord) AddVote(vote Vote) (updated bool) {
 
 	r.count.Set(string(vote.Choice), r.VoteCount(vote.Choice)+1)
 	return
+}
+
+func (r VotingRecord) trySealVote(v Vote) Vote {
+	if r.sealed {
+		// Context will be nil if it's not sealable to avoid unintentional exposure
+		v.Context, _ = v.Context.(Sealable)
+	}
+	return v
 }
 
 // FindMostVotedChoice returns the most voted choice.

--- a/examples/gno.land/p/nt/commondao/v0/record.gno
+++ b/examples/gno.land/p/nt/commondao/v0/record.gno
@@ -37,20 +37,42 @@ type (
 	}
 )
 
-// ReadonlyVotingRecord defines an read only voting record.
-type ReadonlyVotingRecord struct {
-	votes avl.Tree // string(address) -> Vote
-	count avl.Tree // string(choice) -> int
+// VotingRecord stores accounts that voted and vote choices.
+type VotingRecord struct {
+	votes  avl.Tree // string(address) -> Vote
+	count  avl.Tree // string(choice) -> int
+	sealed bool
+}
+
+// Seal returns a sealed copy of the voting record.
+// No further changes are accepted on the returned copy once sealed.
+func (r VotingRecord) Seal() Sealable {
+	r.sealed = true
+	return &r
+}
+
+// IsSealed checks if voting record is sealed.
+func (r VotingRecord) IsSealed() bool {
+	return r.sealed
 }
 
 // Size returns the total number of votes that record contains.
-func (r ReadonlyVotingRecord) Size() int {
+func (r VotingRecord) Size() int {
 	return r.votes.Size()
 }
 
 // Iterate iterates voting record votes.
-func (r ReadonlyVotingRecord) Iterate(offset, count int, reverse bool, fn VoteIterFn) bool {
-	cb := func(_ string, v any) bool { return fn(v.(Vote)) }
+func (r VotingRecord) Iterate(offset, count int, reverse bool, fn VoteIterFn) bool {
+	cb := func(_ string, v any) bool {
+		vote := v.(Vote)
+		if r.sealed {
+			// Context will be nil if it's not sealable to avoid unintentional exposure
+			vote.Context, _ = vote.Context.(Sealable)
+		}
+
+		return fn(vote)
+	}
+
 	if reverse {
 		return r.votes.ReverseIterateByOffset(offset, count, cb)
 	}
@@ -58,14 +80,14 @@ func (r ReadonlyVotingRecord) Iterate(offset, count int, reverse bool, fn VoteIt
 }
 
 // IterateVotesCount iterates voted choices with the amount of votes submited for each.
-func (r ReadonlyVotingRecord) IterateVotesCount(fn VotesCountIterFn) bool {
+func (r VotingRecord) IterateVotesCount(fn VotesCountIterFn) bool {
 	return r.count.Iterate("", "", func(k string, v any) bool {
 		return fn(VoteChoice(k), v.(int))
 	})
 }
 
 // VoteCount returns the number of votes for a single voting choice.
-func (r ReadonlyVotingRecord) VoteCount(c VoteChoice) int {
+func (r VotingRecord) VoteCount(c VoteChoice) int {
 	if v, found := r.count.Get(string(c)); found {
 		return v.(int)
 	}
@@ -73,31 +95,24 @@ func (r ReadonlyVotingRecord) VoteCount(c VoteChoice) int {
 }
 
 // HasVoted checks if an account already voted.
-func (r ReadonlyVotingRecord) HasVoted(user address) bool {
+func (r VotingRecord) HasVoted(user address) bool {
 	return r.votes.Has(user.String())
 }
 
 // GetVote returns a vote.
-func (r ReadonlyVotingRecord) GetVote(user address) (_ Vote, found bool) {
+func (r VotingRecord) GetVote(user address) (_ Vote, found bool) {
 	if v, found := r.votes.Get(user.String()); found {
 		return v.(Vote), true
 	}
 	return Vote{}, false
 }
 
-// VotingRecord stores accounts that voted and vote choices.
-type VotingRecord struct {
-	ReadonlyVotingRecord
-}
-
-// Readonly returns a read only voting record.
-func (r VotingRecord) Readonly() ReadonlyVotingRecord {
-	return r.ReadonlyVotingRecord
-}
-
 // AddVote adds a vote to the voting record.
 // If a vote for the same user already exists is overwritten.
+// It panics when voting record is sealed.
 func (r *VotingRecord) AddVote(vote Vote) (updated bool) {
+	assertNotSealed(r)
+
 	// Get previous member vote if it exists
 	v, _ := r.votes.Get(vote.Address.String())
 
@@ -115,7 +130,7 @@ func (r *VotingRecord) AddVote(vote Vote) (updated bool) {
 // FindMostVotedChoice returns the most voted choice.
 // ChoiceNone is returned when there is a tie between different
 // voting choices or when the voting record has are no votes.
-func FindMostVotedChoice(r ReadonlyVotingRecord) VoteChoice {
+func FindMostVotedChoice(r VotingRecord) VoteChoice {
 	var (
 		choice                  VoteChoice
 		currentCount, prevCount int
@@ -139,7 +154,7 @@ func FindMostVotedChoice(r ReadonlyVotingRecord) VoteChoice {
 // SelectChoiceByAbsoluteMajority select the vote choice by absolute majority.
 // Vote choice is a majority when chosen by more than half of the votes.
 // Absolute majority considers abstentions when counting votes.
-func SelectChoiceByAbsoluteMajority(r ReadonlyVotingRecord, membersCount int) (VoteChoice, bool) {
+func SelectChoiceByAbsoluteMajority(r VotingRecord, membersCount int) (VoteChoice, bool) {
 	choice := FindMostVotedChoice(r)
 	if choice != ChoiceNone && r.VoteCount(choice) > int(membersCount/2) {
 		return choice, true
@@ -149,7 +164,7 @@ func SelectChoiceByAbsoluteMajority(r ReadonlyVotingRecord, membersCount int) (V
 
 // SelectChoiceBySuperMajority select the vote choice by super majority using a 2/3s threshold.
 // Abstentions are considered when calculating the super majority choice.
-func SelectChoiceBySuperMajority(r ReadonlyVotingRecord, membersCount int) (VoteChoice, bool) {
+func SelectChoiceBySuperMajority(r VotingRecord, membersCount int) (VoteChoice, bool) {
 	if membersCount < 3 {
 		return ChoiceNone, false
 	}
@@ -164,7 +179,7 @@ func SelectChoiceBySuperMajority(r ReadonlyVotingRecord, membersCount int) (Vote
 // SelectChoiceByPlurality selects the vote choice by plurality.
 // The choice will be considered a majority if it has votes and if there is no other
 // choice with the same number of votes. A tie won't be considered majority.
-func SelectChoiceByPlurality(r ReadonlyVotingRecord) (VoteChoice, bool) {
+func SelectChoiceByPlurality(r VotingRecord) (VoteChoice, bool) {
 	var (
 		choice       VoteChoice
 		currentCount int

--- a/examples/gno.land/p/nt/commondao/v0/record_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/record_test.gno
@@ -525,7 +525,7 @@ func TestCollectVotes(t *testing.T) {
 			}
 
 			storage := tc.setup()
-			ctx := commondao.MustNewVotingContext(&r, storage)
+			ctx := commondao.MustNewVotingContext(&r, storage.Seal().(commondao.MemberStorage))
 
 			// Act
 			votes, err := commondao.CollectVotes(ctx, tc.groups...)

--- a/examples/gno.land/p/nt/commondao/v0/record_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/record_test.gno
@@ -181,7 +181,7 @@ func TestFindMostVotedChoice(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice := commondao.FindMostVotedChoice(record.Readonly())
+			choice := commondao.FindMostVotedChoice(record)
 
 			uassert.Equal(t, string(choice), string(tc.choice))
 		})
@@ -268,7 +268,7 @@ func TestSelectChoiceByAbsoluteMajority(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := commondao.SelectChoiceByAbsoluteMajority(record.Readonly(), tc.membersCount)
+			choice, success := commondao.SelectChoiceByAbsoluteMajority(record, tc.membersCount)
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")
@@ -356,7 +356,7 @@ func TestSelectChoiceBySuperMajority(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := commondao.SelectChoiceBySuperMajority(record.Readonly(), tc.membersCount)
+			choice, success := commondao.SelectChoiceBySuperMajority(record, tc.membersCount)
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")
@@ -443,7 +443,7 @@ func TestSelectChoiceByPlurality(t *testing.T) {
 				tc.setup(&record)
 			}
 
-			choice, success := commondao.SelectChoiceByPlurality(record.Readonly())
+			choice, success := commondao.SelectChoiceByPlurality(record)
 
 			uassert.Equal(t, string(tc.choice), string(choice), "choice")
 			uassert.Equal(t, tc.success, success, "success")

--- a/examples/gno.land/p/nt/commondao/v0/record_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/record_test.gno
@@ -22,83 +22,277 @@ func TestVotingRecordDefaults(t *testing.T) {
 	uassert.False(t, record.HasVoted(user))
 }
 
-func TestVotingRecordAddVote(t *testing.T) {
+func TestVotingRecordIterate(t *testing.T) {
+	ctxValue := 42
+	votes := []commondao.Vote{
+		{Address: "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt", Context: ctxValue},
+		{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", Context: ctxValue},
+		{Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj", Context: ctxValue},
+	}
+
+	var r commondao.VotingRecord
+	for _, v := range votes {
+		r.AddVote(v)
+	}
+
+	t.Run("forward", func(t *testing.T) {
+		var i int
+		r.Iterate(0, r.Size(), false, func(v commondao.Vote) (stop bool) {
+			uassert.True(t, votes[i].Address == v.Address, "expect vote address to match")
+			uassert.True(t, v.Context == ctxValue, "expect context to be not nil")
+
+			i++
+			return false
+		})
+	})
+
+	t.Run("reverse", func(t *testing.T) {
+		i := r.Size() - 1
+		r.Iterate(0, r.Size(), true, func(v commondao.Vote) (stop bool) {
+			uassert.True(t, votes[i].Address == v.Address, "expect vote address to match")
+			uassert.True(t, v.Context == ctxValue, "expect context to be not nil")
+
+			i--
+			return false
+		})
+	})
+
+	t.Run("sealed record", func(t *testing.T) {
+		r := &commondao.VotingRecord{}
+		for _, v := range votes {
+			r.AddVote(v)
+		}
+
+		// Sealing makes non sealable context nil
+		r = r.Seal().(*commondao.VotingRecord)
+
+		r.Iterate(0, r.Size(), false, func(v commondao.Vote) (stop bool) {
+			uassert.Nil(t, v.Context, "expect context to be nil")
+			return false
+		})
+	})
+
+	t.Run("sealed record with sealable context value", func(t *testing.T) {
+		r := &commondao.VotingRecord{}
+		for _, v := range votes {
+			// Assign a sealable value to the context
+			v.Context = sealableInt(v.Context.(int))
+			r.AddVote(v)
+		}
+
+		r = r.Seal().(*commondao.VotingRecord)
+		want := sealableInt(ctxValue)
+
+		r.Iterate(0, r.Size(), false, func(v commondao.Vote) (stop bool) {
+			uassert.NotNil(t, v.Context, "expect context have a non nil value")
+			uassert.True(t, v.Context == want, "expect context value to match")
+			return false
+		})
+	})
+}
+
+func TestVotingRecordVoteCount(t *testing.T) {
 	cases := []struct {
 		name                            string
 		setup                           func(*commondao.VotingRecord)
-		votes                           []commondao.Vote
 		yesCount, noCount, abstainCount int
-		updated                         bool
 	}{
 		{
+			name: "no votes",
+		},
+		{
 			name: "single vote",
-			votes: []commondao.Vote{
-				{
+			setup: func(r *commondao.VotingRecord) {
+				r.AddVote(commondao.Vote{
 					Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
 					Choice:  commondao.ChoiceYes,
-				},
+				})
 			},
 			yesCount: 1,
 		},
 		{
 			name: "multiple votes",
-			votes: []commondao.Vote{
-				{
-					Address: "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
-					Choice:  commondao.ChoiceNo,
-				},
-				{
-					Address: "g12chzmwxw8sezcxe9h2csp0tck76r4ptwdlyyqk",
-					Choice:  commondao.ChoiceYes,
-				},
-				{
-					Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-					Choice:  commondao.ChoiceNo,
-				},
-				{
-					Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
-					Choice:  commondao.ChoiceAbstain,
-				},
+			setup: func(r *commondao.VotingRecord) {
+				votes := []commondao.Vote{
+					{
+						Address: "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt",
+						Choice:  commondao.ChoiceNo,
+					},
+					{
+						Address: "g12chzmwxw8sezcxe9h2csp0tck76r4ptwdlyyqk",
+						Choice:  commondao.ChoiceYes,
+					},
+					{
+						Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+						Choice:  commondao.ChoiceNo,
+					},
+					{
+						Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+						Choice:  commondao.ChoiceAbstain,
+					},
+				}
+
+				for _, v := range votes {
+					r.AddVote(v)
+				}
 			},
 			yesCount:     1,
 			noCount:      2,
 			abstainCount: 1,
 		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var record commondao.VotingRecord
+			if tc.setup != nil {
+				tc.setup(&record)
+			}
+
+			uassert.Equal(t, record.VoteCount(commondao.ChoiceYes), tc.yesCount, "expect YES vote count to match")
+			uassert.Equal(t, record.VoteCount(commondao.ChoiceNo), tc.noCount, "expect NO vote count to match")
+			uassert.Equal(t, record.VoteCount(commondao.ChoiceAbstain), tc.abstainCount, "expect ABSTAIN vote count to match")
+		})
+	}
+}
+
+func TestVotingRecordGetVote(t *testing.T) {
+	user := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	cases := []struct {
+		name        string
+		setup       func() *commondao.VotingRecord
+		address     address
+		found       bool
+		wantContext any
+	}{
 		{
-			name: "vote exists",
-			votes: []commondao.Vote{
-				{
-					Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-					Choice:  commondao.ChoiceYes,
-				},
+			name: "vote found",
+			setup: func() *commondao.VotingRecord {
+				r := &commondao.VotingRecord{}
+				r.AddVote(commondao.Vote{Address: user})
+				return r
 			},
-			setup: func(r *commondao.VotingRecord) {
-				r.AddVote(commondao.Vote{
-					Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-					Choice:  commondao.ChoiceAbstain,
-				})
+			address: user,
+			found:   true,
+		},
+		{
+			name:    "vote not found",
+			setup:   func() *commondao.VotingRecord { return &commondao.VotingRecord{} },
+			address: user,
+		},
+		{
+			name: "sealed record",
+			setup: func() *commondao.VotingRecord {
+				r := &commondao.VotingRecord{}
+				r.AddVote(commondao.Vote{Address: user, Context: 42})
+				return r.Seal().(*commondao.VotingRecord)
 			},
-			yesCount:     1,
-			abstainCount: 0,
-			updated:      true,
+			address:     user,
+			found:       true,
+			wantContext: nil,
+		},
+		{
+			name: "sealed record with sealable context",
+			setup: func() *commondao.VotingRecord {
+				r := &commondao.VotingRecord{}
+				r.AddVote(commondao.Vote{Address: user, Context: sealableInt(42)})
+				return r.Seal().(*commondao.VotingRecord)
+			},
+			address:     user,
+			found:       true,
+			wantContext: sealableInt(42),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var (
-				record  commondao.VotingRecord
-				updated bool
-			)
+			record := tc.setup()
 
-			if tc.setup != nil {
-				tc.setup(&record)
+			vote, found := record.GetVote(tc.address)
+
+			uassert.Equal(t, tc.found, found, "expect found to match")
+			if !tc.found {
+				return
 			}
 
-			for _, v := range tc.votes {
-				updated = updated || record.AddVote(v)
+			uassert.Equal(t, tc.address, vote.Address, "expect vote address to match")
+
+			if tc.wantContext == nil {
+				uassert.Nil(t, vote.Context, "expect context to be nil")
+			} else {
+				uassert.True(t, vote.Context == tc.wantContext, "expect context to match")
+			}
+		})
+	}
+}
+
+func TestVotingRecordAddVote(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func() *commondao.VotingRecord
+		votes    []commondao.Vote
+		updated  bool
+		panicMsg string
+	}{
+		{
+			name: "single vote",
+			votes: []commondao.Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},
+			},
+			setup: func() *commondao.VotingRecord { return &commondao.VotingRecord{} },
+		},
+		{
+			name: "multiple votes",
+			votes: []commondao.Vote{
+				{Address: "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt"},
+				{Address: "g12chzmwxw8sezcxe9h2csp0tck76r4ptwdlyyqk"},
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},
+				{Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj"},
+			},
+			setup: func() *commondao.VotingRecord { return &commondao.VotingRecord{} },
+		},
+		{
+			name: "vote exists",
+			votes: []commondao.Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},
+			},
+			setup: func() *commondao.VotingRecord {
+				var r commondao.VotingRecord
+				r.AddVote(commondao.Vote{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"})
+				return &r
+			},
+			updated: true,
+		},
+		{
+			name: "sealed record",
+			votes: []commondao.Vote{
+				{Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},
+			},
+			setup: func() *commondao.VotingRecord {
+				r := &commondao.VotingRecord{}
+				return r.Seal().(*commondao.VotingRecord)
+			},
+			panicMsg: "type is sealed so it can't be modified",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var updated bool
+			record := tc.setup()
+
+			fn := func() {
+				for _, v := range tc.votes {
+					updated = updated || record.AddVote(v)
+				}
 			}
 
+			if tc.panicMsg != "" {
+				uassert.PanicsWithMessage(t, tc.panicMsg, fn, "expect a panic")
+				return
+			}
+
+			uassert.NotPanics(t, fn, "expect no panic")
 			urequire.Equal(t, updated, tc.updated, "expect vote to be updated")
 			urequire.Equal(t, record.Size(), len(tc.votes), "expect record size to match")
 
@@ -111,10 +305,6 @@ func TestVotingRecordAddVote(t *testing.T) {
 				i++
 				return false
 			})
-
-			uassert.Equal(t, record.VoteCount(commondao.ChoiceYes), tc.yesCount, "expect YES vote count to match")
-			uassert.Equal(t, record.VoteCount(commondao.ChoiceNo), tc.noCount, "expect NO vote count to match")
-			uassert.Equal(t, record.VoteCount(commondao.ChoiceAbstain), tc.abstainCount, "expect ABSTAIN vote count to match")
 		})
 	}
 }
@@ -525,7 +715,7 @@ func TestCollectVotes(t *testing.T) {
 			}
 
 			storage := tc.setup()
-			ctx := commondao.MustNewVotingContext(&r, storage.Seal().(commondao.MemberStorage))
+			ctx := commondao.MustNewVotingContext(&r, storage)
 
 			// Act
 			votes, err := commondao.CollectVotes(ctx, tc.groups...)

--- a/examples/gno.land/p/nt/commondao/v0/sealable.gno
+++ b/examples/gno.land/p/nt/commondao/v0/sealable.gno
@@ -1,0 +1,18 @@
+package commondao
+
+// Sealable defines an interface for making types readonly.
+// TODO: Improve when generics are supported by Gno
+type Sealable interface {
+	// Seal returns a sealed copy of the sealable type.
+	// No further changes are accepted on the returned copy once sealed.
+	Seal() Sealable
+
+	// IsSealed checks if a sealable instance is sealed.
+	IsSealed() bool
+}
+
+func assertNotSealed(s Sealable) {
+	if s.IsSealed() {
+		panic("type is sealed so it can't be modified")
+	}
+}

--- a/examples/gno.land/p/nt/commondao/v0/voting_context.gno
+++ b/examples/gno.land/p/nt/commondao/v0/voting_context.gno
@@ -6,7 +6,7 @@ import "errors"
 // record for the votes that has been submitted for a proposal and also
 // the list of DAO members. Context is readonly.
 type VotingContext struct {
-	VotingRecord ReadonlyVotingRecord
+	VotingRecord VotingRecord
 	Members      MemberStorage
 }
 
@@ -20,12 +20,22 @@ func NewVotingContext(r *VotingRecord, s MemberStorage) (VotingContext, error) {
 		return VotingContext{}, errors.New("member storage is required")
 	}
 
+	if !r.IsSealed() {
+		r, _ = r.Seal().(*VotingRecord)
+		if r == nil {
+			return VotingContext{}, errors.New("expected voting record to return a sealed copy")
+		}
+	}
+
 	if !s.IsSealed() {
-		return VotingContext{}, errors.New("member storage is not sealed")
+		s, _ = s.Seal().(MemberStorage)
+		if s == nil {
+			return VotingContext{}, errors.New("expected member storage to return a sealed copy")
+		}
 	}
 
 	return VotingContext{
-		VotingRecord: r.Readonly(),
+		VotingRecord: *r,
 		Members:      s,
 	}, nil
 }

--- a/examples/gno.land/p/nt/commondao/v0/voting_context.gno
+++ b/examples/gno.land/p/nt/commondao/v0/voting_context.gno
@@ -4,10 +4,10 @@ import "errors"
 
 // VotingContext contains current voting context, which includes a voting
 // record for the votes that has been submitted for a proposal and also
-// the list of DAO members.
+// the list of DAO members. Context is readonly.
 type VotingContext struct {
 	VotingRecord ReadonlyVotingRecord
-	Members      ReadonlyMemberStorage
+	Members      MemberStorage
 }
 
 // NewVotingContext creates a new voting context.
@@ -20,10 +20,13 @@ func NewVotingContext(r *VotingRecord, s MemberStorage) (VotingContext, error) {
 		return VotingContext{}, errors.New("member storage is required")
 	}
 
-	members := MustNewReadonlyMemberStorage(s)
+	if !s.IsSealed() {
+		return VotingContext{}, errors.New("member storage is not sealed")
+	}
+
 	return VotingContext{
 		VotingRecord: r.Readonly(),
-		Members:      *members,
+		Members:      s,
 	}, nil
 }
 

--- a/examples/gno.land/p/nt/commondao/v0/voting_context_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/voting_context_test.gno
@@ -1,0 +1,27 @@
+package commondao_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+
+	"gno.land/p/nt/commondao/v0"
+)
+
+func TestNewVotingContext(t *testing.T) {
+	r := &commondao.VotingRecord{}
+	s := commondao.NewMemberStorage()
+	urequire.False(t, s.IsSealed(), "expect member storage to be not sealed")
+	urequire.False(t, r.IsSealed(), "expect voting record to be not sealed")
+
+	_, err := commondao.NewVotingContext(nil, nil)
+	urequire.ErrorContains(t, err, "voting record is required")
+
+	_, err = commondao.NewVotingContext(r, nil)
+	urequire.ErrorContains(t, err, "member storage is required")
+
+	ctx, err := commondao.NewVotingContext(r, s)
+	urequire.NoError(t, err)
+	urequire.True(t, ctx.VotingRecord.IsSealed(), "expect voting record to be sealed")
+	urequire.True(t, ctx.Members.IsSealed(), "expect member storage to be sealed")
+}

--- a/examples/gno.land/r/nt/commondao/v0/proposal_members.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_members.gno
@@ -103,7 +103,7 @@ func (membersUpdatePropDefinition) Tally(ctx commondao.VotingContext) (bool, err
 		return ctx.VotingRecord.VoteCount(commondao.ChoiceYes) > 0, nil
 	}
 
-	if !commondao.IsQuorumReached(commondao.QuorumTwoThirds, ctx.VotingRecord, ctx.Members) {
+	if !commondao.IsQuorumReached(commondao.QuorumTwoThirds, &ctx.VotingRecord, ctx.Members) {
 		return false, commondao.ErrNoQuorum
 	}
 

--- a/examples/gno.land/r/nt/commondao/v0/proposal_subdao.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_subdao.gno
@@ -80,7 +80,7 @@ func (p subDAOPropDefinition) Validate() (err error) {
 }
 
 func (subDAOPropDefinition) Tally(ctx commondao.VotingContext) (bool, error) {
-	if !commondao.IsQuorumReached(commondao.QuorumFull, ctx.VotingRecord, ctx.Members) {
+	if !commondao.IsQuorumReached(commondao.QuorumFull, &ctx.VotingRecord, ctx.Members) {
 		return false, commondao.ErrNoQuorum
 	}
 
@@ -143,7 +143,7 @@ func (p dissolvePropDefinition) Validate() (err error) {
 }
 
 func (dissolvePropDefinition) Tally(ctx commondao.VotingContext) (bool, error) {
-	if !commondao.IsQuorumReached(commondao.QuorumFull, ctx.VotingRecord, ctx.Members) {
+	if !commondao.IsQuorumReached(commondao.QuorumFull, &ctx.VotingRecord, ctx.Members) {
 		return false, commondao.ErrNoQuorum
 	}
 

--- a/examples/gno.land/r/nt/commondao/v0/proposal_text.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_text.gno
@@ -62,7 +62,7 @@ func (p TextPropDefinition) Body() string                { return p.body }
 func (p TextPropDefinition) VotingPeriod() time.Duration { return p.votingPeriod }
 
 func (p TextPropDefinition) Tally(ctx commondao.VotingContext) (bool, error) {
-	if !commondao.IsQuorumReached(p.quorum, ctx.VotingRecord, ctx.Members) {
+	if !commondao.IsQuorumReached(p.quorum, &ctx.VotingRecord, ctx.Members) {
 		return false, commondao.ErrNoQuorum
 	}
 


### PR DESCRIPTION
This PR removes a couple of readonly types from `commondao` package to keep it leaner. It introduces a new `Sealable` interface and changes some types to implement it.

Readonly types were originally introduced to be able to expose some types to contexts where the types shouldn't be mutable. For example, the voting record and member storage which could be exposed though the `VotingContext`. Voting context could expose data that should not be mutable in proposal types though the `Tally()` method.

The types that are now sealable are:
- MemberStorage
- MemberGrouping
- MemberGroup
- VotingRecord

Sealing make a readonly copy of the sealable instance, methods that try to modify a sealed instance panic.