### PR TITLE
fix(val-scenarios): remove stopped container before restart to avoid port conflict

### DIFF
--- a/misc/val-scenarios/lib/scenario.sh
+++ b/misc/val-scenarios/lib/scenario.sh
@@ -767,6 +767,10 @@ _resolve_control_port() {
 
 start_node() {
   local node="${1:?node required}"
+  # Remove any stopped container so Docker allocates a fresh ephemeral host
+  # port rather than reusing the previous binding, which can conflict when
+  # multiple nodes are restarted in sequence.
+  compose rm -f "$node" >/dev/null 2>&1 || true
   compose up -d "$node" >/dev/null
   _resolve_rpc_port "$node"
   wait_for_rpc "$node" 120


### PR DESCRIPTION
When `start_node` called `compose up -d` on a stopped container, Docker would "recreate" it and could assign an ephemeral host port that another recently-restarted container had just claimed. This caused flaky failures in CI with `address already in use` when restarting multiple validators in sequence.