### PR TITLE
fix(gnovm): evaluate LHS operands then assign left-to-right in tuple assignment

### DIFF
--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -2613,6 +2613,22 @@ func (m *Machine) PushForPointer(lx Expr) {
 	}
 }
 
+// numStackValuesForPointer reports how many TypedValues PushForPointer
+// pushes onto the value stack for the given LHS expression. Must stay in
+// sync with PushForPointer and PopAsPointer2.
+func numStackValuesForPointer(lx Expr) int {
+	switch lx.(type) {
+	case *NameExpr:
+		return 0
+	case *IndexExpr:
+		return 2
+	case *SelectorExpr, *StarExpr, *CompositeLitExpr:
+		return 1
+	default:
+		panic("illegal LHS expr type")
+	}
+}
+
 // Pop a pointer (for writing only).
 func (m *Machine) PopAsPointer(lx Expr) PointerValue {
 	pv, ro := m.PopAsPointer2(lx)

--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -22,12 +22,24 @@ func (m *Machine) doOpDefine() {
 
 func (m *Machine) doOpAssign() {
 	s := m.PopStmt().(*AssignStmt)
-	// Go spec: operands and RHS are evaluated first, then assignments happen
-	// left-to-right. PopAsPointer for L_i may panic (nil-deref, OOB, nil-map),
-	// so alternate push-operands/resolve/assign in LHS order — a mid-statement
-	// panic then leaves earlier assignments intact.
 	rvs := m.PopValues(len(s.Lhs))
 	m.incrCPU(OpCPUSlopeAssign * int64(len(s.Lhs)))
+	// Single-LHS fast path (the common case): no operand buffering needed —
+	// there is no left-to-right or panic-atomicity concern with one assignment.
+	if len(s.Lhs) == 1 {
+		lv := m.PopAsPointer(s.Lhs[0])
+		if m.Stage != StagePre && isUntyped(rvs[0].T) && rvs[0].T.Kind() != BoolKind {
+			panic("untyped conversion should not happen at runtime")
+		}
+		lv.Assign2(m, m.Alloc, m.Store, m.Realm, rvs[0], true)
+		return
+	}
+	// Multi-LHS — Go spec: operands and RHS are evaluated first, then
+	// assignments happen left-to-right. PopAsPointer for L_i may panic
+	// (nil-deref, OOB, nil-map), so buffer each LHS's operand frame, then
+	// resolve+assign one at a time in LHS order. A mid-statement panic
+	// leaves earlier assignments intact, and duplicate LHS targets observe
+	// left-to-right writes.
 	frames := make([][]TypedValue, len(s.Lhs))
 	for i := len(s.Lhs) - 1; 0 <= i; i-- {
 		frames[i] = m.PopValues(numStackValuesForPointer(s.Lhs[i]))

--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -22,13 +22,20 @@ func (m *Machine) doOpDefine() {
 
 func (m *Machine) doOpAssign() {
 	s := m.PopStmt().(*AssignStmt)
-	// Assign each value evaluated for Lhs.
-	// NOTE: PopValues() returns a slice in
-	// forward order, not the usual reverse.
+	// Go spec: operands and RHS are evaluated first, then assignments happen
+	// left-to-right. PopAsPointer for L_i may panic (nil-deref, OOB, nil-map),
+	// so alternate push-operands/resolve/assign in LHS order — a mid-statement
+	// panic then leaves earlier assignments intact.
 	rvs := m.PopValues(len(s.Lhs))
 	m.incrCPU(OpCPUSlopeAssign * int64(len(s.Lhs)))
+	frames := make([][]TypedValue, len(s.Lhs))
 	for i := len(s.Lhs) - 1; 0 <= i; i-- {
-		// Pop lhs value and desired type.
+		frames[i] = m.PopValues(numStackValuesForPointer(s.Lhs[i]))
+	}
+	for i := range s.Lhs {
+		for _, tv := range frames[i] {
+			m.PushValue(tv)
+		}
 		lv := m.PopAsPointer(s.Lhs[i])
 		if m.Stage != StagePre && isUntyped(rvs[i].T) && rvs[i].T.Kind() != BoolKind {
 			panic("untyped conversion should not happen at runtime")

--- a/gnovm/pkg/gnolang/op_assign.go
+++ b/gnovm/pkg/gnolang/op_assign.go
@@ -40,6 +40,10 @@ func (m *Machine) doOpAssign() {
 	// resolve+assign one at a time in LHS order. A mid-statement panic
 	// leaves earlier assignments intact, and duplicate LHS targets observe
 	// left-to-right writes.
+	// TODO(gas): the buffer+interleave costs ~20-30% more per call than the
+	// previous single-pass design on a dev bench. Recalibrate
+	// OpCPUSlopeAssign (or add a multi-LHS surcharge) on consensus
+	// hardware — see https://github.com/gnolang/gno/issues/5789.
 	frames := make([][]TypedValue, len(s.Lhs))
 	for i := len(s.Lhs) - 1; 0 <= i; i-- {
 		frames[i] = m.PopValues(numStackValuesForPointer(s.Lhs[i]))

--- a/gnovm/pkg/gnolang/op_assign_bench_test.go
+++ b/gnovm/pkg/gnolang/op_assign_bench_test.go
@@ -1,0 +1,87 @@
+package gnolang
+
+import "testing"
+
+// benchAssignNameN benchmarks the NameExpr LHS path. Worst case for the new
+// code's bookkeeping overhead per LHS is small here — empty operand frames —
+// so this isolates the slice-alloc + extra loop costs.
+func benchAssignNameN(b *testing.B, n int) {
+	m := benchMachine()
+	defer m.Release()
+	blk, nxs := benchBlockVars(m, 1)
+	lhs := make([]Expr, n)
+	for i := range n {
+		lhs[i] = nxs[0] // all alias the same slot; harmless for timing
+	}
+	stmt := &AssignStmt{Lhs: lhs, Op: ASSIGN}
+	blk.Values[0] = TypedValue{T: IntType, N: i2n(0)}
+
+	rvs := make([]TypedValue, n)
+	for i := range n {
+		rvs[i] = TypedValue{T: IntType, N: i2n(int64(i + 1))}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, rv := range rvs {
+			m.PushValue(rv)
+		}
+		m.PushStmt(stmt)
+		m.doOpAssign()
+	}
+}
+
+func BenchmarkDoOpAssign_Name_N1(b *testing.B) { benchAssignNameN(b, 1) }
+func BenchmarkDoOpAssign_Name_N2(b *testing.B) { benchAssignNameN(b, 2) }
+func BenchmarkDoOpAssign_Name_N3(b *testing.B) { benchAssignNameN(b, 3) }
+func BenchmarkDoOpAssign_Name_N5(b *testing.B) { benchAssignNameN(b, 5) }
+
+// benchAssignIndexN benchmarks the IndexExpr LHS path — worst case for the
+// new code, since each LHS has 2 operand-frame values to buffer/push/pop.
+func benchAssignIndexN(b *testing.B, n int) {
+	m := benchMachine()
+	defer m.Release()
+
+	st := m.Alloc.NewType(&SliceType{Elt: IntType})
+	baseArray := m.Alloc.NewListArray(nil, n)
+	for i := range n {
+		baseArray.List[i] = TypedValue{T: IntType, N: i2n(0)}
+	}
+	sv := m.Alloc.NewSlice(baseArray, 0, n, n)
+
+	ix := &IndexExpr{}
+	lhs := make([]Expr, n)
+	for i := range n {
+		lhs[i] = ix // shape-only; PopAsPointer reads from the value stack
+	}
+	stmt := &AssignStmt{Lhs: lhs, Op: ASSIGN}
+
+	// Pre-build the push sequence once: per LHS, push X (slice) and Index;
+	// then RHS values.
+	pushes := make([]TypedValue, 0, 3*n)
+	for i := range n {
+		pushes = append(pushes,
+			TypedValue{T: st, V: sv},
+			TypedValue{T: IntType, N: i2n(int64(i))}, // distinct indices
+		)
+	}
+	for i := range n {
+		pushes = append(pushes, TypedValue{T: IntType, N: i2n(int64(10 + i))})
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tv := range pushes {
+			m.PushValue(tv)
+		}
+		m.PushStmt(stmt)
+		m.doOpAssign()
+	}
+}
+
+func BenchmarkDoOpAssign_Index_N1(b *testing.B) { benchAssignIndexN(b, 1) }
+func BenchmarkDoOpAssign_Index_N2(b *testing.B) { benchAssignIndexN(b, 2) }
+func BenchmarkDoOpAssign_Index_N3(b *testing.B) { benchAssignIndexN(b, 3) }
+func BenchmarkDoOpAssign_Index_N5(b *testing.B) { benchAssignIndexN(b, 5) }

--- a/gnovm/pkg/gnolang/op_assign_test.go
+++ b/gnovm/pkg/gnolang/op_assign_test.go
@@ -1,0 +1,69 @@
+package gnolang
+
+import "testing"
+
+// TestDoOpAssign_DuplicateNameLHS_LeftToRight: NameExpr LHS aliasing the
+// same block slot. Covers the forward-Assign2 half of the fix: rvs[n-1] wins.
+// (NameExpr's PopAsPointer does not consume value-stack sub-evals, so this
+// case does not exercise the reverse-pop discipline — that's what
+// TestDoOpAssign_DistinctIndexLHS_ReversePop covers.)
+func TestDoOpAssign_DuplicateNameLHS_LeftToRight(t *testing.T) {
+	for _, n := range []int{2, 3, 5, 17} {
+		m := benchMachine()
+		blk, nxs := benchBlockVars(m, 1)
+		lhs := make([]Expr, n)
+		for i := range n {
+			lhs[i] = nxs[0] // every LHS points to the SAME slot
+		}
+		stmt := &AssignStmt{Lhs: lhs, Op: ASSIGN}
+
+		blk.Values[0] = TypedValue{T: IntType, N: i2n(0)}
+		for i := range n {
+			m.PushValue(TypedValue{T: IntType, N: i2n(int64(i + 1))}) // rvs = 1,2,...,n
+		}
+		m.PushStmt(stmt)
+		m.doOpAssign()
+
+		if got, want := blk.Values[0].GetInt(), int64(n); got != want {
+			t.Errorf("n=%d: got %d, want %d (rightmost RHS should win)", n, got, want)
+		}
+		m.Release()
+	}
+}
+
+// TestDoOpAssign_DistinctIndexLHS_ReversePop: IndexExpr LHS with distinct
+// indices on the same slice. The value-stack sub-eval values must be popped
+// in reverse-LHS order; if a future refactor flips the pop loop to forward,
+// lvs[0] would end up pointing at slice[1] and vice versa, swapping the
+// final element values.
+func TestDoOpAssign_DistinctIndexLHS_ReversePop(t *testing.T) {
+	m := benchMachine()
+	defer m.Release()
+
+	st := m.Alloc.NewType(&SliceType{Elt: IntType})
+	baseArray := m.Alloc.NewListArray(nil, 2)
+	baseArray.List[0] = TypedValue{T: IntType, N: i2n(0)}
+	baseArray.List[1] = TypedValue{T: IntType, N: i2n(0)}
+	sv := m.Alloc.NewSlice(baseArray, 0, 2, 2)
+
+	ix := &IndexExpr{} // shape-only placeholder; PopAsPointer reads from the stack, not the AST
+	stmt := &AssignStmt{Lhs: []Expr{ix, ix}, Op: ASSIGN}
+
+	// Production push order (per op_exec.go AssignStmt case + PushForPointer):
+	// Lhs[0].X, Lhs[0].Index, Lhs[1].X, Lhs[1].Index, Rhs[0], Rhs[1].
+	m.PushValue(TypedValue{T: st, V: sv})           // Lhs[0].X
+	m.PushValue(TypedValue{T: IntType, N: i2n(0)})  // Lhs[0].Index
+	m.PushValue(TypedValue{T: st, V: sv})           // Lhs[1].X
+	m.PushValue(TypedValue{T: IntType, N: i2n(1)})  // Lhs[1].Index
+	m.PushValue(TypedValue{T: IntType, N: i2n(10)}) // Rhs[0]
+	m.PushValue(TypedValue{T: IntType, N: i2n(20)}) // Rhs[1]
+	m.PushStmt(stmt)
+	m.doOpAssign()
+
+	if got := baseArray.List[0].GetInt(); got != 10 {
+		t.Errorf("slice[0]: got %d, want 10 (lvs[0] should resolve to index 0)", got)
+	}
+	if got := baseArray.List[1].GetInt(); got != 20 {
+		t.Errorf("slice[1]: got %d, want 20 (lvs[1] should resolve to index 1)", got)
+	}
+}

--- a/gnovm/tests/files/assign40.gno
+++ b/gnovm/tests/files/assign40.gno
@@ -1,0 +1,21 @@
+// Verifies that in an AssignStmt with duplicate LHS targets referring to the
+// same variable, assignments proceed in left-to-right order (Go spec
+// §Assignments): a, a, a = 1, 2, 3 must leave a == 3, not a == 1.
+package main
+
+var a int
+
+func F() {
+	a, a, a = 1, 2, 3
+}
+
+func main() {
+	F()
+	if a != 3 {
+		panic(a)
+	}
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/assign41.gno
+++ b/gnovm/tests/files/assign41.gno
@@ -1,0 +1,86 @@
+// Extends assign40 to the other LHS shapes that go through PopAsPointer:
+// IndexExpr (slice), IndexExpr (map), StarExpr, SelectorExpr. Each duplicate
+// LHS must observe left-to-right assignment (Go spec §Assignments).
+package main
+
+type T struct{ f int }
+
+func indexSlice() {
+	s := []int{0, 0}
+	s[0], s[0], s[0] = 1, 2, 3
+	if s[0] != 3 {
+		panic(s[0])
+	}
+}
+
+func indexMap() {
+	m := map[string]int{}
+	m["k"], m["k"], m["k"] = 1, 2, 3
+	if m["k"] != 3 {
+		panic(m["k"])
+	}
+}
+
+func starExpr() {
+	x := 0
+	p := &x
+	*p, *p, *p = 1, 2, 3
+	if x != 3 {
+		panic(x)
+	}
+}
+
+func selectorExpr() {
+	s := &T{}
+	s.f, s.f, s.f = 1, 2, 3
+	if s.f != 3 {
+		panic(s.f)
+	}
+}
+
+// Blanks interleaved with duplicate real targets: blanks must not
+// disturb the left-to-right write order of the real LHS.
+func blankInterleaved() {
+	var a int
+	a, _, a, _ = 1, 2, 3, 4
+	if a != 3 {
+		panic(a)
+	}
+}
+
+// Multi-value RHS (single call returning multiple values) into a
+// duplicate LHS. Goes through a different RHS push pattern (one
+// OpEval for the call, multiple values produced).
+func twoVal() (int, int) { return 1, 2 }
+
+func multiReturnRHS() {
+	var a int
+	a, a = twoVal()
+	if a != 2 {
+		panic(a)
+	}
+}
+
+// Multi-blank with mixed-type RHS. All blanks alias the same shared slot
+// (Block.Blank), so the reorder changes which RHS value/type lands there
+// last. This smoke-tests that the statement completes without crashing;
+// the realm-finalization-level effect (assertTypeIsPublic against the
+// surviving type) only manifests in realm code and is out of scope here.
+func multiBlankMixedType() {
+	_, _ = "hello", 42
+	_, _ = 1, "two"
+}
+
+func main() {
+	indexSlice()
+	indexMap()
+	starExpr()
+	selectorExpr()
+	blankInterleaved()
+	multiReturnRHS()
+	multiBlankMixedType()
+	println("ok")
+}
+
+// Output:
+// ok

--- a/gnovm/tests/files/assign_tuple_order.gno
+++ b/gnovm/tests/files/assign_tuple_order.gno
@@ -1,0 +1,19 @@
+package main
+
+// Go spec: in tuple assignment, operands and RHS are evaluated first,
+// then assignments happen left-to-right. A panic during the assignment
+// of L_i must leave assignments to L_0..L_{i-1} in place.
+// See https://github.com/golang/go/issues/23017.
+
+func main() {
+	m := map[int]int{}
+	var p *int
+	defer func() {
+		recover()
+		println(len(m), m[2])
+	}()
+	m[2], *p = 42, 2
+}
+
+// Output:
+// 1 42


### PR DESCRIPTION
Subsumes #5720.

## Bug 1 — mid-statement panic atomicity (golang/go#23017)

Tuple assignment `m[k], *p = 42, 2` panicked on `*p` before `m[k]` was written. The old `doOpAssign` resolved each LHS pointer and assigned in one right-to-left pass, so any panic from `PopAsPointer` (nil-deref, OOB, nil-map) aborted the statement before earlier writes.

## Bug 2 — left-to-right assignment order for duplicate LHS

`a, a, a = 1, 2, 3` left `a == 1` instead of the spec-required `a == 3` ([Go spec §Assignments](https://go.dev/ref/spec#Assignments): "the assignments are carried out in left-to-right order"). Same root cause: the old loop ran right-to-left.

## Fix

`doOpAssign` now:
- Single-LHS fast path: no buffering — preserves the common case's hot path.
- Multi-LHS: buffer each LHS's operand frame (popped in reverse to match the value-stack LIFO from `PushForPointer`), then push-back / `PopAsPointer` / `Assign2` **interleaved** in left-to-right order. A mid-statement panic leaves `L_0..L_{i-1}` written; duplicate LHS targets observe left-to-right writes.

Added `numStackValuesForPointer` helper alongside `PushForPointer` / `PopAsPointer2` (must stay in sync with both).

## Test plan

- [x] `gnovm/tests/files/assign_tuple_order.gno` — `m[k], *p = 42, 2` survives panic, `m[2] == 42`.
- [x] `gnovm/tests/files/assign40.gno` — `a, a, a = 1, 2, 3` → `a == 3`.
- [x] `gnovm/tests/files/assign41.gno` — duplicate LHS across IndexExpr / MapIndex / StarExpr / SelectorExpr / blank-interleaved / multi-return RHS / mixed-type blanks.
- [x] `gnovm/pkg/gnolang/op_assign_test.go` — unit tests for NameExpr (n=2,3,5,17) and IndexExpr reverse-pop.
- [x] `go test ./gno.land/pkg/sdk/vm/ -run Gas`
- [x] `go test ./gno.land/pkg/integration/ -run txtar`
- [x] `go test ./gnovm/pkg/gnolang/ -run Files -test.short` (all `assign*` filetests including the new ones)