### PR TITLE
feat(stdlibs): port upstream additions Go 1.18-1.25 across 11 packages

### DIFF
--- a/gnovm/stdlibs/bufio/bufio.gno
+++ b/gnovm/stdlibs/bufio/bufio.gno
@@ -625,6 +625,14 @@ func (b *Writer) Flush() error {
 // Available returns how many bytes are unused in the buffer.
 func (b *Writer) Available() int { return len(b.buf) - b.n }
 
+// AvailableBuffer returns an empty buffer with b.Available() capacity.
+// This buffer is intended to be appended to and
+// passed to an immediately succeeding Write call.
+// The buffer is only valid until the next write operation on b.
+func (b *Writer) AvailableBuffer() []byte {
+	return b.buf[b.n:][:0]
+}
+
 // Buffered returns the number of bytes that have been written into the current buffer.
 func (b *Writer) Buffered() int { return b.n }
 

--- a/gnovm/stdlibs/bytes/bytes_test.gno
+++ b/gnovm/stdlibs/bytes/bytes_test.gno
@@ -2017,3 +2017,100 @@ func BenchmarkIndexPeriodic(b *testing.B) {
 		})
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Tests ported from upstream go1.25.9 bytes_test.go.
+// Skipped: TestClone, TestContainsFunc, TestCut/TestCutPrefix/TestCutSuffix,
+// TestLines, TestIssue65571, TestNewBufferShallow, TestWriteAppend, related
+// Examples — APIs not present in Gno or require unsupported features.
+// -----------------------------------------------------------------------------
+
+// --- TestCountNearPageBoundary ---
+//
+// Upstream uses a syscall.Mmap-backed dangerousSlice to detect off-by-one
+// reads past a slice's last byte. Gno's boundary_test.gno already stubs
+// dangerousSlice as make([]byte, 4096); we mirror that pattern here.
+
+func nearPageBoundaryBuf() []byte { return make([]byte, 4096) }
+
+func TestCountNearPageBoundary(t *testing.T) {
+	b := nearPageBoundaryBuf()
+	for i := range b {
+		c := bytes.Count(b[i:], []byte{1})
+		if c != 0 {
+			t.Fatalf("Count(b[%d:], {1})=%d, want 0", i, c)
+		}
+		c = bytes.Count(b[:i], []byte{0})
+		if c != i {
+			t.Fatalf("Count(b[:%d], {0})=%d, want %d", i, c, i)
+		}
+	}
+}
+
+// --- Examples (NOT executed by TestStdlibs but provide compile-time coverage) ---
+
+func ExampleBuffer_Cap() {
+	buf1 := bytes.NewBuffer(make([]byte, 10))
+	buf2 := bytes.NewBuffer(make([]byte, 0, 10))
+	fmt.Println(buf1.Cap())
+	fmt.Println(buf2.Cap())
+	// Output:
+	// 10
+	// 10
+}
+
+func ExampleBuffer_Next() {
+	var b bytes.Buffer
+	b.Grow(64)
+	b.Write([]byte("abcde"))
+	fmt.Printf("%s\n", b.Next(2))
+	fmt.Printf("%s\n", b.Next(2))
+	fmt.Printf("%s", b.Next(2))
+	// Output:
+	// ab
+	// cd
+	// e
+}
+
+func ExampleBuffer_Read() {
+	var b bytes.Buffer
+	b.Grow(64)
+	b.Write([]byte("abcde"))
+	rdbuf := make([]byte, 1)
+	n, err := b.Read(rdbuf)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(n)
+	fmt.Println(b.String())
+	fmt.Println(string(rdbuf))
+	// Output:
+	// 1
+	// bcde
+	// a
+}
+
+func ExampleBuffer_ReadByte() {
+	var b bytes.Buffer
+	b.Grow(64)
+	b.Write([]byte("abcde"))
+	c, err := b.ReadByte()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(c)
+	fmt.Println(b.String())
+	// Output:
+	// 97
+	// bcde
+}
+
+func ExampleToValidUTF8() {
+	fmt.Printf("%s\n", bytes.ToValidUTF8([]byte("abc"), []byte("�")))
+	fmt.Printf("%s\n", bytes.ToValidUTF8([]byte("a\xffb\xC0\xAFc\xff"), []byte("")))
+	fmt.Printf("%s\n", bytes.ToValidUTF8([]byte("\xed\xa0\x80"), []byte("abc")))
+	// Output:
+	// abc
+	// abc
+	// abc
+}

--- a/gnovm/stdlibs/encoding/base64/base64.gno
+++ b/gnovm/stdlibs/encoding/base64/base64.gno
@@ -175,6 +175,23 @@ func (enc *Encoding) Encode(dst, src []byte) {
 	}
 }
 
+// AppendEncode appends the base64 encoded src to dst
+// and returns the extended buffer.
+func (enc *Encoding) AppendEncode(dst, src []byte) []byte {
+	n := enc.EncodedLen(len(src))
+	dst = slicesGrow(dst, n)
+	enc.Encode(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n]
+}
+
+// XXX: non-generic slices.Grow
+func slicesGrow(s []byte, n int) []byte {
+	if n -= cap(s) - len(s); n > 0 {
+		s = append(s[:cap(s)], make([]byte, n)...)[:len(s)]
+	}
+	return s
+}
+
 // EncodeToString returns the base64 encoding of src.
 func (enc *Encoding) EncodeToString(src []byte) string {
 	buf := make([]byte, enc.EncodedLen(len(src)))
@@ -394,6 +411,22 @@ func (enc *Encoding) decodeQuantum(dst, src []byte, si int) (nsi, n int, err err
 	}
 
 	return si, dlen - 1, err
+}
+
+// AppendDecode appends the base64 decoded src to dst
+// and returns the extended buffer.
+// If the input is malformed, it returns the partially decoded src and an error.
+func (enc *Encoding) AppendDecode(dst, src []byte) ([]byte, error) {
+	// Compute the output size without padding to avoid over allocating.
+	n := len(src)
+	for n > 0 && rune(src[n-1]) == enc.padChar {
+		n--
+	}
+	n = n * 6 / 8
+
+	dst = slicesGrow(dst, n)
+	n, err := enc.Decode(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n], err
 }
 
 // DecodeString returns the bytes represented by the base64 string s.

--- a/gnovm/stdlibs/encoding/base64/base64_test.gno
+++ b/gnovm/stdlibs/encoding/base64/base64_test.gno
@@ -530,3 +530,33 @@ func TestDecoderRaw(t *testing.T) {
 		t.Errorf("reading NewDecoder(URLEncoding, %q) = %x, %v, want %x, nil", source+"==", dec3, err, want)
 	}
 }
+
+func TestEncodeAppend(t *testing.T) {
+	for _, p := range pairs {
+		for _, tt := range encodingTests {
+			dst := tt.enc.AppendEncode([]byte("lead"), []byte(p.decoded))
+			testEqual(t, `AppendEncode("lead", %q) = %q, want %q`, p.decoded,
+				string(dst), "lead"+tt.conv(p.encoded))
+		}
+	}
+}
+
+func TestDecodeAppend(t *testing.T) {
+	for _, p := range pairs {
+		for _, tt := range encodingTests {
+			encoded := tt.conv(p.encoded)
+			dst, err := tt.enc.AppendDecode([]byte("lead"), []byte(encoded))
+			testEqual(t, "AppendDecode(%q) = error %v, want %v", encoded, err, error(nil))
+			testEqual(t, `AppendDecode("lead", %q) = %q, want %q`, encoded,
+				string(dst), "lead"+p.decoded)
+
+			dst2, err := tt.enc.AppendDecode(dst[:0:len(p.decoded)], []byte(encoded))
+			testEqual(t, "AppendDecode(%q) = error %v, want %v", encoded, err, error(nil))
+			testEqual(t, `AppendDecode("", %q) = %q, want %q`, encoded,
+				string(dst2), p.decoded)
+			if len(dst) > 0 && len(dst2) > 0 && &dst[0] != &dst2[0] {
+				t.Errorf("unexpected capacity growth: got %d, want %d", cap(dst2), cap(dst))
+			}
+		}
+	}
+}

--- a/gnovm/stdlibs/encoding/base64/example_test.gno
+++ b/gnovm/stdlibs/encoding/base64/example_test.gno
@@ -1,0 +1,79 @@
+// Tests ported from upstream Go 1.25.9 stdlib for gap coverage.
+
+package base64_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+func Example() {
+	msg := "Hello, 世界"
+	encoded := base64.StdEncoding.EncodeToString([]byte(msg))
+	fmt.Println(encoded)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		fmt.Println("decode error:", err)
+		return
+	}
+	fmt.Println(string(decoded))
+	// Output:
+	// SGVsbG8sIOS4lueVjA==
+	// Hello, 世界
+}
+
+func ExampleEncoding_EncodeToString() {
+	data := []byte("any + old & data")
+	str := base64.StdEncoding.EncodeToString(data)
+	fmt.Println(str)
+	// Output:
+	// YW55ICsgb2xkICYgZGF0YQ==
+}
+
+func ExampleEncoding_Encode() {
+	data := []byte("Hello, world!")
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+	base64.StdEncoding.Encode(dst, data)
+	fmt.Println(string(dst))
+	// Output:
+	// SGVsbG8sIHdvcmxkIQ==
+}
+
+func ExampleEncoding_DecodeString() {
+	str := "c29tZSBkYXRhIHdpdGggACBhbmQg77u/"
+	data, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Printf("%q\n", data)
+	// Output:
+	// "some data with \x00 and \ufeff"
+}
+
+func ExampleEncoding_Decode() {
+	str := "SGVsbG8sIHdvcmxkIQ=="
+	dst := make([]byte, base64.StdEncoding.DecodedLen(len(str)))
+	n, err := base64.StdEncoding.Decode(dst, []byte(str))
+	if err != nil {
+		fmt.Println("decode error:", err)
+		return
+	}
+	dst = dst[:n]
+	fmt.Printf("%q\n", dst)
+	// Output:
+	// "Hello, world!"
+}
+
+func ExampleNewEncoder() {
+	input := []byte("foo\x00bar")
+	encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
+	encoder.Write(input)
+	// Must close the encoder when finished to flush any partial blocks.
+	// If you comment out the following line, the last partial block "r"
+	// won't be encoded.
+	encoder.Close()
+	// Output:
+	// Zm9vAGJhcg==
+}

--- a/gnovm/stdlibs/encoding/binary/binary_test.gno
+++ b/gnovm/stdlibs/encoding/binary/binary_test.gno
@@ -3,6 +3,8 @@ package binary_test
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 )
 
@@ -186,4 +188,207 @@ func TestbigEndianAppendUint64(t *testing.T) {
 	if !bytes.Equal(b, []byte{0xfe, 0x14, 0xf5, 0xe9, 0x07, 0xd0, 0x03, 0xe8, 0x0b, 0xb8, 0x07, 0xd0, 0xd0, 0x07, 0xe9, 0xf5}) {
 		t.Fatal("bigEndian.AppendUint64 failed")
 	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests ported from upstream go1.25.9 binary_test.go and example_test.go.
+// Examples and tests that depend on binary.Read/Write/Encode/Decode/Append/Size
+// are omitted: Gno's reflect package can't yet drive those generic codecs.
+// -----------------------------------------------------------------------------
+
+func testUint64SmallSliceLengthPanics() (panicked bool) {
+	defer func() {
+		panicked = recover() != nil
+	}()
+	b := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	binary.LittleEndian.Uint64(b[:4])
+	return false
+}
+
+func testPutUint64SmallSliceLengthPanics() (panicked bool) {
+	defer func() {
+		panicked = recover() != nil
+	}()
+	b := [8]byte{}
+	binary.LittleEndian.PutUint64(b[:4], 0x0102030405060708)
+	return false
+}
+
+func TestByteOrder(t *testing.T) {
+	type byteOrder interface {
+		binary.ByteOrder
+		binary.AppendByteOrder
+	}
+	buf := make([]byte, 8)
+	for _, order := range []byteOrder{binary.LittleEndian, binary.BigEndian} {
+		const offset = 3
+		for _, value := range []uint64{
+			0x0000000000000000,
+			0x0123456789abcdef,
+			0xfedcba9876543210,
+			0xffffffffffffffff,
+			0xaaaaaaaaaaaaaaaa,
+			math.Float64bits(math.Pi),
+			math.Float64bits(math.E),
+		} {
+			want16 := uint16(value)
+			order.PutUint16(buf[:2], want16)
+			if got := order.Uint16(buf[:2]); got != want16 {
+				t.Errorf("PutUint16: Uint16 = %v, want %v", got, want16)
+			}
+			buf = order.AppendUint16(buf[:offset], want16)
+			if got := order.Uint16(buf[offset:]); got != want16 {
+				t.Errorf("AppendUint16: Uint16 = %v, want %v", got, want16)
+			}
+			if len(buf) != offset+2 {
+				t.Errorf("AppendUint16: len(buf) = %d, want %d", len(buf), offset+2)
+			}
+
+			want32 := uint32(value)
+			order.PutUint32(buf[:4], want32)
+			if got := order.Uint32(buf[:4]); got != want32 {
+				t.Errorf("PutUint32: Uint32 = %v, want %v", got, want32)
+			}
+			buf = order.AppendUint32(buf[:offset], want32)
+			if got := order.Uint32(buf[offset:]); got != want32 {
+				t.Errorf("AppendUint32: Uint32 = %v, want %v", got, want32)
+			}
+			if len(buf) != offset+4 {
+				t.Errorf("AppendUint32: len(buf) = %d, want %d", len(buf), offset+4)
+			}
+
+			want64 := uint64(value)
+			order.PutUint64(buf[:8], want64)
+			if got := order.Uint64(buf[:8]); got != want64 {
+				t.Errorf("PutUint64: Uint64 = %v, want %v", got, want64)
+			}
+			buf = order.AppendUint64(buf[:offset], want64)
+			if got := order.Uint64(buf[offset:]); got != want64 {
+				t.Errorf("AppendUint64: Uint64 = %v, want %v", got, want64)
+			}
+			if len(buf) != offset+8 {
+				t.Errorf("AppendUint64: len(buf) = %d, want %d", len(buf), offset+8)
+			}
+		}
+	}
+}
+
+func TestEarlyBoundsChecks(t *testing.T) {
+	if testUint64SmallSliceLengthPanics() != true {
+		t.Errorf("binary.LittleEndian.Uint64 expected to panic for small slices, but didn't")
+	}
+	if testPutUint64SmallSliceLengthPanics() != true {
+		t.Errorf("binary.LittleEndian.PutUint64 expected to panic for small slices, but didn't")
+	}
+}
+
+// --- Examples (from upstream example_test.go) ---
+
+func ExampleByteOrder_put() {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint16(b[0:], 0x03e8)
+	binary.LittleEndian.PutUint16(b[2:], 0x07d0)
+	fmt.Printf("% x\n", b)
+	// Output:
+	// e8 03 d0 07
+}
+
+func ExampleByteOrder_get() {
+	b := []byte{0xe8, 0x03, 0xd0, 0x07}
+	x1 := binary.LittleEndian.Uint16(b[0:])
+	x2 := binary.LittleEndian.Uint16(b[2:])
+	fmt.Printf("%#04x %#04x\n", x1, x2)
+	// Output:
+	// 0x03e8 0x07d0
+}
+
+func ExamplePutUvarint() {
+	buf := make([]byte, binary.MaxVarintLen64)
+
+	for _, x := range []uint64{1, 2, 127, 128, 255, 256} {
+		n := binary.PutUvarint(buf, x)
+		fmt.Printf("%x\n", buf[:n])
+	}
+	// Output:
+	// 01
+	// 02
+	// 7f
+	// 8001
+	// ff01
+	// 8002
+}
+
+func ExamplePutVarint() {
+	buf := make([]byte, binary.MaxVarintLen64)
+
+	for _, x := range []int64{-65, -64, -2, -1, 0, 1, 2, 63, 64} {
+		n := binary.PutVarint(buf, x)
+		fmt.Printf("%x\n", buf[:n])
+	}
+	// Output:
+	// 8101
+	// 7f
+	// 03
+	// 01
+	// 00
+	// 02
+	// 04
+	// 7e
+	// 8001
+}
+
+func ExampleUvarint() {
+	inputs := [][]byte{
+		{0x01},
+		{0x02},
+		{0x7f},
+		{0x80, 0x01},
+		{0xff, 0x01},
+		{0x80, 0x02},
+	}
+	for _, b := range inputs {
+		x, n := binary.Uvarint(b)
+		if n != len(b) {
+			fmt.Println("Uvarint did not consume all of in")
+		}
+		fmt.Println(x)
+	}
+	// Output:
+	// 1
+	// 2
+	// 127
+	// 128
+	// 255
+	// 256
+}
+
+func ExampleVarint() {
+	inputs := [][]byte{
+		{0x81, 0x01},
+		{0x7f},
+		{0x03},
+		{0x01},
+		{0x00},
+		{0x02},
+		{0x04},
+		{0x7e},
+		{0x80, 0x01},
+	}
+	for _, b := range inputs {
+		x, n := binary.Varint(b)
+		if n != len(b) {
+			fmt.Println("Varint did not consume all of in")
+		}
+		fmt.Println(x)
+	}
+	// Output:
+	// -65
+	// -64
+	// -2
+	// -1
+	// 0
+	// 1
+	// 2
+	// 63
+	// 64
 }

--- a/gnovm/stdlibs/encoding/csv/example_test.gno
+++ b/gnovm/stdlibs/encoding/csv/example_test.gno
@@ -1,0 +1,128 @@
+// Tests ported from upstream Go 1.25.9 stdlib for gap coverage.
+
+package csv_test
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func ExampleReader() {
+	in := `first_name,last_name,username
+"Rob","Pike",rob
+Ken,Thompson,ken
+"Robert","Griesemer","gri"
+`
+	r := csv.NewReader(strings.NewReader(in))
+
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(record)
+	}
+	// Output:
+	// [first_name last_name username]
+	// [Rob Pike rob]
+	// [Ken Thompson ken]
+	// [Robert Griesemer gri]
+}
+
+// This example shows how csv.Reader can be configured to handle other
+// types of CSV files.
+func ExampleReader_options() {
+	in := `first_name;last_name;username
+"Rob";"Pike";rob
+# lines beginning with a # character are ignored
+Ken;Thompson;ken
+"Robert";"Griesemer";"gri"
+`
+	r := csv.NewReader(strings.NewReader(in))
+	r.Comma = ';'
+	r.Comment = '#'
+
+	records, err := r.ReadAll()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print(records)
+	// Output:
+	// [[first_name last_name username] [Rob Pike rob] [Ken Thompson ken] [Robert Griesemer gri]]
+}
+
+func ExampleReader_ReadAll() {
+	in := `first_name,last_name,username
+"Rob","Pike",rob
+Ken,Thompson,ken
+"Robert","Griesemer","gri"
+`
+	r := csv.NewReader(strings.NewReader(in))
+
+	records, err := r.ReadAll()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print(records)
+	// Output:
+	// [[first_name last_name username] [Rob Pike rob] [Ken Thompson ken] [Robert Griesemer gri]]
+}
+
+func ExampleWriter() {
+	records := [][]string{
+		{"first_name", "last_name", "username"},
+		{"Rob", "Pike", "rob"},
+		{"Ken", "Thompson", "ken"},
+		{"Robert", "Griesemer", "gri"},
+	}
+
+	w := csv.NewWriter(os.Stdout)
+
+	for _, record := range records {
+		if err := w.Write(record); err != nil {
+			panic(err)
+		}
+	}
+
+	// Write any buffered data to the underlying writer (standard output).
+	w.Flush()
+
+	if err := w.Error(); err != nil {
+		panic(err)
+	}
+	// Output:
+	// first_name,last_name,username
+	// Rob,Pike,rob
+	// Ken,Thompson,ken
+	// Robert,Griesemer,gri
+}
+
+func ExampleWriter_WriteAll() {
+	records := [][]string{
+		{"first_name", "last_name", "username"},
+		{"Rob", "Pike", "rob"},
+		{"Ken", "Thompson", "ken"},
+		{"Robert", "Griesemer", "gri"},
+	}
+
+	w := csv.NewWriter(os.Stdout)
+	w.WriteAll(records) // calls Flush internally
+
+	if err := w.Error(); err != nil {
+		panic(err)
+	}
+	// Output:
+	// first_name,last_name,username
+	// Rob,Pike,rob
+	// Ken,Thompson,ken
+	// Robert,Griesemer,gri
+}

--- a/gnovm/stdlibs/encoding/hex/example_test.gno
+++ b/gnovm/stdlibs/encoding/hex/example_test.gno
@@ -1,0 +1,95 @@
+// Tests ported from upstream Go 1.25.9 stdlib for gap coverage.
+
+package hex_test
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+)
+
+func ExampleEncode() {
+	src := []byte("Hello Gopher!")
+
+	dst := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(dst, src)
+
+	fmt.Printf("%s\n", dst)
+
+	// Output:
+	// 48656c6c6f20476f7068657221
+}
+
+func ExampleDecode() {
+	src := []byte("48656c6c6f20476f7068657221")
+
+	dst := make([]byte, hex.DecodedLen(len(src)))
+	n, err := hex.Decode(dst, src)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s\n", dst[:n])
+
+	// Output:
+	// Hello Gopher!
+}
+
+func ExampleDecodeString() {
+	const s = "48656c6c6f20476f7068657221"
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s\n", decoded)
+
+	// Output:
+	// Hello Gopher!
+}
+
+func ExampleDump() {
+	content := []byte("Go is an open source programming language.")
+
+	fmt.Printf("%s", hex.Dump(content))
+
+	// Output:
+	// 00000000  47 6f 20 69 73 20 61 6e  20 6f 70 65 6e 20 73 6f  |Go is an open so|
+	// 00000010  75 72 63 65 20 70 72 6f  67 72 61 6d 6d 69 6e 67  |urce programming|
+	// 00000020  20 6c 61 6e 67 75 61 67  65 2e                    | language.|
+}
+
+func ExampleDumper() {
+	lines := []string{
+		"Go is an open source programming language.",
+		"\n",
+		"We encourage all Go users to subscribe to golang-announce.",
+	}
+
+	stdoutDumper := hex.Dumper(os.Stdout)
+
+	defer stdoutDumper.Close()
+
+	for _, line := range lines {
+		stdoutDumper.Write([]byte(line))
+	}
+
+	// Output:
+	// 00000000  47 6f 20 69 73 20 61 6e  20 6f 70 65 6e 20 73 6f  |Go is an open so|
+	// 00000010  75 72 63 65 20 70 72 6f  67 72 61 6d 6d 69 6e 67  |urce programming|
+	// 00000020  20 6c 61 6e 67 75 61 67  65 2e 0a 57 65 20 65 6e  | language..We en|
+	// 00000030  63 6f 75 72 61 67 65 20  61 6c 6c 20 47 6f 20 75  |courage all Go u|
+	// 00000040  73 65 72 73 20 74 6f 20  73 75 62 73 63 72 69 62  |sers to subscrib|
+	// 00000050  65 20 74 6f 20 67 6f 6c  61 6e 67 2d 61 6e 6e 6f  |e to golang-anno|
+	// 00000060  75 6e 63 65 2e                                    |unce.|
+}
+
+func ExampleEncodeToString() {
+	src := []byte("Hello")
+	encodedStr := hex.EncodeToString(src)
+
+	fmt.Printf("%s\n", encodedStr)
+
+	// Output:
+	// 48656c6c6f
+}

--- a/gnovm/stdlibs/encoding/hex/hex.gno
+++ b/gnovm/stdlibs/encoding/hex/hex.gno
@@ -32,6 +32,15 @@ func Encode(dst, src []byte) int {
 	return len(src) * 2
 }
 
+// AppendEncode appends the hexadecimally encoded src to dst
+// and returns the extended buffer.
+func AppendEncode(dst, src []byte) []byte {
+	n := EncodedLen(len(src))
+	dst = slicesGrow(dst, n)
+	Encode(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n]
+}
+
 // ErrLength reports an attempt to decode an odd-length input
 // using Decode or DecodeString.
 // The stream-based Decoder returns io.ErrUnexpectedEOF instead of ErrLength.
@@ -82,6 +91,16 @@ func Decode(dst, src []byte) (int, error) {
 	return i, nil
 }
 
+// AppendDecode appends the hexadecimally decoded src to dst
+// and returns the extended buffer.
+// If the input is malformed, it returns the partially decoded src and an error.
+func AppendDecode(dst, src []byte) ([]byte, error) {
+	n := DecodedLen(len(src))
+	dst = slicesGrow(dst, n)
+	n, err := Decode(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n], err
+}
+
 // fromHexChar converts a hex character into its value and a success flag.
 func fromHexChar(c byte) (byte, bool) {
 	switch {
@@ -94,6 +113,14 @@ func fromHexChar(c byte) (byte, bool) {
 	}
 
 	return 0, false
+}
+
+// XXX: non-generic slices.Grow
+func slicesGrow(s []byte, n int) []byte {
+	if n -= cap(s) - len(s); n > 0 {
+		s = append(s[:cap(s)], make([]byte, n)...)[:len(s)]
+	}
+	return s
 }
 
 // EncodeToString returns the hexadecimal encoding of src.

--- a/gnovm/stdlibs/encoding/hex/hex_test.gno
+++ b/gnovm/stdlibs/encoding/hex/hex_test.gno
@@ -275,3 +275,28 @@ func BenchmarkDump(b *testing.B) {
 		})
 	}
 }
+
+func TestAppendEncode(t *testing.T) {
+	for i, test := range encDecTests {
+		dst := []byte("lead")
+		dst = AppendEncode(dst, test.dec)
+		if string(dst) != "lead"+test.enc {
+			t.Errorf("#%d: got: %#v want: %#v", i, dst, "lead"+test.enc)
+		}
+	}
+}
+
+func TestAppendDecode(t *testing.T) {
+	// Case for decoding uppercase hex characters, since
+	// Encode always uses lowercase.
+	decTests := append(encDecTests, encDecTest{"F8F9FAFBFCFDFEFF", []byte{0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff}})
+	for i, test := range decTests {
+		dst := []byte("lead")
+		dst, err := AppendDecode(dst, []byte(test.enc))
+		if err != nil {
+			t.Errorf("#%d: AppendDecode error: %v", i, err)
+		} else if string(dst) != "lead"+string(test.dec) {
+			t.Errorf("#%d: got: %#v want: %#v", i, dst, "lead"+string(test.dec))
+		}
+	}
+}

--- a/gnovm/stdlibs/hash/adler32/adler32.gno
+++ b/gnovm/stdlibs/hash/adler32/adler32.gno
@@ -56,11 +56,14 @@ const (
 	marshaledSize = len(magic) + 4
 )
 
-func (d *digest) MarshalBinary() ([]byte, error) {
-	b := make([]byte, 0, marshaledSize)
+func (d *digest) AppendBinary(b []byte) ([]byte, error) {
 	b = append(b, magic...)
 	b = appendUint32(b, uint32(*d))
 	return b, nil
+}
+
+func (d *digest) MarshalBinary() ([]byte, error) {
+	return d.AppendBinary(make([]byte, 0, marshaledSize))
 }
 
 func (d *digest) UnmarshalBinary(b []byte) error {

--- a/gnovm/stdlibs/hash/adler32/adler32_test.gno
+++ b/gnovm/stdlibs/hash/adler32/adler32_test.gno
@@ -1,0 +1,144 @@
+// Tests ported from upstream Go 1.25.9 stdlib for gap coverage.
+// adler32 currently ships with 0 tests in Gno; this file adds them.
+//
+// The AppendBinary subtest of TestGoldenMarshal exercises the AppendBinary
+// method. Gno's encoding package has no BinaryAppender interface, so the
+// subtest type-asserts against a local interface with the same shape.
+
+package adler32
+
+import (
+	"encoding"
+	"io"
+	"strings"
+	"testing"
+)
+
+var golden = []struct {
+	out       uint32
+	in        string
+	halfState string // marshaled hash state after first half of in written, used by TestGoldenMarshal
+}{
+	{0x00000001, "", "adl\x01\x00\x00\x00\x01"},
+	{0x00620062, "a", "adl\x01\x00\x00\x00\x01"},
+	{0x012600c4, "ab", "adl\x01\x00b\x00b"},
+	{0x024d0127, "abc", "adl\x01\x00b\x00b"},
+	{0x03d8018b, "abcd", "adl\x01\x01&\x00\xc4"},
+	{0x05c801f0, "abcde", "adl\x01\x01&\x00\xc4"},
+	{0x081e0256, "abcdef", "adl\x01\x02M\x01'"},
+	{0x0adb02bd, "abcdefg", "adl\x01\x02M\x01'"},
+	{0x0e000325, "abcdefgh", "adl\x01\x03\xd8\x01\x8b"},
+	{0x118e038e, "abcdefghi", "adl\x01\x03\xd8\x01\x8b"},
+	{0x158603f8, "abcdefghij", "adl\x01\x05\xc8\x01\xf0"},
+	{0x3f090f02, "Discard medicine more than two years old.", "adl\x01NU\a\x87"},
+	{0x46d81477, "He who has a shady past knows that nice guys finish last.", "adl\x01\x89\x8e\t\xe9"},
+	{0x40ee0ee1, "I wouldn't marry him with a ten foot pole.", "adl\x01R\t\ag"},
+	{0x16661315, "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave", "adl\x01\x7f\xbb\t\x10"},
+	{0x5b2e1480, "The days of the digital watch are numbered.  -Tom Stoppard", "adl\x01\x99:\n~"},
+	{0x8c3c09ea, "Nepal premier won't resign.", "adl\x01\"\x05\x05\x05"},
+	{0x45ac18fd, "For every action there is an equal and opposite government program.", "adl\x01\xcc\xfa\f\x00"},
+	{0x53c61462, "His money is twice tainted: 'taint yours and 'taint mine.", "adl\x01\x93\xa9\n\b"},
+	{0x7e511e63, "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977", "adl\x01e\xf5\x10\x14"},
+	{0xe4801a6a, "It's a tiny change to the code and not completely disgusting. - Bob Manchek", "adl\x01\xee\x00\f\xb2"},
+	{0x61b507df, "size:  a.out:  bad magic", "adl\x01\x1a\xfc\x04\x1d"},
+	{0xb8631171, "The major problem is with sendmail.  -Mark Horton", "adl\x01mi\b\xdc"},
+	{0x8b5e1904, "Give me a rock, paper and scissors and I will move the world.  CCFestoon", "adl\x01\xe3\n\f\x9f"},
+	{0x7cc6102b, "If the enemy is within range, then so are you.", "adl\x01_\xe0\b\x1e"},
+	{0x700318e7, "It's well we cannot hear the screams/That we create in others' dreams.", "adl\x01ۘ\f\x87"},
+	{0x1e601747, "You remind me of a TV show, but that's all right: I watch it anyway.", "adl\x01\xcc}\v\x83"},
+	{0xb55b0b09, "C is as portable as Stonehedge!!", "adl\x01,^\x05\xad"},
+	{0x39111dd0, "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley", "adl\x01M\xd1\x0e\xc8"},
+	{0x91dd304f, "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule", "adl\x01#\xd8\x17\xd7"},
+	{0x2e5d1316, "How can you write a big system without C++?  -Paul Glick", "adl\x01\x8fU\n\x0f"},
+	{0xd0201df6, "'Invariant assertions' is the most elegant programming technique!  -Tom Szymanski", "adl\x01/\x98\x0e\xc4"},
+	{0x211297c8, strings.Repeat("\xff", 5548) + "8", "adl\x01\x9a\xa6\xcb\xc1"},
+	{0xbaa198c8, strings.Repeat("\xff", 5549) + "9", "adl\x01gu\xcc\xc0"},
+	{0x553499be, strings.Repeat("\xff", 5550) + "0", "adl\x01gu\xcc\xc0"},
+	{0xf0c19abe, strings.Repeat("\xff", 5551) + "1", "adl\x015CͿ"},
+	{0x8d5c9bbe, strings.Repeat("\xff", 5552) + "2", "adl\x015CͿ"},
+	{0x2af69cbe, strings.Repeat("\xff", 5553) + "3", "adl\x01\x04\x10ξ"},
+	{0xc9809dbe, strings.Repeat("\xff", 5554) + "4", "adl\x01\x04\x10ξ"},
+	{0x69189ebe, strings.Repeat("\xff", 5555) + "5", "adl\x01\xd3\xcdϽ"},
+	{0x86af0001, strings.Repeat("\x00", 1e5), "adl\x01\xc3P\x00\x01"},
+	{0x79660b4d, strings.Repeat("a", 1e5), "adl\x01\x81k\x05\xa7"},
+	{0x110588ee, strings.Repeat("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1e4), "adl\x01e\xd2\xc4p"},
+}
+
+// checksum is a slow but simple implementation of the Adler-32 checksum.
+// It is a straight port of the sample code in RFC 1950 section 9.
+func checksum(p []byte) uint32 {
+	s1, s2 := uint32(1), uint32(0)
+	for _, x := range p {
+		s1 = (s1 + uint32(x)) % mod
+		s2 = (s2 + s1) % mod
+	}
+	return s2<<16 | s1
+}
+
+func TestGolden(t *testing.T) {
+	for _, g := range golden {
+		in := g.in
+		if len(in) > 220 {
+			in = in[:100] + "..." + in[len(in)-100:]
+		}
+		p := []byte(g.in)
+		if got := checksum(p); got != g.out {
+			t.Errorf("simple implementation: checksum(%q) = 0x%x want 0x%x", in, got, g.out)
+			continue
+		}
+		if got := Checksum(p); got != g.out {
+			t.Errorf("optimized implementation: Checksum(%q) = 0x%x want 0x%x", in, got, g.out)
+			continue
+		}
+	}
+}
+
+// binaryAppender mirrors the upstream encoding.BinaryAppender interface,
+// which Gno's encoding package does not yet expose.
+type binaryAppender interface {
+	AppendBinary(b []byte) ([]byte, error)
+}
+
+func TestGoldenMarshal(t *testing.T) {
+	for _, g := range golden {
+		h := New()
+		h2 := New()
+
+		io.WriteString(h, g.in[:len(g.in)/2])
+
+		state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+		if err != nil {
+			t.Errorf("could not marshal: %v", err)
+			continue
+		}
+
+		if string(state) != g.halfState {
+			t.Errorf("checksum(%q) state = %q, want %q", g.in, state, g.halfState)
+			continue
+		}
+
+		stateAppend, err := h.(binaryAppender).AppendBinary(make([]byte, 4, 32))
+		if err != nil {
+			t.Errorf("could not marshal: %v", err)
+			continue
+		}
+		stateAppend = stateAppend[4:]
+
+		if string(stateAppend) != g.halfState {
+			t.Errorf("checksum(%q) state = %q, want %q", g.in, stateAppend, g.halfState)
+			continue
+		}
+
+		if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
+			t.Errorf("could not unmarshal: %v", err)
+			continue
+		}
+
+		io.WriteString(h, g.in[len(g.in)/2:])
+		io.WriteString(h2, g.in[len(g.in)/2:])
+
+		if h.Sum32() != h2.Sum32() {
+			t.Errorf("checksum(%q) = 0x%x != marshaled (0x%x)", g.in, h.Sum32(), h2.Sum32())
+		}
+	}
+}

--- a/gnovm/stdlibs/html/example_test.gno
+++ b/gnovm/stdlibs/html/example_test.gno
@@ -1,0 +1,20 @@
+// Tests ported from upstream Go 1.25.9 stdlib for gap coverage.
+
+package html_test
+
+import (
+	"fmt"
+	"html"
+)
+
+func ExampleEscapeString() {
+	const s = `"Fran & Freddie's Diner" <tasty@example.com>`
+	fmt.Println(html.EscapeString(s))
+	// Output: &#34;Fran &amp; Freddie&#39;s Diner&#34; &lt;tasty@example.com&gt;
+}
+
+func ExampleUnescapeString() {
+	const s = `&quot;Fran &amp; Freddie&#39;s Diner&quot; &lt;tasty@example.com&gt;`
+	fmt.Println(html.UnescapeString(s))
+	// Output: "Fran & Freddie's Diner" <tasty@example.com>
+}

--- a/gnovm/stdlibs/math/all_test.gno
+++ b/gnovm/stdlibs/math/all_test.gno
@@ -4025,3 +4025,335 @@ func BenchmarkFMA(b *testing.B) {
 	}
 	GlobalF = x
 }
+
+// -----------------------------------------------------------------------------
+// Tests ported from upstream go1.25.9 example_test.go and huge_test.go.
+//
+// Gno's test harness does not dispatch Example* funcs, so each upstream
+// ExampleX is rewritten as TestExampleX asserting formatted output matches
+// the upstream "// Output: ..." comment.
+//
+// Skipped upstream tests:
+//   - Test*Novec / TestLarge*Novec (s390x-only, use CosNoVec/SinNoVec/...,
+//     require HasVX, all missing API in Gno).
+// -----------------------------------------------------------------------------
+
+func checkExample(t *testing.T, name, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s output mismatch\n got: %q\nwant: %q", name, got, want)
+	}
+}
+
+// --------------------------------------------------------------------
+// Examples (upstream example_test.go), rewritten as Test wrappers.
+// --------------------------------------------------------------------
+
+func TestExampleAcos(t *testing.T) {
+	checkExample(t, "Acos", fmt.Sprintf("%.2f", math.Acos(1)), "0.00")
+}
+
+func TestExampleAcosh(t *testing.T) {
+	checkExample(t, "Acosh", fmt.Sprintf("%.2f", math.Acosh(1)), "0.00")
+}
+
+func TestExampleAsin(t *testing.T) {
+	checkExample(t, "Asin", fmt.Sprintf("%.2f", math.Asin(0)), "0.00")
+}
+
+func TestExampleAsinh(t *testing.T) {
+	checkExample(t, "Asinh", fmt.Sprintf("%.2f", math.Asinh(0)), "0.00")
+}
+
+func TestExampleAtan(t *testing.T) {
+	checkExample(t, "Atan", fmt.Sprintf("%.2f", math.Atan(0)), "0.00")
+}
+
+func TestExampleAtan2(t *testing.T) {
+	checkExample(t, "Atan2", fmt.Sprintf("%.2f", math.Atan2(0, 0)), "0.00")
+}
+
+func TestExampleAtanh(t *testing.T) {
+	checkExample(t, "Atanh", fmt.Sprintf("%.2f", math.Atanh(0)), "0.00")
+}
+
+func TestExampleCopysign(t *testing.T) {
+	checkExample(t, "Copysign", fmt.Sprintf("%.2f", math.Copysign(3.2, -1)), "-3.20")
+}
+
+func TestExampleCos(t *testing.T) {
+	checkExample(t, "Cos", fmt.Sprintf("%.2f", math.Cos(math.Pi/2)), "0.00")
+}
+
+func TestExampleCosh(t *testing.T) {
+	checkExample(t, "Cosh", fmt.Sprintf("%.2f", math.Cosh(0)), "1.00")
+}
+
+func TestExampleSin(t *testing.T) {
+	checkExample(t, "Sin", fmt.Sprintf("%.2f", math.Sin(math.Pi)), "0.00")
+}
+
+func TestExampleSincos(t *testing.T) {
+	sin, cos := math.Sincos(0)
+	checkExample(t, "Sincos", fmt.Sprintf("%.2f, %.2f", sin, cos), "0.00, 1.00")
+}
+
+func TestExampleSinh(t *testing.T) {
+	checkExample(t, "Sinh", fmt.Sprintf("%.2f", math.Sinh(0)), "0.00")
+}
+
+func TestExampleTan(t *testing.T) {
+	checkExample(t, "Tan", fmt.Sprintf("%.2f", math.Tan(0)), "0.00")
+}
+
+func TestExampleTanh(t *testing.T) {
+	checkExample(t, "Tanh", fmt.Sprintf("%.2f", math.Tanh(0)), "0.00")
+}
+
+func TestExampleSqrt(t *testing.T) {
+	const (
+		a = 3
+		b = 4
+	)
+	c := math.Sqrt(a*a + b*b)
+	checkExample(t, "Sqrt", fmt.Sprintf("%.1f", c), "5.0")
+}
+
+func TestExampleCeil(t *testing.T) {
+	c := math.Ceil(1.49)
+	checkExample(t, "Ceil", fmt.Sprintf("%.1f", c), "2.0")
+}
+
+func TestExampleFloor(t *testing.T) {
+	c := math.Floor(1.51)
+	checkExample(t, "Floor", fmt.Sprintf("%.1f", c), "1.0")
+}
+
+func TestExamplePow(t *testing.T) {
+	c := math.Pow(2, 3)
+	checkExample(t, "Pow", fmt.Sprintf("%.1f", c), "8.0")
+}
+
+func TestExamplePow10(t *testing.T) {
+	c := math.Pow10(2)
+	checkExample(t, "Pow10", fmt.Sprintf("%.1f", c), "100.0")
+}
+
+func TestExampleRound(t *testing.T) {
+	p := math.Round(10.5)
+	n := math.Round(-10.5)
+	got := fmt.Sprintf("%.1f\n%.1f\n", p, n)
+	checkExample(t, "Round", got, "11.0\n-11.0\n")
+}
+
+func TestExampleRoundToEven(t *testing.T) {
+	u := math.RoundToEven(11.5)
+	d := math.RoundToEven(12.5)
+	got := fmt.Sprintf("%.1f\n%.1f\n", u, d)
+	checkExample(t, "RoundToEven", got, "12.0\n12.0\n")
+}
+
+func TestExampleLog(t *testing.T) {
+	x := math.Log(1)
+	y := math.Log(2.7183)
+	got := fmt.Sprintf("%.1f\n%.1f\n", x, y)
+	checkExample(t, "Log", got, "0.0\n1.0\n")
+}
+
+func TestExampleLog2(t *testing.T) {
+	checkExample(t, "Log2", fmt.Sprintf("%.1f", math.Log2(256)), "8.0")
+}
+
+func TestExampleLog10(t *testing.T) {
+	checkExample(t, "Log10", fmt.Sprintf("%.1f", math.Log10(100)), "2.0")
+}
+
+func TestExampleRemainder(t *testing.T) {
+	checkExample(t, "Remainder", fmt.Sprintf("%.1f", math.Remainder(100, 30)), "10.0")
+}
+
+func TestExampleMod(t *testing.T) {
+	c := math.Mod(7, 4)
+	checkExample(t, "Mod", fmt.Sprintf("%.1f", c), "3.0")
+}
+
+func TestExampleAbs(t *testing.T) {
+	x := math.Abs(-2)
+	y := math.Abs(2)
+	got := fmt.Sprintf("%.1f\n%.1f\n", x, y)
+	checkExample(t, "Abs", got, "2.0\n2.0\n")
+}
+
+func TestExampleDim(t *testing.T) {
+	got := fmt.Sprintf("%.2f\n%.2f\n", math.Dim(4, -2), math.Dim(-4, 2))
+	checkExample(t, "Dim", got, "6.00\n0.00\n")
+}
+
+func TestExampleExp(t *testing.T) {
+	got := fmt.Sprintf("%.2f\n%.2f\n%.2f\n", math.Exp(1), math.Exp(2), math.Exp(-1))
+	checkExample(t, "Exp", got, "2.72\n7.39\n0.37\n")
+}
+
+func TestExampleExp2(t *testing.T) {
+	got := fmt.Sprintf("%.2f\n%.2f\n", math.Exp2(1), math.Exp2(-3))
+	checkExample(t, "Exp2", got, "2.00\n0.12\n")
+}
+
+func TestExampleExpm1(t *testing.T) {
+	got := fmt.Sprintf("%.6f\n%.6f\n", math.Expm1(0.01), math.Expm1(-1))
+	checkExample(t, "Expm1", got, "0.010050\n-0.632121\n")
+}
+
+func TestExampleTrunc(t *testing.T) {
+	got := fmt.Sprintf("%.2f\n%.2f\n", math.Trunc(math.Pi), math.Trunc(-1.2345))
+	checkExample(t, "Trunc", got, "3.00\n-1.00\n")
+}
+
+func TestExampleCbrt(t *testing.T) {
+	got := fmt.Sprintf("%.2f\n%.2f\n", math.Cbrt(8), math.Cbrt(27))
+	checkExample(t, "Cbrt", got, "2.00\n3.00\n")
+}
+
+func TestExampleModf(t *testing.T) {
+	i, frac := math.Modf(3.14)
+	i2, frac2 := math.Modf(-2.71)
+	got := fmt.Sprintf("%.2f, %.2f\n%.2f, %.2f\n", i, frac, i2, frac2)
+	checkExample(t, "Modf", got, "3.00, 0.14\n-2.00, -0.71\n")
+}
+
+// --------------------------------------------------------------------
+// Huge-angle trig tests (upstream huge_test.go).
+// Exercise the trig argument-reduction path on values where naive
+// reduction loses every bit of precision.
+// --------------------------------------------------------------------
+
+var trigHuge = []float64{
+	1 << 28,
+	1 << 29,
+	1 << 30,
+	1 << 35,
+	1 << 120,
+	1 << 240,
+	1 << 480,
+	1234567891234567 << 180,
+	1234567891234567 << 300,
+	math.MaxFloat64,
+}
+
+// Reference values from upstream Go 1.25.9, computed with ivy at
+// 4096-bit working precision.
+var cosHuge = []float64{
+	-0.16556897949057876,
+	-0.94517382606089662,
+	0.78670712294118812,
+	-0.76466301249635305,
+	-0.92587902285483787,
+	0.93601042593353793,
+	-0.28282777640193788,
+	-0.14616431394103619,
+	-0.79456058210671406,
+	-0.99998768942655994,
+}
+
+var sinHuge = []float64{
+	-0.98619821183697566,
+	0.32656766301856334,
+	-0.61732641504604217,
+	-0.64443035102329113,
+	0.37782010936075202,
+	-0.35197227524865778,
+	0.95917070894368716,
+	0.98926032637023618,
+	-0.60718488235646949,
+	0.00496195478918406,
+}
+
+var tanHuge = []float64{
+	5.95641897939639421,
+	-0.34551069233430392,
+	-0.78469661331920043,
+	0.84276385870875983,
+	-0.40806638884180424,
+	-0.37603456702698076,
+	-3.39135965054779932,
+	-6.76813854009065030,
+	0.76417695016604922,
+	-0.00496201587444489,
+}
+
+// closeHuge mirrors upstream "close": tolerance 1e-14, NaN-aware.
+func closeHuge(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	if a == b {
+		return true
+	}
+	d := math.Abs(a - b)
+	if b != 0 {
+		return d/math.Abs(b) < 1e-14
+	}
+	return d < 1e-14
+}
+
+func TestHugeCos(t *testing.T) {
+	for i := 0; i < len(trigHuge); i++ {
+		f1 := cosHuge[i]
+		f2 := math.Cos(trigHuge[i])
+		if !closeHuge(f1, f2) {
+			t.Errorf("Cos(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				trigHuge[i], f2, math.Float64bits(f2), f1, math.Float64bits(f1))
+		}
+		f3 := math.Cos(-trigHuge[i])
+		if !closeHuge(f1, f3) {
+			t.Errorf("Cos(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				-trigHuge[i], f3, math.Float64bits(f3), f1, math.Float64bits(f1))
+		}
+	}
+}
+
+func TestHugeSin(t *testing.T) {
+	for i := 0; i < len(trigHuge); i++ {
+		f1 := sinHuge[i]
+		f2 := math.Sin(trigHuge[i])
+		if !closeHuge(f1, f2) {
+			t.Errorf("Sin(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				trigHuge[i], f2, math.Float64bits(f2), f1, math.Float64bits(f1))
+		}
+		f3 := math.Sin(-trigHuge[i])
+		if !closeHuge(-f1, f3) {
+			t.Errorf("Sin(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				-trigHuge[i], f3, math.Float64bits(f3), -f1, math.Float64bits(-f1))
+		}
+	}
+}
+
+func TestHugeSinCos(t *testing.T) {
+	for i := 0; i < len(trigHuge); i++ {
+		f1, g1 := sinHuge[i], cosHuge[i]
+		f2, g2 := math.Sincos(trigHuge[i])
+		if !closeHuge(f1, f2) || !closeHuge(g1, g2) {
+			t.Errorf("Sincos(%g) = %g, %g, want %g, %g", trigHuge[i], f2, g2, f1, g1)
+		}
+		f3, g3 := math.Sincos(-trigHuge[i])
+		if !closeHuge(-f1, f3) || !closeHuge(g1, g3) {
+			t.Errorf("Sincos(%g) = %g, %g, want %g, %g", -trigHuge[i], f3, g3, -f1, g1)
+		}
+	}
+}
+
+func TestHugeTan(t *testing.T) {
+	for i := 0; i < len(trigHuge); i++ {
+		f1 := tanHuge[i]
+		f2 := math.Tan(trigHuge[i])
+		if !closeHuge(f1, f2) {
+			t.Errorf("Tan(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				trigHuge[i], f2, math.Float64bits(f2), f1, math.Float64bits(f1))
+		}
+		f3 := math.Tan(-trigHuge[i])
+		if !closeHuge(-f1, f3) {
+			t.Errorf("Tan(%g) = %g (bits 0x%x), want %g (bits 0x%x)",
+				-trigHuge[i], f3, math.Float64bits(f3), -f1, math.Float64bits(-f1))
+		}
+	}
+}

--- a/gnovm/stdlibs/math/bits/bits_test.gno
+++ b/gnovm/stdlibs/math/bits/bits_test.gno
@@ -5,6 +5,7 @@
 package bits_test
 
 import (
+	"fmt"
 	"math/bits"
 	"testing"
 )
@@ -1330,4 +1331,351 @@ func init() {
 		}
 		tab[i].pop = n
 	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests ported from upstream go1.25.9 example_test.go and example_math_test.go.
+//
+// Gno's test harness does not dispatch Example* funcs, so each upstream
+// ExampleX is rewritten as TestExampleX asserting formatted output matches
+// the upstream "// Output: ..." comment.
+//
+// TestUintSize is adapted: upstream uses unsafe.Sizeof; here we just check
+// that UintSize matches Gno's invariant of 64-bit uint.
+// -----------------------------------------------------------------------------
+
+func checkExample(t *testing.T, name, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s output mismatch\n got: %q\nwant: %q (got bytes: % x)",
+			name, got, want, []byte(got))
+	}
+}
+
+// TestUintSize: Gno is always 64-bit. Upstream uses unsafe.Sizeof(uint).
+func TestUintSize(t *testing.T) {
+	if bits.UintSize != 64 {
+		t.Fatalf("UintSize = %d; want 64 (Gno is always 64-bit)", bits.UintSize)
+	}
+}
+
+// --------------------------------------------------------------------
+// Examples (upstream example_test.go), rewritten as Test wrappers.
+// --------------------------------------------------------------------
+
+func TestExampleLeadingZeros8(t *testing.T) {
+	got := fmt.Sprintf("LeadingZeros8(%08b) = %d\n", 1, bits.LeadingZeros8(1))
+	checkExample(t, "LeadingZeros8", got, "LeadingZeros8(00000001) = 7\n")
+}
+
+func TestExampleLeadingZeros16(t *testing.T) {
+	got := fmt.Sprintf("LeadingZeros16(%016b) = %d\n", 1, bits.LeadingZeros16(1))
+	checkExample(t, "LeadingZeros16", got, "LeadingZeros16(0000000000000001) = 15\n")
+}
+
+func TestExampleLeadingZeros32(t *testing.T) {
+	got := fmt.Sprintf("LeadingZeros32(%032b) = %d\n", 1, bits.LeadingZeros32(1))
+	checkExample(t, "LeadingZeros32", got,
+		"LeadingZeros32(00000000000000000000000000000001) = 31\n")
+}
+
+func TestExampleLeadingZeros64(t *testing.T) {
+	got := fmt.Sprintf("LeadingZeros64(%064b) = %d\n", 1, bits.LeadingZeros64(1))
+	checkExample(t, "LeadingZeros64", got,
+		"LeadingZeros64(0000000000000000000000000000000000000000000000000000000000000001) = 63\n")
+}
+
+func TestExampleTrailingZeros8(t *testing.T) {
+	got := fmt.Sprintf("TrailingZeros8(%08b) = %d\n", 14, bits.TrailingZeros8(14))
+	checkExample(t, "TrailingZeros8", got, "TrailingZeros8(00001110) = 1\n")
+}
+
+func TestExampleTrailingZeros16(t *testing.T) {
+	got := fmt.Sprintf("TrailingZeros16(%016b) = %d\n", 14, bits.TrailingZeros16(14))
+	checkExample(t, "TrailingZeros16", got, "TrailingZeros16(0000000000001110) = 1\n")
+}
+
+func TestExampleTrailingZeros32(t *testing.T) {
+	got := fmt.Sprintf("TrailingZeros32(%032b) = %d\n", 14, bits.TrailingZeros32(14))
+	checkExample(t, "TrailingZeros32", got,
+		"TrailingZeros32(00000000000000000000000000001110) = 1\n")
+}
+
+func TestExampleTrailingZeros64(t *testing.T) {
+	got := fmt.Sprintf("TrailingZeros64(%064b) = %d\n", 14, bits.TrailingZeros64(14))
+	checkExample(t, "TrailingZeros64", got,
+		"TrailingZeros64(0000000000000000000000000000000000000000000000000000000000001110) = 1\n")
+}
+
+func TestExampleOnesCount(t *testing.T) {
+	got := fmt.Sprintf("OnesCount(%b) = %d\n", 14, bits.OnesCount(14))
+	checkExample(t, "OnesCount", got, "OnesCount(1110) = 3\n")
+}
+
+func TestExampleOnesCount8(t *testing.T) {
+	got := fmt.Sprintf("OnesCount8(%08b) = %d\n", 14, bits.OnesCount8(14))
+	checkExample(t, "OnesCount8", got, "OnesCount8(00001110) = 3\n")
+}
+
+func TestExampleOnesCount16(t *testing.T) {
+	got := fmt.Sprintf("OnesCount16(%016b) = %d\n", 14, bits.OnesCount16(14))
+	checkExample(t, "OnesCount16", got, "OnesCount16(0000000000001110) = 3\n")
+}
+
+func TestExampleOnesCount32(t *testing.T) {
+	got := fmt.Sprintf("OnesCount32(%032b) = %d\n", 14, bits.OnesCount32(14))
+	checkExample(t, "OnesCount32", got,
+		"OnesCount32(00000000000000000000000000001110) = 3\n")
+}
+
+func TestExampleOnesCount64(t *testing.T) {
+	got := fmt.Sprintf("OnesCount64(%064b) = %d\n", 14, bits.OnesCount64(14))
+	checkExample(t, "OnesCount64", got,
+		"OnesCount64(0000000000000000000000000000000000000000000000000000000000001110) = 3\n")
+}
+
+func TestExampleRotateLeft8(t *testing.T) {
+	got := fmt.Sprintf("%08b\n%08b\n%08b\n",
+		15, bits.RotateLeft8(15, 2), bits.RotateLeft8(15, -2))
+	checkExample(t, "RotateLeft8", got, "00001111\n00111100\n11000011\n")
+}
+
+func TestExampleRotateLeft16(t *testing.T) {
+	got := fmt.Sprintf("%016b\n%016b\n%016b\n",
+		15, bits.RotateLeft16(15, 2), bits.RotateLeft16(15, -2))
+	checkExample(t, "RotateLeft16", got,
+		"0000000000001111\n0000000000111100\n1100000000000011\n")
+}
+
+func TestExampleRotateLeft32(t *testing.T) {
+	got := fmt.Sprintf("%032b\n%032b\n%032b\n",
+		15, bits.RotateLeft32(15, 2), bits.RotateLeft32(15, -2))
+	checkExample(t, "RotateLeft32", got,
+		"00000000000000000000000000001111\n00000000000000000000000000111100\n11000000000000000000000000000011\n")
+}
+
+func TestExampleRotateLeft64(t *testing.T) {
+	got := fmt.Sprintf("%064b\n%064b\n%064b\n",
+		15, bits.RotateLeft64(15, 2), bits.RotateLeft64(15, -2))
+	want := "0000000000000000000000000000000000000000000000000000000000001111\n" +
+		"0000000000000000000000000000000000000000000000000000000000111100\n" +
+		"1100000000000000000000000000000000000000000000000000000000000011\n"
+	checkExample(t, "RotateLeft64", got, want)
+}
+
+func TestExampleReverse8(t *testing.T) {
+	got := fmt.Sprintf("%08b\n%08b\n", 19, bits.Reverse8(19))
+	checkExample(t, "Reverse8", got, "00010011\n11001000\n")
+}
+
+func TestExampleReverse16(t *testing.T) {
+	got := fmt.Sprintf("%016b\n%016b\n", 19, bits.Reverse16(19))
+	checkExample(t, "Reverse16", got, "0000000000010011\n1100100000000000\n")
+}
+
+func TestExampleReverse32(t *testing.T) {
+	got := fmt.Sprintf("%032b\n%032b\n", 19, bits.Reverse32(19))
+	checkExample(t, "Reverse32", got,
+		"00000000000000000000000000010011\n11001000000000000000000000000000\n")
+}
+
+func TestExampleReverse64(t *testing.T) {
+	got := fmt.Sprintf("%064b\n%064b\n", 19, bits.Reverse64(19))
+	want := "0000000000000000000000000000000000000000000000000000000000010011\n" +
+		"1100100000000000000000000000000000000000000000000000000000000000\n"
+	checkExample(t, "Reverse64", got, want)
+}
+
+func TestExampleReverseBytes16(t *testing.T) {
+	got := fmt.Sprintf("%016b\n%016b\n", 15, bits.ReverseBytes16(15))
+	checkExample(t, "ReverseBytes16", got, "0000000000001111\n0000111100000000\n")
+}
+
+func TestExampleReverseBytes32(t *testing.T) {
+	got := fmt.Sprintf("%032b\n%032b\n", 15, bits.ReverseBytes32(15))
+	checkExample(t, "ReverseBytes32", got,
+		"00000000000000000000000000001111\n00001111000000000000000000000000\n")
+}
+
+func TestExampleReverseBytes64(t *testing.T) {
+	got := fmt.Sprintf("%064b\n%064b\n", 15, bits.ReverseBytes64(15))
+	want := "0000000000000000000000000000000000000000000000000000000000001111\n" +
+		"0000111100000000000000000000000000000000000000000000000000000000\n"
+	checkExample(t, "ReverseBytes64", got, want)
+}
+
+func TestExampleLen8(t *testing.T) {
+	got := fmt.Sprintf("Len8(%08b) = %d\n", 8, bits.Len8(8))
+	checkExample(t, "Len8", got, "Len8(00001000) = 4\n")
+}
+
+func TestExampleLen16(t *testing.T) {
+	got := fmt.Sprintf("Len16(%016b) = %d\n", 8, bits.Len16(8))
+	checkExample(t, "Len16", got, "Len16(0000000000001000) = 4\n")
+}
+
+func TestExampleLen32(t *testing.T) {
+	got := fmt.Sprintf("Len32(%032b) = %d\n", 8, bits.Len32(8))
+	checkExample(t, "Len32", got,
+		"Len32(00000000000000000000000000001000) = 4\n")
+}
+
+func TestExampleLen64(t *testing.T) {
+	got := fmt.Sprintf("Len64(%064b) = %d\n", 8, bits.Len64(8))
+	checkExample(t, "Len64", got,
+		"Len64(0000000000000000000000000000000000000000000000000000000000001000) = 4\n")
+}
+
+// --------------------------------------------------------------------
+// Examples (upstream example_math_test.go), rewritten as Test wrappers.
+// --------------------------------------------------------------------
+
+func TestExampleAdd32(t *testing.T) {
+	// 1st number 33<<32 + 12; 2nd 21<<32 + 23; no carry.
+	n1 := []uint32{33, 12}
+	n2 := []uint32{21, 23}
+	d1, carry := bits.Add32(n1[1], n2[1], 0)
+	d0, _ := bits.Add32(n1[0], n2[0], carry)
+	nsum := []uint32{d0, d1}
+	got := fmt.Sprintf("%v + %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	// 1st 1<<32 + 2147483648; 2nd 1<<32 + 2147483648; carry expected.
+	n1 = []uint32{1, 0x80000000}
+	n2 = []uint32{1, 0x80000000}
+	d1, carry = bits.Add32(n1[1], n2[1], 0)
+	d0, _ = bits.Add32(n1[0], n2[0], carry)
+	nsum = []uint32{d0, d1}
+	got += fmt.Sprintf("%v + %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	want := "[33 12] + [21 23] = [54 35] (carry bit was 0)\n" +
+		"[1 2147483648] + [1 2147483648] = [3 0] (carry bit was 1)\n"
+	checkExample(t, "Add32", got, want)
+}
+
+func TestExampleAdd64(t *testing.T) {
+	n1 := []uint64{33, 12}
+	n2 := []uint64{21, 23}
+	d1, carry := bits.Add64(n1[1], n2[1], 0)
+	d0, _ := bits.Add64(n1[0], n2[0], carry)
+	nsum := []uint64{d0, d1}
+	got := fmt.Sprintf("%v + %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	n1 = []uint64{1, 0x8000000000000000}
+	n2 = []uint64{1, 0x8000000000000000}
+	d1, carry = bits.Add64(n1[1], n2[1], 0)
+	d0, _ = bits.Add64(n1[0], n2[0], carry)
+	nsum = []uint64{d0, d1}
+	got += fmt.Sprintf("%v + %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	want := "[33 12] + [21 23] = [54 35] (carry bit was 0)\n" +
+		"[1 9223372036854775808] + [1 9223372036854775808] = [3 0] (carry bit was 1)\n"
+	checkExample(t, "Add64", got, want)
+}
+
+func TestExampleSub32(t *testing.T) {
+	n1 := []uint32{33, 23}
+	n2 := []uint32{21, 12}
+	d1, carry := bits.Sub32(n1[1], n2[1], 0)
+	d0, _ := bits.Sub32(n1[0], n2[0], carry)
+	nsum := []uint32{d0, d1}
+	got := fmt.Sprintf("%v - %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	n1 = []uint32{3, 0x7fffffff}
+	n2 = []uint32{1, 0x80000000}
+	d1, carry = bits.Sub32(n1[1], n2[1], 0)
+	d0, _ = bits.Sub32(n1[0], n2[0], carry)
+	nsum = []uint32{d0, d1}
+	got += fmt.Sprintf("%v - %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	want := "[33 23] - [21 12] = [12 11] (carry bit was 0)\n" +
+		"[3 2147483647] - [1 2147483648] = [1 4294967295] (carry bit was 1)\n"
+	checkExample(t, "Sub32", got, want)
+}
+
+func TestExampleSub64(t *testing.T) {
+	n1 := []uint64{33, 23}
+	n2 := []uint64{21, 12}
+	d1, carry := bits.Sub64(n1[1], n2[1], 0)
+	d0, _ := bits.Sub64(n1[0], n2[0], carry)
+	nsum := []uint64{d0, d1}
+	got := fmt.Sprintf("%v - %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	n1 = []uint64{3, 0x7fffffffffffffff}
+	n2 = []uint64{1, 0x8000000000000000}
+	d1, carry = bits.Sub64(n1[1], n2[1], 0)
+	d0, _ = bits.Sub64(n1[0], n2[0], carry)
+	nsum = []uint64{d0, d1}
+	got += fmt.Sprintf("%v - %v = %v (carry bit was %v)\n", n1, n2, nsum, carry)
+
+	want := "[33 23] - [21 12] = [12 11] (carry bit was 0)\n" +
+		"[3 9223372036854775807] - [1 9223372036854775808] = [1 18446744073709551615] (carry bit was 1)\n"
+	checkExample(t, "Sub64", got, want)
+}
+
+func TestExampleMul32(t *testing.T) {
+	n1 := []uint32{0, 12}
+	n2 := []uint32{0, 12}
+	hi, lo := bits.Mul32(n1[1], n2[1])
+	nsum := []uint32{hi, lo}
+	got := fmt.Sprintf("%v * %v = %v\n", n1[1], n2[1], nsum)
+
+	n1 = []uint32{0, 0x80000000}
+	n2 = []uint32{0, 2}
+	hi, lo = bits.Mul32(n1[1], n2[1])
+	nsum = []uint32{hi, lo}
+	got += fmt.Sprintf("%v * %v = %v\n", n1[1], n2[1], nsum)
+
+	want := "12 * 12 = [0 144]\n2147483648 * 2 = [1 0]\n"
+	checkExample(t, "Mul32", got, want)
+}
+
+func TestExampleMul64(t *testing.T) {
+	n1 := []uint64{0, 12}
+	n2 := []uint64{0, 12}
+	hi, lo := bits.Mul64(n1[1], n2[1])
+	nsum := []uint64{hi, lo}
+	got := fmt.Sprintf("%v * %v = %v\n", n1[1], n2[1], nsum)
+
+	n1 = []uint64{0, 0x8000000000000000}
+	n2 = []uint64{0, 2}
+	hi, lo = bits.Mul64(n1[1], n2[1])
+	nsum = []uint64{hi, lo}
+	got += fmt.Sprintf("%v * %v = %v\n", n1[1], n2[1], nsum)
+
+	want := "12 * 12 = [0 144]\n9223372036854775808 * 2 = [1 0]\n"
+	checkExample(t, "Mul64", got, want)
+}
+
+func TestExampleDiv32(t *testing.T) {
+	n1 := []uint32{0, 6}
+	n2 := []uint32{0, 3}
+	quo, rem := bits.Div32(n1[0], n1[1], n2[1])
+	nsum := []uint32{quo, rem}
+	got := fmt.Sprintf("[%v %v] / %v = %v\n", n1[0], n1[1], n2[1], nsum)
+
+	n1 = []uint32{2, 0x80000000}
+	n2 = []uint32{0, 0x80000000}
+	quo, rem = bits.Div32(n1[0], n1[1], n2[1])
+	nsum = []uint32{quo, rem}
+	got += fmt.Sprintf("[%v %v] / %v = %v\n", n1[0], n1[1], n2[1], nsum)
+
+	want := "[0 6] / 3 = [2 0]\n[2 2147483648] / 2147483648 = [5 0]\n"
+	checkExample(t, "Div32", got, want)
+}
+
+func TestExampleDiv64(t *testing.T) {
+	n1 := []uint64{0, 6}
+	n2 := []uint64{0, 3}
+	quo, rem := bits.Div64(n1[0], n1[1], n2[1])
+	nsum := []uint64{quo, rem}
+	got := fmt.Sprintf("[%v %v] / %v = %v\n", n1[0], n1[1], n2[1], nsum)
+
+	n1 = []uint64{2, 0x8000000000000000}
+	n2 = []uint64{0, 0x8000000000000000}
+	quo, rem = bits.Div64(n1[0], n1[1], n2[1])
+	nsum = []uint64{quo, rem}
+	got += fmt.Sprintf("[%v %v] / %v = %v\n", n1[0], n1[1], n2[1], nsum)
+
+	want := "[0 6] / 3 = [2 0]\n[2 9223372036854775808] / 9223372036854775808 = [5 0]\n"
+	checkExample(t, "Div64", got, want)
 }

--- a/gnovm/stdlibs/net/url/example_test.gno
+++ b/gnovm/stdlibs/net/url/example_test.gno
@@ -1,0 +1,364 @@
+// Examples ported from upstream Go 1.25.9 net/url example_test.go,
+// rewritten as Test* functions so the example bodies are actually
+// executed by Gno's stdlib test runner (which discovers Test* only,
+// not Example*). Each test runs the equivalent example body and
+// asserts the captured output against the upstream "// Output:" block.
+//
+// Adapted: log.Fatal(err) replaced with panic(err) (no log pkg in Gno);
+// ExampleParseQuery skipped (uses encoding/json which is not available).
+//
+// Source: src/net/url/example_test.go @ go1.25.9
+
+package url_test
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// out is a tiny stdout-substitute used by the example bodies below.
+type out struct{ b strings.Builder }
+
+func (o *out) Println(a ...any) { o.b.WriteString(fmt.Sprintln(a...)) }
+func (o *out) Printf(f string, a ...any) {
+	o.b.WriteString(fmt.Sprintf(f, a...))
+}
+func (o *out) String() string { return o.b.String() }
+
+func check(t *testing.T, name, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s output mismatch:\ngot:  %q\nwant: %q", name, got, want)
+	}
+}
+
+func TestExamplePathEscape(t *testing.T) {
+	o := &out{}
+	path := url.PathEscape("my/cool+blog&about,stuff")
+	o.Println(path)
+	check(t, "PathEscape", o.String(), "my%2Fcool+blog&about%2Cstuff\n")
+}
+
+func TestExamplePathUnescape(t *testing.T) {
+	o := &out{}
+	escapedPath := "my%2Fcool+blog&about%2Cstuff"
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(path)
+	check(t, "PathUnescape", o.String(), "my/cool+blog&about,stuff\n")
+}
+
+func TestExampleQueryEscape(t *testing.T) {
+	o := &out{}
+	query := url.QueryEscape("my/cool+blog&about,stuff")
+	o.Println(query)
+	check(t, "QueryEscape", o.String(), "my%2Fcool%2Bblog%26about%2Cstuff\n")
+}
+
+func TestExampleQueryUnescape(t *testing.T) {
+	o := &out{}
+	escapedQuery := "my%2Fcool%2Bblog%26about%2Cstuff"
+	query, err := url.QueryUnescape(escapedQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(query)
+	check(t, "QueryUnescape", o.String(), "my/cool+blog&about,stuff\n")
+}
+
+func TestExampleValues(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Set("name", "Ava")
+	v.Add("friend", "Jess")
+	v.Add("friend", "Sarah")
+	v.Add("friend", "Zoe")
+	o.Println(v.Get("name"))
+	o.Println(v.Get("friend"))
+	o.Println(v["friend"])
+	check(t, "Values", o.String(), "Ava\nJess\n[Jess Sarah Zoe]\n")
+}
+
+func TestExampleValues_Add(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew")
+	v.Add("cat sounds", "mau")
+	o.Println(v["cat sounds"])
+	check(t, "Values.Add", o.String(), "[meow mew mau]\n")
+}
+
+func TestExampleValues_Del(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew")
+	v.Add("cat sounds", "mau")
+	o.Println(v["cat sounds"])
+
+	v.Del("cat sounds")
+	o.Println(v["cat sounds"])
+	check(t, "Values.Del", o.String(), "[meow mew mau]\n[]\n")
+}
+
+func TestExampleValues_Encode(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew/")
+	v.Add("cat sounds", "mau$")
+	o.Println(v.Encode())
+	check(t, "Values.Encode", o.String(), "cat+sounds=meow&cat+sounds=mew%2F&cat+sounds=mau%24\n")
+}
+
+func TestExampleValues_Get(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew")
+	v.Add("cat sounds", "mau")
+	o.Printf("%q\n", v.Get("cat sounds"))
+	o.Printf("%q\n", v.Get("dog sounds"))
+	check(t, "Values.Get", o.String(), "\"meow\"\n\"\"\n")
+}
+
+func TestExampleValues_Has(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew")
+	v.Add("cat sounds", "mau")
+	o.Println(v.Has("cat sounds"))
+	o.Println(v.Has("dog sounds"))
+	check(t, "Values.Has", o.String(), "true\nfalse\n")
+}
+
+func TestExampleValues_Set(t *testing.T) {
+	o := &out{}
+	v := url.Values{}
+	v.Add("cat sounds", "meow")
+	v.Add("cat sounds", "mew")
+	v.Add("cat sounds", "mau")
+	o.Println(v["cat sounds"])
+
+	v.Set("cat sounds", "meow")
+	o.Println(v["cat sounds"])
+	check(t, "Values.Set", o.String(), "[meow mew mau]\n[meow]\n")
+}
+
+func TestExampleURL(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("http://bing.com/search?q=dotnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u.Scheme = "https"
+	u.Host = "google.com"
+	q := u.Query()
+	q.Set("q", "golang")
+	u.RawQuery = q.Encode()
+	o.Println(u)
+	check(t, "URL", o.String(), "https://google.com/search?q=golang\n")
+}
+
+func TestExampleURL_roundtrip(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.com/foo%2fbar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.Path)
+	o.Println(u.RawPath)
+	o.Println(u.String())
+	check(t, "URL_roundtrip", o.String(), "/foo/bar\n/foo%2fbar\nhttps://example.com/foo%2fbar\n")
+}
+
+func TestExampleURL_ResolveReference(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("../../..//search?q=dotnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := url.Parse("http://example.com/directory/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(base.ResolveReference(u))
+	check(t, "URL_ResolveReference", o.String(), "http://example.com/search?q=dotnet\n")
+}
+
+func TestExampleURL_EscapedPath(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("http://example.com/x/y%2Fz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println("Path:", u.Path)
+	o.Println("RawPath:", u.RawPath)
+	o.Println("EscapedPath:", u.EscapedPath())
+	check(t, "URL_EscapedPath", o.String(),
+		"Path: /x/y/z\nRawPath: /x/y%2Fz\nEscapedPath: /x/y%2Fz\n")
+}
+
+func TestExampleURL_EscapedFragment(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("http://example.com/#x/y%2Fz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println("Fragment:", u.Fragment)
+	o.Println("RawFragment:", u.RawFragment)
+	o.Println("EscapedFragment:", u.EscapedFragment())
+	check(t, "URL_EscapedFragment", o.String(),
+		"Fragment: x/y/z\nRawFragment: x/y%2Fz\nEscapedFragment: x/y%2Fz\n")
+}
+
+func TestExampleURL_Hostname(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.org:8000/path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.Hostname())
+	u, err = url.Parse("https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:17000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.Hostname())
+	check(t, "URL_Hostname", o.String(),
+		"example.org\n2001:0db8:85a3:0000:0000:8a2e:0370:7334\n")
+}
+
+func TestExampleURL_IsAbs(t *testing.T) {
+	o := &out{}
+	u := url.URL{Host: "example.com", Path: "foo"}
+	o.Println(u.IsAbs())
+	u.Scheme = "http"
+	o.Println(u.IsAbs())
+	check(t, "URL_IsAbs", o.String(), "false\ntrue\n")
+}
+
+func TestExampleURL_JoinPath(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.com/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.JoinPath("baz", "qux"))
+	check(t, "URL_JoinPath", o.String(), "https://example.com/foo/bar/baz/qux\n")
+}
+
+func TestExampleURL_MarshalBinary(t *testing.T) {
+	o := &out{}
+	u, _ := url.Parse("https://example.org")
+	b, err := u.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Printf("%s\n", b)
+	check(t, "URL_MarshalBinary", o.String(), "https://example.org\n")
+}
+
+func TestExampleURL_Parse(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := u.Parse("/foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(rel)
+	_, err = u.Parse(":foo")
+	if _, ok := err.(*url.Error); !ok {
+		t.Fatalf("u.Parse(\":foo\") err = %v; want *url.Error", err)
+	}
+	check(t, "URL_Parse", o.String(), "https://example.org/foo\n")
+}
+
+func TestExampleURL_Port(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.Port())
+	u, err = url.Parse("https://example.org:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.Port())
+	check(t, "URL_Port", o.String(), "\n8080\n")
+}
+
+func TestExampleURL_Query(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.org/?a=1&a=2&b=&=3&&&&")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := u.Query()
+	o.Println(q["a"])
+	o.Println(q.Get("b"))
+	o.Println(q.Get(""))
+	check(t, "URL_Query", o.String(), "[1 2]\n\n3\n")
+}
+
+func TestExampleURL_String(t *testing.T) {
+	o := &out{}
+	u := &url.URL{
+		Scheme:   "https",
+		User:     url.UserPassword("me", "pass"),
+		Host:     "example.com",
+		Path:     "foo/bar",
+		RawQuery: "x=1&y=2",
+		Fragment: "anchor",
+	}
+	o.Println(u.String())
+	u.Opaque = "opaque"
+	o.Println(u.String())
+	check(t, "URL_String", o.String(),
+		"https://me:pass@example.com/foo/bar?x=1&y=2#anchor\nhttps:opaque?x=1&y=2#anchor\n")
+}
+
+func TestExampleURL_UnmarshalBinary(t *testing.T) {
+	o := &out{}
+	u := &url.URL{}
+	err := u.UnmarshalBinary([]byte("https://example.org/foo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Printf("%s\n", u)
+	check(t, "URL_UnmarshalBinary", o.String(), "https://example.org/foo\n")
+}
+
+func TestExampleURL_Redacted(t *testing.T) {
+	o := &out{}
+	u := &url.URL{
+		Scheme: "https",
+		User:   url.UserPassword("user", "password"),
+		Host:   "example.com",
+		Path:   "foo/bar",
+	}
+	o.Println(u.Redacted())
+	u.User = url.UserPassword("me", "newerPassword")
+	o.Println(u.Redacted())
+	check(t, "URL_Redacted", o.String(),
+		"https://user:xxxxx@example.com/foo/bar\nhttps://me:xxxxx@example.com/foo/bar\n")
+}
+
+func TestExampleURL_RequestURI(t *testing.T) {
+	o := &out{}
+	u, err := url.Parse("https://example.org/path?foo=bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.Println(u.RequestURI())
+	check(t, "URL_RequestURI", o.String(), "/path?foo=bar\n")
+}

--- a/gnovm/stdlibs/net/url/url.gno
+++ b/gnovm/stdlibs/net/url/url.gno
@@ -928,7 +928,16 @@ func ParseQuery(query string) (Values, error) {
 	return m, err
 }
 
+// defaultMaxParams is the maximum number of query parameters returned
+// by [ParseQuery]. If the number of query parameters exceeds this,
+// [ParseQuery] returns an error. Upstream Go tunes this via
+// GODEBUG=urlmaxqueryparams=N; Gno has no GODEBUG so this is a hard limit.
+const defaultMaxParams = 10000
+
 func parseQuery(m Values, query string) (err error) {
+	if strings.Count(query, "&")+1 > defaultMaxParams {
+		return errors.New("number of URL query parameters exceeded limit")
+	}
 	for query != "" {
 		var key string
 		key, query, _ = strings.Cut(query, "&")

--- a/gnovm/stdlibs/net/url/url_test.gno
+++ b/gnovm/stdlibs/net/url/url_test.gno
@@ -1467,6 +1467,31 @@ func TestParseQuery(t *testing.T) {
 	}
 }
 
+func TestParseQueryTooManyParams(t *testing.T) {
+	// 10000 params: under the limit, must succeed.
+	const n = 10000
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString("a=b")
+	}
+	if _, err := ParseQuery(b.String()); err != nil {
+		t.Errorf("ParseQuery with %d params: unexpected error %v", n, err)
+	}
+
+	// 10001 params: over the limit, must error.
+	b.WriteString("&a=b")
+	_, err := ParseQuery(b.String())
+	if err == nil {
+		t.Fatalf("ParseQuery with %d params: got nil error, want too-many-params error", n+1)
+	}
+	if got, want := err.Error(), "number of URL query parameters exceeded limit"; got != want {
+		t.Errorf("ParseQuery error = %q, want %q", got, want)
+	}
+}
+
 type RequestURITest struct {
 	url *URL
 	out string

--- a/gnovm/stdlibs/path/example_test.gno
+++ b/gnovm/stdlibs/path/example_test.gno
@@ -1,0 +1,121 @@
+// Ported from upstream Go's path/example_test.go at go1.25.9.
+// These Examples are present upstream but were missing from Gno's port.
+// Skipped: TestCleanMallocs (needs testing.AllocsPerRun, not in Gno).
+
+package path_test
+
+import (
+	"fmt"
+	"path"
+)
+
+func ExampleBase() {
+	fmt.Println(path.Base("/a/b"))
+	fmt.Println(path.Base("/"))
+	fmt.Println(path.Base(""))
+	// Output:
+	// b
+	// /
+	// .
+}
+
+func ExampleClean() {
+	paths := []string{
+		"a/c",
+		"a//c",
+		"a/c/.",
+		"a/c/b/..",
+		"/../a/c",
+		"/../a/b/../././/c",
+		"",
+	}
+
+	for _, p := range paths {
+		fmt.Printf("Clean(%q) = %q\n", p, path.Clean(p))
+	}
+
+	// Output:
+	// Clean("a/c") = "a/c"
+	// Clean("a//c") = "a/c"
+	// Clean("a/c/.") = "a/c"
+	// Clean("a/c/b/..") = "a/c"
+	// Clean("/../a/c") = "/a/c"
+	// Clean("/../a/b/../././/c") = "/a/c"
+	// Clean("") = "."
+}
+
+func ExampleDir() {
+	fmt.Println(path.Dir("/a/b/c"))
+	fmt.Println(path.Dir("a/b/c"))
+	fmt.Println(path.Dir("/a/"))
+	fmt.Println(path.Dir("a/"))
+	fmt.Println(path.Dir("/"))
+	fmt.Println(path.Dir(""))
+	// Output:
+	// /a/b
+	// a/b
+	// /a
+	// a
+	// /
+	// .
+}
+
+func ExampleExt() {
+	fmt.Println(path.Ext("/a/b/c/bar.css"))
+	fmt.Println(path.Ext("/"))
+	fmt.Println(path.Ext(""))
+	// Output:
+	// .css
+	//
+	//
+}
+
+func ExampleIsAbs() {
+	fmt.Println(path.IsAbs("/dev/null"))
+	// Output: true
+}
+
+func ExampleJoin() {
+	fmt.Println(path.Join("a", "b", "c"))
+	fmt.Println(path.Join("a", "b/c"))
+	fmt.Println(path.Join("a/b", "c"))
+
+	fmt.Println(path.Join("a/b", "../../../xyz"))
+
+	fmt.Println(path.Join("", ""))
+	fmt.Println(path.Join("a", ""))
+	fmt.Println(path.Join("", "a"))
+
+	// Output:
+	// a/b/c
+	// a/b/c
+	// a/b/c
+	// ../xyz
+	//
+	// a
+	// a
+}
+
+func ExampleMatch() {
+	fmt.Println(path.Match("abc", "abc"))
+	fmt.Println(path.Match("a*", "abc"))
+	fmt.Println(path.Match("a*/b", "a/c/b"))
+	// Output:
+	// true <nil>
+	// true <nil>
+	// false <nil>
+}
+
+func ExampleSplit() {
+	split := func(s string) {
+		dir, file := path.Split(s)
+		fmt.Printf("path.Split(%q) = dir: %q, file: %q\n", s, dir, file)
+	}
+	split("static/myfile.css")
+	split("myfile.css")
+	split("")
+	// Output:
+	// path.Split("static/myfile.css") = dir: "static/", file: "myfile.css"
+	// path.Split("myfile.css") = dir: "", file: "myfile.css"
+	// path.Split("") = dir: "", file: ""
+}

--- a/gnovm/stdlibs/regexp/all_test.gno
+++ b/gnovm/stdlibs/regexp/all_test.gno
@@ -948,3 +948,44 @@ func TestMinInputLen(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshalText(t *testing.T) {
+	unmarshaled := new(Regexp)
+	for i := range goodRe {
+		re := compileTest(t, goodRe[i], "")
+		marshaled, err := re.MarshalText()
+		if err != nil {
+			t.Errorf("regexp %#q failed to marshal: %s", re, err)
+			continue
+		}
+		if err := unmarshaled.UnmarshalText(marshaled); err != nil {
+			t.Errorf("regexp %#q failed to unmarshal: %s", re, err)
+			continue
+		}
+		if unmarshaled.String() != goodRe[i] {
+			t.Errorf("UnmarshalText returned unexpected value: %s", unmarshaled.String())
+		}
+
+		buf := make([]byte, 4, 32)
+		marshalAppend, err := re.AppendText(buf)
+		if err != nil {
+			t.Errorf("regexp %#q failed to marshal: %s", re, err)
+			continue
+		}
+		marshalAppend = marshalAppend[4:]
+		if err := unmarshaled.UnmarshalText(marshalAppend); err != nil {
+			t.Errorf("regexp %#q failed to unmarshal: %s", re, err)
+			continue
+		}
+		if unmarshaled.String() != goodRe[i] {
+			t.Errorf("UnmarshalText returned unexpected value: %s", unmarshaled.String())
+		}
+	}
+	t.Run("invalid pattern", func(t *testing.T) {
+		re := new(Regexp)
+		err := re.UnmarshalText([]byte(`\`))
+		if err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}

--- a/gnovm/stdlibs/regexp/regexp.gno
+++ b/gnovm/stdlibs/regexp/regexp.gno
@@ -1276,3 +1276,32 @@ func (re *Regexp) Split(s string, n int) []string {
 
 	return strings
 }
+
+// AppendText implements [encoding.TextAppender]. The output
+// matches that of calling the [Regexp.String] method.
+//
+// Note that the output is lossy in some cases: This method does not indicate
+// POSIX regular expressions (i.e. those compiled by calling [CompilePOSIX]), or
+// those for which the [Regexp.Longest] method has been called.
+func (re *Regexp) AppendText(b []byte) ([]byte, error) {
+	return append(b, re.String()...), nil
+}
+
+// MarshalText implements [encoding.TextMarshaler]. The output
+// matches that of calling the [Regexp.AppendText] method.
+//
+// See [Regexp.AppendText] for more information.
+func (re *Regexp) MarshalText() ([]byte, error) {
+	return re.AppendText(nil)
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler] by calling
+// [Compile] on the encoded value.
+func (re *Regexp) UnmarshalText(text []byte) error {
+	newRE, err := Compile(string(text))
+	if err != nil {
+		return err
+	}
+	*re = *newRE
+	return nil
+}

--- a/gnovm/stdlibs/regexp/syntax/parse.gno
+++ b/gnovm/stdlibs/regexp/syntax/parse.gno
@@ -1860,6 +1860,22 @@ func negateClass(r []rune) []rune {
 	return r
 }
 
+// inCharClass reports whether r is in the class.
+// It assumes the class has been cleaned by cleanClass.
+func inCharClass(r rune, class []rune) bool {
+	_, ok := sort.Find(len(class)/2, func(i int) int {
+		lo, hi := class[2*i], class[2*i+1]
+		if r > hi {
+			return +1
+		}
+		if r < lo {
+			return -1
+		}
+		return 0
+	})
+	return ok
+}
+
 // ranges implements sort.Interface on a []rune.
 // The choice of receiver type definition is strange
 // but avoids an allocation since we already have

--- a/gnovm/stdlibs/regexp/syntax/parse_test.gno
+++ b/gnovm/stdlibs/regexp/syntax/parse_test.gno
@@ -589,3 +589,43 @@ func TestToStringEquivalentParse(t *testing.T) {
 		}
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Tests ported from upstream go1.25.9 parse_test.go.
+// -----------------------------------------------------------------------------
+
+var stringTests = []struct {
+	re  string
+	out string
+}{
+	{`x(?i:ab*c|d?e)1`, `x(?i:AB*C|D?E)1`},
+	{`x(?i:ab*cd?e)1`, `x(?i:AB*CD?E)1`},
+	{`0(?i:ab*c|d?e)1`, `(?i:0(?:AB*C|D?E)1)`},
+	{`0(?i:ab*cd?e)1`, `(?i:0AB*CD?E1)`},
+	{`x(?i:ab*c|d?e)`, `x(?i:AB*C|D?E)`},
+	{`x(?i:ab*cd?e)`, `x(?i:AB*CD?E)`},
+	{`0(?i:ab*c|d?e)`, `(?i:0(?:AB*C|D?E))`},
+	{`0(?i:ab*cd?e)`, `(?i:0AB*CD?E)`},
+	{`(?i:ab*c|d?e)1`, `(?i:(?:AB*C|D?E)1)`},
+	{`(?i:ab*cd?e)1`, `(?i:AB*CD?E1)`},
+	{`(?i:ab)[123](?i:cd)`, `(?i:AB[1-3]CD)`},
+	{`(?i:ab*c|d?e)`, `(?i:AB*C|D?E)`},
+	{`[Aa][Bb]`, `(?i:AB)`},
+	{`[Aa][Bb]*[Cc]`, `(?i:AB*C)`},
+	{`A(?:[Bb][Cc]|[Dd])[Zz]`, `A(?i:(?:BC|D)Z)`},
+	{`[Aa](?:[Bb][Cc]|[Dd])Z`, `(?i:A(?:BC|D))Z`},
+}
+
+func TestString(t *testing.T) {
+	for _, tt := range stringTests {
+		re, err := Parse(tt.re, Perl)
+		if err != nil {
+			t.Errorf("Parse(%#q): %v", tt.re, err)
+			continue
+		}
+		out := re.String()
+		if out != tt.out {
+			t.Errorf("Parse(%#q).String() = %#q, want %#q", tt.re, out, tt.out)
+		}
+	}
+}

--- a/gnovm/stdlibs/regexp/syntax/regexp.gno
+++ b/gnovm/stdlibs/regexp/syntax/regexp.gno
@@ -112,8 +112,171 @@ func (x *Regexp) Equal(y *Regexp) bool {
 	return true
 }
 
+// printFlags is a bit set indicating which flags (including non-capturing parens) to print around a regexp.
+type printFlags uint8
+
+const (
+	flagI    printFlags = 1 << iota // (?i:
+	flagM                           // (?m:
+	flagS                           // (?s:
+	flagOff                         // )
+	flagPrec                        // (?: )
+	negShift = 5                    // flagI<<negShift is (?-i:
+)
+
+// addSpan enables the flags f around start..last,
+// by setting flags[start] = f and flags[last] = flagOff.
+func addSpan(start, last *Regexp, f printFlags, flags *map[*Regexp]printFlags) {
+	if *flags == nil {
+		*flags = make(map[*Regexp]printFlags)
+	}
+	(*flags)[start] = f
+	(*flags)[last] |= flagOff // maybe start==last
+}
+
+// calcFlags calculates the flags to print around each subexpression in re,
+// storing that information in (*flags)[sub] for each affected subexpression.
+// The first time an entry needs to be written to *flags, calcFlags allocates the map.
+// calcFlags also calculates the flags that must be active or can't be active
+// around re and returns those flags.
+func calcFlags(re *Regexp, flags *map[*Regexp]printFlags) (must, cant printFlags) {
+	switch re.Op {
+	default:
+		return 0, 0
+
+	case OpLiteral:
+		// If literal is fold-sensitive, return (flagI, 0) or (0, flagI)
+		// according to whether (?i) is active.
+		// If literal is not fold-sensitive, return 0, 0.
+		for _, r := range re.Rune {
+			if minFold <= r && r <= maxFold && unicode.SimpleFold(r) != r {
+				if re.Flags&FoldCase != 0 {
+					return flagI, 0
+				} else {
+					return 0, flagI
+				}
+			}
+		}
+		return 0, 0
+
+	case OpCharClass:
+		// If literal is fold-sensitive, return 0, flagI - (?i) has been compiled out.
+		// If literal is not fold-sensitive, return 0, 0.
+		for i := 0; i < len(re.Rune); i += 2 {
+			lo := re.Rune[i]
+			if lo < minFold {
+				lo = minFold
+			}
+			hi := re.Rune[i+1]
+			if hi > maxFold {
+				hi = maxFold
+			}
+			for r := lo; r <= hi; r++ {
+				for f := unicode.SimpleFold(r); f != r; f = unicode.SimpleFold(f) {
+					if !(lo <= f && f <= hi) && !inCharClass(f, re.Rune) {
+						return 0, flagI
+					}
+				}
+			}
+		}
+		return 0, 0
+
+	case OpAnyCharNotNL: // (?-s).
+		return 0, flagS
+
+	case OpAnyChar: // (?s).
+		return flagS, 0
+
+	case OpBeginLine, OpEndLine: // (?m)^ (?m)$
+		return flagM, 0
+
+	case OpEndText:
+		if re.Flags&WasDollar != 0 { // (?-m)$
+			return 0, flagM
+		}
+		return 0, 0
+
+	case OpCapture, OpStar, OpPlus, OpQuest, OpRepeat:
+		return calcFlags(re.Sub[0], flags)
+
+	case OpConcat, OpAlternate:
+		// Gather the must and cant for each subexpression.
+		// When we find a conflicting subexpression, insert the necessary
+		// flags around the previously identified span and start over.
+		var must, cant, allCant printFlags
+		start := 0
+		last := 0
+		did := false
+		for i, sub := range re.Sub {
+			subMust, subCant := calcFlags(sub, flags)
+			if must&subCant != 0 || subMust&cant != 0 {
+				if must != 0 {
+					addSpan(re.Sub[start], re.Sub[last], must, flags)
+				}
+				must = 0
+				cant = 0
+				start = i
+				did = true
+			}
+			must |= subMust
+			cant |= subCant
+			allCant |= subCant
+			if subMust != 0 {
+				last = i
+			}
+			if must == 0 && start == i {
+				start++
+			}
+		}
+		if !did {
+			// No conflicts: pass the accumulated must and cant upward.
+			return must, cant
+		}
+		if must != 0 {
+			// Conflicts found; need to finish final span.
+			addSpan(re.Sub[start], re.Sub[last], must, flags)
+		}
+		return 0, allCant
+	}
+}
+
 // writeRegexp writes the Perl syntax for the regular expression re to b.
-func writeRegexp(b *strings.Builder, re *Regexp) {
+func writeRegexp(b *strings.Builder, re *Regexp, f printFlags, flags map[*Regexp]printFlags) {
+	f |= flags[re]
+	if f&flagPrec != 0 && f&^(flagOff|flagPrec) != 0 && f&flagOff != 0 {
+		// flagPrec is redundant with other flags being added and terminated
+		f &^= flagPrec
+	}
+	if f&^(flagOff|flagPrec) != 0 {
+		b.WriteString(`(?`)
+		if f&flagI != 0 {
+			b.WriteString(`i`)
+		}
+		if f&flagM != 0 {
+			b.WriteString(`m`)
+		}
+		if f&flagS != 0 {
+			b.WriteString(`s`)
+		}
+		if f&((flagM|flagS)<<negShift) != 0 {
+			b.WriteString(`-`)
+			if f&(flagM<<negShift) != 0 {
+				b.WriteString(`m`)
+			}
+			if f&(flagS<<negShift) != 0 {
+				b.WriteString(`s`)
+			}
+		}
+		b.WriteString(`:`)
+	}
+	if f&flagOff != 0 {
+		defer b.WriteString(`)`)
+	}
+	if f&flagPrec != 0 {
+		b.WriteString(`(?:`)
+		defer b.WriteString(`)`)
+	}
+
 	switch re.Op {
 	default:
 		b.WriteString("<invalid op" + strconv.Itoa(int(re.Op)) + ">")
@@ -122,14 +285,8 @@ func writeRegexp(b *strings.Builder, re *Regexp) {
 	case OpEmptyMatch:
 		b.WriteString(`(?:)`)
 	case OpLiteral:
-		if re.Flags&FoldCase != 0 {
-			b.WriteString(`(?i:`)
-		}
 		for _, r := range re.Rune {
 			escape(b, r, false)
-		}
-		if re.Flags&FoldCase != 0 {
-			b.WriteString(`)`)
 		}
 	case OpCharClass:
 		if len(re.Rune)%2 != 0 {
@@ -147,7 +304,9 @@ func writeRegexp(b *strings.Builder, re *Regexp) {
 				lo, hi := re.Rune[i]+1, re.Rune[i+1]-1
 				escape(b, lo, lo == '-')
 				if lo != hi {
-					b.WriteRune('-')
+					if hi != lo+1 {
+						b.WriteRune('-')
+					}
 					escape(b, hi, hi == '-')
 				}
 			}
@@ -156,25 +315,25 @@ func writeRegexp(b *strings.Builder, re *Regexp) {
 				lo, hi := re.Rune[i], re.Rune[i+1]
 				escape(b, lo, lo == '-')
 				if lo != hi {
-					b.WriteRune('-')
+					if hi != lo+1 {
+						b.WriteRune('-')
+					}
 					escape(b, hi, hi == '-')
 				}
 			}
 		}
 		b.WriteRune(']')
-	case OpAnyCharNotNL:
-		b.WriteString(`(?-s:.)`)
-	case OpAnyChar:
-		b.WriteString(`(?s:.)`)
+	case OpAnyCharNotNL, OpAnyChar:
+		b.WriteString(`.`)
 	case OpBeginLine:
-		b.WriteString(`(?m:^)`)
+		b.WriteString(`^`)
 	case OpEndLine:
-		b.WriteString(`(?m:$)`)
+		b.WriteString(`$`)
 	case OpBeginText:
 		b.WriteString(`\A`)
 	case OpEndText:
 		if re.Flags&WasDollar != 0 {
-			b.WriteString(`(?-m:$)`)
+			b.WriteString(`$`)
 		} else {
 			b.WriteString(`\z`)
 		}
@@ -191,17 +350,17 @@ func writeRegexp(b *strings.Builder, re *Regexp) {
 			b.WriteRune('(')
 		}
 		if re.Sub[0].Op != OpEmptyMatch {
-			writeRegexp(b, re.Sub[0])
+			writeRegexp(b, re.Sub[0], flags[re.Sub[0]], flags)
 		}
 		b.WriteRune(')')
 	case OpStar, OpPlus, OpQuest, OpRepeat:
-		if sub := re.Sub[0]; sub.Op > OpCapture || sub.Op == OpLiteral && len(sub.Rune) > 1 {
-			b.WriteString(`(?:`)
-			writeRegexp(b, sub)
-			b.WriteString(`)`)
-		} else {
-			writeRegexp(b, sub)
+		p := printFlags(0)
+		sub := re.Sub[0]
+		if sub.Op > OpCapture || sub.Op == OpLiteral && len(sub.Rune) > 1 {
+			p = flagPrec
 		}
+		writeRegexp(b, sub, p, flags)
+
 		switch re.Op {
 		case OpStar:
 			b.WriteRune('*')
@@ -225,27 +384,31 @@ func writeRegexp(b *strings.Builder, re *Regexp) {
 		}
 	case OpConcat:
 		for _, sub := range re.Sub {
+			p := printFlags(0)
 			if sub.Op == OpAlternate {
-				b.WriteString(`(?:`)
-				writeRegexp(b, sub)
-				b.WriteString(`)`)
-			} else {
-				writeRegexp(b, sub)
+				p = flagPrec
 			}
+			writeRegexp(b, sub, p, flags)
 		}
 	case OpAlternate:
 		for i, sub := range re.Sub {
 			if i > 0 {
 				b.WriteRune('|')
 			}
-			writeRegexp(b, sub)
+			writeRegexp(b, sub, 0, flags)
 		}
 	}
 }
 
 func (re *Regexp) String() string {
 	var b strings.Builder
-	writeRegexp(&b, re)
+	var flags map[*Regexp]printFlags
+	must, cant := calcFlags(re, &flags)
+	must |= (cant &^ flagI) << negShift
+	if must != 0 {
+		must |= flagOff
+	}
+	writeRegexp(&b, re, must, flags)
 	return b.String()
 }
 

--- a/gnovm/stdlibs/regexp/syntax/simplify_test.gno
+++ b/gnovm/stdlibs/regexp/syntax/simplify_test.gno
@@ -13,7 +13,7 @@ var simplifyTests = []struct {
 	// Already-simple constructs
 	{`a`, `a`},
 	{`ab`, `ab`},
-	{`a|b`, `[a-b]`},
+	{`a|b`, `[ab]`},
 	{`ab|cd`, `ab|cd`},
 	{`(ab)*`, `(ab)*`},
 	{`(ab)+`, `(ab)+`},
@@ -40,16 +40,16 @@ var simplifyTests = []struct {
 
 	// Perl character classes
 	{`\d`, `[0-9]`},
-	{`\s`, `[\t-\n\f-\r ]`},
+	{`\s`, `[\t\n\f\r ]`},
 	{`\w`, `[0-9A-Z_a-z]`},
 	{`\D`, `[^0-9]`},
-	{`\S`, `[^\t-\n\f-\r ]`},
+	{`\S`, `[^\t\n\f\r ]`},
 	{`\W`, `[^0-9A-Z_a-z]`},
 	{`[\d]`, `[0-9]`},
-	{`[\s]`, `[\t-\n\f-\r ]`},
+	{`[\s]`, `[\t\n\f\r ]`},
 	{`[\w]`, `[0-9A-Z_a-z]`},
 	{`[\D]`, `[^0-9]`},
-	{`[\S]`, `[^\t-\n\f-\r ]`},
+	{`[\S]`, `[^\t\n\f\r ]`},
 	{`[\W]`, `[^0-9A-Z_a-z]`},
 
 	// Posix repetitions
@@ -82,7 +82,7 @@ var simplifyTests = []struct {
 	{`a{0}`, `(?:)`},
 
 	// Character class simplification
-	{`[ab]`, `[a-b]`},
+	{`[ab]`, `[ab]`},
 	{`[a-za-za-z]`, `[a-z]`},
 	{`[A-Za-zA-Za-z]`, `[A-Za-z]`},
 	{`[ABCDEFGH]`, `[A-H]`},
@@ -120,7 +120,7 @@ var simplifyTests = []struct {
 	// interesting than they might otherwise be. String inserts
 	// explicit (?:) in place of non-parenthesized empty strings,
 	// to make them easier to spot for other parsers.
-	{`(a|b|)`, `([a-b]|(?:))`},
+	{`(a|b|)`, `([ab]|(?:))`},
 	{`(|)`, `()`},
 	{`a()`, `a()`},
 	{`(()|())`, `(()|())`},

--- a/gnovm/stdlibs/sort/example_test.gno
+++ b/gnovm/stdlibs/sort/example_test.gno
@@ -1,0 +1,378 @@
+// Ported from upstream Go's sort examples at go1.25.9.
+// Combines content from upstream example_test.go, example_search_test.go,
+// example_keys_test.go, example_multi_test.go, and example_wrapper_test.go.
+// Skipped:
+//   - ExampleFind: sort.Find not in Gno
+//   - ExampleSlice/SliceStable/SliceIsSorted: depend on sort.Slice (not in Gno)
+//   - Example: uses sort.Slice in its second half
+
+package sort_test
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// --- example_test.go ---
+
+func ExampleInts() {
+	s := []int{5, 2, 6, 3, 1, 4} // unsorted
+	sort.Ints(s)
+	fmt.Println(s)
+	// Output: [1 2 3 4 5 6]
+}
+
+func ExampleIntsAreSorted() {
+	s := []int{1, 2, 3, 4, 5, 6} // sorted ascending
+	fmt.Println(sort.IntsAreSorted(s))
+
+	s = []int{6, 5, 4, 3, 2, 1} // sorted descending
+	fmt.Println(sort.IntsAreSorted(s))
+
+	s = []int{3, 2, 4, 1, 5} // unsorted
+	fmt.Println(sort.IntsAreSorted(s))
+
+	// Output: true
+	// false
+	// false
+}
+
+func ExampleFloat64s() {
+	s := []float64{5.2, -1.3, 0.7, -3.8, 2.6} // unsorted
+	sort.Float64s(s)
+	fmt.Println(s)
+
+	s = []float64{math.Inf(1), math.NaN(), math.Inf(-1), 0.0} // unsorted
+	sort.Float64s(s)
+	fmt.Println(s)
+
+	// Output: [-3.8 -1.3 0.7 2.6 5.2]
+	// [NaN -Inf 0 +Inf]
+}
+
+func ExampleFloat64sAreSorted() {
+	s := []float64{0.7, 1.3, 2.6, 3.8, 5.2} // sorted ascending
+	fmt.Println(sort.Float64sAreSorted(s))
+
+	s = []float64{5.2, 3.8, 2.6, 1.3, 0.7} // sorted descending
+	fmt.Println(sort.Float64sAreSorted(s))
+
+	s = []float64{5.2, 1.3, 0.7, 3.8, 2.6} // unsorted
+	fmt.Println(sort.Float64sAreSorted(s))
+
+	// Output: true
+	// false
+	// false
+}
+
+func ExampleReverse() {
+	s := []int{5, 2, 6, 3, 1, 4} // unsorted
+	sort.Sort(sort.Reverse(sort.IntSlice(s)))
+	fmt.Println(s)
+	// Output: [6 5 4 3 2 1]
+}
+
+func ExampleStrings() {
+	s := []string{"Go", "Bravo", "Gopher", "Alpha", "Grin", "Delta"}
+	sort.Strings(s)
+	fmt.Println(s)
+	// Output: [Alpha Bravo Delta Go Gopher Grin]
+}
+
+// --- example_search_test.go ---
+
+// This example demonstrates searching a list sorted in ascending order.
+func ExampleSearch() {
+	a := []int{1, 3, 6, 10, 15, 21, 28, 36, 45, 55}
+	x := 6
+
+	i := sort.Search(len(a), func(i int) bool { return a[i] >= x })
+	if i < len(a) && a[i] == x {
+		fmt.Printf("found %d at index %d in %v\n", x, i, a)
+	} else {
+		fmt.Printf("%d not found in %v\n", x, a)
+	}
+	// Output:
+	// found 6 at index 2 in [1 3 6 10 15 21 28 36 45 55]
+}
+
+// This example demonstrates searching a list sorted in descending order.
+// The approach is the same as searching a list in ascending order,
+// but with the condition inverted.
+func ExampleSearch_descendingOrder() {
+	a := []int{55, 45, 36, 28, 21, 15, 10, 6, 3, 1}
+	x := 6
+
+	i := sort.Search(len(a), func(i int) bool { return a[i] <= x })
+	if i < len(a) && a[i] == x {
+		fmt.Printf("found %d at index %d in %v\n", x, i, a)
+	} else {
+		fmt.Printf("%d not found in %v\n", x, a)
+	}
+	// Output:
+	// found 6 at index 7 in [55 45 36 28 21 15 10 6 3 1]
+}
+
+func ExampleSearchFloat64s() {
+	a := []float64{1.0, 2.0, 3.3, 4.6, 6.1, 7.2, 8.0}
+
+	x := 2.0
+	i := sort.SearchFloat64s(a, x)
+	fmt.Printf("found %g at index %d in %v\n", x, i, a)
+
+	x = 0.5
+	i = sort.SearchFloat64s(a, x)
+	fmt.Printf("%g not found, can be inserted at index %d in %v\n", x, i, a)
+	// Output:
+	// found 2 at index 1 in [1 2 3.3 4.6 6.1 7.2 8]
+	// 0.5 not found, can be inserted at index 0 in [1 2 3.3 4.6 6.1 7.2 8]
+}
+
+func ExampleSearchInts() {
+	a := []int{1, 2, 3, 4, 6, 7, 8}
+
+	x := 2
+	i := sort.SearchInts(a, x)
+	fmt.Printf("found %d at index %d in %v\n", x, i, a)
+
+	x = 5
+	i = sort.SearchInts(a, x)
+	fmt.Printf("%d not found, can be inserted at index %d in %v\n", x, i, a)
+	// Output:
+	// found 2 at index 1 in [1 2 3 4 6 7 8]
+	// 5 not found, can be inserted at index 4 in [1 2 3 4 6 7 8]
+}
+
+func ExampleSearchStrings() {
+	a := []string{"apple", "banana", "cherry", "date", "fig", "grape"}
+
+	x := "banana"
+	i := sort.SearchStrings(a, x)
+	fmt.Printf("found %s at index %d in %v\n", x, i, a)
+
+	x = "coconut"
+	i = sort.SearchStrings(a, x)
+	fmt.Printf("%s not found, can be inserted at index %d in %v\n", x, i, a)
+
+	// Output:
+	// found banana at index 1 in [apple banana cherry date fig grape]
+	// coconut not found, can be inserted at index 3 in [apple banana cherry date fig grape]
+}
+
+// --- example_keys_test.go (custom sort.Interface using a key function) ---
+
+// A couple of type definitions to make the units clear.
+type earthMass float64
+type au float64
+
+// A Planet defines the properties of a solar system object.
+type Planet struct {
+	name     string
+	mass     earthMass
+	distance au
+}
+
+// By is the type of a "less" function that defines the ordering of its
+// Planet arguments.
+type By func(p1, p2 *Planet) bool
+
+// Sort is a method on the function type, By, that sorts the argument slice
+// according to the function.
+func (by By) Sort(planets []Planet) {
+	ps := &planetSorter{
+		planets: planets,
+		by:      by,
+	}
+	sort.Sort(ps)
+}
+
+// planetSorter joins a By function and a slice of Planets to be sorted.
+type planetSorter struct {
+	planets []Planet
+	by      func(p1, p2 *Planet) bool
+}
+
+func (s *planetSorter) Len() int      { return len(s.planets) }
+func (s *planetSorter) Swap(i, j int) { s.planets[i], s.planets[j] = s.planets[j], s.planets[i] }
+func (s *planetSorter) Less(i, j int) bool {
+	return s.by(&s.planets[i], &s.planets[j])
+}
+
+var planets = []Planet{
+	{"Mercury", 0.055, 0.4},
+	{"Venus", 0.815, 0.7},
+	{"Earth", 1.0, 1.0},
+	{"Mars", 0.107, 1.5},
+}
+
+func Example_sortKeys() {
+	name := func(p1, p2 *Planet) bool { return p1.name < p2.name }
+	mass := func(p1, p2 *Planet) bool { return p1.mass < p2.mass }
+	distance := func(p1, p2 *Planet) bool { return p1.distance < p2.distance }
+	decreasingDistance := func(p1, p2 *Planet) bool { return distance(p2, p1) }
+
+	By(name).Sort(planets)
+	fmt.Println("By name:", planets)
+
+	By(mass).Sort(planets)
+	fmt.Println("By mass:", planets)
+
+	By(distance).Sort(planets)
+	fmt.Println("By distance:", planets)
+
+	By(decreasingDistance).Sort(planets)
+	fmt.Println("By decreasing distance:", planets)
+
+	// Output: By name: [{Earth 1 1} {Mars 0.107 1.5} {Mercury 0.055 0.4} {Venus 0.815 0.7}]
+	// By mass: [{Mercury 0.055 0.4} {Mars 0.107 1.5} {Venus 0.815 0.7} {Earth 1 1}]
+	// By distance: [{Mercury 0.055 0.4} {Venus 0.815 0.7} {Earth 1 1} {Mars 0.107 1.5}]
+	// By decreasing distance: [{Mars 0.107 1.5} {Earth 1 1} {Venus 0.815 0.7} {Mercury 0.055 0.4}]
+}
+
+// --- example_multi_test.go ---
+
+type Change struct {
+	user     string
+	language string
+	lines    int
+}
+
+type lessFunc func(p1, p2 *Change) bool
+
+type multiSorter struct {
+	changes []Change
+	less    []lessFunc
+}
+
+func (ms *multiSorter) Sort(changes []Change) {
+	ms.changes = changes
+	sort.Sort(ms)
+}
+
+func OrderedBy(less ...lessFunc) *multiSorter {
+	return &multiSorter{less: less}
+}
+
+func (ms *multiSorter) Len() int      { return len(ms.changes) }
+func (ms *multiSorter) Swap(i, j int) { ms.changes[i], ms.changes[j] = ms.changes[j], ms.changes[i] }
+func (ms *multiSorter) Less(i, j int) bool {
+	p, q := &ms.changes[i], &ms.changes[j]
+	var k int
+	for k = 0; k < len(ms.less)-1; k++ {
+		less := ms.less[k]
+		switch {
+		case less(p, q):
+			return true
+		case less(q, p):
+			return false
+		}
+	}
+	return ms.less[k](p, q)
+}
+
+var changes = []Change{
+	{"gri", "Go", 100},
+	{"ken", "C", 150},
+	{"glenda", "Go", 200},
+	{"rsc", "Go", 200},
+	{"r", "Go", 100},
+	{"ken", "Go", 200},
+	{"dmr", "C", 100},
+	{"r", "C", 150},
+	{"gri", "Smalltalk", 80},
+}
+
+func Example_sortMultiKeys() {
+	user := func(c1, c2 *Change) bool { return c1.user < c2.user }
+	language := func(c1, c2 *Change) bool { return c1.language < c2.language }
+	increasingLines := func(c1, c2 *Change) bool { return c1.lines < c2.lines }
+	decreasingLines := func(c1, c2 *Change) bool { return c1.lines > c2.lines }
+
+	OrderedBy(user).Sort(changes)
+	fmt.Println("By user:", changes)
+
+	OrderedBy(user, increasingLines).Sort(changes)
+	fmt.Println("By user,<lines:", changes)
+
+	OrderedBy(user, decreasingLines).Sort(changes)
+	fmt.Println("By user,>lines:", changes)
+
+	OrderedBy(language, increasingLines).Sort(changes)
+	fmt.Println("By language,<lines:", changes)
+
+	OrderedBy(language, increasingLines, user).Sort(changes)
+	fmt.Println("By language,<lines,user:", changes)
+
+	// Output:
+	// By user: [{dmr C 100} {glenda Go 200} {gri Go 100} {gri Smalltalk 80} {ken C 150} {ken Go 200} {r Go 100} {r C 150} {rsc Go 200}]
+	// By user,<lines: [{dmr C 100} {glenda Go 200} {gri Smalltalk 80} {gri Go 100} {ken C 150} {ken Go 200} {r Go 100} {r C 150} {rsc Go 200}]
+	// By user,>lines: [{dmr C 100} {glenda Go 200} {gri Go 100} {gri Smalltalk 80} {ken Go 200} {ken C 150} {r C 150} {r Go 100} {rsc Go 200}]
+	// By language,<lines: [{dmr C 100} {ken C 150} {r C 150} {gri Go 100} {r Go 100} {glenda Go 200} {ken Go 200} {rsc Go 200} {gri Smalltalk 80}]
+	// By language,<lines,user: [{dmr C 100} {ken C 150} {r C 150} {gri Go 100} {r Go 100} {glenda Go 200} {ken Go 200} {rsc Go 200} {gri Smalltalk 80}]
+}
+
+// --- example_wrapper_test.go ---
+
+type Grams int
+
+func (g Grams) String() string { return fmt.Sprintf("%dg", int(g)) }
+
+type Organ struct {
+	Name   string
+	Weight Grams
+}
+
+type Organs []*Organ
+
+func (s Organs) Len() int      { return len(s) }
+func (s Organs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+type ByName struct{ Organs }
+
+func (s ByName) Less(i, j int) bool { return s.Organs[i].Name < s.Organs[j].Name }
+
+type ByWeight struct{ Organs }
+
+func (s ByWeight) Less(i, j int) bool { return s.Organs[i].Weight < s.Organs[j].Weight }
+
+func Example_sortWrapper() {
+	s := []*Organ{
+		{"brain", 1340},
+		{"heart", 290},
+		{"liver", 1494},
+		{"pancreas", 131},
+		{"prostate", 62},
+		{"spleen", 162},
+	}
+
+	sort.Sort(ByWeight{s})
+	fmt.Println("Organs by weight:")
+	printOrgans(s)
+
+	sort.Sort(ByName{s})
+	fmt.Println("Organs by name:")
+	printOrgans(s)
+
+	// Output:
+	// Organs by weight:
+	// prostate (62g)
+	// pancreas (131g)
+	// spleen   (162g)
+	// heart    (290g)
+	// brain    (1340g)
+	// liver    (1494g)
+	// Organs by name:
+	// brain    (1340g)
+	// heart    (290g)
+	// liver    (1494g)
+	// pancreas (131g)
+	// prostate (62g)
+	// spleen   (162g)
+}
+
+func printOrgans(s []*Organ) {
+	for _, o := range s {
+		fmt.Printf("%-8s (%v)\n", o.Name, o.Weight)
+	}
+}

--- a/gnovm/stdlibs/sort/search.gno
+++ b/gnovm/stdlibs/sort/search.gno
@@ -72,6 +72,48 @@ func Search(n int, f func(int) bool) int {
 	return i
 }
 
+// Find uses binary search to find and return the smallest index i in [0, n)
+// at which cmp(i) <= 0. If there is no such index i, Find returns i = n.
+// The found result is true if i < n and cmp(i) == 0.
+// Find calls cmp(i) only for i in the range [0, n).
+//
+// To permit binary search, Find requires that cmp(i) > 0 for a leading
+// prefix of the range, cmp(i) == 0 in the middle, and cmp(i) < 0 for
+// the final suffix of the range. (Each subrange could be empty.)
+// The usual way to establish this condition is to interpret cmp(i)
+// as a comparison of a desired target value t against entry i in an
+// underlying indexed data structure x, returning <0, 0, and >0
+// when t < x[i], t == x[i], and t > x[i], respectively.
+//
+// For example, to look for a particular string in a sorted, random-access
+// list of strings:
+//
+//	i, found := sort.Find(x.Len(), func(i int) int {
+//	    return strings.Compare(target, x.At(i))
+//	})
+//	if found {
+//	    fmt.Printf("found %s at entry %d\n", target, i)
+//	} else {
+//	    fmt.Printf("%s not found, would insert at %d", target, i)
+//	}
+func Find(n int, cmp func(int) int) (i int, found bool) {
+	// The invariants here are similar to the ones in Search.
+	// Define cmp(-1) > 0 and cmp(n) <= 0
+	// Invariant: cmp(i-1) > 0, cmp(j) <= 0
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		if cmp(h) > 0 {
+			i = h + 1 // preserves cmp(i-1) > 0
+		} else {
+			j = h // preserves cmp(j) <= 0
+		}
+	}
+	// i == j, cmp(i-1) > 0 and cmp(j) <= 0
+	return i, i < n && cmp(i) == 0
+}
+
 // Convenience wrappers for common cases.
 
 // SearchInts searches for x in a sorted slice of ints and returns the index

--- a/gnovm/stdlibs/sort/search_test.gno
+++ b/gnovm/stdlibs/sort/search_test.gno
@@ -6,6 +6,7 @@ package sort_test
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -160,6 +161,110 @@ func TestSearchExhaustive(t *testing.T) {
 			i := sort.Search(size, func(i int) bool { return i >= targ })
 			if i != targ {
 				t.Errorf("Search(%d, %d) = %d", size, targ, i)
+			}
+		}
+	}
+}
+
+func TestFind(t *testing.T) {
+	str1 := []string{"foo"}
+	str2 := []string{"ab", "ca"}
+	str3 := []string{"mo", "qo", "vo"}
+	str4 := []string{"ab", "ad", "ca", "xy"}
+
+	// slice with repeating elements
+	strRepeats := []string{"ba", "ca", "da", "da", "da", "ka", "ma", "ma", "ta"}
+
+	// slice with all element equal
+	strSame := []string{"xx", "xx", "xx"}
+
+	tests := []struct {
+		data      []string
+		target    string
+		wantPos   int
+		wantFound bool
+	}{
+		{[]string{}, "foo", 0, false},
+		{[]string{}, "", 0, false},
+
+		{str1, "foo", 0, true},
+		{str1, "bar", 0, false},
+		{str1, "zx", 1, false},
+
+		{str2, "aa", 0, false},
+		{str2, "ab", 0, true},
+		{str2, "ad", 1, false},
+		{str2, "ca", 1, true},
+		{str2, "ra", 2, false},
+
+		{str3, "bb", 0, false},
+		{str3, "mo", 0, true},
+		{str3, "nb", 1, false},
+		{str3, "qo", 1, true},
+		{str3, "tr", 2, false},
+		{str3, "vo", 2, true},
+		{str3, "xr", 3, false},
+
+		{str4, "aa", 0, false},
+		{str4, "ab", 0, true},
+		{str4, "ac", 1, false},
+		{str4, "ad", 1, true},
+		{str4, "ax", 2, false},
+		{str4, "ca", 2, true},
+		{str4, "cc", 3, false},
+		{str4, "dd", 3, false},
+		{str4, "xy", 3, true},
+		{str4, "zz", 4, false},
+
+		{strRepeats, "da", 2, true},
+		{strRepeats, "db", 5, false},
+		{strRepeats, "ma", 6, true},
+		{strRepeats, "mb", 8, false},
+
+		{strSame, "xx", 0, true},
+		{strSame, "ab", 0, false},
+		{strSame, "zz", 3, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			cmp := func(i int) int {
+				return strings.Compare(tt.target, tt.data[i])
+			}
+
+			pos, found := sort.Find(len(tt.data), cmp)
+			if pos != tt.wantPos || found != tt.wantFound {
+				t.Errorf("Find got (%v, %v), want (%v, %v)", pos, found, tt.wantPos, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestFindExhaustive(t *testing.T) {
+	// Test Find for different sequence sizes and search targets.
+	// For each size, we have a (unmaterialized) sequence of integers:
+	//   2,4...size*2
+	// And we're looking for every possible integer between 1 and size*2 + 1.
+	for size := 0; size <= 100; size++ {
+		for x := 1; x <= size*2+1; x++ {
+			var wantFound bool
+			var wantPos int
+
+			cmp := func(i int) int {
+				// Encodes the unmaterialized sequence with elem[i] == (i+1)*2
+				return x - (i+1)*2
+			}
+			pos, found := sort.Find(size, cmp)
+
+			if x%2 == 0 {
+				wantPos = x/2 - 1
+				wantFound = true
+			} else {
+				wantPos = x / 2
+				wantFound = false
+			}
+			if found != wantFound || pos != wantPos {
+				t.Errorf("Find(%d, %d): got (%v, %v), want (%v, %v)", size, x, pos, found, wantPos, wantFound)
 			}
 		}
 	}

--- a/gnovm/stdlibs/strconv/doc.gno
+++ b/gnovm/stdlibs/strconv/doc.gno
@@ -53,7 +53,4 @@
 // return quoted Go rune literals.
 //
 // [Unquote] and [UnquoteChar] unquote Go string and rune literals.
-//
-// XXX: Gno does not implement any of the functions from Go's strconv which
-// pertain to complex numbers, such as FormatComplex and ParseComplex.
 package strconv

--- a/gnovm/stdlibs/strings/clone.gno
+++ b/gnovm/stdlibs/strings/clone.gno
@@ -1,0 +1,24 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package strings
+
+// Clone returns a fresh copy of s.
+// It guarantees to make a copy of s into a new allocation,
+// which can be important when retaining only a small substring
+// of a much larger string. Using Clone can help such programs
+// use less memory. Of course, since using Clone makes a copy,
+// overuse of Clone can make programs use more memory.
+// Clone should typically be used only rarely, and only when
+// profiling indicates that it is needed.
+// For strings of length zero the string "" will be returned
+// and no allocation is made.
+func Clone(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	b := make([]byte, len(s))
+	copy(b, s)
+	return string(b)
+}

--- a/gnovm/stdlibs/strings/clone_test.gno
+++ b/gnovm/stdlibs/strings/clone_test.gno
@@ -1,0 +1,52 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package strings_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClone(t *testing.T) {
+	var cloneTests = []string{
+		"",
+		strings.Clone(""),
+		strings.Repeat("a", 42)[:0],
+		"short",
+		strings.Repeat("a", 42),
+	}
+	for _, input := range cloneTests {
+		clone := strings.Clone(input)
+		if clone != input {
+			t.Errorf("Clone(%q) = %q; want %q", input, clone, input)
+		}
+	}
+}
+
+// Subset of upstream ContainsRuneTests; the full table lives in
+// strings_test.go and will arrive with PR #5749.
+var containsFuncTests = []struct {
+	str      string
+	r        rune
+	expected bool
+}{
+	{"", 'a', false},
+	{"a", 'a', true},
+	{"aaa", 'a', true},
+	{"abc", 'y', false},
+	{"x\xc2\x4cz", 'L', true},
+	{"x\xc2\x4cz", '䰀', false},
+}
+
+func TestContainsFunc(t *testing.T) {
+	for _, ct := range containsFuncTests {
+		if strings.ContainsFunc(ct.str, func(r rune) bool {
+			return ct.r == r
+		}) != ct.expected {
+			t.Errorf("ContainsFunc(%q, func(%q)) = %v, want %v",
+				ct.str, ct.r, !ct.expected, ct.expected)
+		}
+	}
+}

--- a/gnovm/stdlibs/strings/strings.gno
+++ b/gnovm/stdlibs/strings/strings.gno
@@ -73,6 +73,11 @@ func ContainsRune(s string, r rune) bool {
 	return IndexRune(s, r) >= 0
 }
 
+// ContainsFunc reports whether any Unicode code points r within s satisfy f(r).
+func ContainsFunc(s string, f func(rune) bool) bool {
+	return IndexFunc(s, f) >= 0
+}
+
 // LastIndex returns the index of the last instance of substr in s, or -1 if substr is not present in s.
 func LastIndex(s, substr string) int {
 	n := len(substr)

--- a/gnovm/stdlibs/unicode/utf16/utf16_test.gno
+++ b/gnovm/stdlibs/unicode/utf16/utf16_test.gno
@@ -218,3 +218,33 @@ func BenchmarkEncodeRune(b *testing.B) {
 		}
 	}
 }
+
+// Validate the constants redefined from unicode.
+func TestConstants(t *testing.T) {
+	if maxRune != unicode.MaxRune {
+		t.Errorf("utf16.maxRune is wrong: %x should be %x", maxRune, unicode.MaxRune)
+	}
+	if replacementChar != unicode.ReplacementChar {
+		t.Errorf("utf16.replacementChar is wrong: %x should be %x", replacementChar, unicode.ReplacementChar)
+	}
+}
+
+func TestRuneLen(t *testing.T) {
+	for _, tt := range []struct {
+		r      rune
+		length int
+	}{
+		{0, 1},
+		{surr1 - 1, 1},
+		{surr3, 1},
+		{surrSelf - 1, 1},
+		{surrSelf, 2},
+		{maxRune, 2},
+		{maxRune + 1, -1},
+		{-1, -1},
+	} {
+		if length := RuneLen(tt.r); length != tt.length {
+			t.Errorf("RuneLen(%#U) = %d, want %d", tt.r, length, tt.length)
+		}
+	}
+}


### PR DESCRIPTION
(Not meant to be merged)

## Summary

Ports small post-1.17 additions across 11 stdlib packages plus 12 upstream test files
for coverage parity. All changes are direct ports of upstream Go code; Gno-specific
adaptations are limited to what the language forces (no generics, no `min`/`max`
builtins, no `unsafe.Pointer`, no `GODEBUG`).

## Additions by upstream Go version

| Pkg | Upstream | Adds |
|---|---|---|
| `bufio` | 1.18 | `Writer.AvailableBuffer` |
| `strings` | 1.18 | `Clone` |
| `regexp/syntax` | 1.20+ | `printFlags` pre-pass in `writeRegexp` (CL 444817) — factors shared `FoldCase` up to parent (`Parse("[Aa][Bb]*[Cc]").String()` was `"(?i:A)(?i:B)*(?i:C)"`, now `"(?i:AB*C)"`) |
| `sort` | 1.21 | `Find` (binary search by predicate) |
| `strings` | 1.21 | `ContainsFunc` |
| `encoding/base64` | 1.22 | `Encoding.AppendEncode` / `AppendDecode` |
| `encoding/hex` | 1.22 | `AppendEncode` / `AppendDecode` |
| `unicode/utf16` | 1.23 | `RuneLen` (+ `Encode` refactored to dispatch via `switch RuneLen(v)`) |
| `regexp` | 1.24 | `Regexp.MarshalText` / `UnmarshalText` / `AppendText` |
| `hash/adler32` | 1.24 | `AppendBinary` (with `MarshalBinary` restructured to delegate) |
| `net/url` | 1.25 | 10000-param cap on `ParseQuery` (`defaultMaxParams`) |
| `strconv` | n/a | doc trim (drop ghost `ParseComplex`/`FormatComplex` mention) |

## Test coverage uplift

Ports upstream test cases for behavior already in Gno but previously untested:
- New cases in `bytes_test.gno`, `encoding/binary/binary_test.gno`, `math/all_test.gno`,
  `math/bits/bits_test.gno`
- Eight `Example*` tests rewritten as `TestExample_*` so they actually run
  (`encoding/base64`, `encoding/csv`, `encoding/hex`, `html`, `net/url`, `path`, `sort`,
  `hash/adler32`)
- `hash/adler32` gets its first test file (was empty)

## Gno-specific adaptations (necessary, not stylistic)

- `slicesGrow` helper in `base64`/`hex` — Gno has no generics, so the upstream
  `slices.Grow` call becomes a byte-only helper. Same pattern already used in `base32`.
- `strings.Clone` uses `string(b)` instead of `*(*string)(unsafe.Pointer(&b))` — Gno
  realms have no `unsafe`. Identical behavior; one extra copy.
- `net/url.defaultMaxParams` is a hard `const` — upstream tunes it via
  `GODEBUG=urlmaxqueryparams=N`, Gno has no `GODEBUG`. Error string matches upstream
  verbatim (`"number of URL query parameters exceeded limit"`).
- `regexp/syntax.calcFlags` keeps explicit `if` clamps where upstream uses `min`/`max`
  builtins (Go 1.21+) — Gno lacks those builtins. Follow-up branch
  `feat/min-max-builtins` adds them; after that lands, this can become verbatim.

## What's NOT in this PR (deliberate)

- **`strings.SplitN` invalid-UTF-8 fix** — already in flight as #5749
- **`errors.Is`/`As`/`Unwrap`/`Join`** — already in flight as #5385
- **`bytes.Cut`/`Clone`/`ContainsFunc`/`AvailableBuffer`** — already in flight as #5676
- **`Example*` execution in `TestStdlibs`** — already in flight as #5188 (this PR
  works around by rewriting examples as `TestExample_*`)
- **`crypto/sha256.MarshalBinary`/`UnmarshalBinary`** — Gno's sha256 is a 9-line native
  shim that calls host `crypto/sha256.Sum256`. There is no `digest` struct, `h[8]`, or
  internal block state to marshal. Adding these would require porting the entire
  pure-Go SHA-256 block implementation first — out of scope, separate undertaking.
- **`strings.Lines`/`SplitSeq`/`FieldsSeq`/etc.** (1.23–1.24) — need range-over-func
  (Go 1.23 language feature), not in Gno yet.
- **`slices`/`maps`/`cmp` packages** — need generics, not in Gno yet.

## Test plan

- [x] `go test -count=1 -run 'TestStdlibs/(strings|regexp|regexp-syntax|sort|unicode-utf16|hash-adler32|net-url|strconv|bytes|encoding-binary|math|math-bits|encoding-base64|encoding-csv|encoding-hex|html|path|bufio)$' ./gnovm/pkg/gnolang/` — PASS, 129s, all 18 affected packages green on commit c0eec3f15
- [x] Each commit is independently verified — reviewable per-package via `git log`

## Commit list (12)

1. `test(stdlibs):` port upstream Go 1.25 test cases for coverage parity
2. `feat(stdlibs/strings):` Clone (1.18) + ContainsFunc (1.21)
3. `feat(stdlibs/regexp/syntax):` writeRegexp printFlags pre-pass (1.20+)
4. `feat(stdlibs/regexp):` Regexp.{Marshal,Unmarshal,Append}Text (1.24)
5. `feat(stdlibs/sort):` Find (1.21)
6. `feat(stdlibs/unicode/utf16):` RuneLen (1.23), Encode refactored
7. `feat(stdlibs/hash/adler32):` AppendBinary (1.24)
8. `feat(stdlibs/bufio):` Writer.AvailableBuffer (1.18)
9. `feat(stdlibs/encoding/base64):` AppendEncode + AppendDecode (1.22)
10. `feat(stdlibs/encoding/hex):` AppendEncode + AppendDecode (1.22)
11. `feat(stdlibs/net/url):` cap ParseQuery at 10000 params (1.25)
12. `docs(stdlibs/strconv):` drop ghost ParseComplex/FormatComplex