### PR TITLE
feat(examples/urequire): add missing uassert wrappers

### DIFF
--- a/examples/gno.land/p/nt/urequire/v0/urequire.gno
+++ b/examples/gno.land/p/nt/urequire/v0/urequire.gno
@@ -6,6 +6,7 @@ import "gno.land/p/nt/uassert/v0"
 
 // type TestingT = uassert.TestingT // XXX: bug, should work
 
+// NoError requires that a function returned no error (i.e. `nil`).
 func NoError(t uassert.TestingT, err error, msgs ...string) {
 	t.Helper()
 	if uassert.NoError(t, err, msgs...) {
@@ -14,6 +15,7 @@ func NoError(t uassert.TestingT, err error, msgs ...string) {
 	t.FailNow()
 }
 
+// Error requires that a function returned an error (i.e. not `nil`).
 func Error(t uassert.TestingT, err error, msgs ...string) {
 	t.Helper()
 	if uassert.Error(t, err, msgs...) {
@@ -22,6 +24,8 @@ func Error(t uassert.TestingT, err error, msgs ...string) {
 	t.FailNow()
 }
 
+// ErrorContains requires that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
 func ErrorContains(t uassert.TestingT, err error, contains string, msgs ...string) {
 	t.Helper()
 	if uassert.ErrorContains(t, err, contains, msgs...) {
@@ -30,6 +34,7 @@ func ErrorContains(t uassert.TestingT, err error, contains string, msgs ...strin
 	t.FailNow()
 }
 
+// True requires that the specified value is true.
 func True(t uassert.TestingT, value bool, msgs ...string) {
 	t.Helper()
 	if uassert.True(t, value, msgs...) {
@@ -38,6 +43,7 @@ func True(t uassert.TestingT, value bool, msgs ...string) {
 	t.FailNow()
 }
 
+// False requires that the specified value is false.
 func False(t uassert.TestingT, value bool, msgs ...string) {
 	t.Helper()
 	if uassert.False(t, value, msgs...) {
@@ -46,6 +52,7 @@ func False(t uassert.TestingT, value bool, msgs ...string) {
 	t.FailNow()
 }
 
+// ErrorIs requires that the given error matches the target error.
 func ErrorIs(t uassert.TestingT, err, target error, msgs ...string) {
 	t.Helper()
 	if uassert.ErrorIs(t, err, target, msgs...) {
@@ -61,6 +68,16 @@ func ErrorIs(t uassert.TestingT, err, target error, msgs ...string) {
 func AbortsWithMessage(t uassert.TestingT, msg string, f any, msgs ...string) {
 	t.Helper()
 	if uassert.AbortsWithMessage(t, msg, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// AbortsContains requires that the code inside the specified func aborts
+// (panics when crossing another realm) and the abort message contains the specified substring.
+func AbortsContains(t uassert.TestingT, substr string, f any, msgs ...string) {
+	t.Helper()
+	if uassert.AbortsContains(t, substr, f, msgs...) {
 		return
 	}
 	t.FailNow()
@@ -89,6 +106,16 @@ func PanicsWithMessage(t uassert.TestingT, msg string, f any, msgs ...string) {
 	t.FailNow()
 }
 
+// PanicsContains requires that the code inside the specified func panics
+// locally within the same execution realm and the panic message contains the specified substring.
+func PanicsContains(t uassert.TestingT, substr string, f any, msgs ...string) {
+	t.Helper()
+	if uassert.PanicsContains(t, substr, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NotPanics requires that the code inside the specified func does NOT panic
 // locally within the same execution realm.
 // Use NotAborts for requiring the absence of panics that cross execution boundaries (aborts).
@@ -100,6 +127,7 @@ func NotPanics(t uassert.TestingT, f any, msgs ...string) {
 	t.FailNow()
 }
 
+// Equal requires that two objects are equal.
 func Equal(t uassert.TestingT, expected, actual any, msgs ...string) {
 	t.Helper()
 	if uassert.Equal(t, expected, actual, msgs...) {
@@ -108,6 +136,7 @@ func Equal(t uassert.TestingT, expected, actual any, msgs ...string) {
 	t.FailNow()
 }
 
+// NotEqual requires that two objects are not equal.
 func NotEqual(t uassert.TestingT, expected, actual any, msgs ...string) {
 	t.Helper()
 	if uassert.NotEqual(t, expected, actual, msgs...) {
@@ -116,6 +145,8 @@ func NotEqual(t uassert.TestingT, expected, actual any, msgs ...string) {
 	t.FailNow()
 }
 
+// Empty requires that the specified object is empty
+// (zero value, empty string/slice/map, or nil).
 func Empty(t uassert.TestingT, obj any, msgs ...string) {
 	t.Helper()
 	if uassert.Empty(t, obj, msgs...) {
@@ -124,9 +155,46 @@ func Empty(t uassert.TestingT, obj any, msgs ...string) {
 	t.FailNow()
 }
 
+// NotEmpty requires that the specified object is not empty.
 func NotEmpty(t uassert.TestingT, obj any, msgs ...string) {
 	t.Helper()
 	if uassert.NotEmpty(t, obj, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil requires that the value is nil.
+func Nil(t uassert.TestingT, value any, msgs ...string) {
+	t.Helper()
+	if uassert.Nil(t, value, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil requires that the value is not nil.
+func NotNil(t uassert.TestingT, value any, msgs ...string) {
+	t.Helper()
+	if uassert.NotNil(t, value, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// TypedNil requires that the value is a typed-nil (nil pointer) value.
+func TypedNil(t uassert.TestingT, value any, msgs ...string) {
+	t.Helper()
+	if uassert.TypedNil(t, value, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotTypedNil requires that the value is not a typed-nil (nil pointer) value.
+func NotTypedNil(t uassert.TestingT, value any, msgs ...string) {
+	t.Helper()
+	if uassert.NotTypedNil(t, value, msgs...) {
 		return
 	}
 	t.FailNow()


### PR DESCRIPTION
Add wrappers for AbortsContains, PanicsContains, Nil, NotNil, TypedNil, and NotTypedNil to bring urequire to full parity with uassert. Also document the remaining pre-existing wrappers that lacked doc comments.

Related: #5673