### PR TITLE
docs: streamline getting started section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,6 @@ Gno.land is a smart contract platform built on a novel interpretation of Go
 decentralized applications with a minimalist approach and excellent developer
 experience.
 
-New here? Start with **[Getting started](builders/getting-started.md)** — the
-shortest path from zero to a working local chain and your first on-chain
-transaction (install included). Already comfortable with Go and just want
-the commands? See **[Quick Start](builders/quickstart.md)**. Need Docker, a
-source build, or a specific version? See **[Installation](builders/install.md)**.
-
 ## Use Gno.land
 
 Start exploring and using Gno.land. Setup essential tools, interact with the


### PR DESCRIPTION
The home page (`docs/README.md`) had a "New here?" intro paragraph linking to Getting started / Quick Start / Installation: but those three already appear as cards in the "Build on Gno.land" section (and in the sidebar), so it was duplicated and not at the right place.

The inline bold links also rendered as broken full-width blocks on docs.gno.land, since the home card CSS turns every link/`strong` into a block.

This removes the intro paragraph so the home stays consistent with the sidebar (Use / Build / Resources) and the right UX user journey. The three pages remain discoverable under "Build on Gno.land".