### PR TITLE
ci: re-trigger CI on dependabot tidy by close+reopening the PR

### DIFF
--- a/.github/workflows/meta-dependabot-tidy.yml
+++ b/.github/workflows/meta-dependabot-tidy.yml
@@ -15,6 +15,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
       contents: write # to commit the tidied go.mod/go.sum files
+      pull-requests: write # to close+reopen the PR so CI re-triggers (GITHUB_TOKEN pushes don't)
     steps:
       - name: Checkout code # zizmor: ignore[artipacked]
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -40,9 +41,22 @@ jobs:
           make tidy
 
       - name: Commit changes, if any
+        id: commit
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           skip_dirty_check: false # Enable dirty check, and skip unnecessary committing
           commit_message: "Run 'go mod tidy' via GitHub Actions"
+
+      # Pushes made with GITHUB_TOKEN do not retrigger workflows, so CI would
+      # remain stuck on the pre-tidy commit. Close+reopen the PR to fire a
+      # fresh pull_request event against the new HEAD.
+      - name: Re-trigger CI by closing and reopening the PR
+        if: steps.commit.outputs.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr close "$PR_URL"
+          gh pr reopen "$PR_URL"


### PR DESCRIPTION
fixes https://github.com/gnolang/gno/issues/3312

## Summary

`meta-dependabot-tidy` runs `go mod tidy` on dependabot PRs and pushes the result back to the PR branch. The problem (see e.g. #5724): pushes made with the default `GITHUB_TOKEN` do **not** trigger further workflow runs — this is a deliberate GitHub safety against recursive workflows. As a result, CI on dependabot PRs stays stuck on the pre-tidy SHA.

This PR uses the simplest workaround: after a successful tidy commit, close and immediately reopen the PR. The `pull_request` reopen event fires CI against the new HEAD, no PAT / GitHub App / deploy key required.

## Changes

- `.github/workflows/meta-dependabot-tidy.yml`:
  - Add `pull-requests: write` to the job permissions.
  - Give the auto-commit step an `id` so we can read its `changes_detected` output.
  - Add a final step that runs `gh pr close && gh pr reopen` only when a tidy commit was actually pushed.

## Test plan

- [ ] Next dependabot PR that triggers a tidy commit should show CI running against the post-tidy SHA in addition to the original push.
- [ ] No-op runs (nothing to tidy) should leave the PR untouched — the close/reopen step is gated on `changes_detected == 'true'`.