### PR TITLE
feat(gnovm): capture VM-internal panic origin; deprecate UnhandledPanicError

### DIFF
--- a/gno.land/pkg/sdk/vm/bounded.go
+++ b/gno.land/pkg/sdk/vm/bounded.go
@@ -50,22 +50,19 @@ func boundedString(v any, depth int) string {
 
 	// Gno-specific bounded types
 	case *gno.Exception:
-		// Bounded by BoundedSprintException + the BoundedPanicRender
-		// flag on Machines that built this exception. m=nil here
-		// because boundedString may be called from non-VM contexts;
-		// composites render structurally (no user .Error() dispatch).
+		// Abort'd exceptions have Descriptor pre-rendered (bounded when
+		// the Machine had BoundedPanicRender=true at markAbort time);
+		// prefer it over re-rendering e.Value. For non-abort cases
+		// (e.g. middle-of-handling), fall back to BoundedSprintException
+		// with m=nil since boundedString may run in non-VM contexts.
+		if x.Abort && x.Descriptor != "" {
+			return truncate(x.Descriptor)
+		}
 		return gno.BoundedSprintException(x, nil, maxBoundedBytes)
 	case *gno.PreprocessError:
 		// Bounded by the earlier PreprocessError.Stack() fix in
 		// gnovm/pkg/gnolang/debug.go.
 		return truncate(x.Error())
-	case gno.UnhandledPanicError:
-		// Value type — must precede the generic `error` arm.
-		// Descriptor is bounded at construction when the constructing
-		// Machine had BoundedPanicRender=true (op_call.go flag-true
-		// branch). Validators set the flag on every m.
-		return truncate(x.Descriptor)
-
 	// tm2-specific bounded types
 	case stypes.OutOfGasError:
 		// Short message, source-bounded.

--- a/gno.land/pkg/sdk/vm/bounded_test.go
+++ b/gno.land/pkg/sdk/vm/bounded_test.go
@@ -35,14 +35,14 @@ func TestBoundedString_Bytes(t *testing.T) {
 	assert.Equal(t, maxBoundedBytes+3, len(got))
 }
 
-func TestBoundedString_UnhandledPanicError_Short(t *testing.T) {
-	up := gno.UnhandledPanicError{Descriptor: "panic message"}
-	assert.Equal(t, "panic message", boundedString(up, 0))
+func TestBoundedString_AbortException_Short(t *testing.T) {
+	ex := &gno.Exception{Abort: true, Descriptor: "panic message"}
+	assert.Equal(t, "panic message", boundedString(ex, 0))
 }
 
-func TestBoundedString_UnhandledPanicError_Truncated(t *testing.T) {
-	up := gno.UnhandledPanicError{Descriptor: strings.Repeat("a", maxBoundedBytes*2)}
-	got := boundedString(up, 0)
+func TestBoundedString_AbortException_Truncated(t *testing.T) {
+	ex := &gno.Exception{Abort: true, Descriptor: strings.Repeat("a", maxBoundedBytes*2)}
+	got := boundedString(ex, 0)
 	assert.Equal(t, maxBoundedBytes+3, len(got))
 }
 
@@ -80,13 +80,13 @@ func TestBoundedString_CmnError_HugeFmtUnaffected(t *testing.T) {
 }
 
 func TestBoundedString_CmnError_Wrapped(t *testing.T) {
-	// Wrap an unhandled-panic-like error.
-	inner := gno.UnhandledPanicError{Descriptor: "inner"}
+	// Wrap an abort'd Exception (the post-UnhandledPanicError shape).
+	inner := &gno.Exception{Abort: true, Descriptor: "inner"}
 	err := cmnerrors.Wrap(inner, "outer")
 	got := boundedString(err, 0)
-	// cmnError.Data() returns the wrapped error (UnhandledPanicError);
+	// cmnError.Data() returns the wrapped error (*gno.Exception);
 	// FmtError assertion fails; unwrap returns the wrapped error;
-	// recurse → matches gno.UnhandledPanicError → returns Descriptor.
+	// recurse → matches *gno.Exception abort arm → returns Descriptor.
 	assert.Equal(t, "inner", got)
 }
 

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -946,9 +946,10 @@ func doRecoverInternal(m *gno.Machine, e *error, r any, repanicOutOfGas bool) {
 			*e = oog
 			return
 		}
-		var up gno.UnhandledPanicError
-		if goerrors.As(err, &up) {
-			desc := boundedString(up, 0)
+		var ex *gno.Exception
+		if goerrors.As(err, &ex) && ex.Abort {
+			// Common unhandled panic error, skip machine state.
+			desc := boundedString(ex, 0)
 			trace := gno.BoundedExceptionStacktrace(m,
 				gno.MaxStacktraceFrames*gno.BoundedRenderBytes)
 			*e = errors.Wrapf(

--- a/gnovm/cmd/gno/run.go
+++ b/gnovm/cmd/gno/run.go
@@ -293,7 +293,7 @@ func runExpr(m *gno.Machine, expr string) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch r := r.(type) {
-			case gno.UnhandledPanicError:
+			case *gno.Exception:
 				err = fmt.Errorf("panic running expression %s: %v\nStacktrace:\n%s",
 					expr, r.Error(), m.ExceptionStacktrace())
 			default:

--- a/gnovm/pkg/gnolang/frame.go
+++ b/gnovm/pkg/gnolang/frame.go
@@ -254,12 +254,28 @@ func toConstExpTrace(cte *ConstExpr) string {
 //----------------------------------------
 // Exception
 
-// Exception represents a panic that originates from a gno program.
+// Exception represents a panic that originates from a gno program. It
+// predates the error interface; satisfying it (via Error()) is for
+// recoverers' convenience, so the type keeps its established name even
+// though the errname linter prefers a "...Error" suffix.
+//
+//nolint:errname
 type Exception struct {
 	Value      TypedValue
 	Stacktrace Stacktrace
 	Previous   *Exception
 	Next       *Exception
+
+	// Abort is set by markAbort when defers are exhausted without recover;
+	// Run() panics the *Exception directly instead of re-pushing it.
+	Abort bool
+	// Descriptor caches the joined chain message so external recoverers
+	// (no *Machine in hand) can read it via Error().
+	Descriptor string
+	// GoStack is the VM-internal Go call chain at raise time, formatted
+	// one frame per "funcName\n\tfile:line" pair. Stops at (*Machine).Run
+	// so callers can splice in debug.Stack's harness chain without dupe.
+	GoStack string
 }
 
 func (e *Exception) StringWithStacktrace(m *Machine) string {
@@ -269,6 +285,13 @@ func (e *Exception) StringWithStacktrace(m *Machine) string {
 func (e *Exception) Sprint(m *Machine) string {
 	res := e.Value.Sprint(m)
 	return res
+}
+
+func (e *Exception) Error() string {
+	if e.Abort && e.Descriptor != "" {
+		return e.Descriptor
+	}
+	return e.Value.String()
 }
 
 func (e *Exception) NumExceptions() int {
@@ -295,13 +318,4 @@ func (e *Exception) WithPrevious(e2 *Exception) *Exception {
 	e.Previous = e2
 	e2.Next = e
 	return e
-}
-
-// UnhandledPanicError represents an error thrown when a panic is not handled in the realm.
-type UnhandledPanicError struct {
-	Descriptor string // Description of the unhandled panic.
-}
-
-func (e UnhandledPanicError) Error() string {
-	return e.Descriptor
 }

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -41,6 +41,11 @@ type Machine struct {
 	Stage         Stage         // pre for static eval, add for package init, run otherwise
 	ReviveEnabled bool          // true if revive() enabled (only in testing mode for now)
 	Lastline      int           // the line the VM is currently executing
+	// goStackCaptured gates Exception.GoStack capture to once per panic
+	// chain — m.Exception alone is unreliable because PushFrameCall clears
+	// it before each defer runs (machine.go ~2132), so under N-panicking
+	// defers we'd otherwise pay captureGoStack N times. Reset by Recover().
+	goStackCaptured bool
 
 	Debugger Debugger
 
@@ -1534,7 +1539,10 @@ func (m *Machine) Run(st Stage) {
 		if caught.Stacktrace.IsZero() {
 			caught.Stacktrace = m.Stacktrace()
 		}
-		m.pushPanic(caught.Value)
+		if caught.Abort {
+			panic(caught)
+		}
+		m.pushPanicException(caught)
 	}
 }
 
@@ -1546,6 +1554,9 @@ func (m *Machine) runOnce() (caught *Exception) {
 		if r := recover(); r != nil {
 			if ex, ok := r.(*Exception); ok {
 				caught = ex
+				if ex.GoStack == "" {
+					m.attachGoStack(ex)
+				}
 			} else {
 				panic(r)
 			}
@@ -2658,6 +2669,77 @@ func (m *Machine) PanicString(ex string) {
 	m.Panic(typedString(ex))
 }
 
+// captureGoStack returns the VM-internal call chain up to (*Machine).Run,
+// formatted as "funcName\n\tfile:line" frames separated by '\n'. Stops at
+// Run so callers can splice in debug.Stack's harness chain.
+func captureGoStack() string {
+	var pcs [32]uintptr
+	n := runtime.Callers(2, pcs[:])
+	if n == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	var sb strings.Builder
+	for {
+		f, more := frames.Next()
+		if !goStackIgnore(f.Function) {
+			sb.WriteString(f.Function)
+			sb.WriteString("\n\t")
+			sb.WriteString(TrimOriginFile(f.File))
+			sb.WriteByte(':')
+			sb.WriteString(strconv.Itoa(f.Line))
+			sb.WriteByte('\n')
+			if strings.HasSuffix(f.Function, ".(*Machine).Run") {
+				break
+			}
+		}
+		if !more {
+			break
+		}
+	}
+	return sb.String()
+}
+
+// goStackIgnore drops Go's panic plumbing and our own panic machinery so
+// the first kept frame is the VM raise site rather than a recover helper.
+func goStackIgnore(name string) bool {
+	if strings.HasPrefix(name, "runtime.") {
+		return true
+	}
+	switch {
+	case strings.HasSuffix(name, ".runOnce.func1"),
+		strings.HasSuffix(name, ".captureGoStack"),
+		strings.HasSuffix(name, ".attachGoStack"),
+		strings.HasSuffix(name, ".pushPanic"),
+		strings.HasSuffix(name, ".pushPanicException"),
+		strings.HasSuffix(name, ".(*Machine).Panic"),
+		strings.HasSuffix(name, ".(*Machine).PanicString"):
+		return true
+	}
+	return false
+}
+
+// TrimOriginFile strips the absolute prefix from a Go source path so stack
+// output is stable across build hosts and doesn't leak filesystem layout
+// (developer home directories, CI worker paths, etc.). Matches project
+// modules and Go stdlib by their canonical segment; falls back to basename.
+func TrimOriginFile(file string) string {
+	for _, marker := range projectFileMarkers {
+		if i := strings.Index(file, marker); i >= 0 {
+			return file[i+1:]
+		}
+	}
+	if i := strings.LastIndexByte(file, '/'); i >= 0 {
+		return file[i+1:]
+	}
+	return file
+}
+
+var projectFileMarkers = []string{
+	"/gnovm/", // VM-internal frames + filetest harness
+	"/src/",   // Go stdlib (".../go/src/runtime/panic.go" -> "src/runtime/panic.go")
+}
+
 // This function does go-panic.
 // To stop execution immediately stdlib native code MUST use this rather than
 // pushPanic().
@@ -2665,12 +2747,11 @@ func (m *Machine) PanicString(ex string) {
 // Keep this code in sync with those calls.
 // Note that m.Run() will fill in the stacktrace if it isn't present.
 func (m *Machine) Panic(etv TypedValue) {
-	// Construct a new exception.
 	ex := &Exception{
 		Value:      etv,
 		Stacktrace: m.Stacktrace(),
 	}
-	// Panic immediately.
+	m.attachGoStack(ex)
 	panic(ex)
 }
 
@@ -2679,11 +2760,30 @@ func (m *Machine) Panic(etv TypedValue) {
 // It should ONLY be called from doOp* Op handlers,
 // and should return immediately from the origin Op.
 func (m *Machine) pushPanic(etv TypedValue) {
-	// Construct a new exception.
 	ex := &Exception{
 		Value:      etv,
 		Stacktrace: m.Stacktrace(),
 	}
+	m.attachGoStack(ex)
+	m.pushPanicException(ex)
+}
+
+// attachGoStack stamps the VM-internal Go call chain on ex on the first
+// fresh raise of a panic chain. Subsequent raises (defer-cycle re-raises,
+// 500K-defer attack scenarios) skip the walk so the cost stays O(1) per
+// chain. Reset by Recover() when a Gno-level recover() ends the chain.
+func (m *Machine) attachGoStack(ex *Exception) {
+	if m.goStackCaptured {
+		return
+	}
+	ex.GoStack = captureGoStack()
+	m.goStackCaptured = true
+}
+
+// pushPanicException is pushPanic's internal entry that takes an existing
+// *Exception (caught by runOnce) instead of building a fresh one — so its
+// GoStack/Abort metadata survives the cooperative re-entry.
+func (m *Machine) pushPanicException(ex *Exception) {
 	// Pop after capturing stacktrace.
 	fr := m.PopUntilLastCallFrame()
 	// Link ex.Previous.
@@ -2735,6 +2835,7 @@ func (m *Machine) Recover() *Exception {
 	// call) to an older value when popping a frame with .LastException set
 	// from doOpReturnCallDefers() > m.PushFrameCall(isDefer=true).
 	m.Exception = nil
+	m.goStackCaptured = false
 	return ex
 }
 

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -386,7 +386,7 @@ func (m *Machine) doOpReturnCallDefers() {
 				cfr := m.PopUntilLastReviveFrame()
 				if cfr == nil {
 					// or abort the transaction.
-					panic(m.makeUnhandledPanicError())
+					panic(m.markAbort())
 				}
 				m.PopFrameAndReturn()
 				// assign exception as return of revive().
@@ -567,14 +567,14 @@ func (m *Machine) doOpDefer() {
 	m.PopValue() // pop func
 }
 
-// Build exception string just as go, separated by \n\t.
-// TODO: deprecate UnhandledPanicError and just use the Exception.
-// (use a field to mark transaction abort)
-func (m *Machine) makeUnhandledPanicError() UnhandledPanicError {
+// markAbort flips m.Exception into a terminal state (Abort=true,
+// Descriptor populated) and returns it for the caller to go-panic with.
+// Run() detects Abort and surfaces the *Exception directly.
+func (m *Machine) markAbort() *Exception {
+	m.Exception.Abort = true
 	if m.BoundedPanicRender {
-		return UnhandledPanicError{
-			Descriptor: BoundedSprintException(m.Exception, m, BoundedRenderBytes),
-		}
+		m.Exception.Descriptor = BoundedSprintException(m.Exception, m, BoundedRenderBytes)
+		return m.Exception
 	}
 	numExceptions := m.Exception.NumExceptions()
 	exs := make([]string, numExceptions)
@@ -583,9 +583,8 @@ func (m *Machine) makeUnhandledPanicError() UnhandledPanicError {
 		exs[numExceptions-1-i] = last.Sprint(m)
 		last = last.Previous
 	}
-	return UnhandledPanicError{
-		Descriptor: strings.Join(exs, "\n\t"),
-	}
+	m.Exception.Descriptor = strings.Join(exs, "\n\t")
+	return m.Exception
 }
 
 func (m *Machine) doOpPanic2() {
@@ -597,7 +596,7 @@ func (m *Machine) doOpPanic2() {
 		// If we can't find a call frame, we're in a corrupted state.
 		// This can happen during init functions with realm calls.
 		// Return the original exception as an unhandled panic.
-		panic(m.makeUnhandledPanicError())
+		panic(m.markAbort())
 	}
 	m.PushOp(OpReturnCallDefers)
 }

--- a/gnovm/pkg/test/filetest.go
+++ b/gnovm/pkg/test/filetest.go
@@ -105,9 +105,9 @@ func (opts *TestOptions) runFiletest(fname string, source []byte, tgs gno.Store,
 				if dir.Name == DirectiveError {
 					returnErr = multierr.Append(
 						returnErr,
-						fmt.Errorf("%s diff:\n%s\nstacktrace:\n%s\nstack:\n%v",
+						fmt.Errorf("%s diff:\n%s\ngno stack:\n%s%s",
 							dir.Name, unifiedDiff(content, actual),
-							result.GnoStacktrace, string(result.GoPanicStack)),
+							result.GnoStacktrace, goOriginOrStack(result)),
 					)
 				} else {
 					returnErr = multierr.Append(
@@ -130,8 +130,9 @@ func (opts *TestOptions) runFiletest(fname string, source []byte, tgs gno.Store,
 					Content: "",
 				})
 			} else {
-				return "", m.GasMeter.GasConsumed(), fmt.Errorf("unexpected panic: %s\noutput:\n%s\nstacktrace:\n%s\nstack:\n%v",
-					result.Error, result.Output, result.GnoStacktrace, string(result.GoPanicStack))
+				return "", m.GasMeter.GasConsumed(), fmt.Errorf("unexpected panic: %s%s\ngno stack:\n%s%s",
+					result.Error, optionalOutput(result.Output),
+					result.GnoStacktrace, goOriginOrStack(result))
 			}
 		}
 	} else if result.Output != "" {
@@ -322,8 +323,79 @@ type runResult struct {
 	TypeCheckError string
 	// Set if there was a panic within gno code.
 	GnoStacktrace string
-	// Set if this was recovered from a panic.
+	// Set if this was recovered from a panic. Dual-use: harness chain when
+	// GoVMStack is set (everything after Run), raw dump otherwise.
 	GoPanicStack []byte
+	// GoVMStack is the VM-internal Go chain from *Exception.GoStack.
+	GoVMStack string
+}
+
+// optionalOutput renders the "output: ..." section only when stdout was
+// non-empty — most panic tests have no output, and an empty label is just
+// vertical noise.
+func optionalOutput(out string) string {
+	if out == "" {
+		return ""
+	}
+	return "\noutput:\n" + out
+}
+
+// goOriginOrStack composes the Go-side info shown after a failure. With a
+// captured VM chain, splice it onto the post-Run portion of debug.Stack
+// for one continuous trace; otherwise dump the raw stack as a fallback.
+func goOriginOrStack(r runResult) string {
+	if r.GoVMStack != "" {
+		return "\ngo stack:\n" + r.GoVMStack + harnessAfterRun(r.GoPanicStack)
+	}
+	if len(r.GoPanicStack) > 0 {
+		return "\nstack:\n" + string(r.GoPanicStack)
+	}
+	return ""
+}
+
+// harnessAfterRun slices debug.Stack output past the (*Machine).Run frame
+// and trims absolute paths to project-relative form, so the spliced
+// result is appendable after a VM chain ending at Run without duplicate
+// frames and without leaking local filesystem layout.
+func harnessAfterRun(stack []byte) string {
+	if len(stack) == 0 {
+		return ""
+	}
+	const runMarker = "(*Machine).Run("
+	s := string(stack)
+	i := strings.Index(s, runMarker)
+	if i < 0 {
+		return trimStackPaths(s)
+	}
+	j := strings.Index(s[i:], "\n")
+	if j < 0 {
+		return trimStackPaths(s)
+	}
+	k := strings.Index(s[i+j+1:], "\n")
+	if k < 0 {
+		return trimStackPaths(s)
+	}
+	return trimStackPaths(s[i+j+k+2:])
+}
+
+// trimStackPaths rewrites each "\t/abs/path/file.go:LINE +0xOFF" line in a
+// debug.Stack dump so the path becomes project-relative. Leaves the
+// function lines and "goroutine ..." header untouched.
+func trimStackPaths(stack string) string {
+	lines := strings.Split(stack, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "\t/") {
+			continue
+		}
+		rest := line[1:] // drop the leading tab
+		// "/abs/path/file.go:LINE +0xOFFSET" — split off file from suffix.
+		sep := strings.IndexByte(rest, ':')
+		if sep < 0 {
+			continue
+		}
+		lines[i] = "\t" + gno.TrimOriginFile(rest[:sep]) + rest[sep:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (opts *TestOptions) runTest(m *gno.Machine, pkgPath, fname string, content []byte, opslog io.Writer, tcheck bool) (rr runResult) {
@@ -371,9 +443,10 @@ func (opts *TestOptions) runTest(m *gno.Machine, pkgPath, fname string, content 
 				rr.Error = v.Sprint(m)
 			case *gno.PreprocessError:
 				rr.Error = v.Unwrap().Error()
-			case gno.UnhandledPanicError:
+			case *gno.Exception:
 				rr.Error = v.Error()
 				rr.GnoStacktrace = m.ExceptionStacktrace()
+				rr.GoVMStack = v.GoStack
 			default:
 				rr.Error = fmt.Sprint(v)
 				rr.GnoStacktrace = m.Stacktrace().String()

--- a/gnovm/pkg/test/imports.go
+++ b/gnovm/pkg/test/imports.go
@@ -352,7 +352,7 @@ func LoadImports(store gno.Store, mpkg *std.MemPackage, abortOnError bool) (err 
 					err = errors.New(v.String())
 				case *gno.PreprocessError:
 					err = &stackWrappedError{v.Unwrap(), debug.Stack()}
-				case gno.UnhandledPanicError:
+				case *gno.Exception:
 					err = v
 				case error:
 					err = &stackWrappedError{v, debug.Stack()}


### PR DESCRIPTION
## Summary

- Capture the Go-level call chain at panic raise time (helpers, doOp*, runOnce, Run) and surface it in unhandled-panic reports as a continuous trace, so the failure points straight at the VM site that raised — e.g. `op_exec.go:165` for range-over-nil, `values.go:1986` for a Go-level helper panic — instead of just the harness chain. Captured into a new `Exception.GoStack` field via `runtime.Callers`, gated on the first fresh raise of a chain (a `Machine.goStackCaptured` flag, reset by `Recover()`), so cost stays O(1) under the PR5439 many-panicking-defers scenario.
- Deprecate `UnhandledPanicError` in favor of `*Exception` with `Abort=true` and a pre-rendered `Descriptor` (fulfills the existing TODO at op_call.go). `Run()` short-circuits on `caught.Abort` and re-panics the `*Exception` directly, removing one layer of `runOnce.func1` plumbing from the trace. `*Exception` now satisfies `error` via `Error()` returning the joined Descriptor when `Abort` is set, keeping the legacy message format unchanged for external callers (`bounded.go`, `keeper.go`, `imports.go`, `run.go`, `filetest.go`).
- Filetest output polish: `stacktrace:` → `gno stack:` (parallels new `go stack:`), empty `output:` block suppressed, all paths trimmed to project-relative form via `TrimOriginFile` so the dump doesn't leak local filesystem layout.

## Test plan

- [x] `go test ./gnovm/pkg/gnolang/ -run Files -test.short` — passes on rebased branch
- [x] `go test ./gno.land/pkg/sdk/vm/ -run Gas` — ok
- [x] `go test ./gno.land/pkg/sdk/vm/` — ok (covers `bounded.go` test updates for the new `*Exception` Abort arm)
- [x] `go test ./gno.land/pkg/integration/ -run TestTestdata` — ok (full txtar suite)
- [x] Smoke: probe with `var p *[3]int; for range p {}` (cooperative `pushPanic`) → `go origin: op_exec.go:165`
- [x] Smoke: probe with `s := "abc"; _ = s[10]` (Go-level `panic(&Exception{...})` via `values.go:1986`) → captures `GetPointerAtIndex` → `doOpIndex1` → `runOnce` → `Run` as the VM chain, with helper visible between place A and doOp*

🤖 Generated with [Claude Code](https://claude.com/claude-code)