### PR TITLE
feat(govdao-scripts): normalize v2 scripts + add v3/namereg/valoper-register

### DIFF
--- a/misc/govdao-scripts/README.md
+++ b/misc/govdao-scripts/README.md
@@ -7,14 +7,22 @@ Shared scripts for govDAO governance operations. These scripts require `GNOKEY_N
 ```bash
 # From the deployment directory:
 ./govdao                                     # list available commands
-./govdao add-validator-from-valopers ADDR    # add a validator registered at r/gnops/valopers
-./govdao add-validator ADDR PUBKEY [POWER]   # add a validator with explicit pub_key
-./govdao rm-validator ADDR                   # remove a validator
+./govdao add-validator-from-valopers ADDR    # v2: add a validator registered at r/gnops/valopers
+./govdao add-validator ADDR PUBKEY [POWER]   # v2: add a validator with explicit pub_key
+./govdao rm-validator ADDR                   # v2: remove a validator
+./govdao add-validator-v3 OPADDR [POWER]     # v3: add validator by operator-address (test-13+)
+./govdao rm-validator-v3 OPADDR              # v3: remove validator by operator-address (test-13+)
+./govdao register-valoper MONIKER DESC TYPE OPADDR PUBKEY   # operator self-register profile (NOT govDAO-signed)
+./govdao register-user USERNAME ADDR         # govDAO-grant a custom username for ADDR
 ./govdao extend-govdao-t1                    # add 6 T1 members to govDAO (one-time bootstrap)
 ./govdao unrestrict-account ADDR [ADDR...]   # allow address(es) to transfer ugnot
 ./govdao restrict-account ADDR [ADDR...]     # re-restrict account(s) from transferring ugnot
 ./govdao set-cla URL                         # set/update CLA document via govDAO proposal
 ./govdao set-valoper-minfee AMOUNT           # update valoper registration minimum fee
 ```
+
+The `-v3` validator commands route through `r/sys/validators/v3` (operator-keyed,
+post-VALOPLAN2). Use them on chains running v3 (test-13 onward). On chains still
+running v2 (gnoland1 pre-hardfork), use the unsuffixed `add-validator` / `rm-validator`.
 
 Each deployment wrapper (e.g., `misc/deployments/gnoland1/govdao`) sets the correct chain ID, RPC endpoint, and default key name.

--- a/misc/govdao-scripts/add-validator-from-valopers.sh
+++ b/misc/govdao-scripts/add-validator-from-valopers.sh
@@ -8,12 +8,7 @@
 # Usage:
 #   ./add-validator-from-valopers.sh <address>
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 10000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
@@ -58,8 +53,8 @@ func main() {
 GOEOF
 
 echo "Adding validator from valopers: ${ADDR}"
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/add-validator-v3.sh
+++ b/misc/govdao-scripts/add-validator-v3.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Add an operator to the test-13 active valset via govDAO proposal.
+#
+# Routes through r/sys/validators/v3's operator-keyed
+# NewValidatorProposalRequest (non-crossing) with the given Power.
+# The operator must already exist in r/gnops/valopers' valoperCache
+# (i.e. have called valopers.Register themselves) with
+# KeepRunning=true (the default at Register time). v3's executor
+# re-resolves the signing pubkey from the cache at execution time,
+# so a mid-flight key rotation publishes the current key.
+#
+# Usage:
+#   ./add-validator.sh <operator_address> [voting_power]
+#
+# Environment: see README.md.
+set -eo pipefail
+
+GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
+CHAIN_ID="${CHAIN_ID:?CHAIN_ID is required}"
+REMOTE="${REMOTE:?REMOTE is required}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <operator_address> [voting_power]"
+  echo ""
+  echo "Example:"
+  echo "  $0 g1s2ht24e85qq3t66gc9sgdvk5kzc38yy68aaqvr        # power 1 (default)"
+  echo "  $0 g1s2ht24e85qq3t66gc9sgdvk5kzc38yy68aaqvr 10     # power 10"
+  exit 1
+fi
+
+ADDR="$1"
+POWER="${2:-1}"
+
+# voting_power must be a positive integer — v3 rejects Power=0 as a
+# remove operation, which would silently turn this script into a
+# remove if a user passes 0 by mistake. Catch it here.
+if ! [[ "$POWER" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: voting_power must be a positive integer (got: '$POWER')"
+  echo "       use ./rm-validator.sh to remove an operator from the valset"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/add_validator.gno" <<GOEOF
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	valv3 "gno.land/r/sys/validators/v3"
+)
+
+func main() {
+	r := valv3.NewValidatorProposalRequest(
+		[]valv3.ValoperChange{
+			{OperatorAddress: address("${ADDR}"), Power: ${POWER}},
+		},
+		"Add validator ${ADDR}",
+		"Add operator ${ADDR} to the active valset with voting power ${POWER}.",
+	)
+	pid := dao.MustCreateProposal(cross, r)
+	dao.MustVoteOnProposal(cross, dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.ExecuteProposal(cross, pid)
+}
+GOEOF
+
+echo "Adding validator: ${ADDR} (power=${POWER})"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
+echo "  Remote: ${REMOTE}"
+echo ""
+
+gnokey maketx run \
+  -gas-wanted "$GAS_WANTED" \
+  -gas-fee "$GAS_FEE" \
+  -broadcast \
+  -chainid "$CHAIN_ID" \
+  -remote "$REMOTE" \
+  "$GNOKEY_NAME" \
+  "$TMPDIR/add_validator.gno"

--- a/misc/govdao-scripts/add-validator.sh
+++ b/misc/govdao-scripts/add-validator.sh
@@ -4,12 +4,7 @@
 # Usage:
 #   ./add-validator.sh <address> <pub_key> [voting_power]
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
@@ -29,6 +24,15 @@ fi
 ADDR="$1"
 PUB_KEY="$2"
 POWER="${3:-1}"
+
+# voting_power must be a positive integer. Tendermint treats Power=0 as
+# a remove operation, which would silently turn this script into a
+# remove if a user passes 0 by mistake. Catch it here.
+if ! [[ "$POWER" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: voting_power must be a positive integer (got: '$POWER')"
+  echo "       use ./rm-validator.sh to remove a validator from the set"
+  exit 1
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -63,8 +67,8 @@ func main() {
 GOEOF
 
 echo "Adding validator: ${ADDR} (power=${POWER})"
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/extend-govdao-t1.sh
+++ b/misc/govdao-scripts/extend-govdao-t1.sh
@@ -5,12 +5,7 @@
 # Usage:
 #   ./extend-govdao-t1.sh
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
@@ -47,8 +42,8 @@ func main() {
 GOEOF
 
 echo "Extending govDAO T1 with 6 new members"
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/register-user.sh
+++ b/misc/govdao-scripts/register-user.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Register a custom username for an address via govDAO proposal.
+#
+# Routes through r/sys/users.ProposeRegisterUser. The proposal
+# bypasses the controller whitelist (where r/sys/namereg/v1 lives)
+# and the canonical-collision check (decision #3: DAO grants are
+# sovereign). A canonical-collision warning is auto-injected into
+# the proposal description if relevant; voters can NO it.
+#
+# After execution, <address> can deploy packages under
+# gno.land/r/<username>/* and gno.land/p/<username>/* — the
+# r/sys/names verifier bridges to r/sys/users.ResolveName for
+# registered-name namespaces.
+#
+# Names must match the validateName regex:
+#   ^[a-z][a-z0-9]*([_-][a-z0-9]+)*$
+#
+# Usage:
+#   ./register-user.sh <username> <address>
+#
+# Environment: see README.md.
+set -eo pipefail
+
+GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
+CHAIN_ID="${CHAIN_ID:?CHAIN_ID is required}"
+REMOTE="${REMOTE:?REMOTE is required}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <username> <address>"
+  echo ""
+  echo "Example:"
+  echo "  $0 moul g1moul0123456789abcdefghijklmnopqrstuvwxy"
+  exit 1
+fi
+
+USERNAME="$1"
+ADDR="$2"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/register_user.gno" <<GOEOF
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/sys/users"
+)
+
+func main() {
+	r := users.ProposeRegisterUser("${USERNAME}", address("${ADDR}"))
+	pid := dao.MustCreateProposal(cross, r)
+	dao.MustVoteOnProposal(cross, dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.ExecuteProposal(cross, pid)
+}
+GOEOF
+
+echo "Registering user: ${USERNAME} -> ${ADDR}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
+echo "  Remote: ${REMOTE}"
+echo ""
+
+gnokey maketx run \
+  -gas-wanted "$GAS_WANTED" \
+  -gas-fee "$GAS_FEE" \
+  -broadcast \
+  -chainid "$CHAIN_ID" \
+  -remote "$REMOTE" \
+  "$GNOKEY_NAME" \
+  "$TMPDIR/register_user.gno"

--- a/misc/govdao-scripts/register-valoper.sh
+++ b/misc/govdao-scripts/register-valoper.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Self-register a valoper profile in r/gnops/valopers.
+#
+# This is the prerequisite for governance to promote an operator into
+# the active valset via add-validator.sh — v3's
+# NewValidatorProposalRequest rejects any operator that isn't already
+# in valoperCache, which is populated only by valopers.Register and
+# valopers.UpdateKeepRunning.
+#
+# Auth: at runtime (ChainHeight > 0), r/gnops/valopers enforces
+# ErrOperatorSquatGuard (caller == operator address). $GNOKEY_NAME's
+# address MUST equal the <operator_address> argument; this is why this
+# script is signed by the operator themselves, NOT by the GovDAO T1.
+#
+# Usage:
+#   ./register-valoper.sh <moniker> <description> <server_type> \
+#                         <operator_address> <signing_pubkey>
+#
+# server_type: one of "cloud", "on-prem", "data-center" (validated by
+# the realm).
+#
+# Environment: see README.md. Override $GNOKEY_NAME to the operator's
+# local key name.
+set -eo pipefail
+
+GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
+CHAIN_ID="${CHAIN_ID:?CHAIN_ID is required}"
+REMOTE="${REMOTE:?REMOTE is required}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+
+if [ $# -lt 5 ]; then
+  echo "Usage: $0 <moniker> <description> <server_type> <operator_address> <signing_pubkey>"
+  echo ""
+  echo "Example:"
+  echo "  $0 'aeddi-1' 'Aeddi node #1' cloud \\"
+  echo "     g1s2ht24e85qq3t66gc9sgdvk5kzc38yy68aaqvr \\"
+  echo "     gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqfr74tgql2cvzadga2uts62v3f8a5dx66dauaq6sphg3ynuhgl286cce2mn"
+  exit 1
+fi
+
+MONIKER="$1"
+DESCRIPTION="$2"
+SERVER_TYPE="$3"
+OPERATOR_ADDR="$4"
+SIGNING_PUBKEY="$5"
+
+echo "Registering valoper: ${MONIKER} (${SERVER_TYPE})"
+echo "  Operator addr:  ${OPERATOR_ADDR}"
+echo "  Signing pubkey: ${SIGNING_PUBKEY}"
+echo "  Key:    ${GNOKEY_NAME}   (must control ${OPERATOR_ADDR} — squat guard)"
+echo "  Chain:  ${CHAIN_ID}"
+echo "  Remote: ${REMOTE}"
+echo ""
+
+gnokey maketx call \
+  --pkgpath gno.land/r/gnops/valopers \
+  --func Register \
+  --args "$MONIKER" \
+  --args "$DESCRIPTION" \
+  --args "$SERVER_TYPE" \
+  --args "$OPERATOR_ADDR" \
+  --args "$SIGNING_PUBKEY" \
+  --gas-wanted "$GAS_WANTED" \
+  --gas-fee "$GAS_FEE" \
+  --chainid "$CHAIN_ID" \
+  --remote "$REMOTE" \
+  --broadcast \
+  "$GNOKEY_NAME"

--- a/misc/govdao-scripts/restrict-account.sh
+++ b/misc/govdao-scripts/restrict-account.sh
@@ -8,12 +8,7 @@
 #   ./restrict-account.sh g1abc...123
 #   ./restrict-account.sh g1abc...123 g1def...456
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 if [ $# -eq 0 ]; then
@@ -58,8 +53,8 @@ echo "Restricting $# account(s):"
 for addr in "$@"; do
   echo "  $addr"
 done
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/rm-validator-v3.sh
+++ b/misc/govdao-scripts/rm-validator-v3.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Remove an operator from the test-13 active valset via govDAO proposal.
+#
+# Routes through r/sys/validators/v3's operator-keyed
+# NewValidatorProposalRequest (non-crossing) with Power=0. This is a
+# force-remove — unlike the higher-level facade in
+# r/gnops/valopers/proposal.NewValidatorProposalRequest, this does
+# not require the operator to have called UpdateKeepRunning(false)
+# first. The operator must still exist in r/gnops/valopers'
+# valoperCache (v3 enforces that at proposal-creation time).
+#
+# Usage:
+#   ./rm-validator.sh <operator_address>
+#
+# Environment: see README.md.
+set -eo pipefail
+
+GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
+CHAIN_ID="${CHAIN_ID:?CHAIN_ID is required}"
+REMOTE="${REMOTE:?REMOTE is required}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <operator_address>"
+  echo ""
+  echo "Example:"
+  echo "  $0 g1s2ht24e85qq3t66gc9sgdvk5kzc38yy68aaqvr"
+  exit 1
+fi
+
+ADDR="$1"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/rm_validator.gno" <<GOEOF
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	valv3 "gno.land/r/sys/validators/v3"
+)
+
+func main() {
+	r := valv3.NewValidatorProposalRequest(
+		[]valv3.ValoperChange{
+			{OperatorAddress: address("${ADDR}"), Power: 0},
+		},
+		"Remove validator ${ADDR}",
+		"Remove operator ${ADDR} from the active valset.",
+	)
+	pid := dao.MustCreateProposal(cross, r)
+	dao.MustVoteOnProposal(cross, dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.ExecuteProposal(cross, pid)
+}
+GOEOF
+
+echo "Removing validator: ${ADDR}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
+echo "  Remote: ${REMOTE}"
+echo ""
+
+gnokey maketx run \
+  -gas-wanted "$GAS_WANTED" \
+  -gas-fee "$GAS_FEE" \
+  -broadcast \
+  -chainid "$CHAIN_ID" \
+  -remote "$REMOTE" \
+  "$GNOKEY_NAME" \
+  "$TMPDIR/rm_validator.gno"

--- a/misc/govdao-scripts/rm-validator.sh
+++ b/misc/govdao-scripts/rm-validator.sh
@@ -4,12 +4,7 @@
 # Usage:
 #   ./rm-validator.sh <address>
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 GNOKEY_NAME="${GNOKEY_NAME:?GNOKEY_NAME is required}"
@@ -60,8 +55,8 @@ func main() {
 GOEOF
 
 echo "Removing validator: ${ADDR}"
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/set-cla.sh
+++ b/misc/govdao-scripts/set-cla.sh
@@ -9,12 +9,7 @@
 # Example:
 #   ./set-cla.sh https://raw.githubusercontent.com/gnolang/gno/.../CLA.md
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 if [ $# -ne 1 ]; then
@@ -71,8 +66,8 @@ func main() {
 }
 GOEOF
 
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/set-valoper-minfee.sh
+++ b/misc/govdao-scripts/set-valoper-minfee.sh
@@ -6,12 +6,7 @@
 #   ./set-valoper-minfee.sh 0          # disable registration fee
 #   ./set-valoper-minfee.sh 20000000   # set to 20 GNOT
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 if [ $# -ne 1 ]; then
@@ -49,8 +44,8 @@ func main() {
 GOEOF
 
 echo "Setting valoper registration min fee to: ${MIN_FEE} ugnot"
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 

--- a/misc/govdao-scripts/unrestrict-account.sh
+++ b/misc/govdao-scripts/unrestrict-account.sh
@@ -8,12 +8,7 @@
 #   ./unrestrict-account.sh g1abc...123
 #   ./unrestrict-account.sh g1abc...123 g1def...456
 #
-# Environment:
-#   GNOKEY_NAME   - gnokey key name (required)
-#   CHAIN_ID      - chain ID (required)
-#   REMOTE        - RPC endpoint (required)
-#   GAS_WANTED    - gas limit (default: 50000000)
-#   GAS_FEE       - gas fee (default: 1000000ugnot)
+# Environment: see README.md.
 set -eo pipefail
 
 if [ $# -eq 0 ]; then
@@ -58,8 +53,8 @@ echo "Unrestricting $# account(s):"
 for addr in "$@"; do
   echo "  $addr"
 done
-echo "  Key: ${GNOKEY_NAME}"
-echo "  Chain: ${CHAIN_ID}"
+echo "  Key:    ${GNOKEY_NAME}"
+echo "  Chain:  ${CHAIN_ID}"
 echo "  Remote: ${REMOTE}"
 echo ""
 


### PR DESCRIPTION
Two batches of changes to `misc/govdao-scripts/`, extracted from the test-13 hardfork stack (#5653) so they can land independently and shrink that PR's diff against master.

h/t @aeddi

## 1. Normalize existing v2 scripts

- **Replace inline Environment blocks with `# Environment: see README.md.`** Each script already validates its required env vars at the top via `${VAR:?...}`; the README is the single source of truth. Removes ~5 lines of duplication per script.
- **Align echo formatting** (`Key:    ` / `Chain:  ` / `Remote: `) so per-deployment output reads cleanly across all scripts.
- **`add-validator.sh`: add Power=0 input guard.** Tendermint treats `Power=0` as a remove operation, so an operator running `./govdao add-validator ADDR PUBKEY 0` by mistake would silently remove the validator instead of adding it. The guard catches the input early and points at `rm-validator.sh`.

## 2. Add 4 new shared scripts

- **`add-validator-v3.sh` / `rm-validator-v3.sh`** — route through `r/sys/validators/v3` (operator-keyed, post-VALOPLAN2). Use them on chains running v3 (test-13 onward). The v2 unsuffixed scripts stay canonical for gnoland1 pre-hardfork.
- **`register-user.sh`** — `r/sys/users.ProposeRegisterUser` govDAO proposal granting a custom username for an address (bypasses the controller whitelist; canonical-collision warning auto-injected into the proposal description if relevant).
- **`register-valoper.sh`** — **NOT govDAO-signed** — operator self-registration via `r/gnops/valopers.Register`. The runtime squat guard enforces `caller == operator address`, so this is signed by the operator's local key, not T1. Prerequisite for `add-validator-v3.sh`.

README updated with the 4 new entries and a v2-vs-v3 picking note.

## Test plan

- Wrapper smoke-test: `./govdao` from `misc/deployments/gnoland1/` lists all commands.
- Individual scripts: `./govdao add-validator` (no args) shows usage.
- Power guard: `./govdao add-validator ADDR PUBKEY 0` errors with the new message.
