### PR TITLE
test(misc/e2e): add gnovm audit and e2e regression scripts

### DIFF
--- a/misc/e2e/Makefile
+++ b/misc/e2e/Makefile
@@ -3,7 +3,13 @@
 test:
 	@echo "Running e2e tests with Docker..."
 	docker compose build
-	docker compose up --abort-on-container-exit --exit-code-from gnokey-test
+	docker compose up --abort-on-container-exit --exit-code-from gnokey-test; \
+	EXIT=$$?; \
+	echo ""; \
+	echo "========== TEST REPORT =========="; \
+	docker compose logs gnokey-test 2>/dev/null | grep -E "\[PASS\]|\[FAIL\]|\[KNOWN\]|PASS:|FAIL:|KNOWN:|All tests|Some tests"; \
+	echo "================================="; \
+	exit $$EXIT
 
 clean:
 	docker compose down -v

--- a/misc/e2e/README.md
+++ b/misc/e2e/README.md
@@ -1,0 +1,68 @@
+# misc/e2e — End-to-End Test Suite
+
+Docker-based E2E test suite for gnoland. Tests run against a single local
+validator node and are executed automatically by `make test`.
+
+## Running
+
+```sh
+cd misc/e2e
+make test      # build images, start node, run all tests
+make clean     # tear down containers and volumes
+make logs      # stream container logs
+```
+
+## Structure
+
+```
+misc/e2e/
+├── run_tests.sh          # main entrypoint called by docker-compose
+├── docker-compose.yml    # spins up gnoland + gnokey-test containers
+├── audit/
+│   ├── common.sh         # shared config: RPC, chainid, key setup
+│   └── audit_*.sh        # one script per gnovm fix (see below)
+└── e2e/
+    └── e2e_*.sh          # end-to-end transaction and consensus tests
+```
+
+## Audit scripts (`audit/`)
+
+Each script targets a specific gnovm bugfix and verifies it is present in
+the binary. Scripts exit 0 on ✅ PATCHED and exit 1 on ❌ VULNERABLE.
+
+| Script | Fix | What it verifies |
+| --- | --- | --- |
+| `audit_runtime_pkg.sh` | `afd7e4808` | `runtime` import rejected in production VM |
+| `audit_chan_type.sh` | `4bcd9828e` | `chan` type rejected at preprocess, not at runtime |
+| `audit_security.sh` | `6a6fc4c71` + `3be0408f0` | uint64 overflow caught at compile time; infinite recursion stopped by gas limit |
+| `audit_gas_alloc.sh` | `5d5f9213f` | large allocations consume gas proportionally (per-byte model) |
+| `audit_byteslice.sh` | `a3a356e71` | byte-slice index mutations persist across transactions |
+| `audit_array_alias.sh` | `c64feef1d` | array copy produces independent memory (no pointer aliasing) |
+| `audit_var_init_order.sh` | `50ee56e64` | package-level vars initialized in dependency order |
+| `audit_cross_realm_recover.sh` | `f87249327` | full state rollback when a realm panics and recover() is called |
+
+## E2E scripts (`e2e/`)
+
+| Script | What it verifies |
+| --- | --- |
+| `e2e_nonce_replay.sh` | Replaying a tx with an already-consumed sequence number is rejected |
+| `e2e_counter.sh` | Deploy a realm, increment state, verify committed value |
+| `e2e_mempool_stress.sh` | 10 sequential txs accepted without error; final state matches expected count |
+
+## Shared config (`audit/common.sh`)
+
+All scripts source `audit/common.sh` which sets:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RPC` | `http://gnoland:26657` | Node RPC endpoint |
+| `CHAINID` | `test` | Chain ID |
+| `KEY` | `test1` | Gnokey account name |
+| `PASSWORD` | `test1234` | Key password |
+| `GNOKEY_HOME` | `/tmp/gnokey` | Gnokey home directory |
+| `KEY_ADDR` | `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` | Deterministic address for `test1` |
+
+Override any variable via environment:
+```sh
+RPC=http://localhost:26657 CHAINID=test-13 ./audit/audit_security.sh
+```

--- a/misc/e2e/audit/audit_array_alias.sh
+++ b/misc/e2e/audit/audit_array_alias.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Targets: fix(gnovm): deep-copy array elements in ArrayValue.Copy (c64feef1d)
+# Verifies that local := arr produces an independent copy.
+# Without the fix, the local variable aliased the stored array pointer,
+# so modifying the copy silently corrupted the original persistent state.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/audit/arrayalias${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 c64feef1d — Array copy independence"
+echo "   Package: $PKGPATH"
+
+cat > "$TMPDIR/arrayalias.gno" << EOF
+package arrayalias
+
+import "strconv"
+
+var arr [3]int
+
+func ModifyLocalCopy() {
+	local := arr
+	local[0] = 999
+}
+
+func Render(_ string) string {
+	return strconv.Itoa(arr[0])
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying realm... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+cat > "$TMPDIR/call.gno" << EOF
+package main
+
+import a "${PKGPATH}"
+
+func main() { a.ModifyLocalCopy() }
+EOF
+
+echo -n "   Calling ModifyLocalCopy()... "
+CALL=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 5000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/call.gno" 2>&1)
+if echo "$CALL" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$CALL"; exit 1
+fi
+
+echo -n "   Querying arr[0] (expect 0)... "
+RESULT=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+if echo "$RESULT" | grep -q '"0"'; then
+	echo "✅ PATCHED — arr[0] unchanged after copy modification"
+elif echo "$RESULT" | grep -q '"999"'; then
+	echo "❌ VULNERABLE — arr[0] aliased and corrupted to 999"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"; exit 1
+fi

--- a/misc/e2e/audit/audit_byteslice.sh
+++ b/misc/e2e/audit/audit_byteslice.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Targets: fix(gnovm): call DidUpdate on DataByte index assignment (NEWTENDG-98, a3a356e71)
+# Verifies that bs[i] = v mutations persist across transactions.
+# Without the fix, byte-slice index writes were silently dropped after tx commit.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/audit/byteslice${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 NEWTENDG-98 — Byte-slice index mutation persistence"
+echo "   Package: $PKGPATH"
+
+cat > "$TMPDIR/byteslice.gno" << EOF
+package byteslice
+
+import "strconv"
+
+type ByteState struct {
+	data []byte
+}
+
+func (b *ByteState) set(i int, v byte) {
+	b.data[i] = v
+}
+
+var state = ByteState{data: []byte{0, 0, 0}}
+
+func SetFirst(v byte) {
+	state.set(0, v)
+}
+
+func Render(_ string) string {
+	return strconv.Itoa(int(state.data[0]))
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying realm... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+cat > "$TMPDIR/set.gno" << EOF
+package main
+
+import byteslice "${PKGPATH}"
+
+func main() { byteslice.SetFirst(5) }
+EOF
+
+echo -n "   Setting bs[0] = 5... "
+SET=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 5000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/set.gno" 2>&1)
+if echo "$SET" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$SET"; exit 1
+fi
+
+echo -n "   Querying bs[0] (expect 5)... "
+RESULT=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+if echo "$RESULT" | grep -q '"5"'; then
+	echo "✅ PATCHED — bs[0] = 5 persisted correctly"
+elif echo "$RESULT" | grep -q '"0"'; then
+	echo "❌ VULNERABLE — bs[0] mutation was silently dropped (still 0)"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"; exit 1
+fi

--- a/misc/e2e/audit/audit_chan_type.sh
+++ b/misc/e2e/audit/audit_chan_type.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Targets: fix(gnovm): reject chan type at preprocess/runtime (4bcd9828e)
+# Verifies that chan types are rejected at preprocess time (before execution).
+# Without the fix, deployment succeeded and the node panicked only at runtime
+# when the channel was actually used.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 4bcd9828e — chan type rejection at preprocess"
+
+cat > "$TMPDIR/chan.gno" << 'EOF'
+package main
+
+func main() {
+	ch := make(chan int, 1)
+	ch <- 42
+}
+EOF
+
+echo -n "   Submitting script with chan type... "
+RESULT=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot \
+	-gas-wanted 5000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/chan.gno" 2>&1)
+
+if echo "$RESULT" | grep -q "OK!"; then
+	echo "FAIL: chan type accepted by the VM (VULNERABLE)"
+	exit 1
+else
+	echo "PASS: chan type rejected (PATCHED)"
+fi

--- a/misc/e2e/audit/audit_cross_realm_recover.sh
+++ b/misc/e2e/audit/audit_cross_realm_recover.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Targets: fix(gnovm): prevent cross-realm state corruption via NameExpr assign+recover (f87249327)
+# Verifies that a realm function that writes state then panics causes a full rollback,
+# even when the calling script catches the panic with recover().
+# Without the fix, the state write was not undone and partial state remained.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/audit/realmrecov${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 f87249327 — State rollback on panic + recover()"
+echo "   Package: $PKGPATH"
+
+cat > "$TMPDIR/realmrecov.gno" << EOF
+package realmrecov
+
+import "strconv"
+
+type StateHolder struct {
+	value int
+}
+
+func (s *StateHolder) set(v int) {
+	s.value = v
+}
+
+var holder = StateHolder{value: 0}
+
+func SetAndPanic(v int) {
+	holder.set(v)
+	panic("deliberate panic after state write")
+}
+
+func Render(_ string) string {
+	return strconv.Itoa(holder.value)
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying realm... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+cat > "$TMPDIR/recover.gno" << EOF
+package main
+
+import r "${PKGPATH}"
+
+func main() {
+	defer func() { recover() }()
+	r.SetAndPanic(100)
+}
+EOF
+
+echo -n "   Calling SetAndPanic(100) with recover()... "
+CALL=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 5000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/recover.gno" 2>&1)
+echo "$(echo "$CALL" | grep -oE 'OK!|error' | head -1)"
+
+echo -n "   Querying State (expect 0)... "
+RESULT=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+if echo "$RESULT" | grep -q '"0"'; then
+	echo "✅ PATCHED — State rolled back to 0 after panic"
+elif echo "$RESULT" | grep -q '"100"'; then
+	echo "❌ VULNERABLE — State corrupted to 100 despite panic"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"; exit 1
+fi

--- a/misc/e2e/audit/audit_gas_alloc.sh
+++ b/misc/e2e/audit/audit_gas_alloc.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Targets: fix(gnovm): proper gas consumption for mem allocation (5d5f9213f)
+# Verifies that large memory allocations consume gas proportionally (per-byte model).
+# Without the fix, all allocations used a flat fee — a 10MB alloc cost the same as
+# a 10-byte alloc, making large-alloc DoS attacks virtually free.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 5d5f9213f — Per-byte gas consumption for memory allocation"
+
+# Test 1: large alloc with low gas-wanted must hit OOG
+cat > "$TMPDIR/bigalloc.gno" << 'EOF'
+package main
+
+func main() {
+	_ = make([]byte, 10_000_000)
+}
+EOF
+
+echo -n "   10MB alloc with 100k gas (expect OOG)... "
+RESULT=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot \
+	-gas-wanted 100000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/bigalloc.gno" 2>&1)
+
+if echo "$RESULT" | grep -qiE "out of gas|gas limit|exceeded"; then
+	echo "✅ OOG triggered — per-byte gas model active"
+elif echo "$RESULT" | grep -q "OK!"; then
+	echo "❌ VULNERABLE — 10MB alloc passed with 100k gas (flat-fee model)"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"
+	exit 1
+fi
+
+# Test 2: small alloc with sufficient gas must succeed
+cat > "$TMPDIR/smallalloc.gno" << 'EOF'
+package main
+
+func main() {
+	_ = make([]byte, 10)
+}
+EOF
+
+echo -n "   10-byte alloc with 1M gas (expect OK)... "
+RESULT2=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot \
+	-gas-wanted 1000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/smallalloc.gno" 2>&1)
+
+if echo "$RESULT2" | grep -q "OK!"; then
+	echo "✅ Small alloc passed"
+elif echo "$RESULT2" | grep -qiE "out of gas"; then
+	echo "⚠️  Small alloc hit OOG — raise gas-wanted threshold for this test"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT2"
+	exit 1
+fi

--- a/misc/e2e/audit/audit_runtime_pkg.sh
+++ b/misc/e2e/audit/audit_runtime_pkg.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Targets: feat(gnovm)!: move runtime to testing stdlibs (afd7e4808)
+# Verifies that importing "runtime" in a production script is rejected.
+# The runtime package (GC, MemStats, etc.) has no legitimate on-chain use
+# and was removed from production stdlibs. Any deployed realm importing it
+# would fail replay after the hardfork.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 afd7e4808 — runtime stdlib removed from production"
+
+cat > "$TMPDIR/runtime.gno" << 'EOF'
+package main
+
+import "runtime"
+
+func main() {
+	runtime.GC()
+}
+EOF
+
+echo -n "   Submitting script importing \"runtime\"... "
+RESULT=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot \
+	-gas-wanted 5000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/runtime.gno" 2>&1)
+
+if echo "$RESULT" | grep -qiE "unknown import|cannot find|not found|unavailable|no package"; then
+	echo "✅ PATCHED — runtime import rejected"
+elif echo "$RESULT" | grep -q "OK!"; then
+	echo "❌ VULNERABLE — runtime.GC() executed in production VM"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"
+	exit 1
+fi

--- a/misc/e2e/audit/audit_security.sh
+++ b/misc/e2e/audit/audit_security.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Targets: fix(gnovm): uint64 overflow at compile time (NEWTENDG-164, 6a6fc4c71)
+#          fix(gnovm): iterative stack-overflow recovery (NEWTENDG-182, 3be0408f0)
+# Verifies that uint64 constant overflow is caught at compile time and that
+# infinite recursion is stopped by the gas limit rather than crashing the node.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🛡️  STARTING GNOVM SECURITY AUDIT..."
+echo "------------------------------------"
+
+# --- TEST 1: INTEGER OVERFLOW ---
+cat > "$TMPDIR/ovf.gno" << 'EOF'
+package main
+func main() {
+    const huge = 18446744073709551615 + 1
+    println(huge)
+}
+EOF
+
+echo -n "🧪 Testing Tier 1 (Integer Overflow, 6a6fc4c71)... "
+RESULT_OVF=$(echo "$PASSWORD" | gnokey maketx run \
+    -broadcast -remote "$RPC" -chainid "$CHAINID" \
+    -gas-fee 1000000ugnot -gas-wanted 2000000 \
+    -insecure-password-stdin \
+    -home "$GNOKEY_HOME" \
+    "$KEY" "$TMPDIR/ovf.gno" 2>&1)
+
+if echo "$RESULT_OVF" | grep -qiE "overflows|cannot use huge"; then
+    echo "✅ PATCHED"
+else
+    echo "❌ VULNERABLE"
+    echo "$RESULT_OVF" | grep "Error" | head -n 5
+    exit 1
+fi
+
+# --- TEST 2: STACK RECURSION ---
+cat > "$TMPDIR/kami.gno" << 'EOF'
+package main
+func main() {
+    Recursive()
+}
+func Recursive() {
+    Recursive()
+}
+EOF
+
+echo -n "🧪 Testing Tier 1 (Stack Recursion, 3be0408f0)... "
+RESULT_KAM=$(echo "$PASSWORD" | gnokey maketx run \
+    -broadcast -remote "$RPC" -chainid "$CHAINID" \
+    -gas-fee 1000000ugnot -gas-wanted 5000000 \
+    -insecure-password-stdin \
+    -home "$GNOKEY_HOME" \
+    "$KEY" "$TMPDIR/kami.gno" 2>&1)
+
+if echo "$RESULT_KAM" | grep -qi "out of gas"; then
+    echo "✅ PATCHED (Gas limit hit)"
+elif echo "$RESULT_KAM" | grep -qi "stack overflow"; then
+    echo "✅ PATCHED (Stack limit hit)"
+else
+    echo "❌ CRITICAL"
+    echo "$RESULT_KAM" | grep "Error" | head -n 5
+    exit 1
+fi
+
+echo "------------------------------------"
+echo "🏁 Audit Complete."

--- a/misc/e2e/audit/audit_var_init_order.sh
+++ b/misc/e2e/audit/audit_var_init_order.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Targets: fix(gnovm): implement Go-compliant variable initialization order (NEWTENDG-68, 50ee56e64)
+# Verifies that package-level vars are initialized in dependency order, not declaration order.
+# In Go: var B = A + 1; var A = 2 → A is initialized first → B = 3.
+# Without the fix, Gno initialized in declaration order → A = 0 when B was set → B = 1.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/audit/varinit${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 NEWTENDG-68 — Package-level variable initialization order"
+echo "   Package: $PKGPATH"
+
+cat > "$TMPDIR/varinit.gno" << EOF
+package varinit
+
+import "strconv"
+
+var B = A + 1
+var A = 2
+
+func Render(_ string) string {
+	return strconv.Itoa(B)
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying realm (var B = A+1 declared before var A = 2)... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+echo -n "   Querying B (expect 3, A initialized before B)... "
+RESULT=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+if echo "$RESULT" | grep -q '"3"'; then
+	echo "✅ PATCHED — B = 3 (A was initialized before B)"
+elif echo "$RESULT" | grep -q '"1"'; then
+	echo "❌ VULNERABLE — B = 1 (A was 0 when B was initialized)"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$RESULT"; exit 1
+fi

--- a/misc/e2e/audit/common.sh
+++ b/misc/e2e/audit/common.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Shared setup for gnovm audit scripts.
+# Sources the test1 key into GNOKEY_HOME if not already present.
+
+RPC="${RPC:-http://gnoland:26657}"
+CHAINID="${CHAINID:-test}"
+KEY="${KEY:-test1}"
+PASSWORD="${PASSWORD:-test1234}"
+GNOKEY_HOME="${GNOKEY_HOME:-/tmp/gnokey}"
+# Deterministic address for the test1 key (derived from the mnemonic below)
+KEY_ADDR="g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+
+TEST1_MNEMONIC="source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+
+if ! gnokey list -home "$GNOKEY_HOME" 2>/dev/null | grep -q "$KEY"; then
+    printf "%s\n%s\n%s\n" "$TEST1_MNEMONIC" "$PASSWORD" "$PASSWORD" | \
+        gnokey add "$KEY" -recover -insecure-password-stdin=true -home "$GNOKEY_HOME" > /dev/null 2>&1
+fi

--- a/misc/e2e/e2e/e2e_counter.sh
+++ b/misc/e2e/e2e/e2e_counter.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Tests cross-validator state consistency via a simple counter realm.
+# Deploys a fresh counter realm, sends an Increment tx, then queries the
+# node to verify the state was committed correctly.
+# Note: in a multi-validator setup, query both nodes and assert equal state.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../audit/common.sh
+. "$SCRIPT_DIR/../audit/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/e2e/counter${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🚀 E2E COUNTER TEST"
+
+# --- Deploy counter realm ---
+cat > "$TMPDIR/counter.gno" << EOF
+package counter
+
+import "strconv"
+
+type state struct{ count int }
+
+func (s *state) inc() { s.count++ }
+
+var counter state
+
+func Increment() { counter.inc() }
+
+func Render(_ string) string {
+	return strconv.Itoa(counter.count)
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying counter realm... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+# --- Increment tx ---
+cat > "$TMPDIR/increment.gno" << EOF
+package main
+
+import counter "${PKGPATH}"
+
+func main() { counter.Increment() }
+EOF
+
+echo -n "➡️  Sending Increment tx... "
+INC=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 3000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/increment.gno" 2>&1)
+if echo "$INC" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$INC"; exit 1
+fi
+
+sleep 2
+
+# --- Query and verify ---
+echo -n "🔍 Querying counter state (expect 1)... "
+RESULT=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+if echo "$RESULT" | grep -q '"1"'; then
+	echo "✅ E2E COUNTER OK — state = 1"
+else
+	echo "❌ FAILED — unexpected state"; echo "$RESULT"; exit 1
+fi

--- a/misc/e2e/e2e/e2e_mempool_stress.sh
+++ b/misc/e2e/e2e/e2e_mempool_stress.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Tests sequential mempool throughput by sending N increment transactions
+# one after another without sleep. Verifies that all txs are accepted and
+# the final counter value matches the expected count.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../audit/common.sh
+. "$SCRIPT_DIR/../audit/common.sh"
+
+SUFFIX=$(date +%s)
+PKGPATH="gno.land/r/${KEY_ADDR}/e2e/counter${SUFFIX}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+TX_COUNT=10
+
+echo "⚡ STARTING SEQUENTIAL STRESS TEST ($TX_COUNT tx)"
+
+# --- Deploy counter realm ---
+cat > "$TMPDIR/counter.gno" << EOF
+package counter
+
+import "strconv"
+
+type state struct{ count int }
+
+func (s *state) inc() { s.count++ }
+
+var counter state
+
+func Increment() { counter.inc() }
+
+func Render(_ string) string {
+	return strconv.Itoa(counter.count)
+}
+EOF
+
+cat > "$TMPDIR/gnomod.toml" << EOF
+module = "${PKGPATH}"
+gno = "0.9"
+EOF
+
+echo -n "   Deploying counter realm... "
+DEPLOY=$(echo "$PASSWORD" | gnokey maketx addpkg \
+	-pkgpath "$PKGPATH" -pkgdir "$TMPDIR" \
+	-gas-fee 1000000ugnot -gas-wanted 10000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" 2>&1)
+if echo "$DEPLOY" | grep -q "OK!"; then echo "OK"; else
+	echo "FAILED"; echo "$DEPLOY"; exit 1
+fi
+
+# --- Increment tx file ---
+cat > "$TMPDIR/increment.gno" << EOF
+package main
+
+import counter "${PKGPATH}"
+
+func main() { counter.Increment() }
+EOF
+
+# --- Sequential stress loop ---
+FAILED=0
+for i in $(seq 1 $TX_COUNT); do
+	echo -n "➡️  Tx #$i: "
+	RESULT=$(echo "$PASSWORD" | gnokey maketx run \
+		-broadcast -chainid "$CHAINID" -remote "$RPC" \
+		-gas-fee 1000000ugnot -gas-wanted 3000000 \
+		-insecure-password-stdin -quiet \
+		-home "$GNOKEY_HOME" \
+		"$KEY" "$TMPDIR/increment.gno" 2>&1)
+	if echo "$RESULT" | grep -q "OK!"; then
+		echo "✅ Sent"
+	else
+		echo "❌ Failed"; echo "$RESULT"
+		FAILED=$((FAILED + 1))
+	fi
+done
+
+echo "⏳ Waiting for final commit..."
+sleep 5
+
+FINAL=$(gnokey query "vm/qeval" \
+	-data "${PKGPATH}.Render(\"\")" \
+	-remote "$RPC" 2>&1)
+
+echo "🏁 Final Counter Value (raw): $FINAL"
+
+if echo "$FINAL" | grep -q "\"$TX_COUNT\"" && [ "$FAILED" -eq 0 ]; then
+	echo "✅ MEMPOOL STRESS OK — all $TX_COUNT txs committed"
+else
+	echo "❌ FAILED — $FAILED tx errors, expected counter = $TX_COUNT"
+	exit 1
+fi

--- a/misc/e2e/e2e/e2e_nonce_replay.sh
+++ b/misc/e2e/e2e/e2e_nonce_replay.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Tests replay protection via sequence number enforcement.
+# Verifies that rebroadcasting a transaction with an already-consumed sequence
+# number is rejected with a sequence mismatch error.
+# This is a baseline sanity check that underpins all Tier 1 consensus fixes.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../audit/common.sh
+. "$SCRIPT_DIR/../audit/common.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "🧪 Replay protection — sequence number enforcement"
+
+cat > "$TMPDIR/noop.gno" << 'EOF'
+package main
+
+func main() {}
+EOF
+
+# Tx 1: normal broadcast, auto-sequence (should succeed)
+echo -n "   Tx 1 — normal broadcast... "
+TX1=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 1000000 \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/noop.gno" 2>&1)
+
+if echo "$TX1" | grep -q "OK!"; then
+	echo "OK"
+else
+	echo "FAILED (unexpected)"; echo "$TX1"; exit 1
+fi
+
+# Derive consumed sequence from the account state
+SEQ_INFO=$(gnokey query "auth/accounts/${KEY_ADDR}" -remote "$RPC" 2>&1)
+CURRENT_SEQ=$(echo "$SEQ_INFO" | grep -oE '"sequence":"[0-9]+"' | grep -oE '[0-9]+$')
+if [ -z "$CURRENT_SEQ" ] || [ "$CURRENT_SEQ" -eq 0 ]; then
+	REPLAY_SEQ=0
+else
+	REPLAY_SEQ=$((CURRENT_SEQ - 1))
+fi
+echo "   Current sequence: $CURRENT_SEQ — replaying with sequence: $REPLAY_SEQ"
+
+# Tx 2: replay with the already-used sequence number (must be rejected)
+echo -n "   Tx 2 — replay at sequence $REPLAY_SEQ (expect rejection)... "
+TX2=$(echo "$PASSWORD" | gnokey maketx run \
+	-gas-fee 1000000ugnot -gas-wanted 1000000 \
+	-sequence "$REPLAY_SEQ" \
+	-broadcast -chainid "$CHAINID" -remote "$RPC" \
+	-insecure-password-stdin \
+	-home "$GNOKEY_HOME" \
+	"$KEY" "$TMPDIR/noop.gno" 2>&1)
+
+if echo "$TX2" | grep -qiE "sequence|wrong nonce|invalid sequence|account sequence|mempool"; then
+	echo "✅ PROTECTED — replay rejected"
+elif echo "$TX2" | grep -q "OK!"; then
+	echo "❌ VULNERABLE — replay accepted"
+	exit 1
+else
+	echo "⚠️  UNKNOWN OUTPUT"; echo "$TX2"; exit 1
+fi

--- a/misc/e2e/run_tests.sh
+++ b/misc/e2e/run_tests.sh
@@ -107,8 +107,59 @@ echo "8. Checking test2 balance..."
 echo "9. Checking test1 final balance..."
 /usr/bin/gnokey query bank/balances/"$TEST1_ADDR" -remote="$NODE_URL" || { echo "Failed to query test1 final balance"; exit 1; }
 
-# TODO:
-# - interact with existing contracts
-# - upload a new contract and interact with it
+PASS=0
+FAIL=0
+KNOWN=0
+REPORT=""
 
-echo "All tests passed successfully!"
+run_test() {
+    NAME="$1"
+    SCRIPT="$2"
+    KNOWN_NOTE="$3"
+    echo ""
+    echo "--- $NAME ---"
+    if "$SCRIPT"; then
+        PASS=$((PASS + 1))
+        REPORT="${REPORT}  [PASS]  $NAME\n"
+    elif [ -n "$KNOWN_NOTE" ]; then
+        KNOWN=$((KNOWN + 1))
+        REPORT="${REPORT}  [KNOWN] $NAME — $KNOWN_NOTE\n"
+    else
+        FAIL=$((FAIL + 1))
+        REPORT="${REPORT}  [FAIL]  $NAME\n"
+    fi
+}
+
+echo "=== Running VM Audit Tests ==="
+run_test "audit_runtime_pkg"        /e2e/audit/audit_runtime_pkg.sh
+run_test "audit_chan_type"          /e2e/audit/audit_chan_type.sh
+run_test "audit_security"          /e2e/audit/audit_security.sh
+run_test "audit_gas_alloc"         /e2e/audit/audit_gas_alloc.sh
+run_test "audit_byteslice"         /e2e/audit/audit_byteslice.sh
+run_test "audit_array_alias"       /e2e/audit/audit_array_alias.sh
+run_test "audit_var_init_order"    /e2e/audit/audit_var_init_order.sh
+# audit_cross_realm_recover tests a broader pattern (method-call + recover)
+# than the fix f87249327 (NameExpr assign + recover). Expected VULNERABLE
+# on current master — serves as a regression marker for future fixes.
+run_test "audit_cross_realm_recover" /e2e/audit/audit_cross_realm_recover.sh "broader pattern not yet fixed, see f87249327"
+
+echo ""
+echo "=== Running E2E Tests ==="
+run_test "e2e_nonce_replay"    /e2e/e2e/e2e_nonce_replay.sh
+run_test "e2e_counter"         /e2e/e2e/e2e_counter.sh
+run_test "e2e_mempool_stress"  /e2e/e2e/e2e_mempool_stress.sh
+
+echo ""
+echo "========================================="
+echo "  TEST SUMMARY"
+echo "========================================="
+printf "%b" "$REPORT"
+echo "-----------------------------------------"
+echo "  PASS: $PASS   FAIL: $FAIL   KNOWN: $KNOWN"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "Some tests FAILED."
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

Adds a suite of E2E audit and transaction scripts to `misc/e2e/`, 
validated against the live test-13 network and the local Docker devnet.

**Context:** These scripts were written during the test-13 hardfork 
testing phase to verify that specific gnovm fixes are present in the 
binary and to catch regressions early.

## What's included

**`misc/e2e/audit/`** — one script per gnovm fix, each exits 1 if the 
fix is missing:

| Script | Commit | What it verifies |
| --- | --- | --- |
| `audit_runtime_pkg.sh` | `afd7e4808` | `runtime` import rejected in production VM |
| `audit_chan_type.sh` | `4bcd9828e` | `chan` type rejected at preprocess |
| `audit_security.sh` | `6a6fc4c71` + `3be0408f0` | uint64 overflow + infinite recursion protection |
| `audit_gas_alloc.sh` | `5d5f9213f` | per-byte gas model for large allocations |
| `audit_byteslice.sh` | `a3a356e71` | byte-slice index mutations persist across txs |
| `audit_array_alias.sh` | `c64feef1d` | array copy independence |
| `audit_var_init_order.sh` | `50ee56e64` | package-level var init in dependency order |
| `audit_cross_realm_recover.sh` | `f87249327` | state rollback on panic+recover — **see note below** |

**`misc/e2e/e2e/`** — end-to-end transaction tests:
- `e2e_nonce_replay.sh`: replay protection via sequence number enforcement
- `e2e_counter.sh`: deploy a realm, increment state, verify committed value
- `e2e_mempool_stress.sh`: 10 sequential txs, assert final counter matches

## How to run

```sh
cd misc/e2e
make test
```
The summary is printed at the bottom of the output:


  [PASS]  audit_runtime_pkg
  [PASS]  audit_chan_type
  ...
  [KNOWN] audit_cross_realm_recover — broader pattern not yet fixed
  [PASS]  e2e_nonce_replay
  ...
  PASS: 10   FAIL: 0   KNOWN: 1
  

## Notes for reviewers
audit/common.sh is sourced from both audit/ and e2e/ scripts via a relative path — happy to move it to the misc/e2e/ root if preferred
The misc/e2e/e2e/ directory name is redundant — open to renaming (e.g. consensus/ or transactions/)