### PR TITLE
fix(gnoweb): change gnoweb to find usernames with hyphens

### DIFF
--- a/docs/resources/gnoland-networks.md
+++ b/docs/resources/gnoland-networks.md
@@ -6,7 +6,7 @@
 |-------------------|------------------------------------------|--------------|
 | Betanet (current) | https://rpc.gno.land:443                 | `gnoland1`   |
 | Staging           | https://rpc.staging.gno.land:443         | `staging`    |
-| Test11            | https://rpc.test11.testnets.gno.land:443 | `test11`     |
+| Test13            | https://rpc.test13.testnets.gno.land:443 | `test-13`    |
 
 ### WebSocket endpoints
 
@@ -132,15 +132,15 @@ is the `gnoweb` render of the Staging testnet.
     [`misc/loop`](https://github.com/gnolang/gno/tree/master/misc/loop) folder in the
     monorepo
 
-### Test11
+### Test13
 
-The latest Gno.land testnet, released on the 12th of Februrary, 2025.
+The latest Gno.land testnet, released on the 15th of June, 2026.
 
 - **Persistence of state:**
   - State is fully persisted unless there are breaking changes in a new release,
     where persistence partly depends on implementing a migration strategy
 - **Timeliness of code:**
-  - Pre-deployed packages and realms are at release tag [chain/test11.0](https://github.com/gnolang/gno/releases/tag/chain%2Ftest11.0)
+  - Pre-deployed packages and realms are at release tag [chain/test13](https://github.com/gnolang/gno/releases/tag/chain%2Ftest13)
 - **Intended purpose**
   - Running a full node, testing validator coordination, deploying stable Gno
     dApps, creating tools that require persisted state & transaction history
@@ -148,6 +148,14 @@ The latest Gno.land testnet, released on the 12th of Februrary, 2025.
 ### TestX
 
 These testnets are deprecated and currently serve as archives of previous progress.
+
+### Test12 (archive)
+
+Test12 is the testnet released on the 16th of April, 2026.
+
+### Test11 (archive)
+
+Test11 is the testnet released on the 12th of February, 2025.
 
 ### Test10 (archive)
 

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -218,18 +218,19 @@ func cloneValues(v url.Values) url.Values {
 	return dup
 }
 
-// IsPure checks if the URL path represents a pure path.
+// IsPure checks if the URL path prefix represents a pure path.
 func (gnoURL GnoURL) IsPure() bool {
-	return strings.HasPrefix(gnoURL.Path, "/p/")
+	return strings.HasPrefix(gnoURL.Path, "/p/") && gnoURL.IsValidPath()
 }
 
-// IsRealm checks if the URL path represents a realm path.
+// IsRealm checks if the URL path prefix represents a realm path.
 func (gnoURL GnoURL) IsRealm() bool {
-	return strings.HasPrefix(gnoURL.Path, "/r/")
+	return strings.HasPrefix(gnoURL.Path, "/r/") && gnoURL.IsValidPath()
 }
 
+// IsUser checks if the URL path prefix represents a user path.
 func (gnoURL GnoURL) IsUser() bool {
-	return strings.HasPrefix(gnoURL.Path, "/u/")
+	return strings.HasPrefix(gnoURL.Path, "/u/") && gnoURL.IsValidPath()
 }
 
 // IsFile checks if the URL path represents a file.
@@ -239,25 +240,26 @@ func (gnoURL GnoURL) IsFile() bool {
 
 // IsDir checks if the URL path represents a directory.
 func (gnoURL GnoURL) IsDir() bool {
-	return !gnoURL.IsFile() &&
-		len(gnoURL.Path) > 0 && gnoURL.Path[len(gnoURL.Path)-1] == '/'
+	return !gnoURL.IsFile() && strings.HasSuffix(gnoURL.Path, "/")
 }
 
-// rePkgPath matches and validates a path.
-var rePkgPath = regexp.MustCompile(`^/[a-z0-9_/-]*$`)
+// reGnolandPath matches and validates a Gno.land URL path.
+// The minimum path allowed are the Gno.land prefixed ones so listing can be
+// implemented, for example in Gnoweb "/r/" or "/p/" would list the files or
+// directories within those paths.
+var reGnolandPath = regexp.MustCompile(`^/[rpu]/([a-z][a-z0-9_/-]*)*$`)
 
-// reUserPath matches and validates a user path.
-var reUserPath = regexp.MustCompile(`^/u/[a-zA-Z0-9_-]+$`)
-
+// IsValidPath checks that path is a valid Gno.land URL path.
+// It just validates that the path format can match with Gno.land URL paths, but
+// it doesn't validates semantics, like "/r/", "/p/", etc; Use `IsPure()`,
+// `IsRealm()` or similar methods to check for specific URL path cases.
 func (gnoURL GnoURL) IsValidPath() bool {
-	return rePkgPath.MatchString(gnoURL.Path) || reUserPath.MatchString(gnoURL.Path)
+	return reGnolandPath.MatchString(gnoURL.Path)
 }
 
-var reNamespace = regexp.MustCompile(`^/[a-z]/[a-z][a-z0-9_/-]*$`)
-
-// Extract the package name from the path (e.g., "/r/test/foo" -> "test")
+// Extract the package name from the Gno.land URL path (e.g., "/r/test/foo" -> "test")
 func (gnoURL GnoURL) Namespace() string {
-	if !reNamespace.MatchString(gnoURL.Path) {
+	if !gnoURL.IsValidPath() {
 		return ""
 	}
 
@@ -277,6 +279,11 @@ func (gnoURL GnoURL) Username() string {
 
 	return gnoURL.Path[3:] // skip `/u/`
 }
+
+// reURLPath matches and validates a standard URL path compatible with Gno.land URL paths.
+// Expression considers that "/" is the minimum valid path allowed and then optionally
+// allows any characters allowed within different Gno.land URL paths.
+var reURLPath = regexp.MustCompile(`^/[a-z0-9_/-]*$`)
 
 // ParseFromURL parses a URL into a GnoURL structure, extracting and validating its components.
 // Grammar: `<path>[:<args>][$<webargs>]`. The `$` split runs first so a
@@ -307,7 +314,7 @@ func ParseFromURL(u *url.URL) (*GnoURL, error) {
 		}
 	}
 
-	if !rePkgPath.MatchString(upath) {
+	if !reURLPath.MatchString(upath) {
 		return nil, fmt.Errorf("%w: %q", ErrURLInvalidPath, upath)
 	}
 

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -247,6 +247,8 @@ func (gnoURL GnoURL) IsDir() bool {
 // The minimum path allowed are the Gno.land prefixed ones so listing can be
 // implemented, for example in Gnoweb "/r/" or "/p/" would list the files or
 // directories within those paths.
+// Expression doesn't validate "//" because at this point the URL path should
+// have been validated or normalized by the Gno.land URL parser.
 var reGnolandPath = regexp.MustCompile(`^/[rpu]/([a-z][a-z0-9_/-]*)*$`)
 
 // IsValidPath checks that path is a valid Gno.land URL path.
@@ -283,6 +285,8 @@ func (gnoURL GnoURL) Username() string {
 // reURLPath matches and validates a standard URL path compatible with Gno.land URL paths.
 // Expression considers that "/" is the minimum valid path allowed and then optionally
 // allows any characters allowed within different Gno.land URL paths.
+// Expression doesn't validate "//" matches for simplicity, this validation is done
+// separately when parsing the URL.
 var reURLPath = regexp.MustCompile(`^/[a-z0-9_/-]*$`)
 
 // ParseFromURL parses a URL into a GnoURL structure, extracting and validating its components.
@@ -314,7 +318,11 @@ func ParseFromURL(u *url.URL) (*GnoURL, error) {
 		}
 	}
 
-	if !reURLPath.MatchString(upath) {
+	// Check that path contains valid characters or is the root "/" path.
+	// Also make sure it doesn't contain "//" which semantically are not
+	// considered valid within Gno.land package paths. The "//" is checked
+	// using contains to keep the URL path regexp simple.
+	if strings.Contains(upath, "//") || !reURLPath.MatchString(upath) {
 		return nil, fmt.Errorf("%w: %q", ErrURLInvalidPath, upath)
 	}
 

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -244,16 +244,16 @@ func (gnoURL GnoURL) IsDir() bool {
 }
 
 // rePkgPath matches and validates a path.
-var rePkgPath = regexp.MustCompile(`^/[a-z0-9_/]*$`)
+var rePkgPath = regexp.MustCompile(`^/[a-z0-9_/-]*$`)
 
 // reUserPath matches and validates a user path.
-var reUserPath = regexp.MustCompile(`^/u/[a-zA-Z0-9_]+$`)
+var reUserPath = regexp.MustCompile(`^/u/[a-zA-Z0-9_-]+$`)
 
 func (gnoURL GnoURL) IsValidPath() bool {
 	return rePkgPath.MatchString(gnoURL.Path) || reUserPath.MatchString(gnoURL.Path)
 }
 
-var reNamespace = regexp.MustCompile(`^/[a-z]/[a-z][a-z0-9_/]*$`)
+var reNamespace = regexp.MustCompile(`^/[a-z]/[a-z][a-z0-9_/-]*$`)
 
 // Extract the package name from the path (e.g., "/r/test/foo" -> "test")
 func (gnoURL GnoURL) Namespace() string {

--- a/gno.land/pkg/gnoweb/weburl/url.go
+++ b/gno.land/pkg/gnoweb/weburl/url.go
@@ -251,7 +251,7 @@ var reGnolandPath = regexp.MustCompile(`^/[rpu]/([a-z][a-z0-9_/-]*)*$`)
 
 // IsValidPath checks that path is a valid Gno.land URL path.
 // It just validates that the path format can match with Gno.land URL paths, but
-// it doesn't validates semantics, like "/r/", "/p/", etc; Use `IsPure()`,
+// it doesn't validate semantics, like "/r/", "/p/", etc; Use `IsPure()`,
 // `IsRealm()` or similar methods to check for specific URL path cases.
 func (gnoURL GnoURL) IsValidPath() bool {
 	return reGnolandPath.MatchString(gnoURL.Path)

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -51,15 +51,9 @@ func TestParseGnoURL(t *testing.T) {
 		},
 
 		{
-			Name:  "complex file path",
-			Input: "https://gno.land/r/simple/test///...gno",
-			Expected: &GnoURL{
-				Domain:   "gno.land",
-				Path:     "/r/simple/test//",
-				WebQuery: url.Values{},
-				Query:    url.Values{},
-				File:     "...gno",
-			},
+			Name:  "simple with multiple slashes",
+			Input: "https://gno.land/r/hyphen-simple//test",
+			Err:   ErrURLInvalidPath,
 		},
 
 		{
@@ -150,14 +144,26 @@ func TestParseGnoURL(t *testing.T) {
 
 		{
 			Name:  "empty path",
-			Input: "https://gno.land/r/",
+			Input: "https://gno.land",
+			Err:   ErrURLInvalidPath,
+		},
+
+		{
+			Name:  "root path",
+			Input: "https://gno.land/",
 			Expected: &GnoURL{
-				Path:     "/r/",
+				Path:     "/",
 				Args:     "",
 				WebQuery: url.Values{},
 				Query:    url.Values{},
 				Domain:   "gno.land",
 			},
+		},
+
+		{
+			Name:  "root path with multiple slashes",
+			Input: "https://gno.land//",
+			Err:   ErrURLInvalidPath,
 		},
 
 		{

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -40,6 +40,17 @@ func TestParseGnoURL(t *testing.T) {
 		},
 
 		{
+			Name:  "simple with hyphen",
+			Input: "https://gno.land/r/hyphen-simple/test",
+			Expected: &GnoURL{
+				Domain:   "gno.land",
+				Path:     "/r/hyphen-simple/test",
+				WebQuery: url.Values{},
+				Query:    url.Values{},
+			},
+		},
+
+		{
 			Name:  "complex file path",
 			Input: "https://gno.land/r/simple/test///...gno",
 			Expected: &GnoURL{
@@ -301,7 +312,9 @@ func TestIsValidPath(t *testing.T) {
 		{Path: "/r/valid/path_with/underscores", Valid: true},
 		{Path: "/r/", Valid: true},
 		{Path: "/r/with space", Valid: false},
-		{Path: "/r/hyphen-invalid", Valid: false},
+		{Path: "/hyphen-valid", Valid: true},
+		{Path: "/r/hyphen-valid", Valid: true},
+		{Path: "/u/hyphen-valid", Valid: true},
 	}
 
 	for _, tc := range testCases {
@@ -328,8 +341,8 @@ func TestNamespace(t *testing.T) {
 		{Path: "/r/a_b/c", Expected: "a_b"},
 		{Path: "/invalidpath", Expected: ""},
 		{Path: "/r/", Expected: ""},
-		{Path: "/r/a-b/c", Expected: ""},
-		{Path: "/r/valid-ns", Expected: ""},
+		{Path: "/r/a-b/c", Expected: "a-b"},
+		{Path: "/r/valid-ns", Expected: "valid-ns"},
 	}
 
 	for _, tc := range testCases {

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -51,6 +51,17 @@ func TestParseGnoURL(t *testing.T) {
 		},
 
 		{
+			Name:  "simple with multiple hyphens",
+			Input: "https://gno.land/r/-hyphen--simple/-test-",
+			Expected: &GnoURL{
+				Domain:   "gno.land",
+				Path:     "/r/-hyphen--simple/-test-",
+				WebQuery: url.Values{},
+				Query:    url.Values{},
+			},
+		},
+
+		{
 			Name:  "simple with multiple slashes",
 			Input: "https://gno.land/r/hyphen-simple//test",
 			Err:   ErrURLInvalidPath,

--- a/gno.land/pkg/gnoweb/weburl/url_test.go
+++ b/gno.land/pkg/gnoweb/weburl/url_test.go
@@ -301,7 +301,7 @@ func TestIsValidPath(t *testing.T) {
 		Path  string
 		Valid bool
 	}{
-		{Path: "/", Valid: true},
+		{Path: "/", Valid: false},
 		{Path: "/r/valid", Valid: true},
 		{Path: "/p/abc_123", Valid: true},
 		{Path: "/r/demo/users/", Valid: true},
@@ -312,9 +312,8 @@ func TestIsValidPath(t *testing.T) {
 		{Path: "/r/valid/path_with/underscores", Valid: true},
 		{Path: "/r/", Valid: true},
 		{Path: "/r/with space", Valid: false},
-		{Path: "/hyphen-valid", Valid: true},
 		{Path: "/r/hyphen-valid", Valid: true},
-		{Path: "/u/hyphen-valid", Valid: true},
+		{Path: "/p/hyphen-valid/path", Valid: true},
 	}
 
 	for _, tc := range testCases {
@@ -335,7 +334,7 @@ func TestNamespace(t *testing.T) {
 		{Path: "/p/another", Expected: "another"},
 		{Path: "/r/123invalid", Expected: ""},
 		{Path: "/r/TEST", Expected: ""},
-		{Path: "/x/ns", Expected: "ns"},
+		{Path: "/x/ns", Expected: ""},
 		{Path: "/r/a", Expected: "a"},
 		{Path: "/r/a1", Expected: "a1"},
 		{Path: "/r/a_b/c", Expected: "a_b"},

--- a/gno.land/pkg/integration/testdata/gnokey_qpaths.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_qpaths.txtar
@@ -9,6 +9,10 @@ loadpkg gno.land/p/bbb/ccc/ppp $WORK
 loadpkg gno.land/r/bbb/aaa $WORK
 loadpkg gno.land/r/bbb0 $WORK
 
+# foo-bar namespace (hyphenated)
+loadpkg gno.land/r/foo-bar/baz $WORK
+loadpkg gno.land/p/foo-bar/pkg $WORK
+
 gnoland start
 
 # query path for prefix
@@ -46,14 +50,21 @@ gnokey query vm/qpaths?limit=5 --data "_"
 cmp stdout stdlibs-qpaths.stdout.golden
 cmp stderr empty_file
 
-
 gnokey query vm/qpaths --data "_/encoding"
 cmp stdout stdlibs-encoding-qpaths.stdout.golden
 cmp stderr empty_file
 
-
 gnokey query vm/qpaths?limit=5 --data ""
 cmp stdout empty-qpaths.stdout.golden
+cmp stderr empty_file
+
+# query path for namespace with hyphen
+gnokey query vm/qpaths --data "@foo-bar"
+cmp stdout foo-bar-name-qpaths.stdout.golden
+cmp stderr empty_file
+
+gnokey query vm/qpaths --data "@foo-bar/baz"
+cmp stdout foo-bar-name-subpath-qpaths.stdout.golden
 cmp stderr empty_file
 
 -- main.gno --
@@ -91,6 +102,13 @@ Msg Traces:
 
 -- invalid-name-qpaths.stderr.golden --
 "gnokey" error: invalid username format
+-- foo-bar-name-qpaths.stdout.golden --
+height: 0
+data: gno.land/p/foo-bar/pkg
+gno.land/r/foo-bar/baz
+-- foo-bar-name-subpath-qpaths.stdout.golden --
+height: 0
+data: gno.land/r/foo-bar/baz
 -- ccc-qpaths.stdout.golden --
 height: 0
 data: 

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1139,7 +1139,7 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 	return res, nil
 }
 
-var reUserNamespace = regexp.MustCompile(`^[~_a-zA-Z0-9/]+$`)
+var reUserNamespace = regexp.MustCompile(`^[~_a-zA-Z0-9/-]+$`)
 
 // QueryPaths returns public facing function signatures.
 // XXX: Implement pagination


### PR DESCRIPTION
PR fixes Gnoweb to find usernames that contain hyphens.

It also fixes the Keeper so path queries also work for usernames with hyphen.

Related to #5600