### PR TITLE
fix(gnovm): assign LHS in left-to-right order for AssignStmt

### DIFF
--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -27,13 +27,18 @@ func (m *Machine) doOpAssign() {
 	// forward order, not the usual reverse.
 	rvs := m.PopValues(len(s.Lhs))
 	m.incrCPU(OpCPUSlopeAssign * int64(len(s.Lhs)))
+	// Pop LHS pointers in reverse (matches the LIFO order of sub-eval pushes),
+	// then assign in forward order so that left-to-right assignment semantics
+	// hold for duplicate LHS targets (Go spec §Assignments).
+	lvs := make([]PointerValue, len(s.Lhs))
 	for i := len(s.Lhs) - 1; 0 <= i; i-- {
-		// Pop lhs value and desired type.
-		lv := m.PopAsPointer(s.Lhs[i])
+		lvs[i] = m.PopAsPointer(s.Lhs[i])
+	}
+	for i := range s.Lhs {
 		if m.Stage != StagePre && isUntyped(rvs[i].T) && rvs[i].T.Kind() != BoolKind {
 			panic("untyped conversion should not happen at runtime")
 		}
-		lv.Assign2(m, m.Alloc, m.Store, m.Realm, rvs[i], true)
+		lvs[i].Assign2(m, m.Alloc, m.Store, m.Realm, rvs[i], true)
 	}
 }
 

--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -27,9 +27,20 @@ func (m *Machine) doOpAssign() {
 	// forward order, not the usual reverse.
 	rvs := m.PopValues(len(s.Lhs))
 	m.incrCPU(OpCPUSlopeAssign * int64(len(s.Lhs)))
-	// Pop LHS pointers in reverse (matches the LIFO order of sub-eval pushes),
-	// then assign in forward order so that left-to-right assignment semantics
-	// hold for duplicate LHS targets (Go spec §Assignments).
+	// Single-LHS fast path (the overwhelmingly common case): no buffer needed,
+	// no duplicate-LHS ambiguity.
+	if len(s.Lhs) == 1 {
+		lv := m.PopAsPointer(s.Lhs[0])
+		if m.Stage != StagePre && isUntyped(rvs[0].T) && rvs[0].T.Kind() != BoolKind {
+			panic("untyped conversion should not happen at runtime")
+		}
+		lv.Assign2(m, m.Alloc, m.Store, m.Realm, rvs[0], true)
+		return
+	}
+	// Multi-LHS: pop pointers in reverse (matches the LIFO order of sub-eval
+	// pushes from op_exec.go's AssignStmt case), then assign in forward order
+	// so that left-to-right semantics hold for duplicate LHS targets (Go spec
+	// §Assignments).
 	lvs := make([]PointerValue, len(s.Lhs))
 	for i := len(s.Lhs) - 1; 0 <= i; i-- {
 		lvs[i] = m.PopAsPointer(s.Lhs[i])

--- a/gnovm/pkg/gnolang/op_assign_test.go
+++ b/gnovm/pkg/gnolang/op_assign_test.go
@@ -1,0 +1,32 @@
+package gnolang
+
+import "testing"
+
+// TestDoOpAssign_DuplicateLHS_LeftToRight calls doOpAssign directly with
+// duplicate LHS targets (all pointing to the same block slot) and verifies
+// the assignments run in left-to-right order: rvs[n-1] wins. This is a
+// unit-level guardrail for the bug fixed in
+// "fix(gnovm): assign LHS pointers in left-to-right order for AssignStmt".
+func TestDoOpAssign_DuplicateLHS_LeftToRight(t *testing.T) {
+	for _, n := range []int{2, 3, 5, 17} { // 17 forces the heap-fallback branch
+		m := benchMachine()
+		blk, nxs := benchBlockVars(m, 1)
+		lhs := make([]Expr, n)
+		for i := range n {
+			lhs[i] = nxs[0] // every LHS points to the SAME slot
+		}
+		stmt := &AssignStmt{Lhs: lhs, Op: ASSIGN}
+
+		blk.Values[0] = TypedValue{T: IntType, N: i2n(0)}
+		for i := range n {
+			m.PushValue(TypedValue{T: IntType, N: i2n(int64(i + 1))}) // rvs = 1,2,...,n
+		}
+		m.PushStmt(stmt)
+		m.doOpAssign()
+
+		if got, want := blk.Values[0].GetInt(), int64(n); got != want {
+			t.Errorf("n=%d: got %d, want %d (rightmost RHS should win)", n, got, want)
+		}
+		m.Release()
+	}
+}

--- a/gnovm/pkg/gnolang/op_assign_test.go
+++ b/gnovm/pkg/gnolang/op_assign_test.go
@@ -2,13 +2,13 @@ package gnolang
 
 import "testing"
 
-// TestDoOpAssign_DuplicateLHS_LeftToRight calls doOpAssign directly with
-// duplicate LHS targets (all pointing to the same block slot) and verifies
-// the assignments run in left-to-right order: rvs[n-1] wins. This is a
-// unit-level guardrail for the bug fixed in
-// "fix(gnovm): assign LHS pointers in left-to-right order for AssignStmt".
-func TestDoOpAssign_DuplicateLHS_LeftToRight(t *testing.T) {
-	for _, n := range []int{2, 3, 5, 17} { // 17 forces the heap-fallback branch
+// TestDoOpAssign_DuplicateNameLHS_LeftToRight: NameExpr LHS aliasing the
+// same block slot. Covers the forward-Assign2 half of the fix: rvs[n-1] wins.
+// (NameExpr's PopAsPointer does not consume value-stack sub-evals, so this
+// case does not exercise the reverse-pop discipline — that's what
+// TestDoOpAssign_DistinctIndexLHS_ReversePop covers.)
+func TestDoOpAssign_DuplicateNameLHS_LeftToRight(t *testing.T) {
+	for _, n := range []int{2, 3, 5, 17} {
 		m := benchMachine()
 		blk, nxs := benchBlockVars(m, 1)
 		lhs := make([]Expr, n)
@@ -28,5 +28,42 @@ func TestDoOpAssign_DuplicateLHS_LeftToRight(t *testing.T) {
 			t.Errorf("n=%d: got %d, want %d (rightmost RHS should win)", n, got, want)
 		}
 		m.Release()
+	}
+}
+
+// TestDoOpAssign_DistinctIndexLHS_ReversePop: IndexExpr LHS with distinct
+// indices on the same slice. The value-stack sub-eval values must be popped
+// in reverse-LHS order; if a future refactor flips the pop loop to forward,
+// lvs[0] would end up pointing at slice[1] and vice versa, swapping the
+// final element values.
+func TestDoOpAssign_DistinctIndexLHS_ReversePop(t *testing.T) {
+	m := benchMachine()
+	defer m.Release()
+
+	st := m.Alloc.NewType(&SliceType{Elt: IntType})
+	baseArray := m.Alloc.NewListArray(nil, 2)
+	baseArray.List[0] = TypedValue{T: IntType, N: i2n(0)}
+	baseArray.List[1] = TypedValue{T: IntType, N: i2n(0)}
+	sv := m.Alloc.NewSlice(baseArray, 0, 2, 2)
+
+	ix := &IndexExpr{} // shape-only placeholder; PopAsPointer reads from the stack, not the AST
+	stmt := &AssignStmt{Lhs: []Expr{ix, ix}, Op: ASSIGN}
+
+	// Production push order (per op_exec.go AssignStmt case + PushForPointer):
+	// Lhs[0].X, Lhs[0].Index, Lhs[1].X, Lhs[1].Index, Rhs[0], Rhs[1].
+	m.PushValue(TypedValue{T: st, V: sv})           // Lhs[0].X
+	m.PushValue(TypedValue{T: IntType, N: i2n(0)})  // Lhs[0].Index
+	m.PushValue(TypedValue{T: st, V: sv})           // Lhs[1].X
+	m.PushValue(TypedValue{T: IntType, N: i2n(1)})  // Lhs[1].Index
+	m.PushValue(TypedValue{T: IntType, N: i2n(10)}) // Rhs[0]
+	m.PushValue(TypedValue{T: IntType, N: i2n(20)}) // Rhs[1]
+	m.PushStmt(stmt)
+	m.doOpAssign()
+
+	if got := baseArray.List[0].GetInt(); got != 10 {
+		t.Errorf("slice[0]: got %d, want 10 (lvs[0] should resolve to index 0)", got)
+	}
+	if got := baseArray.List[1].GetInt(); got != 20 {
+		t.Errorf("slice[1]: got %d, want 20 (lvs[1] should resolve to index 1)", got)
 	}
 }

--- a/gnovm/tests/files/assign40.gno
+++ b/gnovm/tests/files/assign40.gno
@@ -1,19 +1,58 @@
-// Verifies that in an AssignStmt with duplicate LHS targets referring to the
-// same variable, assignments proceed in left-to-right order (Go spec
-// §Assignments): a, a, a = 1, 2, 3 must leave a == 3, not a == 1.
+// Verifies left-to-right assignment for duplicate LHS in AssignStmt
+// (Go spec §Assignments: "the assignments are carried out in left-to-right
+// order"). Each shape exercises a different branch of PopAsPointer.
 package main
 
-var a int
+type T struct{ f int }
 
-func F() {
-	a, a, a = 1, 2, 3
+var pkgA int
+
+func nameExpr() {
+	pkgA, pkgA, pkgA = 1, 2, 3
+	if pkgA != 3 {
+		panic(pkgA)
+	}
+}
+
+func indexSlice() {
+	s := []int{0, 0}
+	s[0], s[0], s[0] = 1, 2, 3
+	if s[0] != 3 {
+		panic(s[0])
+	}
+}
+
+func indexMap() {
+	m := map[string]int{}
+	m["k"], m["k"], m["k"] = 1, 2, 3
+	if m["k"] != 3 {
+		panic(m["k"])
+	}
+}
+
+func starExpr() {
+	x := 0
+	p := &x
+	*p, *p, *p = 1, 2, 3
+	if x != 3 {
+		panic(x)
+	}
+}
+
+func selectorExpr() {
+	s := &T{}
+	s.f, s.f, s.f = 1, 2, 3
+	if s.f != 3 {
+		panic(s.f)
+	}
 }
 
 func main() {
-	F()
-	if a != 3 {
-		panic(a)
-	}
+	nameExpr()
+	indexSlice()
+	indexMap()
+	starExpr()
+	selectorExpr()
 }
 
 // Output:

--- a/gnovm/tests/files/assign40.gno
+++ b/gnovm/tests/files/assign40.gno
@@ -14,6 +14,8 @@ func main() {
 	if a != 3 {
 		panic(a)
 	}
+	println("ok")
 }
 
 // Output:
+// ok

--- a/gnovm/tests/files/assign40.gno
+++ b/gnovm/tests/files/assign40.gno
@@ -1,58 +1,19 @@
-// Verifies left-to-right assignment for duplicate LHS in AssignStmt
-// (Go spec §Assignments: "the assignments are carried out in left-to-right
-// order"). Each shape exercises a different branch of PopAsPointer.
+// Verifies that in an AssignStmt with duplicate LHS targets referring to the
+// same variable, assignments proceed in left-to-right order (Go spec
+// §Assignments): a, a, a = 1, 2, 3 must leave a == 3, not a == 1.
 package main
 
-type T struct{ f int }
+var a int
 
-var pkgA int
-
-func nameExpr() {
-	pkgA, pkgA, pkgA = 1, 2, 3
-	if pkgA != 3 {
-		panic(pkgA)
-	}
-}
-
-func indexSlice() {
-	s := []int{0, 0}
-	s[0], s[0], s[0] = 1, 2, 3
-	if s[0] != 3 {
-		panic(s[0])
-	}
-}
-
-func indexMap() {
-	m := map[string]int{}
-	m["k"], m["k"], m["k"] = 1, 2, 3
-	if m["k"] != 3 {
-		panic(m["k"])
-	}
-}
-
-func starExpr() {
-	x := 0
-	p := &x
-	*p, *p, *p = 1, 2, 3
-	if x != 3 {
-		panic(x)
-	}
-}
-
-func selectorExpr() {
-	s := &T{}
-	s.f, s.f, s.f = 1, 2, 3
-	if s.f != 3 {
-		panic(s.f)
-	}
+func F() {
+	a, a, a = 1, 2, 3
 }
 
 func main() {
-	nameExpr()
-	indexSlice()
-	indexMap()
-	starExpr()
-	selectorExpr()
+	F()
+	if a != 3 {
+		panic(a)
+	}
 }
 
 // Output:

--- a/gnovm/tests/files/assign40.gno
+++ b/gnovm/tests/files/assign40.gno
@@ -1,0 +1,19 @@
+// Verifies that in an AssignStmt with duplicate LHS targets referring to the
+// same variable, assignments proceed in left-to-right order (Go spec
+// §Assignments): a, a, a = 1, 2, 3 must leave a == 3, not a == 1.
+package main
+
+var a int
+
+func F() {
+	a, a, a = 1, 2, 3
+}
+
+func main() {
+	F()
+	if a != 3 {
+		panic(a)
+	}
+}
+
+// Output:

--- a/gnovm/tests/files/assign41.gno
+++ b/gnovm/tests/files/assign41.gno
@@ -1,0 +1,48 @@
+// Extends assign40 to the other LHS shapes that go through PopAsPointer:
+// IndexExpr (slice), IndexExpr (map), StarExpr, SelectorExpr. Each duplicate
+// LHS must observe left-to-right assignment (Go spec §Assignments).
+package main
+
+type T struct{ f int }
+
+func indexSlice() {
+	s := []int{0, 0}
+	s[0], s[0], s[0] = 1, 2, 3
+	if s[0] != 3 {
+		panic(s[0])
+	}
+}
+
+func indexMap() {
+	m := map[string]int{}
+	m["k"], m["k"], m["k"] = 1, 2, 3
+	if m["k"] != 3 {
+		panic(m["k"])
+	}
+}
+
+func starExpr() {
+	x := 0
+	p := &x
+	*p, *p, *p = 1, 2, 3
+	if x != 3 {
+		panic(x)
+	}
+}
+
+func selectorExpr() {
+	s := &T{}
+	s.f, s.f, s.f = 1, 2, 3
+	if s.f != 3 {
+		panic(s.f)
+	}
+}
+
+func main() {
+	indexSlice()
+	indexMap()
+	starExpr()
+	selectorExpr()
+}
+
+// Output:

--- a/gnovm/tests/files/assign41.gno
+++ b/gnovm/tests/files/assign41.gno
@@ -61,6 +61,16 @@ func multiReturnRHS() {
 	}
 }
 
+// Multi-blank with mixed-type RHS. All blanks alias the same shared slot
+// (Block.Blank), so the reorder changes which RHS value/type lands there
+// last. This smoke-tests that the statement completes without crashing;
+// the realm-finalization-level effect (assertTypeIsPublic against the
+// surviving type) only manifests in realm code and is out of scope here.
+func multiBlankMixedType() {
+	_, _ = "hello", 42
+	_, _ = 1, "two"
+}
+
 func main() {
 	indexSlice()
 	indexMap()
@@ -68,6 +78,7 @@ func main() {
 	selectorExpr()
 	blankInterleaved()
 	multiReturnRHS()
+	multiBlankMixedType()
 	println("ok")
 }
 

--- a/gnovm/tests/files/assign41.gno
+++ b/gnovm/tests/files/assign41.gno
@@ -38,11 +38,36 @@ func selectorExpr() {
 	}
 }
 
+// Blanks interleaved with duplicate real targets: blanks must not
+// disturb the left-to-right write order of the real LHS.
+func blankInterleaved() {
+	var a int
+	a, _, a, _ = 1, 2, 3, 4
+	if a != 3 {
+		panic(a)
+	}
+}
+
+// Multi-value RHS (single call returning multiple values) into a
+// duplicate LHS. Goes through a different RHS push pattern (one
+// OpEval for the call, multiple values produced).
+func twoVal() (int, int) { return 1, 2 }
+
+func multiReturnRHS() {
+	var a int
+	a, a = twoVal()
+	if a != 2 {
+		panic(a)
+	}
+}
+
 func main() {
 	indexSlice()
 	indexMap()
 	starExpr()
 	selectorExpr()
+	blankInterleaved()
+	multiReturnRHS()
 	println("ok")
 }
 

--- a/gnovm/tests/files/assign41.gno
+++ b/gnovm/tests/files/assign41.gno
@@ -43,6 +43,8 @@ func main() {
 	indexMap()
 	starExpr()
 	selectorExpr()
+	println("ok")
 }
 
 // Output:
+// ok


### PR DESCRIPTION
## Summary

`doOpAssign` was popping LHS pointers in reverse and assigning them immediately, so an `AssignStmt` with duplicate LHS targets executed right-to-left instead of left-to-right.

For `a, a, a = 1, 2, 3`, this left `a == 1` instead of the spec-required `a == 3` ([Go spec §Assignments](https://go.dev/ref/spec#Assignments): "the assignments are carried out in left-to-right order").

Fix: pop the LHS pointers in reverse (still required, since the value stack is LIFO and `Lhs[len-1]`'s sub-eval values are on top), then assign forward.

## Changes

- `gnovm/pkg/gnolang/op_assign.go` — buffer LHS pointers, assign in forward order.
- `gnovm/tests/files/assign40.gno` — regression test.

## Test plan

- [x] `go test ./gnovm/pkg/gnolang/ -run TestFiles/assign -test.short` (all `assign*` filetests still pass)
- [x] `TestFiles/assign40.gno` passes (fails on master)