### PR TITLE
[codex] fix(gnovm): preserve readonly on alias-retaining copies

### DIFF
--- a/docs/resources/gno-interrealm-v2.md
+++ b/docs/resources/gno-interrealm-v2.md
@@ -41,8 +41,8 @@ This document defines:
    (the two borrow rules).
 3. The captured realm value (`cur realm`) and its runtime invariants.
 4. The object model: how storage is attributed (`Storage = Authority`).
-5. Write guards: the storage-ownership (PkgID) check, conversion
-   guards, and the construction-time check.
+5. Write guards: readonly provenance, the storage-ownership (PkgID)
+   check, conversion guards, and the construction-time check.
 6. Panic and recover semantics across realm boundaries.
 
 ## 2. Realm-Context and Realm-Storage-Context
@@ -181,6 +181,20 @@ post-deployment even though the language permits the syntax of a
 mutation. Combined with borrow rule #2 (borrowing `m.Realm` to the
 receiver's stamp on `/p/`-method dispatch), it closes the
 `/p/`-attacker-via-interface class.
+
+### 3.4 Readonly Provenance
+
+Values read from foreign realm storage via selector, index, slice,
+deref, or address-of carry readonly provenance. Mutation sites check
+that provenance in addition to the target object's PkgID ownership.
+
+Array and struct value copies are special. `ArrayValue.Copy` and
+`StructValue.Copy` still use type-driven PkgID stamping (§3.2), so
+transitively value-only `/p/` types such as `uint256.Uint` become
+writable local copies. However, copies that may retain references
+keep readonly provenance. For example, `[1][]byte` is not
+transitively value-only: the copied array wrapper is fresh, but the
+slice header can still alias foreign backing storage.
 
 ## 4. Borrow Rules
 

--- a/gno.land/pkg/integration/testdata/interrealm_v2.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_v2.txtar
@@ -32,9 +32,8 @@
 #     /r/-declared types panic at the call site.
 #
 #   Cross-realm write gate:  writes to an object owned by a realm
-#     other than m.Realm panic ("readonly tainted object"). The
-#     N_Readonly provenance taint has been removed; protection now
-#     rests on this storage-ownership check alone.
+#     other than m.Realm panic ("readonly tainted object"). Foreign
+#     reads that may retain aliases also carry readonly provenance.
 #
 #   Copy semantics:  Copy preserves source PkgID when the source
 #     carries realm authority; when the source PkgID is
@@ -285,17 +284,17 @@ stderr 'cannot allocate gno.land/r/test/owned.Resource in realm gno.land/r/test/
 ## Readonly taint
 ## ============================================================
 
-## READONLY_RoundTripSucceeds: caller reads owned.GlobalSlice and
-## passes it back through owned.MutateSlice. With the readonly taint
-## removed, borrow rule #1 puts m.Realm at /r/owned for the duration
-## of MutateSlice, and the indexed write to owned's own slice commits
-## under owned's authority — the round-trip now succeeds.
+## READONLY_RoundTripFails: caller reads owned.GlobalSlice and passes
+## it back through owned.MutateSlice. Even though borrow rule #1 puts
+## m.Realm at /r/owned for the duration of MutateSlice, the retained
+## slice alias carries readonly provenance and the indexed write
+## panics.
 ##
-##   func READONLY_RoundTripSucceeds(cur realm) {
+##   func READONLY_RoundTripFails(cur realm) {
 ##       owned.MutateSlice(owned.GlobalSlice)
 ##   }
-gnokey maketx call -pkgpath gno.land/r/test/caller -func READONLY_RoundTripSucceeds -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test test1
-stdout OK!
+! gnokey maketx call -pkgpath gno.land/r/test/caller -func READONLY_RoundTripFails -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test test1
+stderr 'cannot directly modify readonly tainted object'
 
 
 ## ============================================================
@@ -653,9 +652,9 @@ func CONSTRUCT_NewFails(cur realm) {
 	_ = new(owned.Resource)
 }
 
-// ----- Readonly taint removed: foreign-slice round-trip now succeeds -----
+// ----- Readonly taint: foreign-slice round-trip is blocked -----
 
-func READONLY_RoundTripSucceeds(cur realm) {
+func READONLY_RoundTripFails(cur realm) {
 	owned.MutateSlice(owned.GlobalSlice)
 }
 

--- a/gno.land/pkg/integration/testdata/issue_5747_alias_roundtrip.txtar
+++ b/gno.land/pkg/integration/testdata/issue_5747_alias_roundtrip.txtar
@@ -1,0 +1,54 @@
+# Reproduce the cross-realm alias round-trip enabled by #5747.
+#
+# The attacker reads a victim-owned array by value. The array copy is fresh, but
+# its element is a slice header that still aliases the victim's backing array.
+# Passing that retained alias back into a victim-declared helper must not let
+# the caller mutate victim.Global.
+
+gnoland start
+
+gnokey maketx addpkg -pkgdir $WORK/victim -pkgpath gno.land/r/test/issue5747/victim -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
+stdout OK!
+
+gnokey maketx addpkg -pkgdir $WORK/attacker -pkgpath gno.land/r/test/issue5747/attacker -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
+stdout OK!
+
+gnokey query vm/qrender --data "gno.land/r/test/issue5747/victim:"
+stdout 'safe'
+
+! gnokey maketx call -pkgpath gno.land/r/test/issue5747/attacker -func Attack -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
+stderr 'cannot copy to readonly tainted slice'
+
+gnokey query vm/qrender --data "gno.land/r/test/issue5747/victim:"
+stdout 'safe'
+
+-- victim/gnomod.toml --
+module = "gno.land/r/test/issue5747/victim"
+gno = "0.9"
+
+-- victim/victim.gno --
+package victim
+
+var Global = [1][]byte{[]byte("safe")}
+
+func Copy(dst []byte, src string) {
+	copy(dst, []byte(src))
+}
+
+func Render(path string) string {
+	return string(Global[0])
+}
+
+-- attacker/gnomod.toml --
+module = "gno.land/r/test/issue5747/attacker"
+gno = "0.9"
+
+-- attacker/attacker.gno --
+package attacker
+
+import "gno.land/r/test/issue5747/victim"
+
+func Attack(cur realm) {
+	x := victim.Global
+	victim.Copy(x[0], "pwn!")
+}

--- a/gnovm/adr/prxxxx_readonly_alias_roundtrip.md
+++ b/gnovm/adr/prxxxx_readonly_alias_roundtrip.md
@@ -1,0 +1,84 @@
+# Preserve Readonly Provenance for Alias-Retaining Copies
+
+## Context
+
+PR #5747 fixed #5736 by changing `ArrayValue.Copy` and `StructValue.Copy` to
+stamp copies from the destination type rather than blindly propagating the
+source object's runtime `PkgID`. This allows `/p/` value types such as
+`uint256.Uint` to be copied inside another realm and then mutated locally:
+
+```go
+type Uint struct {
+    arr [4]uint64
+}
+```
+
+That type is transitively value-only. Copying it cannot retain an alias to
+foreign storage.
+
+The same PR also removed `N_Readonly` provenance taint entirely. That created a
+different behavior for value copies that retain references:
+
+```go
+// /r/victim
+var Global = [1][]byte{[]byte("safe")}
+
+func Copy(dst []byte, src string) {
+    copy(dst, []byte(src))
+}
+
+// /r/attacker
+x := victim.Global
+victim.Copy(x[0], "pwn!")
+```
+
+The array wrapper copied into the attacker is fresh, but `x[0]` is a slice
+header that still aliases `victim.Global[0]`'s backing array. Passing the alias
+back into a victim-declared function borrows storage authority to the victim
+realm, so the ownership gate permits the mutation.
+
+## Decision
+
+Reintroduce readonly provenance for foreign reads, but clear it only when a
+copy is transitively alias-free.
+
+A type is considered alias-free when it is:
+
+- a primitive type,
+- an array whose element type is alias-free,
+- a struct whose fields are all alias-free.
+
+All other types are treated conservatively as alias-retaining, including
+slices, pointers, maps, interfaces, funcs, channels, packages, and unknown
+internal types.
+
+`TypedValue.Copy` therefore keeps `N_Readonly` for copied arrays and structs
+unless `isDeepCopyAliasFree(tv.T)` returns true. `ArrayValue.Copy` and
+`StructValue.Copy` keep the type-driven `PkgID` stamping introduced by #5747.
+
+## Alternatives Considered
+
+1. Keep #5747's full removal of readonly provenance.
+
+   This keeps the implementation simple but makes retained aliases writable
+   whenever they are passed back into the owning realm's helpers.
+
+2. Revert #5747 entirely.
+
+   This closes the alias round-trip but also reintroduces the false-positive
+   panic for value-only `/p/` types such as `uint256.Uint`.
+
+3. Track readonly provenance at precise child-reference granularity.
+
+   This would avoid tainting a whole copied struct when only one field retains
+   an alias, but it is a larger VM change. The conservative parent-level taint
+   is simpler and preserves the security property.
+
+## Consequences
+
+- #5736 remains fixed for transitively value-only `/p/` types.
+- Alias-retaining copies such as `[1][]byte` remain protected from round-trip
+  mutation through borrowed owner-realm functions.
+- Some local writes to copies of foreign structs/arrays with reference fields
+  remain over-blocked. This is intentional until the VM has a more precise
+  per-reference readonly model.

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -2658,12 +2658,11 @@ func (m *Machine) PopAsPointer(lx Expr) PointerValue {
 	return pv
 }
 
-// The "tainted" wording in the message is historical; the failure is the
-// cross-realm ownership check (tvoid.PkgID != m.Realm.ID) — the target is
-// owned by a realm different from the one currently executing. Going
-// through a method or crossing function re-enters via PushFrameCall, whose
-// implicit borrow-realm switch (or hard cross-call) lines m.Realm up with
-// the target's owner.
+// "tainted" here is loose: failures can come from the sticky N_Readonly bit
+// or from the contextual ownership check (tvoid.PkgID != m.Realm.ID). Either
+// way, going through a method or crossing function re-enters via PushFrameCall,
+// whose implicit borrow-realm switch (or hard cross-call) lines m.Realm up
+// with the target's owner.
 func readonlyAccessPanic(x Expr) string {
 	return "cannot directly modify readonly tainted object (use a method or crossing function): " + x.String()
 }
@@ -2672,6 +2671,7 @@ func readonlyAccessPanic(x Expr) string {
 // (PopAsPointer2, uverse append/copy/delete, map assign). Returns false if
 // m.Realm is nil (single user mode). Otherwise returns true iff:
 //   - tv is a ref to (external) package path, or
+//   - tv is N_Readonly, or
 //   - tv is a real object residing in external realm
 //
 // One own-package write exemption: STDLIB code may write its own
@@ -2681,10 +2681,26 @@ func readonlyAccessPanic(x Expr) string {
 // so without this a stdlib package mutating its own global would wrongly
 // panic. Keyed on m.Package (the executing code), so an attacker can't
 // trigger it; and NOT granted to /p/ — a /p/ package writing its own
-// immutable global must still be blocked.
+// immutable global must still be blocked. (isReadonlyForCopy is the
+// read-taint variant, which grants the own-package exemption to all pkgs.)
 func (m *Machine) IsReadonly(tv *TypedValue) bool {
 	var ownPkgID PkgID
 	if m.Package != nil && m.Package.PkgID.IsStdlibPkg() {
+		ownPkgID = m.Package.PkgID
+	}
+	return m.isReadonly(tv, ownPkgID)
+}
+
+// isReadonlyForCopy is the read-taint variant used by value-read ops
+// (index/selector/slice/deref). A package may freely read and copy its
+// OWN package-level data regardless of m.Realm — e.g. stdlib or a /p/
+// library reading its own immutable tables while running under a caller's
+// realm (those top-level callables don't borrow, so m.Realm is the caller's,
+// not the library's). Writes through the copy/alias remain guarded by the
+// strict IsReadonly at PopAsPointer2/builtins.
+func (m *Machine) isReadonlyForCopy(tv *TypedValue) bool {
+	var ownPkgID PkgID
+	if m.Package != nil {
 		ownPkgID = m.Package.PkgID
 	}
 	return m.isReadonly(tv, ownPkgID)
@@ -2703,6 +2719,7 @@ func (m *Machine) isReadonly(tv *TypedValue, ownPkgID PkgID) bool {
 			return true // external package
 		}
 	}
+	//  - tv is N_Readonly, or
 	//  - tv is a real object residing in external realm (unless it is the
 	//    executing package's own data, stamped ownPkgID).
 	return tv.IsReadonlyBy(m.Realm.ID, ownPkgID)

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -11,6 +11,7 @@ func (m *Machine) doOpIndex1() {
 	m.PopExpr()
 	iv := m.PopValue()   // index
 	xv := m.PeekValue(1) // x
+	ro := m.isReadonlyForCopy(xv)
 	switch ct := baseOf(xv.T).(type) {
 	case *MapType:
 		vt := ct.Value
@@ -30,6 +31,7 @@ func (m *Machine) doOpIndex1() {
 		res := xv.GetPointerAtIndex(m, nilRealm, m.Alloc, m.Store, iv)
 		*xv = res.Deref() // reuse as result
 	}
+	xv.SetReadonly(ro)
 }
 
 // NOTE: keep in sync with doOpIndex1.
@@ -37,6 +39,7 @@ func (m *Machine) doOpIndex2() {
 	m.PopExpr()
 	iv := m.PeekValue(1) // index
 	xv := m.PeekValue(2) // x
+	ro := m.isReadonlyForCopy(xv)
 	switch ct := baseOf(xv.T).(type) {
 	case *MapType:
 		vt := ct.Value
@@ -57,6 +60,7 @@ func (m *Machine) doOpIndex2() {
 	default:
 		panic("should not happen")
 	}
+	xv.SetReadonly(ro)
 }
 
 func (m *Machine) doOpSelector() {
@@ -76,12 +80,14 @@ func (m *Machine) doOpSelector() {
 	default:
 		m.incrCPU(OpCPUSelectorField)
 	}
+	ro := m.isReadonlyForCopy(xv)
 	res := xv.GetPointerToFromTV(m.Alloc, m.Store, sx.Path).Deref()
 	if debug {
 		m.Printf("-v[S] %v\n", xv)
 		m.Printf("+v[S] %v\n", res)
 	}
 	*xv = res // reuse as result
+	xv.SetReadonly(ro)
 }
 
 func (m *Machine) doOpSlice() {
@@ -103,6 +109,7 @@ func (m *Machine) doOpSlice() {
 	}
 	// slice base x
 	xv := m.PopValue()
+	ro := m.isReadonlyForCopy(xv)
 	// if a is a pointer to an array, a[low : high : max] is
 	// shorthand for (*a)[low : high : max]
 	// XXX fix this in precompile instead.
@@ -114,6 +121,9 @@ func (m *Machine) doOpSlice() {
 			return
 		}
 		*xv = xv.V.(PointerValue).Deref()
+		if !ro {
+			ro = xv.IsReadonly()
+		}
 	}
 	// fill default based on xv
 	if sx.High == nil {
@@ -122,10 +132,10 @@ func (m *Machine) doOpSlice() {
 	// all low:high:max cases
 	if maxVal == -1 {
 		sv := xv.GetSlice(m.Alloc, lowVal, highVal)
-		m.PushValue(sv)
+		m.PushValue(sv.WithReadonly(ro))
 	} else {
 		sv := xv.GetSlice2(m.Alloc, lowVal, highVal, maxVal)
-		m.PushValue(sv)
+		m.PushValue(sv.WithReadonly(ro))
 	}
 }
 
@@ -160,7 +170,8 @@ func (m *Machine) doOpStar() {
 			tv.SetUint8(dbv.GetByte())
 			m.PushValue(tv)
 		} else {
-			pvtv := *pv.TV
+			ro := m.isReadonlyForCopy(xv)
+			pvtv := (*pv.TV).WithReadonly(ro)
 			if xpt, ok := baseOf(xv.T).(*PointerType); ok {
 				// When a pointer was converted to a different
 				// declared pointer type, the dereferenced value
@@ -196,7 +207,7 @@ func (m *Machine) doOpStar() {
 // TRANS_LEAVE *RefExpr and at each synthetic RefExpr site.
 func (m *Machine) doOpRef() {
 	rx := m.PopExpr().(*RefExpr)
-	xv, _ := m.PopAsPointer2(rx.X)
+	xv, ro := m.PopAsPointer2(rx.X)
 	elt, ok := rx.GetAttribute(ATTR_REF_ELEM_TYPE).(Type)
 	if !ok {
 		panic("ATTR_REF_ELEM_TYPE not set during preprocessing")
@@ -205,7 +216,7 @@ func (m *Machine) doOpRef() {
 	m.PushValue(TypedValue{
 		T: m.Alloc.NewType(&PointerType{Elt: elt}),
 		V: xv,
-	})
+	}.WithReadonly(ro))
 }
 
 // NOTE: keep in sync with doOpTypeAssert2.

--- a/gnovm/pkg/gnolang/ownership.go
+++ b/gnovm/pkg/gnolang/ownership.go
@@ -438,8 +438,8 @@ func (tv *TypedValue) GetFirstObject(store Store) Object {
 	}
 }
 
-// IsReadonlyBy returns true if tv is a real object owned by a realm
-// other than rid (i.e., residing in an external realm).
+// IsReadonlyBy returns true if tv is readonly-tainted or is a real object
+// owned by a realm other than rid (i.e., residing in an external realm).
 //
 // ownPkgID is the executing package's PkgID (m.Package.PkgID). An object
 // stamped with it is the executing package's own package-level data, which
@@ -459,6 +459,9 @@ func (tv *TypedValue) GetFirstObject(store Store) Object {
 // This function controls heavily the behaviour of
 // [Machine.IsReadonly], and thus cross-realm write authority.
 func (tv *TypedValue) IsReadonlyBy(rid, ownPkgID PkgID) bool {
+	if tv.IsReadonly() {
+		return true
+	}
 	var tvoid ObjectID
 	switch cv := tv.V.(type) {
 	case PointerValue:

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -973,6 +973,36 @@ type TypedValue struct {
 	N [8]byte `json:",omitempty"`
 }
 
+// Magic 8 bytes to denote a readonly wrapped non-nil V of mutable type.
+// This happens when subvalues are retrieved from externally stored realm
+// values, such as external realm package vars, or slices or pointers to.
+var N_Readonly [8]byte = [8]byte{'R', 'e', 'a', 'D', 'o', 'N', 'L', 'Y'} // ReaDoNLY
+
+// Returns true if mutable .V is readonly "wrapped".
+func (tv *TypedValue) IsReadonly() bool {
+	return tv.N == N_Readonly && tv.V != nil
+}
+
+// Sets tv.N to N_Readonly if ro and tv is not already immutable. If ro is
+// false, this preserves any existing marker.
+func (tv *TypedValue) SetReadonly(ro bool) {
+	if tv.V == nil {
+		return
+	}
+	if tv.T.IsImmutable() {
+		return
+	}
+	if ro {
+		tv.N = N_Readonly
+	}
+}
+
+// Convenience, makes readonly if ro is true.
+func (tv TypedValue) WithReadonly(ro bool) TypedValue {
+	tv.SetReadonly(ro)
+	return tv
+}
+
 func (tv *TypedValue) IsImmutable() bool {
 	return tv.T == nil || tv.T.IsImmutable()
 }
@@ -1058,13 +1088,41 @@ func (tv TypedValue) Copy(alloc *Allocator) (cp TypedValue) {
 	case *ArrayValue:
 		cp.T = tv.T
 		cp.V = cv.Copy(alloc, tv.T)
+		if !isDeepCopyAliasFree(tv.T) {
+			cp.N = tv.N
+		}
 	case *StructValue:
 		cp.T = tv.T
 		cp.V = cv.Copy(alloc, tv.T)
+		if !isDeepCopyAliasFree(tv.T) {
+			cp.N = tv.N
+		}
 	default:
 		cp = tv
 	}
 	return
+}
+
+// isDeepCopyAliasFree reports whether a value copy of t can retain no aliases
+// into the source object graph. It is intentionally conservative: only
+// primitives, arrays of alias-free values, and structs whose fields are all
+// alias-free are treated as safe to detach from readonly provenance.
+func isDeepCopyAliasFree(t Type) bool {
+	switch ct := baseOf(t).(type) {
+	case PrimitiveType:
+		return true
+	case *ArrayType:
+		return isDeepCopyAliasFree(ct.Elt)
+	case *StructType:
+		for _, field := range ct.Fields {
+			if !isDeepCopyAliasFree(field.Type) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 // unrefCopy makes a copy of the underlying value in the case of reference values.

--- a/gnovm/tests/files/zrealm_crossrealm21.gno
+++ b/gnovm/tests/files/zrealm_crossrealm21.gno
@@ -23,7 +23,7 @@ func main(cur realm) {
 // Realm:
 // finalizerealm["gno.land/r/tests/vm/crossrealm"]
 // u[07e973c6aeab1f1cb747d0903cb1e4d369226376:7](214)=
-//     @@ -2,9 +2,26 @@
+//     @@ -2,9 +2,27 @@
 //          "ObjectInfo": {
 //              "ID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:7",
 //              "LastObjectSize": "190",
@@ -34,6 +34,7 @@ func main(cur realm) {
 //          },
 //     -    "Value": {}
 //     +    "Value": {
+//     +        "N": "UmVhRG9OTFk=",
 //     +        "T": {
 //     +            "@type": "/gno.PointerType",
 //     +            "Elt": {
@@ -91,7 +92,7 @@ func main(cur realm) {
 //                  "V": {
 //                      "@type": "/gno.RefValue",
 //     -                "Hash": "d49b3fb9d433be706f6d81b5bbf3855107b513ca",
-//     +                "Hash": "ad3d96fa63233a8faa78cefad1efde332cd2482b",
+//     +                "Hash": "9dd421ff7a1cb724e558b3465737fcec184757c7",
 //                      "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:7"
 //                  }
 //              },

--- a/gnovm/tests/files/zrealm_crossrealm22.gno
+++ b/gnovm/tests/files/zrealm_crossrealm22.gno
@@ -45,6 +45,7 @@ func main(cur realm) {
 //         "RefCount": "1"
 //     },
 //     "Value": {
+//         "N": "UmVhRG9OTFk=",
 //         "T": {
 //             "@type": "/gno.PointerType",
 //             "Elt": {
@@ -71,7 +72,7 @@ func main(cur realm) {
 //             },
 //             "V": {
 //                 "@type": "/gno.RefValue",
-//                 "Hash": "6e22577dee90926a3bc184c1cd0b706b341aff5d",
+//                 "Hash": "c17906071fc752254f15f17ff49db280d68fb67d",
 //                 "ObjectID": "0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:6"
 //             }
 //         }
@@ -144,7 +145,7 @@ func main(cur realm) {
 //     +        },
 //     +        "V": {
 //     +            "@type": "/gno.RefValue",
-//     +            "Hash": "8d8d45622e3a5236372a1d9b560ef5a3a1c29634",
+//     +            "Hash": "cad1669f8d9d17033a8e6ababf53d40f2b4855f7",
 //     +            "ObjectID": "0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:5"
 //              }
 //          }
@@ -188,7 +189,7 @@ func main(cur realm) {
 //                  "V": {
 //                      "@type": "/gno.RefValue",
 //     -                "Hash": "68684cec1e3a40b9022f09802324c8388b874458",
-//     +                "Hash": "5cab66f9e9dcdb1c5ff2afb9b0bca8c3b9bad879",
+//     +                "Hash": "c22c9ef3c4c768f38d1f8c6f137195235adb5e34",
 //                      "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14"
 //                  }
 //              },
@@ -282,7 +283,7 @@ func main(cur realm) {
 //              },
 //              "V": {
 //                  "@type": "/gno.RefValue",
-//     -            "Hash": "8d8d45622e3a5236372a1d9b560ef5a3a1c29634",
+//     -            "Hash": "cad1669f8d9d17033a8e6ababf53d40f2b4855f7",
 //     -            "ObjectID": "0c8307f7bbe97fdb07b2d0fa6907b8d67517c02a:5"
 //     +            "ObjectID": "06279d1e03ecb38b84822f9caf584bd16913470d:7"
 //              }
@@ -338,7 +339,7 @@ func main(cur realm) {
 //                  },
 //                  "V": {
 //                      "@type": "/gno.RefValue",
-//     -                "Hash": "5cab66f9e9dcdb1c5ff2afb9b0bca8c3b9bad879",
+//     -                "Hash": "c22c9ef3c4c768f38d1f8c6f137195235adb5e34",
 //     +                "Hash": "f304224c3678ae566effa9f679429b3552eabcff",
 //                      "ObjectID": "07e973c6aeab1f1cb747d0903cb1e4d369226376:14"
 //                  }

--- a/gnovm/tests/files/zrealm_map3.gno
+++ b/gnovm/tests/files/zrealm_map3.gno
@@ -5,9 +5,8 @@ import (
 	"gno.land/r/tests/vm/crossrealm_b"
 )
 
-// With the readonly taint removed, assign and delete succeed: the map's
-// ObjectID belongs to the current realm, so the ownership check permits
-// the writes. (Pre-removal the sticky taint blocked them.)
+// Verify that assign and delete on a readonly-tainted map both panic,
+// even when the map's ObjectID belongs to the current realm.
 var m map[string]int
 
 func init() {
@@ -45,6 +44,8 @@ func main(cur realm) {
 }
 
 // Output:
-// admin exists: false
+// assign panic: cannot directly modify readonly tainted object (use a method or crossing function): rm<~VPBlock(1,0)>[(const ("attacker" string))]
+// delete panic: cannot delete from readonly tainted map
+// admin exists: true
 // user1: 500
 // len: 2

--- a/gnovm/tests/files/zrealm_slice0.gno
+++ b/gnovm/tests/files/zrealm_slice0.gno
@@ -5,10 +5,8 @@ import (
 	"gno.land/r/tests/vm/crossrealm_b"
 )
 
-// With the readonly taint removed, append within capacity succeeds: the
-// backing array's ObjectID belongs to the current realm, so the ownership
-// check permits the write. (Pre-removal the sticky taint blocked it even
-// though the backing was current-realm-owned.)
+// Verify that append within capacity on a readonly-tainted slice panics,
+// even when the backing array's ObjectID belongs to the current realm.
 var s []int
 
 func init() {
@@ -39,6 +37,7 @@ func main(cur realm) {
 }
 
 // Output:
+// append panic: cannot append to readonly tainted slice
 // s[0]: 1
 // s[1]: 2
 // s[2]: 3

--- a/gnovm/tests/files/zrealm_slice1.gno
+++ b/gnovm/tests/files/zrealm_slice1.gno
@@ -5,9 +5,8 @@ import (
 	"gno.land/r/tests/vm/crossrealm_b"
 )
 
-// With the readonly taint removed, copy into the slice succeeds: the
-// backing array's ObjectID belongs to the current realm, so the ownership
-// check permits the write. (Pre-removal the sticky taint blocked it.)
+// Verify that copy into a readonly-tainted slice panics, even when the
+// backing array's ObjectID belongs to the current realm.
 var s []int
 
 func init() {
@@ -34,6 +33,7 @@ func main(cur realm) {
 }
 
 // Output:
-// s[0]: 99
-// s[1]: 99
-// s[2]: 99
+// copy panic: cannot copy to readonly tainted slice
+// s[0]: 1
+// s[1]: 2
+// s[2]: 3


### PR DESCRIPTION
## Summary

This is an alternative follow-up to #5747.

#5747 fixed #5736 by making array/struct copies use type-driven PkgID stamping, so value-only `/p/` types such as `uint256.Uint` can be copied and mutated locally. That part is preserved here.

The unsafe part is that #5747 also removed readonly provenance completely. For alias-retaining value copies, the copied wrapper can be fresh while a child reference still points into foreign storage:

```go
// /r/victim
var Global = [1][]byte{[]byte("safe")}
func Copy(dst []byte, src string) { copy(dst, []byte(src)) }

// /r/attacker
x := victim.Global
victim.Copy(x[0], "pwn!")
```

Calling back into a victim-declared helper borrows `m.Realm` to the victim realm, so a pure ownership check permits the write unless the retained alias still carries readonly provenance.

## Change

- Restore `N_Readonly` provenance on foreign reads through selector, index, slice, deref, and address-of.
- Keep #5747's type-driven PkgID stamping for `ArrayValue.Copy` and `StructValue.Copy`.
- Clear readonly provenance only for transitively alias-free copies: primitives, arrays of alias-free values, and structs whose fields are all alias-free.
- Preserve readonly provenance for copies that may retain references, including `[1][]byte`.
- Add a txtar repro for the alias round-trip and update interrealm v2 docs/fixtures.
- Add an ADR at `gnovm/adr/prxxxx_readonly_alias_roundtrip.md`.

## Validation

- `git diff --check`
- `go test ./gno.land/pkg/integration -run 'TestTestdata/(issue_5747_alias_roundtrip|interrealm_v2)' -count=1 -v`
- `(cd examples/gno.land/r/tests/issue5736_bar && go run ../../../../../gnovm/cmd/gno test .)`
- `go test ./gnovm/pkg/gnolang -run 'TestFiles' -count=1 -short`
- `go test ./gnovm/pkg/gnolang -count=1 -short`

AI assistance: generated with Codex.
