### PR TITLE
feat(r/sys/validators/v3): add allow list

### DIFF
--- a/examples/gno.land/r/sys/validators/v3/allowed.gno
+++ b/examples/gno.land/r/sys/validators/v3/allowed.gno
@@ -24,12 +24,20 @@ func assertCallerIsAllowed() {
 }
 
 // AddValidator is a public method that allows whitelisted realms to add
-// a validator to the set. The operator must already be registered in
-// valoperCache with KeepRunning=true.
-func AddValidator(cur realm, change ValoperChange) {
+// a validator to the set. If the operator is not yet in valoperCache, it
+// is auto-registered using the provided signingPubKey and signingAddress
+// with KeepRunning=true.
+func AddValidator(cur realm, change ValoperChange, signingPubKey string, signingAddress address) {
 	assertCallerIsAllowed()
 	if change.Power == 0 {
 		panic("AddValidator requires Power > 0; use RemoveValidator for removals")
+	}
+	if _, ok := valoperCache.Get(change.OperatorAddress.String()); !ok {
+		valoperCache.Set(change.OperatorAddress.String(), cacheEntry{
+			SigningPubKey:  signingPubKey,
+			SigningAddress: signingAddress,
+			KeepRunning:    true,
+		})
 	}
 	exec := newValoperChangeExecutor([]ValoperChange{change})
 	if err := exec.Execute(cross); err != nil {
@@ -38,9 +46,13 @@ func AddValidator(cur realm, change ValoperChange) {
 }
 
 // RemoveValidator is a public method that allows whitelisted realms to remove
-// a validator from the set, looked up by operator address.
+// a validator from the set, looked up by operator address. If the operator
+// is not in valoperCache (never added), this is a no-op.
 func RemoveValidator(cur realm, op address) {
 	assertCallerIsAllowed()
+	if _, ok := valoperCache.Get(op.String()); !ok {
+		return
+	}
 	exec := newValoperChangeExecutor([]ValoperChange{{OperatorAddress: op, Power: 0}})
 	if err := exec.Execute(cross); err != nil {
 		panic(err)

--- a/examples/gno.land/r/sys/validators/v3/allowed.gno
+++ b/examples/gno.land/r/sys/validators/v3/allowed.gno
@@ -1,0 +1,123 @@
+package validators
+
+import (
+	"chain"
+	"chain/runtime"
+	"strings"
+
+	"gno.land/p/nt/bptree/v0"
+	"gno.land/r/gov/dao"
+)
+
+// allowedRealms holds the whitelist of realm paths allowed to modify the validator set.
+var allowedRealms = bptree.NewBPTree32()
+
+func assertCallerIsAllowed() {
+	callerPath := runtime.PreviousRealm().PkgPath()
+	if callerPath == "" {
+		panic("caller must be a realm, not a user")
+	}
+
+	if !IsAllowedRealm(callerPath) {
+		panic("realm " + callerPath + " is not allowed to modify the validator set")
+	}
+}
+
+// AddValidator is a public method that allows whitelisted realms to add
+// a validator to the set. The operator must already be registered in
+// valoperCache with KeepRunning=true.
+func AddValidator(cur realm, change ValoperChange) {
+	assertCallerIsAllowed()
+	if change.Power == 0 {
+		panic("AddValidator requires Power > 0; use RemoveValidator for removals")
+	}
+	exec := newValoperChangeExecutor([]ValoperChange{change})
+	if err := exec.Execute(cross); err != nil {
+		panic(err)
+	}
+}
+
+// RemoveValidator is a public method that allows whitelisted realms to remove
+// a validator from the set, looked up by operator address.
+func RemoveValidator(cur realm, op address) {
+	assertCallerIsAllowed()
+	exec := newValoperChangeExecutor([]ValoperChange{{OperatorAddress: op, Power: 0}})
+	if err := exec.Execute(cross); err != nil {
+		panic(err)
+	}
+}
+
+// IsAllowedRealm returns true if the given realm path is in the whitelist.
+func IsAllowedRealm(pkgPath string) bool {
+	return allowedRealms.Has(pkgPath)
+}
+
+// GetAllowedRealms returns the list of realm paths that are allowed to modify the validator set.
+func GetAllowedRealms() []string {
+	realms := make([]string, 0, allowedRealms.Size())
+	allowedRealms.Iterate("", "", func(key string, _ any) bool {
+		realms = append(realms, key)
+		return false
+	})
+	return realms
+}
+
+// NewPropAllowedRealmUpdateRequest creates a new proposal request that updates
+// the set of realms allowed to modify the validator set.
+//
+// Each path may appear AT MOST ONCE across add and remove combined;
+// duplicates within either list, and any add ∩ remove overlap, are
+// rejected at create-time.
+func NewPropAllowedRealmUpdateRequest(add []string, remove []string, title, description string) dao.ProposalRequest {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		panic("proposal title is empty")
+	}
+
+	if len(add) == 0 && len(remove) == 0 {
+		panic("proposal must add or remove at least one realm")
+	}
+
+	seen := make(map[string]bool, len(add)+len(remove))
+	for _, r := range add {
+		if seen[r] {
+			panic("duplicate realm in proposal: " + r)
+		}
+		seen[r] = true
+	}
+	for _, r := range remove {
+		if seen[r] {
+			panic("duplicate realm in proposal: " + r)
+		}
+		seen[r] = true
+	}
+
+	var desc strings.Builder
+	desc.WriteString(description)
+	if len(description) > 0 {
+		desc.WriteString("\n\n")
+	}
+
+	desc.WriteString("## Allowed Realm Updates\n")
+	for _, r := range add {
+		desc.WriteString("- add: " + r + "\n")
+	}
+	for _, r := range remove {
+		desc.WriteString("- remove: " + r + "\n")
+	}
+
+	callback := func(cur realm) error {
+		for _, r := range add {
+			allowedRealms.Set(r, true)
+			chain.Emit("AllowedRealmAdded", "realm", r)
+		}
+		for _, r := range remove {
+			allowedRealms.Remove(r)
+			chain.Emit("AllowedRealmRemoved", "realm", r)
+		}
+		return nil
+	}
+
+	e := dao.NewSimpleExecutor(callback, "")
+	return dao.NewProposalRequest(title, desc.String(), e)
+}

--- a/examples/gno.land/r/sys/validators/v3/allowed_test.gno
+++ b/examples/gno.land/r/sys/validators/v3/allowed_test.gno
@@ -1,0 +1,187 @@
+package validators
+
+import (
+	"testing"
+
+	"gno.land/p/nt/bptree/v0"
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+func TestAllowedRealms_AddRemove(t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+
+	uassert.False(t, IsAllowedRealm("gno.land/r/demo/ics"))
+
+	allowedRealms.Set("gno.land/r/demo/ics", true)
+	uassert.True(t, IsAllowedRealm("gno.land/r/demo/ics"))
+
+	realms := GetAllowedRealms()
+	uassert.Equal(t, 1, len(realms))
+	uassert.Equal(t, "gno.land/r/demo/ics", realms[0])
+
+	allowedRealms.Remove("gno.land/r/demo/ics")
+	uassert.False(t, IsAllowedRealm("gno.land/r/demo/ics"))
+	uassert.Equal(t, 0, len(GetAllowedRealms()))
+}
+
+func TestAddValidator_NotAllowed(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	resetValset(t)
+	resetCache()
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/unknown"))
+
+	op := testutils.TestAddress("op-A")
+	urequire.AbortsWithMessage(t,
+		"realm gno.land/r/demo/unknown is not allowed to modify the validator set",
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}) },
+	)
+}
+
+func TestAddValidator_UserNotAllowed(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	resetValset(t)
+	resetCache()
+
+	testing.SetRealm(testing.NewUserRealm(mustAddr(t, pubKeyA)))
+
+	op := testutils.TestAddress("op-A")
+	urequire.AbortsWithMessage(t,
+		"caller must be a realm, not a user",
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}) },
+	)
+}
+
+func TestAddValidator_Allowed(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	resetValset(t)
+	resetCache()
+	testing.SetSysParamStrings(module, submodule, currKey, []string{pubKeyA + ":10"})
+
+	op := testutils.TestAddress("op-B")
+	seedCache(t, []struct {
+		op          address
+		pubKey      string
+		keepRunning bool
+	}{{op: op, pubKey: pubKeyB, keepRunning: true}})
+
+	const allowedPath = "gno.land/r/demo/ics"
+	allowedRealms.Set(allowedPath, true)
+
+	testing.SetRealm(testing.NewCodeRealm(allowedPath))
+
+	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10})
+	uassert.True(t, IsValidator(mustAddr(t, pubKeyB)))
+}
+
+func TestRemoveValidator_Allowed(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	resetValset(t)
+	resetCache()
+	testing.SetSysParamStrings(module, submodule, currKey, []string{pubKeyA + ":10"})
+
+	op := testutils.TestAddress("op-B")
+	seedCache(t, []struct {
+		op          address
+		pubKey      string
+		keepRunning bool
+	}{{op: op, pubKey: pubKeyB, keepRunning: true}})
+
+	const allowedPath = "gno.land/r/demo/ics"
+	allowedRealms.Set(allowedPath, true)
+
+	testing.SetRealm(testing.NewCodeRealm(allowedPath))
+
+	addrB := mustAddr(t, pubKeyB)
+	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10})
+	uassert.True(t, IsValidator(addrB))
+
+	RemoveValidator(cross, op)
+	uassert.False(t, IsValidator(addrB))
+}
+
+func TestRemoveValidator_NotAllowed(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	resetValset(t)
+	resetCache()
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/unknown"))
+
+	op := testutils.TestAddress("op-A")
+	urequire.AbortsWithMessage(t,
+		"realm gno.land/r/demo/unknown is not allowed to modify the validator set",
+		func() { RemoveValidator(cross, op) },
+	)
+}
+
+func TestAddValidator_RejectsPowerZero(cur realm, t *testing.T) {
+	allowedRealms = bptree.NewBPTree32()
+	const allowedPath = "gno.land/r/demo/ics"
+	allowedRealms.Set(allowedPath, true)
+
+	testing.SetRealm(testing.NewCodeRealm(allowedPath))
+
+	op := testutils.TestAddress("op-A")
+	urequire.AbortsWithMessage(t,
+		"AddValidator requires Power > 0; use RemoveValidator for removals",
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 0}) },
+	)
+}
+
+func TestNewPropAllowedRealmUpdateRequest_RejectsEmptyTitle(t *testing.T) {
+	uassert.PanicsContains(t, "proposal title is empty", func() {
+		_ = NewPropAllowedRealmUpdateRequest(
+			[]string{"gno.land/r/demo/ics"}, nil, "   ", "",
+		)
+	})
+}
+
+func TestNewPropAllowedRealmUpdateRequest_RejectsEmptyAddAndRemove(t *testing.T) {
+	uassert.PanicsContains(t, "proposal must add or remove at least one realm", func() {
+		_ = NewPropAllowedRealmUpdateRequest(nil, nil, "title", "")
+	})
+}
+
+func TestNewPropAllowedRealmUpdateRequest_RejectsDuplicateInAdd(t *testing.T) {
+	uassert.PanicsContains(t, "duplicate realm in proposal: gno.land/r/demo/ics", func() {
+		_ = NewPropAllowedRealmUpdateRequest(
+			[]string{"gno.land/r/demo/ics", "gno.land/r/demo/ics"}, nil, "dup-add", "",
+		)
+	})
+}
+
+func TestNewPropAllowedRealmUpdateRequest_RejectsDuplicateInRemove(t *testing.T) {
+	uassert.PanicsContains(t, "duplicate realm in proposal: gno.land/r/demo/ics", func() {
+		_ = NewPropAllowedRealmUpdateRequest(
+			nil, []string{"gno.land/r/demo/ics", "gno.land/r/demo/ics"}, "dup-remove", "",
+		)
+	})
+}
+
+func TestNewPropAllowedRealmUpdateRequest_RejectsAddRemoveOverlap(t *testing.T) {
+	uassert.PanicsContains(t, "duplicate realm in proposal: gno.land/r/demo/ics", func() {
+		_ = NewPropAllowedRealmUpdateRequest(
+			[]string{"gno.land/r/demo/ics"},
+			[]string{"gno.land/r/demo/ics"},
+			"overlap", "",
+		)
+	})
+}
+
+func TestNewPropAllowedRealmUpdateRequest_DescriptionRendering(t *testing.T) {
+	pr := NewPropAllowedRealmUpdateRequest(
+		[]string{"gno.land/r/demo/ics"},
+		[]string{"gno.land/r/demo/legacy"},
+		"mixed",
+		"context line",
+	)
+
+	desc := pr.Description()
+	urequire.True(t, len(desc) > 0)
+	uassert.True(t, contains(desc, "context line"))
+	uassert.True(t, contains(desc, "## Allowed Realm Updates"))
+	uassert.True(t, contains(desc, "- add: gno.land/r/demo/ics"))
+	uassert.True(t, contains(desc, "- remove: gno.land/r/demo/legacy"))
+}

--- a/examples/gno.land/r/sys/validators/v3/allowed_test.gno
+++ b/examples/gno.land/r/sys/validators/v3/allowed_test.gno
@@ -36,7 +36,7 @@ func TestAddValidator_NotAllowed(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"realm gno.land/r/demo/unknown is not allowed to modify the validator set",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}) },
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA)) },
 	)
 }
 
@@ -50,7 +50,7 @@ func TestAddValidator_UserNotAllowed(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"caller must be a realm, not a user",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}) },
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA)) },
 	)
 }
 
@@ -72,7 +72,7 @@ func TestAddValidator_Allowed(cur realm, t *testing.T) {
 
 	testing.SetRealm(testing.NewCodeRealm(allowedPath))
 
-	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10})
+	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyB, mustAddr(t, pubKeyB))
 	uassert.True(t, IsValidator(mustAddr(t, pubKeyB)))
 }
 
@@ -95,7 +95,7 @@ func TestRemoveValidator_Allowed(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm(allowedPath))
 
 	addrB := mustAddr(t, pubKeyB)
-	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10})
+	AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyB, mustAddr(t, pubKeyB))
 	uassert.True(t, IsValidator(addrB))
 
 	RemoveValidator(cross, op)
@@ -126,7 +126,7 @@ func TestAddValidator_RejectsPowerZero(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"AddValidator requires Power > 0; use RemoveValidator for removals",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 0}) },
+		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 0}, pubKeyA, mustAddr(t, pubKeyA)) },
 	)
 }
 

--- a/examples/gno.land/r/sys/validators/v3/allowed_test.gno
+++ b/examples/gno.land/r/sys/validators/v3/allowed_test.gno
@@ -36,7 +36,9 @@ func TestAddValidator_NotAllowed(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"realm gno.land/r/demo/unknown is not allowed to modify the validator set",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA)) },
+		func() {
+			AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA))
+		},
 	)
 }
 
@@ -50,7 +52,9 @@ func TestAddValidator_UserNotAllowed(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"caller must be a realm, not a user",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA)) },
+		func() {
+			AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 10}, pubKeyA, mustAddr(t, pubKeyA))
+		},
 	)
 }
 
@@ -126,7 +130,9 @@ func TestAddValidator_RejectsPowerZero(cur realm, t *testing.T) {
 	op := testutils.TestAddress("op-A")
 	urequire.AbortsWithMessage(t,
 		"AddValidator requires Power > 0; use RemoveValidator for removals",
-		func() { AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 0}, pubKeyA, mustAddr(t, pubKeyA)) },
+		func() {
+			AddValidator(cross, ValoperChange{OperatorAddress: op, Power: 0}, pubKeyA, mustAddr(t, pubKeyA))
+		},
 	)
 }
 

--- a/examples/gno.land/r/sys/validators/v3/validators.gno
+++ b/examples/gno.land/r/sys/validators/v3/validators.gno
@@ -23,6 +23,10 @@ import (
 // signing-keyed NewProposalRequest was removed: every valid
 // signing-keyed input is also a valid operator-keyed input under
 // always-on valoper enforcement.
+//
+// Allow-listed realms can bypass GovDAO and call AddValidator /
+// RemoveValidator directly; the whitelist is managed via
+// NewPropAllowedRealmUpdateRequest. See allowed.gno.
 
 // IsValidator returns true if addr is part of the effective validator
 // set (proposed if a v3 proposal is awaiting EndBlocker, else


### PR DESCRIPTION
Backport of the allow list from r/sys/validators/v2 (#5168). Whitelisted realms can call AddValidator/RemoveValidator directly (reusing newValoperChangeExecutor for the apply-and-publish path); the whitelist is managed via NewPropAllowedRealmUpdateRequest GovDAO proposals.

Supersedes #5168