### PR TITLE
auth: panic in SetSessionAccount when account PubKey is nil

### DIFF
--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -202,6 +202,9 @@ func (ak AccountKeeper) GetSessionAccount(ctx sdk.Context, master, session crypt
 
 // SetSessionAccount stores a session account at /a/<master>/s/<session>.
 func (ak AccountKeeper) SetSessionAccount(ctx sdk.Context, master crypto.Address, acc std.Account) {
+	if acc.GetPubKey() == nil {
+		panic("SetSessionAccount: invariant violation: session account must have a non-nil PubKey")
+	}
 	addr := acc.GetAddress()
 	gctx := ctx.GasContext()
 	stor := ctx.Store(ak.key)

--- a/tm2/pkg/sdk/auth/session_test.go
+++ b/tm2/pkg/sdk/auth/session_test.go
@@ -1617,3 +1617,20 @@ func TestSessionExpiredErrorIncludesTimestamps(t *testing.T) {
 	assert.Contains(t, res.Log, "expires_at=", "expiry error should include expires_at")
 	assert.Contains(t, res.Log, "block_time=", "expiry error should include block_time")
 }
+
+func TestSetSessionAccountPanicsOnNilPubKey(t *testing.T) {
+	t.Parallel()
+
+	env, _, _, masterAddr := setupSessionEnv(t)
+
+	// Create a session account but clear its PubKey to violate the invariant.
+	_, sessionPub, _ := tu.KeyTestPubAddr()
+	sa := env.acck.NewSessionAccount(env.ctx, masterAddr, sessionPub)
+	require.NoError(t, sa.SetPubKey(nil))
+
+	assert.PanicsWithValue(
+		t,
+		"SetSessionAccount: invariant violation: session account must have a non-nil PubKey",
+		func() { env.acck.SetSessionAccount(env.ctx, masterAddr, sa) },
+	)
+}


### PR DESCRIPTION
## Summary
- Add an invariant guard at the top of `AccountKeeper.SetSessionAccount` that panics if `acc.GetPubKey()` is nil.
- Add `TestSetSessionAccountPanicsOnNilPubKey` in `session_test.go` confirming the panic.

A session account without a PubKey cannot be authenticated against, so persisting one would silently corrupt the store. Failing fast at the write site makes the invariant explicit.

## Test plan
- [x] `go test ./tm2/pkg/sdk/auth/ -run TestSetSessionAccountPanicsOnNilPubKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)