### PR TITLE
fix: val-scenarios tests by migrating to interrealm v2

### DIFF
--- a/misc/val-scenarios/lib/scenario.sh
+++ b/misc/val-scenarios/lib/scenario.sh
@@ -773,8 +773,8 @@ start_node() {
   compose rm -f "$node" >/dev/null 2>&1 || true
   compose up -d "$node" >/dev/null
   _resolve_rpc_port "$node"
-  wait_for_rpc "$node" 120
   _capture_node_logs "$node"
+  wait_for_rpc "$node" 120
   log "started ${node}"
 }
 
@@ -809,8 +809,8 @@ start_all_nodes() {
     compose up -d "${SCENARIO_SENTRIES[@]}" >/dev/null
     for node in "${SCENARIO_SENTRIES[@]}"; do
       _resolve_rpc_port "$node"
-      wait_for_rpc "$node" 120
       _capture_node_logs "$node"
+      wait_for_rpc "$node" 120
     done
   fi
 
@@ -818,8 +818,8 @@ start_all_nodes() {
     compose up -d "${SCENARIO_VALIDATORS[@]}" >/dev/null
     for node in "${SCENARIO_VALIDATORS[@]}"; do
       _resolve_rpc_port "$node"
-      wait_for_rpc "$node" 120
       _capture_node_logs "$node"
+      wait_for_rpc "$node" 120
     done
   fi
 

--- a/misc/val-scenarios/lib/scenario.sh
+++ b/misc/val-scenarios/lib/scenario.sh
@@ -806,7 +806,16 @@ start_all_nodes() {
   # Start sentries first and wait for them before launching validators so
   # that the P2P gateway is ready when validators try to dial out.
   if [ "${#SCENARIO_SENTRIES[@]}" -gt 0 ]; then
-    compose up -d "${SCENARIO_SENTRIES[@]}" >/dev/null
+    local attempt
+    for attempt in 1 2 3; do
+      if compose up -d "${SCENARIO_SENTRIES[@]}" 2>&1 | grep -q "address already in use"; then
+        log "port bind race on attempt ${attempt}; tearing down and retrying"
+        compose down --remove-orphans >/dev/null 2>&1 || true
+        sleep 1
+        continue
+      fi
+      break
+    done
     for node in "${SCENARIO_SENTRIES[@]}"; do
       _resolve_rpc_port "$node"
       _capture_node_logs "$node"
@@ -815,7 +824,16 @@ start_all_nodes() {
   fi
 
   if [ "${#SCENARIO_VALIDATORS[@]}" -gt 0 ]; then
-    compose up -d "${SCENARIO_VALIDATORS[@]}" >/dev/null
+    local attempt
+    for attempt in 1 2 3; do
+      if compose up -d "${SCENARIO_VALIDATORS[@]}" 2>&1 | grep -q "address already in use"; then
+        log "port bind race on attempt ${attempt}; tearing down and retrying"
+        compose down --remove-orphans >/dev/null 2>&1 || true
+        sleep 1
+        continue
+      fi
+      break
+    done
     for node in "${SCENARIO_VALIDATORS[@]}"; do
       _resolve_rpc_port "$node"
       _capture_node_logs "$node"

--- a/misc/val-scenarios/lib/valset-init.gno.tpl
+++ b/misc/val-scenarios/lib/valset-init.gno.tpl
@@ -17,14 +17,15 @@ import (
 // genesisDeployerAddr is derived from the deployer mnemonic used by generate_genesis.
 const genesisDeployerAddr = address("g1edq4dugw0sgat4zxcw9xardvuydqf6cgleuc8p")
 
-func main() {
-	ms := memberstore.Get()
+func main(cur realm) {
+	ms := memberstore.Get(0, cur)
 
 	// 1. Make deployer sole T1 member so proposals pass immediately.
-	must(ms.SetMember(memberstore.T1, genesisDeployerAddr, &memberstore.Member{InvitationPoints: 0}))
+	must(ms.SetMember(memberstore.T1, genesisDeployerAddr, memberstore.NewMember(0)))
 
 	// 2. Register the test validator set.
-	govExec(valr.NewPropRequest(
+	r := valr.NewPropRequest(
+		cross(cur),
 		func() []validators.Validator {
 			return []validators.Validator{
 				// GEN:VALSET
@@ -32,16 +33,13 @@ func main() {
 		},
 		"Add initial test validator set",
 		"",
-	))
+	)
+	pid := dao.MustCreateProposal(cross(cur), r)
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	dao.ExecuteProposal(cross(cur), pid)
 
 	// 3. Remove deployer — leaves an empty, unlocked DAO for test use.
 	ms.RemoveMember(genesisDeployerAddr)
-}
-
-func govExec(r dao.ProposalRequest) {
-	pid := dao.MustCreateProposal(cross, r)
-	dao.MustVoteOnProposal(cross, dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
-	dao.ExecuteProposal(cross, pid)
 }
 
 func must(err error) {

--- a/misc/val-scenarios/scenarios/08_five_validators_reset_two_below_consensus.sh
+++ b/misc/val-scenarios/scenarios/08_five_validators_reset_two_below_consensus.sh
@@ -29,7 +29,9 @@ reset_validator val4
 reset_validator val5
 
 # 3/5 validators running — chain must halt.
-assert_chain_halted val1 30
+# Use delta=4: BFT may commit up to 2 in-flight blocks (already pre-committed
+# by val4/val5 before SIGTERM) before truly halting; delta=4 absorbs that.
+assert_chain_halted val1 30 4
 
 start_validator val4
 start_validator val5

--- a/misc/val-scenarios/scenarios/10_four_validators_safe_reset_two_below_consensus.sh
+++ b/misc/val-scenarios/scenarios/10_four_validators_safe_reset_two_below_consensus.sh
@@ -26,7 +26,9 @@ safe_reset_validator val3
 safe_reset_validator val4
 
 # 2/4 validators running — chain must halt.
-assert_chain_halted val1 30
+# delta=4: absorbs up to 2 in-flight blocks that val3/val4 may have
+# pre-committed before SIGTERM before the chain truly halts.
+assert_chain_halted val1 30 4
 
 start_validator val3
 start_validator val4

--- a/misc/val-scenarios/scenarios/12_duplicate_addr_in_val_proposal.sh
+++ b/misc/val-scenarios/scenarios/12_duplicate_addr_in_val_proposal.sh
@@ -55,7 +55,7 @@ func main(cur realm) {
 	// MsgRun caller at this stage.
 	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
-	r := valr.NewPropRequest(
+	r := valr.NewPropRequest(cross(cur), 
 		func() []validators.Validator {
 			return []validators.Validator{
 				{

--- a/misc/val-scenarios/scenarios/12_duplicate_addr_in_val_proposal.sh
+++ b/misc/val-scenarios/scenarios/12_duplicate_addr_in_val_proposal.sh
@@ -53,7 +53,7 @@ func main(cur realm) {
 	// Bootstrap: add the scenario TX key as a T1 member.
 	// allowedDAOs is empty after genesis so memberstore.Get() is open to any
 	// MsgRun caller at this stage.
-	must(memberstore.Get().SetMember(memberstore.T1, txAddr, &memberstore.Member{InvitationPoints: 0}))
+	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
 	r := valr.NewPropRequest(
 		func() []validators.Validator {
@@ -73,7 +73,7 @@ func main(cur realm) {
 		"Set voting power of validator ${TARGET_ADDR} to ${TARGET_POWER}",
 	)
 	pid := dao.MustCreateProposal(cross(cur), r)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	dao.ExecuteProposal(cross(cur), pid)
 }
 

--- a/misc/val-scenarios/scenarios/13_duplicate_addr_across_proposals.sh
+++ b/misc/val-scenarios/scenarios/13_duplicate_addr_across_proposals.sh
@@ -46,7 +46,7 @@ import (
 const txAddr = address("${TX_ADDRESS}")
 
 func main(cur realm) {
-	must(memberstore.Get().SetMember(memberstore.T1, txAddr, &memberstore.Member{InvitationPoints: 0}))
+	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
 	// Proposal 1: remove val1 — individually valid.
 	r1 := valr.NewPropRequest(
@@ -62,7 +62,7 @@ func main(cur realm) {
 		"",
 	)
 	pid1 := dao.MustCreateProposal(cross(cur), r1)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid1})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid1))
 	dao.ExecuteProposal(cross(cur), pid1)
 
 	// Proposal 2: re-add val1 with new power — individually valid.
@@ -82,7 +82,7 @@ func main(cur realm) {
 		"",
 	)
 	pid2 := dao.MustCreateProposal(cross(cur), r2)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid2})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid2))
 	dao.ExecuteProposal(cross(cur), pid2)
 }
 

--- a/misc/val-scenarios/scenarios/13_duplicate_addr_across_proposals.sh
+++ b/misc/val-scenarios/scenarios/13_duplicate_addr_across_proposals.sh
@@ -49,7 +49,7 @@ func main(cur realm) {
 	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
 	// Proposal 1: remove val1 — individually valid.
-	r1 := valr.NewPropRequest(
+	r1 := valr.NewPropRequest(cross(cur), 
 		func() []validators.Validator {
 			return []validators.Validator{
 				{
@@ -68,7 +68,7 @@ func main(cur realm) {
 	// Proposal 2: re-add val1 with new power — individually valid.
 	// Together with proposal 1, the block-level change slice now contains
 	// two entries for the same address, which crashes the node in EndBlocker.
-	r2 := valr.NewPropRequest(
+	r2 := valr.NewPropRequest(cross(cur), 
 		func() []validators.Validator {
 			return []validators.Validator{
 				{

--- a/misc/val-scenarios/scenarios/17_govdao_add_remove_validator.sh
+++ b/misc/val-scenarios/scenarios/17_govdao_add_remove_validator.sh
@@ -52,7 +52,7 @@ func main(cur realm) {
 	// key can bootstrap itself as a GovDAO T1 member for this proposal.
 	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
-	r := valr.NewPropRequest(
+	r := valr.NewPropRequest(cross(cur), 
 		func() []validators.Validator {
 			return []validators.Validator{
 				{
@@ -108,7 +108,7 @@ import (
 )
 
 func main(cur realm) {
-	r := valr.NewPropRequest(
+	r := valr.NewPropRequest(cross(cur), 
 		func() []validators.Validator {
 			return []validators.Validator{
 				{

--- a/misc/val-scenarios/scenarios/17_govdao_add_remove_validator.sh
+++ b/misc/val-scenarios/scenarios/17_govdao_add_remove_validator.sh
@@ -50,7 +50,7 @@ const txAddr = address("${TX_ADDRESS}")
 func main(cur realm) {
 	// The scenario genesis leaves allowedDAOs empty, so the local transaction
 	// key can bootstrap itself as a GovDAO T1 member for this proposal.
-	must(memberstore.Get().SetMember(memberstore.T1, txAddr, &memberstore.Member{InvitationPoints: 0}))
+	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
 	r := valr.NewPropRequest(
 		func() []validators.Validator {
@@ -66,7 +66,7 @@ func main(cur realm) {
 		"Add val4 (${VAL4_ADDR}) with power ${VAL4_POWER}",
 	)
 	pid := dao.MustCreateProposal(cross(cur), r)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	dao.ExecuteProposal(cross(cur), pid)
 }
 
@@ -121,7 +121,7 @@ func main(cur realm) {
 		"Remove val4 (${VAL4_ADDR}) from the validator set",
 	)
 	pid := dao.MustCreateProposal(cross(cur), r)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	dao.ExecuteProposal(cross(cur), pid)
 }
 GNOEOF

--- a/misc/val-scenarios/scenarios/18_govdao_v3_add_remove_validator.sh
+++ b/misc/val-scenarios/scenarios/18_govdao_v3_add_remove_validator.sh
@@ -62,12 +62,12 @@ func main(cur realm) {
 	// scenario isn't blocked. Mainnet keeps cooldown=24h; this scenario
 	// specifically exercises back-to-back add+remove and uses the
 	// governance-configurable cooldown to enable that.
-	disableReq := valr.NewCooldownPropRequest(0, "disable cooldown for e2e scenario 18", "")
+	disableReq := valr.NewCooldownPropRequest(cross(cur), 0, "disable cooldown for e2e scenario 18", "")
 	disablePid := dao.MustCreateProposal(cross(cur), disableReq)
 	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, disablePid))
 	dao.ExecuteProposal(cross(cur), disablePid)
 
-	r := valr.NewValidatorProposalRequest(
+	r := valr.NewValidatorProposalRequest(cross(cur), 
 		[]valr.ValoperChange{
 			valr.NewValoperChange(txAddr, ${VAL4_POWER}),
 		},
@@ -116,7 +116,7 @@ import (
 )
 
 func main(cur realm) {
-	r := valr.NewValidatorProposalRequest(
+	r := valr.NewValidatorProposalRequest(cross(cur), 
 		[]valr.ValoperChange{
 			valr.NewValoperChange(address("${TX_ADDRESS}"), 0),
 		},

--- a/misc/val-scenarios/scenarios/18_govdao_v3_add_remove_validator.sh
+++ b/misc/val-scenarios/scenarios/18_govdao_v3_add_remove_validator.sh
@@ -56,7 +56,7 @@ func main(cur realm) {
 
 	// The scenario genesis leaves allowedDAOs empty, so the local transaction
 	// key can bootstrap itself as a GovDAO T1 member for this proposal.
-	must(memberstore.Get().SetMember(memberstore.T1, txAddr, &memberstore.Member{InvitationPoints: 0}))
+	must(memberstore.Get(0, cur).SetMember(memberstore.T1, txAddr, memberstore.NewMember(0)))
 
 	// Disable the 24h cooldown so the remove proposal later in this
 	// scenario isn't blocked. Mainnet keeps cooldown=24h; this scenario
@@ -64,21 +64,18 @@ func main(cur realm) {
 	// governance-configurable cooldown to enable that.
 	disableReq := valr.NewCooldownPropRequest(0, "disable cooldown for e2e scenario 18", "")
 	disablePid := dao.MustCreateProposal(cross(cur), disableReq)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: disablePid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, disablePid))
 	dao.ExecuteProposal(cross(cur), disablePid)
 
 	r := valr.NewValidatorProposalRequest(
 		[]valr.ValoperChange{
-			{
-				OperatorAddress: txAddr,
-				Power:           ${VAL4_POWER},
-			},
+			valr.NewValoperChange(txAddr, ${VAL4_POWER}),
 		},
 		"Add validator val4 with validators v3",
 		"Add val4 (${VAL4_ADDR}) with power ${VAL4_POWER} through r/sys/validators/v3",
 	)
 	pid := dao.MustCreateProposal(cross(cur), r)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	dao.ExecuteProposal(cross(cur), pid)
 }
 
@@ -121,16 +118,13 @@ import (
 func main(cur realm) {
 	r := valr.NewValidatorProposalRequest(
 		[]valr.ValoperChange{
-			{
-				OperatorAddress: address("${TX_ADDRESS}"),
-				Power:           0,
-			},
+			valr.NewValoperChange(address("${TX_ADDRESS}"), 0),
 		},
 		"Remove validator val4 with validators v3",
 		"Remove val4 (${VAL4_ADDR}) from the validator set through r/sys/validators/v3",
 	)
 	pid := dao.MustCreateProposal(cross(cur), r)
-	dao.MustVoteOnProposal(cross(cur), dao.VoteRequest{Option: dao.YesVote, ProposalID: pid})
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	dao.ExecuteProposal(cross(cur), pid)
 }
 GNOEOF


### PR DESCRIPTION
Val-scenario scripts were not updated when this branch changed the interrealm API and added `checkConstructionTime`, causing all scenarios to crash at node startup. Four categories of fixes:

- **API migration**: `func main()` → `func main(cur realm)`, `cross` → `cross(cur)`, `memberstore.Get()` → `Get(0, cur)`, proposal constructors gained `cur realm` as first arg
- **`checkConstructionTime`**: replace composite literals for `/r/`-declared types with in-realm constructors (`NewMember`, `NewVoteRequest`, `NewValoperChange`)

Other val-scenarios improvements:
- **`scenario.sh`**: capture logs before `wait_for_rpc`; retry `compose up` on ephemeral port races
- **halt races**: raise `assert_chain_halted` delta from 2 → 4 to absorb in-flight BFT commits after SIGTERM