### PR TITLE
fix(examples/urequire): pass rlm through AbortsContains and PanicsContains

### DIFF
--- a/examples/gno.land/p/nt/urequire/v0/urequire.gno
+++ b/examples/gno.land/p/nt/urequire/v0/urequire.gno
@@ -76,9 +76,10 @@ func AbortsWithMessage(t uassert.TestingT, rlm realm, msg string, f any, msgs ..
 
 // AbortsContains requires that the code inside the specified func aborts
 // (panics when crossing another realm) and the abort message contains the specified substring.
-func AbortsContains(t uassert.TestingT, substr string, f any, msgs ...string) {
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func AbortsContains(t uassert.TestingT, rlm realm, substr string, f any, msgs ...string) {
 	t.Helper()
-	if uassert.AbortsContains(t, substr, f, msgs...) {
+	if uassert.AbortsContains(t, rlm, substr, f, msgs...) {
 		return
 	}
 	t.FailNow()
@@ -111,9 +112,10 @@ func PanicsWithMessage(t uassert.TestingT, rlm realm, msg string, f any, msgs ..
 
 // PanicsContains requires that the code inside the specified func panics
 // locally within the same execution realm and the panic message contains the specified substring.
-func PanicsContains(t uassert.TestingT, substr string, f any, msgs ...string) {
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func PanicsContains(t uassert.TestingT, rlm realm, substr string, f any, msgs ...string) {
 	t.Helper()
-	if uassert.PanicsContains(t, substr, f, msgs...) {
+	if uassert.PanicsContains(t, rlm, substr, f, msgs...) {
 		return
 	}
 	t.FailNow()


### PR DESCRIPTION
## Problem

`ci / examples` has been red on master since #5673 merged (`889405c34`):

```
urequire.gno:84:42: not enough arguments in call to uassert.AbortsContains
urequire.gno:119:42: not enough arguments in call to uassert.PanicsContains
```

Semantic merge conflict: #5673 added `urequire.AbortsContains`/`PanicsContains` wrappers written against the old `uassert` signatures, but `uassert.AbortsContains`/`PanicsContains` gained a `rlm realm` parameter on master in the meantime. Since `urequire/v0` no longer preprocesses, every package importing it fails too (`p/demo/gnorkle/*`, `p/demo/tokens/grc20`, ...).

## Fix

Add the `rlm realm` parameter to both wrappers and pass it through, matching the sibling wrappers in the same file (`AbortsWithMessage`, `PanicsWithMessage`, `NotAborts`, `NotPanics`). #5673 only touched `urequire.gno`, so this covers its full blast radius. No callers of the new wrappers exist yet.

## Verification

- `gno tool transpile -gobuild examples/gno.land/p/nt/urequire/v0` (the failing CI check) passes
- `gno test` passes for `p/nt/urequire/v0` and the previously cascade-failing `p/demo/gnorkle/feeds/static`, `p/demo/gnorkle/storage/simple`, `p/demo/tokens/grc20`
- `gno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)