### PR TITLE
docs: add GOTOOLCHAIN filetest version matching rules to AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,23 @@ make fmt                        # Format all code
 | Filetests: `_filetest.gno` | Integration: `.txtar` in `gno.land/pkg/integration/testdata/` |
 | VM file tests: `gnovm/tests/files/` with `// Output:` | Standard Go test runner |
 
+### Filetest version matching
+
+VM filetests (`gnovm/tests/files/`) assert exact TypeCheckError messages that
+depend on the Go toolchain version. Always match CI's Go version:
+
+```bash
+# Preferred — reads toolchain from go.mod automatically:
+make -C gnovm _test.filetest
+
+# Or if running go test directly:
+export GOTOOLCHAIN=$(sed -n 's/^toolchain //p' go.mod)
+go test ./gnovm/pkg/gnolang/files_test.go -test.short -run 'TestFiles$/' -v -p 1 -timeout=30m
+```
+
+Skipping `GOTOOLCHAIN` causes spurious filetest diffs when your local Go
+version differs from the `toolchain` directive in `go.mod`.
+
 ---
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - After changing gas constants or allocation/GC logic, always run these before declaring done:
   - `go test ./gno.land/pkg/sdk/vm/ -run Gas`
   - `go test ./gno.land/pkg/integration/ -run txtar`
-  - `go test ./gnovm/pkg/gnolang/ -run Files -test.short`
+  - `make -C gnovm _test.filetest` (not raw `go test` — sets `GOTOOLCHAIN` to match CI; see AGENTS.md)
 - Always run `/simplify` before presenting completed work on non-trivial changes.
 
 ## Before/after comparisons


### PR DESCRIPTION
## Summary

- Added a "Filetest version matching" section to AGENTS.md explaining that VM filetests need `GOTOOLCHAIN` set to match CI's Go toolchain version, with both the Makefile and direct `go test` approaches documented.
- Updated CLAUDE.md's verification rules to route filetest runs through `make -C gnovm _test.filetest` instead of raw `go test`, so the `GOTOOLCHAIN` export in the Makefile takes effect.

## Why

The gnovm Makefile exports `GOTOOLCHAIN=$(shell sed -n 's/^toolchain //p' ../go.mod)` before running filetests, ensuring TypeCheckError messages match CI output. When agents run `go test` directly (as the old CLAUDE.md prescribed), the local Go version may differ from go.mod's `toolchain` directive, causing spurious filetest diffs.

## Test plan

- [ ] Verify `make -C gnovm _test.filetest` runs correctly with GOTOOLCHAIN set
- [ ] Verify the AGENTS.md markdown renders correctly

Generated by Claude Code