### PR TITLE
fix(gnovm): close the nil-realm cross-realm write hole for /p/ and stdlib

### DIFF
--- a/examples/gno.land/p/demo/tests/launderattack/launderattack.gno
+++ b/examples/gno.land/p/demo/tests/launderattack/launderattack.gno
@@ -142,6 +142,18 @@ func EvilObjectWrite(o *launderpkg.Object) {
 	o.Field = "pwnd-via-apply-obj"
 }
 
+// StoredHook is a /p/attack package-level closure: a FuncLit evaluated
+// during /p/launderattack init, so its ObjectInfo.PkgID is stamped
+// /p/launderattack. Unlike a top-level FuncDecl (EvilWrite/EvilObjectWrite,
+// IsClosure=false), invoking a closure triggers PushFrameCall's borrow rule
+// #3, which borrows m.Realm to the closure's construction realm
+// (/p/launderattack). Used to probe rule #3: a write through it to a foreign
+// /r/ object must still be rejected. (If rule #3 ever regressed to a nil
+// borrow, m.Realm would go nil and the write would silently succeed.)
+var StoredHook = func(o *launderpkg.Object) {
+	o.Field = "pwnd-via-stored-closure"
+}
+
 // Tamperer is a stamped /p/attack value (constructed at init under
 // /p/attack's realm context, stamped /p/attack, persisted Frozen).
 // Methods on Tamperer get receiver-borrowed to /p/attack at call

--- a/examples/gno.land/r/tests/vm/laundervictim/laundervictim.gno
+++ b/examples/gno.land/r/tests/vm/laundervictim/laundervictim.gno
@@ -20,12 +20,18 @@ var (
 	// method in /p/launderpkg. Victim exposes a pointer to it,
 	// intending "callers can read but not write."
 	gImm *launderpkg.Immutable
+	// gBuf is a victim-owned byte buffer (real, /r/laundervictim-stamped
+	// after init). Used to probe whether a stdlib method (e.g.
+	// base64.Encode) can be tricked into writing the victim's own buffer
+	// when an attacker passes it as an out-parameter.
+	gBuf []byte
 )
 
 func init() {
 	gVal = launderpkg.Object{Field: "original-val"}
 	gPtr = &launderpkg.Object{Field: "original-ptr"}
 	gImm = &launderpkg.Immutable{Field: "original-imm"}
+	gBuf = []byte("original-buffer!")
 }
 
 // GetVal returns g by VALUE (caller gets a copy).
@@ -44,11 +50,16 @@ func GetValAddr() *launderpkg.Object { return &gVal }
 // but not write.
 func GetImm() *launderpkg.Immutable { return gImm }
 
-// ReadVal / ReadPtr / ReadImm report the current field values for
+// GetBuf returns the victim's own byte buffer. The returned slice
+// aliases the victim's persisted backing array (/r/laundervictim-stamped).
+func GetBuf() []byte { return gBuf }
+
+// ReadVal / ReadPtr / ReadImm / ReadBuf report the current values for
 // after-attack verification.
 func ReadVal() string { return gVal.Field }
 func ReadPtr() string { return gPtr.Field }
 func ReadImm() string { return gImm.Field }
+func ReadBuf() string { return string(gBuf) }
 
 // Exploiter is the interface the victim accepts. The attacker
 // supplies an implementation; the victim invokes Something(g)

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -2328,13 +2328,23 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 	//       function). /r/attacker code runs with /r/attacker's
 	//       authority, not victim's.
 	//
-	//   #2. Otherwise (stdlib or /p/-declared) → if the receiver is a
-	//       real, foreign-stamped object, borrow to the receiver's
-	//       constructing realm (which is the same as its storage realm).
+	//   #2. Otherwise (/p/-declared) → if the receiver is a real,
+	//       foreign-stamped object, borrow to the receiver's constructing
+	//       realm (which is the same as its storage realm).
 	//
 	//   #3. Otherwise, if fv is a closure (FuncLit) declared in a /p/
 	//       package, borrow to the realm context that was active when
 	//       the closure was constructed (and will be stored).
+	//
+	// Stdlib-stamped receivers are EXCLUDED from borrow rule #2: stdlib is
+	// a trusted, frozen transform library that owns no mutable state, so
+	// its methods run with the CALLER's authority (m.Realm unchanged), not
+	// stdlib's. This lets a stdlib method write a caller-supplied out-param
+	// buffer (e.g. base64.Encode(dst, src) where dst is caller-owned), while
+	// still blocking writes to a third realm's data (foreign != caller). It
+	// also keeps the nil-realm write hole closed: a tx's entry realm is
+	// non-nil, so a stdlib method writing a foreign /r/ object is rejected
+	// by the readonly gate against the caller's realm.
 	if IsRealmPath(pv.PkgPath) {
 		if m.Realm == nil || pv.PkgPath != m.Realm.Path {
 			m.setRealm(pv.GetRealm())
@@ -2345,7 +2355,7 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 		obj := recv.GetFirstObject(m.Store)
 		if obj != nil {
 			recvOID := obj.GetObjectInfo().ID
-			if !recvOID.IsZero() &&
+			if !recvOID.IsZero() && !recvOID.PkgID.IsStdlibPkg() &&
 				(m.Realm == nil || recvOID.PkgID != m.Realm.ID) {
 				recvPkgOID := ObjectIDFromPkgID(recvOID.PkgID)
 				objpv := m.Store.GetObject(recvPkgOID).(*PackageValue)
@@ -2366,12 +2376,16 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 	// closed-over capability — borrow rule #1 already handles the /r/-declared
 	// case, and /p/-declared FuncDecls shouldn't shift the realm.
 	//
-	// The zero-PkgID check skips closures constructed in uverse/stdlib
-	// init (no realm context). The equality short-circuit avoids a
-	// redundant setRealm when we're already in the closure's home.
+	// Stdlib-stamped closures are skipped, mirroring borrow rule #2's
+	// stdlib-receiver skip: stdlib owns no mutable state and runs with the
+	// caller's authority, so a stdlib-init-constructed closure keeps m.Realm
+	// at the caller's realm rather than borrowing to the (frozen) stdlib
+	// realm. The zero-PkgID check skips closures constructed with no realm
+	// context (uverse). The equality short-circuit avoids a redundant
+	// setRealm when we're already in the closure's home.
 	if fv.IsClosure {
 		pid := fv.GetObjectInfo().ID.PkgID
-		if !pid.IsZero() && (m.Realm == nil || pid != m.Realm.ID) {
+		if !pid.IsZero() && !pid.IsStdlibPkg() && (m.Realm == nil || pid != m.Realm.ID) {
 			pkgOID := ObjectIDFromPkgID(pid)
 			if pobj := m.Store.GetObject(pkgOID); pobj != nil {
 				if objpv, ok := pobj.(*PackageValue); ok {
@@ -2632,12 +2646,48 @@ func readonlyAccessPanic(x Expr) string {
 	return "cannot directly modify readonly tainted object (use a method or crossing function): " + x.String()
 }
 
-// Returns false if m.Realm is nil (single user mode, nothing is readonly).
-// Otherwise returns true iff:
+// IsReadonly is the write-guard form, used at every mutation site
+// (PopAsPointer2, uverse append/copy/delete, map assign). Returns false if
+// m.Realm is nil (single user mode). Otherwise returns true iff:
 //   - tv is a ref to (external) package path, or
 //   - tv is N_Readonly, or
 //   - tv is a real object residing in external realm
+//
+// One own-package write exemption: STDLIB code may write its own
+// stdlib-stamped data. Stdlib is transient-mutable (re-initialized each tx —
+// e.g. math/rand's global RNG advancing p.lo/p.hi), and stdlib methods run
+// with the caller's realm (borrow rule #2 is skipped for stdlib receivers),
+// so without this a stdlib package mutating its own global would wrongly
+// panic. Keyed on m.Package (the executing code), so an attacker can't
+// trigger it; and NOT granted to /p/ — a /p/ package writing its own
+// immutable global must still be blocked. (isReadonlyForCopy is the
+// read-taint variant, which grants the own-package exemption to all pkgs.)
 func (m *Machine) IsReadonly(tv *TypedValue) bool {
+	var ownPkgID PkgID
+	if m.Package != nil && m.Package.PkgID.IsStdlibPkg() {
+		ownPkgID = m.Package.PkgID
+	}
+	return m.isReadonly(tv, ownPkgID)
+}
+
+// isReadonlyForCopy is the read-taint variant used by value-read ops
+// (index/selector/slice/deref). A package may freely read and copy its
+// OWN package-level data regardless of m.Realm — e.g. stdlib or a /p/
+// library reading its own immutable tables while running under a caller's
+// realm (those top-level callables don't borrow, so m.Realm is the
+// caller's, not the library's). Without this, copying out a table entry
+// (pow := tbl[i]) inherits a foreign taint and a later mutation of the
+// independent copy wrongly panics. Writes through the copy/alias remain
+// guarded by the strict IsReadonly at PopAsPointer2/builtins.
+func (m *Machine) isReadonlyForCopy(tv *TypedValue) bool {
+	var ownPkgID PkgID
+	if m.Package != nil {
+		ownPkgID = m.Package.PkgID
+	}
+	return m.isReadonly(tv, ownPkgID)
+}
+
+func (m *Machine) isReadonly(tv *TypedValue, ownPkgID PkgID) bool {
 	//  m.Realm is nil → single user mode, nothing is readonly
 	if m.Realm == nil {
 		return false
@@ -2651,8 +2701,9 @@ func (m *Machine) IsReadonly(tv *TypedValue) bool {
 		}
 	}
 	//   - tv is N_Readonly, or
-	//   - tv is a real object residing in external realm
-	return tv.IsReadonlyBy(m.Realm.ID)
+	//   - tv is a real object residing in external realm (but, for the
+	//     read-taint variant, not the executing package's own data).
+	return tv.IsReadonlyBy(m.Realm.ID, ownPkgID)
 }
 
 // isExternalRealm returns true if base is a real Object belonging to
@@ -2685,6 +2736,15 @@ func (m *Machine) isExternalRealm(base Value) bool {
 	// at ownership.go:468-490; that's still the authoritative gate
 	// for pointer-deref writes obtained via &name.
 	if _, ok := base.(*HeapItemValue); ok {
+		return false
+	}
+	// Stdlib own-write exemption (mirrors IsReadonly): a stdlib package may
+	// write its own stdlib-stamped package global (e.g. a top-level stdlib
+	// function reassigning a global) even though it runs with the caller's
+	// realm, since borrow rule #2 is skipped for stdlib receivers. Keyed on
+	// m.Package (the executing code), so an attacker can't trigger it; NOT
+	// granted to /p/ — a /p/ global stays immutable post-init.
+	if m.Package != nil && m.Package.PkgID.IsStdlibPkg() && oid.PkgID == m.Package.PkgID {
 		return false
 	}
 	return oid.PkgID != m.Realm.ID

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -302,6 +302,20 @@ func (m *Machine) setRealm(r *Realm) {
 	}
 }
 
+// assertBorrowedRealm panics (debug builds only) when a borrow rule is about
+// to set m.Realm to nil for a package that MUST carry a realm — /r/, /p/, or
+// stdlib (IsRealmPath || isImmutableLibraryPath). That would silently put the
+// machine in "single-user mode" (IsReadonly/isExternalRealm short-circuit on
+// nil m.Realm) and reopen the nil-realm cross-realm write hole. _test overlays
+// and uverse legitimately have no realm and are excluded (neither predicate
+// matches them).
+func assertBorrowedRealm(pkgPath string, r *Realm) {
+	if debugAssert && r == nil &&
+		(IsRealmPath(pkgPath) || isImmutableLibraryPath(pkgPath)) {
+		panic("borrow rule set m.Realm=nil for realm-bearing package: " + pkgPath)
+	}
+}
+
 //----------------------------------------
 // top level Run* methods.
 
@@ -2291,7 +2305,9 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 				mrpath,
 			))
 		}
-		m.setRealm(pv.GetRealm())
+		r := pv.GetRealm()
+		assertBorrowedRealm(pv.PkgPath, r)
+		m.setRealm(r)
 		return
 	}
 
@@ -2347,7 +2363,9 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 	// by the readonly gate against the caller's realm.
 	if IsRealmPath(pv.PkgPath) {
 		if m.Realm == nil || pv.PkgPath != m.Realm.Path {
-			m.setRealm(pv.GetRealm())
+			r := pv.GetRealm()
+			assertBorrowedRealm(pv.PkgPath, r)
+			m.setRealm(r)
 		}
 		return
 	}
@@ -2359,7 +2377,9 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 				(m.Realm == nil || recvOID.PkgID != m.Realm.ID) {
 				recvPkgOID := ObjectIDFromPkgID(recvOID.PkgID)
 				objpv := m.Store.GetObject(recvPkgOID).(*PackageValue)
-				m.setRealm(objpv.GetRealm())
+				r := objpv.GetRealm()
+				assertBorrowedRealm(objpv.PkgPath, r)
+				m.setRealm(r)
 			}
 		}
 	}
@@ -2389,7 +2409,9 @@ func (m *Machine) PushFrameCall(cx *CallExpr, fv *FuncValue, recv TypedValue, is
 			pkgOID := ObjectIDFromPkgID(pid)
 			if pobj := m.Store.GetObject(pkgOID); pobj != nil {
 				if objpv, ok := pobj.(*PackageValue); ok {
-					m.setRealm(objpv.GetRealm())
+					r := objpv.GetRealm()
+					assertBorrowedRealm(objpv.PkgPath, r)
+					m.setRealm(r)
 				}
 			}
 		}

--- a/gnovm/pkg/gnolang/machine_test.go
+++ b/gnovm/pkg/gnolang/machine_test.go
@@ -105,6 +105,8 @@ func TestMachineString(t *testing.T) {
     Blocks:
     Blocks (other):
     Frames:
+    Realm:
+      std
 `,
 		},
 		{
@@ -135,6 +137,8 @@ func TestMachineString(t *testing.T) {
     Blocks:
     Blocks (other):
     Frames:
+    Realm:
+      std
 `,
 		},
 	}

--- a/gnovm/pkg/gnolang/mempackage.go
+++ b/gnovm/pkg/gnolang/mempackage.go
@@ -158,6 +158,25 @@ func IsStdlib(pkgPath string) bool {
 	return match != nil
 }
 
+// isImmutableLibraryPath reports whether pkgPath is a /p/ or stdlib library
+// package that should carry a frozen, immutable realm. That realm is a
+// runtime borrow target for the cross-realm write gate, so a /p/- or
+// stdlib-stamped receiver's method runs with m.Realm set (not nil).
+//
+// External _test overlays are excluded: they are transient test
+// scaffolding, never deployed, and granting one a realm makes a stdlib's
+// own self-tests (e.g. strconv_test) execute under a foreign realm, which
+// breaks legitimate same-package reads/writes of the stdlib's own state.
+// /p/ and /r/ _test overlays already self-exclude (IsPPackagePath /
+// IsRealmPath reject the _test suffix); only stdlib's dot-free _test
+// names slip through IsStdlib, so guard against the suffix here.
+func isImmutableLibraryPath(pkgPath string) bool {
+	if strings.HasSuffix(pkgPath, "_test") {
+		return false
+	}
+	return IsPPackagePath(pkgPath) || IsStdlib(pkgPath)
+}
+
 // IsUserlib determines whether pkgPath is for a non-stdlib path.
 // It must be of the form <domain>/<letter>/<user>(/<repo>).
 func IsUserlib(pkgPath string) bool {

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1375,18 +1375,19 @@ func (pn *PackageNode) NewPackage(alloc *Allocator) *PackageValue {
 	// Cannot set ObjectID here; it is not real yet.
 	// BAD: pv.SetObjectID(ObjectIDFromPkgPath(pv.PkgPath))
 	// Set realm for realm packages, main package, and ephemeral run packages.
-	// /p/ packages also get a realm: it is frozen/immutable (IsRealm() stays
-	// false, so it is never persisted as mutable state), but giving it a real
-	// Realm means borrow rule #2 on a /p/-stamped receiver shifts m.Realm to
-	// this realm instead of nil — so the readonly/PkgID write gate keeps
-	// working inside /p/-method bodies (it short-circuits to "allow" on nil).
+	// /p/ and stdlib packages also get a realm: it is frozen/immutable
+	// (IsRealm() stays false, so it is never persisted as mutable state), but
+	// giving it a real Realm means borrow rule #2 on a /p/- or stdlib-stamped
+	// receiver shifts m.Realm to this realm instead of nil — so the
+	// readonly/PkgID write gate keeps working inside those method bodies (it
+	// short-circuits to "allow" on nil).
 	if IsRealmPath(pn.PkgPath) || pn.PkgPath == "main" {
 		rlm := NewRealm(pn.PkgPath)
 		pv.SetRealm(rlm)
 	} else if _, isRunPath := IsGnoRunPath(pn.PkgPath); isRunPath {
 		rlm := NewRealm(pn.PkgPath)
 		pv.SetRealm(rlm)
-	} else if IsPPackagePath(pn.PkgPath) {
+	} else if isImmutableLibraryPath(pn.PkgPath) {
 		rlm := NewRealm(pn.PkgPath)
 		pv.SetRealm(rlm)
 	}

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1374,11 +1374,19 @@ func (pn *PackageNode) NewPackage(alloc *Allocator) *PackageValue {
 	}
 	// Cannot set ObjectID here; it is not real yet.
 	// BAD: pv.SetObjectID(ObjectIDFromPkgPath(pv.PkgPath))
-	// Set realm for realm packages, main package, and ephemeral run packages
+	// Set realm for realm packages, main package, and ephemeral run packages.
+	// /p/ packages also get a realm: it is frozen/immutable (IsRealm() stays
+	// false, so it is never persisted as mutable state), but giving it a real
+	// Realm means borrow rule #2 on a /p/-stamped receiver shifts m.Realm to
+	// this realm instead of nil — so the readonly/PkgID write gate keeps
+	// working inside /p/-method bodies (it short-circuits to "allow" on nil).
 	if IsRealmPath(pn.PkgPath) || pn.PkgPath == "main" {
 		rlm := NewRealm(pn.PkgPath)
 		pv.SetRealm(rlm)
 	} else if _, isRunPath := IsGnoRunPath(pn.PkgPath); isRunPath {
+		rlm := NewRealm(pn.PkgPath)
+		pv.SetRealm(rlm)
+	} else if IsPPackagePath(pn.PkgPath) {
 		rlm := NewRealm(pn.PkgPath)
 		pv.SetRealm(rlm)
 	}

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -392,14 +392,13 @@ func (m *Machine) doOpCallDeferNativeBody() {
 // Used by return and panic operation handlers.
 // Must finalize for returns, and must abort for panics.
 func (m *Machine) isRealmBoundary(cfr *Frame) bool {
-	// Explicit cross-call always marks a realm boundary, regardless
-	// of whether m.Realm is tracked. /p/ test code that wraps calls
-	// in `func(cur){...}(cross(cur))` relies on this so panics
-	// propagating back through the cross frame route to revive(),
-	// not all the way up — even though /p/ packages have no Realm
-	// (m.Realm is nil under the borrow rule for /p/-stamped
-	// receivers). Pulled out of the `crlm != nil` guard so it fires
-	// on m.Realm==nil too.
+	// Explicit cross-call always marks a realm boundary, regardless of
+	// whether m.Realm is tracked. /p/ test code that wraps calls in
+	// `func(cur){...}(cross(cur))` relies on this so panics propagating
+	// back through the cross frame route to revive(), not all the way up.
+	// Pulled out of the `crlm != nil` guard so it fires on m.Realm==nil too
+	// (e.g. a stdlib-stamped receiver, which keeps the caller's realm and so
+	// may be nil at the top frame of a non-realm test).
 	if cfr.WithCross {
 		return true
 	}
@@ -440,10 +439,12 @@ func (m *Machine) isRealmBoundary(cfr *Frame) bool {
 // Finalize realm updates if realm boundary.
 // NOTE: resource intensive
 func (m *Machine) maybeFinalize(cfr *Frame) {
-	if m.isRealmBoundary(cfr) && m.Realm != nil {
-		// m.Realm==nil only happens for /p/ and stdlib (no real realm),
-		// where there's nothing to finalize even though isRealmBoundary
-		// reports the cross-call frame as a boundary for panic-routing.
+	if m.isRealmBoundary(cfr) && m.Realm != nil && !m.Realm.ID.IsImmutablePkg() {
+		// /p/ and stdlib packages now carry a frozen, immutable realm
+		// (so the readonly gate works inside their method bodies), but
+		// that realm must never be persisted: skip finalization for it.
+		// isRealmBoundary still reports the frame as a boundary for
+		// panic-routing; we just don't run FinalizeRealmTransaction.
 		m.Realm.FinalizeRealmTransaction(m.Store)
 	}
 }

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -11,7 +11,7 @@ func (m *Machine) doOpIndex1() {
 	m.PopExpr()
 	iv := m.PopValue()   // index
 	xv := m.PeekValue(1) // x
-	ro := m.IsReadonly(xv)
+	ro := m.isReadonlyForCopy(xv)
 	switch ct := baseOf(xv.T).(type) {
 	case *MapType:
 		vt := ct.Value
@@ -39,7 +39,7 @@ func (m *Machine) doOpIndex2() {
 	m.PopExpr()
 	iv := m.PeekValue(1) // index
 	xv := m.PeekValue(2) // x
-	ro := m.IsReadonly(xv)
+	ro := m.isReadonlyForCopy(xv)
 	switch ct := baseOf(xv.T).(type) {
 	case *MapType:
 		vt := ct.Value
@@ -80,7 +80,7 @@ func (m *Machine) doOpSelector() {
 	default:
 		m.incrCPU(OpCPUSelectorField)
 	}
-	ro := m.IsReadonly(xv)
+	ro := m.isReadonlyForCopy(xv)
 	res := xv.GetPointerToFromTV(m.Alloc, m.Store, sx.Path).Deref()
 	if debug {
 		m.Printf("-v[S] %v\n", xv)
@@ -109,7 +109,7 @@ func (m *Machine) doOpSlice() {
 	}
 	// slice base x
 	xv := m.PopValue()
-	ro := m.IsReadonly(xv)
+	ro := m.isReadonlyForCopy(xv)
 	// if a is a pointer to an array, a[low : high : max] is
 	// shorthand for (*a)[low : high : max]
 	// XXX fix this in precompile instead.
@@ -171,7 +171,7 @@ func (m *Machine) doOpStar() {
 			tv.SetUint8(dbv.GetByte())
 			m.PushValue(tv)
 		} else {
-			ro := m.IsReadonly(xv)
+			ro := m.isReadonlyForCopy(xv)
 			pvtv := (*pv.TV).WithReadonly(ro)
 			if xpt, ok := baseOf(xv.T).(*PointerType); ok {
 				// When a pointer was converted to a different

--- a/gnovm/pkg/gnolang/ownership.go
+++ b/gnovm/pkg/gnolang/ownership.go
@@ -442,6 +442,13 @@ func (tv *TypedValue) GetFirstObject(store Store) Object {
 //   - tv is N_Readonly, or
 //   - tv is a real object residing in external realm
 //
+// ownPkgID is the executing package's PkgID (m.Package.PkgID). An object
+// stamped with it is the executing package's own package-level data, which
+// the package may always read/copy regardless of rid — e.g. stdlib or a /p/
+// library reading its own immutable tables while running under a caller's
+// realm (those callables don't borrow, so m.Realm is the caller's, not the
+// library's). Pass a zero PkgID to disable this exemption.
+//
 // This is different from GetFirstObject in two significant ways:
 //  1. IsReadonlyBy does not go through RefValues; for this reason, it
 //     also doesn't need a store to fetch the nested object.
@@ -452,7 +459,7 @@ func (tv *TypedValue) GetFirstObject(store Store) Object {
 //
 // This function controls heavily the behaviour of
 // [Machine.IsReadonly], and thus the readonly taint behaviour.
-func (tv *TypedValue) IsReadonlyBy(rid PkgID) bool {
+func (tv *TypedValue) IsReadonlyBy(rid, ownPkgID PkgID) bool {
 	// tv is N_Readonly
 	if tv.IsReadonly() {
 		return true
@@ -469,7 +476,7 @@ func (tv *TypedValue) IsReadonlyBy(rid PkgID) bool {
 			// external while the heap item itself is
 			// not.
 			// See test/files/zrealm_crossrealm25a.gno.
-			if hiv.Value.IsReadonlyBy(rid) {
+			if hiv.Value.IsReadonlyBy(rid, ownPkgID) {
 				return true
 			}
 			// An unreal HIV is a transient heap-promotion wrapper
@@ -528,8 +535,10 @@ func (tv *TypedValue) IsReadonlyBy(rid PkgID) bool {
 	if tvoid.IsZero() {
 		return false
 	}
-	// tv is an object residing in external realm
-	if tvoid.PkgID != rid {
+	// tv is an object residing in external realm — unless it is the
+	// executing package's own package-level data (stamped ownPkgID),
+	// which the package may always read/copy regardless of m.Realm.
+	if tvoid.PkgID != rid && tvoid.PkgID != ownPkgID {
 		return true
 	}
 	return false

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -318,6 +318,18 @@ func (rlm *Realm) DidUpdate(m *Machine, po, xo, co Object) {
 	if po == nil || !po.GetIsReal() {
 		return // do nothing.
 	}
+	// /p/-immutability gate. With /p/ packages now carrying their own
+	// (frozen) realm, a /p/-stamped receiver borrows m.Realm to that /p/
+	// realm rather than nil. Reject post-init mutation of its real state:
+	// the active authority is an immutable (/p/) realm and we're in
+	// StageRun. Stdlib is exempt (stdlib dispatch legitimately reaches
+	// here); init-time writes are StageAdd, also exempt.
+	if m != nil && m.Stage == StageRun &&
+		rlm.ID.IsImmutablePkg() && !rlm.ID.IsStdlibPkg() {
+		panic(fmt.Sprintf(
+			"cannot mutate %s: package is immutable post-init",
+			rlm.Path))
+	}
 	if po.GetObjectID().PkgID != rlm.ID {
 		// Invariant violation: all mutation paths must have a pre-mutation
 		// readonly check (IsReadonly/isExternalRealm) that prevents reaching

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -318,23 +318,33 @@ func (rlm *Realm) DidUpdate(m *Machine, po, xo, co Object) {
 	if po == nil || !po.GetIsReal() {
 		return // do nothing.
 	}
-	// /p/-immutability gate. With /p/ packages now carrying their own
-	// (frozen) realm, a /p/-stamped receiver borrows m.Realm to that /p/
-	// realm rather than nil. Reject post-init mutation of its real state:
-	// the active authority is an immutable (/p/) realm and we're in
-	// StageRun. Stdlib is exempt (stdlib dispatch legitimately reaches
-	// here); init-time writes are StageAdd, also exempt.
+	if poPkgID := po.GetObjectID().PkgID; poPkgID != rlm.ID {
+		// The write target isn't the active realm's own data, yet the
+		// pre-check (IsReadonly) allowed it. The one legitimate case is a
+		// transient stdlib self-mutation: a stdlib method runs with the
+		// CALLER's realm (borrow rule #2 is skipped for stdlib receivers), so
+		// writing its own stdlib-stamped state (e.g. math/rand's global RNG
+		// advancing p.lo/p.hi — including when called from a /p/ context) has
+		// poPkgID != m.Realm. Stdlib is re-initialized each tx and never
+		// persisted → no-op. Anything else means a pre-mutation readonly
+		// check is missing. (Checked before the /p/ gate below so math/rand
+		// run with m.Realm at a /p/ realm isn't mistaken for a /p/
+		// self-mutation; stdlib init writes have poPkgID == rlm.ID.)
+		if poPkgID.IsStdlibPkg() {
+			return
+		}
+		panic("invariant violation: DidUpdate called on external-realm object without prior readonly check")
+	}
+	// po == rlm: the active realm is writing its OWN data. Reject if that
+	// realm is an immutable /p/ realm in StageRun — a /p/-stamped receiver
+	// borrows m.Realm to its frozen /p/ realm, so a post-init write to the
+	// /p/'s own state lands here. Stdlib is handled above; init writes are
+	// StageAdd, also exempt.
 	if m != nil && m.Stage == StageRun &&
 		rlm.ID.IsImmutablePkg() && !rlm.ID.IsStdlibPkg() {
 		panic(fmt.Sprintf(
 			"cannot mutate %s: package is immutable post-init",
 			rlm.Path))
-	}
-	if po.GetObjectID().PkgID != rlm.ID {
-		// Invariant violation: all mutation paths must have a pre-mutation
-		// readonly check (IsReadonly/isExternalRealm) that prevents reaching
-		// here. If this fires, a pre-check is missing.
-		panic("invariant violation: DidUpdate called on external-realm object without prior readonly check")
 	}
 	// XXX check if this boosts performance
 	// XXX with broad integration benchmarking.

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -580,9 +580,16 @@ func (ds *defaultStore) loadObjectSafe(oid ObjectID) Object {
 
 func (ds *defaultStore) fillPackage(pv *PackageValue) {
 	pv.GetBlock(ds) // preload
-	if pv.IsRealm() && pv.Realm == nil {
-		rlm := ds.GetPackageRealm(pv.PkgPath)
-		pv.Realm = rlm
+	if pv.Realm == nil {
+		if pv.IsRealm() {
+			pv.Realm = ds.GetPackageRealm(pv.PkgPath)
+		} else if IsPPackagePath(pv.PkgPath) {
+			// /p/ packages carry a frozen, immutable realm so borrow
+			// rule #2 lands m.Realm on it (not nil). It is not persisted
+			// (IsRealm()==false), so recreate it deterministically — the
+			// realm ID is derived from the pkgpath.
+			pv.Realm = NewRealm(pv.PkgPath)
+		}
 	}
 	// Re-derive denormalized PkgID cache (pv.PkgID is marked
 	// json:"-" so amino skipped it on load).

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -583,11 +583,12 @@ func (ds *defaultStore) fillPackage(pv *PackageValue) {
 	if pv.Realm == nil {
 		if pv.IsRealm() {
 			pv.Realm = ds.GetPackageRealm(pv.PkgPath)
-		} else if IsPPackagePath(pv.PkgPath) {
-			// /p/ packages carry a frozen, immutable realm so borrow
-			// rule #2 lands m.Realm on it (not nil). It is not persisted
-			// (IsRealm()==false), so recreate it deterministically — the
-			// realm ID is derived from the pkgpath.
+		} else if isImmutableLibraryPath(pv.PkgPath) {
+			// /p/ and stdlib packages carry a frozen, immutable realm so
+			// borrow rule #2 lands m.Realm on it (not nil). It is not
+			// persisted (IsRealm()==false), so recreate it
+			// deterministically — the realm ID is derived from the pkgpath.
+			// _test overlays are excluded (see isImmutableLibraryPath).
 			pv.Realm = NewRealm(pv.PkgPath)
 		}
 	}

--- a/gnovm/tests/files/extern/stdlibglobalwrite/x.gno
+++ b/gnovm/tests/files/extern/stdlibglobalwrite/x.gno
@@ -1,0 +1,12 @@
+package stdlibglobalwrite
+
+// counter is a package global. Bump writes it via a bare-identifier
+// (NameExpr) assignment — the write path guarded by isExternalRealm. As a
+// stdlib (dot-free path), this package may mutate its own global even when
+// invoked from a /r/ realm (transient; stdlib is never persisted).
+var counter int
+
+func Bump() int {
+	counter++
+	return counter
+}

--- a/gnovm/tests/files/zrealm_b64_encode_dst.gno
+++ b/gnovm/tests/files/zrealm_b64_encode_dst.gno
@@ -1,0 +1,19 @@
+// PKGPATH: gno.land/r/b64test
+package b64test
+
+// A stdlib method (base64.Encode) writing into a CALLER-supplied, real
+// /r/-stamped out-param buffer now works: borrow rule #2 is skipped for
+// stdlib-stamped receivers, so m.Realm stays /r/b64test and the write to
+// the caller's own buffer passes the readonly gate.
+
+import "encoding/base64"
+
+var dst [4]byte // /r/b64test-stamped, real after init; EncodedLen("hi")==4
+
+func main(cur realm) {
+	base64.StdEncoding.Encode(dst[:], []byte("hi"))
+	println(string(dst[:]))
+}
+
+// Output:
+// aGk=

--- a/gnovm/tests/files/zrealm_launder_m_pstamp_recv.gno
+++ b/gnovm/tests/files/zrealm_launder_m_pstamp_recv.gno
@@ -1,0 +1,31 @@
+// PKGPATH: gno.land/r/launderm
+package launderm
+
+// Attack M: nil-realm hole via a /p/-STAMPED receiver.
+//
+// launderpkg.PInitData is allocated during /p/launderpkg init, so its
+// StructValue is /p/-stamped. Dispatching a method on it borrows m.Realm
+// to /p/launderpkg's realm. UseMutator then dispatches EvilMutator.Run
+// (a no-anchor int, which keeps the borrowed realm), and Run writes to
+// the victim's /r/-stamped Immutable.
+//
+// Before Approach C (/p/ packages getting their own realm), the /p/
+// borrow set m.Realm = nil, and IsReadonly short-circuited to "nothing
+// is readonly" — so the write to victim data succeeded. Now the /p/
+// borrow lands on /p/launderpkg's (immutable) realm, the PkgID-mismatch
+// readonly gate fires, and the cross-realm write is rejected.
+
+import (
+	"gno.land/p/demo/tests/launderattack"
+	"gno.land/p/demo/tests/launderpkg"
+	"gno.land/r/tests/vm/laundervictim"
+)
+
+func main(cur realm) {
+	victim := laundervictim.GetImm() // *launderpkg.Immutable, laundervictim-stamped
+	launderpkg.PInitData.UseMutator(victim, launderattack.EvilMutator(0))
+	println("after:", laundervictim.ReadImm())
+}
+
+// Error:
+// cannot directly modify readonly tainted object (use a method or crossing function): i<VPBlock(1,1)>.Field

--- a/gnovm/tests/files/zrealm_launder_n_stdlib_recv.gno
+++ b/gnovm/tests/files/zrealm_launder_n_stdlib_recv.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/laundern
+package laundern
+
+// Attack N: the stdlib-receiver analogue of attack M (the /p/-receiver case).
+//
+// base64.StdEncoding is a stdlib-init-stamped receiver. Under the borrow
+// rules, a stdlib-stamped receiver does NOT borrow (borrow rule #2 is skipped
+// for stdlib), so base64.Encode runs with the CALLER's realm (/r/laundern),
+// not stdlib's. That lets a stdlib method write the caller's OWN out-param
+// buffer — but it must NOT let the attacker write a *foreign* realm's buffer.
+//
+// Here /r/laundern passes /r/laundervictim's own buffer as the Encode dst.
+// The write is attributed to /r/laundern, which doesn't own the victim's
+// /r/laundervictim-stamped backing array → readonly gate rejects it.
+
+import (
+	"encoding/base64"
+
+	"gno.land/r/tests/vm/laundervictim"
+)
+
+func main(cur realm) {
+	buf := laundervictim.GetBuf() // victim's own /r/laundervictim-stamped buffer
+	base64.StdEncoding.Encode(buf, []byte("xx"))
+	println("after:", laundervictim.ReadBuf())
+}
+
+// Error:
+// cannot directly modify readonly tainted object (use a method or crossing function): dst<VPBlock(1,1)>[di<VPBlock(1,3)> + (const (0 int))]

--- a/gnovm/tests/files/zrealm_launder_o_pstamp_closure.gno
+++ b/gnovm/tests/files/zrealm_launder_o_pstamp_closure.gno
@@ -1,0 +1,29 @@
+// PKGPATH: gno.land/r/laundero
+package laundero
+
+// Attack O: borrow rule #3 (closure) laundering canary.
+//
+// launderattack.StoredHook is a /p/-package-level closure (a FuncLit
+// evaluated at /p/launderattack init, so it's stamped /p/launderattack).
+// Invoking it triggers borrow rule #3, which borrows m.Realm to the
+// closure's construction realm (/p/launderattack) — NOT the caller, and NOT
+// nil. The hook's write to the victim's /r/laundervictim-stamped Object is
+// then rejected by the readonly gate (/r/laundervictim != /p/launderattack).
+//
+// Regression guard: if rule #3 ever borrowed to a nil realm (e.g. the /p/
+// frozen realm regressed), m.Realm would be nil, IsReadonly would
+// short-circuit to "allow", and this write would silently succeed.
+
+import (
+	"gno.land/p/demo/tests/launderattack"
+	"gno.land/r/tests/vm/laundervictim"
+)
+
+func main(cur realm) {
+	p := laundervictim.GetPtr() // *launderpkg.Object, /r/laundervictim-stamped
+	launderattack.StoredHook(p)
+	println("after:", laundervictim.ReadPtr())
+}
+
+// Error:
+// cannot directly modify readonly tainted object (use a method or crossing function): o<VPBlock(1,0)>.Field

--- a/gnovm/tests/files/zrealm_stdlib_global_write.gno
+++ b/gnovm/tests/files/zrealm_stdlib_global_write.gno
@@ -1,0 +1,25 @@
+// PKGPATH: gno.land/r/stdlibgw
+package stdlibgw
+
+// Regression for the DidUpdate stdlib transient no-op on the NameExpr
+// (package-global) write path. A (test-)stdlib top-level function writing
+// its OWN package global via a bare-identifier assignment (counter++) must
+// succeed when called from a /r/ realm — stdlib runs with the caller's
+// authority and may mutate its own transient (never-persisted) state.
+//
+// The write goes: isExternalRealm (HIV branch — package globals are heap
+// items — returns "not external") → DidUpdate, where po (stdlib-stamped) !=
+// m.Realm (/r/). Without the DidUpdate stdlib no-op this hits the
+// "invariant violation" backstop. (import4 covers the SelectorExpr field-
+// write path, math/rand's p.lo; this covers the NameExpr global path.)
+
+import "filetests/extern/stdlibglobalwrite"
+
+func main(cur realm) {
+	println(stdlibglobalwrite.Bump())
+	println(stdlibglobalwrite.Bump())
+}
+
+// Output:
+// 1
+// 2

--- a/gnovm/tests/files/zrealm_strconv_ftoa_rcaller.gno
+++ b/gnovm/tests/files/zrealm_strconv_ftoa_rcaller.gno
@@ -1,0 +1,34 @@
+// PKGPATH: gno.land/r/ftoatest
+package ftoatest
+
+// PROBE: does a /r/ realm calling strconv.FormatFloat on extreme/denormal
+// floats (deep ryu path -> mult128bitPow10 q<0 -> `pow[0] += 1`) hit the
+// readonly taint? If it panics, the stdlib self-table copy-mutate bug is
+// latent at HEAD independent of the /p/+stdlib realm work.
+
+import (
+	"math"
+	"strconv"
+)
+
+func main(cur realm) {
+	vals := []float64{
+		5e-324,                     // smallest denormal
+		math.SmallestNonzeroFloat64,
+		2.2250738585072014e-308,    // smallest normal
+		1.7976931348623157e+308,    // max
+		0.30000000000000004,        // 0.1+0.2
+		1.0 / 3.0,
+		9.999999999999999e22,
+		1e-300, 7.3e-200, 4.9e-100,
+		math.Float64frombits(0x0123456789abcdef),
+		math.Float64frombits(0xfedcba9876543210),
+	}
+	for _, v := range vals {
+		_ = strconv.FormatFloat(v, 'g', -1, 64)
+	}
+	println("ok, no panic")
+}
+
+// Output:
+// ok, no panic


### PR DESCRIPTION
A method declared in a /p/ or stdlib persisted package object (constructed during /p/ init() or MsgAddPackage) ran with `m.Realm == nil`, which disables the cross-realm write check, so it could write another realm's data. (rare).
  
  /p/ and stdlib packages now get a frozen, never-persisted realm so the check
  stays on:
  
  - /p/ stamped object methods run as their own frozen realm: writes to other realms are
    blocked, own data stays immutable after init.
  - Stdlib methods keep the caller's realm instead of borrowing, so they can
    write a caller-supplied buffer (`base64.Encode(dst, src)`) but not a third
    realm's data.
  - Stdlib can still write its own transient state (`math/rand`); a package can
    read/copy its own data.
    
  Filetests cover the blocked and allowed paths, plus a debug-build assert that
  fires if a realm-bearing package loses its realm.
  
