### PR TITLE
chore: Remove unused keyscli MakeTxCfg

### DIFF
--- a/gno.land/pkg/keyscli/maketx.go
+++ b/gno.land/pkg/keyscli/maketx.go
@@ -1,22 +1,9 @@
 package keyscli
 
 import (
-	"flag"
-
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 )
-
-type MakeTxCfg struct {
-	RootCfg *client.BaseCfg
-
-	GasWanted int64
-	GasFee    string
-	Memo      string
-
-	Broadcast bool
-	ChainID   string
-}
 
 func NewMakeTxCmd(rootCfg *client.BaseCfg, io commands.IO) *commands.Command {
 	cfg := &client.MakeTxCfg{
@@ -43,41 +30,4 @@ func NewMakeTxCmd(rootCfg *client.BaseCfg, io commands.IO) *commands.Command {
 	)
 
 	return cmd
-}
-
-func (c *MakeTxCfg) RegisterFlags(fs *flag.FlagSet) {
-	fs.Int64Var(
-		&c.GasWanted,
-		"gas-wanted",
-		0,
-		"gas requested for tx",
-	)
-
-	fs.StringVar(
-		&c.GasFee,
-		"gas-fee",
-		"",
-		"gas payment fee",
-	)
-
-	fs.StringVar(
-		&c.Memo,
-		"memo",
-		"",
-		"any descriptive text",
-	)
-
-	fs.BoolVar(
-		&c.Broadcast,
-		"broadcast",
-		true,
-		"sign and broadcast",
-	)
-
-	fs.StringVar(
-		&c.ChainID,
-		"chainid",
-		"dev",
-		"chainid to sign for (only useful if --broadcast)",
-	)
 }


### PR DESCRIPTION
The gno.land `keyscli` package redefines `NewMakeTxCmd` from [the default](https://github.com/gnolang/gno/blob/0804bb54e4518c9fd3789b82428fe45bce2dcea2/tm2/pkg/crypto/keys/client/maketx.go#L45) in the tm2 `client` package. However it uses [the default client.MakeTxCfg struct](https://github.com/gnolang/gno/blob/0804bb54e4518c9fd3789b82428fe45bce2dcea2/gno.land/pkg/keyscli/maketx.go#L22) from tm2. The `MakeTxCfg` struct and `RegisterFlags` func in `keyscli` are unused. Perhaps they were originally included with the intention for gno.land to add more options than in the tm2 default. But this is dead code and it is already out of sync. (The "default" in tm2 `client` [has `Simulate`](https://github.com/gnolang/gno/blob/0804bb54e4518c9fd3789b82428fe45bce2dcea2/tm2/pkg/crypto/keys/client/maketx.go#L25) which is not in the `keyscli` version.) It also makes reading the code confusing. This PR removes the dead code.