### PR TITLE
fix(gnoland): panic on genesis valoper coverage assertion failure

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -398,12 +398,15 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 	// has lost the operator-keyed management plane for those validators.
 	if cfg.shouldRunValoperCoverageAssertion(req) {
 		if err := assertGenesisValopersConsistent(ctx, cfg.vmk, req); err != nil {
-			return abci.ResponseInitChain{
-				ResponseBase: abci.ResponseBase{
-					Error: abci.StringError(fmt.Errorf("genesis valoper coverage assertion failed: %w", err).Error()),
-				},
-				TxResponses: txResponses,
-			}
+			// Hard-panic so tm2's handshake actually aborts boot.
+			// ResponseInitChain.Error (the previous return shape) is
+			// silently discarded by tm2 — consensus/replay.go:339-342
+			// only checks the Go-level err from InitChainSync, never
+			// the proto Error field. A Go panic propagates as that
+			// Go-level err once baseapp's abci handler unwinds it,
+			// so an uncovered hardfork chain refuses to boot instead
+			// of booting with a broken management plane.
+			panic(fmt.Errorf("genesis valoper coverage assertion failed: %w", err))
 		}
 	}
 

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -398,19 +398,18 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 	// has lost the operator-keyed management plane for those validators.
 	if cfg.shouldRunValoperCoverageAssertion(req) {
 		if err := assertGenesisValopersConsistent(ctx, cfg.vmk, req); err != nil {
-			// Hard-panic so the boot process dies. Returning
-			// ResponseInitChain.Error (the previous shape) is silently
-			// discarded by tm2: consensus/replay.go:339-342 only
-			// inspects the Go-level err from InitChainSync, and the
-			// call chain has no recover() that would convert the proto
-			// Error field into one — baseapp.InitChain (baseapp.go:320
-			// + the 359-361 short-circuit), localClient.InitChainSync
+			// ResponseInitChain.Error is silently discarded by tm2:
+			// consensus/replay.go:339-342 only inspects the Go-level
+			// err from InitChainSync, and the call chain has no
+			// recover() that would convert the proto Error field into
+			// one — baseapp.InitChain (baseapp.go:320 + 359-361
+			// short-circuit), localClient.InitChainSync
 			// (local_client.go:192), and consensus.InitChainSync
-			// (app_conn.go:65) are all pass-through. The panic
-			// therefore propagates up the boot goroutine (NewNode →
+			// (app_conn.go:65) are all pass-through. A panic
+			// propagates up the boot goroutine (NewNode →
 			// Handshaker.ReplayBlocks → InitChainSync) and crashes the
-			// process, so an uncovered hardfork chain dies at boot
-			// instead of coming up with a broken management plane.
+			// process — the only way to abort handshake on uncovered
+			// genesis.
 			panic(fmt.Errorf("genesis valoper coverage assertion failed: %w", err))
 		}
 	}

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -398,14 +398,19 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 	// has lost the operator-keyed management plane for those validators.
 	if cfg.shouldRunValoperCoverageAssertion(req) {
 		if err := assertGenesisValopersConsistent(ctx, cfg.vmk, req); err != nil {
-			// Hard-panic so tm2's handshake actually aborts boot.
-			// ResponseInitChain.Error (the previous return shape) is
-			// silently discarded by tm2 — consensus/replay.go:339-342
-			// only checks the Go-level err from InitChainSync, never
-			// the proto Error field. A Go panic propagates as that
-			// Go-level err once baseapp's abci handler unwinds it,
-			// so an uncovered hardfork chain refuses to boot instead
-			// of booting with a broken management plane.
+			// Hard-panic so the boot process dies. Returning
+			// ResponseInitChain.Error (the previous shape) is silently
+			// discarded by tm2: consensus/replay.go:339-342 only
+			// inspects the Go-level err from InitChainSync, and the
+			// call chain has no recover() that would convert the proto
+			// Error field into one — baseapp.InitChain (baseapp.go:320
+			// + the 359-361 short-circuit), localClient.InitChainSync
+			// (local_client.go:192), and consensus.InitChainSync
+			// (app_conn.go:65) are all pass-through. The panic
+			// therefore propagates up the boot goroutine (NewNode →
+			// Handshaker.ReplayBlocks → InitChainSync) and crashes the
+			// process, so an uncovered hardfork chain dies at boot
+			// instead of coming up with a broken management plane.
 			panic(fmt.Errorf("genesis valoper coverage assertion failed: %w", err))
 		}
 	}

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -351,6 +351,58 @@ func TestInitChainer_SkipValoperCoverageAssertion(t *testing.T) {
 	}
 }
 
+// TestInitChainer_PanicsOnValoperCoverageFailure pins that an
+// assertGenesisValopersConsistent failure aborts boot via a Go-level
+// panic, not via the ResponseInitChain.Error field that tm2's
+// consensus/replay.go:339-342 silently discards. Without this guarantee
+// a hardfork chain can boot in a state where genesis validators have no
+// v3 operator-keyed management plane — the safety net would fire but
+// not actually stop the boot.
+func TestInitChainer_PanicsOnValoperCoverageFailure(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	baseCapKey := store.NewStoreKey("baseCapKey")
+	iavlCapKey := store.NewStoreKey("iavlCapKey")
+	ms.MountStoreWithDB(baseCapKey, dbadapter.StoreConstructor, db)
+	ms.MountStoreWithDB(iavlCapKey, iavl.StoreConstructor, db)
+	ms.LoadLatestVersion()
+	testCtx := sdk.NewContext(sdk.RunTxModeDeliver, ms.MultiCacheWrap(),
+		&bft.Header{ChainID: "test-chain-id"}, log.NewNoopLogger())
+
+	// vmk.Call is what assertGenesisValopersConsistent invokes; returning
+	// an error from it is the realistic shape of an assertion failure
+	// (uncovered genesis validator → v3 panics → vmk.Call returns the
+	// wrapped error).
+	mock := &mockVMKeeper{
+		callFn: func(_ sdk.Context, _ vm.MsgCall) (string, error) {
+			return "", fmt.Errorf("synthetic v3 assertion: uncovered validator")
+		},
+	}
+
+	cfg := InitChainerConfig{
+		vmk:   mock,
+		acck:  &mockAuthKeeper{},
+		bankk: &mockBankKeeper{},
+		prmk:  &mockParamsKeeper{},
+		gpk:   &mockGasPriceKeeper{},
+	}
+
+	// PastChainIDs + Validators → shouldAssertValoperCoverage returns
+	// true → the assertion runs against the mocked vmk and fails.
+	req := abci.RequestInitChain{
+		Validators: generateValidatorUpdates(t, 1),
+		AppState:   GnoGenesisState{PastChainIDs: []string{"old-chain"}},
+	}
+
+	assert.PanicsWithError(t,
+		"genesis valoper coverage assertion failed: synthetic v3 assertion: uncovered validator",
+		func() { cfg.InitChainer(testCtx, req) },
+		"InitChainer must panic on valoper coverage failure so tm2's handshake aborts; ResponseInitChain.Error is discarded by consensus/replay.go",
+	)
+}
+
 // generateValidatorUpdates generates dummy validator updates
 func generateValidatorUpdates(t *testing.T, count int) []abci.ValidatorUpdate {
 	t.Helper()


### PR DESCRIPTION
The hardfork-mode safety net at `gno.land/pkg/gnoland/app.go:399-408` runs `v3.AssertGenesisValopersConsistent` from InitChainer and is documented as a "fatal, unconditional" abort:

> Failure here is unconditionally fatal — independent of StrictReplay — because a hardfork that boots with uncovered genesis validators has lost the operator-keyed management plane for those validators.

It wasn't actually fatal. The failure path returned `ResponseInitChain{Error: ...}`, which tm2 silently discards. From `tm2/pkg/bft/consensus/replay.go:339-342`:

```go
res, err := proxyApp.Consensus().InitChainSync(req)
if err != nil {
    return nil, err
}
// res.ResponseBase.Error is never checked
```

Only the Go-level `err` from `InitChainSync` aborts boot. The proto `ResponseInitChain.Error` field is read once by `baseapp.InitChain` to skip post-init bookkeeping (`tm2/pkg/sdk/baseapp.go:359-361`) and then thrown away. So a chain whose genesis validators have no `valoperCache` entries booted normally — exactly the test-13 footgun this assertion was supposed to prevent.

## The fix

One-line change in InitChainer: panic with the wrapped error instead of returning `ResponseInitChain.Error`. The call chain has no `recover()` — `baseapp.InitChain` (`tm2/pkg/sdk/baseapp.go:320`), `localClient.InitChainSync` (`tm2/pkg/bft/abci/client/local_client.go:192`), and `consensus.InitChainSync` (`tm2/pkg/bft/appconn/app_conn.go:65`) are all pass-through. The panic therefore propagates up the boot goroutine (`NewNode` → `Handshaker.ReplayBlocks` → `InitChainSync`) and crashes the process. The chain refuses to boot, which is the documented contract — just via process death rather than an err return.

```go
// before
return abci.ResponseInitChain{
    ResponseBase: abci.ResponseBase{
        Error: abci.StringError(fmt.Errorf("genesis valoper coverage assertion failed: %w", err).Error()),
    },
    TxResponses: txResponses,
}

// after
panic(fmt.Errorf("genesis valoper coverage assertion failed: %w", err))
```

## Test plan

- Added `TestInitChainer_PanicsOnValoperCoverageFailure` in `app_test.go`. Builds a real-ish `sdk.Context`, mocks `vmk.Call` to return an error (the realistic shape of an assertion failure: v3 panics → vmk.Call returns the wrapped err), drives InitChainer with `PastChainIDs` + `Validators` set (triggers `shouldAssertValoperCoverage`), asserts `assert.PanicsWithError` with the exact wrapped message.
- Verified RED: pre-fix the test reports `"should panic, Panic value: <nil>"` — InitChainer returns the ResponseInitChain.Error path instead of panicking.
- Verified GREEN: test passes; surrounding `TestInitChainer_*` / `TestShouldAssertValoperCoverage` / `TestNewAppWithOptions` still pass.

## Out of scope (follow-up worth considering)

`loadAppState` failures at `app.go:373-386` use the same `ResponseInitChain{Error: ...}` shape and have the same swallowing problem. Same class of bug, but kept out of this PR to keep the change minimal and the test scope tight. Worth a follow-up that audits every `ResponseInitChain.Error` return in gnoland for "is this actually meant to be fatal?"