### PR TITLE
feat(gnogenesis): verify catches uncovered hardfork genesis validators

### DIFF
--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -20,9 +20,10 @@ var (
 	errUncoveredGenesisValidator = errors.New("genesis validator has no corresponding valopers.Register migration tx")
 )
 
-// The realm + function valopers.Register lives at. Mirrors the
-// constants in contribs/gnogenesis/internal/fork/valoper_seed.go; kept
-// duplicated here to avoid coupling verify to fork.
+// Realm path and function name for the valopers.Register MsgCall the
+// coverage check matches. Mirrors the constants in
+// contribs/gnogenesis/internal/fork/valoper_seed.go; kept duplicated
+// here to avoid coupling verify to fork.
 const (
 	valopersPkgPath    = "gno.land/r/gnops/valopers"
 	valopersRegisterFn = "Register"
@@ -149,8 +150,15 @@ func checkGenesisValoperCoverage(genesis *types.GenesisDoc, state gnoland.GnoGen
 		return nil
 	}
 
-	covered := map[crypto.Address]bool{}
+	covered := make(map[crypto.Address]bool, len(genesis.Validators))
 	for _, tx := range state.Txs {
+		// Runtime gno.land/pkg/gnoland/app.go:779-787 short-circuits
+		// metadata.Failed=true txs before baseApp.Deliver, so a Failed
+		// Register never populates valoperCache. Mirror that here so
+		// verify doesn't report coverage the runtime won't honor.
+		if tx.Metadata != nil && tx.Metadata.Failed {
+			continue
+		}
 		for _, msg := range tx.Tx.Msgs {
 			call, ok := msg.(vm.MsgCall)
 			if !ok {

--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -8,13 +8,24 @@ import (
 
 	"github.com/gnolang/contribs/gnogenesis/internal/common"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
 )
 
 var (
-	errInvalidGenesisState = errors.New("invalid genesis state type")
-	errInvalidTxSignature  = errors.New("invalid tx signature")
+	errInvalidGenesisState       = errors.New("invalid genesis state type")
+	errInvalidTxSignature        = errors.New("invalid tx signature")
+	errUncoveredGenesisValidator = errors.New("genesis validator has no corresponding valopers.Register migration tx")
+)
+
+// The realm + function valopers.Register lives at. Mirrors the
+// constants in contribs/gnogenesis/internal/fork/valoper_seed.go; kept
+// duplicated here to avoid coupling verify to fork.
+const (
+	valopersPkgPath    = "gno.land/r/gnops/valopers"
+	valopersRegisterFn = "Register"
 )
 
 type verifyCfg struct {
@@ -101,9 +112,72 @@ func execVerify(cfg *verifyCfg, io commands.IO) error {
 				return fmt.Errorf("invalid balance: %w", err)
 			}
 		}
+
+		// Hardfork-mode genesis valoper coverage: every entry in
+		// GenesisDoc.Validators must have a matching valopers.Register
+		// migration tx in state.Txs. See checkGenesisValoperCoverage
+		// for why and the runtime gate it mirrors.
+		if err := checkGenesisValoperCoverage(genesis, state); err != nil {
+			return err
+		}
 	}
 
 	io.Printfln("Genesis at %s is valid", cfg.GenesisPath)
 
+	return nil
+}
+
+// checkGenesisValoperCoverage pre-flights the same invariant gnoland's
+// InitChainer auto-asserts at boot under PastChainIDs (see
+// shouldAssertValoperCoverage in gno.land/pkg/gnoland/app.go): every
+// GenesisDoc.Validators entry must have a matching valopers.Register
+// migration tx in state.Txs whose pubkey arg derives to the validator's
+// signing address. Without coverage, the chain boots with orphan
+// validators that v3's operator-keyed proposal flow can't manage — the
+// test-13 footgun this check exists to catch.
+//
+// Gate mirrors the runtime exactly: PastChainIDs non-empty AND
+// Validators non-empty. Fresh chains and dev/lazy-init setups skip both
+// at runtime and here.
+//
+// Args[4] of the Register MsgCall is the signing pubkey (see
+// buildRegisterTx in contribs/gnogenesis/internal/fork/valoper_seed.go).
+// Unparseable pubkeys are skipped silently — the on-chain Register
+// would reject them via bech32 decode, so this surface is downstream.
+func checkGenesisValoperCoverage(genesis *types.GenesisDoc, state gnoland.GnoGenesisState) error {
+	if len(state.PastChainIDs) == 0 || len(genesis.Validators) == 0 {
+		return nil
+	}
+
+	covered := map[crypto.Address]bool{}
+	for _, tx := range state.Txs {
+		for _, msg := range tx.Tx.Msgs {
+			call, ok := msg.(vm.MsgCall)
+			if !ok {
+				continue
+			}
+			if call.PkgPath != valopersPkgPath || call.Func != valopersRegisterFn {
+				continue
+			}
+			if len(call.Args) < 5 {
+				continue
+			}
+			pk, err := crypto.PubKeyFromBech32(call.Args[4])
+			if err != nil {
+				continue
+			}
+			covered[pk.Address()] = true
+		}
+	}
+
+	var uncovered []string
+	for _, v := range genesis.Validators {
+		if !covered[v.Address] {
+			uncovered = append(uncovered, v.Address.String())
+		}
+	}
+	if len(uncovered) > 0 {
+		return fmt.Errorf("%w: %v", errUncoveredGenesisValidator, uncovered)
+	}
 	return nil
 }

--- a/contribs/gnogenesis/internal/verify/verify_test.go
+++ b/contribs/gnogenesis/internal/verify/verify_test.go
@@ -283,15 +283,19 @@ func TestGenesis_Verify(t *testing.T) {
 		// argument so derive(arg[4]) == Validators[0].Address.
 		valPubKey := g.Validators[0].PubKey
 		pubKeyBech32 := crypto.PubKeyToBech32(valPubKey)
-		opAddr := valPubKey.Address() // any non-zero addr is fine for the verify-time check
+		// verify ignores Args[3] (operator addr); only Args[4]
+		// (signing pubkey) matters for the coverage check. Runtime
+		// distinguishes the two, but any non-zero addr is fine in
+		// this verify-time test.
+		opAddr := valPubKey.Address()
 
 		// Sign the Register tx so it passes the existing per-tx
 		// signature loop in execVerify before the coverage check runs.
 		signer := ed25519.GenPrivKey()
 		registerMsg := vm.MsgCall{
 			Caller:  signer.PubKey().Address(),
-			PkgPath: "gno.land/r/gnops/valopers",
-			Func:    "Register",
+			PkgPath: valopersPkgPath,
+			Func:    valopersRegisterFn,
 			Args:    []string{"moul-1", "moul-1's profile", "cloud", opAddr.String(), pubKeyBech32},
 		}
 		tx := std.Tx{
@@ -319,6 +323,127 @@ func TestGenesis_Verify(t *testing.T) {
 
 		cmdErr := cmd.ParseAndRun(context.Background(), args)
 		require.NoError(t, cmdErr)
+	})
+
+	t.Run("hardfork-mode genesis with two validators, only one covered", func(t *testing.T) {
+		// Exercises the partial-coverage path: the uncovered []string
+		// aggregation must list ONLY the uncovered validator, and the
+		// error message must surface that address (not the covered one).
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis()
+
+		// Add a second validator with a distinct pubkey.
+		secondKey := mock.GenPrivKey().PubKey()
+		g.Validators = append(g.Validators, types.GenesisValidator{
+			Address: secondKey.Address(),
+			PubKey:  secondKey,
+			Power:   1,
+			Name:    "uncovered validator",
+		})
+
+		// Build a Register tx that covers ONLY the first validator.
+		coveredPubKey := g.Validators[0].PubKey
+		pubKeyBech32 := crypto.PubKeyToBech32(coveredPubKey)
+		opAddr := coveredPubKey.Address()
+
+		signer := ed25519.GenPrivKey()
+		registerMsg := vm.MsgCall{
+			Caller:  signer.PubKey().Address(),
+			PkgPath: valopersPkgPath,
+			Func:    valopersRegisterFn,
+			Args:    []string{"covered-1", "covered profile", "cloud", opAddr.String(), pubKeyBech32},
+		}
+		tx := std.Tx{
+			Msgs: []std.Msg{registerMsg},
+			Fee:  std.Fee{GasWanted: 1000000, GasFee: std.NewCoin("ugnot", 20)},
+		}
+		signBytes, err := tx.GetSignBytes(g.ChainID, 0, 0)
+		require.NoError(t, err)
+		signature, err := signer.Sign(signBytes)
+		require.NoError(t, err)
+		tx.Signatures = append(tx.Signatures, std.Signature{
+			PubKey:    signer.PubKey(),
+			Signature: signature,
+		})
+
+		state := g.AppState.(gnoland.GnoGenesisState)
+		state.PastChainIDs = []string{"old-chain"}
+		state.Txs = []gnoland.TxWithMetadata{{Tx: tx}}
+		g.AppState = state
+
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{"--genesis-path", tempFile.Name()}
+
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		require.ErrorIs(t, cmdErr, errUncoveredGenesisValidator)
+		// Only the second (uncovered) validator's address must appear
+		// in the error; the first (covered) must not.
+		assert.Contains(t, cmdErr.Error(), secondKey.Address().String())
+		assert.NotContains(t, cmdErr.Error(), coveredPubKey.Address().String())
+	})
+
+	t.Run("hardfork-mode genesis: Failed Register tx does not cover validator", func(t *testing.T) {
+		// Runtime gno.land/pkg/gnoland/app.go:779-787 short-circuits
+		// metadata.Failed=true txs before baseApp.Deliver runs, so a
+		// Failed Register tx never actually populates valoperCache.
+		// The verify-time check must skip Failed txs the same way,
+		// otherwise verify reports coverage that the runtime ignores —
+		// verify-OK followed by chain-PANIC at boot, the exact
+		// leaky-shift-left this PR is meant to close.
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis()
+
+		valPubKey := g.Validators[0].PubKey
+		pubKeyBech32 := crypto.PubKeyToBech32(valPubKey)
+		opAddr := valPubKey.Address()
+
+		signer := ed25519.GenPrivKey()
+		registerMsg := vm.MsgCall{
+			Caller:  signer.PubKey().Address(),
+			PkgPath: valopersPkgPath,
+			Func:    valopersRegisterFn,
+			Args:    []string{"moul-1", "moul-1's profile", "cloud", opAddr.String(), pubKeyBech32},
+		}
+		tx := std.Tx{
+			Msgs: []std.Msg{registerMsg},
+			Fee:  std.Fee{GasWanted: 1000000, GasFee: std.NewCoin("ugnot", 20)},
+		}
+		signBytes, err := tx.GetSignBytes(g.ChainID, 0, 0)
+		require.NoError(t, err)
+		signature, err := signer.Sign(signBytes)
+		require.NoError(t, err)
+		tx.Signatures = append(tx.Signatures, std.Signature{
+			PubKey:    signer.PubKey(),
+			Signature: signature,
+		})
+
+		state := g.AppState.(gnoland.GnoGenesisState)
+		state.PastChainIDs = []string{"old-chain"}
+		// Failed=true is the only diff vs the "covered" subtest — the
+		// asymmetry under test.
+		state.Txs = []gnoland.TxWithMetadata{{
+			Tx:       tx,
+			Metadata: &gnoland.GnoTxMetadata{Failed: true},
+		}}
+		g.AppState = state
+
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{"--genesis-path", tempFile.Name()}
+
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorIs(t, cmdErr, errUncoveredGenesisValidator)
 	})
 
 	t.Run("non-hardfork genesis: coverage check skipped", func(t *testing.T) {

--- a/contribs/gnogenesis/internal/verify/verify_test.go
+++ b/contribs/gnogenesis/internal/verify/verify_test.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 	"github.com/gnolang/gno/tm2/pkg/crypto/mock"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
@@ -228,6 +230,113 @@ func TestGenesis_Verify(t *testing.T) {
 		}
 
 		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		require.NoError(t, cmdErr)
+	})
+
+	t.Run("hardfork-mode genesis with uncovered validator", func(t *testing.T) {
+		// Pre-flight the same invariant gnoland's InitChainer
+		// auto-asserts at boot under PastChainIDs (see
+		// gno.land/pkg/gnoland/app.go shouldAssertValoperCoverage):
+		// every GenesisDoc.Validators entry must have a matching
+		// valopers.Register migration tx in state.Txs that derives
+		// to the same signing address. Otherwise the chain boots
+		// with orphan validators that v3's operator-keyed flow
+		// can't manage. Catching this at verify time means the
+		// failure surfaces during genesis build, not at first boot.
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis()
+
+		// Mark as hardfork-mode: PastChainIDs non-empty triggers the
+		// runtime auto-assertion; the verify-time check uses the same
+		// gate. With no valopers.Register MsgCalls in state.Txs, the
+		// single GenesisDoc.Validators entry is uncovered.
+		state := g.AppState.(gnoland.GnoGenesisState)
+		state.PastChainIDs = []string{"old-chain"}
+		g.AppState = state
+
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{"--genesis-path", tempFile.Name()}
+
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorIs(t, cmdErr, errUncoveredGenesisValidator)
+	})
+
+	t.Run("hardfork-mode genesis with covered validator", func(t *testing.T) {
+		// Positive case for the same gate: when state.Txs contains a
+		// valopers.Register MsgCall whose pubkey argument derives to
+		// the validator's address, the coverage check passes.
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis()
+
+		// Re-use the genesis validator's PubKey as the Register
+		// argument so derive(arg[4]) == Validators[0].Address.
+		valPubKey := g.Validators[0].PubKey
+		pubKeyBech32 := crypto.PubKeyToBech32(valPubKey)
+		opAddr := valPubKey.Address() // any non-zero addr is fine for the verify-time check
+
+		// Sign the Register tx so it passes the existing per-tx
+		// signature loop in execVerify before the coverage check runs.
+		signer := ed25519.GenPrivKey()
+		registerMsg := vm.MsgCall{
+			Caller:  signer.PubKey().Address(),
+			PkgPath: "gno.land/r/gnops/valopers",
+			Func:    "Register",
+			Args:    []string{"moul-1", "moul-1's profile", "cloud", opAddr.String(), pubKeyBech32},
+		}
+		tx := std.Tx{
+			Msgs: []std.Msg{registerMsg},
+			Fee:  std.Fee{GasWanted: 1000000, GasFee: std.NewCoin("ugnot", 20)},
+		}
+		signBytes, err := tx.GetSignBytes(g.ChainID, 0, 0)
+		require.NoError(t, err)
+		signature, err := signer.Sign(signBytes)
+		require.NoError(t, err)
+		tx.Signatures = append(tx.Signatures, std.Signature{
+			PubKey:    signer.PubKey(),
+			Signature: signature,
+		})
+
+		state := g.AppState.(gnoland.GnoGenesisState)
+		state.PastChainIDs = []string{"old-chain"}
+		state.Txs = []gnoland.TxWithMetadata{{Tx: tx}}
+		g.AppState = state
+
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{"--genesis-path", tempFile.Name()}
+
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		require.NoError(t, cmdErr)
+	})
+
+	t.Run("non-hardfork genesis: coverage check skipped", func(t *testing.T) {
+		// Gate symmetry with shouldAssertValoperCoverage: fresh
+		// chains (empty PastChainIDs) skip the coverage check at
+		// runtime, so verify skips it too. A fresh chain with a
+		// validator but no valoper-seed must still verify cleanly.
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis() // PastChainIDs left empty by default
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{"--genesis-path", tempFile.Name()}
+
 		cmdErr := cmd.ParseAndRun(context.Background(), args)
 		require.NoError(t, cmdErr)
 	})


### PR DESCRIPTION
Adds a pre-flight coverage check to `gnogenesis verify`: when a genesis is hardfork-mode (`PastChainIDs` non-empty) and seeds `GenesisDoc.Validators`, every validator must have a matching `valopers.Register` migration tx in `state.Txs` whose pubkey arg (5th, per `buildRegisterTx` in `contribs/gnogenesis/internal/fork/valoper_seed.go`) derives to the validator's signing address.

This is the same invariant that gnoland's InitChainer auto-asserts at boot under `PastChainIDs` (`shouldAssertValoperCoverage` in `gno.land/pkg/gnoland/app.go`). Catching it at verify time means the failure surfaces during the genesis-build run, with a clear message naming the offending addresses, instead of at first-boot of the cluster.

## Why this didn't already get caught

Three sibling safety mechanisms exist, none of which closes this hole on its own:

| Mechanism                            | Where                                | Why it misses                                                                                                                                                                |
| ------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `v3.AssertGenesisValopersConsistent` | called from gnoland InitChainer      | Runtime-only. Doesn't surface until cluster boot.                                                                                                                            |
| `gnogenesis fork test` audit         | post-`fork generate`                 | Uses a synthetic MockPV; the auto-call is suppressed via `SkipValoperCoverageAssertion=true` (per the comment on the field in `app.go:328-335`). Wouldn't see the misconfig. |
| `gnogenesis verify` (this PR)        | pre-flight on the serialized genesis | Was checking signatures + balances but not coverage.                                                                                                                         |

The runtime assertion is the source of truth; this verify-time check is a "shift-left" copy of it. The two should always agree (and the unit test pins the gate symmetry).

## Concretely: how test-13 escaped

`misc/deployments/test13.gno.land/build-test-13-genesis.sh` adds two validators via `gnogenesis validator add` in step 5 but never runs `gnogenesis fork valoper-seed`. The resulting genesis passes `gnogenesis verify` cleanly today (pre-this-PR), passes the `apply-test-13-replay.sh` audit (gating around mockpv), and only the runtime assertion would catch the gap — and even that is also fixed in a companion PR because tm2 discards `ResponseInitChain.Error`. With all three guards in place, the same misconfig would fail at `verify`, abort `apply-test-13-replay`, and (belt-and-braces) crash gnoland start.

## What the check does

```go
func checkGenesisValoperCoverage(genesis *types.GenesisDoc, state gnoland.GnoGenesisState) error {
    // Gate exactly mirrors shouldAssertValoperCoverage:
    if len(state.PastChainIDs) == 0 || len(genesis.Validators) == 0 {
        return nil
    }

    covered := map[crypto.Address]bool{}
    for _, tx := range state.Txs {
        for _, msg := range tx.Tx.Msgs {
            call, ok := msg.(vm.MsgCall)
            if !ok { continue }
            if call.PkgPath != valopersPkgPath || call.Func != valopersRegisterFn { continue }
            if len(call.Args) < 5 { continue }
            pk, err := crypto.PubKeyFromBech32(call.Args[4])
            if err != nil { continue }
            covered[pk.Address()] = true
        }
    }

    var uncovered []string
    for _, v := range genesis.Validators {
        if !covered[v.Address] {
            uncovered = append(uncovered, v.Address.String())
        }
    }
    if len(uncovered) > 0 {
        return fmt.Errorf("%w: %v", errUncoveredGenesisValidator, uncovered)
    }
    return nil
}
```

Wired in at the end of `execVerify` (after signature and balance checks). `valopersPkgPath` / `valopersRegisterFn` are duplicated from `fork/valoper_seed.go` rather than imported to keep `verify` free of cross-package coupling — they're two strings, low maintenance.

## Test plan

Added three subtests to `TestGenesis_Verify`:

- `hardfork-mode genesis with uncovered validator` — `PastChainIDs` set, single validator, no `Register` tx → asserts `assert.ErrorIs(t, cmdErr, errUncoveredGenesisValidator)`. **This is the RED test**; pre-fix it failed because `errUncoveredGenesisValidator` didn't exist (compile error).
- `hardfork-mode genesis with covered validator` — same setup plus a signed `valopers.Register` MsgCall whose `Args[4]` is the validator's bech32 pubkey → `require.NoError`. Regression guard against false positives.
- `non-hardfork genesis: coverage check skipped` — `PastChainIDs` empty (default), single validator, no `Register` tx → `require.NoError`. Pins the gate symmetry with the runtime assertion: fresh chains aren't subject to coverage at runtime, so neither at verify.

Verified GREEN: all three new subtests pass. Full `go test ./contribs/gnogenesis/...` still passes (verify + balances + fork + generate + params + txs + validator + top-level).
