### PR TITLE
WIP feat(gnovm): add math/big stdlib (Int subset)

### DIFF
--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -50,7 +50,7 @@ import (
 // verify the change is actually consensus-breaking before updating this
 // constant — re-run the zrealm_crossrealm38.gno filetest and inspect the
 // save-set diff first.
-const expectedCrossrealm38Hash = "b00c384226ac5a85b58232b316c58f941da2c39c52b3196263495544d1f8c95b"
+const expectedCrossrealm38Hash = "e280eff735a492d387aeba7de5a26314a9fbf96dccbc43b6295c2317ef2c4428"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -50,7 +50,7 @@ import (
 // verify the change is actually consensus-breaking before updating this
 // constant — re-run the zrealm_crossrealm38.gno filetest and inspect the
 // save-set diff first.
-const expectedCrossrealm38Hash = "71ceb2a2fdb652e741a4f85cc4d045a5dc6139aeb0ddae523bc5f2ca868708fc"
+const expectedCrossrealm38Hash = "b00c384226ac5a85b58232b316c58f941da2c39c52b3196263495544d1f8c95b"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gnovm/adr/pr5678_math_big_stdlib.md
+++ b/gnovm/adr/pr5678_math_big_stdlib.md
@@ -98,6 +98,28 @@ arguments are read out of the call block into Go locals before the X_
 function runs; the result `(neg, abs)` is fresh and assigned to the
 receiver only after the call returns. Tested in `TestAliasing`.
 
+Two deliberate divergences from Go, both in corners where Go silently
+returns wrong values (probed empirically against Go's math/big):
+
+- `QuoRem(x, y, r)` with `z == r` (same pointer for both outputs): Go
+  overwrites the quotient with the remainder (17/5 yields q=2, r=2).
+  Gno panics instead.  Same for `DivMod` with `z == m`.
+- `DivMod(x, y, m)` with `m == y` (modulus receiver aliases divisor):
+  Go re-reads y in the sign fixup after writing m, corrupting the
+  result (-7 divmod 3 yields q=-1, m=0). Gno returns the correct
+  (q=-3, m=2) because all inputs are decoded before any receiver is
+  written.
+
+No valid Go program is affected: both corners produce garbage in Go.
+
+### Panic and nil-receiver parity
+
+Panic messages match Go's math/big byte-for-byte so ported code that
+matches on recover() values keeps working: `"division by zero"`,
+`"invalid base"` (Text), `"invalid number base %d"` (SetString).
+`String`/`Text` on a nil `*Int` return `"<nil>"`, and the nil check
+precedes base validation exactly as in Go. All pinned in tests.
+
 ### Gas
 
 Seven new native functions (`add`, `sub`, `mul`, `quoRem`, `divMod`,

--- a/gnovm/adr/pr5678_math_big_stdlib.md
+++ b/gnovm/adr/pr5678_math_big_stdlib.md
@@ -1,4 +1,4 @@
-# PRxxxx: math/big stdlib (Int subset)
+# PR5678: math/big stdlib (Int subset)
 
 ## Context
 
@@ -113,6 +113,10 @@ Single-slope (`SlopeIdx=1` on the first `[]byte` operand) under-counts
 for binary ops when `|b| > |a|`. A two-dimensional fit (Slope2 on `b`)
 is in scope for the calibration follow-up — the schema already supports
 it; only the placeholder rows here use the single-slope form.
+
+`setString` is the exception: its first parameter is the input `string`,
+not a sign `bool`, so its row uses `SlopeIdx=0` (sloping on the length
+of `s`) rather than `SlopeIdx=1`.
 
 ### Note on PR #5646
 

--- a/gnovm/adr/prxxxx_math_big_stdlib.md
+++ b/gnovm/adr/prxxxx_math_big_stdlib.md
@@ -1,0 +1,186 @@
+# PRxxxx: math/big stdlib (Int subset)
+
+## Context
+
+Gno today has no user-facing arbitrary-precision integer type:
+
+- `UntypedBigintType` / `UntypedBigdecType` exist only at preprocess time
+  for constant folding (e.g. `1 << 200` evaluated in a const context).
+  They are never exposed to user code and constants must collapse to a
+  sized type (`int`, `int64`, `uint64`, etc.) before runtime.
+- The runtime has full machinery — `BigintValue`, `BigdecValue`,
+  `BigintKind`/`BigdecKind` in `op_binary.go` — but no `.gno` program
+  can reach it.
+- The ecosystem has filled the gap with fixed-width libraries
+  (`p/onbloc/int256`, ~2.3k lines of hand-written `[]uint64` arithmetic).
+  Arbitrary precision is unavailable.
+- PR #5646 wired CPU gas metering for `BigintKind`/`BigdecKind` operator
+  helpers (`isEql`, `isLss`, etc.). The ADR for that PR called out that
+  the metering covers an unreachable path. Either we expose the type
+  (the metering becomes live) or we should revisit whether the metering
+  is worth keeping. This PR takes the first option for `Int`.
+
+## Decision
+
+Add `math/big` as a stdlib, starting with `Int` only. The `.gno` API
+mirrors Go's `math/big.Int` so existing Go code ports with minimal
+change.
+
+Wire format: an `Int` carries `(neg bool, abs []byte)` where `abs` is the
+big-endian unsigned magnitude with no leading zeros (empty for zero).
+Methods that do heavy lifting (`Add`, `Sub`, `Mul`, `QuoRem`, `DivMod`,
+`SetString`, `Text`) call into native Go-side functions via the existing
+`genstd` bridge; the Go side decodes to `*big.Int`, computes, re-encodes.
+Trivial methods (`Set`, `SetInt64`, `Sign`, `Neg`, `Abs`, `Cmp`, `Bytes`,
+`SetBytes`, `BitLen`, etc.) are pure Gno.
+
+## Scope
+
+Included in this PR (subset of Go's `math/big.Int`):
+
+- Construction / conversion: `NewInt`, `Set`, `SetInt64`, `SetUint64`,
+  `Int64`, `Uint64`, `IsInt64`, `IsUint64`, `Bytes`, `SetBytes`,
+  `SetString`, `String`, `Text`
+- Sign / magnitude: `Sign`, `Neg`, `Abs`, `BitLen`
+- Comparison: `Cmp`, `CmpAbs`
+- Arithmetic: `Add`, `Sub`, `Mul`, `Quo`, `Rem`, `QuoRem`, `Div`, `Mod`,
+  `DivMod`
+
+Explicitly deferred (see "Follow-ups"):
+
+- `big.Float`, `big.Rat`
+- Bit operations (`Lsh`, `Rsh`, `And`, `Or`, `Xor`, `AndNot`, `Bit`,
+  `SetBit`)
+- Advanced ops (`Exp`, `ModInverse`, `GCD`, `Sqrt`, `ProbablyPrime`)
+- Formatting helpers (`Format`, `Append`, `FillBytes`)
+- Encoding helpers (`MarshalJSON`, `GobEncode`, `MarshalText`)
+
+## Alternatives Considered
+
+1. **Pure-Gno reimplementation of `math/big`** (Karatsuba on `[]uint64`,
+   etc.). Honest but enormous — Go's upstream is roughly 5k LOC for `Int`
+   alone, plus `nat`. Native bridge gets us 95% of the value at 5% of the
+   surface; the API surface stays portable so a pure-Gno backing can
+   replace the native one later without changing call sites.
+
+2. **Hook `*big.Int` directly into the VM as a first-class `BigintKind`
+   type**, so `==`, `<`, etc. dispatch through the existing operator
+   handlers in `op_binary.go` (and PR #5646's metering becomes live).
+   This is the right long-term answer but requires preprocess changes to
+   accept a user-facing type with `BigintKind`, plus careful spec work
+   for operator/literal semantics. Out of scope here. See "Open
+   Question."
+
+3. **Don't add the type; revert PR #5646.** Coherent — if no `.gno`
+   program can hold a runtime bigint, gas-charging the operator helpers
+   is dead defensive code. Rejected because real ecosystem demand exists
+   (see `p/onbloc/int256`).
+
+## Implementation Notes
+
+### Wire format
+
+`(neg bool, abs []byte)` chosen over a single signed-magnitude `[]byte`
+or a length-prefixed encoding because:
+
+- Two clean primitive params with no parser. `genstd` handles `bool` and
+  `[]byte` directly with no custom type plumbing.
+- Mirrors `*big.Int`'s internal representation closely. `toBig` /
+  `fromBig` are trivial.
+- Empty `abs` is canonical zero. `neg=true, abs=nil` is rejected at the
+  Gno setter so the `Sign() == 0` check is just `len(abs) == 0`.
+
+### Aliasing
+
+Go's `math/big` allows the receiver to alias any argument
+(`z.Add(z, y)`, `z.Mul(z, z)`, etc.). Native calls preserve this because
+arguments are read out of the call block into Go locals before the X_
+function runs; the result `(neg, abs)` is fresh and assigned to the
+receiver only after the call returns. Tested in `TestAliasing`.
+
+### Gas
+
+Seven new native functions (`add`, `sub`, `mul`, `quoRem`, `divMod`,
+`setString`, `text`) are registered in
+`gnovm/stdlibs/native_gas.go` with **placeholder** calibration values.
+They are conservative (over-charge rather than under-charge), but real
+calibration must come from a benchmark run in
+`gnovm/cmd/calibrate/native_bench_test.go` before any consensus-relevant
+deployment. The placeholders are clearly marked `TODO: calibrate` in
+the table comment and on each row.
+
+Single-slope (`SlopeIdx=1` on the first `[]byte` operand) under-counts
+for binary ops when `|b| > |a|`. A two-dimensional fit (Slope2 on `b`)
+is in scope for the calibration follow-up — the schema already supports
+it; only the placeholder rows here use the single-slope form.
+
+### Note on PR #5646
+
+This PR does **not** make PR #5646's `BigintKind` operator metering
+reachable. `*big.Int` is a regular Gno struct here, not a
+`BigintKind`-typed value at the VM level — so `==`, `<`, etc. on a
+`*big.Int` go through ordinary struct/pointer comparison, not through
+`op_binary.go:isEql`/`isLss`. The metering in PR #5646 remains
+unreachable from `.gno` source.
+
+Making it reachable is a separate, larger piece of work: it requires
+either (a) hooking `math/big.Int` into the VM as a `BigintKind`-typed
+type with operator support (preprocess + type-checker changes), or
+(b) adding a `bigint` primitive keyword. Alternative 2 above. The two
+PRs are decoupled — this one stands on its own utility for users today,
+and the operator path can come later without invalidating the API
+shipped here.
+
+## Consequences
+
+### Positive
+
+- Gno gets arbitrary-precision integers in the stdlib, matching Go's
+  API. Ecosystem libraries (`p/onbloc/int256`, future u256 wrappers)
+  can wrap or migrate.
+- `genstd` bridge surface stays small (7 native functions, all using
+  primitive Gno types).
+- Determinism is inherited from Go's `math/big` (deterministic across
+  platforms by construction).
+
+### Negative
+
+- Per-op overhead is non-trivial: every arithmetic call goes through
+  `Gno2GoValue` (param decode) → `SetBytes` (build `*big.Int`) → op →
+  `Bytes` (encode result) → `Go2GnoValue` (push). For tight loops over
+  small integers, this is meaningfully slower than fixed-width
+  alternatives like `int64` or `p/onbloc/int256`.
+- Placeholder gas values are not safe for mainnet. A calibration pass is
+  a hard prerequisite before any production rollout.
+
+## Open Question
+
+Should we follow up with **(2)** from "Alternatives" — exposing
+`big.Int` as a true `BigintKind` value at the VM level so `==`, `<`,
+`+`, etc. dispatch through `op_binary.go`?
+
+Arguments for: makes the type natural to use (`a + b` instead of
+`new(big.Int).Add(a, b)`), makes PR #5646's metering live, retires the
+dead-code question for the `Bigint`/`Bigdec` runtime paths.
+
+Arguments against: breaks Go API parity (Go's `*big.Int` does *not*
+support operators), opens a non-trivial spec discussion (literal
+syntax, type inference rules, how `bigint` interacts with `int`/`int64`
+in mixed expressions), and adds VM/preprocess surface for a feature
+that the method-based API already covers.
+
+I think this is worth a separate ADR after the method-based stdlib has
+seen real use. Filing as a tracking issue rather than embedding the
+decision here.
+
+## Follow-ups
+
+- Real gas calibration: add `BenchmarkNative_MathBig_*` benches to
+  `gnovm/cmd/calibrate/native_bench_test.go` (sweeping input lengths
+  for add/sub/mul/divMod, plus base/length sweeps for setString/text),
+  re-fit, replace placeholder rows in `native_gas.go`.
+- Bit operations: `Lsh`, `Rsh`, `And`, `Or`, `Xor`, `AndNot`, `Bit`,
+  `SetBit`. Add one native per op; same wire format.
+- `Exp`, `ModInverse`, `GCD`, `Sqrt`, `ProbablyPrime`.
+- `big.Float`, `big.Rat`. Larger surface; defer until `Int` has shipped
+  and the calibration model is validated.

--- a/gnovm/stdlibs/generated.go
+++ b/gnovm/stdlibs/generated.go
@@ -14,6 +14,7 @@ import (
 	libs_crypto_ed25519 "github.com/gnolang/gno/gnovm/stdlibs/crypto/ed25519"
 	libs_crypto_sha256 "github.com/gnolang/gno/gnovm/stdlibs/crypto/sha256"
 	libs_math "github.com/gnolang/gno/gnovm/stdlibs/math"
+	libs_math_big "github.com/gnolang/gno/gnovm/stdlibs/math/big"
 	libs_sys_params "github.com/gnolang/gno/gnovm/stdlibs/sys/params"
 	libs_time "github.com/gnolang/gno/gnovm/stdlibs/time"
 )
@@ -992,6 +993,390 @@ var nativeFuncs = [...]NativeFunc{
 		},
 	},
 	{
+		"math/big",
+		"add",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p3"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  bool
+				rp2 = reflect.ValueOf(&p2).Elem()
+				p3  []byte
+				rp3 = reflect.ValueOf(&p3).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+			tv3 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 3, "")).TV
+			tv3.DeepFill(m.Store)
+			gno.Gno2GoValue(tv3, rp3)
+
+			r0, r1 := libs_math_big.X_add(p0, p1, p2, p3)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"sub",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p3"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  bool
+				rp2 = reflect.ValueOf(&p2).Elem()
+				p3  []byte
+				rp3 = reflect.ValueOf(&p3).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+			tv3 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 3, "")).TV
+			tv3.DeepFill(m.Store)
+			gno.Gno2GoValue(tv3, rp3)
+
+			r0, r1 := libs_math_big.X_sub(p0, p1, p2, p3)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"mul",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p3"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  bool
+				rp2 = reflect.ValueOf(&p2).Elem()
+				p3  []byte
+				rp3 = reflect.ValueOf(&p3).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+			tv3 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 3, "")).TV
+			tv3.DeepFill(m.Store)
+			gno.Gno2GoValue(tv3, rp3)
+
+			r0, r1 := libs_math_big.X_mul(p0, p1, p2, p3)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"quoRem",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p3"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("r2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r3"), Type: gno.X("[]byte")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  bool
+				rp2 = reflect.ValueOf(&p2).Elem()
+				p3  []byte
+				rp3 = reflect.ValueOf(&p3).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+			tv3 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 3, "")).TV
+			tv3.DeepFill(m.Store)
+			gno.Gno2GoValue(tv3, rp3)
+
+			r0, r1, r2, r3 := libs_math_big.X_quoRem(p0, p1, p2, p3)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r2).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r3).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"divMod",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p3"), Type: gno.X("[]byte")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("r2"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r3"), Type: gno.X("[]byte")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  bool
+				rp2 = reflect.ValueOf(&p2).Elem()
+				p3  []byte
+				rp3 = reflect.ValueOf(&p3).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+			tv3 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 3, "")).TV
+			tv3.DeepFill(m.Store)
+			gno.Gno2GoValue(tv3, rp3)
+
+			r0, r1, r2, r3 := libs_math_big.X_divMod(p0, p1, p2, p3)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r2).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r3).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"setString",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("string")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("int")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("r1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("r2"), Type: gno.X("bool")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  string
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  int
+				rp1 = reflect.ValueOf(&p1).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+
+			r0, r1, r2 := libs_math_big.X_setString(p0, p1)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r1).Elem(),
+			))
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r2).Elem(),
+			))
+		},
+	},
+	{
+		"math/big",
+		"text",
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("p0"), Type: gno.X("bool")},
+			{NameExpr: *gno.Nx("p1"), Type: gno.X("[]byte")},
+			{NameExpr: *gno.Nx("p2"), Type: gno.X("int")},
+		},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("string")},
+		},
+		false,
+		func(m *gno.Machine) {
+			b := m.LastBlock()
+			var (
+				p0  bool
+				rp0 = reflect.ValueOf(&p0).Elem()
+				p1  []byte
+				rp1 = reflect.ValueOf(&p1).Elem()
+				p2  int
+				rp2 = reflect.ValueOf(&p2).Elem()
+			)
+
+			tv0 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 0, "")).TV
+			tv0.DeepFill(m.Store)
+			gno.Gno2GoValue(tv0, rp0)
+			tv1 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 1, "")).TV
+			tv1.DeepFill(m.Store)
+			gno.Gno2GoValue(tv1, rp1)
+			tv2 := b.GetPointerTo(nil, gno.NewValuePathBlock(1, 2, "")).TV
+			tv2.DeepFill(m.Store)
+			gno.Gno2GoValue(tv2, rp2)
+
+			r0 := libs_math_big.X_text(p0, p1, p2)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+		},
+	},
+	{
 		"sys/params",
 		"setSysParamString",
 		[]gno.FieldTypeExpr{
@@ -1696,6 +2081,7 @@ var initOrder = [...]string{
 	"hash",
 	"hash/adler32",
 	"html",
+	"math/big",
 	"math/rand",
 	"path",
 	"net/url",

--- a/gnovm/stdlibs/math/big/gnomod.toml
+++ b/gnovm/stdlibs/math/big/gnomod.toml
@@ -1,0 +1,2 @@
+module = "math/big"
+gno = "0.9"

--- a/gnovm/stdlibs/math/big/int.gno
+++ b/gnovm/stdlibs/math/big/int.gno
@@ -1,0 +1,401 @@
+// Package big implements arbitrary-precision arithmetic (big numbers).
+//
+// This package is a subset of Go's math/big. Only the Int type is
+// currently provided. Float and Rat are planned follow-ups.
+//
+// The semantics, naming, and method signatures mirror Go's math/big so
+// existing Go code that uses *big.Int can be ported with minimal change:
+//
+//	z := new(big.Int).SetInt64(1)
+//	z.Lsh(z, 256)        // not yet implemented; see godoc for the supported subset
+//	z.Add(z, big.NewInt(1))
+//	println(z.String())
+//
+// All arithmetic methods take pointer arguments and return the receiver,
+// allowing chaining. As in Go's math/big, the receiver may alias any
+// argument: z.Add(z, y) is well-defined.
+package big
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// An Int represents a signed multi-precision integer. The zero value
+// for Int represents the value 0.
+//
+// Operations always take pointer arguments (*Int) rather than Int values,
+// and each unique Int value requires its own unique *Int pointer. To
+// "copy" an Int value, an existing (or newly allocated) Int must be set
+// to the new value using the Int.Set method; shallow copies of Ints are
+// not supported and may lead to errors.
+type Int struct {
+	// neg is true when the integer is strictly negative.
+	// abs is the big-endian unsigned magnitude, with no leading zero
+	// bytes. The empty/nil slice represents zero, in which case neg
+	// must be false (there is a single representation for zero).
+	neg bool
+	abs []byte
+}
+
+// NewInt allocates and returns a new Int set to x.
+func NewInt(x int64) *Int {
+	return new(Int).SetInt64(x)
+}
+
+// Set sets z to x and returns z.
+func (z *Int) Set(x *Int) *Int {
+	if z != x {
+		z.neg = x.neg
+		z.abs = append(z.abs[:0], x.abs...)
+	}
+	return z
+}
+
+// SetInt64 sets z to x and returns z.
+func (z *Int) SetInt64(x int64) *Int {
+	neg := false
+	var u uint64
+	if x < 0 {
+		neg = true
+		// uint64(-x) is correct even for x == math.MinInt64
+		// because -MinInt64 wraps to MinInt64 and the uint64
+		// conversion reinterprets the bit pattern as 1<<63.
+		u = uint64(-x)
+	} else {
+		u = uint64(x)
+	}
+	z.abs = appendUint64(z.abs[:0], u)
+	z.neg = neg && len(z.abs) > 0
+	return z
+}
+
+// SetUint64 sets z to x and returns z.
+func (z *Int) SetUint64(x uint64) *Int {
+	z.abs = appendUint64(z.abs[:0], x)
+	z.neg = false
+	return z
+}
+
+func appendUint64(buf []byte, x uint64) []byte {
+	if x == 0 {
+		return buf
+	}
+	var tmp [8]byte
+	binary.BigEndian.PutUint64(tmp[:], x)
+	i := 0
+	for i < 7 && tmp[i] == 0 {
+		i++
+	}
+	return append(buf, tmp[i:]...)
+}
+
+// IsUint64 reports whether x can be represented as a uint64.
+func (x *Int) IsUint64() bool {
+	return !x.neg && len(x.abs) <= 8
+}
+
+// IsInt64 reports whether x can be represented as an int64.
+func (x *Int) IsInt64() bool {
+	if len(x.abs) < 8 {
+		return true
+	}
+	if len(x.abs) > 8 {
+		return false
+	}
+	hi := x.abs[0]
+	if x.neg {
+		// MinInt64 is exactly 0x8000000000000000 with sign bit.
+		if hi < 0x80 {
+			return true
+		}
+		if hi > 0x80 {
+			return false
+		}
+		for i := 1; i < 8; i++ {
+			if x.abs[i] != 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return hi < 0x80
+}
+
+// Uint64 returns the uint64 representation of x.
+// If x cannot be represented in a uint64, the result is undefined.
+func (x *Int) Uint64() uint64 {
+	var v uint64
+	for _, b := range x.abs {
+		v = v<<8 | uint64(b)
+	}
+	return v
+}
+
+// Int64 returns the int64 representation of x.
+// If x cannot be represented in an int64, the result is undefined.
+func (x *Int) Int64() int64 {
+	v := int64(x.Uint64())
+	if x.neg {
+		v = -v
+	}
+	return v
+}
+
+// Sign returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+func (x *Int) Sign() int {
+	if len(x.abs) == 0 {
+		return 0
+	}
+	if x.neg {
+		return -1
+	}
+	return 1
+}
+
+// Neg sets z to -x and returns z.
+func (z *Int) Neg(x *Int) *Int {
+	if z != x {
+		z.Set(x)
+	}
+	z.neg = len(z.abs) > 0 && !z.neg
+	return z
+}
+
+// Abs sets z to |x| (the absolute value of x) and returns z.
+func (z *Int) Abs(x *Int) *Int {
+	if z != x {
+		z.Set(x)
+	}
+	z.neg = false
+	return z
+}
+
+// BitLen returns the length of the absolute value of x in bits. The
+// bit length of 0 is 0.
+func (x *Int) BitLen() int {
+	if len(x.abs) == 0 {
+		return 0
+	}
+	return (len(x.abs)-1)*8 + bits.Len8(x.abs[0])
+}
+
+// Bytes returns the absolute value of x as a big-endian byte slice.
+// To use a fixed length slice, or a preallocated one, use FillBytes.
+func (x *Int) Bytes() []byte {
+	out := make([]byte, len(x.abs))
+	copy(out, x.abs)
+	return out
+}
+
+// SetBytes interprets buf as the bytes of a big-endian unsigned
+// integer, sets z to that value, and returns z.
+func (z *Int) SetBytes(buf []byte) *Int {
+	// Skip leading zeros so the abs invariant is maintained.
+	i := 0
+	for i < len(buf) && buf[i] == 0 {
+		i++
+	}
+	z.abs = append(z.abs[:0], buf[i:]...)
+	z.neg = false
+	return z
+}
+
+// CmpAbs compares the absolute values of x and y and returns:
+//
+//	-1 if |x| <  |y|
+//	 0 if |x| == |y|
+//	+1 if |x| >  |y|
+func (x *Int) CmpAbs(y *Int) int {
+	return cmpAbsBytes(x.abs, y.abs)
+}
+
+func cmpAbsBytes(a, b []byte) int {
+	if len(a) != len(b) {
+		if len(a) < len(b) {
+			return -1
+		}
+		return 1
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// Cmp compares x and y and returns:
+//
+//	-1 if x <  y
+//	 0 if x == y
+//	+1 if x >  y
+func (x *Int) Cmp(y *Int) int {
+	switch {
+	case x.neg == y.neg:
+		c := cmpAbsBytes(x.abs, y.abs)
+		if x.neg {
+			return -c
+		}
+		return c
+	case x.neg:
+		return -1
+	default:
+		return 1
+	}
+}
+
+// String returns the decimal representation of x as generated by x.Text(10).
+func (x *Int) String() string {
+	return x.Text(10)
+}
+
+// Text returns the string representation of x in the given base. Base
+// must be between 2 and 62, inclusive. The result uses the lower-case
+// letters 'a' to 'z' for digit values 10 to 35, and the upper-case
+// letters 'A' to 'Z' for digit values 36 to 61. No prefix (such as "0x")
+// is added to the string.
+func (x *Int) Text(base int) string {
+	if base < 2 || base > 62 {
+		panic("invalid base")
+	}
+	return text(x.neg, x.abs, base)
+}
+
+// SetString sets z to the value of s, interpreted in the given base,
+// and returns z and a boolean indicating success. The entire string
+// (not just a prefix) must be valid for success. If SetString fails,
+// the value of z is undefined but the returned value is nil.
+//
+// The base argument must be 0 or a value between 2 and 62, inclusive;
+// otherwise SetString panics. For base 0, the number prefix determines
+// the actual conversion base: a prefix of "0b" or "0B" selects base 2,
+// "0", "0o" or "0O" selects base 8, and "0x" or "0X" selects base 16.
+// Otherwise, the selected base is 10 and no prefix is accepted.
+func (z *Int) SetString(s string, base int) (*Int, bool) {
+	if base != 0 && (base < 2 || base > 62) {
+		panic("invalid base")
+	}
+	neg, abs, ok := setString(s, base)
+	if !ok {
+		return nil, false
+	}
+	z.neg = neg && len(abs) > 0
+	z.abs = abs
+	return z, true
+}
+
+// Add sets z to the sum x+y and returns z.
+func (z *Int) Add(x, y *Int) *Int {
+	z.neg, z.abs = add(x.neg, x.abs, y.neg, y.abs)
+	return z
+}
+
+// Sub sets z to the difference x-y and returns z.
+func (z *Int) Sub(x, y *Int) *Int {
+	z.neg, z.abs = sub(x.neg, x.abs, y.neg, y.abs)
+	return z
+}
+
+// Mul sets z to the product x*y and returns z.
+func (z *Int) Mul(x, y *Int) *Int {
+	z.neg, z.abs = mul(x.neg, x.abs, y.neg, y.abs)
+	return z
+}
+
+// Quo sets z to the quotient x/y for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs. Quo implements truncated division (like Go); see
+// QuoRem for more details.
+func (z *Int) Quo(x, y *Int) *Int {
+	qNeg, q, _, _ := quoRem(x.neg, x.abs, y.neg, y.abs)
+	z.neg = qNeg
+	z.abs = q
+	return z
+}
+
+// Rem sets z to the remainder x%y for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs. Rem implements truncated modulus (like Go); see
+// QuoRem for more details.
+func (z *Int) Rem(x, y *Int) *Int {
+	_, _, rNeg, r := quoRem(x.neg, x.abs, y.neg, y.abs)
+	z.neg = rNeg
+	z.abs = r
+	return z
+}
+
+// QuoRem sets z to the quotient x/y and r to the remainder x%y and
+// returns the pair (z, r) for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs.
+//
+// QuoRem implements T-division and modulus (like Go):
+//
+//	q = x/y      with the result truncated to zero
+//	r = x - y*q
+func (z *Int) QuoRem(x, y, r *Int) (*Int, *Int) {
+	qNeg, q, rNeg, rem := quoRem(x.neg, x.abs, y.neg, y.abs)
+	z.neg = qNeg
+	z.abs = q
+	r.neg = rNeg
+	r.abs = rem
+	return z, r
+}
+
+// Div sets z to the quotient x/y for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs. Div implements Euclidean division (unlike Go);
+// see DivMod for more details.
+func (z *Int) Div(x, y *Int) *Int {
+	qNeg, q, _, _ := divMod(x.neg, x.abs, y.neg, y.abs)
+	z.neg = qNeg
+	z.abs = q
+	return z
+}
+
+// Mod sets z to the modulus x%y for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs. Mod implements Euclidean modulus (unlike Go);
+// see DivMod for more details.
+func (z *Int) Mod(x, y *Int) *Int {
+	_, _, rNeg, r := divMod(x.neg, x.abs, y.neg, y.abs)
+	z.neg = rNeg
+	z.abs = r
+	return z
+}
+
+// DivMod sets z to the quotient x div y and m to the modulus x mod y
+// and returns the pair (z, m) for y != 0. If y == 0, a division-by-zero
+// run-time panic occurs.
+//
+// DivMod implements Euclidean division and modulus (unlike Go):
+//
+//	q = x div y  such that
+//	m = x - y*q  with 0 <= m < |y|
+func (z *Int) DivMod(x, y, m *Int) (*Int, *Int) {
+	qNeg, q, mNeg, mod := divMod(x.neg, x.abs, y.neg, y.abs)
+	z.neg = qNeg
+	z.abs = q
+	m.neg = mNeg
+	m.abs = mod
+	return z, m
+}
+
+// Native bridge stubs. Implementations live in int.go.
+
+func add(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) // injected
+
+func sub(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) // injected
+
+func mul(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) // injected
+
+func quoRem(xNeg bool, x []byte, yNeg bool, y []byte) (bool, []byte, bool, []byte) // injected
+
+func divMod(xNeg bool, x []byte, yNeg bool, y []byte) (bool, []byte, bool, []byte) // injected
+
+func setString(s string, base int) (bool, []byte, bool) // injected
+
+func text(neg bool, abs []byte, base int) string // injected

--- a/gnovm/stdlibs/math/big/int.gno
+++ b/gnovm/stdlibs/math/big/int.gno
@@ -22,17 +22,13 @@ import (
 	"strconv"
 )
 
-func invalidBaseError(base int) string {
-	return "big: invalid base: " + strconv.Itoa(base)
-}
-
 // divCheck panics on the Gno side for y == 0 so the division-by-zero
 // error is a normal recoverable Gno panic instead of a native Go panic
 // surfaced through the genstd bridge (which is not catchable by a
-// realm-level recover()).
+// realm-level recover()). The message matches Go's math/big exactly.
 func divCheck(y *Int) {
 	if len(y.abs) == 0 {
-		panic("big: division by zero")
+		panic("division by zero")
 	}
 }
 
@@ -143,9 +139,15 @@ func (x *Int) IsInt64() bool {
 // Uint64 returns the uint64 representation of x.
 // If x cannot be represented in a uint64, the result is undefined.
 func (x *Int) Uint64() uint64 {
+	// Low 64 bits of the magnitude, like Go's low64: wider values
+	// truncate instead of scanning the whole slice.
+	b := x.abs
+	if len(b) > 8 {
+		b = b[len(b)-8:]
+	}
 	var v uint64
-	for _, b := range x.abs {
-		v = v<<8 | uint64(b)
+	for _, c := range b {
+		v = v<<8 | uint64(c)
 	}
 	return v
 }
@@ -281,10 +283,15 @@ func (x *Int) String() string {
 // must be between 2 and 62, inclusive. The result uses the lower-case
 // letters 'a' to 'z' for digit values 10 to 35, and the upper-case
 // letters 'A' to 'Z' for digit values 36 to 61. No prefix (such as "0x")
-// is added to the string.
+// is added to the string. If x is a nil pointer it returns "<nil>".
 func (x *Int) Text(base int) string {
+	// Like Go, the nil check comes before base validation:
+	// (*Int)(nil).Text(1) is "<nil>", not a panic.
+	if x == nil {
+		return "<nil>"
+	}
 	if base < 2 || base > 62 {
-		panic(invalidBaseError(base))
+		panic("invalid base")
 	}
 	return text(x.neg, x.abs, base)
 }
@@ -301,7 +308,7 @@ func (x *Int) Text(base int) string {
 // Otherwise, the selected base is 10 and no prefix is accepted.
 func (z *Int) SetString(s string, base int) (*Int, bool) {
 	if base != 0 && (base < 2 || base > 62) {
-		panic(invalidBaseError(base))
+		panic("invalid number base " + strconv.Itoa(base))
 	}
 	neg, abs, ok := setString(s, base)
 	if !ok {

--- a/gnovm/stdlibs/math/big/int.gno
+++ b/gnovm/stdlibs/math/big/int.gno
@@ -19,7 +19,22 @@ package big
 import (
 	"encoding/binary"
 	"math/bits"
+	"strconv"
 )
+
+func invalidBaseError(base int) string {
+	return "big: invalid base: " + strconv.Itoa(base)
+}
+
+// divCheck panics on the Gno side for y == 0 so the division-by-zero
+// error is a normal recoverable Gno panic instead of a native Go panic
+// surfaced through the genstd bridge (which is not catchable by a
+// realm-level recover()).
+func divCheck(y *Int) {
+	if len(y.abs) == 0 {
+		panic("big: division by zero")
+	}
+}
 
 // An Int represents a signed multi-precision integer. The zero value
 // for Int represents the value 0.
@@ -46,8 +61,11 @@ func NewInt(x int64) *Int {
 // Set sets z to x and returns z.
 func (z *Int) Set(x *Int) *Int {
 	if z != x {
-		z.neg = x.neg
 		z.abs = append(z.abs[:0], x.abs...)
+		// Re-normalize defensively: every other setter enforces the
+		// invariant len(abs) == 0 ⇒ neg == false. Set honors it too even
+		// if x was constructed by an internal path that bypassed it.
+		z.neg = x.neg && len(z.abs) > 0
 	}
 	return z
 }
@@ -137,6 +155,8 @@ func (x *Int) Uint64() uint64 {
 func (x *Int) Int64() int64 {
 	v := int64(x.Uint64())
 	if x.neg {
+		// Inverse of the SetInt64 trick: for x == MinInt64, -v wraps
+		// back to MinInt64 in two's complement, which is what we want.
 		v = -v
 	}
 	return v
@@ -264,7 +284,7 @@ func (x *Int) String() string {
 // is added to the string.
 func (x *Int) Text(base int) string {
 	if base < 2 || base > 62 {
-		panic("invalid base")
+		panic(invalidBaseError(base))
 	}
 	return text(x.neg, x.abs, base)
 }
@@ -281,7 +301,7 @@ func (x *Int) Text(base int) string {
 // Otherwise, the selected base is 10 and no prefix is accepted.
 func (z *Int) SetString(s string, base int) (*Int, bool) {
 	if base != 0 && (base < 2 || base > 62) {
-		panic("invalid base")
+		panic(invalidBaseError(base))
 	}
 	neg, abs, ok := setString(s, base)
 	if !ok {
@@ -314,6 +334,7 @@ func (z *Int) Mul(x, y *Int) *Int {
 // run-time panic occurs. Quo implements truncated division (like Go); see
 // QuoRem for more details.
 func (z *Int) Quo(x, y *Int) *Int {
+	divCheck(y)
 	qNeg, q, _, _ := quoRem(x.neg, x.abs, y.neg, y.abs)
 	z.neg = qNeg
 	z.abs = q
@@ -324,6 +345,7 @@ func (z *Int) Quo(x, y *Int) *Int {
 // run-time panic occurs. Rem implements truncated modulus (like Go); see
 // QuoRem for more details.
 func (z *Int) Rem(x, y *Int) *Int {
+	divCheck(y)
 	_, _, rNeg, r := quoRem(x.neg, x.abs, y.neg, y.abs)
 	z.neg = rNeg
 	z.abs = r
@@ -338,7 +360,16 @@ func (z *Int) Rem(x, y *Int) *Int {
 //
 //	q = x/y      with the result truncated to zero
 //	r = x - y*q
+//
+// The two output receivers z and r must be distinct *Int values (i.e.
+// z != r); passing the same pointer for both panics, since the natural
+// "last write wins" semantics would silently overwrite the quotient
+// with the remainder.
 func (z *Int) QuoRem(x, y, r *Int) (*Int, *Int) {
+	divCheck(y)
+	if z == r {
+		panic("big: QuoRem requires distinct *Int for quotient and remainder")
+	}
 	qNeg, q, rNeg, rem := quoRem(x.neg, x.abs, y.neg, y.abs)
 	z.neg = qNeg
 	z.abs = q
@@ -351,6 +382,7 @@ func (z *Int) QuoRem(x, y, r *Int) (*Int, *Int) {
 // run-time panic occurs. Div implements Euclidean division (unlike Go);
 // see DivMod for more details.
 func (z *Int) Div(x, y *Int) *Int {
+	divCheck(y)
 	qNeg, q, _, _ := divMod(x.neg, x.abs, y.neg, y.abs)
 	z.neg = qNeg
 	z.abs = q
@@ -361,6 +393,7 @@ func (z *Int) Div(x, y *Int) *Int {
 // run-time panic occurs. Mod implements Euclidean modulus (unlike Go);
 // see DivMod for more details.
 func (z *Int) Mod(x, y *Int) *Int {
+	divCheck(y)
 	_, _, rNeg, r := divMod(x.neg, x.abs, y.neg, y.abs)
 	z.neg = rNeg
 	z.abs = r
@@ -375,7 +408,16 @@ func (z *Int) Mod(x, y *Int) *Int {
 //
 //	q = x div y  such that
 //	m = x - y*q  with 0 <= m < |y|
+//
+// The two output receivers z and m must be distinct *Int values (i.e.
+// z != m); passing the same pointer for both panics, since the natural
+// "last write wins" semantics would silently overwrite the quotient
+// with the modulus.
 func (z *Int) DivMod(x, y, m *Int) (*Int, *Int) {
+	divCheck(y)
+	if z == m {
+		panic("big: DivMod requires distinct *Int for quotient and modulus")
+	}
 	qNeg, q, mNeg, mod := divMod(x.neg, x.abs, y.neg, y.abs)
 	z.neg = qNeg
 	z.abs = q

--- a/gnovm/stdlibs/math/big/int.go
+++ b/gnovm/stdlibs/math/big/int.go
@@ -1,0 +1,67 @@
+package big
+
+import (
+	"math/big"
+)
+
+// Wire format: a *big.Int is represented as (neg bool, abs []byte) where
+// abs is the big-endian unsigned magnitude with no leading zero bytes
+// (empty/nil for zero).
+
+func X_add(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) {
+	return fromBig(new(big.Int).Add(toBig(aNeg, a), toBig(bNeg, b)))
+}
+
+func X_sub(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) {
+	return fromBig(new(big.Int).Sub(toBig(aNeg, a), toBig(bNeg, b)))
+}
+
+func X_mul(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) {
+	return fromBig(new(big.Int).Mul(toBig(aNeg, a), toBig(bNeg, b)))
+}
+
+func X_quoRem(xNeg bool, x []byte, yNeg bool, y []byte) (bool, []byte, bool, []byte) {
+	q, r := new(big.Int), new(big.Int)
+	q.QuoRem(toBig(xNeg, x), toBig(yNeg, y), r)
+	qNeg, qAbs := fromBig(q)
+	rNeg, rAbs := fromBig(r)
+	return qNeg, qAbs, rNeg, rAbs
+}
+
+func X_divMod(xNeg bool, x []byte, yNeg bool, y []byte) (bool, []byte, bool, []byte) {
+	q, m := new(big.Int), new(big.Int)
+	q.DivMod(toBig(xNeg, x), toBig(yNeg, y), m)
+	qNeg, qAbs := fromBig(q)
+	mNeg, mAbs := fromBig(m)
+	return qNeg, qAbs, mNeg, mAbs
+}
+
+func X_setString(s string, base int) (bool, []byte, bool) {
+	v, ok := new(big.Int).SetString(s, base)
+	if !ok {
+		return false, nil, false
+	}
+	neg, abs := fromBig(v)
+	return neg, abs, true
+}
+
+func X_text(neg bool, abs []byte, base int) string {
+	return toBig(neg, abs).Text(base)
+}
+
+func toBig(neg bool, abs []byte) *big.Int {
+	x := new(big.Int).SetBytes(abs)
+	if neg {
+		x.Neg(x)
+	}
+	return x
+}
+
+func fromBig(x *big.Int) (bool, []byte) {
+	sign := x.Sign()
+	if sign == 0 {
+		return false, nil
+	}
+	// Bytes returns the magnitude regardless of sign — no Abs needed.
+	return sign < 0, x.Bytes()
+}

--- a/gnovm/stdlibs/math/big/int.go
+++ b/gnovm/stdlibs/math/big/int.go
@@ -6,7 +6,12 @@ import (
 
 // Wire format: a *big.Int is represented as (neg bool, abs []byte) where
 // abs is the big-endian unsigned magnitude with no leading zero bytes
-// (empty/nil for zero).
+// (empty/nil for zero). See gnovm/adr/pr5678_math_big_stdlib.md for the
+// design rationale.
+//
+// All Gno-side setters maintain this canonical form. toBig defends
+// against a non-canonical input anyway by stripping leading zeros and
+// forcing neg=false when the magnitude is empty.
 
 func X_add(aNeg bool, a []byte, bNeg bool, b []byte) (bool, []byte) {
 	return fromBig(new(big.Int).Add(toBig(aNeg, a), toBig(bNeg, b)))
@@ -50,8 +55,16 @@ func X_text(neg bool, abs []byte, base int) string {
 }
 
 func toBig(neg bool, abs []byte) *big.Int {
+	// Skip leading zeros; an all-zero or empty abs decodes to zero.
+	i := 0
+	for i < len(abs) && abs[i] == 0 {
+		i++
+	}
+	abs = abs[i:]
 	x := new(big.Int).SetBytes(abs)
-	if neg {
+	// neg is honored only for non-zero magnitudes — there is no negative
+	// zero in *big.Int and the wire format mirrors that.
+	if neg && len(abs) > 0 {
 		x.Neg(x)
 	}
 	return x

--- a/gnovm/stdlibs/math/big/int_test.gno
+++ b/gnovm/stdlibs/math/big/int_test.gno
@@ -1,0 +1,402 @@
+package big_test
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestNewInt(t *testing.T) {
+	tests := []struct {
+		v    int64
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{-1, "-1"},
+		{42, "42"},
+		{-42, "-42"},
+		{1<<62 + 1, "4611686018427387905"},
+		{-1 << 63, "-9223372036854775808"},
+	}
+	for _, tc := range tests {
+		got := big.NewInt(tc.v).String()
+		if got != tc.want {
+			t.Errorf("NewInt(%d).String() = %q, want %q", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestInt64RoundTrip(t *testing.T) {
+	tests := []int64{0, 1, -1, 1 << 62, -1 << 62, 1<<63 - 1, -1 << 63}
+	for _, v := range tests {
+		got := big.NewInt(v).Int64()
+		if got != v {
+			t.Errorf("NewInt(%d).Int64() = %d", v, got)
+		}
+	}
+}
+
+func TestSign(t *testing.T) {
+	tests := []struct {
+		v    int64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{-1, -1},
+		{1 << 32, 1},
+		{-1 << 32, -1},
+	}
+	for _, tc := range tests {
+		got := big.NewInt(tc.v).Sign()
+		if got != tc.want {
+			t.Errorf("NewInt(%d).Sign() = %d, want %d", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"0", "0", "0"},
+		{"1", "2", "3"},
+		{"-1", "1", "0"},
+		{"-5", "3", "-2"},
+		{"100000000000000000000", "1", "100000000000000000001"},
+		{"100000000000000000000", "-100000000000000000000", "0"},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		got := new(big.Int).Add(x, y).String()
+		if got != tc.want {
+			t.Errorf("Add(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestSub(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"0", "0", "0"},
+		{"3", "1", "2"},
+		{"1", "3", "-2"},
+		{"-5", "-3", "-2"},
+		{"100000000000000000000", "1", "99999999999999999999"},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		got := new(big.Int).Sub(x, y).String()
+		if got != tc.want {
+			t.Errorf("Sub(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestMul(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"0", "1234", "0"},
+		{"1", "0", "0"},
+		{"2", "3", "6"},
+		{"-2", "3", "-6"},
+		{"-2", "-3", "6"},
+		// 2^64 * 2^64 = 2^128
+		{"18446744073709551616", "18446744073709551616", "340282366920938463463374607431768211456"},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		got := new(big.Int).Mul(x, y).String()
+		if got != tc.want {
+			t.Errorf("Mul(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestQuoRem(t *testing.T) {
+	// Truncated division (Go semantics).
+	tests := []struct {
+		x, y, wantQ, wantR string
+	}{
+		{"7", "3", "2", "1"},
+		{"-7", "3", "-2", "-1"},
+		{"7", "-3", "-2", "1"},
+		{"-7", "-3", "2", "-1"},
+		{"0", "5", "0", "0"},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		q, r := new(big.Int), new(big.Int)
+		q.QuoRem(x, y, r)
+		if q.String() != tc.wantQ || r.String() != tc.wantR {
+			t.Errorf("QuoRem(%s, %s) = (%s, %s), want (%s, %s)",
+				tc.x, tc.y, q.String(), r.String(), tc.wantQ, tc.wantR)
+		}
+	}
+}
+
+func TestDivMod(t *testing.T) {
+	// Euclidean division (Go's Div/Mod): remainder always in [0, |y|).
+	tests := []struct {
+		x, y, wantQ, wantM string
+	}{
+		{"7", "3", "2", "1"},
+		{"-7", "3", "-3", "2"},
+		{"7", "-3", "-2", "1"},
+		{"-7", "-3", "3", "2"},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		q, m := new(big.Int), new(big.Int)
+		q.DivMod(x, y, m)
+		if q.String() != tc.wantQ || m.String() != tc.wantM {
+			t.Errorf("DivMod(%s, %s) = (%s, %s), want (%s, %s)",
+				tc.x, tc.y, q.String(), m.String(), tc.wantQ, tc.wantM)
+		}
+	}
+}
+
+func TestCmp(t *testing.T) {
+	tests := []struct {
+		x, y string
+		want int
+	}{
+		{"0", "0", 0},
+		{"1", "2", -1},
+		{"2", "1", 1},
+		{"-1", "1", -1},
+		{"-1", "-1", 0},
+		{"-2", "-1", -1},
+		{"100000000000000000000", "100000000000000000000", 0},
+		{"100000000000000000000", "99999999999999999999", 1},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		got := x.Cmp(y)
+		if got != tc.want {
+			t.Errorf("Cmp(%s, %s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestAliasing(t *testing.T) {
+	// z.Add(z, z), z.Mul(z, z), etc. must work.
+	z := big.NewInt(5)
+	z.Add(z, z)
+	if z.String() != "10" {
+		t.Errorf("z.Add(z, z) starting from 5: got %s, want 10", z.String())
+	}
+	z = big.NewInt(3)
+	z.Mul(z, z)
+	if z.String() != "9" {
+		t.Errorf("z.Mul(z, z) starting from 3: got %s, want 9", z.String())
+	}
+	// QuoRem with quotient-aliased dividend, separate remainder.
+	q := big.NewInt(17)
+	r := new(big.Int)
+	q.QuoRem(q, big.NewInt(5), r)
+	if q.String() != "3" || r.String() != "2" {
+		t.Errorf("QuoRem(17, 5) aliased q=x: q=%s r=%s, want q=3 r=2", q.String(), r.String())
+	}
+	// DivMod with modulus-aliased divisor.
+	d := big.NewInt(-7)
+	m := big.NewInt(3)
+	d.DivMod(d, m, m)
+	if d.String() != "-3" || m.String() != "2" {
+		t.Errorf("DivMod(-7, 3) aliased q=x, m=y: q=%s m=%s, want q=-3 m=2", d.String(), m.String())
+	}
+}
+
+func TestIsInt64Boundaries(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"0", true},
+		{"9223372036854775807", true},   // MaxInt64
+		{"9223372036854775808", false},  // MaxInt64+1
+		{"-9223372036854775808", true},  // MinInt64
+		{"-9223372036854775809", false}, // MinInt64-1
+	}
+	for _, tc := range tests {
+		z := mustParse(t, tc.s)
+		if got := z.IsInt64(); got != tc.want {
+			t.Errorf("IsInt64(%s) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestIsUint64Boundaries(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"0", true},
+		{"18446744073709551615", true},  // MaxUint64
+		{"18446744073709551616", false}, // MaxUint64+1
+		{"-1", false},
+	}
+	for _, tc := range tests {
+		z := mustParse(t, tc.s)
+		if got := z.IsUint64(); got != tc.want {
+			t.Errorf("IsUint64(%s) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestSetBytesNormalization(t *testing.T) {
+	// Leading zeros must be stripped.
+	z := new(big.Int).SetBytes([]byte{0, 0, 1, 2, 3})
+	got := z.Bytes()
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("SetBytes leading-zeros normalization: got %v, want [1 2 3]", got)
+	}
+	// All-zero input means zero, never neg=true.
+	z = new(big.Int).SetBytes([]byte{0, 0, 0})
+	if z.Sign() != 0 || z.String() != "0" {
+		t.Errorf("SetBytes all-zero: sign=%d str=%q, want 0/\"0\"", z.Sign(), z.String())
+	}
+}
+
+func TestCmpAbs(t *testing.T) {
+	tests := []struct {
+		x, y string
+		want int
+	}{
+		{"5", "3", 1},
+		{"-5", "3", 1},
+		{"5", "-3", 1},
+		{"-5", "-3", 1},
+		{"3", "3", 0},
+		{"-3", "3", 0},
+	}
+	for _, tc := range tests {
+		x := mustParse(t, tc.x)
+		y := mustParse(t, tc.y)
+		if got := x.CmpAbs(y); got != tc.want {
+			t.Errorf("CmpAbs(%s, %s) = %d, want %d", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestSetStringInvalidBase(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("SetString with base=1 did not panic")
+		}
+	}()
+	new(big.Int).SetString("0", 1)
+}
+
+func TestBytes(t *testing.T) {
+	z := big.NewInt(0x010203)
+	got := z.Bytes()
+	if len(got) != 3 || got[0] != 0x01 || got[1] != 0x02 || got[2] != 0x03 {
+		t.Errorf("Bytes() = %v, want [1 2 3]", got)
+	}
+	z2 := new(big.Int).SetBytes(got)
+	if z2.Cmp(z) != 0 {
+		t.Errorf("SetBytes(Bytes()) round trip failed")
+	}
+	// Zero
+	if len(big.NewInt(0).Bytes()) != 0 {
+		t.Errorf("NewInt(0).Bytes() should be empty")
+	}
+}
+
+func TestBitLen(t *testing.T) {
+	tests := []struct {
+		v    int64
+		want int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{255, 8},
+		{256, 9},
+	}
+	for _, tc := range tests {
+		got := big.NewInt(tc.v).BitLen()
+		if got != tc.want {
+			t.Errorf("NewInt(%d).BitLen() = %d, want %d", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestSetString(t *testing.T) {
+	tests := []struct {
+		s    string
+		base int
+		want string
+		ok   bool
+	}{
+		{"0", 10, "0", true},
+		{"123", 10, "123", true},
+		{"-456", 10, "-456", true},
+		{"ff", 16, "255", true},
+		{"0xff", 0, "255", true},
+		{"0b1010", 0, "10", true},
+		{"100000000000000000000", 10, "100000000000000000000", true},
+		{"not a number", 10, "", false},
+	}
+	for _, tc := range tests {
+		z, ok := new(big.Int).SetString(tc.s, tc.base)
+		if ok != tc.ok {
+			t.Errorf("SetString(%q, %d) ok = %v, want %v", tc.s, tc.base, ok, tc.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if z.String() != tc.want {
+			t.Errorf("SetString(%q, %d) = %s, want %s", tc.s, tc.base, z.String(), tc.want)
+		}
+	}
+}
+
+func TestText(t *testing.T) {
+	z := big.NewInt(255)
+	if got := z.Text(16); got != "ff" {
+		t.Errorf("Text(16) of 255 = %q, want %q", got, "ff")
+	}
+	if got := z.Text(2); got != "11111111" {
+		t.Errorf("Text(2) of 255 = %q, want %q", got, "11111111")
+	}
+}
+
+func TestNegAbs(t *testing.T) {
+	z := big.NewInt(-5)
+	z.Abs(z)
+	if z.String() != "5" {
+		t.Errorf("Abs(-5) = %s, want 5", z.String())
+	}
+	z.Neg(z)
+	if z.String() != "-5" {
+		t.Errorf("Neg(5) = %s, want -5", z.String())
+	}
+	// Neg of zero stays zero.
+	z = big.NewInt(0)
+	z.Neg(z)
+	if z.Sign() != 0 || z.String() != "0" {
+		t.Errorf("Neg(0) = %s sign=%d, want 0 sign=0", z.String(), z.Sign())
+	}
+}
+
+func mustParse(t *testing.T, s string) *big.Int {
+	t.Helper()
+	z, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		t.Fatalf("failed to parse %q", s)
+	}
+	return z
+}

--- a/gnovm/stdlibs/math/big/int_test.gno
+++ b/gnovm/stdlibs/math/big/int_test.gno
@@ -264,6 +264,15 @@ func TestSetBytesNormalization(t *testing.T) {
 	if z.Sign() != 0 || z.String() != "0" {
 		t.Errorf("SetBytes all-zero: sign=%d str=%q, want 0/\"0\"", z.Sign(), z.String())
 	}
+	// Nil and empty inputs decode to canonical zero.
+	z = new(big.Int).SetBytes(nil)
+	if z.Sign() != 0 || z.String() != "0" {
+		t.Errorf("SetBytes(nil): sign=%d str=%q, want 0/\"0\"", z.Sign(), z.String())
+	}
+	z = new(big.Int).SetBytes([]byte{})
+	if z.Sign() != 0 || z.String() != "0" {
+		t.Errorf("SetBytes([]): sign=%d str=%q, want 0/\"0\"", z.Sign(), z.String())
+	}
 }
 
 func TestCmpAbs(t *testing.T) {
@@ -390,6 +399,12 @@ func TestNegAbs(t *testing.T) {
 	if z.Sign() != 0 || z.String() != "0" {
 		t.Errorf("Neg(0) = %s sign=%d, want 0 sign=0", z.String(), z.Sign())
 	}
+	// Abs of zero stays zero.
+	z = big.NewInt(0)
+	z.Abs(z)
+	if z.Sign() != 0 || z.String() != "0" {
+		t.Errorf("Abs(0) = %s sign=%d, want 0 sign=0", z.String(), z.Sign())
+	}
 }
 
 func mustParse(t *testing.T, s string) *big.Int {
@@ -399,4 +414,197 @@ func mustParse(t *testing.T, s string) *big.Int {
 		t.Fatalf("failed to parse %q", s)
 	}
 	return z
+}
+
+// Single-result helpers (Quo/Rem/Div/Mod) take their own native-bridge
+// call path; the pair forms QuoRem/DivMod are tested separately.
+
+func TestQuo(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"7", "3", "2"},
+		{"-7", "3", "-2"},
+		{"7", "-3", "-2"},
+		{"-7", "-3", "2"},
+		{"0", "5", "0"},
+	}
+	for _, tc := range tests {
+		got := new(big.Int).Quo(mustParse(t, tc.x), mustParse(t, tc.y)).String()
+		if got != tc.want {
+			t.Errorf("Quo(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestRem(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"7", "3", "1"},
+		{"-7", "3", "-1"},
+		{"7", "-3", "1"},
+		{"-7", "-3", "-1"},
+	}
+	for _, tc := range tests {
+		got := new(big.Int).Rem(mustParse(t, tc.x), mustParse(t, tc.y)).String()
+		if got != tc.want {
+			t.Errorf("Rem(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestDiv(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"7", "3", "2"},
+		{"-7", "3", "-3"},
+		{"7", "-3", "-2"},
+		{"-7", "-3", "3"},
+	}
+	for _, tc := range tests {
+		got := new(big.Int).Div(mustParse(t, tc.x), mustParse(t, tc.y)).String()
+		if got != tc.want {
+			t.Errorf("Div(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestMod(t *testing.T) {
+	tests := []struct {
+		x, y, want string
+	}{
+		{"7", "3", "1"},
+		{"-7", "3", "2"},
+		{"7", "-3", "1"},
+		{"-7", "-3", "2"},
+	}
+	for _, tc := range tests {
+		got := new(big.Int).Mod(mustParse(t, tc.x), mustParse(t, tc.y)).String()
+		if got != tc.want {
+			t.Errorf("Mod(%s, %s) = %s, want %s", tc.x, tc.y, got, tc.want)
+		}
+	}
+}
+
+func TestDivByZero(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func()
+	}{
+		{"Quo", func() { new(big.Int).Quo(big.NewInt(5), big.NewInt(0)) }},
+		{"Rem", func() { new(big.Int).Rem(big.NewInt(5), big.NewInt(0)) }},
+		{"Div", func() { new(big.Int).Div(big.NewInt(5), big.NewInt(0)) }},
+		{"Mod", func() { new(big.Int).Mod(big.NewInt(5), big.NewInt(0)) }},
+		{"QuoRem", func() {
+			new(big.Int).QuoRem(big.NewInt(5), big.NewInt(0), new(big.Int))
+		}},
+		{"DivMod", func() {
+			new(big.Int).DivMod(big.NewInt(5), big.NewInt(0), new(big.Int))
+		}},
+	}
+	for _, tc := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("%s by zero did not panic (recover()ed nil)", tc.name)
+				}
+			}()
+			tc.run()
+		}()
+	}
+}
+
+func TestQuoRemDistinctOutputs(t *testing.T) {
+	// Passing the same *Int for z and r must panic: the natural
+	// last-write-wins order would silently overwrite the quotient with
+	// the remainder.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("QuoRem with z == r did not panic")
+		}
+	}()
+	z := new(big.Int)
+	z.QuoRem(big.NewInt(17), big.NewInt(5), z)
+}
+
+func TestDivModDistinctOutputs(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("DivMod with z == m did not panic")
+		}
+	}()
+	z := new(big.Int)
+	z.DivMod(big.NewInt(17), big.NewInt(5), z)
+}
+
+func TestSetStringEdgeCases(t *testing.T) {
+	// Pin Go-math/big-stdlib behaviors so a future Go upgrade can't
+	// silently shift Gno semantics.
+	tests := []struct {
+		s    string
+		base int
+		want string
+		ok   bool
+	}{
+		{"+1", 10, "1", true},     // leading + accepted
+		{"-0", 10, "0", true},     // canonical zero
+		{"", 10, "", false},       // empty rejected
+		{"0x", 0, "", false},      // dangling base prefix
+		{"0o755", 0, "493", true}, // octal prefix
+		{"5_000", 0, "5000", true}, // digit separator (base 0 only)
+		{"5_000", 10, "", false},  // underscore rejected outside base 0
+	}
+	for _, tc := range tests {
+		z, ok := new(big.Int).SetString(tc.s, tc.base)
+		if ok != tc.ok {
+			t.Errorf("SetString(%q, %d) ok = %v, want %v", tc.s, tc.base, ok, tc.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if z.String() != tc.want {
+			t.Errorf("SetString(%q, %d) = %s, want %s", tc.s, tc.base, z.String(), tc.want)
+		}
+	}
+}
+
+func TestTextInvalidBase(t *testing.T) {
+	for _, b := range []int{-1, 0, 1, 63, 100} {
+		func(base int) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("Text(%d) did not panic", base)
+				}
+			}()
+			big.NewInt(255).Text(base)
+		}(b)
+	}
+}
+
+func TestZeroCanonical(t *testing.T) {
+	// Every op that can produce zero must produce the canonical form
+	// (Sign == 0, String == "0"). This guards against any future change
+	// to the bridge or Gno-side normalization that would create a
+	// negative-zero or leading-zero-byte state.
+	a := mustParse(t, "100000000000000000000")
+	cases := []struct {
+		name string
+		z    *big.Int
+	}{
+		{"Sub(x,x)", new(big.Int).Sub(a, a)},
+		{"Mul(x,0)", new(big.Int).Mul(a, big.NewInt(0))},
+		{"Mul(0,x)", new(big.Int).Mul(big.NewInt(0), a)},
+		{"Quo(0,x)", new(big.Int).Quo(big.NewInt(0), a)},
+		{"Rem(x,1)", new(big.Int).Rem(a, big.NewInt(1))},
+		{"Mod(x,1)", new(big.Int).Mod(a, big.NewInt(1))},
+	}
+	for _, tc := range cases {
+		if tc.z.Sign() != 0 || tc.z.String() != "0" {
+			t.Errorf("%s: sign=%d str=%q, want 0/\"0\"",
+				tc.name, tc.z.Sign(), tc.z.String())
+		}
+	}
 }

--- a/gnovm/stdlibs/math/big/int_test.gno
+++ b/gnovm/stdlibs/math/big/int_test.gno
@@ -2,8 +2,27 @@ package big_test
 
 import (
 	"math/big"
+	"strconv"
 	"testing"
 )
+
+// mustPanicWith runs fn and asserts it panics with exactly the wanted
+// message. Messages shared with Go's math/big are pinned so ported code
+// that matches on recover() values keeps working.
+func mustPanicWith(t *testing.T, label, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("%s: did not panic, want %q", label, want)
+			return
+		}
+		if s, ok := r.(string); !ok || s != want {
+			t.Errorf("%s: panic = %v, want %q", label, r, want)
+		}
+	}()
+	fn()
+}
 
 func TestNewInt(t *testing.T) {
 	tests := []struct {
@@ -206,7 +225,11 @@ func TestAliasing(t *testing.T) {
 	if q.String() != "3" || r.String() != "2" {
 		t.Errorf("QuoRem(17, 5) aliased q=x: q=%s r=%s, want q=3 r=2", q.String(), r.String())
 	}
-	// DivMod with modulus-aliased divisor.
+	// DivMod with modulus-aliased divisor. Deliberate divergence from Go:
+	// Go's DivMod reads y again after writing m, so m==y silently
+	// corrupts the result (q=-1 m=0 here). The bridge decodes all
+	// arguments before writing any receiver, so every input aliasing is
+	// well-defined and mathematically correct.
 	d := big.NewInt(-7)
 	m := big.NewInt(3)
 	d.DivMod(d, m, m)
@@ -297,12 +320,9 @@ func TestCmpAbs(t *testing.T) {
 }
 
 func TestSetStringInvalidBase(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("SetString with base=1 did not panic")
-		}
-	}()
-	new(big.Int).SetString("0", 1)
+	mustPanicWith(t, "SetString base=1", "invalid number base 1", func() {
+		new(big.Int).SetString("0", 1)
+	})
 }
 
 func TestBytes(t *testing.T) {
@@ -505,38 +525,27 @@ func TestDivByZero(t *testing.T) {
 		}},
 	}
 	for _, tc := range cases {
-		func() {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("%s by zero did not panic (recover()ed nil)", tc.name)
-				}
-			}()
-			tc.run()
-		}()
+		mustPanicWith(t, tc.name+" by zero", "division by zero", tc.run)
 	}
 }
 
 func TestQuoRemDistinctOutputs(t *testing.T) {
 	// Passing the same *Int for z and r must panic: the natural
 	// last-write-wins order would silently overwrite the quotient with
-	// the remainder.
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("QuoRem with z == r did not panic")
-		}
-	}()
-	z := new(big.Int)
-	z.QuoRem(big.NewInt(17), big.NewInt(5), z)
+	// the remainder (which is what Go does in this corner).
+	mustPanicWith(t, "QuoRem z==r",
+		"big: QuoRem requires distinct *Int for quotient and remainder", func() {
+			z := new(big.Int)
+			z.QuoRem(big.NewInt(17), big.NewInt(5), z)
+		})
 }
 
 func TestDivModDistinctOutputs(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("DivMod with z == m did not panic")
-		}
-	}()
-	z := new(big.Int)
-	z.DivMod(big.NewInt(17), big.NewInt(5), z)
+	mustPanicWith(t, "DivMod z==m",
+		"big: DivMod requires distinct *Int for quotient and modulus", func() {
+			z := new(big.Int)
+			z.DivMod(big.NewInt(17), big.NewInt(5), z)
+		})
 }
 
 func TestSetStringEdgeCases(t *testing.T) {
@@ -548,13 +557,25 @@ func TestSetStringEdgeCases(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{"+1", 10, "1", true},     // leading + accepted
-		{"-0", 10, "0", true},     // canonical zero
-		{"", 10, "", false},       // empty rejected
-		{"0x", 0, "", false},      // dangling base prefix
-		{"0o755", 0, "493", true}, // octal prefix
+		{"+1", 10, "1", true},      // leading + accepted
+		{"-0", 10, "0", true},      // canonical zero
+		{"", 10, "", false},        // empty rejected
+		{"0x", 0, "", false},       // dangling base prefix
+		{"0o755", 0, "493", true},  // octal prefix
 		{"5_000", 0, "5000", true}, // digit separator (base 0 only)
-		{"5_000", 10, "", false},  // underscore rejected outside base 0
+		{"5_000", 10, "", false},   // underscore rejected outside base 0
+		{"0377", 0, "255", true},   // legacy leading-0 octal
+		{"08", 0, "", false},       // 8 is not an octal digit
+		{"00", 0, "0", true},       // repeated zeros still base-8 zero
+		{"0x_10", 0, "16", true},   // underscore after prefix ok
+		{"1__0", 0, "", false},     // doubled underscore rejected
+		{"_1", 0, "", false},       // leading underscore rejected
+		{"-0X10", 0, "-16", true},  // sign + upper-case prefix
+		{"+0o10", 0, "8", true},    // sign + octal prefix
+		{"0b", 0, "", false},       // dangling binary prefix
+		{"ZZ", 62, "3843", true},   // 'Z' is 61 in base 62
+		{"zz", 36, "1295", true},   // 'z' is 35 in base 36
+		{"Zz", 62, "3817", true},   // case-sensitive digits above 36
 	}
 	for _, tc := range tests {
 		z, ok := new(big.Int).SetString(tc.s, tc.base)
@@ -573,14 +594,63 @@ func TestSetStringEdgeCases(t *testing.T) {
 
 func TestTextInvalidBase(t *testing.T) {
 	for _, b := range []int{-1, 0, 1, 63, 100} {
-		func(base int) {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("Text(%d) did not panic", base)
-				}
-			}()
-			big.NewInt(255).Text(base)
-		}(b)
+		// Unlike SetString, Go's Text message carries no base number.
+		mustPanicWith(t, "Text("+strconv.Itoa(b)+")", "invalid base", func() {
+			big.NewInt(255).Text(b)
+		})
+	}
+}
+
+func TestNilReceiverText(t *testing.T) {
+	var x *big.Int
+	if got := x.String(); got != "<nil>" {
+		t.Errorf(`nil.String() = %q, want "<nil>"`, got)
+	}
+	if got := x.Text(16); got != "<nil>" {
+		t.Errorf(`nil.Text(16) = %q, want "<nil>"`, got)
+	}
+	// Like Go, the nil check precedes base validation: no panic even
+	// for an invalid base.
+	if got := x.Text(1); got != "<nil>" {
+		t.Errorf(`nil.Text(1) = %q, want "<nil>"`, got)
+	}
+}
+
+func TestTextNegativeAndBase62(t *testing.T) {
+	tests := []struct {
+		v    int64
+		base int
+		want string
+	}{
+		{-255, 16, "-ff"},
+		{-255, 2, "-11111111"},
+		{-255, 62, "-47"},
+		{3843, 62, "ZZ"}, // upper-case letters for digit values 36-61
+	}
+	for _, tc := range tests {
+		if got := big.NewInt(tc.v).Text(tc.base); got != tc.want {
+			t.Errorf("(%d).Text(%d) = %q, want %q", tc.v, tc.base, got, tc.want)
+		}
+	}
+}
+
+func TestLow64Truncation(t *testing.T) {
+	// Go documents Uint64/Int64 as undefined when the value doesn't fit,
+	// but the actual behavior is stable (low 64 bits of the magnitude,
+	// negated for negative x) and code in the wild relies on it. Pin it.
+	wide := mustParse(t, "36893488147419103232") // 2^65
+	if got := wide.Uint64(); got != 0 {
+		t.Errorf("2^65 Uint64() = %d, want 0", got)
+	}
+	if got := wide.Int64(); got != 0 {
+		t.Errorf("2^65 Int64() = %d, want 0", got)
+	}
+	nwide := mustParse(t, "-36893488147419103233") // -(2^65+1)
+	if got := nwide.Uint64(); got != 1 {
+		t.Errorf("-(2^65+1) Uint64() = %d, want 1", got)
+	}
+	if got := nwide.Int64(); got != -1 {
+		t.Errorf("-(2^65+1) Int64() = %d, want -1", got)
 	}
 }
 

--- a/gnovm/stdlibs/native_gas.go
+++ b/gnovm/stdlibs/native_gas.go
@@ -80,8 +80,10 @@ type nativeGasEntry struct {
 //
 // math/big rows (7) are placeholders, NOT calibrated: real values must
 // come from a benchmark run before any consensus-relevant deployment.
-// They are conservative (over-charge rather than under-charge) so the
-// stdlib is safe to exercise from tests today. See ADR.
+// They over-charge small balanced operands but the linear slopes still
+// under-charge large or super-linear inputs (mul O(n*m), decimal
+// conversion O(n^2)) — safe to exercise from tests, NOT mainnet-safe.
+// See ADR.
 var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "crypto/sha256", Fn: "sum256", Base: 226, Slope: 8906, SlopeIdx: 0, SlopeKind: SizeLenBytes},                                                           // fit base=226.3ns slope=8.6969ns/N (=8906/1024) R²=1.000
 	{Pkg: "crypto/ed25519", Fn: "verify", Base: 56534, Slope: 8975, SlopeIdx: 1, SlopeKind: SizeLenBytes},                                                        // fit base=56534.0ns slope=8.7645ns/N (=8975/1024) R²=0.991
@@ -130,19 +132,23 @@ var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "sys/params", Fn: "updateSysParamStrings", Base: 413, Slope: 26861, SlopeIdx: 3, SlopeKind: SizeLenSlice},                                              // fit base=413.4ns slope=26.2318ns/N (=26861/1024) R²=0.998
 	{Pkg: "sys/params", Fn: "getSysParamStrings", Base: 349, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 23215, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=348.9ns + 22.6713ns/N (=23215/1024) R²=0.999
 
-	// math/big — PLACEHOLDER values. Slope is over input length of the
-	// first []byte operand (SlopeIdx=1 = "a"); for binary ops with two
-	// []byte inputs, the slope under-counts when |b| > |a|. Conservative
-	// bases are set so trivial cases over-charge rather than under-charge.
+	// math/big — PLACEHOLDER values. Binary ops slope on BOTH []byte
+	// operands (Slope on a=p1, Slope2 on b=p3) so an asymmetric call
+	// (tiny a, huge b, or vice versa) is metered on the larger operand
+	// rather than escaping the slope entirely. Bases are conservative so
+	// trivial cases over-charge. These slopes are still linear: mul is
+	// O(n*m) and setString/text decimal conversion is O(n^2), so a long
+	// enough operand still under-charges — a length cap or a quadratic
+	// term (not expressible in this schema) is the real follow-up.
 	// Re-run gnovm/cmd/calibrate with a math/big-aware benchmark before
 	// consensus-relevant deployment and replace this block.
-	{Pkg: "math/big", Fn: "add", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes},        // TODO: calibrate
-	{Pkg: "math/big", Fn: "sub", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes},        // TODO: calibrate
-	{Pkg: "math/big", Fn: "mul", Base: 3000, Slope: 100000, SlopeIdx: 1, SlopeKind: SizeLenBytes},       // TODO: calibrate; mul is O(n*m), single-slope underestimates
-	{Pkg: "math/big", Fn: "quoRem", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes},    // TODO: calibrate
-	{Pkg: "math/big", Fn: "divMod", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes},    // TODO: calibrate
-	{Pkg: "math/big", Fn: "setString", Base: 2500, Slope: 80000, SlopeIdx: 0, SlopeKind: SizeLenString}, // TODO: calibrate; decimal parse is O(n^2)
-	{Pkg: "math/big", Fn: "text", Base: 2500, Slope: 80000, SlopeIdx: 1, SlopeKind: SizeLenBytes},       // TODO: calibrate; decimal format is O(n^2)
+	{Pkg: "math/big", Fn: "add", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 20000, Slope2Idx: 3, Slope2Kind: SizeLenBytes},      // TODO: calibrate
+	{Pkg: "math/big", Fn: "sub", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 20000, Slope2Idx: 3, Slope2Kind: SizeLenBytes},      // TODO: calibrate
+	{Pkg: "math/big", Fn: "mul", Base: 3000, Slope: 100000, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 100000, Slope2Idx: 3, Slope2Kind: SizeLenBytes},    // TODO: calibrate; mul is O(n*m), linear slopes still underestimate
+	{Pkg: "math/big", Fn: "quoRem", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 120000, Slope2Idx: 3, Slope2Kind: SizeLenBytes}, // TODO: calibrate
+	{Pkg: "math/big", Fn: "divMod", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 120000, Slope2Idx: 3, Slope2Kind: SizeLenBytes}, // TODO: calibrate
+	{Pkg: "math/big", Fn: "setString", Base: 2500, Slope: 80000, SlopeIdx: 0, SlopeKind: SizeLenString},                                                      // TODO: calibrate; decimal parse is O(n^2)
+	{Pkg: "math/big", Fn: "text", Base: 2500, Slope: 80000, SlopeIdx: 1, SlopeKind: SizeLenBytes},                                                            // TODO: calibrate; decimal format is O(n^2)
 }
 
 func init() {

--- a/gnovm/stdlibs/native_gas.go
+++ b/gnovm/stdlibs/native_gas.go
@@ -76,7 +76,12 @@ type nativeGasEntry struct {
 // today, so the table stays single-slope; the schema fields support
 // future natives that genuinely scale on both dimensions.
 //
-// 46 entries — exhaustive coverage of gnovm/stdlibs/generated.go.
+// 53 entries — exhaustive coverage of gnovm/stdlibs/generated.go.
+//
+// math/big rows (7) are placeholders, NOT calibrated: real values must
+// come from a benchmark run before any consensus-relevant deployment.
+// They are conservative (over-charge rather than under-charge) so the
+// stdlib is safe to exercise from tests today. See ADR.
 var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "crypto/sha256", Fn: "sum256", Base: 226, Slope: 8906, SlopeIdx: 0, SlopeKind: SizeLenBytes},                                                           // fit base=226.3ns slope=8.6969ns/N (=8906/1024) R²=1.000
 	{Pkg: "crypto/ed25519", Fn: "verify", Base: 56534, Slope: 8975, SlopeIdx: 1, SlopeKind: SizeLenBytes},                                                        // fit base=56534.0ns slope=8.7645ns/N (=8975/1024) R²=0.991
@@ -124,6 +129,20 @@ var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "sys/params", Fn: "setSysParamStrings", Base: 341, Slope: 27034, SlopeIdx: 3, SlopeKind: SizeLenSlice},                                                 // fit base=341.0ns slope=26.4006ns/N (=27034/1024) R²=0.997
 	{Pkg: "sys/params", Fn: "updateSysParamStrings", Base: 413, Slope: 26861, SlopeIdx: 3, SlopeKind: SizeLenSlice},                                              // fit base=413.4ns slope=26.2318ns/N (=26861/1024) R²=0.998
 	{Pkg: "sys/params", Fn: "getSysParamStrings", Base: 349, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 23215, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=348.9ns + 22.6713ns/N (=23215/1024) R²=0.999
+
+	// math/big — PLACEHOLDER values. Slope is over input length of the
+	// first []byte operand (SlopeIdx=1 = "a"); for binary ops with two
+	// []byte inputs, the slope under-counts when |b| > |a|. Conservative
+	// bases are set so trivial cases over-charge rather than under-charge.
+	// Re-run gnovm/cmd/calibrate with a math/big-aware benchmark before
+	// consensus-relevant deployment and replace this block.
+	{Pkg: "math/big", Fn: "add", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes},        // TODO: calibrate
+	{Pkg: "math/big", Fn: "sub", Base: 2000, Slope: 20000, SlopeIdx: 1, SlopeKind: SizeLenBytes},        // TODO: calibrate
+	{Pkg: "math/big", Fn: "mul", Base: 3000, Slope: 100000, SlopeIdx: 1, SlopeKind: SizeLenBytes},       // TODO: calibrate; mul is O(n*m), single-slope underestimates
+	{Pkg: "math/big", Fn: "quoRem", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes},    // TODO: calibrate
+	{Pkg: "math/big", Fn: "divMod", Base: 3500, Slope: 120000, SlopeIdx: 1, SlopeKind: SizeLenBytes},    // TODO: calibrate
+	{Pkg: "math/big", Fn: "setString", Base: 2500, Slope: 80000, SlopeIdx: 0, SlopeKind: SizeLenString}, // TODO: calibrate; decimal parse is O(n^2)
+	{Pkg: "math/big", Fn: "text", Base: 2500, Slope: 80000, SlopeIdx: 1, SlopeKind: SizeLenBytes},       // TODO: calibrate; decimal format is O(n^2)
 }
 
 func init() {

--- a/gnovm/tests/files/math_big0.gno
+++ b/gnovm/tests/files/math_big0.gno
@@ -1,0 +1,26 @@
+package main
+
+import "math/big"
+
+// Exercises math/big from user code (end-to-end import path) and covers
+// SetUint64/Uint64, which have no direct in-package test.
+func main() {
+	// SetUint64 must stay positive even above MaxInt64.
+	z := new(big.Int).SetUint64(1 << 63)
+	println(z.String(), z.Sign())
+
+	// MaxUint64 round-trips through Uint64.
+	const maxU64 = uint64(18446744073709551615)
+	r := new(big.Int).SetUint64(maxU64).Uint64()
+	println(r == maxU64)
+
+	// A heavy op reached through the native bridge.
+	a, _ := new(big.Int).SetString("100000000000000000000", 10)
+	a.Mul(a, big.NewInt(3))
+	println(a.String())
+}
+
+// Output:
+// 9223372036854775808 1
+// true
+// 300000000000000000000


### PR DESCRIPTION
(WIP)

Adds math/big as a stdlib, starting with Int. Mirrors Go's math/big.Int API so existing Go code ports with minimal change. Wire format is (neg bool, abs []byte); heavy ops bridge to Go-side *big.Int via genstd.

Included: NewInt/Set/SetInt64/SetUint64/Int64/Uint64/IsInt64/IsUint64, Sign/Neg/Abs/Cmp/CmpAbs/BitLen/Bytes/SetBytes, String/Text/SetString, Add/Sub/Mul/Quo/Rem/QuoRem/Div/Mod/DivMod. Bit ops, Exp/GCD/ModInverse, Float and Rat are deferred — see ADR.

The 7 new native gas rows in stdlibs/native_gas.go are placeholders, not calibrated. Real calibration via gnovm/cmd/calibrate is a documented prerequisite before any consensus-relevant deployment.

This does not make PR #5646's BigintKind operator metering reachable — big.Int here is a regular Gno struct, not a VM-level BigintKind. Hooking math/big into the VM operator path is a separate follow-up.