### PR TITLE
perf(ci): run gno.land txtar integration tests on in-memory nodes

### DIFF
--- a/.github/workflows/_ci-go.yml
+++ b/.github/workflows/_ci-go.yml
@@ -11,6 +11,9 @@ on:
       tests-ts-seq:
         required: false
         type: boolean
+      tests-ts-inmemory:
+        required: false
+        type: boolean
       go-version:
         description: "Go version to use; defaults to the version in go.mod"
         required: false
@@ -88,6 +91,7 @@ jobs:
         working-directory: ${{ inputs.modulepath }}
         env:
           SEQ_TS: ${{ inputs.tests-ts-seq }}
+          INMEMORY_TS: ${{ inputs.tests-ts-inmemory }}
           TXTARCOVERDIR: /tmp/txtarcoverdir
           GOCOVERDIR: /tmp/gocoverdir
           COVERDIR: /tmp/coverdir

--- a/.github/workflows/ci-dir-gnoland.yml
+++ b/.github/workflows/ci-dir-gnoland.yml
@@ -23,8 +23,12 @@ jobs:
     with:
       modulepath: "gno.land"
       tests-extra-args: "-coverpkg=github.com/gnolang/gno/gno.land/..."
-      # FIXME(gfanton): run txtar integration test sequentially to avoid timeout
-      tests-ts-seq: true
+      # Run txtar integration tests against in-memory nodes (still
+      # sequential). The previous CI mode spawned a subprocess node per
+      # txtar; each fresh process paid a cold stdlib load (~4s/boot). A
+      # single in-memory process shares the stdlib/typecheck caches across
+      # all txtars, cutting this job's runtime ~2.5x (1204s -> 468s).
+      tests-ts-inmemory: true
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

The `gno.land` integration test job runs ~22 min, dominated by the txtar suite (`gno.land/pkg/integration`: **1204s**). Running it against **in-memory nodes** cuts that to **468s (2.5x)**, bringing the `main / test` job from ~22m to **~10m**, with all 169 txtars passing and coverage intact.

## Why it was slow

CI ran the suite in the default "testing" mode, which re-execs the test binary as a **subprocess per node boot**. Each fresh process has a cold stdlib cache (`cachedStdlibOnce` is process-global), so every one of ~170 boots reloads and type-checks the stdlibs from scratch (~4s/boot).

## Change

Run the suite against **in-memory nodes** (`INMEMORY_TS`): a single process shares the stdlib/typecheck caches across all txtars, so boots after the first are warm. Execution stays sequential, as before (`INMEMORY_TS` implies the sequential shim) — this swaps the *subprocess* node for an *in-process* one, nothing else.

- `_ci-go.yml`: add a `tests-ts-inmemory` input → `INMEMORY_TS` env (mirrors the existing `tests-ts-seq` plumbing; empty/no-op for every other caller).
- `ci-dir-gnoland.yml`: use `tests-ts-inmemory: true` in place of `tests-ts-seq: true`.

The subprocess node machinery is unaffected and remains covered by `TestNodeProcess` / `TestInMemoryNodeProcess`.

## Measurements (CI)

| | Before | After |
|---|---|---|
| `gno.land/pkg/integration` (test-exec) | 1204s | 468s |
| `main / test` job (wall) | ~22m | 9m57s |

## Follow-up

There is more efficiency to unlock here. Running the in-memory nodes **in parallel** would cut this substantially further (~5.4x locally). The rpc/core global state that previously forced sequential execution was moved per-node in #5574, so parallel in-memory now runs — except for one txtar whose exact gas-used assertion is non-deterministic under parallel execution (the metered gas depends on process-global cache warmth). A follow-up PR will pin and fix that, then enable parallel in-memory and remove the now-redundant sequential machinery.
