### PR TITLE
chore(test): Remove unneeded -broadcast flag in txtars

### DIFF
--- a/gno.land/pkg/integration/testdata/addpkg.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg.txtar
@@ -4,7 +4,7 @@
 gnoland start
 
 ## deploy realm
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 
 ## check output
 stdout OK!
@@ -15,7 +15,7 @@ stdout 'EVENTS:     \[.*\]'
 stdout 'TX HASH:    '
 
 ## call added realm
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello   -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello   -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
 
 ## check output
 stdout '\("hello world!" string\)'
@@ -27,7 +27,7 @@ stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ## call added realm with 1 parmeter
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello1 -args foo   -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello1 -args foo   -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
 
 ## check output
 stdout '\("hello foo!" string\)'
@@ -39,7 +39,7 @@ stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ## call added realm with 2 parmeter
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello2 -args hello -args bar  -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello2 -args hello -args bar  -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
 
 ## check output
 stdout '\("hello bar!" string\)'
@@ -51,7 +51,7 @@ stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ##  get previous realm
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func PreviousRealm  -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func PreviousRealm  -gas-fee 190001ugnot -gas-wanted 1_900_000 test1
 
 stdout 'UserRealm{ g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 }'
 

--- a/gno.land/pkg/integration/testdata/addpkg_cla.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_cla.txtar
@@ -16,7 +16,7 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 # Give alice more tokens for gas
-gnokey maketx send -send 1000000000ugnot -to $alice_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $alice_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test test1
 
 # ============================================================
 # Test 1: CLA enforcement disabled (no required hash set)
@@ -27,7 +27,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$alice_user
 stdout 'true bool'
 
 # Alice should be able to addpkg when CLA is disabled
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -broadcast -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test alice
 stdout 'OK!'
 
 # ============================================================
@@ -35,14 +35,14 @@ stdout 'OK!'
 # ============================================================
 
 # Create proposal to set required CLA hash and URL
-gnokey maketx run -gas-fee 2800001ugnot -gas-wanted 28_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/propose_cla1.gno
+gnokey maketx run -gas-fee 2800001ugnot -gas-wanted 28_000_000 -chainid=tendermint_test member $WORK/proposer/propose_cla1.gno
 stdout OK!
 
 # Vote and execute proposal 0
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Alice's signature is now invalid (hasn't signed)
@@ -50,7 +50,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$alice_user
 stdout 'false bool'
 
 # Alice tries to deploy without signing CLA - should FAIL
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test alice
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test alice
 stderr 'A Contributor License Agreement'
 
 # ============================================================
@@ -58,7 +58,7 @@ stderr 'A Contributor License Agreement'
 # ============================================================
 
 # Alice signs the CLA with correct hash
-gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "abc123hash" -gas-fee 560001ugnot -gas-wanted 5_600_000 -broadcast -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "abc123hash" -gas-fee 560001ugnot -gas-wanted 5_600_000 -chainid tendermint_test alice
 stdout 'OK!'
 
 # Verify Alice's signature
@@ -66,7 +66,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$alice_user
 stdout 'true bool'
 
 # Now Alice should be able to deploy
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg3 -gas-fee 710001ugnot -gas-wanted 7_100_000 -broadcast -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg3 -gas-fee 710001ugnot -gas-wanted 7_100_000 -chainid=tendermint_test alice
 stdout 'OK!'
 
 # ============================================================
@@ -74,14 +74,14 @@ stdout 'OK!'
 # ============================================================
 
 # Create proposal to update hash
-gnokey maketx run -gas-fee 3100001ugnot -gas-wanted 31_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/propose_cla2.gno
+gnokey maketx run -gas-fee 3100001ugnot -gas-wanted 31_000_000 -chainid=tendermint_test member $WORK/proposer/propose_cla2.gno
 stdout OK!
 
 # Vote and execute proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test member
 stdout OK!
 
 # Alice's signature was reset
@@ -89,15 +89,15 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$alice_user
 stdout 'false bool'
 
 # Alice tries to deploy - should FAIL
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg4 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test alice
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg4 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test alice
 stderr 'A Contributor License Agreement'
 
 # Alice re-signs with new hash
-gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "newhash456" -gas-fee 560001ugnot -gas-wanted 5_600_000 -broadcast -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "newhash456" -gas-fee 560001ugnot -gas-wanted 5_600_000 -chainid tendermint_test alice
 stdout 'OK!'
 
 # Now Alice can deploy again
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg5 -gas-fee 710001ugnot -gas-wanted 7_100_000 -broadcast -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$alice_user_addr/pkg5 -gas-fee 710001ugnot -gas-wanted 7_100_000 -chainid=tendermint_test alice
 stdout 'OK!'
 
 # ============================================================
@@ -105,14 +105,14 @@ stdout 'OK!'
 # ============================================================
 
 # Create proposal to clear hash
-gnokey maketx run -gas-fee 3200001ugnot -gas-wanted 32_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/propose_cla_clear.gno
+gnokey maketx run -gas-fee 3200001ugnot -gas-wanted 32_000_000 -chainid=tendermint_test member $WORK/proposer/propose_cla_clear.gno
 stdout OK!
 
 # Vote and execute proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 2 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 2 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 2 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 2 -chainid=tendermint_test member
 stdout OK!
 
 # Anyone passes validation when enforcement is disabled
@@ -120,7 +120,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$test1_user
 stdout 'true bool'
 
 # Any user can deploy when enforcement is disabled (even test1 who never signed)
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- proposer/propose_cla1.gno --

--- a/gno.land/pkg/integration/testdata/addpkg_domain.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_domain.txtar
@@ -1,13 +1,13 @@
 gnoland start
 
 # addpkg with anotherdomain.land
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath anotherdomain.land/r/foobar/bar -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath anotherdomain.land/r/foobar/bar -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stdout 'TX HASH:'
 stderr 'invalid package path'
 stderr 'invalid domain: anotherdomain.land/r/foobar/bar'
 
 # addpkg with gno.land
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_draft.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_draft.txtar
@@ -2,7 +2,7 @@
 gnoland start
 
 # add bar package located in $WORK directory as gno.land/r/$test1_user_addr/bar
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 
 # check error message
 stdout 'TX HASH:    '

--- a/gno.land/pkg/integration/testdata/addpkg_identifier_mismatch.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_identifier_mismatch.txtar
@@ -4,11 +4,11 @@ loadpkg $WORK/hello
 gnoland start
 
 ## deploy realm should succeed
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 stdout OK!
 
 ## deploy realm should fail, because we import incorrectly.
-! gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/$test1_user_addr/bye -gas-fee 5000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/$test1_user_addr/bye -gas-fee 5000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
 stderr 'match its expected identifier'
 
 -- hello/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_import_draft.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_import_draft.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/draftrealm
 gnoland start
 
 # add bar package located in $WORK directory as gno.land/r/$test1_user_addr/bar
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 
 # check error message
 stdout 'TX HASH:    '

--- a/gno.land/pkg/integration/testdata/addpkg_import_private.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_import_private.txtar
@@ -2,11 +2,11 @@
 gnoland start
 
 # add the private realm
-gnokey maketx addpkg -pkgdir $WORK/private -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/private -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # add bar package located in $WORK directory as gno.land/r/$test1_user_addr/bar
-! gnokey maketx addpkg -pkgdir $WORK/public -pkgpath gno.land/r/foobar/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx addpkg -pkgdir $WORK/public -pkgpath gno.land/r/foobar/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test $test1_user_addr
 
 # check error message
 stdout 'TX HASH:    '

--- a/gno.land/pkg/integration/testdata/addpkg_invalid.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_invalid.txtar
@@ -4,7 +4,7 @@
 gnoland start
 
 # add bar package located in $WORK directory as gno.land/r/foobar/bar
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 
 # check error message
 stdout 'TX HASH:    '

--- a/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
@@ -8,7 +8,7 @@ patchpkg "g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh" $admin_user_addr # use our c
 gnoland start
 
 # give gui user more tokens
-gnokey maketx send -send 1000000000ugnot -to $gui_user_addr  -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $gui_user_addr  -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test test1
 
 # Check if sys/names is disabled
 # qeval -> sys/names.IsEnabled
@@ -17,17 +17,17 @@ stdout 'false bool'
 
 # Gui should be able to addpkg on test1 addr
 # gui addpkg -> gno.land/r/<addr_test1>/mysuperpkg
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/mysuperpkg -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test gui
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/mysuperpkg -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test gui
 stdout 'OK!'
 
 # Gui should be able to addpkg on random name
 # gui addpkg -> gno.land/r/randomname/mysuperpkg
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/randomname/mysuperpkg -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test gui
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/randomname/mysuperpkg -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test gui
 stdout 'OK!'
 
 # Enable `sys/names`
 # admin call -> sys/names.Enable
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -broadcast -chainid tendermint_test admin
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid tendermint_test admin
 stdout 'OK!'
 
 # Check that `sys/names` has been enabled
@@ -38,27 +38,27 @@ stdout 'true bool'
 
 # Try to add a pkg with a user on someone else's address as namespace
 # gui addpkg -> gno.land/r/<addr_test1>/one
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/one -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test gui
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/one -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test gui
 stderr 'is not authorized to deploy packages to namespace'
 
 # Try to add a pkg on own address as namespace (PA namespace)
 # gui addpkg -> gno.land/r/<addr_gui>/one
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$gui_user_addr/one -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test gui
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$gui_user_addr/one -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test gui
 stdout 'OK!'
 
 ## Test non-PA namespace
 
 # Call addpkg with admin user on arbitrary namespace
 # admin addpkg -> gno.land/r/guiland/one
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/guiland/one -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test admin
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/guiland/one -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test admin
 stderr 'is not authorized to deploy packages to namespace'
 
 # Invalid package path characters
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/random!name/mypkg -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test gui
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/random!name/mypkg -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test gui
 stderr 'but got "gno.land/r/random!name/mypkg"'
 
 # Test that publishing to filetests is prohibited
-! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$gui_user_addr/filetests -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test gui
+! gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$gui_user_addr/filetests -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test gui
 stderr 'ending in filetests'
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_outofgas.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_outofgas.txtar
@@ -4,12 +4,12 @@
 gnoland start
 
 # add foo package
-gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 
 
 # add bar package - out of gas at store.GetPackage() with gas 60000
 
-! gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 1000000ugnot -gas-wanted 60000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 1000000ugnot -gas-wanted 60000 -chainid=tendermint_test test1
 
 stderr '--= Error =--'
 stderr 'Data: out of gas error'
@@ -19,7 +19,7 @@ stderr '--= /Error =--'
 
 # out of gas at store.store.GetTypeSafe()  with gas 63000
 
-! gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 1000000ugnot -gas-wanted 63000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 1000000ugnot -gas-wanted 63000 -chainid=tendermint_test test1
 
 stderr '--= Error =--'
 stderr 'Data: out of gas error'

--- a/gno.land/pkg/integration/testdata/addpkg_private.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_private.txtar
@@ -7,147 +7,147 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # add the public realm first
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 820001ugnot -gas-wanted 8_200_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 820001ugnot -gas-wanted 8_200_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # add the private realm
-gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 1100001ugnot -gas-wanted 11_000_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 1100001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadTreeToPublicRealm -gas-fee 540001ugnot -gas-wanted 5_400_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadTreeToPublicRealm -gas-fee 540001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeAsAValueOfTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeAsAValueOfTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveIntToPublicRealm -gas-fee 460001ugnot -gas-wanted 4_600_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveIntToPublicRealm -gas-fee 460001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStringToPublicRealm -gas-fee 460001ugnot -gas-wanted 4_600_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStringToPublicRealm -gas-fee 460001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveSliceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveSliceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadSliceToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadSliceToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test $test1_user_addr
 stdout 'private1'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadMapToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadMapToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test $test1_user_addr
 stdout 100
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveValueFromPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveValueFromPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptySliceOfPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptySliceOfPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 580001ugnot -gas-wanted 5_800_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithNewPrivateData -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithNewPrivateData -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func EditMixedStructWithPublicRealm -gas-fee 520001ugnot -gas-wanted 5_200_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func EditMixedStructWithPublicRealm -gas-fee 520001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test $test1_user_addr
 stdout 'Read Mixed Struct'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveInterfaceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveInterfaceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayToPublicRealm3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithPrivateKeyToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithPrivateKeyToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithPrivateValueToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithPrivateValueToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithBothPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapWithBothPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptyMapWithPrivateTypesToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptyMapWithPrivateTypesToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNestedToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNestedToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveClosureToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveClosureToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist reference of object from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveClosure2ToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveClosure2ToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist function or method from the private realm gno.land/r/foobar/privaterealm'
 
 # these functions are allowed since they do not use private types or references to private realm objects
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfSimpleFunctionsToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfSimpleFunctionsToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist function or method from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfFunctionsWithPrivateDataToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfFunctionsWithPrivateDataToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfFunctionsWithTreePointerToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveArrayOfFunctionsWithTreePointerToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist function or method from the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNilPointerToPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNilPointerToPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptyStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptyStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SavePrivateMapToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SavePrivateMapToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SavePrivateMapToPublicRealm2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SavePrivateMapToPublicRealm2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveCustomTypeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveCustomTypeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit1 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func TryToExploit3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapOfMapOfMapOfPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapOfMapOfMapOfPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNilSliceOfSliceOfPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveNilSliceOfSliceOfPrivateToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test $test1_user_addr $WORK/msgrun/run.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr $WORK/msgrun/run.gno
 
 gnokey query vm/qeval --data 'gno.land/r/foobar/privaterealm.GetTreePointer()'
 stdout 'gno.land/p/nt/avl/v0.Tree'

--- a/gno.land/pkg/integration/testdata/addpkg_private_basic.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_private_basic.txtar
@@ -4,19 +4,19 @@
 gnoland start
 
 # add a public realm
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # update the public realm
-! gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test $test1_user_addr
 stderr 'package already exists'
 
 # add a private realm
-gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # update the same private realm
-gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # ensure A is present
@@ -24,7 +24,7 @@ gnokey query vm/qeval --data "gno.land/r/foobar/privaterealm.A"
 stdout '123'
 
 # update the edited private realm over the original
-gnokey maketx addpkg -pkgdir $WORK/privaterealmedited -pkgpath gno.land/r/foobar/privaterealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/privaterealmedited -pkgpath gno.land/r/foobar/privaterealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # ensure A is deleted
@@ -36,11 +36,11 @@ gnokey query vm/qeval --data "gno.land/r/foobar/privaterealm.B"
 stdout '456'
 
 # overwrite public realm with private realm
-! gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test $test1_user_addr
 stderr 'package already exists'
 
 # overwrite private realm with public realm
-! gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 10000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test $test1_user_addr
+! gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 10000000ugnot -gas-wanted 200000000 -chainid=tendermint_test $test1_user_addr
 stderr 'a private package cannot be overridden by a public package'
 
 -- privaterealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_public.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_public.txtar
@@ -7,56 +7,56 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # add the public realm first
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 750001ugnot -gas-wanted 7_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 750001ugnot -gas-wanted 7_500_000 -chainid=tendermint_test test1
 stdout OK!
 
 # add the normal realm (not marked as private)
-gnokey maketx addpkg -pkgdir $WORK/normalrealm -pkgpath gno.land/r/foobar/normalrealm -gas-fee 910001ugnot -gas-wanted 9_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/normalrealm -pkgpath gno.land/r/foobar/normalrealm -gas-fee 910001ugnot -gas-wanted 9_100_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveTreeToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveTreeToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveIntToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveIntToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveSliceToPublicRealm -gas-fee 450001ugnot -gas-wanted 4_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveSliceToPublicRealm -gas-fee 450001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMapToPublicRealm -gas-fee 450001ugnot -gas-wanted 4_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMapToPublicRealm -gas-fee 450001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveStructToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveStructToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 600001ugnot -gas-wanted 6_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 600001ugnot -gas-wanted 6_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 640001ugnot -gas-wanted 6_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 640001ugnot -gas-wanted 6_400_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 730001ugnot -gas-wanted 7_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 730001ugnot -gas-wanted 7_300_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveInterfaceToPublicRealm -gas-fee 610001ugnot -gas-wanted 6_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveInterfaceToPublicRealm -gas-fee 610001ugnot -gas-wanted 6_100_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveArrayToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveArrayToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealm -gas-fee 590001ugnot -gas-wanted 5_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealm -gas-fee 590001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 740001ugnot -gas-wanted 7_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveClosureToPublicRealm -gas-fee 550001ugnot -gas-wanted 5_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveClosureToPublicRealm -gas-fee 550001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveValueFromNormalStructToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveValueFromNormalStructToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data 'gno.land/r/foobar/normalrealm.GetTreePointer()'

--- a/gno.land/pkg/integration/testdata/adduser.txtar
+++ b/gno.land/pkg/integration/testdata/adduser.txtar
@@ -4,10 +4,10 @@ adduser test8
 gnoland start
 
 ## add bar.gno package located in $WORK directory as gno.land/r/foobar/bar
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test8
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test8
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -broadcast -chainid=tendermint_test test8 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid=tendermint_test test8 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'

--- a/gno.land/pkg/integration/testdata/alloc_array.txtar
+++ b/gno.land/pkg/integration/testdata/alloc_array.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/alloc $WORK
 
 gnoland start
 
-! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: allocation limit exceeded'
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/alloc_byte_slice.txtar
+++ b/gno.land/pkg/integration/testdata/alloc_byte_slice.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/alloc $WORK
 
 gnoland start
 
-! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: allocation limit exceeded'
 
 -- alloc.gno --

--- a/gno.land/pkg/integration/testdata/alloc_slice.txtar
+++ b/gno.land/pkg/integration/testdata/alloc_slice.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/alloc $WORK
 
 gnoland start
 
-! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/alloc -func DoAlloc -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: allocation limit exceeded'
 
 -- alloc.gno --

--- a/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
@@ -26,16 +26,16 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Variant A: close BEFORE callee.Store (no taint expected).
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseBeforeStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseBeforeStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant B: close AFTER callee.Store, INLINE (no defer wrapper).
 # If this panics with taint, value-based taint is the cause.
 # If this succeeds, the defer mechanism specifically is the issue.
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 
 # Variant C: close AFTER callee.Store, via inline closure call.
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func ClosureCallAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func ClosureCallAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 
 -- diagcallee/gnomod.toml --
 module = "gno.land/r/test/diagcallee"

--- a/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
@@ -12,25 +12,25 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Variant D: defer al.Close() with NO cross call at all. Should succeed.
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseNoCross -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseNoCross -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant E: defer al.Close() + cross call WITHOUT persistence.
 # Callee receives but discards. Does the cross call alone (without
 # persistence) trigger taint on the deferred receiver?
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossNoPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossNoPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 
 # Variant F: defer + cross + persist. With the VM fix (Defer.IsBoundMethod
 # threading the receiver through PushFrameCall so the implicit borrow-
 # realm switch fires for deferred method calls), this now SUCCEEDS.
 # Pre-fix behavior was a "cannot directly modify readonly tainted" panic.
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant G: defer + cross + persist + INLINE al.Close() before defer fires.
 # Diagnostic question: does the inline close succeed AND does the
 # deferred close still panic?
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersistAlsoInline -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersistAlsoInline -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 
 -- diag2callee/gnomod.toml --
 module = "gno.land/r/test/diag2callee"

--- a/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
@@ -23,7 +23,7 @@ gnoland start
 # tx1: granter installs outer recover-defer FIRST, then defer al.Close()
 # (so Close runs first on unwind, then outer recover catches if needed).
 # Callee persists the pointer. Outcome under test.
-gnokey maketx call -pkgpath gno.land/r/test/outerrecovergranter -func GrantWithOuterRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/outerrecovergranter -func GrantWithOuterRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 
 # tx2: inspect the persisted state. With the fix, Close ran cleanly
 # (no panic) and the persisted struct is closed.
@@ -32,7 +32,7 @@ stdout '"true"'
 
 # tx3: drain attempt. Persisted allowance is closed → panics with
 # "allowancesender: closed". Kill switch holds.
-! gnokey maketx call -pkgpath gno.land/r/test/outerrecovercallee -func DrainStored -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/outerrecovercallee -func DrainStored -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stderr 'allowancesender: closed'
 
 -- outerrecovercallee/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
@@ -34,7 +34,7 @@ gnoland start
 # granter creates 500_000 ugnot allowance, callee spends 200_000
 # during the call, granter's defer closes after. Funds move via
 # the inner banker; allowance correctly tracks spent.
-gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 500000 -args 200000 -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 500000 -args 200000 -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 # ============================================================
@@ -42,7 +42,7 @@ stdout OK!
 # ============================================================
 # granter creates 100_000 cap, callee tries to spend 200_000.
 # Wrapper rejects with "cap exceeded".
-! gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 100000 -args 200000 -send 100000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 100000 -args 200000 -send 100000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stderr 'cap exceeded'
 
 # ============================================================
@@ -50,7 +50,7 @@ stderr 'cap exceeded'
 # ============================================================
 # callee constructs a negative chain.Coin and passes to Send.
 # Wrapper rejects with "negative amount not allowed".
-! gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpendNegative -send 100000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpendNegative -send 100000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stderr 'negative amount not allowed'
 
 # ============================================================
@@ -63,7 +63,7 @@ stderr 'negative amount not allowed'
 # the receiver is propagated through the deferred call's
 # PushFrameCall, the implicit borrow-realm switch fires, m.Realm
 # becomes callee inside Close, and the field write succeeds.
-gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 -- callee/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
@@ -26,7 +26,7 @@ gnoland start
 # tx1: granter creates allowance with cap 1M, callee persists, granter
 # tries to recover from the Close-time taint panic. Observe: does the
 # tx succeed (recover worked) or fail (taint panic is un-recoverable)?
-gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreWithRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreWithRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout '.'  # match anything; we'll inspect the actual outcome below
 
 # tx2: state inspection. Use qeval to read the persisted state without
@@ -36,7 +36,7 @@ stdout 'true|false|nil'
 
 # tx3: try to actually use the persisted struct. If it's closed, the
 # call panics with "allowancesender: closed".
-! gnokey maketx call -pkgpath gno.land/r/test/recovercallee -func DrainStored -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/recovercallee -func DrainStored -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stderr 'allowancesender: closed'
 
 # tx4: DIRECT defer al.Close() — with the VM fix (Defer.IsBoundMethod
@@ -45,7 +45,7 @@ stderr 'allowancesender: closed'
 # Close runs in callee's realm context, the field write is allowed,
 # and the kill switch engages. Pre-fix this panicked with
 # "cannot directly modify readonly tainted object".
-gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreDirect -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreDirect -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test user1
 stdout OK!
 
 -- recovercallee/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/append.txtar
+++ b/gno.land/pkg/integration/testdata/append.txtar
@@ -5,18 +5,18 @@ loadpkg gno.land/r/append $WORK
 gnoland start
 
 # Call Append 1
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 270001ugnot -gas-wanted 2_700_000 -args '1' -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 270001ugnot -gas-wanted 2_700_000 -args '1' -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func AppendNil -gas-fee 270001ugnot -gas-wanted 2_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func AppendNil -gas-fee 270001ugnot -gas-wanted 2_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call Append 2
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 280001ugnot -gas-wanted 2_800_000 -args '2' -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 280001ugnot -gas-wanted 2_800_000 -args '2' -chainid=tendermint_test test1
 stdout OK!
 
 # Call Append 3
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 290001ugnot -gas-wanted 2_900_000 -args '3' -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 290001ugnot -gas-wanted 2_900_000 -args '3' -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
@@ -24,34 +24,34 @@ gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '1-2-3-'
 
 # Call Pop
-gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 290001ugnot -gas-wanted 2_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 stdout OK!
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-'
 
 # Call Append 42
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 230001ugnot -gas-wanted 2_300_000 -args '42' -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 230001ugnot -gas-wanted 2_300_000 -args '42' -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-42-'
 
-gnokey maketx call -pkgpath gno.land/r/append -func CopyAppend -gas-fee 300001ugnot -gas-wanted 3_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func CopyAppend -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func PopB -gas-fee 320001ugnot -gas-wanted 3_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func PopB -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-42-'
 
-gnokey maketx call -pkgpath gno.land/r/append -func AppendMoreAndC -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func AppendMoreAndC -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func ReassignC -gas-fee 270001ugnot -gas-wanted 2_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func ReassignC -gas-fee 270001ugnot -gas-wanted 2_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qrender --data 'gno.land/r/append:'

--- a/gno.land/pkg/integration/testdata/append_string.txtar
+++ b/gno.land/pkg/integration/testdata/append_string.txtar
@@ -2,12 +2,12 @@ loadpkg gno.land/r/append $WORK
 
 gnoland start
 
-! gnokey maketx call -pkgpath gno.land/r/append -func Doappend -gas-fee 5000000ugnot -gas-wanted 2900000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/append -func Doappend -gas-fee 5000000ugnot -gas-wanted 2900000000 -chainid=tendermint_test test1
 
 stdout 'TX HASH:'
 stderr 'Data: allocation limit exceeded'
 
-! gnokey maketx call -pkgpath gno.land/r/append -func Doappend2 -gas-fee 5000000ugnot -gas-wanted 2900000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/append -func Doappend2 -gas-fee 5000000ugnot -gas-wanted 2900000000 -chainid=tendermint_test test1
 
 stdout 'TX HASH:'
 stderr 'Data: allocation limit exceeded'

--- a/gno.land/pkg/integration/testdata/assertorigincall.txtar
+++ b/gno.land/pkg/integration/testdata/assertorigincall.txtar
@@ -36,85 +36,85 @@ gnoland start
 
 # Test cases
 ## 1. MsgCall -> myrlm.A: PANIC
-! gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 stderr 'invalid non-origin call'
 
 ## 2. MsgCall -> myrlm.B: PASS
-gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 3. MsgCall -> myrlm.C: PASS
-gnokey maketx call -pkgpath gno.land/r/myrlm -func C -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func C -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 4. MsgCall -> r/foo.A -> myrlm.A: PANIC
-! gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 stderr 'invalid non-origin call'
 
 ## 5. MsgCall -> r/foo.B -> myrlm.B: PASS
-gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 6. MsgCall -> r/foo.C -> myrlm.C: PANIC
-! gnokey maketx call -pkgpath gno.land/r/foo -func C -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo -func C -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 stderr 'invalid non-origin call'
 
 ## remove due to update to maketx call can only call realm (case 7,8,9)
 ## 7. MsgCall -> p/demo/bar.A: PANIC
-## ! gnokey maketx call -pkgpath gno.land/p/demo/bar -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## ! gnokey maketx call -pkgpath gno.land/p/demo/bar -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stderr 'invalid non-origin call'
 
 ## 8. MsgCall -> p/demo/bar.B: PASS
-## gnokey maketx call -pkgpath gno.land/p/demo/bar -func B -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## gnokey maketx call -pkgpath gno.land/p/demo/bar -func B -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stdout 'OK!'
 
 ## 9. MsgCall -> p/demo/bar.C: PANIC
-## ! gnokey maketx call -pkgpath gno.land/p/demo/bar -func C -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## ! gnokey maketx call -pkgpath gno.land/p/demo/bar -func C -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stderr 'invalid non-origin call'
 
 ## 10. MsgRun -> run.main -> myrlm.A: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
 stderr 'invalid non-origin call'
 
 ## 11. MsgRun -> run.main -> myrlm.B: PASS
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -broadcast -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
 stdout 'OK!'
 
 ## 12. MsgRun -> run.main -> myrlm.C: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/myrlm-c.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/myrlm-c.gno
 stderr 'invalid non-origin call'
 
 ## 13. MsgRun -> run.main -> foo.A: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/foo-a.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/foo-a.gno
 stderr 'invalid non-origin call'
 
 ## 14. MsgRun -> run.main -> foo.B: PASS
-gnokey maketx run -gas-fee 210001ugnot -gas-wanted 2_100_000 -broadcast -chainid tendermint_test test1 $WORK/run/foo-b.gno
+gnokey maketx run -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
 stdout 'OK!'
 
 ## 15. MsgRun -> run.main -> foo.C: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/foo-c.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/foo-c.gno
 stderr 'invalid non-origin call'
 
 ## 16. MsgRun -> run.main -> bar.A: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/bar-a.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/bar-a.gno
 stderr 'invalid non-origin call'
 
 ## 17. MsgRun -> run.main -> bar.B: PASS
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -broadcast -chainid tendermint_test test1 $WORK/run/bar-b.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid tendermint_test test1 $WORK/run/bar-b.gno
 stdout 'OK!'
 
 ## 18. MsgRun -> run.main -> bar.C: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/bar-c.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/bar-c.gno
 stderr 'invalid non-origin call'
 
 ## remove testcase 19 due to maketx call forced to call a realm
 ## 19. MsgCall -> std.AssertOriginCall: pass
-## gnokey maketx call -pkgpath std -func AssertOriginCall -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## gnokey maketx call -pkgpath std -func AssertOriginCall -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stdout 'OK!'
 
 ## 20. MsgRun -> std.AssertOriginCall: PANIC
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/baz.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/baz.gno
 stderr 'invalid non-origin call'
 
 

--- a/gno.land/pkg/integration/testdata/atomicswap.txtar
+++ b/gno.land/pkg/integration/testdata/atomicswap.txtar
@@ -21,7 +21,7 @@ stdout 'coins.*:.*1010000000ugnot'
 #   test2 after Claim       = 1008854654  (unchanged — Claim moves escrow to test3, not from test2)
 #   test3 after NewCoinSwap = 1010000000  (unchanged)
 #   test3 after Claim       = 1010000000 + 12345 (escrow) - 700001 (gas) - 500 (storage) = 1009311844
-gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func NewCoinSwap -gas-fee 680001ugnot -send 12345ugnot -gas-wanted 6_800_000 -args $test3_user_addr -args '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func NewCoinSwap -gas-fee 680001ugnot -send 12345ugnot -gas-wanted 6_800_000 -args $test3_user_addr -args '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' -chainid=tendermint_test test2
 stdout '(1 int)'
 stdout ".*$test2_user_addr.*$test3_user_addr.*12345ugnot.*"
 stdout 'OK!'
@@ -34,7 +34,7 @@ stdout 'coins.*:.*1008854654ugnot'
 gnokey query auth/accounts/$test3_user_addr
 stdout 'coins.*:.*1010000000ugnot'
 
-gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func Claim -gas-fee 700001ugnot -gas-wanted 7_000_000 -args '1' -args 'secret' -broadcast -chainid=tendermint_test test3
+gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func Claim -gas-fee 700001ugnot -gas-wanted 7_000_000 -args '1' -args 'secret' -chainid=tendermint_test test3
 stdout 'OK!'
 stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":500\}.*\]'
 

--- a/gno.land/pkg/integration/testdata/banker_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/banker_persistence.txtar
@@ -19,25 +19,25 @@ gnoland start
 # Phase 1: same-realm persistence over multiple txs + exhaustion.
 # ============================================================
 # tx1: A.Save() stores a banker for itself, funded with 1M ugnot.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func Save -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func Save -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx2: A's balance is 1_000_000. Spend 600_000 via the persisted banker.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 600000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 600000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx3: A's balance is now 400_000. Spend 300_000.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 300000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 300000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx4: A's balance is now 100_000. Spend 99_000 (cuts it close).
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 99000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 99000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx5: A has only 1000 left. Try to spend 50_000 — must fail with
 # bank-level insufficient-funds error. Confirms the persisted banker
 # isn't somehow detached from real-time balance state.
-! gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 50000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 50000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stderr 'insufficient'
 
 # ============================================================
@@ -49,26 +49,26 @@ stderr 'insufficient'
 # tx6: A.GiveBankerToB() creates a RealmSend-typed banker (scoped to
 #      A's address) and passes it to B. -send funds A's address with
 #      another 500_000 ugnot to give B something to drain.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func GiveBankerToB -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func GiveBankerToB -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx7: B.UseGivenBanker spends 200_000 from A's address. (A had 1000
 #      left + 500_000 added = 501_000 going into this.)
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 200000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 200000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx8: A's balance is now 301_000. B drains another 250_000.
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 250000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 250000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx9: A's balance is now 51_000. Try to drain 100_000 — must fail.
 # Confirms cross-realm persisted banker also enforces bank-level limits.
-! gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 100000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stderr 'insufficient'
 
 # tx10: B confirms the persisted banker still works for any amount
 #       within balance (sanity check after the failed overdraft).
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 50000 -gas-fee 1000000ugnot -gas-wanted 5000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 50000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
 stdout OK!
 
 -- bankera/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/banker_security.txtar
+++ b/gno.land/pkg/integration/testdata/banker_security.txtar
@@ -21,7 +21,7 @@ gnokey query bank/balances/${attacker_user_addr}
 stdout '1000000000ugnot'
 
 ## Deploy the malicious realm that attempts to steal coins
-gnokey maketx addpkg -pkgdir $WORK/malicious -pkgpath gno.land/r/test/malicious -gas-fee 380001ugnot -gas-wanted 3_800_000 -broadcast -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/malicious -pkgpath gno.land/r/test/malicious -gas-fee 380001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## ============================================
@@ -30,7 +30,7 @@ stdout OK!
 ## This should FAIL - banker should only allow sending from the realm's own address
 ## ============================================
 
-! gnokey maketx call -pkgpath gno.land/r/test/malicious -func StealWithOriginSend -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/test/malicious -func StealWithOriginSend -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test attacker
 stderr 'can only send coins from realm that created banker'
 
 ## Verify victim's coins are NOT stolen (still has 1000 GNOT)
@@ -43,7 +43,7 @@ stdout '1000000000ugnot'
 ## This should FAIL - banker should only allow sending from the realm's own address
 ## ============================================
 
-! gnokey maketx call -pkgpath gno.land/r/test/malicious -func StealWithRealmSend -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/test/malicious -func StealWithRealmSend -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test attacker
 stderr 'can only send coins from realm that created banker'
 
 ## Verify victim's coins are still safe (still has 1000 GNOT)
@@ -55,7 +55,7 @@ stdout '1000000000ugnot'
 ## Even if user sends some coins, realm cannot send more than what was sent
 ## ============================================
 
-! gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 100000 -send 10ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test victim
+! gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 100000 -send 10ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test victim
 stderr 'cannot send "100000ugnot", limit "10ugnot" exceeded'
 
 ## ============================================
@@ -63,7 +63,7 @@ stderr 'cannot send "100000ugnot", limit "10ugnot" exceeded'
 ## This verifies the banker does work correctly for legitimate use
 ## ============================================
 
-gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 5 -send 10ugnot -gas-fee 300001ugnot -gas-wanted 3_000_000 -broadcast -chainid=tendermint_test victim
+gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 5 -send 10ugnot -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test victim
 stdout OK!
 
 ## ============================================
@@ -71,16 +71,16 @@ stdout OK!
 ## Deploy a "helper" realm that the malicious realm tries to use to steal coins
 ## ============================================
 
-gnokey maketx addpkg -pkgdir $WORK/helper -pkgpath gno.land/r/test/helper -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/helper -pkgpath gno.land/r/test/helper -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## Update malicious realm to have access to helper
-gnokey maketx addpkg -pkgdir $WORK/malicious_v2 -pkgpath gno.land/r/test/malicious_v2 -gas-fee 400001ugnot -gas-wanted 4_000_000 -broadcast -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/malicious_v2 -pkgpath gno.land/r/test/malicious_v2 -gas-fee 400001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## Try cross-realm attack - helper realm should not be able to create OriginSend banker
 ## because it's not the origin package
-! gnokey maketx call -pkgpath gno.land/r/test/malicious_v2 -func CrossRealmAttack -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/test/malicious_v2 -func CrossRealmAttack -args ${victim_user_addr} -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test attacker
 stderr 'banker with type BankerTypeOriginSend can only be instantiated by the origin package'
 
 ## Final verification - victim's coins remain safe throughout all tests

--- a/gno.land/pkg/integration/testdata/cpu-cycle-overrun1.txtar
+++ b/gno.land/pkg/integration/testdata/cpu-cycle-overrun1.txtar
@@ -3,20 +3,20 @@ loadpkg gno.land/p/nt/avl/v0
 # start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/cpu_cycle_overrun1 -gas-fee 710001ugnot -gas-wanted 7_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/cpu_cycle_overrun1 -gas-fee 710001ugnot -gas-wanted 7_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call AddData 3 times
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 5600001ugnot -gas-wanted 56_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 5600001ugnot -gas-wanted 56_000_000 -chainid=tendermint_test test1
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 7400001ugnot -gas-wanted 74_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 7400001ugnot -gas-wanted 74_000_000 -chainid=tendermint_test test1
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8100001ugnot -gas-wanted 81_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8100001ugnot -gas-wanted 81_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call AddData one more time. The call to Render used to hang. If you commented this out, then the call to Render would return quickly.
 # This bug was fixed by https://github.com/gnolang/gno/pull/4060
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8400001ugnot -gas-wanted 84_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8400001ugnot -gas-wanted 84_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call Render

--- a/gno.land/pkg/integration/testdata/err_metadata.txtar
+++ b/gno.land/pkg/integration/testdata/err_metadata.txtar
@@ -3,7 +3,7 @@
 # start a new node
 gnoland start
 
-! gnokey maketx addpkg -pkgdir $WORK/invalid -pkgpath gno.land/r/invalid -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/invalid -pkgpath gno.land/r/invalid -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 
 stdout 'TX HASH:'
 stdout 'INFO:.*vm.version=develop'

--- a/gno.land/pkg/integration/testdata/event_callback.txtar
+++ b/gno.land/pkg/integration/testdata/event_callback.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/cbee $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/cbee -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/cbee -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 2100000'
 stdout 'GAS USED:   [0-9]+'

--- a/gno.land/pkg/integration/testdata/event_defer_callback_loop.txtar
+++ b/gno.land/pkg/integration/testdata/event_defer_callback_loop.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/edcl $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/edcl -func Main -gas-fee 240001ugnot -gas-wanted 2_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/edcl -func Main -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 2400000'
 stdout 'GAS USED:   [0-9]+'

--- a/gno.land/pkg/integration/testdata/event_for_statement.txtar
+++ b/gno.land/pkg/integration/testdata/event_for_statement.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/foree $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/foree -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/foree -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 2100000'
 stdout 'GAS USED:   [0-9]+'
@@ -12,7 +12,7 @@ stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"}\]'
 stdout 'TX HASH:    '
 
-gnokey maketx call -pkgpath gno.land/r/demo/foree -func Bar -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/foree -func Bar -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 2200000'
 stdout 'GAS USED:   [0-9]+'

--- a/gno.land/pkg/integration/testdata/event_normal.txtar
+++ b/gno.land/pkg/integration/testdata/event_normal.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/ee $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/ee -func Foo -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ee -func Foo -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 2000000'
 stdout 'GAS USED:   \d+'
@@ -12,7 +12,7 @@ stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[{\"type\":\"foo\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"},{\"key\":\"key3\",\"value\":\"value3\"}\],\"pkg_path\":\"gno.land/r/demo/ee\"},{\"type\":\"bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land/r/demo/ee\"}\]'
 stdout 'TX HASH:    '
 
-gnokey maketx call -pkgpath gno.land/r/demo/ee -func Bar -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ee -func Bar -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: 1900000'
 stdout 'GAS USED:   \d+'

--- a/gno.land/pkg/integration/testdata/exploit_users_init.txtar
+++ b/gno.land/pkg/integration/testdata/exploit_users_init.txtar
@@ -30,10 +30,10 @@ gnokey query vm/qeval --data "gno.land/r/sys/users.ResolveAddress(\"g1jg8mtutu9k
 stdout 'foundinguser'
 
 # Attack 1 (BLOCKED): attacker self-registers `vitalik` post-genesis.
-! gnokey maketx call -pkgpath gno.land/r/sys/users/init -func RegisterUser -args 'vitalik' -args $attacker_user_addr -gas-fee 1500001ugnot -gas-wanted 15_000_000 -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/sys/users/init -func RegisterUser -args 'vitalik' -args $attacker_user_addr -gas-fee 1500001ugnot -gas-wanted 15_000_000 -chainid=tendermint_test attacker
 stderr 'genesis-only'
 
 # Attack 2 (BLOCKED): attacker tries to land-grab `administrator` for victim's
 # address (cross-EOA registration without consent).
-! gnokey maketx call -pkgpath gno.land/r/sys/users/init -func RegisterUser -args 'administrator' -args $victim_user_addr -gas-fee 1500001ugnot -gas-wanted 15_000_000 -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/sys/users/init -func RegisterUser -args 'administrator' -args $victim_user_addr -gas-fee 1500001ugnot -gas-wanted 15_000_000 -chainid=tendermint_test attacker
 stderr 'genesis-only'

--- a/gno.land/pkg/integration/testdata/gc.txtar
+++ b/gno.land/pkg/integration/testdata/gc.txtar
@@ -6,7 +6,7 @@ loadpkg gno.land/r/gc $WORK/r/gc
 gnoland start -no-parallel
 
 
-gnokey maketx call -pkgpath gno.land/r/gc -func Alloc -gas-fee 17000000ugnot -gas-wanted 170_000_000 -simulate skip -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gc -func Alloc -gas-fee 17000000ugnot -gas-wanted 170_000_000 -simulate skip -chainid tendermint_test test1
 stdout 'GAS USED:   151379006'
 
 -- r/gc/gc.gno --

--- a/gno.land/pkg/integration/testdata/ghverify.txtar
+++ b/gno.land/pkg/integration/testdata/ghverify.txtar
@@ -4,35 +4,35 @@ loadpkg gno.land/r/gnoland/ghverify
 gnoland start
 
 # make a verification request
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func RequestVerification -args 'deelawn' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func RequestVerification -args 'deelawn' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # request tasks to complete (this is done by the agent)
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'request' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'request' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test test1
 stdout '\("\[\{\\"id\\":\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\",\\"type\\":\\"0\\",\\"value_type\\":\\"string\\",\\"tasks\\":\[\{\\"gno_address\\":\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\",\\"github_handle\\":\\"deelawn\\"\}\]\}\]" string\)'
 
 # a verification request was made but there should be no verified address
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 stdout ""
 
 # a verification request was made but there should be no verified handle
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 stdout ""
 
 # fail on ingestion with a bad task ID
-! gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'ingest,a' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'ingest,a' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'invalid ingest id: a'
 
 # the agent publishes their response to the task and the verification is complete
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'ingest,g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5,OK' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint -args 'ingest,g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5,OK' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # get verified github handle by gno address
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 550001ugnot -gas-wanted 5_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 550001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
 stdout "deelawn"
 
 # get verified gno address by github handle
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 550001ugnot -gas-wanted 5_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 550001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
 stdout "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
 
 gnokey query vm/qrender --data 'gno.land/r/gnoland/ghverify:'

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -12,7 +12,7 @@ stdout '"coins": "10000000000000ugnot"'
 # Tx add package -simulate only, estimate gas used and gas fee.
 # gas-wanted/gas-fee on the simulate call are generous; simulate reports
 # the actual gas the real tx would consume.
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -broadcast -chainid tendermint_test -simulate only test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -chainid tendermint_test -simulate only test1
 stdout 'GAS USED:\s+2814892'
 stdout 'INFO:       estimated gas usage: 2814892, gas fee: 2955ugnot, current gas price: 1ugnot/1000gas'
 
@@ -25,7 +25,7 @@ stdout '"coins": "10000000000000ugnot"'
 # This is the documented simulate->broadcast workflow; the values on this
 # line MUST match the simulate output above (modulo a small gas-wanted
 # headroom).
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_815_000 -gas-fee 2955ugnot -broadcast -chainid tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_815_000 -gas-fee 2955ugnot -chainid tendermint_test test1
 stdout 'OK'
 stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":206900\}.*\]'
 
@@ -35,7 +35,7 @@ stdout '"sequence": "1"'
 stdout '"coins": "9999999790145ugnot"'
 
 # Tx Call -simulate only, estimate gas used and gas fee.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -broadcast -chainid tendermint_test -simulate only test1
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -chainid tendermint_test -simulate only test1
 stdout 'GAS USED:\s+1269716'
 stdout 'INFO:       estimated gas usage: 1269716, gas fee: 1333ugnot, current gas price: 1ugnot/1000gas'
 
@@ -45,7 +45,7 @@ stdout '"sequence": "1"'
 stdout '"coins": "9999999790145ugnot"'
 
 # Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_269_900 -gas-fee 1333ugnot -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_269_900 -gas-fee 1333ugnot -chainid tendermint_test test1
 stdout 'OK'
 
 ## fee is charged and sequence number increased

--- a/gno.land/pkg/integration/testdata/gnokey_simulate.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_simulate.txtar
@@ -12,34 +12,34 @@ stdout '"sequence": "1"'
 # attempt adding the "test" package.
 # the package has a syntax error; simulation should catch this ahead of time and prevent the tx.
 # -simulate test
-! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test -simulate test test1
+! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -chainid=tendermint_test -simulate test test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
 # -simulate only
-! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test -simulate only test1
+! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -chainid=tendermint_test -simulate only test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
 # -simulate skip
-! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test -simulate skip test1
+! gnokey maketx addpkg -pkgdir $WORK/test -pkgpath gno.land/r/test -gas-fee 1000000ugnot -gas-wanted 20000000 -chainid=tendermint_test -simulate skip test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "2"'
 
 # attempt calling hello.SetName correctly.
 # -simulate test and skip should do it successfully, -simulate only should not.
 # -simulate test
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args John -gas-wanted 2_300_000 -gas-fee 230001ugnot -broadcast -chainid tendermint_test -simulate test test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args John -gas-wanted 2_300_000 -gas-fee 230001ugnot -chainid tendermint_test -simulate test test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "3"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, John!'
 # -simulate only
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 1_900_000 -gas-fee 190001ugnot -broadcast -chainid tendermint_test -simulate only test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 1_900_000 -gas-fee 190001ugnot -chainid tendermint_test -simulate only test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "3"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, John!'
 # -simulate skip
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args George -gas-wanted 2_300_000 -gas-fee 230001ugnot -broadcast -chainid tendermint_test -simulate skip test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args George -gas-wanted 2_300_000 -gas-fee 230001ugnot -chainid tendermint_test -simulate skip test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "4"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
@@ -49,26 +49,26 @@ stdout 'Hello, George!'
 # all calls should fail, however -test skip should increase the account sequence.
 # none should change the name (ie. panic rollbacks).
 # -simulate test
-! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -broadcast -chainid tendermint_test -simulate test test1
+! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid tendermint_test -simulate test test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "4"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, George!'
 # -simulate only
-! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -broadcast -chainid tendermint_test -simulate only test1
+! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid tendermint_test -simulate only test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "4"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, George!'
 # -simulate skip
-! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -broadcast -chainid tendermint_test -simulate skip test1
+! gnokey maketx call -pkgpath gno.land/r/hello -func Grumpy -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid tendermint_test -simulate skip test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "5"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, George!'
 
 # simulate should panic if gas-wanted is beyond the max block gas.
-! gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 100_000_000_000_000 -gas-fee 1000000ugnot -broadcast -chainid tendermint_test -simulate only test1
+! gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 100_000_000_000_000 -gas-fee 1000000ugnot -chainid tendermint_test -simulate only test1
 stderr 'invalid gas wanted'
 
 -- test/test.gno --

--- a/gno.land/pkg/integration/testdata/govdao_invite_t3_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_invite_t3_member.txtar
@@ -19,23 +19,23 @@ gnoland start
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 
 # Call from a non-member
-! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -broadcast -chainid=tendermint_test newmember2
+! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -chainid=tendermint_test newmember2
 stderr 'caller is not a member'
 
 # Call from with a proxy realm
-! gnokey maketx call -pkgpath gno.land/r/demo/proxy -func CreateMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/demo/proxy -func CreateMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -chainid=tendermint_test member
 stderr 'this function must be called by an EOA through msg call or msg run'
 
 # Add a T3 member with invitation points
-gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 1400001ugnot -gas-wanted 14_000_000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 1400001ugnot -gas-wanted 14_000_000 -args g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 -chainid=tendermint_test member
 stdout OK!
 
 # No invitation point left for the member
-! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args ${newmember2_user_addr} -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args ${newmember2_user_addr} -chainid=tendermint_test member
 stderr 'not enough invitation points'
 
 # Call from a T3 member
-! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args ${newmember2_user_addr} -broadcast -chainid=tendermint_test newmember
+! gnokey maketx call -pkgpath gno.land/r/gov/dao/v3/impl -func AddMember -gas-fee 5000000ugnot -gas-wanted 50000000 -args ${newmember2_user_addr} -chainid=tendermint_test newmember
 stderr 'caller is not on T1 or T2. To add members, propose them through proposals'
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
@@ -18,13 +18,13 @@ stdout 'data: # GovDAO'
 
 # add the proposal (temporarily comment out to debug)
 # First run a debug script to understand the addresses
-gnokey maketx run -gas-fee 110001ugnot -gas-wanted 1_100_000 -broadcast -chainid=tendermint_test member $WORK/debug/check_addresses.gno
+gnokey maketx run -gas-fee 110001ugnot -gas-wanted 1_100_000 -chainid=tendermint_test member $WORK/debug/check_addresses.gno
 stdout '=== Debug info ==='
 stdout 'Origin caller: g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0'
 stdout 'Current realm: CodeRealm{ g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0, gno.land/e/g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0/run }'
 
 # Create a proposal
-gnokey maketx run -gas-fee 4300001ugnot -gas-wanted 43_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4300001ugnot -gas-wanted 43_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -32,11 +32,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This is a proposal to add `g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0` to \*\*T2\*\*.'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_change_law.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_change_law.txtar
@@ -13,7 +13,7 @@ gnoland start
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 
 # add the proposal
-gnokey maketx run -gas-fee 3700001ugnot -gas-wanted 37_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 3700001ugnot -gas-wanted 37_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -21,11 +21,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout '## Prop #0 - Change Law Proposal'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 -- proposer/create_proposal.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_new_param.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_new_param.txtar
@@ -14,7 +14,7 @@ gnoland start
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 
 # add the proposal
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -22,11 +22,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This proposal wants to add a new key to sys/params: vm:bar:baz'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output:

--- a/gno.land/pkg/integration/testdata/govdao_proposal_new_post.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_new_post.txtar
@@ -15,7 +15,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # add the proposal
-gnokey maketx run -gas-fee 2800001ugnot -gas-wanted 28_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 2800001ugnot -gas-wanted 28_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -23,11 +23,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This propoposal is looking to add a new post to gnoland blog'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 29_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 29_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_only_members_proposals.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_only_members_proposals.txtar
@@ -16,7 +16,7 @@ gnoland start
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 
 # try to add the proposal using a non-member
-gnokey maketx run -gas-fee 1700001ugnot -gas-wanted 17_000_000 -broadcast -chainid=tendermint_test newmember $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 1700001ugnot -gas-wanted 17_000_000 -chainid=tendermint_test newmember $WORK/proposer/create_proposal.gno
 stdout 'only members can create new proposals'
 
 -- proposer/create_proposal.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_promote_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_promote_member.txtar
@@ -17,7 +17,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # add the proposal
-gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_invalid_proposal.gno
+gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -chainid=tendermint_test member $WORK/proposer/create_invalid_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -26,19 +26,19 @@ stdout 'Prop #0 - Member Promotion Proposal'
 stdout 'This is a proposal to promote g16jv3rpz7mkt0gqulxas56se2js7v5vmc6n6e0r from \*\*T3\*\* to \*\*T2\*\*.'
 
 # vote on the proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # vote on the proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test withdrawmember
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
 stdout OK!
 
 # add the proposal
-gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call proposal execution
-! gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000000ugnot -gas-wanted 50000000 -args 0 -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000000ugnot -gas-wanted 50000000 -args 0 -chainid=tendermint_test member
 stderr 'member not found, so cannot be promoted'
 
 # call gov/dao render to check everything the proposal was created
@@ -47,15 +47,15 @@ stdout 'Prop #1 - Member Promotion Proposal'
 stdout 'This is a proposal to promote g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 from \*\*T2\*\* to \*\*T3\*\*.'
 
 # vote on the proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # vote on the proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test withdrawmember
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 1 -args YES -chainid=tendermint_test withdrawmember
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2400001ugnot -gas-wanted 24_000_000 -args 1 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2400001ugnot -gas-wanted 24_000_000 -args 1 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_treasury_payment.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_treasury_payment.txtar
@@ -23,7 +23,7 @@ gnokey query bank/balances/g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm
 stdout 'data: ""'
 
 # member send 42 ugnot to treasury realm
-gnokey maketx send -send 42ugnot -to g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid tendermint_test member
+gnokey maketx send -send 42ugnot -to g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test member
 
 # 2/3 verify receiver and treasury balances
 gnokey query bank/balances/${receiver_user_addr}
@@ -32,7 +32,7 @@ gnokey query bank/balances/g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm
 stdout 'data: "42ugnot"'
 
 # add the proposal
-gnokey maketx run -gas-fee 4400001ugnot -gas-wanted 44_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4400001ugnot -gas-wanted 44_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the proposal was created
@@ -41,11 +41,11 @@ stdout 'Reason: integration test payment'
 stdout 'Payment: 42ugnot to g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 29_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 29_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_treasury_tokens_update.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_treasury_tokens_update.txtar
@@ -17,14 +17,14 @@ gnoland start
 gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 
 # register the tokens and fund the treasury address
-gnokey maketx run -gas-fee 2000001ugnot -gas-wanted 20_000_000 -broadcast -chainid=tendermint_test member $WORK/tokens/register_tokens.gno
+gnokey maketx run -gas-fee 2000001ugnot -gas-wanted 20_000_000 -chainid=tendermint_test member $WORK/tokens/register_tokens.gno
 
 # verify no balances are found even though the treasury address got tokens
 gnokey query vm/qrender --data 'gno.land/r/gov/dao/v3/treasury:GRC20'
 stdout 'No balances found.'
 
 # add the tokens update proposal
-gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check the tokens update proposal was created
@@ -35,11 +35,11 @@ stdout '- gno.land/r/demo/defi/grc20factory.TOKEN2'
 stdout '- gno.land/r/demo/defi/grc20factory.TOKEN3'
 
 # vote on the tokens update proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call tokens update proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # verify the balances associated with the tokens update proposal

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_add_controller.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_add_controller.txtar
@@ -9,7 +9,7 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Initialize GovDAO members
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Render GovDAO to check it's working
@@ -17,11 +17,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # Try to register a new user as a non controller
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user1.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -chainid=tendermint_test test1 $WORK/run/register_user1.gno
 stderr 'panic: r/sys/users: current realm/user does not exist in whitelist'
 
 # Create proposal to add @test1 as controller
-gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
 stdout OK!
 
 # Check proposal exists
@@ -29,15 +29,15 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Add Whitelisted Caller to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Register a new user as a controller
-gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user1.gno
+gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/register_user1.gno
 stdout OK!
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_add_remove_controller.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_add_remove_controller.txtar
@@ -15,7 +15,7 @@ stdout 'g16dverxg6s6vzha89k22c3zusx6sug5ycjyjq2j'
 gnoland start
 
 # Initialize GovDAO members
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Render GovDAO to check it's working
@@ -23,7 +23,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # Create proposal to add @test1 as controller
-gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
 stdout OK!
 
 # Check proposal exists
@@ -31,23 +31,23 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Add Whitelisted Caller to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Register a new user as a controller (@test1)
-gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user1.gno
+gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/register_user1.gno
 stdout OK!
 
 # Try to register a new user as a non controller (@controller1)
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test controller1 $WORK/run/register_user2.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -chainid=tendermint_test controller1 $WORK/run/register_user2.gno
 stderr 'panic: r/sys/users: current realm/user does not exist in whitelist'
 
 # Create proposal to remove @test1 from controllers and add @controller1 as controller
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_controller_add_remove_proposal.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/create_controller_add_remove_proposal.gno
 stdout OK!
 
 # Check proposal exists
@@ -55,19 +55,19 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:1'
 stdout 'Add and Remove Whitelisted Callers From \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 
 # Try to register a new user as a non controller (@test1)
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user2.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -chainid=tendermint_test test1 $WORK/run/register_user2.gno
 stderr 'panic: r/sys/users: current realm/user does not exist in whitelist'
 
 # Register a new user as a controller (@controller1)
-gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test controller1 $WORK/run/register_user2.gno
+gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test controller1 $WORK/run/register_user2.gno
 stdout OK!
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_remove_controller.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_remove_controller.txtar
@@ -12,7 +12,7 @@ stdout 'g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp'
 gnoland start
 
 # Initialize GovDAO members
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Render GovDAO to check it's working
@@ -20,7 +20,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # Create proposal to add @test1 as controller
-gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1 $WORK/run/create_controller_add_proposal.gno
 stdout OK!
 
 # Check proposal exists
@@ -28,19 +28,19 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Add Whitelisted Caller to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Register a new user as a controller
-gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user1.gno
+gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/register_user1.gno
 stdout OK!
 
 # Create proposal to remove @test1 from controllers
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/create_controller_remove_proposal.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/create_controller_remove_proposal.gno
 stdout OK!
 
 # Check proposal exists
@@ -48,15 +48,15 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:1'
 stdout 'Remove Whitelisted Caller From \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 
 # Try to register a new user as a non controller
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/register_user2.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 95000000 -chainid=tendermint_test test1 $WORK/run/register_user2.gno
 stderr 'panic: r/sys/users: current realm/user does not exist in whitelist'
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_withdraw_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_withdraw_member.txtar
@@ -17,7 +17,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'data: # GovDAO'
 
 # add the proposal
-gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4100001ugnot -gas-wanted 41_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # call gov/dao render to check everything the proposal was created
@@ -25,15 +25,15 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This is a proposal to remove g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 from the GovDAO'
 
 # vote on the proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # vote on the proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test withdrawmember
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 20_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/governance_param_validation.txtar
+++ b/gno.land/pkg/integration/testdata/governance_param_validation.txtar
@@ -12,21 +12,21 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 ## Deploy a realm and verify it works
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/test/hello -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/test/hello -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 stdout 'hello world'
 
 ## Propose setting StoragePrice to an invalid value
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_invalid.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/propose_invalid.gno
 stdout OK!
 
-gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_yes.gno
+gnokey maketx run -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/vote_yes.gno
 stdout OK!
 
 ## Executing the proposal should fail because the value is invalid
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1 $WORK/run/execute_proposal.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1 $WORK/run/execute_proposal.gno
 stderr 'invalid param'
 
 ## StoragePrice should remain unchanged
@@ -34,7 +34,7 @@ gnokey query params/vm:p:storage_price
 stdout '100ugnot'
 
 ## VM operations should still work
-gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 stdout 'hello world'
 
 -- hello/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/grc20_invalid_address.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_invalid_address.txtar
@@ -4,10 +4,10 @@ loadpkg gno.land/r/demo/defi/foo20
 gnoland start
 
 # execute Faucet
-gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 # execute Transfer for invalid address
 # This is expected to fail at the transaction simulation stage.
-! gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Transfer -args g1ubwj0apf60hd90txhnh855fkac34rxlsvua0aa -args 1 -gas-fee 5000000ugnot -gas-wanted 50000000 -simulate only -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Transfer -args g1ubwj0apf60hd90txhnh855fkac34rxlsvua0aa -args 1 -gas-fee 5000000ugnot -gas-wanted 50000000 -simulate only -chainid=tendermint_test test1
 stderr '"gnokey" error: --= Error =--\nData: invalid address'

--- a/gno.land/pkg/integration/testdata/grc20_registry.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry.txtar
@@ -8,15 +8,15 @@ loadpkg gno.land/r/registry $WORK/registry
 gnoland start
 
 # we call Transfer with foo20, before it's registered
-gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout 'not found'
 
 # add foo20, and foo20wrapper
-gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/foo20 -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/foo20wrapper -pkgpath gno.land/r/foo20wrapper -gas-fee 590001ugnot -gas-wanted 5_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/foo20 -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo20wrapper -pkgpath gno.land/r/foo20wrapper -gas-fee 590001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
 
 # we call Transfer with foo20, after it's registered
-gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 260001ugnot -gas-wanted 2_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid=tendermint_test test1
 stdout 'same address, success!'
 
 -- registry/registry.gno --

--- a/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
@@ -8,10 +8,10 @@ loadpkg gno.land/r/grc20transfer $WORK
 gnoland start
 
 # run the faucet before transferring the balance
-gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
 
 # check the event after transferring the grc20 token
-gnokey maketx call -pkgpath gno.land/r/grc20transfer -func TransferBy -args 'gno.land/r/demo/defi/foo20' -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '1000000' -gas-fee 940001ugnot -gas-wanted 9_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/grc20transfer -func TransferBy -args 'gno.land/r/demo/defi/foo20' -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '1000000' -gas-fee 940001ugnot -gas-wanted 9_400_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: [0-9]+'
 stdout 'GAS USED:   [0-9]+'

--- a/gno.land/pkg/integration/testdata/grc721_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc721_emit.txtar
@@ -5,23 +5,23 @@ loadpkg gno.land/r/foo721 $WORK/foo721
 gnoland start
 
 # Mint
-gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 920001ugnot -gas-wanted 9_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 920001ugnot -gas-wanted 9_200_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Mint\",\"attrs\":\[{\"key\":\"slug\",\"value\":\"FNFT\"},{\"key\":\"to\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # Approve
-gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 890001ugnot -gas-wanted 8_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 890001ugnot -gas-wanted 8_900_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Approval\",\"attrs\":\[{\"key\":\"slug\",\"value\":\"FNFT\"},{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # SetApprovalForAll
-gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 880001ugnot -gas-wanted 8_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 880001ugnot -gas-wanted 8_800_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"ApprovalForAll\",\"attrs\":\[{\"key\":\"slug\",\"value\":\"FNFT\"},{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"approved\",\"value\":\"false\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # TransferFrom
-gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 990001ugnot -gas-wanted 9_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 990001ugnot -gas-wanted 9_900_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"slug\",\"value\":\"FNFT\"},{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # Burn
-gnokey maketx call -pkgpath gno.land/r/foo721 -func Burn -args 1  -gas-fee 1000001ugnot -gas-wanted 10_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Burn -args 1  -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Burn\",\"attrs\":\[{\"key\":\"slug\",\"value\":\"FNFT\"},{\"key\":\"from\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 

--- a/gno.land/pkg/integration/testdata/improved_coins.txtar
+++ b/gno.land/pkg/integration/testdata/improved_coins.txtar
@@ -2,32 +2,32 @@ loadpkg gno.land/r/demo/coins $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "MakeNewCoins" -gas-fee 210001ugnot -gas-wanted 2_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "MakeNewCoins" -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
 stdout '(300 int64)'
 stdout '(321 int64)'
 stdout '("ugnot" string)'
 stdout '("example" string)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "AddCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "AddCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout '(300 int64)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "SubCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "SubCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout '(123 int64)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "StringZeroCoin" -gas-fee 210001ugnot -gas-wanted 2_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "StringZeroCoin" -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
 stdout '("0ugnot" string)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsZero" -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsZero" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
 stdout '(true bool)'
 stdout '(false bool)'
 stdout '(false bool)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsPositive" -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsPositive" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
 stdout '(false bool)'
 stdout '(false bool)'
 stdout '(true bool)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsNegative" -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsNegative" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
 stdout '(true bool)'
 stdout '(false bool)'
 stdout '(false bool)'

--- a/gno.land/pkg/integration/testdata/infinite_loop.txtar
+++ b/gno.land/pkg/integration/testdata/infinite_loop.txtar
@@ -6,27 +6,27 @@
 gnoland start
 
 # addpkg + -simulate skip
-! gnokey maketx addpkg -pkgdir $WORK/r1 -pkgpath gno.land/r/demo/r1 -simulate skip -gas-fee 10000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/r1 -pkgpath gno.land/r/demo/r1 -simulate skip -gas-fee 10000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1
 ! stdout OK!
 stderr 'out of gas.* location: CPUCycles'
 
 # addpkg + -simulate only
-! gnokey maketx addpkg -pkgdir $WORK/r1 -pkgpath gno.land/r/demo/r1 -simulate only -gas-fee 10000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/r1 -pkgpath gno.land/r/demo/r1 -simulate only -gas-fee 10000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1
 ! stdout OK!
 stderr 'out of gas.* location: CPUCycles'
 
 # run + -simulate skip
-! gnokey maketx run -simulate skip -gas-fee 10000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run.gno
+! gnokey maketx run -simulate skip -gas-fee 10000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run.gno
 ! stdout OK!
 stderr 'out of gas.* location: CPUCycles'
 
 # run + -simulate only
-! gnokey maketx run -simulate only -gas-fee 10000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run.gno
+! gnokey maketx run -simulate only -gas-fee 10000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run.gno
 ! stdout OK!
 stderr 'out of gas.* location: CPUCycles'
 
 # maketx addpkg on r2 (successful)
-gnokey maketx addpkg -pkgdir $WORK/r2 -pkgpath gno.land/r/demo/r2 -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/r2 -pkgpath gno.land/r/demo/r2 -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 stdout OK!
 
 # qeval on the render function

--- a/gno.land/pkg/integration/testdata/interrealm_final.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_final.txtar
@@ -16,61 +16,61 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/bob -pkgpath gno.land/r/test/bob -gas-fee 570001ugnot -gas-wanted 5_700_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/alice -pkgpath gno.land/r/test/alice -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/peter -pkgpath gno.land/p/test/peter -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 730001ugnot -gas-wanted 7_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bob -pkgpath gno.land/r/test/bob -gas-fee 570001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/alice -pkgpath gno.land/r/test/alice -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/peter -pkgpath gno.land/p/test/peter -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 730001ugnot -gas-wanted 7_300_000 -chainid=tendermint_test test1
 
 ## test CASE_rA1
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA1 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rA2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rA3
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rB1
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB1 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rB2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rB3
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rB4
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB4 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB4 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rC1
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC1 -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC1 -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rC2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rC3
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC3 -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC3 -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rC4
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC4 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC4 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rC5
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rC5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_rD1
-! gnokey maketx addpkg -pkgdir $WORK/callerrealm_rd1 -pkgpath gno.land/r/test/callerrealm_rd1 -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/callerrealm_rd1 -pkgpath gno.land/r/test/callerrealm_rd1 -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 stderr 'cannot directly mutate gno.land/r/test/bob.AllowedList from gno.land/r/test/callerrealm_rd1'
 
 ## query
@@ -78,50 +78,50 @@ stderr 'cannot directly mutate gno.land/r/test/bob.AllowedList from gno.land/r/t
 # stdout 'AllowedList = \[1, 2, 3\]'
 
 ## test CASE_pA1
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA1 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pA2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pA3 -- omitted (illegal crossing function)
-# ! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+# ! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pA3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 
 ## test CASE_pB1
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB1 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pB2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pB3
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB3 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pB4
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB4 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB4 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pC1
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC1 -gas-fee 340001ugnot -gas-wanted 3_400_000 -broadcast -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC1 -gas-fee 340001ugnot -gas-wanted 3_400_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_pC2
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pC3
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC3 -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC3 -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_pC4
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC4 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC4 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 ## test CASE_pC5
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test runner
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
 stderr 'cannot directly modify readonly tainted object'
 
 

--- a/gno.land/pkg/integration/testdata/interrealm_final_omarsy.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_final_omarsy.txtar
@@ -3,10 +3,10 @@ loadpkg gno.land/p/demo/peter $WORK/peter
 loadpkg gno.land/r/demo/main $WORK/main
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/main -func ExecGood -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/main -func ExecGood -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
-! gnokey maketx call -pkgpath gno.land/r/demo/main -func ExecBad -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/demo/main -func ExecBad -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'cannot directly modify readonly tainted object'
 
 -- alice/alice.gno --

--- a/gno.land/pkg/integration/testdata/interrealm_mix_call.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_mix_call.txtar
@@ -6,9 +6,9 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 6_200_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 700001ugnot -gas-wanted 7_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 6_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 700001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 
 ## validate initial state
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
@@ -17,44 +17,44 @@ gnokey query "vm/qrender" --data "gno.land/r/test/callerrealm:"
 stdout 'obj\.value = 0'
 
 ## execute NonCrossingMutation
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingMutation -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test2
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingMutation -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test2
 stderr 'cannot directly modify readonly tainted object'
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 0'
 
 ## execute CrossingMutation
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CrossingMutation -gas-fee 300001ugnot -gas-wanted 3_000_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CrossingMutation -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 1'
 
 ## execute NonCrossingObjectMutation
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingObjectMutation -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingObjectMutation -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 1, value = 1'
 
 ## execute ObjectMutationRootedAtCaller
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func ObjectMutationRootedAtCaller -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func ObjectMutationRootedAtCaller -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/callerrealm:"
 stdout 'obj\.value = 1'
 
 ## execute CallMutateObject
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CallMutateObject -gas-fee 310001ugnot -gas-wanted 3_100_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CallMutateObject -gas-fee 310001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 2, value = 1'
 
 ## execute InspectRealmsCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test2
 
 ## execute InspectRealmsNonCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsNonCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsNonCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test2
 
 ## execute MutateObjectWithBorrowCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateObjectWithBorrowCrossing -gas-fee 310001ugnot -gas-wanted 3_100_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateObjectWithBorrowCrossing -gas-fee 310001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 3, value = 1'
 
 ## execute MutateCrossingObjectRootedAtCaller
-! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateCrossingObjectRootedAtCaller -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test2
+! gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateCrossingObjectRootedAtCaller -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test2
 stderr 'cannot directly modify readonly tainted object'
 gnokey query "vm/qrender" --data "gno.land/r/test/callerrealm:"
 stdout 'obj\.value = 1'

--- a/gno.land/pkg/integration/testdata/interrealm_mix_run.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_mix_run.txtar
@@ -7,55 +7,55 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 6_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 6_200_000 -chainid=tendermint_test test1
 
 ## validate initial state
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 0'
 
 ## run non_crossing_mutation
-! gnokey maketx run runner $WORK/run/non_crossing_mutation.gno -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test
+! gnokey maketx run runner $WORK/run/non_crossing_mutation.gno -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test
 stderr 'cannot directly modify readonly tainted object'
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 0'
 
 ## run crossing_mutation
-gnokey maketx run runner $WORK/run/crossing_mutation.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/crossing_mutation.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 1'
 
 ## run borrowed_object_mutation
-gnokey maketx run runner $WORK/run/borrowed_object_mutation.gno -gas-fee 380001ugnot -gas-wanted 3_800_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/borrowed_object_mutation.gno -gas-fee 380001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 1, value = 1'
 
 ## run object_mutation_rooted_at_caller
-gnokey maketx run runner $WORK/run/object_mutation_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/object_mutation_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
 
 ## run call_mutate_object
-gnokey maketx run runner $WORK/run/call_mutate_object.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/call_mutate_object.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 2, value = 1'
 
 ## run inspect_realms_crossing
-gnokey maketx run runner $WORK/run/inspect_realms_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/inspect_realms_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
 
 ## run inspect_realms_non_crossing
-gnokey maketx run runner $WORK/run/inspect_realms_non_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/inspect_realms_non_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
 
 ## run mutate_object_with_borrow_crossing
-gnokey maketx run runner $WORK/run/mutate_object_with_borrow_crossing.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_object_with_borrow_crossing.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 3, value = 1'
 
 ## run mutate_crossing_object
-gnokey maketx run runner $WORK/run/mutate_crossing_object.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_crossing_object.gno -gas-fee 340001ugnot -gas-wanted 3_400_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 4, value = 1'
 
 ## run mutate_crossing_object_rooted_at_caller
-gnokey maketx run runner $WORK/run/mutate_crossing_object_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_crossing_object_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
 
 -- run/non_crossing_mutation.gno --
 package main

--- a/gno.land/pkg/integration/testdata/issue_1167.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1167.txtar
@@ -4,25 +4,25 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # add contract
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 700001ugnot -gas-wanted 7_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 700001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # execute New
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func New -args X -gas-fee 500001ugnot -gas-wanted 5_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func New -args X -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # execute Delta for the first time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 560001ugnot -gas-wanted 5_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 560001ugnot -gas-wanted 5_600_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '"1,1,1;'
 
 # execute Delta for the second time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '1,1,1;2,2,2;'
 
 # execute Delta for the third time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 590001ugnot -gas-wanted 5_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 590001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '1,1,1;2,2,2;3,3,3;'
 

--- a/gno.land/pkg/integration/testdata/issue_1588.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1588.txtar
@@ -3,13 +3,13 @@
 gnoland start
 
 # add contract
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func DefineFamily -gas-fee 300001ugnot -gas-wanted 3_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func DefineFamily -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func GetOutcastChildAge -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func GetOutcastChildAge -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '(10 int)'
 

--- a/gno.land/pkg/integration/testdata/issue_1786.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1786.txtar
@@ -7,7 +7,7 @@ loadpkg gno.land/r/gnoland/wugnot
 gnoland start
 
 # user deposits directly into wugnot (origin call)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot --send "10000ugnot" -func Deposit -gas-fee 900001ugnot -gas-wanted 9_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot --send "10000ugnot" -func Deposit -gas-fee 900001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check user's wugnot balance
@@ -15,7 +15,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"g1jg8mtutu9k
 stdout '10000 int64'
 
 # user withdraws 500 wugnot directly (origin call)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 500 -gas-fee 980001ugnot -gas-wanted 9_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 500 -gas-fee 980001ugnot -gas-wanted 9_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check user's wugnot balance after withdraw

--- a/gno.land/pkg/integration/testdata/issue_2283.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2283.txtar
@@ -17,7 +17,7 @@ gnoland start
 
 ! gnokey broadcast $WORK/add_feeds.tx
 
-gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 380001ugnot -gas-wanted 3_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 380001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- imports/imports.gno --

--- a/gno.land/pkg/integration/testdata/issue_2283_cacheTypes.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2283_cacheTypes.txtar
@@ -19,7 +19,7 @@ gnoland start
 
 ! gnokey broadcast $WORK/add_feeds.tx
 
-gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- add_feeds.tx --

--- a/gno.land/pkg/integration/testdata/issue_2763.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2763.txtar
@@ -3,7 +3,7 @@ gnoland start
 # add contract
 # Note: previously "addpkg does not add *_test.gno files, so it works as expected without causing any redeclaration issues."
 # addpkg now add `_test.gno` files so redeclarations is not allowed aymore
-! gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/demo/foo -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/demo/foo -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'add2 redeclared in this block'
 
 -- foo/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/issue_4983.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4983.txtar
@@ -1,14 +1,14 @@
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -broadcast -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
 
-gnokey maketx call -pkgpath gno.land/r/foo -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -chainid=tendermint_test test1
 stdout 'GAS USED: +\d+'
 
 gnoland restart
 
-gnokey maketx call -pkgpath gno.land/r/bar -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/bar -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -chainid=tendermint_test test1
 stdout 'GAS USED: +\d+'
 
 

--- a/gno.land/pkg/integration/testdata/issue_gnochess_97.txtar
+++ b/gno.land/pkg/integration/testdata/issue_gnochess_97.txtar
@@ -4,13 +4,13 @@ loadpkg gno.land/r/demo/bug97 $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 290001ugnot -gas-wanted 2_900_000 -send '' -broadcast -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 290001ugnot -gas-wanted 2_900_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall2' -gas-fee 230001ugnot -gas-wanted 2_300_000 -send '' -broadcast -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall2' -gas-fee 230001ugnot -gas-wanted 2_300_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 250001ugnot -gas-wanted 2_500_000 -send '' -broadcast -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 250001ugnot -gas-wanted 2_500_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
 -- bug97.gno --

--- a/gno.land/pkg/integration/testdata/loadpkg_example.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_example.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/p/nt/ufmt/v0
 ## start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/importtest -gas-fee 520001ugnot -gas-wanted 5_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/importtest -gas-fee 520001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
 stdout OK!
 
 ## execute Render

--- a/gno.land/pkg/integration/testdata/loadpkg_work.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_work.txtar
@@ -5,7 +5,7 @@ loadpkg gno.land/r/foobar/bar $WORK/bar
 gnoland start
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -broadcast -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'

--- a/gno.land/pkg/integration/testdata/maketx_call_array_len.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_call_array_len.txtar
@@ -6,15 +6,15 @@ loadpkg gno.land/r/test/arrlen $WORK/realm
 gnoland start
 
 # Correct length (32 bytes) should succeed.
-gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout '("32" string)'
 
 # Oversized input (100 bytes) must be rejected.
-! gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiYw==' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiYw==' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'array length mismatch'
 
 # Empty input (0 bytes) must be rejected.
-! gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args '' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args '' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'array length mismatch'
 
 -- realm/realm.gno --

--- a/gno.land/pkg/integration/testdata/maketx_call_pure.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_call_pure.txtar
@@ -10,19 +10,19 @@ gnokey query vm/qeval --data 'gno.land/p/foo/call_pure.Hello()'
 stdout 'notok'
 
 # 2. call to pure package ERROR
-! gnokey maketx call -pkgpath gno.land/p/foo/call_pure -func Hello -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/p/foo/call_pure -func Hello -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr '"gnokey" error: --= Error =--\nData: invalid package path'
 
 # 3. call to stdlibs ERROR
-! gnokey maketx call -pkgpath strconv -func Itoa -args 11 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath strconv -func Itoa -args 11 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr '"gnokey" error: --= Error =--\nData: invalid package path'
 
 # 4. normal call to realm ERROR (need crossing)
-! gnokey maketx call -pkgpath gno.land/r/foo/call_realm -func Render2 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo/call_realm -func Render2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'function Render2 is non-crossing and cannot be called with MsgCall; query with vm/qeval or use MsgRun'
 
 # 5. normal call to realm ERROR (need crossing)
-! gnokey maketx call -pkgpath gno.land/r/foo/call_realm -func Render -args "" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo/call_realm -func Render -args "" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'function Render is non-crossing and cannot be called with MsgCall; query with vm/qeval or use MsgRun'
 # XXX: While the error is correct, the correct message should be something like the message below:
 # stderr 'cannot cross-call a non-crossing function gno.land/r/foo/call_realm.Render from <no realm>'

--- a/gno.land/pkg/integration/testdata/maketx_call_send.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_call_send.txtar
@@ -15,7 +15,7 @@ gnokey query auth/accounts/g1x4ykzcqksj2hc5qpvr8kd9zaffkd82rvmzqup7
 stdout 'data: null'
 
 # call to realm with -send
-gnokey maketx call -send 42ugnot -pkgpath gno.land/r/foo/call_realm -func GimmeMoney -gas-fee 240001ugnot -gas-wanted 2_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -send 42ugnot -pkgpath gno.land/r/foo/call_realm -func GimmeMoney -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
 stdout '("send: 42ugnot")'
 
 ## user balance after realm send

--- a/gno.land/pkg/integration/testdata/maketx_run.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_run.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/foobar/bar $WORK/bar
 gnoland start
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -broadcast -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'

--- a/gno.land/pkg/integration/testdata/maketx_run_send.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_run_send.txtar
@@ -6,7 +6,7 @@ gnokey query auth/accounts/$test1_user_addr
 stdout '"coins": "10000000000000ugnot"'
 
 ## run script/script.gno with send flag
-gnokey maketx run -send 42ugnot -gas-fee 170001ugnot -gas-wanted 1_700_000 -broadcast -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -send 42ugnot -gas-fee 170001ugnot -gas-wanted 1_700_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 stdout 'send: 42ugnot'
 
 ## user balance after realm send

--- a/gno.land/pkg/integration/testdata/map_delete.txtar
+++ b/gno.land/pkg/integration/testdata/map_delete.txtar
@@ -3,7 +3,7 @@ loadpkg gno.land/r/demo/mapdelete $WORK
 gnoland start
 
 # delete map
-gnokey maketx call -pkgpath gno.land/r/demo/mapdelete -func DeleteMap -args 3 -gas-fee 240001ugnot -gas-wanted 2_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/mapdelete -func DeleteMap -args 3 -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check deletion

--- a/gno.land/pkg/integration/testdata/moul_authz.txtar
+++ b/gno.land/pkg/integration/testdata/moul_authz.txtar
@@ -7,11 +7,11 @@ stdout 'g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0'
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/testing/resource -func Edit -args edited -gas-fee 740001ugnot -gas-wanted 7_400_000 -broadcast -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/resource -func Edit -args edited -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid tendermint_test alice
 
-gnokey maketx call -pkgpath gno.land/r/testing/admin -func ExecuteAction -args 0 -gas-fee 760001ugnot -gas-wanted 7_600_000 -broadcast -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/admin -func ExecuteAction -args 0 -gas-fee 760001ugnot -gas-wanted 7_600_000 -chainid tendermint_test alice
 
-gnokey maketx call -pkgpath gno.land/r/testing/resource -func Value -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/resource -func Value -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test alice
 stdout 'edited'
 
 

--- a/gno.land/pkg/integration/testdata/object_pointer.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer.txtar
@@ -5,17 +5,17 @@ loadpkg gno.land/r/testing/bug_caller $WORK/bug_caller
 gnoland start
 
 # 1. (Working) Init the object, Set a value and Get the value
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func WorkingNew -gas-fee 290001ugnot -gas-wanted 2_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func WorkingNew -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 290001ugnot -gas-wanted 2_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected
 
 # 2. (Also working)
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func BuggedNew -gas-fee 430001ugnot -gas-wanted 4_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func BuggedNew -gas-fee 430001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 320001ugnot -gas-wanted 3_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected

--- a/gno.land/pkg/integration/testdata/object_pointer_2.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer_2.txtar
@@ -3,9 +3,9 @@ loadpkg gno.land/r/testing/ext_realm $WORK/ext_realm
 loadpkg gno.land/r/testing/caller_realm $WORK/caller_realm
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func SaveObject -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func SaveObject -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func Mutate -args "hello" -gas-fee 300001ugnot -gas-wanted 3_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func Mutate -args "hello" -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout 'OK!'
 stdout '("reply from ext realm" string)'
 

--- a/gno.land/pkg/integration/testdata/object_pointer_pure.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer_pure.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/testing/realm_caller $WORK/realm_caller
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/testing/realm_caller -func Set -args 42 -gas-fee 230001ugnot -gas-wanted 2_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/realm_caller -func Set -args 42 -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid=tendermint_test test1
 stdout 'OK'
 
 gnokey query vm/qeval --data "gno.land/r/testing/realm_caller.Get()"

--- a/gno.land/pkg/integration/testdata/params.txtar
+++ b/gno.land/pkg/integration/testdata/params.txtar
@@ -13,7 +13,7 @@ gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: $'
 
 # add params to gno.land/r/myrealm
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 380001ugnot -gas-wanted 3_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 380001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 
 # query after adding the package, but before setting values
 gnokey query params/vm:gno.land/r/myrealm:foo
@@ -24,47 +24,47 @@ gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: $'
 
 ## set foo (string)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo1 -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo1 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:foo
 stdout 'data: "foo1"'
 
 # override foo
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo2 -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo2 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:foo
 stdout 'data: "foo2"'
 
 
 # set bar (bool)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args true -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args true -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bar
 stdout 'data: true'
 
 # override bar
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args false -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args false -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bar
 stdout 'data: false'
 
 
 # set baz (int64)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args 1337 -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args 1337 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: "1337"'
 
 # override baz
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args -31337 -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args -31337 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: "-31337"'
 
 # It is impossible to call std.SetParamXXX with a param key in the <prefix>:<key> format (e.g. "bank:p:lockTransfer") because it is an invalid key.
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetLockTransfer -args ugnot -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetLockTransfer -args ugnot -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 stderr 'Data: invalid param key: bank:p:lockTransfer'
 
 # <prefix>.<key> is invalid (e.g., "bank.lockTransfer")
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetInvalidString -args ugnot -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetInvalidString -args ugnot -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1
 stderr 'Data: invalid param key: bank:p:lockTransfer'
 
 # <key_name>.<type> (e.g., "bank_lockTransfer") is a valid name.
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetValidString -args ugnot -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetValidString -args ugnot -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bank_lockTransfer
 stdout 'data: "ugnot"'
 

--- a/gno.land/pkg/integration/testdata/params_sysparams1.txtar
+++ b/gno.land/pkg/integration/testdata/params_sysparams1.txtar
@@ -4,14 +4,14 @@ gnoland start
 
 # Test sys/params.SetSysParamXXX when called from gno.land/r/sys/params
 
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 
 ## before set lock transfer
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \[\]\n'
 
 ## lock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 
 ## query bank module
 gnokey query params/bank:p:restricted_denoms

--- a/gno.land/pkg/integration/testdata/params_sysparams2.txtar
+++ b/gno.land/pkg/integration/testdata/params_sysparams2.txtar
@@ -4,24 +4,24 @@ gnoland start
 
 # ---- 1 Test sys/params.SetSysParamXXX when called from gno.land/r/sys/params
 
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 390001ugnot -gas-wanted 3_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 390001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 
 ## lock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \["ugnot"\]'
 
 # unlock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func UnlockTransfer -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func UnlockTransfer -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \[\]'
 
 # set non-existing module param
-! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetBankArbitrary -args "foo" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetBankArbitrary -args "foo" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'unknown bank param key: "p:newkey"'
 
 # set invalid key
-! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetInvalidKey -args "ugnot" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetInvalidKey -args "ugnot" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'invalid param name: bank:restricted_denoms'
 
 gnokey query params/bank:p:restricted_denoms
@@ -31,41 +31,41 @@ gnokey query params/bank:restricted_denoms
 stdout 'data: \n'
 
 # set wrong type for restricted_denoms
-! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetRestrictedDenomsWrongType -args "ugnot" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/sys/params -func SetRestrictedDenomsWrongType -args "ugnot" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'invalid type for restricted_denoms param: expected \[\]string, got string'
 
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \[\]' # still the same, value was not written.
 
 # ---- 2 Test sys/params.SetSysParamXXX when called outside of gno.land/r/sys/params
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 390001ugnot -gas-wanted 3_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 390001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 
 ## can not call SetSysParamXXX out side of gno.land/r/params
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamString -args "foo" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamString -args "foo" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: "sys/params" can only be used from "gno.land/r/sys/params"' # XXX can only be *imported* from... enforce import rule
 
 gnokey query params/bank:p:foo
 stdout 'data: \n'
 
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamBool -args true -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamBool -args true -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: "sys/params" can only be used from "gno.land/r/sys/params"' # XXX can only be *imported* from... enforce import rule
 
 gnokey query params/bank:p:bar
 stdout 'data: \n'
 
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamInt64 -args -100 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamInt64 -args -100 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: "sys/params" can only be used from "gno.land/r/sys/params"' # XXX can only be *imported* from... enforce import rule
 
 gnokey query params/bank:p:baz
 stdout 'data: \n'
 
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamUint64 -args 100 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamUint64 -args 100 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: "sys/params" can only be used from "gno.land/r/sys/params"' # XXX can only be *imported* from... enforce import rule
 
 gnokey query params/bank:p:baz
 stdout 'data: \n'
 
-! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamBytes -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/myrealm -func SetSysParamBytes -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'Data: "sys/params" can only be used from "gno.land/r/sys/params"' # XXX can only be *imported* from... enforce import rule
 
 gnokey query params/bank:p:baz

--- a/gno.land/pkg/integration/testdata/params_valset_auth.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_auth.txtar
@@ -16,7 +16,7 @@ stdout 'data:'
 
 # Exploit attempt: any user calls SetValsetProposal directly via MsgRun.
 # Must fail with the auth panic; tx should be rejected.
-! gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 95000000 -broadcast -chainid=tendermint_test test1 $WORK/run/exploit.gno
+! gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 95000000 -chainid=tendermint_test test1 $WORK/run/exploit.gno
 stderr 'unauthorized: only gno.land/r/sys/validators/v3 may write valset params'
 
 # Confirm the attacker's pubkey did NOT reach valset:current.

--- a/gno.land/pkg/integration/testdata/params_valset_govdao_bypass.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_govdao_bypass.txtar
@@ -33,21 +33,21 @@ gnokey query params/node:valset:current
 stdout 'gpub1'
 
 # 1) Strings factory targeting node:valset:proposed — must panic.
-! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/bypass_strings.gno
+! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/bypass_strings.gno
 stderr 'node:valset:\* is reserved for r/sys/validators/v3'
 
 # 2) Bytes factory targeting node:valset:proposed — must panic.
-! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/bypass_bytes.gno
+! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/bypass_bytes.gno
 stderr 'node:valset:\* is reserved for r/sys/validators/v3'
 
 # 3) Bool factory targeting node:valset:dirty — must panic.
-! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/bypass_bool.gno
+! gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/bypass_bool.gno
 stderr 'node:valset:\* is reserved for r/sys/validators/v3'
 
 # 4) Positive control: a legitimate non-valset write through the same
 # factory family must still succeed. (Construction; we don't execute
 # the proposal — just prove proposal-creation doesn't panic.)
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/legit_nonvalset.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/legit_nonvalset.gno
 stdout OK!
 
 # Post-state: valset:current and valset:dirty unchanged. The

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
@@ -44,7 +44,7 @@ stdout 'gpub1'
 
 # Submit a v3 proposal to add a new validator (deterministic ed25519
 # pubkey from seed "e2e-valset-test-validator-seed-v1").
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # Sanity: proposal is in gov/dao at id 0. The proposal text shows
@@ -53,14 +53,14 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'g1rz5cpd8kcm0x36us8fccsq5wsf3kdgpzdwfkk9: add'
 
 # Vote YES.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # Execute. v3 callback runs -> SetValsetProposal writes proposed +
 # dirty=true. The execute tx itself is a block; EndBlocker at the
 # end of THAT block reads dirty=true, computes diff, writes
 # valset:current = proposed, emits ValidatorUpdates.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Post-EndBlocker state: valset:current must now contain BOTH the
@@ -83,7 +83,7 @@ stdout 'false'
 # self-transfer. If the chain stalled at H+2 because the new
 # validator can't sign, this maketx would time out. A successful
 # OK! proves consensus made progress through the transition.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -broadcast -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- proposer/create_proposal.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
@@ -29,13 +29,13 @@ gnoland start
 
 # === PROPOSAL 0: ADD VALIDATOR AT POWER 1 ===
 
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/add_proposal.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Post-add: pubkey at power 1.
@@ -44,13 +44,13 @@ stdout 'gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aad
 
 # === PROPOSAL 1: UPDATE POWER 1 → 3 ===
 
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/update_proposal.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/update_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -chainid=tendermint_test member
 stdout OK!
 
 # Post-update: pubkey at power 3, NOT at power 1.
@@ -63,7 +63,7 @@ stdout 'false'
 
 # Liveness check past H+2 — chain made progress through the
 # power-update transition.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -broadcast -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- run/add_proposal.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
@@ -26,13 +26,13 @@ gnoland start
 
 # === PROPOSAL 0: ADD VALIDATOR ===
 
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/add_proposal.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Post-add: valset:current contains both genesis + new validator.
@@ -42,13 +42,13 @@ stdout '","gpub1'
 
 # === PROPOSAL 1: REMOVE THE SAME VALIDATOR ===
 
-gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/remove_proposal.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/remove_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -chainid=tendermint_test member
 stdout OK!
 
 # Post-remove: the e2e-test-validator pubkey must be GONE from
@@ -66,7 +66,7 @@ stdout 'false'
 
 # Liveness check past H+2 — chain made progress through both the
 # add and the remove validator-set transitions.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -broadcast -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- run/add_proposal.gno --

--- a/gno.land/pkg/integration/testdata/prevrealm.txtar
+++ b/gno.land/pkg/integration/testdata/prevrealm.txtar
@@ -34,62 +34,62 @@ env RFOO_USER_ADDR=g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469
 
 # Test cases
 ## 1. MsgCall -> myrlm.A: user address
-gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
 stdout ${test1_user_addr}
 
 ## 2. MsgCall -> myrealm.B -> myrlm.A: user address
-gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test test1
 stdout ${test1_user_addr}
 
 ## 3. MsgCall -> r/foo.A -> myrlm.A: r/foo
-gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1
 stdout ${RFOO_USER_ADDR}
 
 ## 4. MsgCall -> r/foo.B -> myrlm.B -> r/foo.A: r/foo
-gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 230001ugnot -gas-wanted 2_300_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1
 stdout ${RFOO_USER_ADDR}
 
 ## remove due to update to maketx call can only call realm (case 5, 6, 13)
 ## 5. MsgCall -> p/demo/bar.A: user address
-## gnokey maketx call -pkgpath gno.land/p/demo/bar -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## gnokey maketx call -pkgpath gno.land/p/demo/bar -func A -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stdout ${test1_user_addr}
 
 ## 6. MsgCall -> p/demo/bar.B: user address
-## gnokey maketx call -pkgpath gno.land/p/demo/bar -func B -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## gnokey maketx call -pkgpath gno.land/p/demo/bar -func B -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stdout ${test1_user_addr}
 
 ## 7. MsgRun -> myrlm.A: user address
-gnokey maketx run -gas-fee 160001ugnot -gas-wanted 1_600_000 -broadcast -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
+gnokey maketx run -gas-fee 160001ugnot -gas-wanted 1_600_000 -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
 stdout ${test1_user_addr}
 
 ## 8. MsgRun -> myrealm.B -> myrlm.A: user address
-gnokey maketx run -gas-fee 170001ugnot -gas-wanted 1_700_000 -broadcast -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
+gnokey maketx run -gas-fee 170001ugnot -gas-wanted 1_700_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
 stdout ${test1_user_addr}
 
 ## 9. MsgRun -> r/foo.A -> myrlm.A: r/foo
-gnokey maketx run -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid tendermint_test test1 $WORK/run/foo-a.gno
+gnokey maketx run -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1 $WORK/run/foo-a.gno
 stdout ${RFOO_USER_ADDR}
 
 ## 10. MsgRun -> r/foo.B -> myrlm.B -> r/foo.A: r/foo
-gnokey maketx run -gas-fee 230001ugnot -gas-wanted 2_300_000 -broadcast -chainid tendermint_test test1 $WORK/run/foo-b.gno
+gnokey maketx run -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
 stdout ${RFOO_USER_ADDR}
 
 ## 11. MsgRun -> p/demo/bar.A -> myrlm.A: user address
 ## XXX: crossing call only allowed in realm packages, doesn't work - not possible
-# ! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/bar-a.gno
+# ! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/bar-a.gno
 # stderr 'crossing'
 
 ## 12. MsgRun -> p/demo/bar.B -> myrlm.B -> r/foo.A: user address
 ## XXX: crossing call only allowed in realm packages, doesn't work - not possible
-# ! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1 $WORK/run/bar-b.gno
+# ! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1 $WORK/run/bar-b.gno
 # stderr 'crossing'
 
 ## 13. MsgCall -> std.PreviousRealm(): user address
-## gnokey maketx call -pkgpath std -func PreviousRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid tendermint_test test1
+## gnokey maketx call -pkgpath std -func PreviousRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid tendermint_test test1
 ## stdout ${test1_user_addr}
 
 ## 14. MsgRun -> std.PreviousRealm(): user address
-gnokey maketx run -gas-fee 100001ugnot -gas-wanted 1_000_000 -broadcast -chainid tendermint_test test1 $WORK/run/baz.gno
+gnokey maketx run -gas-fee 100001ugnot -gas-wanted 1_000_000 -chainid tendermint_test test1 $WORK/run/baz.gno
 stdout ${test1_user_addr}
 
 -- r/myrlm/myrlm.gno --

--- a/gno.land/pkg/integration/testdata/ptr_mapkey.txtar
+++ b/gno.land/pkg/integration/testdata/ptr_mapkey.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/demo/ptrmap $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/ptrmap -func AddToMap -args 5 -gas-fee 280001ugnot -gas-wanted 2_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ptrmap -func AddToMap -args 5 -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/demo/ptrmap.GetFromMap()"

--- a/gno.land/pkg/integration/testdata/realm_banker_issued_coin_denom.txtar
+++ b/gno.land/pkg/integration/testdata/realm_banker_issued_coin_denom.txtar
@@ -7,40 +7,40 @@ adduser test2
 gnoland start
 
 ## add realm_banker
-gnokey maketx addpkg -pkgdir $WORK/short -pkgpath gno.land/r/test/realm_banker -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/short -pkgpath gno.land/r/test/realm_banker -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 
 ## add realm_banker with long package_name
-gnokey maketx addpkg -pkgdir $WORK/long -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/long -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
 
 ## add invalid realm_denom
-gnokey maketx addpkg -pkgdir $WORK/invalid_realm_denom -pkgpath gno.land/r/test/invalid_realm_denom -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/invalid_realm_denom -pkgpath gno.land/r/test/invalid_realm_denom -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 
 ## test2 spend all balance
-gnokey maketx send -send "995000000ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx send -send "995000000ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test2
 
 ## check test2 balance
 gnokey query bank/balances/${test2_user_addr}
 stdout ''
 
 ## mint coin from banker
-gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args ${test2_user_addr} -args "ugnot" -args "31337" -gas-fee 280001ugnot -gas-wanted 2_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args ${test2_user_addr} -args "ugnot" -args "31337" -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 
 ## check balance after minting, without patching banker will return '31337ugnot'
 gnokey query bank/balances/${test2_user_addr}
 stdout '31337/gno.land/r/test/realm_banker:ugnot'
 
 ## burn coin
-gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args ${test2_user_addr} -args "ugnot" -args "7" -gas-fee 280001ugnot -gas-wanted 2_800_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args ${test2_user_addr} -args "ugnot" -args "7" -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 
 ## check balance after burning
 gnokey query bank/balances/${test2_user_addr}
 stdout '31330/gno.land/r/test/realm_banker:ugnot'
 
 ## transfer 5000000ugnot to test2 for gas-fee of below tx
-gnokey maketx send -send "5000000ugnot" -to ${test2_user_addr} -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx send -send "5000000ugnot" -to ${test2_user_addr} -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
 
 ## transfer coin
-gnokey maketx send -send "1330/gno.land/r/test/realm_banker:ugnot" -to g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0 -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test test2
+gnokey maketx send -send "1330/gno.land/r/test/realm_banker:ugnot" -to g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test2
 
 ## check sender balance
 gnokey query bank/balances/${test2_user_addr}
@@ -51,24 +51,24 @@ gnokey query bank/balances/g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0
 stdout '1330/gno.land/r/test/realm_banker:ugnot'
 
 ## mint coin from long named package with banker
-gnokey maketx call -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 320001ugnot -gas-wanted 3_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 gnokey query bank/balances/g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7
 stdout '"100/gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890:ugnot"'
 
 ## mint invalid base denom
-! gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "2gnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "2gnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'cannot issue coins with invalid denom base name, it should start by a lowercase letter and be followed by 2-15 lowercase letters or digits'
 
 ## burn invalid base denom
-! gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "2gnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "2gnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'cannot issue coins with invalid denom base name, it should start by a lowercase letter and be followed by 2-15 lowercase letters or digits'
 
 ## mint invalid realm denom
-! gnokey maketx call -pkgpath gno.land/r/test/invalid_realm_denom -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/invalid_realm_denom -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'invalid denom, can only issue/remove coins with the realm.s prefix'
 
 ## burn invalid realm denom
-! gnokey maketx call -pkgpath gno.land/r/test/invalid_realm_denom -func Burn -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/invalid_realm_denom -func Burn -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'invalid denom, can only issue/remove coins with the realm.s prefix'
 
 -- short/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/restart.txtar
+++ b/gno.land/pkg/integration/testdata/restart.txtar
@@ -4,12 +4,12 @@
 loadpkg gno.land/r/demo/counter $WORK
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 230001ugnot -gas-wanted 2_300_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1
 stdout '\(1 int\)'
 
 gnoland restart
 
-gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 190001ugnot -gas-wanted 1_900_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test test1
 stdout '\(2 int\)'
 
 -- counter.gno --

--- a/gno.land/pkg/integration/testdata/restart_gas.txtar
+++ b/gno.land/pkg/integration/testdata/restart_gas.txtar
@@ -9,15 +9,15 @@
 
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 stdout 'GAS USED:\s+2820971'
 
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 stdout 'GAS USED:\s+2823300'
 
 gnoland restart
 
-gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 stdout 'GAS USED:\s+2823314'
 
 -- bar/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/restart_missing_type.txtar
+++ b/gno.land/pkg/integration/testdata/restart_missing_type.txtar
@@ -10,7 +10,7 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # give gui user more tokens
-gnokey maketx send -send 1000000000ugnot -to $user1_user_addr  -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $user1_user_addr  -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test test1
 
 # tx1 out of gas
 gnokey sign -tx-path $WORK/tx1.tx -chainid tendermint_test -account-sequence 0 -account-number 58 user1

--- a/gno.land/pkg/integration/testdata/save_struct.txtar
+++ b/gno.land/pkg/integration/testdata/save_struct.txtar
@@ -3,15 +3,15 @@
 gnoland start
 
 # Deploy the public realm that holds saved data.
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/test/publicrealm -gas-fee 360001ugnot -gas-wanted 3_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/test/publicrealm -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Deploy the caller realm.
-gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 420001ugnot -gas-wanted 4_200_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 420001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call SaveStructToPublicRealm — stores a struct cross-realm.
-gnokey maketx call -pkgpath gno.land/r/test/caller -func SaveStructToPublicRealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/caller -func SaveStructToPublicRealm -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- publicrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/set_fee_collector.txtar
+++ b/gno.land/pkg/integration/testdata/set_fee_collector.txtar
@@ -12,18 +12,18 @@ loadpkg gno.land/r/gov/dao
 gnoland start
 
 ## Load member as T1 to be able to vote afterwards
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 ## Submit a proposal to change fee_collector to collector1
 
 ## pay the fee and submit a proposal to change the fee collector.
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_collector1.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/propose_collector1.gno
 stdout '0'
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check collector1 balance
@@ -31,7 +31,7 @@ gnokey query bank/balances/$collector1_user_addr
 stdout '1000000000ugnot'
 
 ## Make costly tx
-gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1 $WORK/run/costly.gno
+gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
 
 ## Check collector1 balance, must have changed
 gnokey query bank/balances/$collector1_user_addr
@@ -40,13 +40,13 @@ stdout '1000350001ugnot'
 ## Submit a proposal to change fee_collector to collector2
 
 ## pay the fee and submit a proposal to change the fee collector.
-gnokey maketx run -gas-fee 2600001ugnot -gas-wanted 26_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_collector2.gno
+gnokey maketx run -gas-fee 2600001ugnot -gas-wanted 26_000_000 -chainid=tendermint_test test1 $WORK/run/propose_collector2.gno
 stdout '1'
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 1 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 1 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check collector1 balance
@@ -58,7 +58,7 @@ gnokey query bank/balances/$collector2_user_addr
 stdout '1000000000ugnot'
 
 ## Make costly tx
-gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_500_000 -broadcast -chainid=tendermint_test test1 $WORK/run/costly.gno
+gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
 
 ## Check collector1 balance, must not have changed
 gnokey query bank/balances/$collector1_user_addr

--- a/gno.land/pkg/integration/testdata/simulate_gas.txtar
+++ b/gno.land/pkg/integration/testdata/simulate_gas.txtar
@@ -5,11 +5,11 @@ loadpkg gno.land/r/simulate $WORK/simulate
 gnoland start
 
 # simulate only
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test -simulate only test1
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test -simulate only test1
 stdout 'GAS USED:   \d+'
 
 # simulate skip
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -broadcast -chainid=tendermint_test -simulate skip test1
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test -simulate skip test1
 stdout 'GAS USED:   \d+' # same as simulate only
 
 -- package/package.gno --

--- a/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
@@ -8,21 +8,21 @@ env EXACT_GAS=1973588
 
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/myrealm -pkgpath gno.land/r/test/myrealm -gas-fee 1000001ugnot -gas-wanted $ADDPKG_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/myrealm -pkgpath gno.land/r/test/myrealm -gas-fee 1000001ugnot -gas-wanted $ADDPKG_GAS -chainid=tendermint_test test1
 stdout OK!
 
 # Set lastResult="42" (setup — gas not checked).
-gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -chainid=tendermint_test test1
 stdout OK!
 
 # No restart. lastResult="42" -> "42". Must match EXACT_GAS.
-gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -chainid=tendermint_test test1
 stdout 'GAS USED:\s+'${EXACT_GAS}
 
 gnoland restart
 
 # After restart. lastResult="42" -> "42". Must match same EXACT_GAS.
-gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $SETUP_GAS -chainid=tendermint_test test1
 stdout 'GAS USED:\s+'${EXACT_GAS}
 
 -- myrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/stdlib_runtime.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_runtime.txtar
@@ -11,23 +11,23 @@ env CALL_GAS=3_200_000
 gnoland start
 
 # Deploy realm that uses strconv/strings at runtime.
-gnokey maketx addpkg -pkgdir $WORK/myrealm -pkgpath gno.land/r/test/myrealm -gas-fee 1000001ugnot -gas-wanted $ADDPKG_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/myrealm -pkgpath gno.land/r/test/myrealm -gas-fee 1000001ugnot -gas-wanted $ADDPKG_GAS -chainid=tendermint_test test1
 stdout OK!
 
 # Call Convert — must fit in CALL_GAS.
-gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '42' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -chainid=tendermint_test test1
 stdout OK!
 
 # ConvertHeavy does more stdlib work — must NOT fit in CALL_GAS.
 # This proves the budget is tight, not just generous.
-! gnokey maketx call -pkgpath gno.land/r/test/myrealm -func ConvertHeavy -args '42' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/test/myrealm -func ConvertHeavy -args '42' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -chainid=tendermint_test test1
 stderr 'out of gas'
 
 gnoland restart
 
 # After restart, stdlib cache is repopulated from committed store.
 # Same budget must still work.
-gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '7' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/myrealm -func Convert -args '7' -gas-fee 1000001ugnot -gas-wanted $CALL_GAS -chainid=tendermint_test test1
 stdout OK!
 
 -- myrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/storage_deposit.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit.txtar
@@ -9,7 +9,7 @@ gnoland start
 #   STORAGE FEE   == fee_delta
 #   qstorage "storage/deposit" echoes the on-chain values
 #   TOTAL TX COST == gas-fee +/- STORAGE FEE/REFUND
-gnokey maketx addpkg -pkgdir $WORK/realm -pkgpath gno.land/r/foo -gas-fee 380001ugnot -gas-wanted 3_800_000 -max-deposit 900000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/realm -pkgpath gno.land/r/foo -gas-fee 380001ugnot -gas-wanted 3_800_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
 stdout 'EVENTS:     \[{\"bytes_delta\":4930,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":493000},\"pkg_path\":\"gno.land/r/foo\"}\]'
 stdout 'STORAGE DELTA:  4930 bytes'
 stdout 'STORAGE FEE:    493000ugnot'
@@ -20,7 +20,7 @@ gnokey query vm/qstorage --data gno.land/r/foo
 stdout 'storage: 4930, deposit: 493000'
 
 ## Set an object with a smaller size. Exactly 2 bytes are released when we update the realm record from 'hello' to 'foo'.
-gnokey maketx call -pkgpath gno.land/r/foo -func NewFoo -args "foo"  -gas-fee 260001ugnot -gas-wanted 2_600_000  -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func NewFoo -args "foo"  -gas-fee 260001ugnot -gas-wanted 2_600_000  -chainid=tendermint_test test1
 stdout OK!
 stdout 'EVENTS:     \[{\"bytes_delta\":-2,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":200},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
 stdout 'STORAGE DELTA:  -2 bytes'
@@ -33,7 +33,7 @@ stdout 'storage: 4928, deposit: 492800'
 
 ## remove an object
 
- gnokey maketx call -pkgpath gno.land/r/foo -func Clear -gas-fee 260001ugnot -gas-wanted 2_600_000  -broadcast -chainid=tendermint_test test1
+ gnokey maketx call -pkgpath gno.land/r/foo -func Clear -gas-fee 260001ugnot -gas-wanted 2_600_000  -chainid=tendermint_test test1
  stdout OK!
  stdout 'EVENTS:     \[{\"bytes_delta\":-27,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":2700},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
  stdout 'STORAGE DELTA:  -27 bytes'
@@ -48,7 +48,7 @@ stdout 'storage: 4928, deposit: 492800'
  stdout '"coins": "9999998609897ugnot"'
 
 ## test storage deposit for package gno.land/p/foo
-gnokey maketx addpkg -pkgdir $WORK/package -pkgpath gno.land/p/foo -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 500000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/package -pkgpath gno.land/p/foo -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 500000ugnot -chainid=tendermint_test test1
 stdout OK!
 stdout 'EVENTS:     \[{\"bytes_delta\":2940,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":294000},\"pkg_path\":\"gno.land/p/foo\"}\]'
 stdout 'STORAGE DELTA:  2940 bytes'

--- a/gno.land/pkg/integration/testdata/storage_deposit_bank_send.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_bank_send.txtar
@@ -3,13 +3,13 @@
 ## start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/contracts -pkgpath gno.land/r/foo -gas-fee 420001ugnot -gas-wanted 4_200_000 -max-deposit 1500000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/contracts -pkgpath gno.land/r/foo -gas-fee 420001ugnot -gas-wanted 4_200_000 -max-deposit 1500000ugnot -chainid=tendermint_test test1
 stdout OK!
 
 
 # Users are not allowed to withdraw deposits from the realm balance via the realm banker.
 ## Get realm gno.land/r/foo (g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469) balance
-gnokey maketx call -pkgpath gno.land/r/foo -func PkgAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func PkgAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout 'g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469'
 stdout OK!
 
@@ -21,7 +21,7 @@ stdout 'data: null'
 
 
 ## Get realm gno.land/r/foo storage deposit address  balance (g1nln0nrcd20s6a2736n864ma8lac0zep8hw7th9) balance
-gnokey maketx call -pkgpath gno.land/r/foo -func StorageDepositAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func StorageDepositAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
 stdout 'g1nln0nrcd20s6a2736n864ma8lac0zep8hw7th9'
 stdout OK!
 
@@ -38,7 +38,7 @@ gnokey query auth/accounts/$test1_user_addr
 stdout '"coins": "\d+ugnot"'
 
 ## realm send
-! gnokey maketx call -pkgpath gno.land/r/foo -func RealmSend -args $test1_user_addr -args 1  -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo -func RealmSend -args $test1_user_addr -args 1  -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'insufficient coins error'
 
 ## realm balance after realm send has not changed (account still doesn't exist)
@@ -54,7 +54,7 @@ gnokey query auth/accounts/$test1_user_addr
 stdout '\d+ugnot'
 
 ## realm banker send in msg run should bebehave the same.
-! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1 $WORK/run/realm_send.gno
+! gnokey maketx run -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1 $WORK/run/realm_send.gno
 stderr 'insufficient coins error'
 
 
@@ -62,16 +62,16 @@ stderr 'insufficient coins error'
 
 
 ## Origin banker send within user's allowed amount
-gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1 -send 1ugnot -gas-fee 240001ugnot -gas-wanted 2_400_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1 -send 1ugnot -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
 stdout 'OK'
 
 ## Origin banker send more than user's allowed amount
-! gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 2 -send 1ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 2 -send 1ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'cannot send "2ugnot", limit "1ugnot" exceeded'
 
 
 ## Origin banker send more than user's allowed amount (no send flag specified)
-! gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1  -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1  -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test1
 stderr 'cannot send "1ugnot", limit "" exceeded'
 
 

--- a/gno.land/pkg/integration/testdata/storage_deposit_collector.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_collector.txtar
@@ -19,27 +19,27 @@ loadpkg gno.land/r/sys/users
 gnoland start -lock-transfer
 
 ## Load member as T1 to be able to vote afterwards
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 ## Submit a proposal to change storage_fee_collector to storage_collector
 
 ## pay the fee and submit a proposal to change the fee collector.
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_collector.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/propose_collector.gno
 stdout '0'
 
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check storage_collector balance
 gnokey query bank/balances/$storage_collector_user_addr
 stdout '1000000000ugnot'
 
-gnokey maketx addpkg -pkgdir $WORK/bytesbank -pkgpath gno.land/r/bytesbank -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 900000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bytesbank -pkgpath gno.land/r/bytesbank -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
 stdout 'EVENTS:     \[{\"bytes_delta\":\d+,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":\d+},\"pkg_path\":\"gno.land/r/bytesbank\"}]'
 stdout 'STORAGE DELTA:  \d+ bytes'
 stdout 'STORAGE FEE:    \d+ugnot'
@@ -50,7 +50,7 @@ gnokey query vm/qstorage --data gno.land/r/bytesbank
 stdout 'storage: \d+, deposit: \d+'
 
 ## Set an object with a smaller size. Exactly 2 bytes are released when we update the realm record from 'hello' to 'foo'.
-gnokey maketx call -pkgpath gno.land/r/bytesbank -func Credit -args $norman_user_addr -args 500000  -gas-fee 1200001ugnot -gas-wanted 12_000_000  -broadcast -chainid=tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/bytesbank -func Credit -args $norman_user_addr -args 500000  -gas-fee 1200001ugnot -gas-wanted 12_000_000  -chainid=tendermint_test alice
 stdout OK!
 stdout 'STORAGE DELTA:  \d+ bytes'
 stdout 'STORAGE FEE:    \d+ugnot'
@@ -61,7 +61,7 @@ stdout 'storage: \d+, deposit: \d+'
 
 ## Norman frees the storage of bytes bank, but storage deposit goes to storage fee collector
 ## instead of him
-gnokey maketx call -pkgpath gno.land/r/bytesbank -func Debit -args 0  -gas-fee 1400001ugnot -gas-wanted 14_000_000  -broadcast -chainid=tendermint_test norman
+gnokey maketx call -pkgpath gno.land/r/bytesbank -func Debit -args 0  -gas-fee 1400001ugnot -gas-wanted 14_000_000  -chainid=tendermint_test norman
 stdout OK!
 stdout 'STORAGE DELTA:  -\d+ bytes'
 

--- a/gno.land/pkg/integration/testdata/sys_namereg_v1_canonical.txtar
+++ b/gno.land/pkg/integration/testdata/sys_namereg_v1_canonical.txtar
@@ -30,17 +30,17 @@ stdout 'g1mtmrdmqfu0aryqfl4aw65n35haw2wdjkh5p4cp'
 gnoland start
 
 # user1 registers nym-balloon123 successfully.
-gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-balloon123' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-balloon123' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user1
 stdout OK!
 
 # user2 attempts a canonical-confusable variant (l→i applied to the
 # stem). Must reject with ErrCanonicalCollision from r/sys/users — the
 # unified canonical store doing its job.
-! gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-baiioon123' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user2
+! gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-baiioon123' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user2
 stderr 'name collides with a confusable variant of an existing name'
 
 # Same alpha stem with different digit suffix is a DIFFERENT canonical
 # string (decision #2: store keyed by full canonical name). user2 can
 # register nym-balloon999 — does not collide with user1's nym-balloon123.
-gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-balloon999' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-balloon999' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user2
 stdout OK!

--- a/gno.land/pkg/integration/testdata/sys_namereg_v1_controller.txtar
+++ b/gno.land/pkg/integration/testdata/sys_namereg_v1_controller.txtar
@@ -29,17 +29,17 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Initialize GovDAO members so we can drive proposals later in the test.
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Sanity: the realm is already a whitelisted controller (init.gno did this at
 # genesis height 0). user1 calls namereg/v1.Register with the required 20 GNOT.
 # The username "nym-alice123" matches the Open Nym Tier regex ^nym-[a-z]{5,13}\d{3}$.
-gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-alice123' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-alice123' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user1
 stdout OK!
 
 # Verify: r/sys/users now resolves user1's address to "nym-alice123".
-gnokey maketx run -gas-fee 1500001ugnot -gas-wanted 15_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/verify_registered.gno
+gnokey maketx run -gas-fee 1500001ugnot -gas-wanted 15_000_000 -chainid=tendermint_test test1 $WORK/run/verify_registered.gno
 stdout OK!
 
 # End-to-end bridge check: enable r/sys/names so the verifier actually runs,
@@ -49,34 +49,34 @@ stdout OK!
 # captured paths at the first `-`, so a deploy under `gno.land/r/nym-alice123/*`
 # would have lookup-up "nym" instead of "nym-alice123" and failed with
 # "is not authorized to deploy packages to namespace nym".
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/nym-alice123/hello -gas-fee 1500001ugnot -gas-wanted 15_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/nym-alice123/hello -gas-fee 1500001ugnot -gas-wanted 15_000_000 -chainid=tendermint_test user1
 stdout OK!
 
 # Sanity: a different namespace user1 doesn't own must still fail. Confirms
 # the verifier is actually consulted (i.e. Enable took effect) and didn't
 # silently allow everything.
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/notmine999/hello -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/notmine999/hello -gas-fee 5000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test user1
 stderr 'is not authorized to deploy packages to namespace'
 
 # Now exercise the removal path. DAO proposes to REMOVE namereg/v1 from the
 # controller whitelist.
-gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_remove_namereg.gno
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1 $WORK/run/propose_remove_namereg.gno
 stdout OK!
 
 # Vote + execute.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Now Register must fail — the realm is no longer in the controller whitelist.
 # A second registration attempt for a different (valid) name from the same
 # user should hard-fail with the whitelist error from r/sys/users.
-! gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-bobcat456' -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/sys/namereg/v1 -func Register -args 'nym-bobcat456' -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user1
 stderr 'does not exist in whitelist'
 
 -- pkg/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/sys_names_pause.txtar
+++ b/gno.land/pkg/integration/testdata/sys_names_pause.txtar
@@ -21,18 +21,18 @@ gnoland start
 
 # Initialize GovDAO members so we can drive proposals. test1 becomes a
 # T1 member, eligible to vote on pause proposals (which are T1-tier).
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Propose pause via GovDAO (T1 tier).
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
 stdout OK!
 
 # Vote YES + execute.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 # Lock in PreviousRealm semantics for the same-package non-crossing call
 # inside setPaused: cb (declared in r/sys/names) crosses in from r/gov/dao,
@@ -44,28 +44,28 @@ stdout OK!
 stdout '\{"type":"NamespaceEnforcementPaused","attrs":\[\{"key":"by","value":"gno\.land/r/gov/dao"\}\],"pkg_path":"gno\.land/r/sys/names"\}'
 
 # Verify the pause took effect: IsPaused returns true.
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/verify_paused.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/verify_paused.gno
 stdout OK!
 
 # Idempotency: trying to propose pause again must panic at proposal
 # creation time (the realm's paused state already matches v=true).
-! gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
+! gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
 stderr 'paused state already matches'
 
 # Now propose unpause. Vote + execute.
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_unpause.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_unpause.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 # Same regression guard as above, mirrored for the unpause event.
 stdout '\{"type":"NamespaceEnforcementUnpaused","attrs":\[\{"key":"by","value":"gno\.land/r/gov/dao"\}\],"pkg_path":"gno\.land/r/sys/names"\}'
 
 # Verify unpause took effect.
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/verify_unpaused.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/verify_unpaused.gno
 stdout OK!
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/sys_names_pause_addpkg.txtar
+++ b/gno.land/pkg/integration/testdata/sys_names_pause_addpkg.txtar
@@ -29,7 +29,7 @@ patchpkg "g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh" $test1_user_addr
 gnoland start
 
 # Initialize GovDAO members so test1 can drive proposals.
-gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
+gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/init_govdao.gno
 stdout OK!
 
 # Sanity: r/sys/names disabled at start.
@@ -37,32 +37,32 @@ gnokey query vm/qeval --data "gno.land/r/sys/names.IsEnabled()"
 stdout 'false bool'
 
 # (1) Pre-Enable bypass: deploy under an arbitrary (non-PA) namespace succeeds.
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/preenable/hello -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/preenable/hello -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Enable namespace enforcement.
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/sys/names.IsEnabled()"
 stdout 'true bool'
 
 # (2a) Post-Enable: deploy under test1's PA namespace succeeds.
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 # (2b) Post-Enable: deploy under non-PA namespace fails (no registered name).
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/notmyspace/hello -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/notmyspace/hello -gas-fee 5000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1
 stderr 'is not authorized to deploy packages to namespace'
 
 # Propose pause via GovDAO (T1 tier). Vote + execute.
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/sys/names.IsPaused()"
@@ -70,36 +70,36 @@ stdout 'true bool'
 
 # (3) After pause: addpkg under test1's PA namespace MUST fail. This is
 # the fail-closed semantic — pause halts every deploy including PA.
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/paused_attempt -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/paused_attempt -gas-fee 5000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1
 stderr 'is not authorized to deploy packages to namespace'
 
 # Non-PA also still fails (would've failed pre-pause too — confirm pause
 # doesn't accidentally invert behavior).
-! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/anotherspace/paused_attempt -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+! gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/anotherspace/paused_attempt -gas-fee 5000000ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1
 stderr 'is not authorized to deploy packages to namespace'
 
 # (4) MsgCall against the package deployed pre-pause MUST keep working.
 # The package doc claims pause is scoped to MsgAddPackage; existing
 # realms continue to receive MsgCall traffic normally. This locks that in.
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -func Hello -gas-fee 1000000ugnot -gas-wanted 10_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -func Hello -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'hi from hello'
 
 # Propose unpause. Vote + execute.
-gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_unpause.gno
+gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_unpause.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/sys/names.IsPaused()"
 stdout 'false bool'
 
 # (5) After unpause: addpkg under PA succeeds again.
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/after_unpause -gas-fee 410001ugnot -gas-wanted 4_100_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/after_unpause -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/time_simple.txtar
+++ b/gno.land/pkg/integration/testdata/time_simple.txtar
@@ -3,7 +3,7 @@
 
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/time_simple -gas-fee 390001ugnot -gas-wanted 3_900_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/time_simple -gas-fee 390001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/transfer_lock.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_lock.txtar
@@ -15,25 +15,25 @@ gnoland start -lock-transfer
 
 ## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
 ## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
-gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
 ## Restricted simple token transfer
-! gnokey maketx send -send "9999999ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular1
+! gnokey maketx send -send "9999999ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular1
 stderr 'restricted token transfer error'
 
 ## Restricted token transfer by calling a realm deposit function.
-! gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -gas-fee 5000000ugnot -send "10000ugnot" -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular1
+! gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -gas-fee 5000000ugnot -send "10000ugnot" -gas-wanted 50000000 -chainid=tendermint_test regular1
 stderr 'restricted token transfer error'
 
 
 ## making a storage deposit to a realm package while adding the package is acceptable
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/bank -max-deposit "2000000ugnot" -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test regular1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/bank -max-deposit "2000000ugnot" -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test regular1
 stdout 'OK!'
 
 ## paying gas fees to add a package is acceptable.
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/bank2 -gas-fee 370001ugnot -gas-wanted 3_700_000 -broadcast -chainid=tendermint_test regular1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/bank2 -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test regular1
 stdout 'OK!'
 
 ## paying gas fees to call a realm function is acceptable.

--- a/gno.land/pkg/integration/testdata/transfer_unlock.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_unlock.txtar
@@ -10,36 +10,36 @@ gnoland start -lock-transfer
 
 ## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
 ## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
-gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
 ## Restricted simple token transfer for a regular account
-! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular1
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular1
 
 stderr 'restricted token transfer error'
 
 ## Load member as T1 to be able to vote afterwards
-gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 ## Submit a proposal to unlock the transfer. When token transfer is locked, only the predefined unrestricted account test1 in the genesis state can
 ## pay the fee and submit a proposal to unlock the transfer.
-gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_unlock.gno
+gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/propose_unlock.gno
 
 stdout '0'
 
 ## Vote unlock proposal with unrestricted account test1
-gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
+gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
 
 stdout 'OK!'
 
 ## Execute unlock proposal with unrestricted account test1
-gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
+gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000  -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
 
 stdout 'OK!'
 
 ## Restricted transfer is unlocked, allowing simple token transfers for regular accounts.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test regular1
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular1
 
 stdout 'OK!'
 

--- a/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
@@ -15,49 +15,49 @@ gnoland start -lock-transfer
 
 ## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
 ## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
-gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
-gnokey maketx send -send "9999999ugnot" -to $regular2_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular2_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
 ## Restricted simple token transfer for a regular account
-! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular1
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular1
 
 stderr 'restricted token transfer error'
 
-! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular2
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular2
 
 stderr 'restricted token transfer error'
 
 
 ## Load member as T1 to be able to vote afterwards
-gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 ## Submit a proposal to add a regular use as the unrestricted account.
-gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_unrestricted.gno
+gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/propose_unrestricted.gno
 
 stdout '0'
 
 ## Vote for the unrestricted account proposal using test1
-gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
+gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
 
 stdout 'OK!'
 
 ## Execute the unrestricted account proposal using test1
-gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
+gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
 
 stdout 'OK!'
 
 ## Token transfers for regular1 accounts is allowed.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test regular1
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular1
 
 stdout 'OK!'
 
 ## Token transfers for regular2 accounts is allowed.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid=tendermint_test regular2
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular2
 
 stdout 'OK!'
 
@@ -67,17 +67,17 @@ stdout '["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5","g18e22n23g462drp4pyszyl6e6m
 
 
 ## Submit a proposal to remove regular1 and regular2 as the unrestricted accounts.
-gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_restricted.gno
+gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000 -chainid=tendermint_test test1 $WORK/run/propose_restricted.gno
 
 stdout '1'
 
 ## Vote for the remove unrestricted account proposal using test1
-gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal1.gno
+gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/vote_proposal1.gno
 
 stdout 'OK!'
 
 ## Execute the remove unrestricted account proposal using test1
-gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal1.gno
+gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -chainid=tendermint_test test1 $WORK/run/exec_proposal1.gno
 
 stdout 'OK!'
 
@@ -86,11 +86,11 @@ gnokey query params/auth:p:unrestricted_addrs
 stdout '["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"]'
 
 ## Restricted simple token transfer for a regular account
-! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular1
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular1
 
 stderr 'restricted token transfer error'
 
-! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test regular2
+! gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test regular2
 
 stderr 'restricted token transfer error'
 

--- a/gno.land/pkg/integration/testdata/update_storage_params.txtar
+++ b/gno.land/pkg/integration/testdata/update_storage_params.txtar
@@ -11,16 +11,16 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 ## add a contract
-gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/storage -gas-fee 380001ugnot -gas-wanted 3_800_000  -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/storage -gas-fee 380001ugnot -gas-wanted 3_800_000  -chainid=tendermint_test test1
 stdout OK!
 
 ## Propose to update default deposit.
-gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/submit_proposal.gno
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test test1 $WORK/run/submit_proposal.gno
 
 stdout OK!
 
 ## Vote "update default deposit"
-gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
+gnokey maketx run  -gas-fee 2200001ugnot -gas-wanted 22_000_000 -chainid=tendermint_test test1 $WORK/run/vote_proposal.gno
 
 stdout 'OK!'
 
@@ -29,7 +29,7 @@ gnokey query params/vm:p:default_deposit
 stdout '600000000ugnot'
 
 ## Execute "update default deposit" proposal
-gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -broadcast -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
+gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 26_000_000  -chainid=tendermint_test test1 $WORK/run/exec_proposal.gno
 
 stdout 'OK!'
 
@@ -40,7 +40,7 @@ stdout '1ugnot'
 
 ## failed due to not providing enough default deposit
 
-! gnokey maketx call -pkgpath gno.land/r/storage -func SetName -args "hellooo"  -gas-fee 5000000ugnot -gas-wanted 50000000  -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/storage -func SetName -args "hellooo"  -gas-fee 5000000ugnot -gas-wanted 50000000  -chainid=tendermint_test test1
 
 stderr 'not enough deposit to cover the storage usage'
 

--- a/gno.land/pkg/integration/testdata/user_journey.txtar
+++ b/gno.land/pkg/integration/testdata/user_journey.txtar
@@ -40,7 +40,7 @@ stdout 'data: "100000000000ugnot"'
 ################################
 
 # User3 funds user1 (100ugnot) and user2 (4e10ugnot) using the disperse Realm
-gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseUgnotString -args "$user1_user_addr,$user2_user_addr" -args '100,40000000000' -send 40000000100ugnot -gas-fee 530001ugnot -gas-wanted 5_300_000 -broadcast -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseUgnotString -args "$user1_user_addr,$user2_user_addr" -args '100,40000000000' -send 40000000100ugnot -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 # Verify users' new balances
@@ -52,7 +52,7 @@ gnokey query bank/balances/${user3_user_addr}
 stdout 'data: "\d+ugnot"' # Disperse + Gas used
 
 # User2 sends some more ugnot to user1 (1e10ugnot)
-gnokey maketx send -send 10000000000ugnot -to $user1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -broadcast -chainid tendermint_test user2
+gnokey maketx send -send 10000000000ugnot -to $user1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test user2
 stdout 'OK!'
 
 # Verify users' new balances
@@ -72,13 +72,13 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # user2 make a deposit of 1e7ugnot
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000  -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000  -chainid=tendermint_test user2
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user_addr}\")"
 stdout '10000000 int64'
 
 # user2 transfers 1e7ugnot to user1
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -args ${user1_user_addr} -args 10000000 -gas-fee 690001ugnot -gas-wanted 6_900_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -args ${user1_user_addr} -args 10000000 -gas-fee 690001ugnot -gas-wanted 6_900_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Verify users' new balances
@@ -88,7 +88,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # user1 withdraw 1e7ugnot
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 ################################
@@ -99,11 +99,11 @@ stdout 'OK!'
 env DISPERSE_REALM_ADDR=g1yryw6qs8h9anvguu4dfdc0u7zh4gvv8vqf59sj
 
 # user1 creates a new token with 5 decimals and 10 drip ammount for the faucet
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func New -args MyAwesomeToken -args MAT -args 5 -args 0 -args 10 -gas-fee 1100001ugnot -gas-wanted 11_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func New -args MyAwesomeToken -args MAT -args 5 -args 0 -args 10 -gas-fee 1100001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # user1 mints 1000 MAT to himself
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Mint -args MAT -args "$user1_user_addr" -args 1000 -gas-fee 930001ugnot -gas-wanted 9_300_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Mint -args MAT -args "$user1_user_addr" -args 1000 -gas-fee 930001ugnot -gas-wanted 9_300_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # Verify user1's MAT balance
@@ -111,7 +111,7 @@ gnokey query vm/qeval --data "gno.land/r/demo/defi/grc20factory.BalanceOf(\"MAT\
 stdout '1000 int64'
 
 # Approve disperse Realm to spend 500 MAT on behalf of user1
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Approve -args MAT -args "$DISPERSE_REALM_ADDR" -args 500 -gas-fee 870001ugnot -gas-wanted 8_700_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Approve -args MAT -args "$DISPERSE_REALM_ADDR" -args 500 -gas-fee 870001ugnot -gas-wanted 8_700_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # Check disperse Realm allowance to spend MAT on behalf of user1
@@ -119,7 +119,7 @@ gnokey query vm/qeval --data "gno.land/r/demo/defi/grc20factory.Allowance(\"MAT\
 stdout '500 int64'
 
 # Disperse 490 MAT to user2 and 10 to user3
-gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseGRC20String -args "$user2_user_addr,$user3_user_addr" -args '490MAT,10MAT' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseGRC20String -args "$user2_user_addr,$user3_user_addr" -args '490MAT,10MAT' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # Verify user2's and user3's MAT balances
@@ -129,7 +129,7 @@ gnokey query vm/qeval --data "gno.land/r/demo/defi/grc20factory.BalanceOf(\"MAT\
 stdout '10 int64'
 
 # user3 requests MAT from the faucet
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Faucet -args MAT -gas-fee 990001ugnot -gas-wanted 9_900_000 -broadcast -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Faucet -args MAT -gas-fee 990001ugnot -gas-wanted 9_900_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 # Verify user3's MAT balance
@@ -137,7 +137,7 @@ gnokey query vm/qeval --data "gno.land/r/demo/defi/grc20factory.BalanceOf(\"MAT\
 stdout '20 int64'
 
 # user2 transfers 200 MAT to user3
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Transfer -args MAT -args "$user3_user_addr" -args 200 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func Transfer -args MAT -args "$user3_user_addr" -args 200 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Verify user2's and user3's MAT balances
@@ -154,25 +154,25 @@ stdout '220 int64'
 # genesiscall lines before `gnoland start`.)
 
 # user3 creates a new board and a thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateBoard -args 'user3_awesome_board' -gas-fee 1700001ugnot -gas-wanted 17_000_000 -broadcast -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateBoard -args 'user3_awesome_board' -gas-fee 1700001ugnot -gas-wanted 17_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My first thread' -args 'Hey Guys!' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -broadcast -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My first thread' -args 'Hey Guys!' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 # user1 tries to reply to the thread without registering
-! gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hello!' -gas-fee 5000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hello!' -gas-fee 5000000ugnot -gas-wanted 100000000 -chainid=tendermint_test user1
 stderr 'please register, otherwise minimum fee 100000000 is required if anonymous'
 
 # user2 posts a reply to the thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hey hey hey!' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hey hey hey!' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # user2 creates a new thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My own thread' -args 'Posting on my own thread' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My own thread' -args 'Posting on my own thread' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # user1 replies to user3's thread anonymously
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'I prefer not to register' -send 100000000ugnot -gas-fee 1400001ugnot -gas-wanted 14_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'I prefer not to register' -send 100000000ugnot -gas-fee 1400001ugnot -gas-wanted 14_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 ######################
@@ -180,11 +180,11 @@ stdout 'OK!'
 ######################
 
 # Enable `sys/names` to enforce namespace restrictions
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -broadcast -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 # user2 publishes a custom home package to its address namespace
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$user2_user_addr/home -gas-fee 540001ugnot -gas-wanted 5_400_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$user2_user_addr/home -gas-fee 540001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Render user2's home package
@@ -192,7 +192,7 @@ gnokey query vm/qrender --data "gno.land/r/$user2_user_addr/home:"
 stdout 'My awesome home package with admin: '${user2_user_addr}
 
 # user2's transfer ownership to user1
-gnokey maketx call -pkgpath gno.land/r/$user2_user_addr/home -func TransferOwnership -args "$user1_user_addr" -send 100000000ugnot -gas-fee 220001ugnot -gas-wanted 2_200_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/$user2_user_addr/home -func TransferOwnership -args "$user1_user_addr" -send 100000000ugnot -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Wait for https://github.com/gnolang/gno/pull/4278 to be merged

--- a/gno.land/pkg/integration/testdata/valopers.txtar
+++ b/gno.land/pkg/integration/testdata/valopers.txtar
@@ -7,14 +7,14 @@ adduser regular1
 gnoland start
 
 # Add user as a member for govdao
-gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/load_user.gno
+gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 34_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 # add a valoper with a bad address
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args 1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args 1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -chainid=tendermint_test test1
 stderr 'panic: invalid address'
 
 # add a valoper with a bad pubkey
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40zzz -broadcast -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40zzz -chainid=tendermint_test test1
 stderr 'panic: invalid checksum'
 
 # add a valoper. The Address arg below is the canonical (pubkey-
@@ -23,7 +23,7 @@ stderr 'panic: invalid checksum'
 # rejects mismatches between Validator.Address and
 # PubKeyAddress(Validator.PubKey) so the description and consensus
 # can never disagree about which validator is being added.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 2500001ugnot -gas-wanted 25_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 2500001ugnot -gas-wanted 25_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -chainid=tendermint_test test1
 stdout OK!
 
 # see the valoper in the Render
@@ -31,11 +31,11 @@ gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
 stdout '\* \[berty\]'
 
 # make a proposal for a non-existing valoper
-! gnokey maketx run  -gas-fee 5000000ugnot -gas-wanted 200000000 -broadcast -chainid=tendermint_test test1 $WORK/run/new_proposal_bad.gno
+! gnokey maketx run  -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test test1 $WORK/run/new_proposal_bad.gno
 stderr 'panic: valoper does not exist'
 
 # make a proposal
-gnokey maketx run  -gas-fee 4400001ugnot -gas-wanted 44_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/new_proposal_good.gno
+gnokey maketx run  -gas-fee 4400001ugnot -gas-wanted 44_000_000 -chainid=tendermint_test test1 $WORK/run/new_proposal_good.gno
 stdout OK!
 
 # see the valoper in gov/dao Render
@@ -43,7 +43,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:'
 stdout 'Add valoper berty'
 
 # make a proposal for updating instructions
-gnokey maketx run  -gas-fee 3500001ugnot -gas-wanted 35_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/new_instructions_proposal.gno
+gnokey maketx run  -gas-fee 3500001ugnot -gas-wanted 35_000_000 -chainid=tendermint_test test1 $WORK/run/new_instructions_proposal.gno
 stdout OK!
 
 # see the instructions in gov/dao proposition Render
@@ -51,7 +51,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:1'
 stdout 'new instructions'
 
 # make a proposal for updating minimum fee
-gnokey maketx run  -gas-fee 3600001ugnot -gas-wanted 36_000_000 -broadcast -chainid=tendermint_test test1 $WORK/run/new_minfee_proposal.gno
+gnokey maketx run  -gas-fee 3600001ugnot -gas-wanted 36_000_000 -chainid=tendermint_test test1 $WORK/run/new_minfee_proposal.gno
 stdout OK!
 
 # see the instructions in gov/dao proposition Render

--- a/gno.land/pkg/integration/testdata/wugnot.txtar
+++ b/gno.land/pkg/integration/testdata/wugnot.txtar
@@ -21,7 +21,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user
 stdout '0 int64'
 
 # Deposit using user1
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user_addr}\")"
@@ -37,7 +37,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # Deposit using user2
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 930001ugnot -gas-wanted 9_300_000 -broadcast -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 930001ugnot -gas-wanted 9_300_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user_addr}\")"
@@ -52,7 +52,7 @@ stdout 'Total supply..: 20000'
 stdout 'Known accounts..: 2'
 
 
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -gas-fee 750001ugnot -gas-wanted 7_500_000 -args ${user3_user_addr} -args '10000' -broadcast -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -gas-fee 750001ugnot -gas-wanted 7_500_000 -args ${user3_user_addr} -args '10000' -chainid=tendermint_test user1
 stdout 'OK!'
 
 gnokey query vm/qrender --data "gno.land/r/gnoland/wugnot:"
@@ -60,7 +60,7 @@ stdout 'Total supply..: 20000'
 stdout 'Known accounts..: 2' # user1 is no longer known, as they transferred all their balance
 
 # XXX: use test3 instead (depends on https://github.com/gnolang/gno/issues/1269#issuecomment-1806386069)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -broadcast -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 gnokey query vm/qrender --data "gno.land/r/gnoland/wugnot:"
@@ -72,12 +72,12 @@ stdout 'Known accounts..: 1' # user3 is no longer known, as they withdrew all th
 # ============================================
 
 # Deploy the malicious intermediary realm
-gnokey maketx addpkg -pkgdir $WORK/mitm -pkgpath gno.land/r/test/mitm -gas-fee 860001ugnot -gas-wanted 8_600_000 -broadcast -chainid=tendermint_test user1
+gnokey maketx addpkg -pkgdir $WORK/mitm -pkgpath gno.land/r/test/mitm -gas-fee 860001ugnot -gas-wanted 8_600_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # user1 tries to deposit through the malicious intermediary - this should FAIL
 # The intermediary calls wugnot.Deposit(cross) but AssertOriginCall() blocks it
-! gnokey maketx call -pkgpath gno.land/r/test/mitm -func ProxyDeposit -send 10000ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test user1
+! gnokey maketx call -pkgpath gno.land/r/test/mitm -func ProxyDeposit -send 10000ugnot -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test user1
 stderr 'invalid non-origin call'
 
 # Verify no wugnot was minted (total supply should remain 10000 from user2)


### PR DESCRIPTION
PR https://github.com/gnolang/gno/pull/4965 changed the gnokey `-broadcast` flag to default true, and removed the unneeded flag in many txtar files. A recent (big) PR updated many txtar to re-introduce the flag. This PR removes them.