### PR TITLE
docs(interrealm-v2): correct /p/ copy-stamping description for #5747

### DIFF
--- a/docs/resources/gno-interrealm-v2.md
+++ b/docs/resources/gno-interrealm-v2.md
@@ -151,6 +151,15 @@ Two practical consequences:
    for the allocation). See `gnovm/pkg/gnolang/alloc.go`
    `checkConstructionTime`.
 
+3. **Copies are type-driven, not source-propagated.**
+   `{Array,Struct}Value.Copy` stamps the copy from the *declared type*
+   (`getDeclaredPkgID`), mirroring the allocation rule: a `/r/`-declared
+   type keeps its declared `/r/` owner, while a `/p/`-declared (or
+   unnamed) value's copy takes the copying realm's PkgID. So an in-place
+   value-copy of a `/p/`-typed value (e.g. `*z = *x` in `uint256.Set`)
+   belongs to the realm doing the copy, not the source's realm — this is
+   the #5736 / #5747 fix. See `gnovm/pkg/gnolang/values.go`.
+
 ### 3.3 /p/-Immutability
 
 `/p/` packages and the stdlib have no persisted `Realm` of their own.

--- a/gnovm/adr/interrealm_v2.md
+++ b/gnovm/adr/interrealm_v2.md
@@ -185,9 +185,12 @@ under the source's /r/ realm. In other words, all /r/realmA.Objects live in
 /p/ packages themselves are immutable (no realm state, library semantics), but
 /p/-declared types used as values acquire a /r/ stamp (on ObjectInfo.PkgID) at
 construction and are then mutable by that /r/ — see borrow rules #2 and #3. In
-v1 there was no such construction-time ObjectInfo.PkgID stamping. In v2 once
-ObjectInfo.PkgID is stamped with a /r/ realm, even copies retain that source /r/
-realm.
+v1 there was no such construction-time ObjectInfo.PkgID stamping. In v2 the
+construction stamp is the constructing realm's PkgID, and copies are stamped
+type-driven (stampPkgID's split rule, #5706/#5747): a /r/-declared type keeps
+its declared /r/ owner across copies, but a /p/-declared value's copy takes the
+copying realm's PkgID — it does NOT retain the source /r/. That is what makes
+cross-realm in-place /p/ arithmetic work (#5736).
 
   - Borrow rule #3: if fv is a closure (FuncLit) declared in a /p/ package,
     borrow to the realm context that was active when the closure was


### PR DESCRIPTION
The type-driven Copy stamping merged in #5747 (310dc2a04) means a /p/-declared value's copy takes the copying realm's PkgID, not the source's /r/. Two docs still described the old source-propagation model:

- gnovm/adr/interrealm_v2.md: the "/p/-declared things are different" paragraph still claimed "even copies retain that source /r/ realm" — rewritten to describe the type-driven split. (#5747 fixed the adjacent worked example but missed this prose.)
- docs/resources/gno-interrealm-v2.md §3.2: was silent on copy stamping; added it as a third practical consequence of "Storage = Authority".