### PR TITLE
fix: interact-with-gnokey multisig needs -broadcast=false

### DIFF
--- a/docs/users/interact-with-gnokey.md
+++ b/docs/users/interact-with-gnokey.md
@@ -821,7 +821,7 @@ Create the tx once (any participant can do it), then distribute the JSON to sign
 TX_PAYLOAD="./multisig-abc-send.json"
 rm -f "$TX_PAYLOAD"
 
-gnokey maketx send --home "./alice-kb" -chainid staging -send "100000ugnot" -gas-fee 100000ugnot -gas-wanted 100000 -to g1pm60rkcvkt4j6s24vgygyfuu3c2f5gt76lqtss multisig-abc > "$TX_PAYLOAD"
+gnokey maketx send --home "./alice-kb" -chainid staging -send "100000ugnot" -gas-fee 100000ugnot -gas-wanted 100000 -to g1pm60rkcvkt4j6s24vgygyfuu3c2f5gt76lqtss -broadcast=false multisig-abc > "$TX_PAYLOAD"
 ```
 
 **Important: sign using the multisig account number + sequence**


### PR DESCRIPTION
This is a follow-on to https://github.com/gnolang/gno/pull/4965 which missed a spot in `interact-with-gnokey.md` where we need to set
`-broadcast=false` .