### PR TITLE
feat(examples): add `memberstorage` boards sub-package

### DIFF
--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/gnomod.toml
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/gnoland/boards/exts/memberstorage"
+gno = "0.9"

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group.gno
@@ -22,7 +22,7 @@ type MemberGroup interface {
 }
 
 // IsCanonical checks whether a member group is the canonical one, created
-// using the New() function defined within this package.
+// using the NewMemberGroup() function defined within this package.
 //
 // Use this function at any public entry point that accepts a MemberGroup
 // from an external caller before invoking any of its methods.

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group.gno
@@ -1,0 +1,76 @@
+package memberstorage
+
+import "strings"
+
+// MemberGroup defines an interface for a group of members.
+type MemberGroup interface {
+	// Name returns the name of the group.
+	Name() string
+
+	// Members returns the members that belong to the group.
+	Members() MemberStorage
+
+	// SetMeta sets any metadata relevant to the group.
+	// Metadata can be used to store data which is specific to the group.
+	// Usually can be used to store parameter values which would be useful
+	// during proposal voting or tallying to resolve things like voting
+	// weights or rights for example.
+	SetMeta(any)
+
+	// GetMeta returns the group metadata.
+	GetMeta() any
+}
+
+// IsCanonical checks whether a member group is the canonical one, created
+// using the New() function defined within this package.
+//
+// Use this function at any public entry point that accepts a MemberGroup
+// from an external caller before invoking any of its methods.
+func IsCanonical(g MemberGroup) bool {
+	_, ok := g.(*memberGroup)
+	return ok
+}
+
+// NewMemberGroup creates a new group of members.
+// It panics if name is empty or when members is nil.
+func NewMemberGroup(name string, members MemberStorage) MemberGroup {
+	if members == nil {
+		panic("member storage is required")
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		panic("member group name is required")
+	}
+
+	return &memberGroup{
+		name:    name,
+		members: members,
+	}
+}
+
+type memberGroup struct {
+	name    string
+	members MemberStorage
+	meta    any
+}
+
+// Name returns the name of the group.
+func (g *memberGroup) Name() string {
+	return g.name
+}
+
+// Members returns the members that belong to the group.
+func (g *memberGroup) Members() MemberStorage {
+	return g.members
+}
+
+// SetMeta sets any metadata relevant to the group.
+func (g *memberGroup) SetMeta(meta any) {
+	g.meta = meta
+}
+
+// GetMeta returns the group metadata.
+func (g *memberGroup) GetMeta() any {
+	return g.meta
+}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group_test.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_group_test.gno
@@ -1,0 +1,141 @@
+package memberstorage_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+
+	"gno.land/p/gnoland/boards/exts/memberstorage"
+)
+
+func TestMemberGroupNew(cur realm, t *testing.T) {
+	urequire.PanicsWithMessage(t, cur, "member storage is required", func() {
+		memberstorage.NewMemberGroup("", nil)
+	})
+
+	storage := memberstorage.New()
+	urequire.PanicsWithMessage(t, cur, "member group name is required", func() {
+		memberstorage.NewMemberGroup("", storage)
+	})
+
+	urequire.NotPanics(t, cur, func() {
+		name := "Tier 1"
+		g := memberstorage.NewMemberGroup(name, storage)
+		uassert.Equal(t, name, g.Name(), "expect group name to match")
+		uassert.NotNil(t, g.Members(), "expect members to be not nil")
+		uassert.Nil(t, g.GetMeta(), "expect default group meta to be nil")
+	})
+}
+
+func TestMemberGroupSetMeta(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantMeta any
+		setup    func() memberstorage.MemberGroup
+	}{
+		{
+			name:     "ok",
+			wantMeta: 42,
+			setup: func() memberstorage.MemberGroup {
+				return memberstorage.NewMemberGroup("Test", memberstorage.New())
+			},
+		},
+		{
+			name:     "overwrite",
+			wantMeta: 42,
+			setup: func() memberstorage.MemberGroup {
+				g := memberstorage.NewMemberGroup("Test", memberstorage.New())
+				g.SetMeta(123)
+				return g
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
+			// Arrange
+			g := tc.setup()
+
+			// Act
+			g.SetMeta(tc.wantMeta)
+
+			// Assert
+			uassert.True(t, g.GetMeta() == tc.wantMeta, "expect metadata to match")
+		})
+	}
+}
+
+func TestMemberGroupGetMeta(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantMeta any
+		setup    func() memberstorage.MemberGroup
+		panicMsg string
+	}{
+		{
+			name:     "ok",
+			wantMeta: 42,
+			setup: func() memberstorage.MemberGroup {
+				g := memberstorage.NewMemberGroup("Test", memberstorage.New())
+				g.SetMeta(42)
+				return g
+			},
+		},
+		{
+			name:     "default",
+			wantMeta: nil,
+			setup: func() memberstorage.MemberGroup {
+				return memberstorage.NewMemberGroup("Test", memberstorage.New())
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
+			// Arrange
+			var got any
+			g := tc.setup()
+
+			// Act
+			got = g.GetMeta()
+
+			// Assert
+			uassert.True(t, got == tc.wantMeta, "expect metadata to match")
+		})
+	}
+}
+
+func TestIsCanonical(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() memberstorage.MemberGroup
+		want  bool
+	}{
+		{
+			name: "canonical",
+			setup: func() memberstorage.MemberGroup {
+				return memberstorage.NewMemberGroup("Test", memberstorage.New())
+			},
+			want: true,
+		},
+		{
+			name:  "non canonical",
+			setup: func() memberstorage.MemberGroup { return stubMemberGroup{} },
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
+			uassert.Equal(t, tc.want, memberstorage.IsCanonical(tc.setup()))
+		})
+	}
+}
+
+type stubMemberGroup struct{}
+
+func (stubMemberGroup) Name() string                         { return "" }
+func (stubMemberGroup) Members() memberstorage.MemberStorage { return nil }
+func (stubMemberGroup) SetMeta(any)                          {}
+func (stubMemberGroup) GetMeta() any                         { return nil }

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_grouping.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_grouping.gno
@@ -1,0 +1,116 @@
+package memberstorage
+
+import (
+	"errors"
+
+	"gno.land/p/nt/bptree/v0"
+)
+
+type (
+	// MemberGroupIterFn defines a callback to iterate member groups.
+	MemberGroupIterFn func(MemberGroup) bool
+
+	// MemberGrouping defines an interface for storing multiple member groups.
+	// Member grouping can be used by implementations that require grouping users
+	// by roles or by tiers for example.
+	MemberGrouping interface {
+		// Size returns the number of groups that grouping contains.
+		Size() int
+
+		// Has checks if a group exists.
+		Has(name string) bool
+
+		// Add adds a new member group if it doesn't exist.
+		Add(name string) (MemberGroup, error)
+
+		// Get returns a member group.
+		Get(name string) (_ MemberGroup, found bool)
+
+		// Delete deletes a member group.
+		Delete(name string) error
+
+		// IterateByOffset iterates member groups starting at the given offset.
+		// The callback can return true to stop iteration.
+		IterateByOffset(offset, count int, fn MemberGroupIterFn) (stopped bool)
+	}
+)
+
+// IsCanonicalMemberGrouping checks whether a member grouping is the canonical
+// one, created using the NewMemberGrouping function defined within this package.
+//
+// Use this function at any public entry point that accepts a MemberGrouping
+// from an external caller before invoking any of its methods.
+func IsCanonicalMemberGrouping(g MemberGrouping) bool {
+	_, ok := g.(*memberGrouping)
+	return ok
+}
+
+// NewMemberGrouping creates a new member grouping.
+func NewMemberGrouping() MemberGrouping {
+	return &memberGrouping{}
+}
+
+type memberGrouping struct {
+	groups bptree.BPTree // string(name) -> MemberGroup
+}
+
+// Size returns the number of groups that grouping contains.
+func (g *memberGrouping) Size() int {
+	return g.groups.Size()
+}
+
+// Has checks if a group exists.
+func (g *memberGrouping) Has(name string) bool {
+	return g.groups.Has(name)
+}
+
+// Add adds a new member group if it doesn't exist.
+func (g *memberGrouping) Add(name string) (MemberGroup, error) {
+	if g.groups.Has(name) {
+		return nil, errors.New("member group already exists: " + name)
+	}
+
+	group := NewMemberGroup(name, New())
+	g.groups.Set(name, group)
+	return group, nil
+}
+
+// Get returns a member group.
+func (g *memberGrouping) Get(name string) (_ MemberGroup, found bool) {
+	v, found := g.groups.Get(name)
+	if !found {
+		return nil, false
+	}
+	return v.(MemberGroup), true
+}
+
+// Delete deletes a member group.
+func (g *memberGrouping) Delete(name string) error {
+	g.groups.Remove(name)
+	return nil
+}
+
+// IterateByOffset iterates member groups starting at the given offset.
+// The callback can return true to stop iteration.
+func (g *memberGrouping) IterateByOffset(offset, count int, fn MemberGroupIterFn) bool {
+	return g.groups.IterateByOffset(offset, count, func(_ string, v any) bool {
+		return fn(v.(MemberGroup))
+	})
+}
+
+// GetMemberGroups returns the groups that a member belongs to.
+func GetMemberGroups(s MemberStorage, member address) []string {
+	grouping := s.Grouping()
+	if grouping == nil {
+		return nil
+	}
+
+	var groups []string
+	grouping.IterateByOffset(0, grouping.Size(), func(g MemberGroup) bool {
+		if g.Members().Has(member) {
+			groups = append(groups, g.Name())
+		}
+		return false
+	})
+	return groups
+}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_grouping_test.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_grouping_test.gno
@@ -1,0 +1,132 @@
+package memberstorage_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+
+	"gno.land/p/gnoland/boards/exts/memberstorage"
+)
+
+func TestMemberGroupingAdd(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		name := "Foo"
+		g := memberstorage.NewMemberGrouping()
+
+		uassert.False(t, g.Has(name), "expect grouping group not to be found")
+		uassert.Equal(t, 0, g.Size(), "expect grouping to be empty")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		name := "Foo"
+		g := memberstorage.NewMemberGrouping()
+		mg, err := g.Add(name)
+
+		urequire.NoError(t, err, "expect no error")
+		uassert.True(t, g.Has(name), "expect grouping group to be found")
+		uassert.Equal(t, 1, g.Size(), "expect grouping to have a single group")
+
+		urequire.True(t, mg != nil, "expected grouping group to be not nil")
+		uassert.Equal(t, name, mg.Name(), "expect group to have the right name")
+	})
+
+	t.Run("duplicated name", func(t *testing.T) {
+		name := "Foo"
+		g := memberstorage.NewMemberGrouping()
+		_, err := g.Add(name)
+		urequire.NoError(t, err, "expect no error")
+
+		_, err = g.Add(name)
+		uassert.ErrorContains(t, err, "member group already exists: Foo", "expect duplication error")
+	})
+}
+
+func TestMemberGroupingGet(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		name := "Foo"
+		g := memberstorage.NewMemberGrouping()
+		g.Add(name)
+
+		mg, found := g.Get(name)
+
+		urequire.True(t, found, "expect grouping group to be found")
+		urequire.True(t, mg != nil, "expect grouping group to be not nil")
+		uassert.Equal(t, name, mg.Name(), "expect group to have the right name")
+	})
+
+	t.Run("group not found", func(t *testing.T) {
+		g := memberstorage.NewMemberGrouping()
+
+		_, found := g.Get("Foo")
+
+		urequire.False(t, found, "expect grouping group to be not found")
+	})
+}
+
+func TestMemberGroupingDelete(t *testing.T) {
+	name := "Foo"
+	g := memberstorage.NewMemberGrouping()
+	g.Add(name)
+
+	err := g.Delete(name)
+
+	urequire.NoError(t, err, "expect no error")
+	uassert.False(t, g.Has(name), "expect grouping group not to be found")
+}
+
+func TestMemberGroupingIterate(t *testing.T) {
+	groups := []string{"Tier 1", "Tier 2", "Tier 3"}
+	g := memberstorage.NewMemberGrouping()
+	for _, name := range groups {
+		g.Add(name)
+	}
+
+	var i int
+	g.IterateByOffset(0, g.Size(), func(mg memberstorage.MemberGroup) bool {
+		urequire.True(t, mg != nil, "expect member group not to be nil")
+		urequire.Equal(t, groups[i], mg.Name(), "expect group to be iterated in order")
+
+		i++
+		return false
+	})
+
+	uassert.Equal(t, len(groups), i, "expect all groups to be iterated")
+}
+
+func TestIsCanonicalMemberGrouping(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() memberstorage.MemberGrouping
+		want  bool
+	}{
+		{
+			name:  "canonical",
+			setup: func() memberstorage.MemberGrouping { return memberstorage.NewMemberGrouping() },
+			want:  true,
+		},
+		{
+			name:  "non canonical",
+			setup: func() memberstorage.MemberGrouping { return stubMemberGrouping{} },
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uassert.Equal(t, tc.want, memberstorage.IsCanonicalMemberGrouping(tc.setup()))
+		})
+	}
+}
+
+type stubMemberGrouping struct{}
+
+func (stubMemberGrouping) Size() int                                     { return 0 }
+func (stubMemberGrouping) Has(string) bool                               { return false }
+func (stubMemberGrouping) Add(string) (memberstorage.MemberGroup, error) { return nil, nil }
+func (stubMemberGrouping) Get(string) (memberstorage.MemberGroup, bool)  { return nil, false }
+func (stubMemberGrouping) Delete(string) error                           { return nil }
+
+func (stubMemberGrouping) IterateByOffset(offset, count int, fn memberstorage.MemberGroupIterFn) bool {
+	return false
+}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
@@ -1,0 +1,211 @@
+package memberstorage
+
+import (
+	"gno.land/p/moul/addrset"
+)
+
+type (
+	// MemberIterFn defines a callback to iterate members.
+	MemberIterFn func(address) bool
+
+	// MemberStorage defines an interface for member storages.
+	MemberStorage interface {
+		// Size returns the number of ungrouped members in the storage.
+		Size() int
+
+		// Has checks if an ungrouped member exists in the storage.
+		// Grouped members are not checked; use ExistsInMemberStorage to
+		// check across grouped and ungrouped members.
+		Has(address) bool
+
+		// Add adds a member to the storage.
+		// Returns true if the member is added, or false if it already existed.
+		Add(address) bool
+
+		// Remove removes a member from the storage.
+		// Returns true if member was removed, or false if it was not found.
+		Remove(address) bool
+
+		// Grouping returns member groups when supported.
+		// When nil is returned it means that grouping of members is not supported.
+		// Member groups can be used by implementations that require grouping users
+		// by roles or by tiers for example.
+		Grouping() MemberGrouping
+
+		// IterateByOffset iterates ungrouped members starting at the given offset.
+		// Grouped members are not iterated; use IterateMemberStorage to walk
+		// both grouped and ungrouped members.
+		// The callback can return true to stop iteration.
+		IterateByOffset(offset, count int, fn MemberIterFn) (stopped bool)
+	}
+)
+
+// IsCanonicalMemberStorage checks whether a member storage is the canonical
+// one, created using the New or NewWithGrouping functions defined within
+// this package.
+//
+// Use this function at any public entry point that accepts a MemberStorage
+// from an external caller before invoking any of its methods.
+func IsCanonicalMemberStorage(s MemberStorage) bool {
+	_, ok := s.(*memberStorage)
+	return ok
+}
+
+// New creates a new member storage that doesn't support member groups.
+// This type of storage is useful when there is no need to group members.
+func New() MemberStorage {
+	return &memberStorage{}
+}
+
+// NewWithGrouping creates a new member storage with support for member groups.
+// Member groups can be used by implementations that require grouping users by roles
+// or by tiers for example. It also supports members without grouping.
+func NewWithGrouping() MemberStorage {
+	return &memberStorage{grouping: NewMemberGrouping()}
+}
+
+type memberStorage struct {
+	members  addrset.Set
+	grouping MemberGrouping
+}
+
+// Size returns the number of ungrouped members in the storage.
+func (s memberStorage) Size() int {
+	return s.members.Size()
+}
+
+// Has checks if a member exists in the base underlying storage.
+// Grouped members are not checked.
+func (s memberStorage) Has(member address) bool {
+	return s.members.Has(member)
+}
+
+// Add adds a member to the storage.
+// Returns true if the member is added, or false if it already existed.
+func (s *memberStorage) Add(member address) bool {
+	return s.members.Add(member)
+}
+
+// Remove removes a member from the storage.
+// Returns true if member was removed, or false if it was not found.
+func (s *memberStorage) Remove(member address) bool {
+	return s.members.Remove(member)
+}
+
+// Grouping returns member groups.
+func (s memberStorage) Grouping() MemberGrouping {
+	return s.grouping
+}
+
+// IterateByOffset iterates ungrouped members starting at the given offset.
+// The callback can return true to stop iteration.
+// To iterate across both grouped and ungrouped members use the
+// IterateMemberStorage helper.
+func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool {
+	if offset < 0 {
+		offset = 0
+	}
+
+	var stopped bool
+	s.members.IterateByOffset(offset, count, func(member address) bool {
+		stopped = fn(member)
+		return stopped
+	})
+	return stopped
+}
+
+// GetTotalMemberStorageSize returns the total number of member occurrences
+// in the storage, counting grouped and ungrouped members. The same address
+// appearing in multiple groups (or in both grouped and ungrouped) is counted
+// once per occurrence; results are not deduplicated.
+func GetTotalMemberStorageSize(s MemberStorage) int {
+	// TODO: Support deduplication, for example through a UniqueMemberIterator interface
+
+	count := s.Size()
+	if s.Grouping() == nil {
+		return count
+	}
+
+	s.Grouping().IterateByOffset(0, s.Grouping().Size(), func(g MemberGroup) bool {
+		count += g.Members().Size()
+		return false
+	})
+	return count
+}
+
+// ExistsInMemberStorage checks if a member exists within a storage.
+// It checks grouped and ungrouped members.
+func ExistsInMemberStorage(s MemberStorage, member address) bool {
+	if s.Has(member) {
+		// Member exists as an ungrouped member
+		return true
+	}
+
+	if s.Grouping() == nil {
+		return false
+	}
+
+	// Check if member exists within any of the groups
+	return s.Grouping().IterateByOffset(0, s.Grouping().Size(), func(g MemberGroup) bool {
+		return g.Members().Has(member)
+	})
+}
+
+// IterateMemberStorage iterates members starting at the given offset across
+// the entire storage. Ungrouped members are iterated first, followed by the
+// members of each group in group iteration order. Members that appear in
+// multiple groups (or in both grouped and ungrouped) are visited once per
+// occurrence. A negative offset is treated as 0. The callback can return true
+// to stop iteration.
+func IterateMemberStorage(s MemberStorage, offset, count int, fn MemberIterFn) bool {
+	if count <= 0 {
+		return false
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Define a callback to walk storage members
+	var stopped bool
+	walk := func(storage MemberStorage) bool {
+		size := storage.Size()
+		if offset >= size {
+			offset -= size
+			return false
+		}
+
+		// Update current count to fit storage boundaries
+		currentCount := count
+		if currentCount > size-offset {
+			currentCount = size - offset
+		}
+
+		if storage.IterateByOffset(offset, currentCount, fn) {
+			stopped = true
+			return true // Walk stopped by the callback
+		}
+
+		// Discount iterated members and reset offset for next grouping storage
+		count -= currentCount
+		offset = 0
+
+		// When zero walk stops because specified amount of members were iterated
+		return count == 0
+	}
+
+	// Walk ungrouped members
+	if walk(s) {
+		return stopped
+	}
+
+	grouping := s.Grouping()
+	if grouping == nil {
+		return false
+	}
+
+	// Walk grouped members
+	grouping.IterateByOffset(0, grouping.Size(), func(g MemberGroup) bool {
+		return walk(g.Members())
+	})
+	return stopped
+}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
@@ -14,8 +14,6 @@ type (
 		Size() int
 
 		// Has checks if an ungrouped member exists in the storage.
-		// Grouped members are not checked; use ExistsInMemberStorage to
-		// check across grouped and ungrouped members.
 		Has(address) bool
 
 		// Add adds a member to the storage.
@@ -33,8 +31,6 @@ type (
 		Grouping() MemberGrouping
 
 		// IterateByOffset iterates ungrouped members starting at the given offset.
-		// Grouped members are not iterated; use IterateMemberStorage to walk
-		// both grouped and ungrouped members.
 		// The callback can return true to stop iteration.
 		IterateByOffset(offset, count int, fn MemberIterFn) (stopped bool)
 	}
@@ -70,12 +66,15 @@ type memberStorage struct {
 }
 
 // Size returns the number of ungrouped members in the storage.
+// Grouped members are not counted, use `GetTotalMemberStorageSize()` to count
+// both grouped and ungrouped members.
 func (s memberStorage) Size() int {
 	return s.members.Size()
 }
 
 // Has checks if a member exists in the base underlying storage.
-// Grouped members are not checked.
+// Grouped members are not checked, use `ExistsInMemberStorage()` to
+// check across grouped and ungrouped members.
 func (s memberStorage) Has(member address) bool {
 	return s.members.Has(member)
 }
@@ -99,8 +98,8 @@ func (s memberStorage) Grouping() MemberGrouping {
 
 // IterateByOffset iterates ungrouped members starting at the given offset.
 // The callback can return true to stop iteration.
-// To iterate across both grouped and ungrouped members use the
-// IterateMemberStorage helper.
+// Grouped members are not iterated, use `IterateMemberStorage()` to walk
+// both grouped and ungrouped members.
 func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool {
 	if offset < 0 {
 		offset = 0
@@ -117,7 +116,7 @@ func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool 
 // GetTotalMemberStorageSize returns the total number of member occurrences
 // in the storage, counting grouped and ungrouped members. The same address
 // appearing in multiple groups (or in both grouped and ungrouped) is counted
-// once per occurrence; results are not deduplicated.
+// once per occurrence, results are not deduplicated.
 func GetTotalMemberStorageSize(s MemberStorage) int {
 	// TODO: Support deduplication, for example through a UniqueMemberIterator interface
 
@@ -151,16 +150,17 @@ func ExistsInMemberStorage(s MemberStorage, member address) bool {
 	})
 }
 
-// IterateMemberStorage iterates members starting at the given offset across
-// the entire storage. Ungrouped members are iterated first, followed by the
-// members of each group in group iteration order. Members that appear in
-// multiple groups (or in both grouped and ungrouped) are visited once per
-// occurrence. A negative offset is treated as 0. The callback can return true
-// to stop iteration.
+// IterateMemberStorage iterates members starting at the given offset across the entire
+// storage. Ungrouped members are iterated first, followed by the members of each group
+// in group iteration order. Members that appear in multiple groups (or in both grouped
+// and ungrouped) are visited once per occurrence.
+// A negative offset is treated as 0.
+// The callback can return true to stop iteration.
 func IterateMemberStorage(s MemberStorage, offset, count int, fn MemberIterFn) bool {
 	if count <= 0 {
 		return false
 	}
+
 	if offset < 0 {
 		offset = 0
 	}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage.gno
@@ -66,15 +66,15 @@ type memberStorage struct {
 }
 
 // Size returns the number of ungrouped members in the storage.
-// Grouped members are not counted, use `GetTotalMemberStorageSize()` to count
+// Grouped members are not counted, use `GetTotalSize()` to count
 // both grouped and ungrouped members.
 func (s memberStorage) Size() int {
 	return s.members.Size()
 }
 
 // Has checks if a member exists in the base underlying storage.
-// Grouped members are not checked, use `ExistsInMemberStorage()` to
-// check across grouped and ungrouped members.
+// Grouped members are not checked, use `HasMember()` to check
+// across grouped and ungrouped members.
 func (s memberStorage) Has(member address) bool {
 	return s.members.Has(member)
 }
@@ -98,8 +98,8 @@ func (s memberStorage) Grouping() MemberGrouping {
 
 // IterateByOffset iterates ungrouped members starting at the given offset.
 // The callback can return true to stop iteration.
-// Grouped members are not iterated, use `IterateMemberStorage()` to walk
-// both grouped and ungrouped members.
+// Grouped members are not iterated, use `Iterate()` to walk both grouped and
+// ungrouped members.
 func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool {
 	if offset < 0 {
 		offset = 0
@@ -113,11 +113,11 @@ func (s memberStorage) IterateByOffset(offset, count int, fn MemberIterFn) bool 
 	return stopped
 }
 
-// GetTotalMemberStorageSize returns the total number of member occurrences
-// in the storage, counting grouped and ungrouped members. The same address
-// appearing in multiple groups (or in both grouped and ungrouped) is counted
-// once per occurrence, results are not deduplicated.
-func GetTotalMemberStorageSize(s MemberStorage) int {
+// GetTotalSize returns the total number of member occurrences in the storage,
+// counting grouped and ungrouped members. The same address appearing in
+// multiple groups (or in both grouped and ungrouped) is counted once per
+// occurrence, results are not deduplicated.
+func GetTotalSize(s MemberStorage) int {
 	// TODO: Support deduplication, for example through a UniqueMemberIterator interface
 
 	count := s.Size()
@@ -132,9 +132,9 @@ func GetTotalMemberStorageSize(s MemberStorage) int {
 	return count
 }
 
-// ExistsInMemberStorage checks if a member exists within a storage.
+// HasMember checks if a member exists within a storage.
 // It checks grouped and ungrouped members.
-func ExistsInMemberStorage(s MemberStorage, member address) bool {
+func HasMember(s MemberStorage, member address) bool {
 	if s.Has(member) {
 		// Member exists as an ungrouped member
 		return true
@@ -150,13 +150,13 @@ func ExistsInMemberStorage(s MemberStorage, member address) bool {
 	})
 }
 
-// IterateMemberStorage iterates members starting at the given offset across the entire
-// storage. Ungrouped members are iterated first, followed by the members of each group
-// in group iteration order. Members that appear in multiple groups (or in both grouped
+// Iterate iterates members starting at the given offset across the entire storage.
+// Ungrouped members are iterated first, followed by the members of each group in
+// group iteration order. Members that appear in multiple groups (or in both grouped
 // and ungrouped) are visited once per occurrence.
 // A negative offset is treated as 0.
 // The callback can return true to stop iteration.
-func IterateMemberStorage(s MemberStorage, offset, count int, fn MemberIterFn) bool {
+func Iterate(s MemberStorage, offset, count int, fn MemberIterFn) bool {
 	if count <= 0 {
 		return false
 	}

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage_test.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage_test.gno
@@ -134,7 +134,7 @@ func TestMemberStorageHas(t *testing.T) {
 	}
 }
 
-func TestGetTotalMemberStorageSize(t *testing.T) {
+func TestGetTotalSize(t *testing.T) {
 	cases := []struct {
 		name  string
 		setup func() memberstorage.MemberStorage
@@ -220,7 +220,7 @@ func TestGetTotalMemberStorageSize(t *testing.T) {
 			storage := tc.setup()
 
 			// Act
-			got := memberstorage.GetTotalMemberStorageSize(storage)
+			got := memberstorage.GetTotalSize(storage)
 
 			// Assert
 			uassert.Equal(t, tc.want, got)
@@ -316,7 +316,7 @@ func TestMemberStorageRemove(t *testing.T) {
 	}
 }
 
-func TestExistsInMemberStorage(t *testing.T) {
+func TestHasMember(t *testing.T) {
 	member := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
 	cases := []struct {
 		name  string
@@ -376,7 +376,7 @@ func TestExistsInMemberStorage(t *testing.T) {
 			storage := tc.setup()
 
 			// Act
-			got := memberstorage.ExistsInMemberStorage(storage, member)
+			got := memberstorage.HasMember(storage, member)
 
 			// Assert
 			uassert.Equal(t, tc.want, got)
@@ -384,7 +384,7 @@ func TestExistsInMemberStorage(t *testing.T) {
 	}
 }
 
-func TestIterateMemberStorage(t *testing.T) {
+func TestIterate(t *testing.T) {
 	// Sorted address order: u1 < u2 < a1 < a2 < b1.
 	var (
 		u1 address = "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt"
@@ -593,7 +593,7 @@ func TestIterateMemberStorage(t *testing.T) {
 			}
 
 			// Act
-			stopped := memberstorage.IterateMemberStorage(storage, tc.offset, tc.count, fn)
+			stopped := memberstorage.Iterate(storage, tc.offset, tc.count, fn)
 
 			// Assert
 			uassert.Equal(t, tc.wantStopped, stopped, "expect stopped to match")

--- a/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage_test.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/memberstorage/member_storage_test.gno
@@ -1,0 +1,660 @@
+package memberstorage_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+
+	"gno.land/p/gnoland/boards/exts/memberstorage"
+)
+
+func TestMemberStorageWithGrouping(t *testing.T) {
+	// Prepare
+	tiers := []struct {
+		Name    string
+		Weight  int
+		Members []address
+	}{
+		{
+			Name:   "Tier 1",
+			Weight: 3,
+			Members: []address{
+				"g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq",
+				"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			},
+		},
+		{
+			Name:   "Tier 2",
+			Weight: 2,
+			Members: []address{
+				"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
+			},
+		},
+	}
+
+	storage := memberstorage.NewWithGrouping()
+	for _, tier := range tiers {
+		mg, err := storage.Grouping().Add(tier.Name)
+		urequire.NoError(t, err, "expect no error adding tier")
+
+		mg.SetMeta(tier.Weight)
+
+		for _, addr := range tier.Members {
+			ok := mg.Members().Add(addr)
+			urequire.True(t, ok, "expect member to be added")
+		}
+	}
+
+	// Assert
+	for i := 0; i < len(tiers); i++ {
+		tier := tiers[i]
+		mg, found := storage.Grouping().Get(tier.Name)
+		urequire.True(t, found, "expect member group to be found")
+
+		v := mg.GetMeta()
+		urequire.True(t, v != nil, "expect meta to be not nil")
+
+		weight, ok := v.(int)
+		urequire.True(t, ok, "expect group metadata to be an integer")
+		uassert.Equal(t, tier.Weight, weight, "expect group weight to match")
+
+		var i int
+		mg.Members().IterateByOffset(0, len(tier.Members), func(addr address) bool {
+			uassert.Equal(t, tier.Members[i], addr, "expect tier member to match")
+
+			i++
+			return false
+		})
+
+		uassert.Equal(t, len(tier.Members), i, "expect all tier members to be iterated")
+	}
+}
+
+func TestMemberStorageHas(t *testing.T) {
+	cases := []struct {
+		name  string
+		found bool
+		setup func() memberstorage.MemberStorage
+	}{
+		{
+			name:  "found",
+			found: true,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+		},
+		{
+			name:  "not found",
+			found: false,
+			setup: func() memberstorage.MemberStorage { return memberstorage.New() },
+		},
+		{
+			name:  "found in base storage with grouping",
+			found: true,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				s.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+
+				g, _ := s.Grouping().Add("foo")
+				g.Members().Add("g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt")
+				return s
+			},
+		},
+		{
+			name:  "not found with grouping",
+			found: false,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				g, _ := s.Grouping().Add("foo")
+				g.Members().Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+		},
+		{
+			name:  "not found with empty grouping",
+			found: false,
+			setup: func() memberstorage.MemberStorage { return memberstorage.NewWithGrouping() },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			storage := tc.setup()
+
+			// Act
+			found := storage.Has("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+
+			// Assert
+			urequire.Equal(t, tc.found, found)
+		})
+	}
+}
+
+func TestGetTotalMemberStorageSize(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() memberstorage.MemberStorage
+		want  int
+	}{
+		{
+			name: "empty",
+			setup: func() memberstorage.MemberStorage {
+				return memberstorage.New()
+			},
+		},
+		{
+			name: "empty with grouping",
+			setup: func() memberstorage.MemberStorage {
+				return memberstorage.NewWithGrouping()
+			},
+		},
+		{
+			name: "one member",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+				return s
+			},
+			want: 1,
+		},
+		{
+			name: "multiple members",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+				s.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+			want: 2,
+		},
+		{
+			name: "one grouped member",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				g, _ := s.Grouping().Add("A")
+				g.Members().Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+			want: 1,
+		},
+		{
+			name: "multiple grouped members",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+
+				g, _ := s.Grouping().Add("A")
+				g.Members().Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				g.Members().Add("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj")
+
+				g, _ = s.Grouping().Add("B")
+				g.Members().Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+				return s
+			},
+			want: 3,
+		},
+		{
+			name: "multiple members with grouping",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				s.Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+
+				g, _ := s.Grouping().Add("A")
+				g.Members().Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				g.Members().Add("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj")
+
+				g, _ = s.Grouping().Add("B")
+				g.Members().Add("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // Add a member that exists in other group
+				return s
+			},
+			want: 4,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			storage := tc.setup()
+
+			// Act
+			got := memberstorage.GetTotalMemberStorageSize(storage)
+
+			// Assert
+			uassert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMemberStorageAdd(t *testing.T) {
+	cases := []struct {
+		name   string
+		member address
+		want   bool
+		setup  func() memberstorage.MemberStorage
+	}{
+		{
+			name:   "success",
+			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			want:   true,
+			setup: func() memberstorage.MemberStorage {
+				return memberstorage.New()
+			},
+		},
+		{
+			name:   "existing member",
+			member: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			want:   false,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+				return s
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
+			// Arrange
+			var got bool
+			storage := tc.setup()
+
+			// Act
+			got = storage.Add(tc.member)
+
+			// Assert
+			urequire.True(t, got == tc.want, "expect member to be added")
+			urequire.True(t, storage.Has(tc.member), "expect member to be found")
+		})
+	}
+}
+
+func TestMemberStorageRemove(t *testing.T) {
+	member := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	cases := []struct {
+		name   string
+		member address
+		want   bool
+		setup  func() memberstorage.MemberStorage
+	}{
+		{
+			name:   "success",
+			member: member,
+			want:   true,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(member)
+				return s
+			},
+		},
+		{
+			name:   "member not found",
+			member: member,
+			want:   false,
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				return s
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
+			// Arrange
+			var got bool
+			storage := tc.setup()
+
+			// Act
+			got = storage.Remove(tc.member)
+
+			// Assert
+			urequire.True(t, got == tc.want, "expect member to be removed")
+			urequire.False(t, storage.Has(tc.member), "expect member to be missing")
+		})
+	}
+}
+
+func TestExistsInMemberStorage(t *testing.T) {
+	member := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	cases := []struct {
+		name  string
+		setup func() memberstorage.MemberStorage
+		want  bool
+	}{
+		{
+			name: "empty storage",
+			setup: func() memberstorage.MemberStorage {
+				return memberstorage.New()
+			},
+			want: false,
+		},
+		{
+			name: "exists",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(member)
+				return s
+			},
+			want: true,
+		},
+		{
+			name: "not found",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+				return s
+			},
+			want: false,
+		},
+		{
+			name: "exists in grouping storage",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				g, _ := s.Grouping().Add("foo")
+				g.Members().Add(member)
+				return s
+			},
+			want: true,
+		},
+		{
+			name: "not found in grouping storage",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				g, _ := s.Grouping().Add("foo")
+				g.Members().Add("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+				return s
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			storage := tc.setup()
+
+			// Act
+			got := memberstorage.ExistsInMemberStorage(storage, member)
+
+			// Assert
+			uassert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIterateMemberStorage(t *testing.T) {
+	// Sorted address order: u1 < u2 < a1 < a2 < b1.
+	var (
+		u1 address = "g125t352u4pmdrr57emc4pe04y40sknr5ztng5mt"
+		u2 address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+		a1 address = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+		a2 address = "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj"
+		b1 address = "g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5"
+	)
+
+	// mixed builds a storage with ungrouped {u1, u2}, group A {a1, a2}, group B {b1}.
+	mixed := func() memberstorage.MemberStorage {
+		s := memberstorage.NewWithGrouping()
+		s.Add(u1)
+		s.Add(u2)
+		ga, _ := s.Grouping().Add("A")
+		ga.Members().Add(a1)
+		ga.Members().Add(a2)
+		gb, _ := s.Grouping().Add("B")
+		gb.Members().Add(b1)
+		return s
+	}
+
+	cases := []struct {
+		name        string
+		setup       func() memberstorage.MemberStorage
+		offset      int
+		count       int
+		stopAfter   int // when > 0, fn returns true on the Nth visit (1-indexed)
+		wantStopped bool
+		want        []address
+	}{
+		{
+			name:  "empty storage without grouping",
+			setup: func() memberstorage.MemberStorage { return memberstorage.New() },
+			count: 10,
+		},
+		{
+			name:  "empty storage with grouping",
+			setup: func() memberstorage.MemberStorage { return memberstorage.NewWithGrouping() },
+			count: 10,
+		},
+		{
+			name: "ungrouped only - full walk",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(u1)
+				s.Add(u2)
+				return s
+			},
+			count: 10,
+			want:  []address{u1, u2},
+		},
+		{
+			name: "ungrouped only - offset skips first",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(u1)
+				s.Add(u2)
+				return s
+			},
+			offset: 1,
+			count:  10,
+			want:   []address{u2},
+		},
+		{
+			name: "ungrouped only - count limits walk",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(u1)
+				s.Add(u2)
+				return s
+			},
+			count: 1,
+			want:  []address{u1},
+		},
+		{
+			name: "ungrouped only - offset beyond size",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(u1)
+				return s
+			},
+			offset: 10,
+			count:  10,
+		},
+		{
+			name: "ungrouped only - negative offset treated as zero",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.New()
+				s.Add(u1)
+				s.Add(u2)
+				return s
+			},
+			offset: -1,
+			count:  10,
+			want:   []address{u1, u2},
+		},
+		{
+			name: "grouped only - full walk in group order",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				ga, _ := s.Grouping().Add("A")
+				ga.Members().Add(a1)
+				ga.Members().Add(a2)
+				gb, _ := s.Grouping().Add("B")
+				gb.Members().Add(b1)
+				return s
+			},
+			count: 10,
+			want:  []address{a1, a2, b1},
+		},
+		{
+			name:  "mixed - ungrouped first then groups in order",
+			setup: mixed,
+			count: 10,
+			want:  []address{u1, u2, a1, a2, b1},
+		},
+		{
+			name:   "mixed - offset spans into groups",
+			setup:  mixed,
+			offset: 2,
+			count:  10,
+			want:   []address{a1, a2, b1},
+		},
+		{
+			name:   "mixed - offset spans ungrouped and first group",
+			setup:  mixed,
+			offset: 4,
+			count:  10,
+			want:   []address{b1},
+		},
+		{
+			name:   "mixed - offset beyond total",
+			setup:  mixed,
+			offset: 100,
+			count:  10,
+		},
+		{
+			name:   "mixed - negative offset treated as zero",
+			setup:  mixed,
+			offset: -5,
+			count:  10,
+			want:   []address{u1, u2, a1, a2, b1},
+		},
+		{
+			name:  "mixed - count limits within ungrouped",
+			setup: mixed,
+			count: 1,
+			want:  []address{u1},
+		},
+		{
+			name:  "mixed - count limits across boundary",
+			setup: mixed,
+			count: 3,
+			want:  []address{u1, u2, a1},
+		},
+		{
+			name:        "mixed - fn stops in ungrouped",
+			setup:       mixed,
+			count:       10,
+			stopAfter:   1,
+			wantStopped: true,
+			want:        []address{u1},
+		},
+		{
+			name:        "mixed - fn stops in group",
+			setup:       mixed,
+			count:       10,
+			stopAfter:   3,
+			wantStopped: true,
+			want:        []address{u1, u2, a1},
+		},
+		{
+			name:  "mixed - count zero",
+			setup: mixed,
+		},
+		{
+			name:  "mixed - count negative",
+			setup: mixed,
+			count: -5,
+		},
+		{
+			name: "duplicate across groups visited twice",
+			setup: func() memberstorage.MemberStorage {
+				s := memberstorage.NewWithGrouping()
+				ga, _ := s.Grouping().Add("A")
+				ga.Members().Add(a1)
+				gb, _ := s.Grouping().Add("B")
+				gb.Members().Add(a1)
+				return s
+			},
+			count: 10,
+			want:  []address{a1, a1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			storage := tc.setup()
+
+			var visited []address
+			fn := func(member address) bool {
+				visited = append(visited, member)
+				return tc.stopAfter > 0 && len(visited) == tc.stopAfter
+			}
+
+			// Act
+			stopped := memberstorage.IterateMemberStorage(storage, tc.offset, tc.count, fn)
+
+			// Assert
+			uassert.Equal(t, tc.wantStopped, stopped, "expect stopped to match")
+			urequire.Equal(t, len(tc.want), len(visited), "expect visited count to match")
+			for i, want := range tc.want {
+				uassert.Equal(t, want, visited[i], "expect member at visit index to match")
+			}
+		})
+	}
+}
+
+func TestMemberStorageGrouping(t *testing.T) {
+	t.Run("with grouping", func(t *testing.T) {
+		storage := memberstorage.NewWithGrouping()
+		urequire.True(t, storage.Grouping() != nil, "expect a grouping to be returned")
+	})
+
+	t.Run("without grouping", func(t *testing.T) {
+		storage := memberstorage.New()
+		urequire.True(t, storage.Grouping() == nil, "expect a grouping to be nil")
+	})
+}
+
+func TestIsCanonicalMemberStorage(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() memberstorage.MemberStorage
+		want  bool
+	}{
+		{
+			name:  "canonical without grouping",
+			setup: func() memberstorage.MemberStorage { return memberstorage.New() },
+			want:  true,
+		},
+		{
+			name:  "canonical with grouping",
+			setup: func() memberstorage.MemberStorage { return memberstorage.NewWithGrouping() },
+			want:  true,
+		},
+		{
+			name:  "non canonical",
+			setup: func() memberstorage.MemberStorage { return stubMemberStorage{} },
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uassert.Equal(t, tc.want, memberstorage.IsCanonicalMemberStorage(tc.setup()))
+		})
+	}
+}
+
+type stubMemberStorage struct{}
+
+func (stubMemberStorage) Size() int                              { return 0 }
+func (stubMemberStorage) Has(address) bool                       { return false }
+func (stubMemberStorage) Add(address) bool                       { return false }
+func (stubMemberStorage) Remove(address) bool                    { return false }
+func (stubMemberStorage) Grouping() memberstorage.MemberGrouping { return nil }
+
+func (stubMemberStorage) IterateByOffset(offset, count int, fn memberstorage.MemberIterFn) bool {
+	return false
+}

--- a/examples/gno.land/p/gnoland/boards/exts/permissions/options.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/permissions/options.gno
@@ -24,7 +24,7 @@ func WithSuperRole(r boards.Role) Option {
 		}
 
 		name := string(r)
-		p.dao.Members().Grouping().Add(name)
+		p.members.Grouping().Add(name)
 		p.superRole = r
 	}
 }

--- a/examples/gno.land/p/gnoland/boards/exts/permissions/permissions.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/permissions/permissions.gno
@@ -2,9 +2,8 @@ package permissions
 
 import (
 	"gno.land/p/gnoland/boards"
+	"gno.land/p/gnoland/boards/exts/memberstorage"
 	"gno.land/p/nt/bptree/v0"
-	"gno.land/p/nt/commondao/v0"
-	"gno.land/p/nt/commondao/v0/exts/storage"
 )
 
 // ValidatorFunc defines a function type for permissions validators.
@@ -23,7 +22,7 @@ type ValidatorFunc func(boards.Permissions, boards.Args) error
 // be configured to only allow one role per user.
 type Permissions struct {
 	superRole      boards.Role
-	dao            *commondao.CommonDAO
+	members        memberstorage.MemberStorage
 	public         boards.PermissionSet
 	validators     *bptree.BPTree // string(boards.Permission) -> ValidatorFunc
 	singleUserRole bool
@@ -31,21 +30,15 @@ type Permissions struct {
 
 // New creates a new permissions type.
 func New(options ...Option) *Permissions {
-	s := storage.NewMemberStorage()
 	ps := &Permissions{
 		validators: bptree.NewBPTree32(),
-		dao:        commondao.New(commondao.WithMemberStorage(s)),
+		members:    memberstorage.NewWithGrouping(),
 	}
 
 	for _, apply := range options {
 		apply(ps)
 	}
 	return ps
-}
-
-// DAO returns the underlying permissions DAO.
-func (ps Permissions) DAO() *commondao.CommonDAO {
-	return ps.dao
 }
 
 // ValidateFunc adds a custom permission validator function.
@@ -70,7 +63,7 @@ func (ps *Permissions) AddRole(r boards.Role, p boards.Permission, extra ...boar
 	}
 
 	// Get member group for the role if it exists or otherwise create a new group
-	grouping := ps.dao.Members().Grouping()
+	grouping := ps.members.Grouping()
 	name := string(r)
 	group, found := grouping.Get(name)
 	if !found {
@@ -88,12 +81,12 @@ func (ps *Permissions) AddRole(r boards.Role, p boards.Permission, extra ...boar
 
 // RoleExists checks if a role exists.
 func (ps Permissions) RoleExists(r boards.Role) bool {
-	return r == ps.superRole || ps.dao.Members().Grouping().Has(string(r))
+	return r == ps.superRole || ps.members.Grouping().Has(string(r))
 }
 
 // GetUserRoles returns the list of roles assigned to a user.
 func (ps Permissions) GetUserRoles(user address) []boards.Role {
-	groups := storage.GetMemberGroups(ps.dao.Members(), user)
+	groups := memberstorage.GetMemberGroups(ps.members, user)
 	if groups == nil {
 		return nil
 	}
@@ -108,7 +101,7 @@ func (ps Permissions) GetUserRoles(user address) []boards.Role {
 // HasRole checks if a user has a specific role assigned.
 func (ps Permissions) HasRole(user address, r boards.Role) bool {
 	name := string(r)
-	group, found := ps.dao.Members().Grouping().Get(name)
+	group, found := ps.members.Grouping().Get(name)
 	if !found {
 		return false
 	}
@@ -121,12 +114,12 @@ func (ps Permissions) HasPermission(user address, perm boards.Permission) bool {
 		return true
 	}
 
-	groups := storage.GetMemberGroups(ps.dao.Members(), user)
+	groups := memberstorage.GetMemberGroups(ps.members, user)
 	if groups == nil {
 		return false
 	}
 
-	grouping := ps.dao.Members().Grouping()
+	grouping := ps.members.Grouping()
 	for _, name := range groups {
 		role := boards.Role(name)
 		if ps.superRole == role {
@@ -155,11 +148,11 @@ func (ps *Permissions) SetUserRoles(user address, roles ...boards.Role) {
 		panic("user can only have one role")
 	}
 
-	groups := storage.GetMemberGroups(ps.dao.Members(), user)
+	groups := memberstorage.GetMemberGroups(ps.members, user)
 	isGuest := len(roles) == 0
 
 	// Clear current user roles
-	grouping := ps.dao.Members().Grouping()
+	grouping := ps.members.Grouping()
 	for _, name := range groups {
 		group, found := grouping.Get(name)
 		if !found {
@@ -171,7 +164,7 @@ func (ps *Permissions) SetUserRoles(user address, roles ...boards.Role) {
 
 	// Add user to the storage as guest when no roles are assigned
 	if isGuest {
-		ps.dao.Members().Add(user)
+		ps.members.Add(user)
 		return
 	}
 
@@ -189,12 +182,12 @@ func (ps *Permissions) SetUserRoles(user address, roles ...boards.Role) {
 
 // RemoveUser removes a user from permissions.
 func (ps *Permissions) RemoveUser(user address) bool {
-	groups := storage.GetMemberGroups(ps.dao.Members(), user)
+	groups := memberstorage.GetMemberGroups(ps.members, user)
 	if groups == nil {
-		return ps.dao.Members().Remove(user)
+		return ps.members.Remove(user)
 	}
 
-	grouping := ps.dao.Members().Grouping()
+	grouping := ps.members.Grouping()
 	for _, name := range groups {
 		group, found := grouping.Get(name)
 		if !found {
@@ -208,19 +201,19 @@ func (ps *Permissions) RemoveUser(user address) bool {
 
 // HasUser checks if a user exists.
 func (ps Permissions) HasUser(user address) bool {
-	return ps.dao.Members().Has(user)
+	return memberstorage.ExistsInMemberStorage(ps.members, user)
 }
 
 // UsersCount returns the total number of users the permissioner contains.
 func (ps Permissions) UsersCount() int {
-	return ps.dao.Members().Size()
+	return memberstorage.GetTotalMemberStorageSize(ps.members)
 }
 
 // IterateUsers iterates permissions' users.
-func (ps Permissions) IterateUsers(start, count int, fn boards.UsersIterFn) (stopped bool) {
-	ps.dao.Members().IterateByOffset(start, count, func(addr address) bool {
+func (ps Permissions) IterateUsers(start, count int, fn boards.UsersIterFn) bool {
+	return memberstorage.IterateMemberStorage(ps.members, start, count, func(addr address) bool {
 		user := boards.User{Address: addr}
-		groups := storage.GetMemberGroups(ps.dao.Members(), addr)
+		groups := memberstorage.GetMemberGroups(ps.members, addr)
 		if groups != nil {
 			user.Roles = make([]boards.Role, len(groups))
 			for i, name := range groups {
@@ -230,7 +223,6 @@ func (ps Permissions) IterateUsers(start, count int, fn boards.UsersIterFn) (sto
 
 		return fn(user)
 	})
-	return
 }
 
 // WithPermission calls a callback when a user has a specific permission.

--- a/examples/gno.land/p/gnoland/boards/exts/permissions/permissions.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/permissions/permissions.gno
@@ -201,17 +201,17 @@ func (ps *Permissions) RemoveUser(user address) bool {
 
 // HasUser checks if a user exists.
 func (ps Permissions) HasUser(user address) bool {
-	return memberstorage.ExistsInMemberStorage(ps.members, user)
+	return memberstorage.HasMember(ps.members, user)
 }
 
 // UsersCount returns the total number of users the permissioner contains.
 func (ps Permissions) UsersCount() int {
-	return memberstorage.GetTotalMemberStorageSize(ps.members)
+	return memberstorage.GetTotalSize(ps.members)
 }
 
 // IterateUsers iterates permissions' users.
 func (ps Permissions) IterateUsers(start, count int, fn boards.UsersIterFn) bool {
-	return memberstorage.IterateMemberStorage(ps.members, start, count, func(addr address) bool {
+	return memberstorage.Iterate(ps.members, start, count, func(addr address) bool {
 		user := boards.User{Address: addr}
 		groups := memberstorage.GetMemberGroups(ps.members, addr)
 		if groups != nil {

--- a/examples/gno.land/p/gnoland/boards/exts/permissions/permissions_test.gno
+++ b/examples/gno.land/p/gnoland/boards/exts/permissions/permissions_test.gno
@@ -510,16 +510,16 @@ func TestBasicPermissionsRemoveUser(t *testing.T) {
 func TestBasicPermissionsIterateUsers(t *testing.T) {
 	users := []boards.User{
 		{
-			Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
-			Roles:   []boards.Role{"foo"},
-		},
-		{
 			Address: "g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj",
 			Roles:   []boards.Role{"bar", "foo"},
 		},
 		{
 			Address: "g1vh7krmmzfua5xjmkatvmx09z37w34lsvd2mxa5",
 			Roles:   []boards.Role{"bar"},
+		},
+		{
+			Address: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			Roles:   []boards.Role{"foo"},
 		},
 	}
 

--- a/examples/gno.land/r/gnoland/boards2/v1/filetests/z_iterate_realm_members_00_filetest.gno
+++ b/examples/gno.land/r/gnoland/boards2/v1/filetests/z_iterate_realm_members_00_filetest.gno
@@ -32,5 +32,5 @@ func main(cur realm) {
 }
 
 // Output:
-// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh owner
 // g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj admin
+// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh owner

--- a/examples/gno.land/r/gnoland/boards2/v1/hub/filetests/z_4_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/boards2/v1/hub/filetests/z_4_a_filetest.gno
@@ -35,6 +35,6 @@ func main(cur realm) {
 }
 
 // Output:
-// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 slice[("owner" gno.land/p/gnoland/boards.Role)]
-// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh slice[("owner" gno.land/p/gnoland/boards.Role)]
-// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj slice[("admin" gno.land/p/gnoland/boards.Role)]
+// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj readonly(slice[("admin" gno.land/p/gnoland/boards.Role)])
+// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 readonly(slice[("owner" gno.land/p/gnoland/boards.Role)])
+// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh readonly(slice[("owner" gno.land/p/gnoland/boards.Role)])

--- a/examples/gno.land/r/gnoland/boards2/v1/hub/filetests/z_4_a_filetest.gno
+++ b/examples/gno.land/r/gnoland/boards2/v1/hub/filetests/z_4_a_filetest.gno
@@ -35,6 +35,6 @@ func main(cur realm) {
 }
 
 // Output:
-// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj readonly(slice[("admin" gno.land/p/gnoland/boards.Role)])
-// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 readonly(slice[("owner" gno.land/p/gnoland/boards.Role)])
-// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh readonly(slice[("owner" gno.land/p/gnoland/boards.Role)])
+// g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj slice[("admin" gno.land/p/gnoland/boards.Role)]
+// g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 slice[("owner" gno.land/p/gnoland/boards.Role)]
+// g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh slice[("owner" gno.land/p/gnoland/boards.Role)]


### PR DESCRIPTION
Adds a new `gno.land/p/gnoland/boards/exts/memberstorage` that brings a set of features to define a storage for board members with optional member grouping support, originally implemented by CommonDAO package.

This change **removes Boards2 dependency on the CommonDAO package**, by changing the default `Permissions` interface implementation that Boards2 uses to use `memberstorage` instead of `commondao` package.



