### PR TITLE
docs(validators/tmkms): secure-setup quickstart for tmkms-backed validators

### DIFF
--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -202,6 +202,14 @@ its sharpest edges, so the rule for this section is: **provision the
 device by hand, and never run the automated setup or test commands
 against a production key.**
 
+Install tmkms with the `yubihsm` provider (it is **not** in the default
+build — you must enable the feature explicitly):
+
+```sh
+cargo install tmkms --version 0.15.0 --features yubihsm --locked
+tmkms version   # → 0.15.0
+```
+
 ## B.1 Provision the YubiHSM by hand — never `tmkms yubihsm setup`
 
 > **Do not run `tmkms yubihsm setup`.** That command prints the recovery
@@ -769,8 +777,18 @@ the provider and the device handling change.
 
 ## D.1 Prerequisites
 
-- tmkms built with the **`ledgertm`** provider (it is in the default
-  build; to keep softsign too, build `--features ledgertm,softsign`).
+Install tmkms with the **`ledgertm`** provider. Unlike the YubiHSM and
+softsign features, `ledgertm` *is* in the default build, so plain
+`cargo install tmkms` gives it to you; pass it explicitly (and add
+`softsign` if you want both) to be sure:
+
+```sh
+cargo install tmkms --version 0.15.0 --features ledgertm --locked
+# or, to keep softsign too: --features ledgertm,softsign
+```
+
+You also need:
+
 - A Ledger with the **"Tendermint Validator"** app installed (the
   dedicated ed25519 consensus app — *not* the regular Cosmos app),
   plugged in, unlocked, with that app **open**. tmkms cannot reach a

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -777,14 +777,15 @@ the provider and the device handling change.
 
 ## D.1 Prerequisites
 
-Install tmkms with the **`ledgertm`** provider. Unlike the YubiHSM and
-softsign features, `ledgertm` *is* in the default build, so plain
-`cargo install tmkms` gives it to you; pass it explicitly (and add
-`softsign` if you want both) to be sure:
+Install tmkms with the Ledger provider. The cargo feature is named
+**`ledger`** in 0.15.0 (older versions called it `ledgertm`, which is
+why the config block below is still `[[providers.ledgertm]]`). tmkms
+0.15.0 ships **no** default features, so plain `cargo install tmkms`
+gives you neither Ledger nor softsign — pass them explicitly:
 
 ```sh
-cargo install tmkms --version 0.15.0 --features ledgertm --locked
-# or, to keep softsign too: --features ledgertm,softsign
+cargo install tmkms --version 0.15.0 --features ledger --locked
+# or, to keep softsign too: --features ledger,softsign
 ```
 
 You also need:

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -457,29 +457,43 @@ onboarding path performs in the production case.
 
 ## B.4 Write `tmkms.toml`
 
-Store it at `/etc/tmkms/tmkms.toml`, `0600`, owned by `tmkms`. Absolute
-paths throughout; the password lives in `password_file`, never inline.
+Set the signer address to match the transport you picked in Part A.3 —
+pick **one** (the TCP form embeds the mandatory peer-ID pin from B.2):
 
-```toml
+```sh
+# TCP (separate hosts):
+export TMKMS_ADDR="tcp://${VALIDATOR_PEER_ID}@<validator_ip>:26659"
+# OR same host (Unix socket — no peer ID; socket perms are the boundary):
+export TMKMS_ADDR="unix:///run/gnoland/privval.sock"
+```
+
+Write the config with a heredoc, then lock it down to `0600` owned by
+`tmkms` (the password stays in the separate `password_file`, never
+inline; all paths are absolute):
+
+```sh
+sudo tee /etc/tmkms/tmkms.toml >/dev/null <<TOML
 [[chain]]
-id = "gno-tmkms-prod"
-key_format = { type = "hex" }                       # logs the pubkey in hex (B.3)
+id = "${CHAIN_ID}"
+key_format = { type = "hex" }                                # logs the pubkey in hex (B.3)
 state_file = "/var/lib/tmkms/secrets/consensus_state.json"   # absolute! the HRS gate
 
 [[providers.yubihsm]]
-adapter = { type = "usb" }                          # or { type = "http", addr = "..." }
+adapter = { type = "usb" }                                   # or { type = "http", addr = "..." }
 auth = { key = 2, password_file = "/etc/tmkms/yubihsm-password" }
-keys = [{ chain_ids = ["gno-tmkms-prod"], key = 100, type = "consensus" }]
-# serial_number = "0123456789"                       # pin to one physical device
+keys = [{ chain_ids = ["${CHAIN_ID}"], key = 100, type = "consensus" }]
+# serial_number = "0123456789"                               # pin to one physical device
 
 [[validator]]
-chain_id = "gno-tmkms-prod"
-# TCP (separate hosts): the <peer_id>@ prefix is MANDATORY — see below.
-addr = "tcp://243cef06…dcac@<validator_ip>:26659"
-# Same host instead: addr = "unix:///run/gnoland/privval.sock"
+chain_id = "${CHAIN_ID}"
+addr = "${TMKMS_ADDR}"                                       # from above; peer-ID pin is MANDATORY on TCP
 secret_key = "/var/lib/tmkms/secrets/kms-identity.key"
 protocol_version = "v0.34"
 reconnect = true
+TOML
+
+sudo chown tmkms:tmkms /etc/tmkms/tmkms.toml
+sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
 The fields that carry security weight:
@@ -576,7 +590,13 @@ Within a few seconds the node should advance through heights.
 - **Identity check:** the validator address in the `Signed and pushed
   vote` lines must equal the address from B.3 and the genesis entry.
 - **Kill tmkms** and watch gnoland stop committing; restart it and watch
-  it resume. That is the proof the key lives in the HSM, not the node.
+  it resume. That is the proof the key lives in the HSM, not the node:
+
+  ```sh
+  sudo systemctl stop tmkms     # or: sudo pkill -f 'tmkms start'
+  # gnoland's committed height stops climbing...
+  sudo systemctl start tmkms    # ...and resumes after tmkms reconnects
+  ```
 
 > **Benign log noise.** Even when signing works, gnoland periodically
 > logs `SignerListener: accept failed … i/o timeout` and `already
@@ -599,7 +619,13 @@ Within a few seconds the node should advance through heights.
   tmkms yourself.)
 - **Back up the state file** as part of every maintenance procedure — and
   understand a backup is for disaster recovery of the *latest* state, not
-  a checkpoint to roll back to.
+  a checkpoint to roll back to:
+
+  ```sh
+  sudo install -o tmkms -g tmkms -m 600 \
+    /var/lib/tmkms/secrets/consensus_state.json \
+    /var/lib/tmkms/secrets/consensus_state.json.bak
+  ```
 - **Drain the audit log.** With forced auditing on (B.1) the HSM stops
   signing once its audit buffer fills, so run a small auditor that reads
   and clears the log periodically (e.g. every 30s) and ships it off-box.
@@ -628,9 +654,12 @@ hardening on top:
 - **`0600` on `consensus.key` and the state file**, owned by `tmkms`. A
   readable softsign key *is* the validator's private key.
 - **Swap exposure.** tmkms zeroizes the key on drop but does not `mlock`
-  it, so it can be paged to disk. Disable swap on the signer host, or use
-  encrypted swap, if you care about the key never hitting persistent
-  storage in the clear.
+  it, so it can be paged to disk. Disable swap on the signer host (or use
+  encrypted swap) so the key never hits persistent storage in the clear:
+
+  ```sh
+  sudo swapoff -a                     # and comment swap out of /etc/fstab to persist
+  ```
 - **Don't re-run `secrets init` / keygen over an existing key file** —
   it can overwrite without warning. Back up first.
 

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -57,12 +57,11 @@ Two tiny **stdlib-only** Go helpers, compiled once. They build/run from
 any directory (Part B.3's `pkconv.go` is the exception — it imports gno
 crypto, run from the repo root; defined where it's used).
 
-> **Run helpers as the secret's owner.** In Parts B/D the secrets live
-> under `/var/lib` owned by a service user (separate `tmkms` on TCP; shared
-> `gnoland` on UDS — [A.1](#a1-pick-the-user-model-it-depends-on-the-transport)).
-> Run each helper `sudo -u <that user>` — least privilege, no copying the
-> secret to your dir. Those users have no home, so the Go toolchain can't
-> run as them: compile as yourself, run only the built binary under sudo.
+> **Run helpers as `gnoland`.** In Parts B/D the secrets live under
+> `/var/lib` owned by `gnoland`; run each helper `sudo -u gnoland` (least
+> privilege, no copying the secret to your dir). That user has no home, so
+> the Go toolchain can't run as it: compile as yourself, run only the built
+> binary under sudo.
 
 `nodeid-hex.go` — prints a gnoland node's peer ID in the hex form tmkms
 pins in its `addr` (TCP layouts):
@@ -147,40 +146,36 @@ afterward if you don't want them lying around.
 
 ## Put the binaries on a system path
 
-Service users (no home) can't reach binaries under your home, so
-`sudo -u … <bin>` fails with `Permission denied`. Build gnoland/gnogenesis
-and install them — with the `tmkms` binary `cargo` drops in
-`~/.cargo/bin` — to `/usr/local/bin`:
+Clone gno **once** to `/opt/gno`: you build the binaries from it and later
+point `GNOROOT` at it, so the binary and its stdlibs always match. Own it as
+your user (to build in place); it stays world-readable for the service
+users, who — having no home — can't reach a clone under yours and otherwise
+hit `Permission denied` on `sudo -u … <bin>`. Build gnoland and gnogenesis
+and install them to `/usr/local/bin`:
 
 ```sh
-# from the gno repo root (output lands in each component's build/ dir)
+sudo install -d -o "$(id -un)" /opt/gno
+git clone https://github.com/gnolang/gno /opt/gno   # or reuse a clone, building from the same checkout
+cd /opt/gno
 make -C gno.land build.gnoland
 make -C contribs/gnogenesis build
 sudo install -m 0755 gno.land/build/gnoland contribs/gnogenesis/build/gnogenesis /usr/local/bin/
 ```
 
-The backend sections repeat the `tmkms` step after its `cargo install`:
-
-```sh
-sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # after cargo install (Parts B/D)
-```
-
 ## Set `GNOROOT` to a gno checkout
 
 gnoland loads stdlib `.gno` sources from `$GNOROOT/gnovm/stdlibs/` on every
-start (and panics without `GNOROOT` set). So it must point at a **complete
-checkout whose stdlibs match the binary you built** — empty/mismatched
-fails with `failed loading stdlib "…": does not exist`. Your build clone is
-under your home (unreadable to `gnoland`), so copy it to `/opt/gno`:
+start (and panics without `GNOROOT` set). Point it at the `/opt/gno`
+checkout you just built from — same commit, so the stdlibs match the binary
+(empty/mismatched fails with `failed loading stdlib "…": does not exist`).
+It's world-readable, so the `gnoland` user can read it:
 
 ```sh
-sudo git clone --local "$(git -C . rev-parse --show-toplevel)" /opt/gno
-sudo git -C /opt/gno checkout "$(git rev-parse --abbrev-ref HEAD)"   # match your built binary
 export GNOROOT=/opt/gno
 ```
 
 `sudo -u gnoland` scrubs the env, so every `gnoland` command below passes
-`env GNOROOT="$GNOROOT"` (systemd: `Environment=GNOROOT=/opt/gno`).
+`env GNOROOT="$GNOROOT"`.
 
 ---
 
@@ -189,24 +184,14 @@ export GNOROOT=/opt/gno
 tmkms doesn't enforce permissions on its own key/state/config (it accepts
 world-readable secrets silently) — the OS must.
 
-## A.1 Pick the user model (it depends on the transport)
+## A.1 Run everything as the gnoland user
 
-Never run as root or your login user — use locked-down system accounts (no
-shell, no home). **How many** depends on the transport
-([A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp)):
-
-- **TCP (Part B, or loopback): two users.** They authenticate
-  cryptographically, so isolate them as distinct accounts.
-- **Same-host UDS (Parts C, D): one user.** gnoland forces the socket to
-  `0600` owned by *itself* (`tm2/pkg/bft/privval/config.go`), and
-  connecting needs write access — so only that user can dial in (a separate
-  `tmkms` user gets `Permission denied (os error 13)`). Run tmkms as the
-  gnoland user. Want isolation on one host? Use loopback TCP.
+Never run as root or your login user. Use **one** locked-down system
+account, `gnoland`, for both gnoland and tmkms — on each host, if you run
+them on two:
 
 ```sh
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin gnoland
-# TCP only — separate signer user (UDS runs tmkms as gnoland):
-sudo useradd --system --no-create-home --shell /usr/sbin/nologin tmkms
 ```
 
 ## A.2 Lay out directories with strict permissions
@@ -215,19 +200,13 @@ The state file is the **double-sign gate** — losing or rolling it back can
 get you slashed. Give the secrets a private `0600` home:
 
 ```sh
-sudo install -d -o tmkms -g tmkms -m 700 /etc/tmkms          # config
-sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms       # state + identity key
-sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms/secrets
-
-# gnoland's own data dir (it creates secrets/ and config/ itself):
-sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland
+sudo install -d -o gnoland -g gnoland -m 700 /etc/tmkms          # tmkms config
+sudo install -d -o gnoland -g gnoland -m 700 /var/lib/tmkms       # state + identity key
+sudo install -d -o gnoland -g gnoland -m 700 /var/lib/tmkms/secrets
+sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland     # gnoland data dir
 ```
 
-> **UDS (single user):** own `/etc/tmkms` and `/var/lib/tmkms` with
-> `-o gnoland -g gnoland` instead (tmkms runs as `gnoland`, A.1). The above
-> is the two-user TCP layout.
-
-- Secrets + state `0600`, owned by the signer user — tmkms won't reject
+- Secrets + state `0600`, owned by `gnoland` — tmkms won't reject
   world-readable secrets, so you must.
 - **Absolute paths** in `tmkms.toml` — a CWD-relative state file can
   silently become a fresh, height-zero one.
@@ -238,26 +217,23 @@ sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland
 
 Two layouts, different auth boundaries — pick deliberately:
 
-### Same host → Unix-domain socket (auth by filesystem, single user)
+### Same host → Unix-domain socket (auth by filesystem)
 
-gnoland creates the socket `0600` owned by **its own user**, and
-connecting needs write access — so only that user dials in. tmkms runs as
-gnoland (A.1); just create the dir:
+gnoland creates the socket `0600` owned by `gnoland`; tmkms (also `gnoland`)
+connects. Just create the dir:
 
 ```sh
 sudo install -d -o gnoland -g gnoland -m 700 /run/gnoland
-# gnoland creates /run/gnoland/privval.sock at 0600; tmkms (as gnoland) connects.
 ```
 
 > On UDS the `allowed_kms_pubkeys` allowlist can't be crypto-checked — the
-> `0600` socket is the whole auth boundary (one user in, every other local
-> user out). Set the allowlist anyway (gnoland requires it non-empty), but
-> it's belt-and-suspenders. For per-user isolation, use loopback TCP.
+> `0600` socket is the whole auth boundary. Set it anyway (gnoland requires
+> it non-empty), but it's belt-and-suspenders.
 
-### TCP, firewalled (auth by cryptography, two users)
+### TCP, firewalled (auth by cryptography)
 
-Run the signer on its **own host** (or `127.0.0.1` for two isolated users
-on one box). Auth is cryptographic, both halves mandatory:
+Run the signer on its **own host** (or `127.0.0.1` on one box). Auth is
+cryptographic, both halves mandatory:
 
 - gnoland verifies tmkms via `allowed_kms_pubkeys` (the signer's pubkey).
 - tmkms verifies gnoland via the **peer ID pinned in its `addr`**.
@@ -300,7 +276,7 @@ Install tmkms with the `yubihsm` provider (not in the default build):
 
 ```sh
 cargo install tmkms --version 0.15.0 --features yubihsm --locked
-sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # so sudo -u tmkms can run it
+sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # so sudo -u gnoland can run it
 tmkms version   # → 0.15.0
 ```
 
@@ -360,7 +336,7 @@ Store the password in a file, not the config:
 
 ```sh
 printf '%s' "$TMKMS_AUTH_PASSWORD" | sudo tee /etc/tmkms/yubihsm-password >/dev/null
-sudo chown tmkms:tmkms /etc/tmkms/yubihsm-password
+sudo chown gnoland:gnoland /etc/tmkms/yubihsm-password
 sudo chmod 600 /etc/tmkms/yubihsm-password
 unset TMKMS_AUTH_PASSWORD   # drop it from the shell once it's in the file
 ```
@@ -388,23 +364,23 @@ echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned in B.4
 ```
 
 **tmkms's SecretConnection identity (TCP)** — its pubkey must be in
-`allowed_kms_pubkeys`. Run `tmkms-identity-keygen` as the tmkms user so the
-key lands tmkms-owned:
+`allowed_kms_pubkeys`. Run `tmkms-identity-keygen` as `gnoland` so the key
+lands gnoland-owned:
 
 ```sh
-ALLOW=$(sudo -u tmkms tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
+ALLOW=$(sudo -u gnoland tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
 echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in B.5
 ```
 
 ## B.3 Read the consensus pubkey out of the HSM and register the validator
 
 The key never leaves the HSM, so you read its **public** half from tmkms
-and register that. Start tmkms once (as the tmkms user, `tmkms.toml` from
+and register that. Start tmkms once (as `gnoland`, `tmkms.toml` from
 B.4); it logs the consensus pubkey on startup. Read it, then `Ctrl-C`
 (gnoland isn't up; tmkms just retries meanwhile):
 
 ```sh
-sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
 ```
 
 ```
@@ -492,11 +468,7 @@ export TMKMS_ADDR="tcp://${VALIDATOR_PEER_ID}@<validator_ip>:26659"
 export TMKMS_ADDR="unix:///run/gnoland/privval.sock"
 ```
 
-> **Picking UDS here?** Part B is two-user (TCP). Over a socket only the
-> owner connects (A.3), so run tmkms as `gnoland` and own its
-> config/secrets with `gnoland` — see Part D's single-user ownership.
-
-Write the config, then lock it `0600` owned by `tmkms` (password stays in
+Write the config, then lock it `0600` owned by `gnoland` (password stays in
 the `password_file`; all paths absolute):
 
 ```sh
@@ -520,7 +492,7 @@ protocol_version = "v0.34"
 reconnect = true
 TOML
 
-sudo chown tmkms:tmkms /etc/tmkms/tmkms.toml
+sudo chown gnoland:gnoland /etc/tmkms/tmkms.toml
 sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
@@ -569,16 +541,15 @@ empty):
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
-## B.6 Run both as services, in the right order
+## B.6 Run both, in the right order
 
 **Order matters.** gnoland blocks up to `wait_for_connection_timeout`
 (default 60s) waiting for tmkms, so start tmkms first (`reconnect = true`
-makes it retry). Run each as its own user (systemd `User=tmkms` /
-`User=gnoland`):
+makes it retry). Run each in its own terminal, both as `gnoland`:
 
 ```sh
-# signer (as the tmkms user)
-sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+# signer (as gnoland)
+sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
 
 # validator (as the gnoland user) — -genesis = the network's genesis;
 # NO -lazy (you're not minting a local key).
@@ -605,9 +576,8 @@ Within seconds the node should advance through heights.
   it resume. That is the proof the key lives in the HSM, not the node:
 
   ```sh
-  sudo systemctl stop tmkms     # or: sudo pkill -f 'tmkms start'
-  # gnoland's committed height stops climbing...
-  sudo systemctl start tmkms    # ...and resumes after tmkms reconnects
+  sudo pkill -f 'tmkms start'   # gnoland's committed height stops climbing...
+  sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml   # ...resumes after tmkms reconnects
   ```
 
 > **Benign log noise.** `SignerListener: accept failed … i/o timeout` and
@@ -626,7 +596,7 @@ Within seconds the node should advance through heights.
   rollback checkpoint):
 
   ```sh
-  sudo install -o tmkms -g tmkms -m 600 \
+  sudo install -o gnoland -g gnoland -m 600 \
     /var/lib/tmkms/secrets/consensus_state.json \
     /var/lib/tmkms/secrets/consensus_state.json.bak
   ```
@@ -806,11 +776,8 @@ as Part B; only the provider and device handling change.
 
 ## D.1 Prerequisites
 
-This is a same-host **UDS** layout, so per
-[A.1](#a1-pick-the-user-model-it-depends-on-the-transport) tmkms runs as the
-**`gnoland`** user (own `/etc/tmkms` + `/var/lib/tmkms` with `gnoland`, A.2)
-— no separate `tmkms` user. For two isolated users, use Part B's loopback
-TCP instead.
+Same-host **UDS** layout; tmkms runs as `gnoland` like everything else
+(A.1).
 
 Install tmkms with the Ledger provider — the feature is `ledger` in 0.15.0
 (the config block is still `[[providers.ledgertm]]`); 0.15.0 has no default
@@ -1012,7 +979,7 @@ sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" co
 
 **Order matters.** gnoland blocks up to `wait_for_connection_timeout`
 (default 60s) waiting for tmkms, so start tmkms first (`reconnect = true`
-retries). **Both run as `gnoland`** (A.1; systemd `User=gnoland` on both):
+retries). Run each in its own terminal, both as `gnoland`:
 
 ```sh
 # signer (as gnoland) — Ledger plugged in, unlocked, app open
@@ -1058,7 +1025,7 @@ go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `sudo -u tmkms`/`gnoland`: `unable to execute …: Permission denied` | binary under `~/.cargo/bin` or your home; service user can't traverse it | `sudo install -m 0755 <binary> /usr/local/bin/` ([Prerequisites](#put-the-binaries-on-a-system-path)) |
+| `sudo -u gnoland …`: `unable to execute …: Permission denied` | binary under `~/.cargo/bin` or your home; the `gnoland` user can't traverse it | `sudo install -m 0755 <binary> /usr/local/bin/` ([Prerequisites](#put-the-binaries-on-a-system-path)) |
 | gnoland panics: `unable to determine GNOROOT` | `GNOROOT` unset, or scrubbed by `sudo -u` | `export GNOROOT=/opt/gno` and pass `env GNOROOT="$GNOROOT"` through sudo ([Prerequisites](#set-gnoroot-to-a-gno-checkout)) |
 | gnoland panics at InitChainer: `failed loading stdlib "…": does not exist` | `GNOROOT` isn't a complete checkout, or its stdlibs don't match the binary | Point `GNOROOT` at a full checkout of the tree you built, at the same commit ([Prerequisites](#set-gnoroot-to-a-gno-checkout)) |
 | tmkms: `unknown field 'softsign', expected 'ledgertm'` | tmkms built without softsign | `cargo install tmkms --version 0.15.0 --features softsign --locked` |
@@ -1069,7 +1036,7 @@ go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
 | Node never advances past height 1, no signing in tmkms log | `chain_id` mismatch across genesis / config.toml / tmkms.toml | Make all three identical and restart |
 | Signatures produced but rejected by the chain | consensus key in the signer ≠ genesis validator key | Re-seed genesis from the *same* key the signer holds |
 | tmkms: `unverified validator peer ID! (<hex>)` | peer-ID prefix missing from `addr` (TCP) | Pin `tcp://<hex>@host:port` with `$VALIDATOR_PEER_ID` (B.4) |
-| tmkms (UDS): `I/O error: Permission denied (os error 13)` | tmkms runs as a *different* user than gnoland; the socket is `0600` owner-only | Run both as one user (A.1), or switch to loopback TCP for two users |
+| tmkms (UDS): `I/O error: Permission denied (os error 13)` | tmkms isn't running as `gnoland`; the socket is `0600` owned by `gnoland` | Run tmkms as `gnoland` (A.1) |
 | tmkms (Ledger): `error loading configuration: signing operation failed` | the user running tmkms can't open the Ledger's `/dev/hidraw*` node | Add the hidraw udev rule for that user's group, reload, replug (D.1) |
 | tmkms (Ledger): startup `SigningError` / no pubkey | device locked, asleep, or wrong app | Unlock, open **Tendermint Validator** app, restart tmkms |
 
@@ -1081,16 +1048,16 @@ Run down this list before putting real stake behind the validator. Each
 item plainly states why it matters.
 
 **Host & OS**
-- [ ] tmkms runs as a dedicated, no-shell system user — *limits what a
-  compromised signer process can reach.*
-- [ ] Config, state, and key files are `0600`, owned by `tmkms` — *tmkms
+- [ ] gnoland and tmkms run as the dedicated, no-shell `gnoland` user —
+  *limits what a compromised process can reach.*
+- [ ] Config, state, and key files are `0600`, owned by `gnoland` — *tmkms
   won't reject world-readable secrets; the OS must.*
 - [ ] All paths in `tmkms.toml` are absolute — *stops a CWD-relative
   state file from silently becoming a fresh, height-zero one.*
 
 **Transport & auth**
-- [ ] Same host: Unix socket in a directory only tmkms+gnoland can reach —
-  *on UDS, filesystem permissions are the only auth boundary.*
+- [ ] Same host: socket `0600` owned by `gnoland` — *on UDS, the owner-only
+  socket is the auth boundary.*
 - [ ] Separate hosts: TCP with the peer-ID pinned in `addr` **and** the
   signer pubkey in `allowed_kms_pubkeys` — *both halves of mutual auth;
   without the pin tmkms signs for any impostor on the port.*

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -1,69 +1,39 @@
 # gnoland + tmkms: secure setup
 
-A step-by-step guide to standing up a gnoland validator whose consensus
-key is held by [tmkms] instead of living on the node — and configuring
-both the host and tmkms so that the failure modes a security review of
-tmkms surfaced are closed *before* they can bite you.
-
-The review of tmkms 0.15.0 catalogued dozens of findings; the large
-majority of them are not code bugs you can hit by accident but
-**operational footguns** — bad defaults, convenience commands that leak
-secrets, missing permission checks — every one of which is neutralised by
-provisioning and configuring the system correctly. This guide bakes that
-hardening in. Where a residual *code-level* risk remains (there is
-essentially one that matters: state-file durability on power loss), it is
-called out at the exact step where it applies.
+Stand up a gnoland validator whose consensus key lives in [tmkms], not on
+the node. tmkms 0.15.0's risks are mostly **operational footguns** (bad
+defaults, secret-leaking convenience commands, missing permission checks),
+not accidental code bugs — this guide provisions around them. One residual
+*code* risk remains (state-file durability on power loss); it's flagged
+where it applies. See [tmkms.md](tmkms.md) for architecture and threat model.
 
 [tmkms]: https://github.com/iqlusioninc/tmkms
 
 ## How to read this guide
 
-It is ordered by what you should actually run for real stake first, and
-descends toward test/lab setups:
+Ordered real-stake-first:
 
-- **[Prerequisites — helper tools](#prerequisites--build-the-helper-tools)** —
-  two small stdlib-only Go helpers every backend uses; build them once.
-- **[Part A — Host hardening](#part-a--host-hardening-do-this-first-for-every-backend)** —
-  the OS-level groundwork (dedicated user, locked-down directories,
-  transport choice). Do this regardless of which signer backend you pick.
-- **[Part B — Production with a YubiHSM](#part-b--production-validator-with-a-yubihsm-recommended)** —
-  the recommended production path. The consensus key is generated inside
-  the HSM and **never exists outside it**.
-- **[Part C — Testnet/lab with softsign](#part-c--testnetlab-with-softsign-key-on-disk)** —
-  the file-based backend. Simple, but the key touches disk: testnets and
-  learning only.
-- **[Part D — Ledger hardware signer](#part-d--advanced-ledger-hardware-signer)** —
-  a hardware key for advanced/low-stake setups without HSM-grade failover.
-- **[Part E — Prove it](#part-e--prove-it-with-the-repos-automated-test)** and the
-  **[checklist](#secure-setup-checklist)**.
+- **[Prerequisites](#prerequisites--build-the-helper-tools)** — helper tools, binaries on PATH, GNOROOT.
+- **[Part A](#part-a--host-hardening-do-this-first-for-every-backend)** — host hardening (users, dirs, transport); do first.
+- **[Part B](#part-b--production-validator-with-a-yubihsm-recommended)** — YubiHSM, key never leaves hardware (recommended).
+- **[Part C](#part-c--testnetlab-with-softsign-key-on-disk)** — softsign, key on disk (lab/learning only).
+- **[Part D](#part-d--advanced-ledger-hardware-signer)** — Ledger hardware signer (advanced/low-stake).
+- **[Part E](#part-e--prove-it-with-the-repos-automated-test)** + [checklist](#secure-setup-checklist).
 
-> **What is verified vs. derived.** The gnoland side of every path here —
-> the listener, the allowlist, the peer-ID pin, the `v0.34` protocol pin,
-> and signing through tmkms — is exercised end-to-end by the repo's
-> real-tmkms integration test, with **softsign** and a **Ledger** as the
-> backends (see [Part E](#part-e--prove-it-with-the-repos-automated-test)).
-> The **YubiHSM** provisioning and provider config in Part B are derived
-> from the tmkms security review, the tmkms source, and YubiHSM's own
-> documentation; they need the physical device to exercise. Treat the
-> exact `yubihsm-shell` / TOML tokens as a recipe to verify against your
-> firmware and tmkms version — but the *security policy* they encode
-> (non-exportable key, audit log on, minimal capabilities) is firm.
-
-See [tmkms.md](tmkms.md) for the architecture, the threat model, and the
-operational checklist this guide is the hands-on companion to.
+> **Verified vs. derived.** The gnoland side of every path (listener,
+> allowlist, peer-ID pin, `v0.34` pin, signing) is covered by the repo's
+> real-tmkms test with softsign and a Ledger (Part E). Part B's YubiHSM
+> steps are derived from the review + tmkms/YubiHSM docs — verify the exact
+> tokens against your firmware; the policy they encode (non-exportable key,
+> audit on, minimal caps) is firm.
 
 ## The security model in one paragraph
 
-The connection between gnoland and tmkms is **mutually authenticated**,
-and the defining property of this mode is that **tmkms dials gnoland** —
-gnoland listens, tmkms connects in. gnoland verifies it is talking to
-*your* signer (not an impostor) and tmkms verifies it is talking to
-*your* validator (not an attacker's listener). How that mutual check is
-enforced depends on the transport, and getting it right is the single
-most important configuration decision — see
-[Part A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp).
-
-Three distinct ed25519 keys are in play — don't mix them up:
+tmkms **dials** gnoland (gnoland listens); the connection is mutually
+authenticated, and *how* depends on the transport
+([A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp)) — the
+single most important choice here. Three ed25519 keys are in play — don't
+mix them up:
 
 | Key | Lives in | Role |
 |---|---|---|
@@ -71,10 +41,9 @@ Three distinct ed25519 keys are in play — don't mix them up:
 | **kms-identity key** | tmkms `kms-identity.key` | tmkms's SecretConnection identity; its pubkey goes in gnoland's `allowed_kms_pubkeys` (TCP only) |
 | **node key** | gnoland `node_key.json` | gnoland's SecretConnection identity; its peer ID (hex) is pinned in tmkms's `addr` (TCP only) |
 
-The `chain_id` must be **identical** everywhere — the gnoland genesis,
-gnoland's `tmkms_listener.chain_id`, and tmkms's `[[chain]].id` /
-`[[validator]].chain_id`. If they drift, tmkms refuses to sign. Pick it
-once and reuse it:
+`chain_id` must be **identical** everywhere (gnoland genesis,
+`tmkms_listener.chain_id`, tmkms's `[[chain]].id` and
+`[[validator]].chain_id`) or tmkms refuses to sign. Set once:
 
 ```sh
 export CHAIN_ID=gno-tmkms-prod
@@ -84,23 +53,16 @@ export CHAIN_ID=gno-tmkms-prod
 
 # Prerequisites — build the helper tools
 
-Every backend below needs two tiny **stdlib-only** Go helpers. Define and
-**compile them once**, here; later sections run the resulting binaries.
-They have no module dependencies, so they build and run from any
-directory (Part B.3's `pkconv.go` is the one exception — it imports the
-gno crypto packages and must be run from the gno repo root; it's defined
-where it's used).
+Two tiny **stdlib-only** Go helpers, compiled once. They build/run from
+any directory (Part B.3's `pkconv.go` is the exception — it imports gno
+crypto, run from the repo root; defined where it's used).
 
-> **Running a helper against a service-owned secret.** In Parts B and D
-> the secrets live under `/var/lib`, owned by a service user (the separate
-> `tmkms` user on Part B's TCP layout; the shared `gnoland` user on Part
-> D's UDS layout — see [A.1](#a1-pick-the-user-model-it-depends-on-the-transport)).
-> Run each helper **as the owning user** (`sudo -u <user>`) so it touches
-> the secret with exactly the privilege it needs — not as root, and
-> without copying the secret into a directory you own. Those users have no
-> home directory, so the Go *toolchain* can't run as them; that is why we
-> compile the helpers as yourself first and only run the finished
-> **binary** under `sudo -u`.
+> **Run helpers as the secret's owner.** In Parts B/D the secrets live
+> under `/var/lib` owned by a service user (separate `tmkms` on TCP; shared
+> `gnoland` on UDS — [A.1](#a1-pick-the-user-model-it-depends-on-the-transport)).
+> Run each helper `sudo -u <that user>` — least privilege, no copying the
+> secret to your dir. Those users have no home, so the Go toolchain can't
+> run as them: compile as yourself, run only the built binary under sudo.
 
 `nodeid-hex.go` — prints a gnoland node's peer ID in the hex form tmkms
 pins in its `addr` (TCP layouts):
@@ -172,11 +134,7 @@ func main() {
 GO
 ```
 
-Compile both as your normal user (the Go toolchain needs its build
-cache), then install them where every user — including the `tmkms` and
-`gnoland` service users — can execute them. Later steps invoke them by
-name, under `sudo -u` when the target is a service-owned `/var/lib`
-secret:
+Compile as yourself, install where the service users can run them:
 
 ```sh
 go build -o nodeid-hex ./nodeid-hex.go
@@ -184,28 +142,24 @@ go build -o tmkms-identity-keygen ./tmkms-identity-keygen.go
 sudo install -m 0755 nodeid-hex tmkms-identity-keygen /usr/local/bin/
 ```
 
-They are one-shot setup tools; remove them with
-`sudo rm /usr/local/bin/{nodeid-hex,tmkms-identity-keygen}` afterward if
-you'd rather not leave them on the box.
+One-shot tools; `sudo rm /usr/local/bin/{nodeid-hex,tmkms-identity-keygen}`
+afterward if you don't want them lying around.
 
 ## Put the binaries on a system path
 
-Anything you run under `sudo -u tmkms` / `sudo -u gnoland` must live where
-those no-home users can reach it. Build `gnoland` and `gnogenesis` from the
-repo, then install them — together with the `tmkms` binary `cargo` drops in
-`~/.cargo/bin` — to `/usr/local/bin`. They otherwise land under your home,
-which the service users can't traverse, so `sudo -u tmkms tmkms …` fails
-with `Permission denied`.
+Service users (no home) can't reach binaries under your home, so
+`sudo -u … <bin>` fails with `Permission denied`. Build gnoland/gnogenesis
+and install them — with the `tmkms` binary `cargo` drops in
+`~/.cargo/bin` — to `/usr/local/bin`:
 
 ```sh
-# build from the gno repo root (output lands in each component's build/ dir)
+# from the gno repo root (output lands in each component's build/ dir)
 make -C gno.land build.gnoland
 make -C contribs/gnogenesis build
 sudo install -m 0755 gno.land/build/gnoland contribs/gnogenesis/build/gnogenesis /usr/local/bin/
 ```
 
-The backend sections repeat the `tmkms` step right after its
-`cargo install`:
+The backend sections repeat the `tmkms` step after its `cargo install`:
 
 ```sh
 sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # after cargo install (Parts B/D)
@@ -213,18 +167,11 @@ sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # after cargo install 
 
 ## Set `GNOROOT` to a gno checkout
 
-`gnoland` needs `GNOROOT` for two things: it panics at startup without it
-(a flag-default quirk), and — on **every** path — `InitChainer` loads the
-standard library `.gno` sources from `$GNOROOT/gnovm/stdlibs/` when it
-initialises the chain. So `GNOROOT` must point at a **complete gno
-checkout**, and one whose stdlib set **matches the `gnoland` binary you
-built** — a mismatched or empty directory fails with
-`failed loading stdlib "…": does not exist`.
-
-Your build clone almost certainly sits under your home directory, which
-the no-home `gnoland` user can't traverse. Put a readable copy at
-`/opt/gno` by cloning **your own tree at the same commit** (not GitHub
-master, whose stdlibs may differ from your binary):
+gnoland loads stdlib `.gno` sources from `$GNOROOT/gnovm/stdlibs/` on every
+start (and panics without `GNOROOT` set). So it must point at a **complete
+checkout whose stdlibs match the binary you built** — empty/mismatched
+fails with `failed loading stdlib "…": does not exist`. Your build clone is
+under your home (unreadable to `gnoland`), so copy it to `/opt/gno`:
 
 ```sh
 sudo git clone --local "$(git -C . rev-parse --show-toplevel)" /opt/gno
@@ -232,182 +179,124 @@ sudo git -C /opt/gno checkout "$(git rev-parse --abbrev-ref HEAD)"   # match you
 export GNOROOT=/opt/gno
 ```
 
-`/opt/gno` is world-readable, so the `gnoland` user can read the stdlibs.
-Because `sudo -u gnoland` scrubs the environment, every `gnoland` command
-below passes `GNOROOT` back with `env GNOROOT="$GNOROOT"` (for a systemd
-unit, `Environment=GNOROOT=/opt/gno`).
+`sudo -u gnoland` scrubs the env, so every `gnoland` command below passes
+`env GNOROOT="$GNOROOT"` (systemd: `Environment=GNOROOT=/opt/gno`).
 
 ---
 
 # Part A — Host hardening (do this first, for every backend)
 
-These steps apply whether you end up on a YubiHSM, a Ledger, or softsign.
-tmkms does **not** enforce file permissions on its own key, state, or
-config files (it accepts world-readable secrets silently), so the OS must
-enforce them for it.
+tmkms doesn't enforce permissions on its own key/state/config (it accepts
+world-readable secrets silently) — the OS must.
 
 ## A.1 Pick the user model (it depends on the transport)
 
-Never run the signer as root or as your login user — use locked-down
-system accounts with no shell and no home. **How many** you create depends
-on the transport you'll choose in [A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp),
-because the two transports authenticate differently:
+Never run as root or your login user — use locked-down system accounts (no
+shell, no home). **How many** depends on the transport
+([A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp)):
 
-- **TCP (Part B, and any cross-host or same-host loopback layout): two
-  separate users.** gnoland and tmkms authenticate each other
-  cryptographically over the connection, so isolating them as distinct
-  unprivileged accounts is the local hardening you want.
-- **Same-host Unix socket (Parts C and D): one shared user.** gnoland
-  forces the socket to `0600` owned by *its own* user
-  (`tm2/pkg/bft/privval/config.go`), and connecting to a Unix socket needs
-  write access to it — so **only that one user can dial in**. tmkms must
-  run as the *same* user as gnoland; a separate `tmkms` user simply gets
-  `Permission denied (os error 13)`. You trade local process isolation for
-  simplicity here — if you want the two roles isolated on one host, use the
-  loopback **TCP** layout instead.
-
-Create the gnoland user (every path uses it):
+- **TCP (Part B, or loopback): two users.** They authenticate
+  cryptographically, so isolate them as distinct accounts.
+- **Same-host UDS (Parts C, D): one user.** gnoland forces the socket to
+  `0600` owned by *itself* (`tm2/pkg/bft/privval/config.go`), and
+  connecting needs write access — so only that user can dial in (a separate
+  `tmkms` user gets `Permission denied (os error 13)`). Run tmkms as the
+  gnoland user. Want isolation on one host? Use loopback TCP.
 
 ```sh
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin gnoland
-```
-
-For a **TCP** layout, also create the separate signer user:
-
-```sh
+# TCP only — separate signer user (UDS runs tmkms as gnoland):
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin tmkms
 ```
 
-For a **same-host UDS** layout, skip that — both processes run as one
-user: Part D runs them as the `gnoland` user (tmkms's config and secrets
-living under `gnoland` ownership), while Part C's lab runs both as your
-operator user.
-
 ## A.2 Lay out directories with strict permissions
 
-tmkms's secrets and its state file are the crown jewels. The state file
-in particular is the **double-sign gate** — losing or rolling it back is
-the one thing that can get you slashed. Give them a private home:
+The state file is the **double-sign gate** — losing or rolling it back can
+get you slashed. Give the secrets a private `0600` home:
 
 ```sh
 sudo install -d -o tmkms -g tmkms -m 700 /etc/tmkms          # config
 sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms       # state + identity key
 sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms/secrets
 
-# gnoland's own data dir, owned by the gnoland user (it creates the
-# secrets/ and config/ subdirs itself):
+# gnoland's own data dir (it creates secrets/ and config/ itself):
 sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland
 ```
 
-> **Same-host UDS (single user):** tmkms runs as `gnoland` (A.1), so own
-> `/etc/tmkms` and `/var/lib/tmkms` with `-o gnoland -g gnoland` instead.
-> The commands above are written for the two-user TCP layout (Part B).
+> **UDS (single user):** own `/etc/tmkms` and `/var/lib/tmkms` with
+> `-o gnoland -g gnoland` instead (tmkms runs as `gnoland`, A.1). The above
+> is the two-user TCP layout.
 
-Rules that close whole classes of findings at once:
-
-- **Every secret and the state file is `0600`, owned by `tmkms`.** A
-  world- or group-readable consensus key, identity key, or YubiHSM
-  password is game over; tmkms won't warn you, so enforce it yourself.
-- **Use absolute paths everywhere** in `tmkms.toml`. tmkms resolves some
-  paths (notably the default state-file path) relative to its *current
-  working directory*; an absolute path removes any ambiguity about which
-  state file is the authoritative one and stops a stray relative path
-  from silently creating a fresh, height-zero state.
-- **Never put a password inline** in `tmkms.toml`. Use a separate
-  `password_file` (Part B.5), itself `0600`, so the config can be read
-  for debugging without exposing the credential.
+- Secrets + state `0600`, owned by the signer user — tmkms won't reject
+  world-readable secrets, so you must.
+- **Absolute paths** in `tmkms.toml` — a CWD-relative state file can
+  silently become a fresh, height-zero one.
+- Password in a separate `password_file` (B.5), never inline — keeps it out
+  of the config and process listings.
 
 ## A.3 Choose the transport: Unix socket or firewalled TCP
 
-This is where mutual authentication actually lives. Two valid layouts,
-each with a *different* auth boundary — pick deliberately:
+Two layouts, different auth boundaries — pick deliberately:
 
 ### Same host → Unix-domain socket (auth by filesystem, single user)
 
-If tmkms and gnoland run on the same machine, a Unix socket is the
-simplest layout. gnoland creates the socket and `chmod`s it to `0600`
-owned by **its own user** — and because connecting to a Unix socket needs
-write access, **only that user can dial in.** So on UDS, tmkms runs as the
-*same* user as gnoland (A.1); the socket directory just needs to exist,
-owned by that user:
+gnoland creates the socket `0600` owned by **its own user**, and
+connecting needs write access — so only that user dials in. tmkms runs as
+gnoland (A.1); just create the dir:
 
 ```sh
 sudo install -d -o gnoland -g gnoland -m 700 /run/gnoland
-# gnoland will create /run/gnoland/privval.sock at 0600, owned by gnoland;
-# tmkms, running as gnoland, connects to it.
+# gnoland creates /run/gnoland/privval.sock at 0600; tmkms (as gnoland) connects.
 ```
 
-> **Important:** over a Unix socket the `allowed_kms_pubkeys` allowlist is
-> **not** the gate — gnoland cannot crypto-verify a UDS peer against it.
-> *The socket's owner-only `0600` mode is the entire authentication
-> boundary:* the single user running both processes can connect, every
-> other local user is locked out. You still set the allowlist (gnoland
-> requires a non-empty one), but on UDS it is belt-and-suspenders, not the
-> lock. If you need the signer isolated in its **own** user on one host,
-> that is exactly what the loopback TCP layout below buys you.
+> On UDS the `allowed_kms_pubkeys` allowlist can't be crypto-checked — the
+> `0600` socket is the whole auth boundary (one user in, every other local
+> user out). Set the allowlist anyway (gnoland requires it non-empty), but
+> it's belt-and-suspenders. For per-user isolation, use loopback TCP.
 
 ### TCP, firewalled (auth by cryptography, two users)
 
-For real stake, run the signer on its **own host**. (The same TCP layout
-on `127.0.0.1` also works on a single host — that is how you keep gnoland
-and tmkms in two isolated users on one box, since UDS can't.) Either way
-the auth boundary is cryptographic:
+Run the signer on its **own host** (or `127.0.0.1` for two isolated users
+on one box). Auth is cryptographic, both halves mandatory:
 
 - gnoland verifies tmkms via `allowed_kms_pubkeys` (the signer's pubkey).
 - tmkms verifies gnoland via the **peer ID pinned in its `addr`**.
 
-Both are mandatory. Then firewall the listen port so that **only the
-signer host** can reach it — the crypto is the lock, the firewall keeps
-strangers from even knocking (and from using your validator as a free
-oracle to probe):
+Firewall the port to the signer host only (crypto is the lock; the firewall
+stops strangers knocking or using you as a signing oracle to probe):
 
 ```sh
-# allow only the signer host to reach the privval port; deny the rest
 sudo ufw allow from <SIGNER_HOST_IP> to any port 26659 proto tcp
 sudo ufw deny 26659/tcp
 ```
 
-Bind gnoland's listener to the specific reachable interface, not a
-wildcard, when you can.
+Bind gnoland to the specific interface, not a wildcard, when you can.
 
-The rest of this guide uses placeholders you can set to match your
-choice. For a same-host UDS layout:
+Placeholders for the rest of the guide:
 
 ```sh
-export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"   # gnoland listens here
-export TMKMS_ADDR="unix:///run/gnoland/privval.sock"       # tmkms dials here (no peer-ID on UDS)
-```
-
-For a two-host TCP layout (note the **mandatory** `<peer_id>@` prefix in
-the tmkms address — filled in at B.3):
-
-```sh
+# UDS:
+export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"
+export TMKMS_ADDR="unix:///run/gnoland/privval.sock"   # no peer-ID on UDS
+# TCP (peer-ID prefix on TMKMS_ADDR is mandatory; filled at B.3):
 export PRIVVAL_LISTEN="tcp://<validator_interface_ip>:26659"
-# TMKMS_ADDR set in B.5 once the peer ID is known: tcp://<peer_id>@<validator_ip>:26659
 ```
 
-The two transports are independent of the signer backend, so the worked
-examples below deliberately show both: **Part B (YubiHSM) uses TCP** (the
-peer-ID-pinned, cross-host form), while **Parts C (softsign) and D
-(Ledger) use the same-host Unix socket** (the simpler form). Use
-whichever matches your real deployment regardless of which backend you
-picked.
+Examples below show both: **Part B uses TCP**, **Parts C/D use UDS** — mix
+transport and backend freely.
 
 ---
 
 # Part B — Production validator with a YubiHSM (recommended)
 
-A YubiHSM holds the consensus key inside tamper-resistant hardware and,
-provisioned correctly, **never lets it out** — not even to its own
-operator. That single property removes the entire "key stolen off disk /
-exported silently" class of risk that softsign cannot. The catch is that
-tmkms's *convenience* tooling around the YubiHSM is where the review found
-its sharpest edges, so the rule for this section is: **provision the
-device by hand, and never run the automated setup or test commands
+A YubiHSM holds the consensus key in hardware and, provisioned correctly,
+**never lets it out** — removing the entire "key stolen/exported off disk"
+class softsign can't. The catch: tmkms's *convenience* tooling around the
+YubiHSM is where the review found its sharpest edges. Rule for this
+section: **provision by hand, never run the automated setup/test commands
 against a production key.**
 
-Install tmkms with the `yubihsm` provider (it is **not** in the default
-build — you must enable the feature explicitly):
+Install tmkms with the `yubihsm` provider (not in the default build):
 
 ```sh
 cargo install tmkms --version 0.15.0 --features yubihsm --locked
@@ -423,38 +312,28 @@ tmkms version   # → 0.15.0
 > roles with key-export capability. Provision with `yubihsm-shell`
 > instead, so the secrets never leave your control.
 
-Work on an **offline** machine. The high-level policy you are encoding —
-and which the rest follows from — is:
+Work on an **offline** machine. The policy to encode:
 
-1. **Generate the consensus key inside the device** (or import it once and
-   destroy the source). It must **not** carry the `exportable-under-wrap`
-   capability. A non-exportable key cannot be wrapped out, so a stolen
-   credential later cannot exfiltrate it.
-2. **The auth key tmkms uses to log in gets `sign-eddsa` only.** No
-   `export-wrapped`, no `sign-attestation-certificate`, no broad
-   delegated capabilities. If that credential leaks, it can ask for
-   signatures (which the firewall + state machine still gate) but cannot
-   extract or clone the key.
-3. **Turn the audit log on and force it.** The device ships with auditing
-   off; with it forced on, the HSM records every operation and refuses to
-   sign once its log buffer fills — so an attempted misuse leaves a trail
-   and cannot run unbounded.
-4. **Store the recovery seed offline, on paper, in a safe.** Never on the
-   validator host.
+1. **Generate the consensus key inside the device** (or import once and
+   destroy the source), **without** `exportable-under-wrap` — so a stolen
+   credential can't wrap it out.
+2. **tmkms's auth key gets `sign-eddsa` only** — no `export-wrapped`, no
+   `sign-attestation-certificate`. If it leaks it can request signatures
+   (still gated by firewall + state machine) but not clone the key.
+3. **Force the audit log on** (ships off) — the HSM logs every op and
+   refuses to sign once the buffer fills, so misuse leaves a trail.
+4. **Store the recovery seed offline on paper** — never on the host.
 
-The `<tmkms-auth-password>` below is a credential **you choose** — it is
-what tmkms presents to log in to the device. Generate a long random one
-(don't type a memorable string) and keep it only in the `0600`
-`password_file` created further down; never commit it or paste it into
-`tmkms.toml`:
+`<tmkms-auth-password>` is a credential **you choose** for tmkms to log in.
+Generate a long random one; keep it only in the `0600` `password_file`
+below, never in `tmkms.toml`:
 
 ```sh
 TMKMS_AUTH_PASSWORD=$(openssl rand -base64 32)   # generate once; use it below and in the password_file
 ```
 
-A representative `yubihsm-shell` session (verify the exact token spelling
-against your firmware — capability and option names are the firm part).
-Substitute `$TMKMS_AUTH_PASSWORD` for `<tmkms-auth-password>`:
+A representative `yubihsm-shell` session (verify exact token spelling
+against your firmware). Substitute `$TMKMS_AUTH_PASSWORD`:
 
 ```sh
 yubihsm-shell
@@ -474,11 +353,10 @@ yubihsm-shell
 # Replace/disable the default admin auth key (id 1) afterwards.
 ```
 
-The two things to never grant the signer's auth key: `export-wrapped` and
-`sign-attestation-certificate`. The first turns a leaked credential into
-key theft; the second lets it produce attestations you didn't intend.
+Never grant the auth key `export-wrapped` (turns a leak into key theft) or
+`sign-attestation-certificate` (lets it forge attestations).
 
-Store that same password in a file, not the config:
+Store the password in a file, not the config:
 
 ```sh
 printf '%s' "$TMKMS_AUTH_PASSWORD" | sudo tee /etc/tmkms/yubihsm-password >/dev/null
@@ -489,35 +367,29 @@ unset TMKMS_AUTH_PASSWORD   # drop it from the shell once it's in the file
 
 ## B.2 Generate gnoland's node + listener identity
 
-The consensus key lives in the HSM, but gnoland still needs its own node
-identity (the peer ID that tmkms pins on TCP), and tmkms needs a
-SecretConnection identity key. Generate the gnoland node secrets:
+The key lives in the HSM, but gnoland still needs a node identity (the peer
+ID tmkms pins) and tmkms needs a SecretConnection identity key. Generate
+the node secrets:
 
 ```sh
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland secrets init -data-dir /var/lib/gnoland/secrets
 ```
 
-In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
-— tmkms signs. Only `node_key.json` (the peer ID) matters here.
+In tmkms mode `priv_validator_key.json` doesn't sign — only `node_key.json`
+(the peer ID) matters.
 
-**Peer ID in hex (TCP layouts).** tmkms pins your validator's peer ID to
-make sure it signs for *your* node and not whoever answers on the port.
-gnoland reports the identity in bech32 (`g1…`); tmkms wants the same 20
-bytes in hex. Run the `nodeid-hex` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools) as the gnoland
-user (it owns `node_key.json`):
+**Peer ID in hex (TCP)** — tmkms pins it to sign only for *your* node.
+gnoland reports bech32; tmkms wants the same 20 bytes in hex. Run
+`nodeid-hex` as the gnoland user (it owns the key):
 
 ```sh
 export VALIDATOR_PEER_ID=$(sudo -u gnoland nodeid-hex /var/lib/gnoland/secrets/node_key.json)
-echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in B.4 (TCP)
+echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned in B.4
 ```
 
-**tmkms's SecretConnection identity (TCP layouts).** gnoland only accepts
-the connection if this key's public half is in `allowed_kms_pubkeys`. Run
-the `tmkms-identity-keygen` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools) as the tmkms user,
-so the key is written into tmkms's secrets dir already owned by tmkms (no
-`chown` needed):
+**tmkms's SecretConnection identity (TCP)** — its pubkey must be in
+`allowed_kms_pubkeys`. Run `tmkms-identity-keygen` as the tmkms user so the
+key lands tmkms-owned:
 
 ```sh
 ALLOW=$(sudo -u tmkms tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
@@ -526,12 +398,10 @@ echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in B.5
 
 ## B.3 Read the consensus pubkey out of the HSM and register the validator
 
-Because the key never leaves the HSM, you can't push it into genesis —
-you read the **public** half out of tmkms and register *that* as your
-validator identity. Start tmkms once (as the tmkms user, with the
-`tmkms.toml` from B.4); it logs the device's consensus pubkey on startup.
-Read that line, then stop it with `Ctrl-C` (gnoland isn't up yet, so it
-will just retry the connection in the meantime):
+The key never leaves the HSM, so you read its **public** half from tmkms
+and register that. Start tmkms once (as the tmkms user, `tmkms.toml` from
+B.4); it logs the consensus pubkey on startup. Read it, then `Ctrl-C`
+(gnoland isn't up; tmkms just retries meanwhile):
 
 ```sh
 sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
@@ -541,11 +411,10 @@ sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
 [keyring:yubihsm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
 ```
 
-The hex string above is an **example** — copy the one *your* device logs.
+That hex is an **example** — copy the one *your* device logs.
 
-Convert that hex pubkey to gno's `gpub1…` / `g1…` forms with this helper.
-Write the file, then run it **from the gno repo root** (so the
-`github.com/gnolang/gno/...` imports resolve):
+Convert it to gno's `gpub1…` / `g1…` forms with this helper, run **from the
+gno repo root** (so the imports resolve):
 
 ```sh
 cat > pkconv.go <<'GO'
@@ -588,23 +457,15 @@ go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D
 # address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
 ```
 
-That `gpub1…` / `g1…` pair is your validator's public identity. What you
-do with it depends on whether you are joining a chain or bootstrapping
-one:
+That `gpub1…` / `g1…` pair is your validator's public identity. Then:
 
-**Joining an existing chain (the production case).** You do **not**
-generate genesis — the chain already exists. Submit your `gpub1…` pubkey
-and `g1…` address to that chain's validator-onboarding path (its staking
-/ governance process, or the genesis coordinator if it hasn't launched
-yet) to be added to the validator set. The pubkey→address relationship is
-your integrity check: whoever registers you can confirm the address is
-the hash of the pubkey. Keep the pair; you'll confirm gnoland signs with
-this address in B.7. Then skip to [B.4](#b4-write-tmkmstoml).
+**Joining an existing chain (production).** Don't generate genesis — submit
+the `gpub1…` / `g1…` to the chain's validator-onboarding path. Keep the
+pair (confirmed in B.7), then skip to [B.4](#b4-write-tmkmstoml).
 
-**Bootstrapping your own chain (test / private networks).** Build genesis
-explicitly with `gnogenesis`, seeding it with the HSM pubkey. Do **not**
-use `gnoland start -lazy` here — it would mint a throwaway local key and
-seed genesis with *that* instead of your HSM key:
+**Bootstrapping your own chain (test).** Build genesis with `gnogenesis`,
+seeded with the HSM pubkey. **No** `gnoland start -lazy` — it would mint a
+throwaway local key and seed genesis with that instead:
 
 ```sh
 sudo -u gnoland gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
@@ -616,14 +477,13 @@ sudo -u gnoland gnogenesis validator add \
   -power    10
 ```
 
-`validator add` checks that the pubkey hashes to the address, so a
-copy-paste slip is caught right here — the same integrity check the
-onboarding path performs in the production case.
+`validator add` checks the pubkey hashes to the address, catching a
+copy-paste slip here (same check the onboarding path runs).
 
 ## B.4 Write `tmkms.toml`
 
-Set the signer address to match the transport you picked in Part A.3 —
-pick **one** (the TCP form embeds the mandatory peer-ID pin from B.2):
+Set the signer `addr` to match A.3 — pick **one** (the TCP form embeds the
+mandatory peer-ID pin from B.2):
 
 ```sh
 # TCP (separate hosts):
@@ -632,14 +492,12 @@ export TMKMS_ADDR="tcp://${VALIDATOR_PEER_ID}@<validator_ip>:26659"
 export TMKMS_ADDR="unix:///run/gnoland/privval.sock"
 ```
 
-> **Picking the UDS form here?** Part B is written for two isolated users
-> (TCP). Over a Unix socket only the socket's owner can connect (A.3), so
-> you must run tmkms as the `gnoland` user and own its config/secrets with
-> `gnoland` — follow the single-user ownership shown in Part D.
+> **Picking UDS here?** Part B is two-user (TCP). Over a socket only the
+> owner connects (A.3), so run tmkms as `gnoland` and own its
+> config/secrets with `gnoland` — see Part D's single-user ownership.
 
-Write the config with a heredoc, then lock it down to `0600` owned by
-`tmkms` (the password stays in the separate `password_file`, never
-inline; all paths are absolute):
+Write the config, then lock it `0600` owned by `tmkms` (password stays in
+the `password_file`; all paths absolute):
 
 ```sh
 sudo tee /etc/tmkms/tmkms.toml >/dev/null <<TOML
@@ -666,52 +524,35 @@ sudo chown tmkms:tmkms /etc/tmkms/tmkms.toml
 sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
-The fields that carry security weight:
+Security-weight fields:
 
-- **`addr` peer-ID pin (TCP).** The `<peer_id>@` prefix is the half of
-  mutual auth that lets tmkms verify gnoland. **Omit it and tmkms will
-  sign for whoever answers on that port** — an on-path attacker becomes a
-  signing oracle — and it only logs `unverified validator peer ID!` while
-  doing so. Always pin `$VALIDATOR_PEER_ID` from B.2. (On a `unix://`
-  socket there is no peer ID; the socket permissions from Part A.3 are the
-  boundary instead.)
-- **`state_file` (absolute).** This is tmkms's authoritative double-sign
-  (height/round/step) gate. It must be an absolute path on durable
-  storage. **Never restore a stale copy of it** — rolling it back to an
-  older height is the classic self-double-sign. See B.7 for the one
-  durability caveat that remains.
-- **`password_file`, not an inline `password`.** Keeps the credential out
-  of the config and out of process listings.
-- **`protocol_version = "v0.34"`.** gnoland speaks only the v0.34 privval
-  dialect and refuses any other value. tmkms 0.15.0 prints a
-  `deprecated protocol_version v0.34 (update to v0.38)!` warning — that is
-  expected; stay on a tmkms release that still supports v0.34. Do **not**
-  drop the field or bump it to v0.38 for gnoland.
-- **No `state_hook`.** tmkms's hook subsystem for regenerating state has
-  sharp edges (its stdout is never captured, so a `fail_closed` hook can
-  silently kill startup). Write/seed the state file directly instead;
-  don't wire a hook.
+- **`addr` peer-ID pin (TCP)** — the `<peer_id>@` prefix lets tmkms verify
+  gnoland. Omit it and tmkms signs for whoever answers the port (only
+  logging `unverified validator peer ID!`). Always pin `$VALIDATOR_PEER_ID`.
+  (No peer ID on `unix://`; socket perms are the boundary.)
+- **`state_file` (absolute, durable)** — the double-sign (HRS) gate. Never
+  restore a stale copy (classic self-double-sign). One caveat in B.7.
+- **`password_file`, not inline `password`** — keeps the credential out of
+  the config and process listings.
+- **`protocol_version = "v0.34"`** — gnoland speaks only v0.34; the
+  `deprecated … update to v0.38!` warning is expected. Don't drop or bump it.
+- **No `state_hook`** — its stdout is never captured, so a `fail_closed`
+  hook can silently kill startup. Seed the state file directly.
 
 ## B.5 Configure gnoland's tmkms listener
 
-Create a default config, then set the four `tmkms_listener` fields. The
-allowlist must be non-empty — gnoland refuses to enable the mode with an
-empty one, because an empty allowlist means *accept any peer that
-completes a handshake* (fail-open).
-
-All `gnoland config` commands write under `/var/lib/gnoland`, so run them
-**as the gnoland user** (`sudo -u gnoland`):
+Set the four `tmkms_listener` fields. The allowlist must be non-empty — an
+empty one is fail-open (accept any peer that handshakes). Run as the
+gnoland user (all `gnoland config` commands write under `/var/lib/gnoland`):
 
 ```sh
 CFG=/var/lib/gnoland/config/config.toml
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config init -config-path "$CFG"
 ```
 
-> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
-> block on every write, and a non-empty `listen_addr` is what *enables*
-> that validation. Set `listen_addr` **last** — set it first and the
-> write is rejected because `chain_id` is still empty, and it silently
-> stays unset.
+> **Ordering gotcha.** A non-empty `listen_addr` enables validation of the
+> whole block, so set it **last** — set it first and the write is rejected
+> (`chain_id` still empty) and silently stays unset.
 
 ```sh
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
@@ -730,19 +571,17 @@ sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" co
 
 ## B.6 Run both as services, in the right order
 
-**Order matters.** gnoland blocks at startup for up to
-`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in.
-Start tmkms first (with `reconnect = true` it will retry until gnoland is
-listening). Run each under its own user — for example with systemd units
-(`User=tmkms` / `User=gnoland`), or manually:
+**Order matters.** gnoland blocks up to `wait_for_connection_timeout`
+(default 60s) waiting for tmkms, so start tmkms first (`reconnect = true`
+makes it retry). Run each as its own user (systemd `User=tmkms` /
+`User=gnoland`):
 
 ```sh
 # signer (as the tmkms user)
 sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
 
-# validator (as the gnoland user) — point -genesis at the network's
-# genesis.json (the chain you're joining, or the one you built in B.3);
-# either way NO -lazy, since you're not minting a local key.
+# validator (as the gnoland user) — -genesis = the network's genesis;
+# NO -lazy (you're not minting a local key).
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland start \
   -data-dir /var/lib/gnoland \
   -genesis /var/lib/gnoland/genesis.json \
@@ -751,7 +590,7 @@ sudo -u gnoland env GNOROOT="$GNOROOT" gnoland start \
 
 ## B.7 Verify it's really the HSM signing — and keep it that way
 
-Within a few seconds the node should advance through heights.
+Within seconds the node should advance through heights.
 
 - **tmkms log:** `connected to validator successfully`, then ongoing
   `signed Proposal/Prevote/Precommit …`. **No** `unverified validator
@@ -771,95 +610,76 @@ Within a few seconds the node should advance through heights.
   sudo systemctl start tmkms    # ...and resumes after tmkms reconnects
   ```
 
-> **Benign log noise.** Even when signing works, gnoland periodically
-> logs `SignerListener: accept failed … i/o timeout` and `already
-> connected, dropping listen request`. The endpoint holds one live signer
-> connection and these are idle re-accept attempts timing out. Watch the
-> committed height, not these lines.
+> **Benign log noise.** `SignerListener: accept failed … i/o timeout` and
+> `already connected, dropping listen request` are idle re-accept attempts
+> on the one live connection — ignore them, watch the committed height.
 
 **Keep it safe in production:**
 
-- **The one residual code-level risk — state-file durability.** tmkms
-  writes its state file but, in 0.15.0, does not `fsync` it before
-  signing the next block. A hard power loss in that window can roll the
-  on-disk height *backward*, and signing again from the lower height is a
-  double-sign. Mitigate operationally: run the signer host on reliable
-  power (UPS), keep the state file on durable local storage (not a flaky
-  network mount), and **never** restore an old state file after a crash —
-  if you're unsure of its freshness, treat the validator as needing a
-  fresh, carefully-reconciled state rather than a rollback. (A two-line
-  upstream patch adding the `fsync` closes this; track it if you build
-  tmkms yourself.)
-- **Back up the state file** as part of every maintenance procedure — and
-  understand a backup is for disaster recovery of the *latest* state, not
-  a checkpoint to roll back to:
+- **Residual code risk — state-file durability.** tmkms 0.15.0 doesn't
+  `fsync` its state file before signing the next block, so a power loss can
+  roll the on-disk height backward → double-sign. Mitigate: reliable power
+  (UPS), durable local storage (no flaky network mount), and **never**
+  restore an old state file after a crash. (A two-line upstream `fsync`
+  patch closes it.)
+- **Back up the state file** (for recovery of the *latest* state, not as a
+  rollback checkpoint):
 
   ```sh
   sudo install -o tmkms -g tmkms -m 600 \
     /var/lib/tmkms/secrets/consensus_state.json \
     /var/lib/tmkms/secrets/consensus_state.json.bak
   ```
-- **Drain the audit log.** With forced auditing on (B.1) the HSM stops
-  signing once its audit buffer fills, so run a small auditor that reads
-  and clears the log periodically (e.g. every 30s) and ships it off-box.
-- **Never run `tmkms yubihsm test` against the production key.** It is an
-  unbounded signing oracle that bypasses the double-sign state machine
-  entirely. Test only against a throwaway key on a non-production device.
-- **Don't re-run provisioning over a live key.** tmkms's key-write path
-  has no "refuse if exists" guard, so a re-run of an init/keygen can
-  silently overwrite. Provision once; back up before you ever touch it.
+- **Drain the audit log** — with forced auditing on (B.1) the HSM stops
+  signing when the buffer fills; run an auditor that reads/clears it (~30s)
+  and ships it off-box.
+- **Never `tmkms yubihsm test` against the production key** — it's an
+  unbounded signing oracle that bypasses the double-sign gate.
+- **Don't re-run provisioning over a live key** — the key-write path has no
+  "refuse if exists" guard and can silently overwrite. Provision once.
 
 ---
 
 # Part C — Testnet/lab with softsign (key on disk)
 
-softsign keeps the consensus key in a **file on the validator host**.
-That is fine for understanding the wiring and for testnets, but the key
-touches disk, so this path is **not for real stake** — use Part B for
-that. Everything about the *connection* (Part A transport, allowlist,
-peer-ID pin, `protocol_version`, verification) is identical; only key
-custody and the genesis bootstrap differ.
+softsign keeps the consensus key in a **file on the host** — fine for
+testnets and learning the wiring, but **not for real stake** (use Part B).
+The *connection* (transport, allowlist, peer-ID pin, `protocol_version`,
+verification) is identical to Part B; only key custody and genesis differ.
 
-This lab is a same-host **UDS** layout, so it follows A.1's single-user
-rule the simplest way: it runs **both processes as your operator user** in
-local directories, rather than provisioning the `gnoland`/`tmkms` system
-users. Apply the rest of Part A's hardening — `0600` secrets, locked
-directories, the transport choice — scaled to that. The softsign-specific
-hardening on top:
+This lab is a same-host **UDS** layout, so per A.1 it runs **both processes
+as your operator user** in local dirs (no system users). softsign-specific
+hardening:
 
-- **`0600` on `consensus.key` and the state file**, owned by the user
-  running both processes (you). A readable softsign key *is* the
-  validator's private key.
-- **Swap exposure.** tmkms zeroizes the key on drop but does not `mlock`
-  it, so it can be paged to disk. Disable swap on the signer host (or use
-  encrypted swap) so the key never hits persistent storage in the clear:
+- **`0600` on `consensus.key` and the state file** — a readable softsign
+  key *is* the validator's private key.
+- **Disable swap** — tmkms zeroizes the key but doesn't `mlock` it, so it
+  can be paged to disk:
 
   ```sh
   sudo swapoff -a                     # and comment swap out of /etc/fstab to persist
   ```
-- **Don't re-run `secrets init` / keygen over an existing key file** —
-  it can overwrite without warning. Back up first.
+- **Don't re-run `secrets init` / keygen over an existing key** — it can
+  overwrite without warning.
 
 ## C.1 Generate node secrets and export the consensus key
 
-Install tmkms with the softsign feature (it is **not** in the default
-build):
+Install tmkms with the softsign feature (not in the default build):
 
 ```sh
 cargo install tmkms --version 0.15.0 --features softsign --locked
 ```
 
-Generate the gnoland node secrets (this also creates the consensus key
-that softsign will load and that genesis will register):
+Generate the node secrets (this also makes the consensus key softsign
+loads and genesis registers):
 
 ```sh
 gnoland secrets init -data-dir ./gnoland-data/secrets
 ```
 
-gnoland stores the ed25519 private key as base64 of the 64-byte
-`seed‖pubkey`; tmkms softsign wants base64 of just the 32-byte **seed**.
-Reslice and re-encode (no crypto — a byte slice — so plain `python3` is
-fine):
+gnoland stores the key as base64 of the 64-byte `seed‖pubkey`; softsign
+wants base64 of just the 32-byte **seed**. Reslice (just bytes, plain
+`python3`):
 
 ```sh
 mkdir -p ./tmkms/secrets
@@ -871,24 +691,18 @@ PY
 chmod 600 ./tmkms/secrets/consensus.key
 ```
 
-This lab uses a **same-host Unix socket** (A.3) — the simplest transport
-and the counterpart to Part B's TCP setup — so there is **no peer-ID pin
-to generate**. You still need tmkms's SecretConnection identity key
-(gnoland requires a non-empty allowlist even on a socket). Generate it
-with the [Prerequisites](#prerequisites--build-the-helper-tools) helper:
+UDS layout, so **no peer-ID pin**. You still need tmkms's SecretConnection
+identity key (gnoland requires a non-empty allowlist even on a socket):
 
 ```sh
-ALLOW=$(tmkms-identity-keygen ./tmkms/secrets/kms-identity.key)   # operator-owned path, no sudo
+ALLOW=$(tmkms-identity-keygen ./tmkms/secrets/kms-identity.key)   # operator-owned, no sudo
 echo "$ALLOW"   # goes into gnoland's allowed_kms_pubkeys (C.3)
 ```
 
 ## C.2 tmkms.toml with the softsign provider
 
-Same shape as B.4, with two lab changes: the provider block is
-**softsign**, and the transport is a same-host **Unix socket** instead of
-TCP (so no peer-ID pin — Part B already showed the TCP form). tmkms needs
-**absolute** paths (A.2), so resolve the lab dirs first, then write the
-file with a heredoc so the paths expand:
+Like B.4, but **softsign** provider and a **Unix socket** (no peer-ID pin).
+tmkms needs **absolute** paths (A.2), so resolve the lab dirs first:
 
 ```sh
 export TMKMS_DIR=$(cd ./tmkms && pwd)                            # ./tmkms from C.1
@@ -918,15 +732,12 @@ chmod 600 "$TMKMS_DIR/tmkms.toml"
 
 ## C.3 Configure gnoland's tmkms listener and start (lazy genesis is fine here)
 
-Because the consensus key exists on disk *and* is registered locally, you
-can let `-lazy` build genesis from `priv_validator_key.json`.
+The key is on disk *and* registered locally, so `-lazy` can build genesis
+from `priv_validator_key.json`.
 
-First configure the listener. Create a default config, then set the four
-`tmkms_listener` fields. The allowlist must be non-empty — gnoland
-refuses to enable the mode with an empty one. On this Unix-socket layout
-the allowlist is belt-and-suspenders — **filesystem permissions on the
-socket are the real boundary** (A.3) — but gnoland still requires it
-non-empty, so set it with `$ALLOW` from C.1.
+Configure the listener — set the four `tmkms_listener` fields with `$ALLOW`
+from C.1 (non-empty allowlist required; on UDS it's belt-and-suspenders,
+the socket perms are the real boundary, A.3):
 
 ```sh
 export CHAIN_ID=gno-tmkms-test                 # must match C.2's [[chain]].id
@@ -935,11 +746,9 @@ CFG=./gnoland-data/config/config.toml
 gnoland config init -config-path "$CFG"
 ```
 
-> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
-> block on every write, and a non-empty `listen_addr` is what *enables*
-> that validation. Set `listen_addr` **last** — set it first and the
-> write is rejected because `chain_id` is still empty, and it silently
-> stays unset.
+> **Ordering gotcha.** A non-empty `listen_addr` enables validation of the
+> whole block, so set it **last** — set it first and the write is rejected
+> (`chain_id` still empty) and silently stays unset.
 
 ```sh
 gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
@@ -956,11 +765,9 @@ empty):
 gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
-This lab runs both processes as your operator user, so the exported
-`GNOROOT` (from [Prerequisites](#set-gnoroot-to-a-gno-checkout)) carries
-through — no `env GNOROOT=…` prefix needed. The `-lazy` start additionally
-reads `examples/` from `GNOROOT`, one more reason it must be a full
-checkout. Then start both:
+Both run as your operator user, so the exported `GNOROOT` carries through
+(no `env` prefix). `-lazy` also reads `examples/` from `GNOROOT` — another
+reason it must be a full checkout. Start both:
 
 ```sh
 # terminal 1
@@ -975,49 +782,39 @@ gnoland start \
   -skip-genesis-sig-verification
 ```
 
-- `-skip-genesis-sig-verification` is the standard dev-genesis flag (the
-  default `-lazy` genesis contains example txs signed by test accounts);
-  it is unrelated to tmkms.
-- `-lazy` only generates *missing* files — it will not clobber your tmkms
-  config or secrets — reads the local consensus pubkey to register the
-  genesis validator, then boots using the tmkms listener for signing.
+- `-skip-genesis-sig-verification` — standard dev-genesis flag (the `-lazy`
+  genesis has example txs from test accounts); unrelated to tmkms.
+- `-lazy` only generates *missing* files (won't clobber tmkms config), reads
+  the local pubkey to register the validator, then signs via tmkms.
 
-Verify exactly as in B.7.
+Verify as in B.7.
 
 ---
 
 # Part D — Advanced: Ledger hardware signer
 
-A Ledger holds the consensus key **on the device** and never exports it —
-like a YubiHSM, but it is a single signer with no failover, so it suits
-advanced/low-stake setups rather than high-availability mainnet duty (for
-HA use a YubiHSM or threshold signing such as Horcrux). The bootstrap is
-the same "read the pubkey out, seed genesis from it" flow as Part B; only
-the provider and the device handling change.
+A Ledger holds the consensus key **on the device**, like a YubiHSM but a
+single signer with no failover — so advanced/low-stake, not HA mainnet (use
+a YubiHSM or Horcrux for HA). Same "read the pubkey out, seed genesis" flow
+as Part B; only the provider and device handling change.
 
-> **Residual hardware caveat.** In tmkms 0.15.0 the Ledger code path does
-> not check the device's APDU return code on the pubkey and signature
-> responses, so in principle a device/transport error could be accepted
-> as if valid. In practice the `gnogenesis validator add` pubkey→address
-> check (B.3) catches a wrong *pubkey* at setup time, and a malformed
-> *signature* simply fails consensus rather than producing a bad valid
-> one. Use a known-good device and verify the pubkey out-of-band.
+> **Residual hardware caveat.** tmkms 0.15.0 doesn't check the Ledger's
+> APDU return codes, so a device/transport error could be accepted as
+> valid. In practice the `gnogenesis validator add` pubkey→address check
+> (B.3) catches a wrong pubkey, and a bad signature just fails consensus.
+> Use a known-good device and verify the pubkey out-of-band.
 
 ## D.1 Prerequisites
 
-Part D is a **same-host Unix-socket** layout, so — per
-[A.1](#a1-pick-the-user-model-it-depends-on-the-transport) — tmkms runs as
-the **`gnoland`** user, not a separate `tmkms` user, and its config and
-secrets live under `gnoland` ownership. The commands below reflect that;
-own `/etc/tmkms` and `/var/lib/tmkms` with `gnoland` (A.2). For a
-two-isolated-user Ledger setup, switch to the loopback-TCP layout from
-Part B instead.
+This is a same-host **UDS** layout, so per
+[A.1](#a1-pick-the-user-model-it-depends-on-the-transport) tmkms runs as the
+**`gnoland`** user (own `/etc/tmkms` + `/var/lib/tmkms` with `gnoland`, A.2)
+— no separate `tmkms` user. For two isolated users, use Part B's loopback
+TCP instead.
 
-Install tmkms with the Ledger provider. The cargo feature is named
-**`ledger`** in 0.15.0 (older versions called it `ledgertm`, which is
-why the config block below is still `[[providers.ledgertm]]`). tmkms
-0.15.0 ships **no** default features, so plain `cargo install tmkms`
-gives you neither Ledger nor softsign — pass them explicitly:
+Install tmkms with the Ledger provider — the feature is `ledger` in 0.15.0
+(the config block is still `[[providers.ledgertm]]`); 0.15.0 has no default
+features:
 
 ```sh
 cargo install tmkms --version 0.15.0 --features ledger --locked
@@ -1027,15 +824,11 @@ sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # so sudo -u gnoland c
 
 You also need:
 
-- A Ledger with the **"Tendermint Validator"** app installed (the
-  dedicated ed25519 consensus app — *not* the regular Cosmos app),
-  plugged in, unlocked, with that app **open**. tmkms cannot reach a
-  locked device or a different app.
-- **Device access for the `gnoland` user.** tmkms runs as `gnoland`; if
-  that user can't open the Ledger's `/dev/hidraw*` node,
-  `sudo -u gnoland tmkms start` fails with `signing operation failed`.
-  Grant the `gnoland` group the hidraw device, reload, then **replug** the
-  Ledger:
+- A Ledger with the **"Tendermint Validator"** app (the ed25519 consensus
+  app, *not* the Cosmos app) plugged in, unlocked, app **open**.
+- **Device access for `gnoland`.** If `gnoland` can't open the Ledger's
+  `/dev/hidraw*`, `tmkms start` fails with `signing operation failed`. Grant
+  the `gnoland` group the hidraw device, reload, then **replug**:
 
   ```sh
   echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", MODE="0660", GROUP="gnoland"' \
@@ -1045,23 +838,17 @@ You also need:
 
 ## D.2 Generate gnoland's node and listener identity
 
-The consensus key lives on the Ledger, but gnoland still needs its own
-node identity, and tmkms needs a SecretConnection identity key. Generate
-the gnoland node secrets:
+The key is on the Ledger, but gnoland still needs a node identity and tmkms
+a SecretConnection identity key. Generate the node secrets:
 
 ```sh
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland secrets init -data-dir /var/lib/gnoland/secrets
 ```
 
-In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
-— the Ledger signs. On this same-host Unix-socket layout there is **no
-peer-ID pin** to generate (the socket's `0600` owner-only mode is the auth
-boundary, A.3). You do still need tmkms's SecretConnection identity key —
-gnoland only enables the listener with a non-empty `allowed_kms_pubkeys`.
-Run the `tmkms-identity-keygen` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools) as the `gnoland`
-user (tmkms runs as `gnoland` here), so the key lands in the secrets dir
-already owned by `gnoland`:
+`priv_validator_key.json` doesn't sign (the Ledger does), and UDS has **no
+peer-ID pin**. You still need the identity key (allowlist must be
+non-empty); run `tmkms-identity-keygen` as `gnoland` so it lands
+gnoland-owned:
 
 ```sh
 ALLOW=$(sudo -u gnoland tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
@@ -1070,19 +857,15 @@ echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in D.5
 
 ## D.3 Write `tmkms.toml`
 
-This is the same-host UDS layout, so the socket directory is the one you
-already created in [A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp).
-If you skipped it there, create it now — owned by `gnoland`, which creates
-the socket inside it at `0600` and (running as `gnoland`) connects to it:
+Socket dir from [A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp)
+(create it if you skipped it):
 
 ```sh
 sudo install -d -o gnoland -g gnoland -m 700 /run/gnoland
 ```
 
-Write the config with a heredoc, then lock it to `0600` owned by `gnoland`
-(tmkms runs as `gnoland`; all paths absolute). The provider is `ledgertm`
-— no key files, the key is on the device — and the transport is the Unix
-socket, so the `addr` carries no peer-ID pin:
+Write the config, lock it `0600` owned by `gnoland`. Provider is `ledgertm`
+(no key files — the key is on the device); UDS, so no peer-ID pin:
 
 ```sh
 sudo tee /etc/tmkms/tmkms.toml >/dev/null <<TOML
@@ -1106,28 +889,22 @@ sudo chown gnoland:gnoland /etc/tmkms/tmkms.toml
 sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
-Only one `[[providers.ledgertm]]` is allowed and it always signs the
-**consensus** key. The fields that carry security weight:
+One `[[providers.ledgertm]]`, always signs the **consensus** key.
+Security-weight fields:
 
-- **`state_file` (absolute).** tmkms's authoritative double-sign
-  (height/round/step) gate. **Never restore a stale copy** — rolling it
-  back to an older height is the classic self-double-sign (see D.6).
-- **`protocol_version = "v0.34"`.** gnoland speaks only the v0.34 privval
-  dialect; tmkms 0.15.0 prints a `deprecated … update to v0.38!` warning,
-  which is expected. Do **not** drop or bump it.
-- **No peer-ID pin / no `state_hook`.** On UDS the socket permissions are
-  the auth boundary (A.3), so `addr` has no `<peer_id>@` prefix; and don't
-  wire a `state_hook` (its stdout is never captured, so a `fail_closed`
-  hook can silently kill startup).
+- **`state_file` (absolute)** — the double-sign (HRS) gate. Never restore a
+  stale copy (D.6).
+- **`protocol_version = "v0.34"`** — gnoland speaks only v0.34; the
+  `deprecated … update to v0.38!` warning is expected. Don't drop or bump it.
+- **No peer-ID pin / no `state_hook`** — UDS has no `<peer_id>@`; and a
+  `state_hook`'s stdout is never captured, so a `fail_closed` hook can
+  silently kill startup.
 
 ## D.4 Read the consensus pubkey off the device and register the validator
 
-Because the key never leaves the Ledger, you read the **public** half out
-of tmkms and register *that* as your validator identity. Start tmkms once
-(as the `gnoland` user, with the `tmkms.toml` from D.3); it loads the
-device key and logs its consensus pubkey on startup. Read that line, then
-stop it with `Ctrl-C` (gnoland isn't up yet, so it will just retry the
-connection in the meantime):
+The key never leaves the Ledger, so read its **public** half from tmkms.
+Start tmkms once (as `gnoland`, `tmkms.toml` from D.3); it logs the consensus
+pubkey on startup. Read it, then `Ctrl-C` (gnoland isn't up; tmkms retries):
 
 ```sh
 sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
@@ -1137,11 +914,10 @@ sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
 [keyring:ledgertm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
 ```
 
-The hex string above is an **example** — copy the one *your* device logs.
+That hex is an **example** — copy the one *your* device logs.
 
-Convert that hex pubkey to gno's `gpub1…` / `g1…` forms with the
-`pkconv.go` helper. Write the file, then run it **from the gno repo root**
-(so the `github.com/gnolang/gno/...` imports resolve):
+Convert it to gno's `gpub1…` / `g1…` forms with `pkconv.go`, run **from the
+gno repo root**:
 
 ```sh
 cat > pkconv.go <<'GO'
@@ -1184,12 +960,10 @@ go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D
 # address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
 ```
 
-That `gpub1…` / `g1…` pair is your validator's public identity. Either
-submit it to an existing chain's validator-onboarding path (the
-production case — the chain already exists, so you do **not** generate
-genesis), or bootstrap your own chain by seeding genesis with it. Do
-**not** use `gnoland start -lazy` here — it would mint a throwaway local
-key and seed genesis with *that* instead of your device key:
+That `gpub1…` / `g1…` pair is your validator's identity. Either submit it to
+an existing chain's onboarding path (no genesis to generate), or bootstrap
+your own by seeding genesis with it. **No** `gnoland start -lazy` — it would
+mint a throwaway key and seed genesis with that:
 
 ```sh
 sudo -u gnoland gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
@@ -1206,15 +980,9 @@ copy-paste slip right here.
 
 ## D.5 Configure gnoland's tmkms listener
 
-Create a default config, then set the four `tmkms_listener` fields. The
-allowlist must be non-empty — gnoland refuses to enable the mode with an
-empty one. On this Unix-socket layout the allowlist is
-belt-and-suspenders (the socket's filesystem permissions are the real
-boundary, A.3), but gnoland still requires it non-empty, so set it with
-`$ALLOW` from D.2.
-
-All `gnoland config` commands write under `/var/lib/gnoland`, so run them
-**as the gnoland user** (`sudo -u gnoland`):
+Set the four `tmkms_listener` fields with `$ALLOW` from D.2 (non-empty
+allowlist required; on UDS it's belt-and-suspenders, A.3). Run as the
+gnoland user:
 
 ```sh
 export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"   # gnoland listens on the socket from D.3
@@ -1222,11 +990,9 @@ CFG=/var/lib/gnoland/config/config.toml
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config init -config-path "$CFG"
 ```
 
-> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
-> block on every write, and a non-empty `listen_addr` is what *enables*
-> that validation. Set `listen_addr` **last** — set it first and the
-> write is rejected because `chain_id` is still empty, and it silently
-> stays unset.
+> **Ordering gotcha.** A non-empty `listen_addr` enables validation of the
+> whole block, so set it **last** — set it first and the write is rejected
+> (`chain_id` still empty) and silently stays unset.
 
 ```sh
 sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
@@ -1244,11 +1010,9 @@ sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" co
 
 ## D.6 Run both, verify, and keep the device awake
 
-**Order matters.** gnoland blocks at startup for up to
-`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in.
-Start tmkms first (with `reconnect = true` it retries until gnoland is
-listening). On this UDS layout **both run as the `gnoland` user** (A.1) —
-with systemd, `User=gnoland` on both units — or manually:
+**Order matters.** gnoland blocks up to `wait_for_connection_timeout`
+(default 60s) waiting for tmkms, so start tmkms first (`reconnect = true`
+retries). **Both run as `gnoland`** (A.1; systemd `User=gnoland` on both):
 
 ```sh
 # signer (as gnoland) — Ledger plugged in, unlocked, app open
@@ -1273,23 +1037,20 @@ Within a few seconds the node should advance through heights:
 - **Kill tmkms** and watch gnoland stop committing; restart it and watch
   it resume — proof the key lives on the device, not the node.
 
-> **Keep the device awake.** If the Ledger locks, sleeps, or the app is
-> backgrounded, signing stops and the node stalls until you reopen the
-> app. Plan for that on anything you care about.
+> **Keep the device awake.** If the Ledger locks/sleeps or the app is
+> backgrounded, signing stops and the node stalls until you reopen it.
 
-> **State-file durability.** Like every backend, tmkms 0.15.0 does not
-> `fsync` its state file before signing the next block, so a hard power
-> loss can roll the on-disk height backward — a double-sign risk. Keep the
-> signer on reliable power and **never** restore an old state file (the
-> full discussion is in [B.7](#b7-verify-its-really-the-hsm-signing--and-keep-it-that-way)).
+> **State-file durability.** As in every backend, tmkms 0.15.0 doesn't
+> `fsync` its state file before signing, so a power loss can roll the height
+> backward (double-sign). Reliable power, never restore an old state file
+> ([B.7](#b7-verify-its-really-the-hsm-signing--and-keep-it-that-way)).
 
 ---
 
 # Part E — Prove it with the repo's automated test
 
-A build-tagged Go test drives a **real tmkms binary** through the full
-signing flow (softsign and Ledger backends), exercising the gnoland side
-of every path above:
+A build-tagged Go test drives a **real tmkms binary** (softsign + Ledger)
+through the full signing flow, exercising the gnoland side of every path:
 
 ```sh
 go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -92,13 +92,15 @@ gno crypto packages and must be run from the gno repo root; it's defined
 where it's used).
 
 > **Running a helper against a service-owned secret.** In Parts B and D
-> the secrets live under `/var/lib` owned by the `tmkms` / `gnoland`
-> users. Run each helper **as the owning user** (`sudo -u tmkms` /
-> `sudo -u gnoland`) so it touches the secret with exactly the privilege
-> it needs — not as root, and without copying the secret into a directory
-> you own. Those users have no home directory, so the Go *toolchain*
-> can't run as them; that is why we compile the helpers as yourself first
-> and only run the finished **binary** under `sudo -u`.
+> the secrets live under `/var/lib`, owned by a service user (the separate
+> `tmkms` user on Part B's TCP layout; the shared `gnoland` user on Part
+> D's UDS layout — see [A.1](#a1-pick-the-user-model-it-depends-on-the-transport)).
+> Run each helper **as the owning user** (`sudo -u <user>`) so it touches
+> the secret with exactly the privilege it needs — not as root, and
+> without copying the secret into a directory you own. Those users have no
+> home directory, so the Go *toolchain* can't run as them; that is why we
+> compile the helpers as yourself first and only run the finished
+> **binary** under `sudo -u`.
 
 `nodeid-hex.go` — prints a gnoland node's peer ID in the hex form tmkms
 pins in its `addr` (TCP layouts):
@@ -186,6 +188,55 @@ They are one-shot setup tools; remove them with
 `sudo rm /usr/local/bin/{nodeid-hex,tmkms-identity-keygen}` afterward if
 you'd rather not leave them on the box.
 
+## Put the binaries on a system path
+
+Anything you run under `sudo -u tmkms` / `sudo -u gnoland` must live where
+those no-home users can reach it. Build `gnoland` and `gnogenesis` from the
+repo, then install them — together with the `tmkms` binary `cargo` drops in
+`~/.cargo/bin` — to `/usr/local/bin`. They otherwise land under your home,
+which the service users can't traverse, so `sudo -u tmkms tmkms …` fails
+with `Permission denied`.
+
+```sh
+# build from the gno repo root (output lands in each component's build/ dir)
+make -C gno.land build.gnoland
+make -C contribs/gnogenesis build
+sudo install -m 0755 gno.land/build/gnoland contribs/gnogenesis/build/gnogenesis /usr/local/bin/
+```
+
+The backend sections repeat the `tmkms` step right after its
+`cargo install`:
+
+```sh
+sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # after cargo install (Parts B/D)
+```
+
+## Set `GNOROOT` to a gno checkout
+
+`gnoland` needs `GNOROOT` for two things: it panics at startup without it
+(a flag-default quirk), and — on **every** path — `InitChainer` loads the
+standard library `.gno` sources from `$GNOROOT/gnovm/stdlibs/` when it
+initialises the chain. So `GNOROOT` must point at a **complete gno
+checkout**, and one whose stdlib set **matches the `gnoland` binary you
+built** — a mismatched or empty directory fails with
+`failed loading stdlib "…": does not exist`.
+
+Your build clone almost certainly sits under your home directory, which
+the no-home `gnoland` user can't traverse. Put a readable copy at
+`/opt/gno` by cloning **your own tree at the same commit** (not GitHub
+master, whose stdlibs may differ from your binary):
+
+```sh
+sudo git clone --local "$(git -C . rev-parse --show-toplevel)" /opt/gno
+sudo git -C /opt/gno checkout "$(git rev-parse --abbrev-ref HEAD)"   # match your built binary
+export GNOROOT=/opt/gno
+```
+
+`/opt/gno` is world-readable, so the `gnoland` user can read the stdlibs.
+Because `sudo -u gnoland` scrubs the environment, every `gnoland` command
+below passes `GNOROOT` back with `env GNOROOT="$GNOROOT"` (for a systemd
+unit, `Environment=GNOROOT=/opt/gno`).
+
 ---
 
 # Part A — Host hardening (do this first, for every backend)
@@ -195,23 +246,42 @@ tmkms does **not** enforce file permissions on its own key, state, or
 config files (it accepts world-readable secrets silently), so the OS must
 enforce them for it.
 
-## A.1 Run tmkms as its own locked-down user
+## A.1 Pick the user model (it depends on the transport)
 
-Never run the signer as root or as your login user. A dedicated system
-account with no shell and no home limits what a compromised tmkms process
-— or anyone who later reads its files — can reach.
+Never run the signer as root or as your login user — use locked-down
+system accounts with no shell and no home. **How many** you create depends
+on the transport you'll choose in [A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp),
+because the two transports authenticate differently:
+
+- **TCP (Part B, and any cross-host or same-host loopback layout): two
+  separate users.** gnoland and tmkms authenticate each other
+  cryptographically over the connection, so isolating them as distinct
+  unprivileged accounts is the local hardening you want.
+- **Same-host Unix socket (Parts C and D): one shared user.** gnoland
+  forces the socket to `0600` owned by *its own* user
+  (`tm2/pkg/bft/privval/config.go`), and connecting to a Unix socket needs
+  write access to it — so **only that one user can dial in**. tmkms must
+  run as the *same* user as gnoland; a separate `tmkms` user simply gets
+  `Permission denied (os error 13)`. You trade local process isolation for
+  simplicity here — if you want the two roles isolated on one host, use the
+  loopback **TCP** layout instead.
+
+Create the gnoland user (every path uses it):
+
+```sh
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin gnoland
+```
+
+For a **TCP** layout, also create the separate signer user:
 
 ```sh
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin tmkms
 ```
 
-If gnoland and tmkms share a host, run gnoland under its own dedicated
-user too — two unprivileged users that can only meet over a single
-tightly-permissioned socket is the local isolation you want:
-
-```sh
-sudo useradd --system --no-create-home --shell /usr/sbin/nologin gnoland
-```
+For a **same-host UDS** layout, skip that — both processes run as one
+user: Part D runs them as the `gnoland` user (tmkms's config and secrets
+living under `gnoland` ownership), while Part C's lab runs both as your
+operator user.
 
 ## A.2 Lay out directories with strict permissions
 
@@ -228,6 +298,10 @@ sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms/secrets
 # secrets/ and config/ subdirs itself):
 sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland
 ```
+
+> **Same-host UDS (single user):** tmkms runs as `gnoland` (A.1), so own
+> `/etc/tmkms` and `/var/lib/tmkms` with `-o gnoland -g gnoland` instead.
+> The commands above are written for the two-user TCP layout (Part B).
 
 Rules that close whole classes of findings at once:
 
@@ -248,29 +322,36 @@ Rules that close whole classes of findings at once:
 This is where mutual authentication actually lives. Two valid layouts,
 each with a *different* auth boundary — pick deliberately:
 
-### Same host → Unix-domain socket (auth by filesystem)
+### Same host → Unix-domain socket (auth by filesystem, single user)
 
-If tmkms and gnoland run on the same machine, prefer a Unix socket.
-gnoland creates it and `chmod`s it to `0600`, so only gnoland's user owns
-it; place it in a directory only the tmkms and gnoland users can traverse:
+If tmkms and gnoland run on the same machine, a Unix socket is the
+simplest layout. gnoland creates the socket and `chmod`s it to `0600`
+owned by **its own user** — and because connecting to a Unix socket needs
+write access, **only that user can dial in.** So on UDS, tmkms runs as the
+*same* user as gnoland (A.1); the socket directory just needs to exist,
+owned by that user:
 
 ```sh
-sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland
-# gnoland will create /run/gnoland/privval.sock at 0600
+sudo install -d -o gnoland -g gnoland -m 700 /run/gnoland
+# gnoland will create /run/gnoland/privval.sock at 0600, owned by gnoland;
+# tmkms, running as gnoland, connects to it.
 ```
 
 > **Important:** over a Unix socket the `allowed_kms_pubkeys` allowlist is
 > **not** the gate — gnoland cannot crypto-verify a UDS peer against it.
-> *Filesystem permissions are the entire authentication boundary.* That
-> is exactly why the socket directory and node-user separation in A.1–A.2
-> matter: anyone who can open that socket becomes the signer. You still
-> set the allowlist (gnoland requires a non-empty one), but on UDS it is
-> belt-and-suspenders, not the lock.
+> *The socket's owner-only `0600` mode is the entire authentication
+> boundary:* the single user running both processes can connect, every
+> other local user is locked out. You still set the allowlist (gnoland
+> requires a non-empty one), but on UDS it is belt-and-suspenders, not the
+> lock. If you need the signer isolated in its **own** user on one host,
+> that is exactly what the loopback TCP layout below buys you.
 
-### Separate hosts → TCP, firewalled (auth by cryptography)
+### TCP, firewalled (auth by cryptography, two users)
 
-For real stake, run the signer on its **own host**. Then the auth
-boundary is cryptographic and works across the network:
+For real stake, run the signer on its **own host**. (The same TCP layout
+on `127.0.0.1` also works on a single host — that is how you keep gnoland
+and tmkms in two isolated users on one box, since UDS can't.) Either way
+the auth boundary is cryptographic:
 
 - gnoland verifies tmkms via `allowed_kms_pubkeys` (the signer's pubkey).
 - tmkms verifies gnoland via the **peer ID pinned in its `addr`**.
@@ -330,6 +411,7 @@ build — you must enable the feature explicitly):
 
 ```sh
 cargo install tmkms --version 0.15.0 --features yubihsm --locked
+sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # so sudo -u tmkms can run it
 tmkms version   # → 0.15.0
 ```
 
@@ -412,7 +494,7 @@ identity (the peer ID that tmkms pins on TCP), and tmkms needs a
 SecretConnection identity key. Generate the gnoland node secrets:
 
 ```sh
-sudo -u gnoland gnoland secrets init -data-dir /var/lib/gnoland/secrets
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland secrets init -data-dir /var/lib/gnoland/secrets
 ```
 
 In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
@@ -550,6 +632,11 @@ export TMKMS_ADDR="tcp://${VALIDATOR_PEER_ID}@<validator_ip>:26659"
 export TMKMS_ADDR="unix:///run/gnoland/privval.sock"
 ```
 
+> **Picking the UDS form here?** Part B is written for two isolated users
+> (TCP). Over a Unix socket only the socket's owner can connect (A.3), so
+> you must run tmkms as the `gnoland` user and own its config/secrets with
+> `gnoland` — follow the single-user ownership shown in Part D.
+
 Write the config with a heredoc, then lock it down to `0600` owned by
 `tmkms` (the password stays in the separate `password_file`, never
 inline; all paths are absolute):
@@ -617,7 +704,7 @@ All `gnoland config` commands write under `/var/lib/gnoland`, so run them
 
 ```sh
 CFG=/var/lib/gnoland/config/config.toml
-sudo -u gnoland gnoland config init -config-path "$CFG"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config init -config-path "$CFG"
 ```
 
 > **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
@@ -627,18 +714,18 @@ sudo -u gnoland gnoland config init -config-path "$CFG"
 > stays unset.
 
 ```sh
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
 # listen_addr LAST — this enables the mode:
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
 ```
 
 Verify it stuck (`listen_addr` should be your `$PRIVVAL_LISTEN`, not
 empty):
 
 ```sh
-sudo -u gnoland gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
 ## B.6 Run both as services, in the right order
@@ -656,7 +743,7 @@ sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
 # validator (as the gnoland user) — point -genesis at the network's
 # genesis.json (the chain you're joining, or the one you built in B.3);
 # either way NO -lazy, since you're not minting a local key.
-sudo -u gnoland gnoland start \
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland start \
   -data-dir /var/lib/gnoland \
   -genesis /var/lib/gnoland/genesis.json \
   -chainid "$CHAIN_ID"
@@ -733,12 +820,16 @@ that. Everything about the *connection* (Part A transport, allowlist,
 peer-ID pin, `protocol_version`, verification) is identical; only key
 custody and the genesis bootstrap differ.
 
-You still apply Part A: dedicated `tmkms` user, `0600` secrets, locked
-directories, and the same transport choice. The softsign-specific
+This lab is a same-host **UDS** layout, so it follows A.1's single-user
+rule the simplest way: it runs **both processes as your operator user** in
+local directories, rather than provisioning the `gnoland`/`tmkms` system
+users. Apply the rest of Part A's hardening — `0600` secrets, locked
+directories, the transport choice — scaled to that. The softsign-specific
 hardening on top:
 
-- **`0600` on `consensus.key` and the state file**, owned by `tmkms`. A
-  readable softsign key *is* the validator's private key.
+- **`0600` on `consensus.key` and the state file**, owned by the user
+  running both processes (you). A readable softsign key *is* the
+  validator's private key.
 - **Swap exposure.** tmkms zeroizes the key on drop but does not `mlock`
   it, so it can be paged to disk. Disable swap on the signer host (or use
   encrypted swap) so the key never hits persistent storage in the clear:
@@ -865,7 +956,11 @@ empty):
 gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
-Then start both:
+This lab runs both processes as your operator user, so the exported
+`GNOROOT` (from [Prerequisites](#set-gnoroot-to-a-gno-checkout)) carries
+through — no `env GNOROOT=…` prefix needed. The `-lazy` start additionally
+reads `examples/` from `GNOROOT`, one more reason it must be a full
+checkout. Then start both:
 
 ```sh
 # terminal 1
@@ -910,6 +1005,14 @@ the provider and the device handling change.
 
 ## D.1 Prerequisites
 
+Part D is a **same-host Unix-socket** layout, so — per
+[A.1](#a1-pick-the-user-model-it-depends-on-the-transport) — tmkms runs as
+the **`gnoland`** user, not a separate `tmkms` user, and its config and
+secrets live under `gnoland` ownership. The commands below reflect that;
+own `/etc/tmkms` and `/var/lib/tmkms` with `gnoland` (A.2). For a
+two-isolated-user Ledger setup, switch to the loopback-TCP layout from
+Part B instead.
+
 Install tmkms with the Ledger provider. The cargo feature is named
 **`ledger`** in 0.15.0 (older versions called it `ledgertm`, which is
 why the config block below is still `[[providers.ledgertm]]`). tmkms
@@ -919,6 +1022,7 @@ gives you neither Ledger nor softsign — pass them explicitly:
 ```sh
 cargo install tmkms --version 0.15.0 --features ledger --locked
 # or, to keep softsign too: --features ledger,softsign
+sudo install -m 0755 ~/.cargo/bin/tmkms /usr/local/bin/   # so sudo -u gnoland can run it
 ```
 
 You also need:
@@ -927,6 +1031,17 @@ You also need:
   dedicated ed25519 consensus app — *not* the regular Cosmos app),
   plugged in, unlocked, with that app **open**. tmkms cannot reach a
   locked device or a different app.
+- **Device access for the `gnoland` user.** tmkms runs as `gnoland`; if
+  that user can't open the Ledger's `/dev/hidraw*` node,
+  `sudo -u gnoland tmkms start` fails with `signing operation failed`.
+  Grant the `gnoland` group the hidraw device, reload, then **replug** the
+  Ledger:
+
+  ```sh
+  echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="2c97", MODE="0660", GROUP="gnoland"' \
+    | sudo tee /etc/udev/rules.d/51-gnoland-ledger.rules
+  sudo udevadm control --reload-rules && sudo udevadm trigger
+  ```
 
 ## D.2 Generate gnoland's node and listener identity
 
@@ -935,37 +1050,39 @@ node identity, and tmkms needs a SecretConnection identity key. Generate
 the gnoland node secrets:
 
 ```sh
-sudo -u gnoland gnoland secrets init -data-dir /var/lib/gnoland/secrets
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland secrets init -data-dir /var/lib/gnoland/secrets
 ```
 
 In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
 — the Ledger signs. On this same-host Unix-socket layout there is **no
-peer-ID pin** to generate (the socket's filesystem permissions are the
-auth boundary, A.3). You do still need tmkms's SecretConnection identity
-key — gnoland only enables the listener with a non-empty
-`allowed_kms_pubkeys`. Run the `tmkms-identity-keygen` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools) as the tmkms user,
-so the key is written into tmkms's secrets dir already owned by tmkms (no
-`chown` needed):
+peer-ID pin** to generate (the socket's `0600` owner-only mode is the auth
+boundary, A.3). You do still need tmkms's SecretConnection identity key —
+gnoland only enables the listener with a non-empty `allowed_kms_pubkeys`.
+Run the `tmkms-identity-keygen` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools) as the `gnoland`
+user (tmkms runs as `gnoland` here), so the key lands in the secrets dir
+already owned by `gnoland`:
 
 ```sh
-ALLOW=$(sudo -u tmkms tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
+ALLOW=$(sudo -u gnoland tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
 echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in D.5
 ```
 
 ## D.3 Write `tmkms.toml`
 
-Create the socket directory first — only the gnoland and tmkms users can
-traverse it, and gnoland creates the socket inside it at `0600`:
+This is the same-host UDS layout, so the socket directory is the one you
+already created in [A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp).
+If you skipped it there, create it now — owned by `gnoland`, which creates
+the socket inside it at `0600` and (running as `gnoland`) connects to it:
 
 ```sh
-sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland
+sudo install -d -o gnoland -g gnoland -m 700 /run/gnoland
 ```
 
-Write the config with a heredoc, then lock it to `0600` owned by `tmkms`
-(all paths absolute). The provider is `ledgertm` — no key files, the key
-is on the device — and the transport is the Unix socket, so the `addr`
-carries no peer-ID pin:
+Write the config with a heredoc, then lock it to `0600` owned by `gnoland`
+(tmkms runs as `gnoland`; all paths absolute). The provider is `ledgertm`
+— no key files, the key is on the device — and the transport is the Unix
+socket, so the `addr` carries no peer-ID pin:
 
 ```sh
 sudo tee /etc/tmkms/tmkms.toml >/dev/null <<TOML
@@ -985,7 +1102,7 @@ protocol_version = "v0.34"
 reconnect = true
 TOML
 
-sudo chown tmkms:tmkms /etc/tmkms/tmkms.toml
+sudo chown gnoland:gnoland /etc/tmkms/tmkms.toml
 sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
@@ -1007,13 +1124,13 @@ Only one `[[providers.ledgertm]]` is allowed and it always signs the
 
 Because the key never leaves the Ledger, you read the **public** half out
 of tmkms and register *that* as your validator identity. Start tmkms once
-(as the tmkms user, with the `tmkms.toml` from D.3); it loads the device
-key and logs its consensus pubkey on startup. Read that line, then stop it
-with `Ctrl-C` (gnoland isn't up yet, so it will just retry the connection
-in the meantime):
+(as the `gnoland` user, with the `tmkms.toml` from D.3); it loads the
+device key and logs its consensus pubkey on startup. Read that line, then
+stop it with `Ctrl-C` (gnoland isn't up yet, so it will just retry the
+connection in the meantime):
 
 ```sh
-sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
 ```
 
 ```
@@ -1102,7 +1219,7 @@ All `gnoland config` commands write under `/var/lib/gnoland`, so run them
 ```sh
 export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"   # gnoland listens on the socket from D.3
 CFG=/var/lib/gnoland/config/config.toml
-sudo -u gnoland gnoland config init -config-path "$CFG"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config init -config-path "$CFG"
 ```
 
 > **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
@@ -1112,17 +1229,17 @@ sudo -u gnoland gnoland config init -config-path "$CFG"
 > stays unset.
 
 ```sh
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
 # listen_addr LAST — this enables the mode:
-sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
 ```
 
 Verify it stuck (`listen_addr` should be your socket, not empty):
 
 ```sh
-sudo -u gnoland gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
 ## D.6 Run both, verify, and keep the device awake
@@ -1130,16 +1247,16 @@ sudo -u gnoland gnoland config get -config-path "$CFG" consensus.priv_validator.
 **Order matters.** gnoland blocks at startup for up to
 `wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in.
 Start tmkms first (with `reconnect = true` it retries until gnoland is
-listening). Run each under its own user — for example with systemd units
-(`User=tmkms` / `User=gnoland`), or manually:
+listening). On this UDS layout **both run as the `gnoland` user** (A.1) —
+with systemd, `User=gnoland` on both units — or manually:
 
 ```sh
-# signer (as the tmkms user) — Ledger plugged in, unlocked, app open
-sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+# signer (as gnoland) — Ledger plugged in, unlocked, app open
+sudo -u gnoland tmkms start -c /etc/tmkms/tmkms.toml
 
-# validator (as the gnoland user) — NO -lazy; genesis already holds the
+# validator (as gnoland) — NO -lazy; genesis already holds the
 # device's pubkey from D.4
-sudo -u gnoland gnoland start \
+sudo -u gnoland env GNOROOT="$GNOROOT" gnoland start \
   -data-dir /var/lib/gnoland \
   -genesis /var/lib/gnoland/genesis.json \
   -chainid "$CHAIN_ID"
@@ -1180,6 +1297,9 @@ go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| `sudo -u tmkms`/`gnoland`: `unable to execute …: Permission denied` | binary under `~/.cargo/bin` or your home; service user can't traverse it | `sudo install -m 0755 <binary> /usr/local/bin/` ([Prerequisites](#put-the-binaries-on-a-system-path)) |
+| gnoland panics: `unable to determine GNOROOT` | `GNOROOT` unset, or scrubbed by `sudo -u` | `export GNOROOT=/opt/gno` and pass `env GNOROOT="$GNOROOT"` through sudo ([Prerequisites](#set-gnoroot-to-a-gno-checkout)) |
+| gnoland panics at InitChainer: `failed loading stdlib "…": does not exist` | `GNOROOT` isn't a complete checkout, or its stdlibs don't match the binary | Point `GNOROOT` at a full checkout of the tree you built, at the same commit ([Prerequisites](#set-gnoroot-to-a-gno-checkout)) |
 | tmkms: `unknown field 'softsign', expected 'ledgertm'` | tmkms built without softsign | `cargo install tmkms --version 0.15.0 --features softsign --locked` |
 | gnoland: `allowed_kms_pubkeys must not be empty` | allowlist unset, or `listen_addr` set before the other fields | Set the four fields with `listen_addr` **last** (B.5) |
 | gnoland exits after ~60s waiting for connection | tmkms not running, can't reach `addr`, or pubkey not in allowlist | Start tmkms first; check `addr` vs `listen_addr`; confirm the hex in `allowed_kms_pubkeys` |
@@ -1188,6 +1308,8 @@ go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
 | Node never advances past height 1, no signing in tmkms log | `chain_id` mismatch across genesis / config.toml / tmkms.toml | Make all three identical and restart |
 | Signatures produced but rejected by the chain | consensus key in the signer ≠ genesis validator key | Re-seed genesis from the *same* key the signer holds |
 | tmkms: `unverified validator peer ID! (<hex>)` | peer-ID prefix missing from `addr` (TCP) | Pin `tcp://<hex>@host:port` with `$VALIDATOR_PEER_ID` (B.4) |
+| tmkms (UDS): `I/O error: Permission denied (os error 13)` | tmkms runs as a *different* user than gnoland; the socket is `0600` owner-only | Run both as one user (A.1), or switch to loopback TCP for two users |
+| tmkms (Ledger): `error loading configuration: signing operation failed` | the user running tmkms can't open the Ledger's `/dev/hidraw*` node | Add the hidraw udev rule for that user's group, reload, replug (D.1) |
 | tmkms (Ledger): startup `SigningError` / no pubkey | device locked, asleep, or wrong app | Unlock, open **Tendermint Validator** app, restart tmkms |
 
 ---

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -1,0 +1,587 @@
+# gnoland + tmkms: end-to-end setup
+
+A hands-on, copy-paste walkthrough that stands up a single-host gnoland
+validator whose consensus key is held by [tmkms] instead of sitting on
+the node. It takes you from an empty directory to a node producing
+blocks that are signed remotely by tmkms.
+
+This is the practical companion to [tmkms.md](tmkms.md) — read that for
+the architecture, the security model, and the production checklist. This
+page is the "just make it work once" path.
+
+[tmkms]: https://github.com/iqlusioninc/tmkms
+
+> **Single host, softsign, for learning.** This walkthrough runs tmkms
+> and gnoland on the same machine with tmkms's file-based `softsign`
+> backend. That is fine for understanding the wiring and for testnets,
+> but it is **not** a production layout — the consensus key still touches
+> the validator host's disk. For real stake, move tmkms to its own host
+> with an HSM/Ledger/cloud-KMS backend. See
+> [tmkms.md § When to use this mode](tmkms.md#when-to-use-this-mode).
+
+## How the pieces connect
+
+```
+  gnoland (validator)                 tmkms (signer)
+  ───────────────────                 ──────────────
+  listens on :26659  ◄────dials in──── [[validator]] addr = tcp://<peer_id>@…:26659
+  allowed_kms_pubkeys ─ verifies ────► kms-identity.key   (SecretConnection identity)
+  node_id (peer ID)  ◄─ verifies ───── <peer_id> pinned in addr
+  genesis validator  = consensus pubkey = consensus.key   (the key that signs votes)
+  chain_id           ══════ must match ══════ [[chain]].id / [[validator]].chain_id
+```
+
+The connection is **mutually** authenticated: gnoland verifies tmkms via
+`allowed_kms_pubkeys`, and tmkms verifies gnoland via the `<peer_id>`
+pinned in its `addr`. Both directions are mandatory here.
+
+Three distinct ed25519 keys are in play — don't mix them up:
+
+| Key | Lives in | Role |
+|---|---|---|
+| **consensus key** | tmkms `consensus.key` (softsign) | signs votes/proposals; its pubkey is the validator's identity in genesis |
+| **kms-identity key** | tmkms `kms-identity.key` | tmkms's SecretConnection identity; its pubkey goes in gnoland's `allowed_kms_pubkeys` |
+| **node key** | gnoland `node_key.json` | gnoland's SecretConnection identity; its peer ID (hex) is pinned in tmkms's `addr` |
+
+The defining property of this mode: **tmkms dials gnoland**, not the
+other way around. gnoland listens; tmkms connects in.
+
+## 0. Prerequisites
+
+- **Go** (to build `gnoland`).
+- **Rust / cargo** (to install tmkms).
+- **tmkms 0.15.0 built with the `softsign` feature.** The default
+  release does *not* include softsign — install it explicitly:
+
+  ```sh
+  cargo install tmkms --version 0.15.0 --features softsign --locked
+  tmkms version   # → 0.15.0
+  ```
+
+- **`gnoland`** built from this repo:
+
+  ```sh
+  # from the repo root
+  go build -o ./build/gnoland ./gno.land/cmd/gnoland
+  ```
+
+Pick a working directory and a chain ID you'll reuse everywhere:
+
+```sh
+export WORK=~/gno-tmkms-lab
+export CHAIN_ID=gno-tmkms-test
+export GNOLAND=$(pwd)/build/gnoland   # absolute path to the binary you just built
+
+mkdir -p "$WORK"/gnoland-data/secrets "$WORK"/tmkms/secrets
+cd "$WORK"
+```
+
+> The `chain_id` must be **identical** in three places: the gnoland
+> genesis (`-chainid`), the `tmkms_listener.chain_id` in `config.toml`,
+> and the `[[chain]].id` / `[[validator]].chain_id` in `tmkms.toml`. If
+> they drift, tmkms refuses to sign or the signatures won't verify.
+
+## 1. Generate the gnoland node secrets
+
+This creates the consensus key, the node's p2p key, and the sign-state
+file:
+
+```sh
+"$GNOLAND" secrets init -data-dir ./gnoland-data/secrets
+```
+
+You now have `gnoland-data/secrets/priv_validator_key.json` (the
+consensus key), `node_key.json` (p2p identity), and
+`priv_validator_state.json`.
+
+> In tmkms mode gnoland does **not** use `priv_validator_key.json` to
+> sign at runtime — tmkms does. But gnoland *does* read it once, at
+> genesis-generation time, to learn the validator's pubkey. So the
+> consensus key in this file and the key you load into tmkms (next step)
+> **must be the same key**. We achieve that by exporting this one into
+> tmkms rather than generating a second one.
+
+Note the validator address — you'll confirm it matches the genesis later:
+
+```sh
+"$GNOLAND" secrets get -data-dir ./gnoland-data/secrets validator_key
+```
+
+You also need the node's **peer ID** in hex — tmkms uses it to verify it
+is talking to *your* validator and not an impostor on the listen port
+(step 4 pins it). gnoland's `secrets get node_id` reports this identity
+in bech32 (`g1…`); tmkms wants the same 20 bytes in hex. This tiny
+stdlib-only Go helper reads `node_key.json` and prints the hex form:
+
+```sh
+cat > nodeid-hex.go <<'GO'
+// Prints a gnoland node's peer ID in the hex form tmkms expects.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	raw, err := os.ReadFile(os.Args[1]) // path to node_key.json
+	if err != nil {
+		panic(err)
+	}
+	var nk struct {
+		PrivKey string `json:"priv_key"`
+	}
+	if err := json.Unmarshal(raw, &nk); err != nil {
+		panic(err)
+	}
+	priv, err := base64.StdEncoding.DecodeString(nk.PrivKey)
+	if err != nil {
+		panic(err)
+	}
+	pub := priv[32:]           // ed25519: priv = seed(32) ‖ pub(32)
+	addr := sha256.Sum256(pub) // node address = SHA256(pubkey)[:20]
+	fmt.Println(hex.EncodeToString(addr[:20]))
+}
+GO
+
+export VALIDATOR_PEER_ID=$(go run ./nodeid-hex.go ./gnoland-data/secrets/node_key.json)
+echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in step 4
+```
+
+## 2. Export the consensus key into tmkms's softsign format
+
+gnoland stores the ed25519 private key as base64 of the 64-byte
+`seed‖pubkey`. tmkms softsign wants base64 of just the 32-byte **seed**.
+Slice off the first 32 bytes and re-encode:
+
+```sh
+python3 - <<'PY' > ./tmkms/secrets/consensus.key
+import json, base64
+v = json.load(open("gnoland-data/secrets/priv_validator_key.json"))["priv_key"]["value"]
+print(base64.b64encode(base64.b64decode(v)[:32]).decode(), end="")
+PY
+chmod 600 ./tmkms/secrets/consensus.key
+```
+
+(No crypto involved — it's a byte reslice — so plain `python3` is enough.)
+
+## 3. Generate tmkms's SecretConnection identity key
+
+tmkms needs its own identity key to authenticate the inbound connection.
+gnoland will only accept the connection if this key's **public** half is
+in `allowed_kms_pubkeys`. Generate the key and print its hex pubkey with
+this tiny Go helper:
+
+```sh
+cat > tmkms-identity-keygen.go <<'GO'
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+)
+
+func main() {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		panic(err)
+	}
+	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	// tmkms softsign connection key = base64 of the 32-byte seed.
+	if err := os.WriteFile(os.Args[1], []byte(base64.StdEncoding.EncodeToString(seed)), 0o600); err != nil {
+		panic(err)
+	}
+	// Hex pubkey for gnoland's allowed_kms_pubkeys.
+	fmt.Println("ed25519:" + hex.EncodeToString(pub))
+}
+GO
+
+ALLOW=$(go run ./tmkms-identity-keygen.go ./tmkms/secrets/kms-identity.key)
+echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy this for step 5
+```
+
+## 4. Write `tmkms.toml`
+
+This is the format verified by the repo's real-tmkms integration test
+(`tm2/pkg/bft/privval/upstream/tmkms_integration_test.go`). Note
+`protocol_version = "v0.34"` — gnoland only speaks that dialect and
+refuses to start otherwise.
+
+```sh
+cat > ./tmkms/tmkms.toml <<TOML
+[[chain]]
+id = "${CHAIN_ID}"
+key_format = { type = "hex" }
+state_file = "$(pwd)/tmkms/secrets/consensus_state.json"
+
+[[providers.softsign]]
+chain_ids = ["${CHAIN_ID}"]
+key_type = "consensus"
+key_format = "base64"
+path = "$(pwd)/tmkms/secrets/consensus.key"
+
+[[validator]]
+chain_id = "${CHAIN_ID}"
+addr = "tcp://${VALIDATOR_PEER_ID}@127.0.0.1:26659"
+secret_key = "$(pwd)/tmkms/secrets/kms-identity.key"
+protocol_version = "v0.34"
+reconnect = true
+TOML
+```
+
+- `addr` is where gnoland is listening (step 6), with the
+  **validator peer ID from step 1 pinned in front** (`<peer_id>@host:port`,
+  Tendermint-style). This is **required**, not cosmetic — it is the
+  mirror of gnoland's `allowed_kms_pubkeys`, and it makes the
+  authentication mutual:
+
+  | Direction | Authenticated by |
+  |---|---|
+  | gnoland verifies tmkms | `allowed_kms_pubkeys` (step 5) |
+  | tmkms verifies gnoland | the peer ID pinned in `addr` (here) |
+
+  Omit the `<peer_id>@` prefix and tmkms will sign for *whoever* answers
+  on the port and log `unverified validator peer ID!` on every
+  connection. On a single host `127.0.0.1` is fine; across hosts use the
+  validator's reachable IP (the peer ID stays the same).
+- `state_file` is tmkms's `consensus.json` — the authoritative
+  double-sign (HRS) gate. tmkms creates it on first run. **Never restore
+  a stale copy of it.**
+- `reconnect = true` makes tmkms keep retrying the dial, so you can
+  start it before or after gnoland.
+
+> tmkms 0.15.0 prints `deprecated protocol_version v0.34 (update to
+> v0.38)! Will be a hard error in next release` on startup. That's
+> expected: gnoland speaks **only** v0.34 today (see
+> [tmkms.md § Protocol version pin](tmkms.md#protocol-version-pin)), so
+> stay on a tmkms release that still supports v0.34 — 0.15.0 does.
+
+## 5. Configure gnoland for tmkms mode
+
+Create a default `config.toml`, then point the `tmkms_listener` block at
+tmkms.
+
+```sh
+CFG=./gnoland-data/config/config.toml
+"$GNOLAND" config init -config-path "$CFG"
+```
+
+> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
+> block on every write, and a non-empty `listen_addr` is what *enables*
+> validation of the other fields. So set `listen_addr` **last** — if you
+> set it first, the write is rejected because `chain_id` is still empty,
+> and it silently stays unset.
+
+```sh
+"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+# listen_addr LAST — this enables the mode:
+"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "tcp://0.0.0.0:26659"
+```
+
+Verify it stuck:
+
+```sh
+"$GNOLAND" config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+```
+
+`listen_addr` should be `tcp://0.0.0.0:26659` and not empty.
+
+## 6. Start tmkms, then gnoland
+
+**Order matters.** gnoland blocks at startup for up to
+`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in,
+and it needs that connection during its own startup. Start tmkms first.
+
+Terminal 1 — tmkms:
+
+```sh
+tmkms start -c ./tmkms/tmkms.toml
+```
+
+You should see it load the softsign provider and (once gnoland is up)
+complete the SecretConnection handshake. With `reconnect = true` it logs
+connection-refused retries until gnoland is listening — that's expected.
+
+Terminal 2 — gnoland:
+
+```sh
+"$GNOLAND" start \
+  -data-dir ./gnoland-data \
+  -genesis ./gnoland-data/genesis.json \
+  -chainid "$CHAIN_ID" \
+  -lazy \
+  -skip-genesis-sig-verification
+```
+
+- `-genesis ./gnoland-data/genesis.json` keeps the generated genesis
+  alongside the rest of the node state. Without it, `genesis.json` is
+  written to your **current working directory**.
+- `-skip-genesis-sig-verification` is needed because the default
+  `-lazy` genesis includes example deploy txs signed by test accounts;
+  without this flag the node panics replaying them at boot. It has
+  nothing to do with tmkms — it's the standard dev-genesis flag (the
+  same one in the gnoland README quick-start).
+
+What `-lazy` does here, in order:
+
+1. Keeps your existing `config.toml` and `secrets/` (it only generates
+   files that are missing — it will **not** clobber your tmkms config).
+2. Generates `genesis.json`, reading the **local** consensus pubkey from
+   `priv_validator_key.json` to register this node as the genesis
+   validator. (This is why the exported key in step 2 must match.)
+3. Boots the node. The privval stack now uses the tmkms listener: it
+   waits for tmkms's dial-in, fetches the pubkey over the link, and from
+   then on every vote/proposal is signed by tmkms.
+
+## 7. Verify it's really tmkms signing
+
+Within a few seconds you should see the node advancing through heights.
+
+- **tmkms log**: `connected to validator successfully`, then ongoing
+  sign activity. That's the signer doing the work.
+- **gnoland log**: `Signed and pushed vote …`, `Finalizing commit of
+  block`, and `Committed state … height=N` climbing. If signing were
+  broken the node would stall at height 1 instead of advancing.
+
+  ```sh
+  grep "Committed state" ./gnoland.log | tail
+  ```
+
+- **Identity check** — the validator address gnoland signs with must be
+  the address from step 1:
+
+  ```sh
+  "$GNOLAND" secrets get -data-dir ./gnoland-data/secrets validator_key
+  # the "address" must match the `validator address` in the
+  # "Signed and pushed vote" log lines, and the validator entry in
+  # ./gnoland-data/genesis.json
+  ```
+
+- **Mutual auth holds** — tmkms logs clean
+  `signed Proposal/Prevote/Precommit …` lines and **no**
+  `unverified validator peer ID!` warning. If you do see that warning,
+  the peer ID pinned in `tmkms.toml`'s `addr` (step 4) is missing or
+  wrong — tmkms prints the value it expected in the parentheses, so
+  compare it against `$VALIDATOR_PEER_ID` from step 1.
+
+- **Kill tmkms** and watch gnoland stop committing blocks (the height
+  stops climbing; the log shows the signer connection dropping). Restart
+  tmkms and it resumes. That's the clearest proof the key lives in
+  tmkms, not gnoland.
+
+> **Benign log noise.** Even when signing works, gnoland periodically
+> logs `SignerListener: accept failed … i/o timeout` and `already
+> connected, dropping listen request`. The endpoint holds one live
+> signer connection and these are the idle re-accept attempts timing
+> out; they don't interrupt signing. Watch the committed height, not
+> these lines.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| tmkms: `unknown field 'softsign', expected 'ledgertm'` | tmkms built without the softsign feature | Reinstall: `cargo install tmkms --version 0.15.0 --features softsign --locked` |
+| gnoland: `tmkms_listener.allowed_kms_pubkeys must not be empty` | allowlist not set, or `listen_addr` was set before the other fields | Set the four fields with `listen_addr` **last** (step 5) |
+| gnoland exits after ~60s waiting for connection | tmkms isn't running, can't reach `addr`, or its pubkey isn't in the allowlist | Start tmkms first; check `addr` matches `listen_addr`; confirm the hex in `allowed_kms_pubkeys` is the one printed in step 3 |
+| gnoland: `protocol_version` rejected at startup | a value other than `v0.34` | Use `v0.34` on both sides |
+| gnoland panics at boot: `PubKey does not match Signer address … InvalidPubKeyError` | default `-lazy` genesis has example txs signed by test accounts | Add `-skip-genesis-sig-verification` (step 6) — unrelated to tmkms |
+| Node never advances past height 1, no signing in tmkms log | `chain_id` mismatch between genesis, `config.toml`, and `tmkms.toml` | Make all three identical and restart |
+| Signatures produced but rejected by the chain | consensus key in tmkms ≠ genesis validator key | Re-export in step 2 from the *same* `priv_validator_key.json` used for genesis |
+| gnoland logs `accept failed: i/o timeout` / `already connected, dropping listen request` while still committing blocks | benign idle re-accept attempts on the held connection | Ignore — confirm the committed height is climbing |
+| tmkms: `unverified validator peer ID! (<hex>)` | the peer ID prefix is missing from `tmkms.toml`'s `addr`, so tmkms signs for whoever answers on the port | Pin it: `addr = "tcp://<hex>@host:port"` using `$VALIDATOR_PEER_ID` from step 1 (step 4) |
+| tmkms (Ledger): startup `SigningError` / can't get pubkey | device locked, asleep, or not on the Tendermint Validator app | Unlock the Ledger and open the **Tendermint Validator** app, then restart tmkms (L0) |
+| gnoland (Ledger): boots but `This node is NOT a validator`, height stuck at 0 | the `gpub`/address in genesis doesn't match the device key | Re-read the hex from tmkms's `added consensus Ed25519 key` log (L2), re-run `pkconv.go` (L3), rebuild genesis (L4) |
+
+## Variant: a Ledger hardware signer instead of softsign
+
+softsign keeps the consensus key in a file — fine for a lab, but the
+key still touches disk. A Ledger holds the key **on the device** and
+never exports it. That single fact flips the bootstrap around:
+
+> With softsign you generated the key in gnoland and *pushed it into*
+> the signer (step 2). With a Ledger you can't — the private key never
+> leaves the device. So you go the other way: read the **public** key
+> *out of* the Ledger and seed the genesis validator from it.
+
+Everything about the connection (listener, allowlist, peer-ID pin,
+`protocol_version`, `chain_id`) is identical. Only the key custody and
+the genesis-bootstrap change.
+
+> **Scope note.** The gno-side of this flow — converting the device
+> pubkey, seeding genesis with it, and signing through the tmkms
+> listener — is verified end-to-end. The physical-device half (the
+> `ledgertm` provider talking to a real Ledger) is described from the
+> tmkms source and the Ledger app; it needs the hardware to exercise.
+> A Ledger is also a single signer with no failover — for real
+> high-availability use Horcrux or an HSM (see [tmkms.md](tmkms.md)).
+
+### L0. Prerequisites
+
+- tmkms built with the **`ledgertm`** provider. It's in the default
+  build (`cargo install tmkms` with no `--features` gives you exactly
+  `ledgertm`); to keep softsign too, build
+  `--features ledgertm,softsign`.
+- A Ledger with the **"Tendermint Validator"** app installed (the
+  dedicated ed25519 consensus-signing app — *not* the regular Cosmos
+  app), plugged in, unlocked, with that app **open**. tmkms can't reach
+  a locked device or a different app.
+
+### L1. Point tmkms at the Ledger
+
+Same `tmkms.toml` as step 4, but replace the `[[providers.softsign]]`
+block with a `[[providers.ledgertm]]` block — no key files, no paths:
+
+```toml
+[[chain]]
+id = "${CHAIN_ID}"
+key_format = { type = "hex" }       # makes tmkms log the pubkey in hex (L2)
+state_file = "/abs/path/tmkms/secrets/consensus_state.json"
+
+[[providers.ledgertm]]
+chain_ids = ["${CHAIN_ID}"]
+
+[[validator]]
+chain_id = "${CHAIN_ID}"
+addr = "tcp://${VALIDATOR_PEER_ID}@127.0.0.1:26659"   # peer-ID pin from step 1
+secret_key = "/abs/path/tmkms/secrets/kms-identity.key"
+protocol_version = "v0.34"
+reconnect = true
+```
+
+Only one `[[providers.ledgertm]]` is allowed, and it always signs the
+**consensus** key.
+
+### L2. Read the consensus pubkey out of the Ledger
+
+Start tmkms alone. On connect it logs the device's consensus pubkey —
+in hex, because of `key_format = { type = "hex" }`:
+
+```sh
+tmkms start -c ./tmkms/tmkms.toml
+# [keyring:ledgertm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
+```
+
+Copy that hex string — it's your validator's consensus public key.
+
+### L3. Convert the hex pubkey to gno format
+
+gnoland's genesis wants the pubkey as a `gpub1…` bech32 and the matching
+`g1…` address. This stdlib-plus-gno-crypto helper converts the hex (run
+it **from the gno repo root** so the imports resolve):
+
+```sh
+cat > pkconv.go <<'GO'
+// Converts a raw ed25519 consensus pubkey (hex or base64) to gno's
+// gpub1… / g1… forms. Run from the gno repo root: go run ./pkconv.go <hex>
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+)
+
+func main() {
+	in := strings.TrimSpace(os.Args[1])
+	bz, err := hex.DecodeString(in)
+	if err != nil {
+		if bz, err = base64.StdEncoding.DecodeString(in); err != nil {
+			panic("pubkey must be 32-byte ed25519 in hex or base64")
+		}
+	}
+	if len(bz) != 32 {
+		panic(fmt.Sprintf("expected 32 bytes, got %d", len(bz)))
+	}
+	var pk ed25519.PubKeyEd25519
+	copy(pk[:], bz)
+	fmt.Println("gpub:   ", crypto.PubKeyToBech32(pk))
+	fmt.Println("address:", pk.Address().String())
+}
+GO
+
+go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
+# gpub:    gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z...
+# address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
+```
+
+### L4. Seed genesis with the Ledger validator
+
+Because the validator key lives on the device, you **can't** use
+`-lazy` (it would mint a throwaway local key and put *that* in genesis
+instead). Build the genesis explicitly with `gnogenesis`
+(`contribs/gnogenesis`), using the `gpub`/address from L3:
+
+```sh
+gnogenesis generate -chain-id "$CHAIN_ID" -output-path ./gnoland-data/genesis.json
+gnogenesis validator add \
+  -genesis-path ./gnoland-data/genesis.json \
+  -address  g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4 \
+  -pub-key  gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z... \
+  -name     ledgervalidator \
+  -power    10
+```
+
+`validator add` checks that the pubkey hashes to the address, so a
+copy-paste slip is caught here.
+
+You still need gnoland's node secrets for the **listener identity** —
+run `secrets init` (step 1) as usual. Its `priv_validator_key.json` is
+ignored for signing in tmkms mode; only `node_key.json` (the peer ID)
+matters.
+
+### L5. Configure gnoland and start (non-lazy)
+
+Configure `tmkms_listener` exactly as in step 5, then start — with an
+explicit `-genesis` and **no `-lazy`** (the genesis already exists):
+
+```sh
+# terminal 1: Ledger plugged in, app open
+tmkms start -c ./tmkms/tmkms.toml
+
+# terminal 2
+"$GNOLAND" start \
+  -data-dir ./gnoland-data \
+  -genesis ./gnoland-data/genesis.json \
+  -chainid "$CHAIN_ID" \
+  -skip-genesis-sig-verification
+```
+
+Verify as in step 7 — gnoland should log `This node is a validator`
+with the `gpub1…` from L3, the height should climb, and tmkms should log
+`signed Proposal/Prevote/Precommit …`. The Tendermint Validator app
+signs consensus messages without a per-vote button press (it must, for
+liveness); it enforces its own monotonic HRS on-device, and tmkms's
+`state_file` is still the authoritative gate — keep it.
+
+> **Keep the device awake.** If the Ledger locks, sleeps, or the app is
+> backgrounded, signing stops and the node stalls until you reopen the
+> app. Plan for that on anything you care about.
+
+## Where to go next
+
+- **Run the repo's automated proof.** A build-tagged Go test drives a
+  real tmkms binary through the full signing flow:
+
+  ```sh
+  go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
+  ```
+
+- **Production hardening** — separate signer host, HSM/Ledger backend,
+  TCP firewalling, `consensus.json` backups, Horcrux threshold signing:
+  see [tmkms.md](tmkms.md), especially *Security notes*, *TCP vs UDS*,
+  and the *Operational checklist*.

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -21,6 +21,8 @@ called out at the exact step where it applies.
 It is ordered by what you should actually run for real stake first, and
 descends toward test/lab setups:
 
+- **[Prerequisites — helper tools](#prerequisites--build-the-helper-tools)** —
+  two small stdlib-only Go helpers every backend uses; build them once.
 - **[Part A — Host hardening](#part-a--host-hardening-do-this-first-for-every-backend)** —
   the OS-level groundwork (dedicated user, locked-down directories,
   transport choice). Do this regardless of which signer backend you pick.
@@ -76,6 +78,86 @@ once and reuse it:
 
 ```sh
 export CHAIN_ID=gno-tmkms-prod
+```
+
+---
+
+# Prerequisites — build the helper tools
+
+Every backend below needs two tiny **stdlib-only** Go helpers. Write them
+once, here, and later sections just `go run` them. They have no module
+dependencies, so they run from any directory (Part B.3's `pkconv.go` is
+the one exception — it imports the gno crypto packages and must be run
+from the gno repo root; it's defined where it's used).
+
+`nodeid-hex.go` — prints a gnoland node's peer ID in the hex form tmkms
+pins in its `addr` (TCP layouts):
+
+```sh
+cat > nodeid-hex.go <<'GO'
+// Prints a gnoland node's peer ID in the hex form tmkms expects.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	raw, err := os.ReadFile(os.Args[1]) // path to node_key.json
+	if err != nil {
+		panic(err)
+	}
+	var nk struct {
+		PrivKey string `json:"priv_key"`
+	}
+	if err := json.Unmarshal(raw, &nk); err != nil {
+		panic(err)
+	}
+	priv, err := base64.StdEncoding.DecodeString(nk.PrivKey)
+	if err != nil {
+		panic(err)
+	}
+	pub := priv[32:]           // ed25519: priv = seed(32) ‖ pub(32)
+	addr := sha256.Sum256(pub) // node address = SHA256(pubkey)[:20]
+	fmt.Println(hex.EncodeToString(addr[:20]))
+}
+GO
+```
+
+`tmkms-identity-keygen.go` — generates tmkms's SecretConnection identity
+key at the path you pass and prints its pubkey for gnoland's
+`allowed_kms_pubkeys`:
+
+```sh
+cat > tmkms-identity-keygen.go <<'GO'
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+)
+
+func main() {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		panic(err)
+	}
+	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	if err := os.WriteFile(os.Args[1], []byte(base64.StdEncoding.EncodeToString(seed)), 0o600); err != nil {
+		panic(err)
+	}
+	fmt.Println("ed25519:" + hex.EncodeToString(pub)) // for gnoland's allowed_kms_pubkeys
+}
+GO
 ```
 
 ---
@@ -189,6 +271,13 @@ export PRIVVAL_LISTEN="tcp://<validator_interface_ip>:26659"
 # TMKMS_ADDR set in B.5 once the peer ID is known: tcp://<peer_id>@<validator_ip>:26659
 ```
 
+The two transports are independent of the signer backend, so the worked
+examples below deliberately show both: **Part B (YubiHSM) uses TCP** (the
+peer-ID-pinned, cross-host form), while **Parts C (softsign) and D
+(Ledger) use the same-host Unix socket** (the simpler form). Use
+whichever matches your real deployment regardless of which backend you
+picked.
+
 ---
 
 # Part B — Production validator with a YubiHSM (recommended)
@@ -298,76 +387,20 @@ In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
 **Peer ID in hex (TCP layouts).** tmkms pins your validator's peer ID to
 make sure it signs for *your* node and not whoever answers on the port.
 gnoland reports the identity in bech32 (`g1…`); tmkms wants the same 20
-bytes in hex. This stdlib-only helper converts it:
+bytes in hex. Run the `nodeid-hex.go` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools):
 
 ```sh
-cat > nodeid-hex.go <<'GO'
-// Prints a gnoland node's peer ID in the hex form tmkms expects.
-package main
-
-import (
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"os"
-)
-
-func main() {
-	raw, err := os.ReadFile(os.Args[1]) // path to node_key.json
-	if err != nil {
-		panic(err)
-	}
-	var nk struct {
-		PrivKey string `json:"priv_key"`
-	}
-	if err := json.Unmarshal(raw, &nk); err != nil {
-		panic(err)
-	}
-	priv, err := base64.StdEncoding.DecodeString(nk.PrivKey)
-	if err != nil {
-		panic(err)
-	}
-	pub := priv[32:]           // ed25519: priv = seed(32) ‖ pub(32)
-	addr := sha256.Sum256(pub) // node address = SHA256(pubkey)[:20]
-	fmt.Println(hex.EncodeToString(addr[:20]))
-}
-GO
-
 export VALIDATOR_PEER_ID=$(go run ./nodeid-hex.go /var/lib/gnoland/secrets/node_key.json)
 echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in B.5 (TCP)
 ```
 
 **tmkms's SecretConnection identity (TCP layouts).** gnoland only accepts
-the connection if this key's public half is in `allowed_kms_pubkeys`:
+the connection if this key's public half is in `allowed_kms_pubkeys`. Run
+the `tmkms-identity-keygen.go` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools):
 
 ```sh
-cat > tmkms-identity-keygen.go <<'GO'
-package main
-
-import (
-	"crypto/ed25519"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/hex"
-	"fmt"
-	"os"
-)
-
-func main() {
-	seed := make([]byte, ed25519.SeedSize)
-	if _, err := rand.Read(seed); err != nil {
-		panic(err)
-	}
-	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
-	if err := os.WriteFile(os.Args[1], []byte(base64.StdEncoding.EncodeToString(seed)), 0o600); err != nil {
-		panic(err)
-	}
-	fmt.Println("ed25519:" + hex.EncodeToString(pub)) // for gnoland's allowed_kms_pubkeys
-}
-GO
-
 ALLOW=$(go run ./tmkms-identity-keygen.go /var/lib/tmkms/secrets/kms-identity.key)
 sudo chown tmkms:tmkms /var/lib/tmkms/secrets/kms-identity.key
 echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy for B.6
@@ -693,6 +726,7 @@ Reslice and re-encode (no crypto — a byte slice — so plain `python3` is
 fine):
 
 ```sh
+mkdir -p ./tmkms/secrets
 python3 - <<'PY' > ./tmkms/secrets/consensus.key
 import json, base64
 v = json.load(open("gnoland-data/secrets/priv_validator_key.json"))["priv_key"]["value"]
@@ -701,38 +735,92 @@ PY
 chmod 600 ./tmkms/secrets/consensus.key
 ```
 
-Then generate the peer-ID and kms-identity values exactly as in B.2
-(`nodeid-hex.go`, `tmkms-identity-keygen.go`).
+This lab uses a **same-host Unix socket** (A.3) — the simplest transport
+and the counterpart to Part B's TCP setup — so there is **no peer-ID pin
+to generate**. You still need tmkms's SecretConnection identity key
+(gnoland requires a non-empty allowlist even on a socket). Generate it
+with the [Prerequisites](#prerequisites--build-the-helper-tools) helper:
+
+```sh
+ALLOW=$(go run ./tmkms-identity-keygen.go ./tmkms/secrets/kms-identity.key)
+echo "$ALLOW"   # goes into gnoland's allowed_kms_pubkeys (C.3)
+```
 
 ## C.2 tmkms.toml with the softsign provider
 
-Same shape as B.4, with the provider block swapped for softsign:
+Same shape as B.4, with two lab changes: the provider block is
+**softsign**, and the transport is a same-host **Unix socket** instead of
+TCP (so no peer-ID pin — Part B already showed the TCP form). tmkms needs
+**absolute** paths (A.2), so resolve the lab dirs first, then write the
+file with a heredoc so the paths expand:
 
-```toml
+```sh
+export TMKMS_DIR=$(cd ./tmkms && pwd)                            # ./tmkms from C.1
+export PRIVVAL_SOCK="$(cd ./gnoland-data && pwd)/privval.sock"   # gnoland creates it at 0600
+
+tee "$TMKMS_DIR/tmkms.toml" >/dev/null <<TOML
 [[chain]]
 id = "gno-tmkms-test"
 key_format = { type = "hex" }
-state_file = "/abs/path/tmkms/secrets/consensus_state.json"
+state_file = "$TMKMS_DIR/secrets/consensus_state.json"
 
 [[providers.softsign]]
 chain_ids = ["gno-tmkms-test"]
 key_type = "consensus"
 key_format = "base64"
-path = "/abs/path/tmkms/secrets/consensus.key"
+path = "$TMKMS_DIR/secrets/consensus.key"
 
 [[validator]]
 chain_id = "gno-tmkms-test"
-addr = "tcp://<peer_id>@127.0.0.1:26659"   # or unix:///… on one host
-secret_key = "/abs/path/tmkms/secrets/kms-identity.key"
+addr = "unix://$PRIVVAL_SOCK"   # same-host UDS; no peer-ID pin (A.3)
+secret_key = "$TMKMS_DIR/secrets/kms-identity.key"
 protocol_version = "v0.34"
 reconnect = true
+TOML
+chmod 600 "$TMKMS_DIR/tmkms.toml"
 ```
 
-## C.3 Configure gnoland and start (lazy genesis is fine here)
+## C.3 Configure gnoland's tmkms listener and start (lazy genesis is fine here)
 
 Because the consensus key exists on disk *and* is registered locally, you
-can let `-lazy` build genesis from `priv_validator_key.json`. Configure
-the listener as in B.5, then:
+can let `-lazy` build genesis from `priv_validator_key.json`.
+
+First configure the listener. Create a default config, then set the four
+`tmkms_listener` fields. The allowlist must be non-empty — gnoland
+refuses to enable the mode with an empty one. On this Unix-socket layout
+the allowlist is belt-and-suspenders — **filesystem permissions on the
+socket are the real boundary** (A.3) — but gnoland still requires it
+non-empty, so set it with `$ALLOW` from C.1.
+
+```sh
+export CHAIN_ID=gno-tmkms-test                 # must match C.2's [[chain]].id
+export PRIVVAL_LISTEN="unix://$PRIVVAL_SOCK"   # gnoland listens on the socket from C.2
+CFG=./gnoland-data/config/config.toml
+gnoland config init -config-path "$CFG"
+```
+
+> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
+> block on every write, and a non-empty `listen_addr` is what *enables*
+> that validation. Set `listen_addr` **last** — set it first and the
+> write is rejected because `chain_id` is still empty, and it silently
+> stays unset.
+
+```sh
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+# listen_addr LAST — this enables the mode:
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+```
+
+Verify it stuck (`listen_addr` should be your `$PRIVVAL_LISTEN`, not
+empty):
+
+```sh
+gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+```
+
+Then start both:
 
 ```sh
 # terminal 1
@@ -797,19 +885,38 @@ You also need:
 
 ## D.2 Provider block and bootstrap
 
-Use the B.4 `tmkms.toml` but replace the provider with `ledgertm` — no
-key files, no paths:
+Use a `tmkms.toml` like B.4's, with two changes: the provider is
+`ledgertm` (no key files — the key is on the device), and like Part C
+this uses a same-host **Unix socket** (A.3) instead of TCP, so there is
+no peer-ID pin. Create the socket directory as in A.3
+(`sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland`), then write
+the config exactly as in B.4 (`sudo tee /etc/tmkms/tmkms.toml`) with:
 
 ```toml
+[[chain]]
+id = "${CHAIN_ID}"
+key_format = { type = "hex" }
+state_file = "/var/lib/tmkms/secrets/consensus_state.json"
+
 [[providers.ledgertm]]
-chain_ids = ["gno-tmkms-test"]
+chain_ids = ["${CHAIN_ID}"]
+
+[[validator]]
+chain_id = "${CHAIN_ID}"
+addr = "unix:///run/gnoland/privval.sock"   # same-host UDS; no peer-ID pin (A.3)
+secret_key = "/var/lib/tmkms/secrets/kms-identity.key"
+protocol_version = "v0.34"
+reconnect = true
 ```
 
 Only one `[[providers.ledgertm]]` is allowed and it always signs the
-**consensus** key. Then follow B.2 (node + identity), B.3 (start tmkms,
-read `added consensus Ed25519 key`, `pkconv.go`, `gnogenesis`), B.5
-(listener), and B.6/B.7 (start non-lazy, verify). gnoland should log
-`This node is a validator` with the `gpub1…` from B.3 and climb.
+**consensus** key. Then follow B.2 (node + identity — on UDS the peer-ID
+hex from `nodeid-hex.go` is unused, but you still need the kms-identity
+key for the allowlist), B.3 (start tmkms, read `added consensus Ed25519
+key`, `pkconv.go`, `gnogenesis`), B.5 (listener — set `listen_addr` to
+the same `unix:///run/gnoland/privval.sock`), and B.6/B.7 (start
+non-lazy, verify). gnoland should log `This node is a validator` with the
+`gpub1…` from B.3 and climb.
 
 > **Keep the device awake.** If the Ledger locks, sleeps, or the app is
 > backgrounded, signing stops and the node stalls until you reopen the

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -229,8 +229,19 @@ and which the rest follows from — is:
 4. **Store the recovery seed offline, on paper, in a safe.** Never on the
    validator host.
 
+The `<tmkms-auth-password>` below is a credential **you choose** — it is
+what tmkms presents to log in to the device. Generate a long random one
+(don't type a memorable string) and keep it only in the `0600`
+`password_file` created further down; never commit it or paste it into
+`tmkms.toml`:
+
+```sh
+TMKMS_AUTH_PASSWORD=$(openssl rand -base64 32)   # generate once; use it below and in the password_file
+```
+
 A representative `yubihsm-shell` session (verify the exact token spelling
-against your firmware — capability and option names are the firm part):
+against your firmware — capability and option names are the firm part).
+Substitute `$TMKMS_AUTH_PASSWORD` for `<tmkms-auth-password>`:
 
 ```sh
 yubihsm-shell
@@ -254,12 +265,13 @@ The two things to never grant the signer's auth key: `export-wrapped` and
 `sign-attestation-certificate`. The first turns a leaked credential into
 key theft; the second lets it produce attestations you didn't intend.
 
-Put the tmkms auth password in a file, not the config:
+Store that same password in a file, not the config:
 
 ```sh
-printf '%s' '<tmkms-auth-password>' | sudo tee /etc/tmkms/yubihsm-password >/dev/null
+printf '%s' "$TMKMS_AUTH_PASSWORD" | sudo tee /etc/tmkms/yubihsm-password >/dev/null
 sudo chown tmkms:tmkms /etc/tmkms/yubihsm-password
 sudo chmod 600 /etc/tmkms/yubihsm-password
+unset TMKMS_AUTH_PASSWORD   # drop it from the shell once it's in the file
 ```
 
 ## B.2 Generate gnoland's node + listener identity
@@ -353,24 +365,27 @@ sudo chown tmkms:tmkms /var/lib/tmkms/secrets/kms-identity.key
 echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy for B.6
 ```
 
-## B.3 Read the consensus pubkey out of the HSM and seed genesis
+## B.3 Read the consensus pubkey out of the HSM and register the validator
 
 Because the key never leaves the HSM, you can't push it into genesis —
-you read the **public** half out of tmkms and build genesis around it.
-Start tmkms once (with the `tmkms.toml` from B.5) and it logs the
-device's consensus pubkey on connect:
+you read the **public** half out of tmkms and register *that* as your
+validator identity. Start tmkms once (with the `tmkms.toml` from B.4) and
+it logs the device's consensus pubkey on connect:
 
 ```
 [keyring:yubihsm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
 ```
 
-Convert that hex pubkey to gno's `gpub1…` / `g1…` forms (run from the gno
-repo root so the imports resolve):
+The hex string above is an **example** — copy the one *your* device logs.
+
+Convert that hex pubkey to gno's `gpub1…` / `g1…` forms with this helper.
+Write the file, then run it **from the gno repo root** (so the
+`github.com/gnolang/gno/...` imports resolve):
 
 ```sh
 cat > pkconv.go <<'GO'
 // Converts a raw ed25519 consensus pubkey (hex or base64) to gno's
-// gpub1… / g1… forms. Run from the gno repo root: go run ./pkconv.go <hex>
+// gpub1… / g1… forms.
 package main
 
 import (
@@ -402,14 +417,29 @@ func main() {
 }
 GO
 
+# pass the hex YOUR device logged (the value below is just an example):
 go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
 # gpub:    gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z...
 # address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
 ```
 
-Then build genesis explicitly with `gnogenesis` (do **not** use
-`gnoland start -lazy` here — it would mint a throwaway local key and seed
-genesis with *that* instead of your HSM key):
+That `gpub1…` / `g1…` pair is your validator's public identity. What you
+do with it depends on whether you are joining a chain or bootstrapping
+one:
+
+**Joining an existing chain (the production case).** You do **not**
+generate genesis — the chain already exists. Submit your `gpub1…` pubkey
+and `g1…` address to that chain's validator-onboarding path (its staking
+/ governance process, or the genesis coordinator if it hasn't launched
+yet) to be added to the validator set. The pubkey→address relationship is
+your integrity check: whoever registers you can confirm the address is
+the hash of the pubkey. Keep the pair; you'll confirm gnoland signs with
+this address in B.7. Then skip to [B.4](#b4-write-tmkmstoml).
+
+**Bootstrapping your own chain (test / private networks).** Build genesis
+explicitly with `gnogenesis`, seeding it with the HSM pubkey. Do **not**
+use `gnoland start -lazy` here — it would mint a throwaway local key and
+seed genesis with *that* instead of your HSM key:
 
 ```sh
 gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
@@ -422,9 +452,8 @@ gnogenesis validator add \
 ```
 
 `validator add` checks that the pubkey hashes to the address, so a
-copy-paste slip is caught right here — which also doubles as your
-out-of-band confirmation that the pubkey the HSM reported is the one
-going into genesis.
+copy-paste slip is caught right here — the same integrity check the
+onboarding path performs in the production case.
 
 ## B.4 Write `tmkms.toml`
 
@@ -524,7 +553,9 @@ listening). Run each under its own user — for example with systemd units
 # signer (as the tmkms user)
 sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
 
-# validator (as the gnoland user) — genesis already built in B.3, so NO -lazy
+# validator (as the gnoland user) — point -genesis at the network's
+# genesis.json (the chain you're joining, or the one you built in B.3);
+# either way NO -lazy, since you're not minting a local key.
 sudo -u gnoland gnoland start \
   -data-dir /var/lib/gnoland \
   -genesis /var/lib/gnoland/genesis.json \

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -1,117 +1,284 @@
-# gnoland + tmkms: end-to-end setup
+# gnoland + tmkms: secure setup
 
-A hands-on, copy-paste walkthrough that stands up a single-host gnoland
-validator whose consensus key is held by [tmkms] instead of sitting on
-the node. It takes you from an empty directory to a node producing
-blocks that are signed remotely by tmkms.
+A step-by-step guide to standing up a gnoland validator whose consensus
+key is held by [tmkms] instead of living on the node — and configuring
+both the host and tmkms so that the failure modes a security review of
+tmkms surfaced are closed *before* they can bite you.
 
-This is the practical companion to [tmkms.md](tmkms.md) — read that for
-the architecture, the security model, and the production checklist. This
-page is the "just make it work once" path.
+The review of tmkms 0.15.0 catalogued dozens of findings; the large
+majority of them are not code bugs you can hit by accident but
+**operational footguns** — bad defaults, convenience commands that leak
+secrets, missing permission checks — every one of which is neutralised by
+provisioning and configuring the system correctly. This guide bakes that
+hardening in. Where a residual *code-level* risk remains (there is
+essentially one that matters: state-file durability on power loss), it is
+called out at the exact step where it applies.
 
 [tmkms]: https://github.com/iqlusioninc/tmkms
 
-> **Single host, softsign, for learning.** This walkthrough runs tmkms
-> and gnoland on the same machine with tmkms's file-based `softsign`
-> backend. That is fine for understanding the wiring and for testnets,
-> but it is **not** a production layout — the consensus key still touches
-> the validator host's disk. For real stake, move tmkms to its own host
-> with an HSM/Ledger/cloud-KMS backend. See
-> [tmkms.md § When to use this mode](tmkms.md#when-to-use-this-mode).
+## How to read this guide
 
-## How the pieces connect
+It is ordered by what you should actually run for real stake first, and
+descends toward test/lab setups:
 
-```
-  gnoland (validator)                 tmkms (signer)
-  ───────────────────                 ──────────────
-  listens on :26659  ◄────dials in──── [[validator]] addr = tcp://<peer_id>@…:26659
-  allowed_kms_pubkeys ─ verifies ────► kms-identity.key   (SecretConnection identity)
-  node_id (peer ID)  ◄─ verifies ───── <peer_id> pinned in addr
-  genesis validator  = consensus pubkey = consensus.key   (the key that signs votes)
-  chain_id           ══════ must match ══════ [[chain]].id / [[validator]].chain_id
-```
+- **[Part A — Host hardening](#part-a--host-hardening-do-this-first-for-every-backend)** —
+  the OS-level groundwork (dedicated user, locked-down directories,
+  transport choice). Do this regardless of which signer backend you pick.
+- **[Part B — Production with a YubiHSM](#part-b--production-validator-with-a-yubihsm-recommended)** —
+  the recommended production path. The consensus key is generated inside
+  the HSM and **never exists outside it**.
+- **[Part C — Testnet/lab with softsign](#part-c--testnetlab-with-softsign-key-on-disk)** —
+  the file-based backend. Simple, but the key touches disk: testnets and
+  learning only.
+- **[Part D — Ledger hardware signer](#part-d--advanced-ledger-hardware-signer)** —
+  a hardware key for advanced/low-stake setups without HSM-grade failover.
+- **[Part E — Prove it](#part-e--prove-it-with-the-repos-automated-test)** and the
+  **[checklist](#secure-setup-checklist)**.
 
-The connection is **mutually** authenticated: gnoland verifies tmkms via
-`allowed_kms_pubkeys`, and tmkms verifies gnoland via the `<peer_id>`
-pinned in its `addr`. Both directions are mandatory here.
+> **What is verified vs. derived.** The gnoland side of every path here —
+> the listener, the allowlist, the peer-ID pin, the `v0.34` protocol pin,
+> and signing through tmkms — is exercised end-to-end by the repo's
+> real-tmkms integration test, with **softsign** and a **Ledger** as the
+> backends (see [Part E](#part-e--prove-it-with-the-repos-automated-test)).
+> The **YubiHSM** provisioning and provider config in Part B are derived
+> from the tmkms security review, the tmkms source, and YubiHSM's own
+> documentation; they need the physical device to exercise. Treat the
+> exact `yubihsm-shell` / TOML tokens as a recipe to verify against your
+> firmware and tmkms version — but the *security policy* they encode
+> (non-exportable key, audit log on, minimal capabilities) is firm.
+
+See [tmkms.md](tmkms.md) for the architecture, the threat model, and the
+operational checklist this guide is the hands-on companion to.
+
+## The security model in one paragraph
+
+The connection between gnoland and tmkms is **mutually authenticated**,
+and the defining property of this mode is that **tmkms dials gnoland** —
+gnoland listens, tmkms connects in. gnoland verifies it is talking to
+*your* signer (not an impostor) and tmkms verifies it is talking to
+*your* validator (not an attacker's listener). How that mutual check is
+enforced depends on the transport, and getting it right is the single
+most important configuration decision — see
+[Part A.3](#a3-choose-the-transport-unix-socket-or-firewalled-tcp).
 
 Three distinct ed25519 keys are in play — don't mix them up:
 
 | Key | Lives in | Role |
 |---|---|---|
-| **consensus key** | tmkms `consensus.key` (softsign) | signs votes/proposals; its pubkey is the validator's identity in genesis |
-| **kms-identity key** | tmkms `kms-identity.key` | tmkms's SecretConnection identity; its pubkey goes in gnoland's `allowed_kms_pubkeys` |
-| **node key** | gnoland `node_key.json` | gnoland's SecretConnection identity; its peer ID (hex) is pinned in tmkms's `addr` |
+| **consensus key** | the signer (YubiHSM / Ledger / softsign file) | signs votes & proposals; its pubkey is the validator's identity in genesis |
+| **kms-identity key** | tmkms `kms-identity.key` | tmkms's SecretConnection identity; its pubkey goes in gnoland's `allowed_kms_pubkeys` (TCP only) |
+| **node key** | gnoland `node_key.json` | gnoland's SecretConnection identity; its peer ID (hex) is pinned in tmkms's `addr` (TCP only) |
 
-The defining property of this mode: **tmkms dials gnoland**, not the
-other way around. gnoland listens; tmkms connects in.
-
-## 0. Prerequisites
-
-- **Go** (to build `gnoland`).
-- **Rust / cargo** (to install tmkms).
-- **tmkms 0.15.0 built with the `softsign` feature.** The default
-  release does *not* include softsign — install it explicitly:
-
-  ```sh
-  cargo install tmkms --version 0.15.0 --features softsign --locked
-  tmkms version   # → 0.15.0
-  ```
-
-- **`gnoland`** built from this repo:
-
-  ```sh
-  # from the repo root
-  go build -o ./build/gnoland ./gno.land/cmd/gnoland
-  ```
-
-Pick a working directory and a chain ID you'll reuse everywhere:
+The `chain_id` must be **identical** everywhere — the gnoland genesis,
+gnoland's `tmkms_listener.chain_id`, and tmkms's `[[chain]].id` /
+`[[validator]].chain_id`. If they drift, tmkms refuses to sign. Pick it
+once and reuse it:
 
 ```sh
-export WORK=~/gno-tmkms-lab
-export CHAIN_ID=gno-tmkms-test
-export GNOLAND=$(pwd)/build/gnoland   # absolute path to the binary you just built
-
-mkdir -p "$WORK"/gnoland-data/secrets "$WORK"/tmkms/secrets
-cd "$WORK"
+export CHAIN_ID=gno-tmkms-prod
 ```
 
-> The `chain_id` must be **identical** in three places: the gnoland
-> genesis (`-chainid`), the `tmkms_listener.chain_id` in `config.toml`,
-> and the `[[chain]].id` / `[[validator]].chain_id` in `tmkms.toml`. If
-> they drift, tmkms refuses to sign or the signatures won't verify.
+---
 
-## 1. Generate the gnoland node secrets
+# Part A — Host hardening (do this first, for every backend)
 
-This creates the consensus key, the node's p2p key, and the sign-state
-file:
+These steps apply whether you end up on a YubiHSM, a Ledger, or softsign.
+tmkms does **not** enforce file permissions on its own key, state, or
+config files (it accepts world-readable secrets silently), so the OS must
+enforce them for it.
+
+## A.1 Run tmkms as its own locked-down user
+
+Never run the signer as root or as your login user. A dedicated system
+account with no shell and no home limits what a compromised tmkms process
+— or anyone who later reads its files — can reach.
 
 ```sh
-"$GNOLAND" secrets init -data-dir ./gnoland-data/secrets
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin tmkms
 ```
 
-You now have `gnoland-data/secrets/priv_validator_key.json` (the
-consensus key), `node_key.json` (p2p identity), and
-`priv_validator_state.json`.
+If gnoland and tmkms share a host, run gnoland as its own user too (e.g.
+`gnoland`). Two unprivileged users that can only meet over a single
+tightly-permissioned socket is the local isolation you want.
 
-> In tmkms mode gnoland does **not** use `priv_validator_key.json` to
-> sign at runtime — tmkms does. But gnoland *does* read it once, at
-> genesis-generation time, to learn the validator's pubkey. So the
-> consensus key in this file and the key you load into tmkms (next step)
-> **must be the same key**. We achieve that by exporting this one into
-> tmkms rather than generating a second one.
+## A.2 Lay out directories with strict permissions
 
-Note the validator address — you'll confirm it matches the genesis later:
+tmkms's secrets and its state file are the crown jewels. The state file
+in particular is the **double-sign gate** — losing or rolling it back is
+the one thing that can get you slashed. Give them a private home:
 
 ```sh
-"$GNOLAND" secrets get -data-dir ./gnoland-data/secrets validator_key
+sudo install -d -o tmkms -g tmkms -m 700 /etc/tmkms          # config
+sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms       # state + identity key
+sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms/secrets
 ```
 
-You also need the node's **peer ID** in hex — tmkms uses it to verify it
-is talking to *your* validator and not an impostor on the listen port
-(step 4 pins it). gnoland's `secrets get node_id` reports this identity
-in bech32 (`g1…`); tmkms wants the same 20 bytes in hex. This tiny
-stdlib-only Go helper reads `node_key.json` and prints the hex form:
+Rules that close whole classes of findings at once:
+
+- **Every secret and the state file is `0600`, owned by `tmkms`.** A
+  world- or group-readable consensus key, identity key, or YubiHSM
+  password is game over; tmkms won't warn you, so enforce it yourself.
+- **Use absolute paths everywhere** in `tmkms.toml`. tmkms resolves some
+  paths (notably the default state-file path) relative to its *current
+  working directory*; an absolute path removes any ambiguity about which
+  state file is the authoritative one and stops a stray relative path
+  from silently creating a fresh, height-zero state.
+- **Never put a password inline** in `tmkms.toml`. Use a separate
+  `password_file` (Part B.5), itself `0600`, so the config can be read
+  for debugging without exposing the credential.
+
+## A.3 Choose the transport: Unix socket or firewalled TCP
+
+This is where mutual authentication actually lives. Two valid layouts,
+each with a *different* auth boundary — pick deliberately:
+
+### Same host → Unix-domain socket (auth by filesystem)
+
+If tmkms and gnoland run on the same machine, prefer a Unix socket.
+gnoland creates it and `chmod`s it to `0600`, so only gnoland's user owns
+it; place it in a directory only the tmkms and gnoland users can traverse:
+
+```sh
+sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland
+# gnoland will create /run/gnoland/privval.sock at 0600
+```
+
+> **Important:** over a Unix socket the `allowed_kms_pubkeys` allowlist is
+> **not** the gate — gnoland cannot crypto-verify a UDS peer against it.
+> *Filesystem permissions are the entire authentication boundary.* That
+> is exactly why the socket directory and node-user separation in A.1–A.2
+> matter: anyone who can open that socket becomes the signer. You still
+> set the allowlist (gnoland requires a non-empty one), but on UDS it is
+> belt-and-suspenders, not the lock.
+
+### Separate hosts → TCP, firewalled (auth by cryptography)
+
+For real stake, run the signer on its **own host**. Then the auth
+boundary is cryptographic and works across the network:
+
+- gnoland verifies tmkms via `allowed_kms_pubkeys` (the signer's pubkey).
+- tmkms verifies gnoland via the **peer ID pinned in its `addr`**.
+
+Both are mandatory. Then firewall the listen port so that **only the
+signer host** can reach it — the crypto is the lock, the firewall keeps
+strangers from even knocking (and from using your validator as a free
+oracle to probe):
+
+```sh
+# allow only the signer host to reach the privval port; deny the rest
+sudo ufw allow from <SIGNER_HOST_IP> to any port 26659 proto tcp
+sudo ufw deny 26659/tcp
+```
+
+Bind gnoland's listener to the specific reachable interface, not a
+wildcard, when you can.
+
+The rest of this guide uses placeholders you can set to match your
+choice. For a same-host UDS layout:
+
+```sh
+export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"   # gnoland listens here
+export TMKMS_ADDR="unix:///run/gnoland/privval.sock"       # tmkms dials here (no peer-ID on UDS)
+```
+
+For a two-host TCP layout (note the **mandatory** `<peer_id>@` prefix in
+the tmkms address — filled in at B.3):
+
+```sh
+export PRIVVAL_LISTEN="tcp://<validator_interface_ip>:26659"
+# TMKMS_ADDR set in B.5 once the peer ID is known: tcp://<peer_id>@<validator_ip>:26659
+```
+
+---
+
+# Part B — Production validator with a YubiHSM (recommended)
+
+A YubiHSM holds the consensus key inside tamper-resistant hardware and,
+provisioned correctly, **never lets it out** — not even to its own
+operator. That single property removes the entire "key stolen off disk /
+exported silently" class of risk that softsign cannot. The catch is that
+tmkms's *convenience* tooling around the YubiHSM is where the review found
+its sharpest edges, so the rule for this section is: **provision the
+device by hand, and never run the automated setup or test commands
+against a production key.**
+
+## B.1 Provision the YubiHSM by hand — never `tmkms yubihsm setup`
+
+> **Do not run `tmkms yubihsm setup`.** That command prints the recovery
+> mnemonic, the wrap key, and the auth passwords to standard output
+> (captured by every terminal logger and scrollback), and it provisions
+> roles with key-export capability. Provision with `yubihsm-shell`
+> instead, so the secrets never leave your control.
+
+Work on an **offline** machine. The high-level policy you are encoding —
+and which the rest follows from — is:
+
+1. **Generate the consensus key inside the device** (or import it once and
+   destroy the source). It must **not** carry the `exportable-under-wrap`
+   capability. A non-exportable key cannot be wrapped out, so a stolen
+   credential later cannot exfiltrate it.
+2. **The auth key tmkms uses to log in gets `sign-eddsa` only.** No
+   `export-wrapped`, no `sign-attestation-certificate`, no broad
+   delegated capabilities. If that credential leaks, it can ask for
+   signatures (which the firewall + state machine still gate) but cannot
+   extract or clone the key.
+3. **Turn the audit log on and force it.** The device ships with auditing
+   off; with it forced on, the HSM records every operation and refuses to
+   sign once its log buffer fills — so an attempted misuse leaves a trail
+   and cannot run unbounded.
+4. **Store the recovery seed offline, on paper, in a safe.** Never on the
+   validator host.
+
+A representative `yubihsm-shell` session (verify the exact token spelling
+against your firmware — capability and option names are the firm part):
+
+```sh
+yubihsm-shell
+# connect
+# session open 1 <default-or-changed-admin-password>
+
+# Force the audit log on (records every op; refuses to sign when full):
+# put option 0 force-audit 01
+
+# Generate a NON-exportable ed25519 consensus key (note: no
+# 'exportable-under-wrap' in the capability list):
+# generate asymmetric 0 100 "gno-consensus" 1 sign-eddsa ed25519
+
+# Create the auth key tmkms will use — sign-eddsa ONLY, no export:
+# put authkey 0 2 "tmkms-signer" 1 sign-eddsa sign-eddsa <tmkms-auth-password>
+
+# Replace/disable the default admin auth key (id 1) afterwards.
+```
+
+The two things to never grant the signer's auth key: `export-wrapped` and
+`sign-attestation-certificate`. The first turns a leaked credential into
+key theft; the second lets it produce attestations you didn't intend.
+
+Put the tmkms auth password in a file, not the config:
+
+```sh
+printf '%s' '<tmkms-auth-password>' | sudo tee /etc/tmkms/yubihsm-password >/dev/null
+sudo chown tmkms:tmkms /etc/tmkms/yubihsm-password
+sudo chmod 600 /etc/tmkms/yubihsm-password
+```
+
+## B.2 Generate gnoland's node + listener identity
+
+The consensus key lives in the HSM, but gnoland still needs its own node
+identity (the peer ID that tmkms pins on TCP), and tmkms needs a
+SecretConnection identity key. Generate the gnoland node secrets:
+
+```sh
+gnoland secrets init -data-dir /var/lib/gnoland/secrets
+```
+
+In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
+— tmkms signs. Only `node_key.json` (the peer ID) matters here.
+
+**Peer ID in hex (TCP layouts).** tmkms pins your validator's peer ID to
+make sure it signs for *your* node and not whoever answers on the port.
+gnoland reports the identity in bech32 (`g1…`); tmkms wants the same 20
+bytes in hex. This stdlib-only helper converts it:
 
 ```sh
 cat > nodeid-hex.go <<'GO'
@@ -148,33 +315,12 @@ func main() {
 }
 GO
 
-export VALIDATOR_PEER_ID=$(go run ./nodeid-hex.go ./gnoland-data/secrets/node_key.json)
-echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in step 4
+export VALIDATOR_PEER_ID=$(go run ./nodeid-hex.go /var/lib/gnoland/secrets/node_key.json)
+echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in B.5 (TCP)
 ```
 
-## 2. Export the consensus key into tmkms's softsign format
-
-gnoland stores the ed25519 private key as base64 of the 64-byte
-`seed‖pubkey`. tmkms softsign wants base64 of just the 32-byte **seed**.
-Slice off the first 32 bytes and re-encode:
-
-```sh
-python3 - <<'PY' > ./tmkms/secrets/consensus.key
-import json, base64
-v = json.load(open("gnoland-data/secrets/priv_validator_key.json"))["priv_key"]["value"]
-print(base64.b64encode(base64.b64decode(v)[:32]).decode(), end="")
-PY
-chmod 600 ./tmkms/secrets/consensus.key
-```
-
-(No crypto involved — it's a byte reslice — so plain `python3` is enough.)
-
-## 3. Generate tmkms's SecretConnection identity key
-
-tmkms needs its own identity key to authenticate the inbound connection.
-gnoland will only accept the connection if this key's **public** half is
-in `allowed_kms_pubkeys`. Generate the key and print its hex pubkey with
-this tiny Go helper:
+**tmkms's SecretConnection identity (TCP layouts).** gnoland only accepts
+the connection if this key's public half is in `allowed_kms_pubkeys`:
 
 ```sh
 cat > tmkms-identity-keygen.go <<'GO'
@@ -195,289 +341,31 @@ func main() {
 		panic(err)
 	}
 	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
-	// tmkms softsign connection key = base64 of the 32-byte seed.
 	if err := os.WriteFile(os.Args[1], []byte(base64.StdEncoding.EncodeToString(seed)), 0o600); err != nil {
 		panic(err)
 	}
-	// Hex pubkey for gnoland's allowed_kms_pubkeys.
-	fmt.Println("ed25519:" + hex.EncodeToString(pub))
+	fmt.Println("ed25519:" + hex.EncodeToString(pub)) // for gnoland's allowed_kms_pubkeys
 }
 GO
 
-ALLOW=$(go run ./tmkms-identity-keygen.go ./tmkms/secrets/kms-identity.key)
-echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy this for step 5
+ALLOW=$(go run ./tmkms-identity-keygen.go /var/lib/tmkms/secrets/kms-identity.key)
+sudo chown tmkms:tmkms /var/lib/tmkms/secrets/kms-identity.key
+echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy for B.6
 ```
 
-## 4. Write `tmkms.toml`
+## B.3 Read the consensus pubkey out of the HSM and seed genesis
 
-This is the format verified by the repo's real-tmkms integration test
-(`tm2/pkg/bft/privval/upstream/tmkms_integration_test.go`). Note
-`protocol_version = "v0.34"` — gnoland only speaks that dialect and
-refuses to start otherwise.
+Because the key never leaves the HSM, you can't push it into genesis —
+you read the **public** half out of tmkms and build genesis around it.
+Start tmkms once (with the `tmkms.toml` from B.5) and it logs the
+device's consensus pubkey on connect:
 
-```sh
-cat > ./tmkms/tmkms.toml <<TOML
-[[chain]]
-id = "${CHAIN_ID}"
-key_format = { type = "hex" }
-state_file = "$(pwd)/tmkms/secrets/consensus_state.json"
-
-[[providers.softsign]]
-chain_ids = ["${CHAIN_ID}"]
-key_type = "consensus"
-key_format = "base64"
-path = "$(pwd)/tmkms/secrets/consensus.key"
-
-[[validator]]
-chain_id = "${CHAIN_ID}"
-addr = "tcp://${VALIDATOR_PEER_ID}@127.0.0.1:26659"
-secret_key = "$(pwd)/tmkms/secrets/kms-identity.key"
-protocol_version = "v0.34"
-reconnect = true
-TOML
+```
+[keyring:yubihsm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
 ```
 
-- `addr` is where gnoland is listening (step 6), with the
-  **validator peer ID from step 1 pinned in front** (`<peer_id>@host:port`,
-  Tendermint-style). This is **required**, not cosmetic — it is the
-  mirror of gnoland's `allowed_kms_pubkeys`, and it makes the
-  authentication mutual:
-
-  | Direction | Authenticated by |
-  |---|---|
-  | gnoland verifies tmkms | `allowed_kms_pubkeys` (step 5) |
-  | tmkms verifies gnoland | the peer ID pinned in `addr` (here) |
-
-  Omit the `<peer_id>@` prefix and tmkms will sign for *whoever* answers
-  on the port and log `unverified validator peer ID!` on every
-  connection. On a single host `127.0.0.1` is fine; across hosts use the
-  validator's reachable IP (the peer ID stays the same).
-- `state_file` is tmkms's `consensus.json` — the authoritative
-  double-sign (HRS) gate. tmkms creates it on first run. **Never restore
-  a stale copy of it.**
-- `reconnect = true` makes tmkms keep retrying the dial, so you can
-  start it before or after gnoland.
-
-> tmkms 0.15.0 prints `deprecated protocol_version v0.34 (update to
-> v0.38)! Will be a hard error in next release` on startup. That's
-> expected: gnoland speaks **only** v0.34 today (see
-> [tmkms.md § Protocol version pin](tmkms.md#protocol-version-pin)), so
-> stay on a tmkms release that still supports v0.34 — 0.15.0 does.
-
-## 5. Configure gnoland for tmkms mode
-
-Create a default `config.toml`, then point the `tmkms_listener` block at
-tmkms.
-
-```sh
-CFG=./gnoland-data/config/config.toml
-"$GNOLAND" config init -config-path "$CFG"
-```
-
-> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
-> block on every write, and a non-empty `listen_addr` is what *enables*
-> validation of the other fields. So set `listen_addr` **last** — if you
-> set it first, the write is rejected because `chain_id` is still empty,
-> and it silently stays unset.
-
-```sh
-"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
-"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
-"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
-# listen_addr LAST — this enables the mode:
-"$GNOLAND" config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "tcp://0.0.0.0:26659"
-```
-
-Verify it stuck:
-
-```sh
-"$GNOLAND" config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
-```
-
-`listen_addr` should be `tcp://0.0.0.0:26659` and not empty.
-
-## 6. Start tmkms, then gnoland
-
-**Order matters.** gnoland blocks at startup for up to
-`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in,
-and it needs that connection during its own startup. Start tmkms first.
-
-Terminal 1 — tmkms:
-
-```sh
-tmkms start -c ./tmkms/tmkms.toml
-```
-
-You should see it load the softsign provider and (once gnoland is up)
-complete the SecretConnection handshake. With `reconnect = true` it logs
-connection-refused retries until gnoland is listening — that's expected.
-
-Terminal 2 — gnoland:
-
-```sh
-"$GNOLAND" start \
-  -data-dir ./gnoland-data \
-  -genesis ./gnoland-data/genesis.json \
-  -chainid "$CHAIN_ID" \
-  -lazy \
-  -skip-genesis-sig-verification
-```
-
-- `-genesis ./gnoland-data/genesis.json` keeps the generated genesis
-  alongside the rest of the node state. Without it, `genesis.json` is
-  written to your **current working directory**.
-- `-skip-genesis-sig-verification` is needed because the default
-  `-lazy` genesis includes example deploy txs signed by test accounts;
-  without this flag the node panics replaying them at boot. It has
-  nothing to do with tmkms — it's the standard dev-genesis flag (the
-  same one in the gnoland README quick-start).
-
-What `-lazy` does here, in order:
-
-1. Keeps your existing `config.toml` and `secrets/` (it only generates
-   files that are missing — it will **not** clobber your tmkms config).
-2. Generates `genesis.json`, reading the **local** consensus pubkey from
-   `priv_validator_key.json` to register this node as the genesis
-   validator. (This is why the exported key in step 2 must match.)
-3. Boots the node. The privval stack now uses the tmkms listener: it
-   waits for tmkms's dial-in, fetches the pubkey over the link, and from
-   then on every vote/proposal is signed by tmkms.
-
-## 7. Verify it's really tmkms signing
-
-Within a few seconds you should see the node advancing through heights.
-
-- **tmkms log**: `connected to validator successfully`, then ongoing
-  sign activity. That's the signer doing the work.
-- **gnoland log**: `Signed and pushed vote …`, `Finalizing commit of
-  block`, and `Committed state … height=N` climbing. If signing were
-  broken the node would stall at height 1 instead of advancing.
-
-  ```sh
-  grep "Committed state" ./gnoland.log | tail
-  ```
-
-- **Identity check** — the validator address gnoland signs with must be
-  the address from step 1:
-
-  ```sh
-  "$GNOLAND" secrets get -data-dir ./gnoland-data/secrets validator_key
-  # the "address" must match the `validator address` in the
-  # "Signed and pushed vote" log lines, and the validator entry in
-  # ./gnoland-data/genesis.json
-  ```
-
-- **Mutual auth holds** — tmkms logs clean
-  `signed Proposal/Prevote/Precommit …` lines and **no**
-  `unverified validator peer ID!` warning. If you do see that warning,
-  the peer ID pinned in `tmkms.toml`'s `addr` (step 4) is missing or
-  wrong — tmkms prints the value it expected in the parentheses, so
-  compare it against `$VALIDATOR_PEER_ID` from step 1.
-
-- **Kill tmkms** and watch gnoland stop committing blocks (the height
-  stops climbing; the log shows the signer connection dropping). Restart
-  tmkms and it resumes. That's the clearest proof the key lives in
-  tmkms, not gnoland.
-
-> **Benign log noise.** Even when signing works, gnoland periodically
-> logs `SignerListener: accept failed … i/o timeout` and `already
-> connected, dropping listen request`. The endpoint holds one live
-> signer connection and these are the idle re-accept attempts timing
-> out; they don't interrupt signing. Watch the committed height, not
-> these lines.
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| tmkms: `unknown field 'softsign', expected 'ledgertm'` | tmkms built without the softsign feature | Reinstall: `cargo install tmkms --version 0.15.0 --features softsign --locked` |
-| gnoland: `tmkms_listener.allowed_kms_pubkeys must not be empty` | allowlist not set, or `listen_addr` was set before the other fields | Set the four fields with `listen_addr` **last** (step 5) |
-| gnoland exits after ~60s waiting for connection | tmkms isn't running, can't reach `addr`, or its pubkey isn't in the allowlist | Start tmkms first; check `addr` matches `listen_addr`; confirm the hex in `allowed_kms_pubkeys` is the one printed in step 3 |
-| gnoland: `protocol_version` rejected at startup | a value other than `v0.34` | Use `v0.34` on both sides |
-| gnoland panics at boot: `PubKey does not match Signer address … InvalidPubKeyError` | default `-lazy` genesis has example txs signed by test accounts | Add `-skip-genesis-sig-verification` (step 6) — unrelated to tmkms |
-| Node never advances past height 1, no signing in tmkms log | `chain_id` mismatch between genesis, `config.toml`, and `tmkms.toml` | Make all three identical and restart |
-| Signatures produced but rejected by the chain | consensus key in tmkms ≠ genesis validator key | Re-export in step 2 from the *same* `priv_validator_key.json` used for genesis |
-| gnoland logs `accept failed: i/o timeout` / `already connected, dropping listen request` while still committing blocks | benign idle re-accept attempts on the held connection | Ignore — confirm the committed height is climbing |
-| tmkms: `unverified validator peer ID! (<hex>)` | the peer ID prefix is missing from `tmkms.toml`'s `addr`, so tmkms signs for whoever answers on the port | Pin it: `addr = "tcp://<hex>@host:port"` using `$VALIDATOR_PEER_ID` from step 1 (step 4) |
-| tmkms (Ledger): startup `SigningError` / can't get pubkey | device locked, asleep, or not on the Tendermint Validator app | Unlock the Ledger and open the **Tendermint Validator** app, then restart tmkms (L0) |
-| gnoland (Ledger): boots but `This node is NOT a validator`, height stuck at 0 | the `gpub`/address in genesis doesn't match the device key | Re-read the hex from tmkms's `added consensus Ed25519 key` log (L2), re-run `pkconv.go` (L3), rebuild genesis (L4) |
-
-## Variant: a Ledger hardware signer instead of softsign
-
-softsign keeps the consensus key in a file — fine for a lab, but the
-key still touches disk. A Ledger holds the key **on the device** and
-never exports it. That single fact flips the bootstrap around:
-
-> With softsign you generated the key in gnoland and *pushed it into*
-> the signer (step 2). With a Ledger you can't — the private key never
-> leaves the device. So you go the other way: read the **public** key
-> *out of* the Ledger and seed the genesis validator from it.
-
-Everything about the connection (listener, allowlist, peer-ID pin,
-`protocol_version`, `chain_id`) is identical. Only the key custody and
-the genesis-bootstrap change.
-
-> **Scope note.** The gno-side of this flow — converting the device
-> pubkey, seeding genesis with it, and signing through the tmkms
-> listener — is verified end-to-end. The physical-device half (the
-> `ledgertm` provider talking to a real Ledger) is described from the
-> tmkms source and the Ledger app; it needs the hardware to exercise.
-> A Ledger is also a single signer with no failover — for real
-> high-availability use Horcrux or an HSM (see [tmkms.md](tmkms.md)).
-
-### L0. Prerequisites
-
-- tmkms built with the **`ledgertm`** provider. It's in the default
-  build (`cargo install tmkms` with no `--features` gives you exactly
-  `ledgertm`); to keep softsign too, build
-  `--features ledgertm,softsign`.
-- A Ledger with the **"Tendermint Validator"** app installed (the
-  dedicated ed25519 consensus-signing app — *not* the regular Cosmos
-  app), plugged in, unlocked, with that app **open**. tmkms can't reach
-  a locked device or a different app.
-
-### L1. Point tmkms at the Ledger
-
-Same `tmkms.toml` as step 4, but replace the `[[providers.softsign]]`
-block with a `[[providers.ledgertm]]` block — no key files, no paths:
-
-```toml
-[[chain]]
-id = "${CHAIN_ID}"
-key_format = { type = "hex" }       # makes tmkms log the pubkey in hex (L2)
-state_file = "/abs/path/tmkms/secrets/consensus_state.json"
-
-[[providers.ledgertm]]
-chain_ids = ["${CHAIN_ID}"]
-
-[[validator]]
-chain_id = "${CHAIN_ID}"
-addr = "tcp://${VALIDATOR_PEER_ID}@127.0.0.1:26659"   # peer-ID pin from step 1
-secret_key = "/abs/path/tmkms/secrets/kms-identity.key"
-protocol_version = "v0.34"
-reconnect = true
-```
-
-Only one `[[providers.ledgertm]]` is allowed, and it always signs the
-**consensus** key.
-
-### L2. Read the consensus pubkey out of the Ledger
-
-Start tmkms alone. On connect it logs the device's consensus pubkey —
-in hex, because of `key_format = { type = "hex" }`:
-
-```sh
-tmkms start -c ./tmkms/tmkms.toml
-# [keyring:ledgertm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
-```
-
-Copy that hex string — it's your validator's consensus public key.
-
-### L3. Convert the hex pubkey to gno format
-
-gnoland's genesis wants the pubkey as a `gpub1…` bech32 and the matching
-`g1…` address. This stdlib-plus-gno-crypto helper converts the hex (run
-it **from the gno repo root** so the imports resolve):
+Convert that hex pubkey to gno's `gpub1…` / `g1…` forms (run from the gno
+repo root so the imports resolve):
 
 ```sh
 cat > pkconv.go <<'GO'
@@ -519,69 +407,404 @@ go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D
 # address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
 ```
 
-### L4. Seed genesis with the Ledger validator
-
-Because the validator key lives on the device, you **can't** use
-`-lazy` (it would mint a throwaway local key and put *that* in genesis
-instead). Build the genesis explicitly with `gnogenesis`
-(`contribs/gnogenesis`), using the `gpub`/address from L3:
+Then build genesis explicitly with `gnogenesis` (do **not** use
+`gnoland start -lazy` here — it would mint a throwaway local key and seed
+genesis with *that* instead of your HSM key):
 
 ```sh
-gnogenesis generate -chain-id "$CHAIN_ID" -output-path ./gnoland-data/genesis.json
+gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
 gnogenesis validator add \
-  -genesis-path ./gnoland-data/genesis.json \
+  -genesis-path /var/lib/gnoland/genesis.json \
   -address  g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4 \
   -pub-key  gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z... \
-  -name     ledgervalidator \
+  -name     hsm-validator \
   -power    10
 ```
 
 `validator add` checks that the pubkey hashes to the address, so a
-copy-paste slip is caught here.
+copy-paste slip is caught right here — which also doubles as your
+out-of-band confirmation that the pubkey the HSM reported is the one
+going into genesis.
 
-You still need gnoland's node secrets for the **listener identity** —
-run `secrets init` (step 1) as usual. Its `priv_validator_key.json` is
-ignored for signing in tmkms mode; only `node_key.json` (the peer ID)
-matters.
+## B.4 Write `tmkms.toml`
 
-### L5. Configure gnoland and start (non-lazy)
+Store it at `/etc/tmkms/tmkms.toml`, `0600`, owned by `tmkms`. Absolute
+paths throughout; the password lives in `password_file`, never inline.
 
-Configure `tmkms_listener` exactly as in step 5, then start — with an
-explicit `-genesis` and **no `-lazy`** (the genesis already exists):
+```toml
+[[chain]]
+id = "gno-tmkms-prod"
+key_format = { type = "hex" }                       # logs the pubkey in hex (B.3)
+state_file = "/var/lib/tmkms/secrets/consensus_state.json"   # absolute! the HRS gate
+
+[[providers.yubihsm]]
+adapter = { type = "usb" }                          # or { type = "http", addr = "..." }
+auth = { key = 2, password_file = "/etc/tmkms/yubihsm-password" }
+keys = [{ chain_ids = ["gno-tmkms-prod"], key = 100, type = "consensus" }]
+# serial_number = "0123456789"                       # pin to one physical device
+
+[[validator]]
+chain_id = "gno-tmkms-prod"
+# TCP (separate hosts): the <peer_id>@ prefix is MANDATORY — see below.
+addr = "tcp://243cef06…dcac@<validator_ip>:26659"
+# Same host instead: addr = "unix:///run/gnoland/privval.sock"
+secret_key = "/var/lib/tmkms/secrets/kms-identity.key"
+protocol_version = "v0.34"
+reconnect = true
+```
+
+The fields that carry security weight:
+
+- **`addr` peer-ID pin (TCP).** The `<peer_id>@` prefix is the half of
+  mutual auth that lets tmkms verify gnoland. **Omit it and tmkms will
+  sign for whoever answers on that port** — an on-path attacker becomes a
+  signing oracle — and it only logs `unverified validator peer ID!` while
+  doing so. Always pin `$VALIDATOR_PEER_ID` from B.2. (On a `unix://`
+  socket there is no peer ID; the socket permissions from Part A.3 are the
+  boundary instead.)
+- **`state_file` (absolute).** This is tmkms's authoritative double-sign
+  (height/round/step) gate. It must be an absolute path on durable
+  storage. **Never restore a stale copy of it** — rolling it back to an
+  older height is the classic self-double-sign. See B.7 for the one
+  durability caveat that remains.
+- **`password_file`, not an inline `password`.** Keeps the credential out
+  of the config and out of process listings.
+- **`protocol_version = "v0.34"`.** gnoland speaks only the v0.34 privval
+  dialect and refuses any other value. tmkms 0.15.0 prints a
+  `deprecated protocol_version v0.34 (update to v0.38)!` warning — that is
+  expected; stay on a tmkms release that still supports v0.34. Do **not**
+  drop the field or bump it to v0.38 for gnoland.
+- **No `state_hook`.** tmkms's hook subsystem for regenerating state has
+  sharp edges (its stdout is never captured, so a `fail_closed` hook can
+  silently kill startup). Write/seed the state file directly instead;
+  don't wire a hook.
+
+## B.5 Configure gnoland's tmkms listener
+
+Create a default config, then set the four `tmkms_listener` fields. The
+allowlist must be non-empty — gnoland refuses to enable the mode with an
+empty one, because an empty allowlist means *accept any peer that
+completes a handshake* (fail-open).
 
 ```sh
-# terminal 1: Ledger plugged in, app open
+CFG=/var/lib/gnoland/config/config.toml
+gnoland config init -config-path "$CFG"
+```
+
+> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
+> block on every write, and a non-empty `listen_addr` is what *enables*
+> that validation. Set `listen_addr` **last** — set it first and the
+> write is rejected because `chain_id` is still empty, and it silently
+> stays unset.
+
+```sh
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+# listen_addr LAST — this enables the mode:
+gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+```
+
+Verify it stuck (`listen_addr` should be your `$PRIVVAL_LISTEN`, not
+empty):
+
+```sh
+gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+```
+
+## B.6 Run both as services, in the right order
+
+**Order matters.** gnoland blocks at startup for up to
+`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in.
+Start tmkms first (with `reconnect = true` it will retry until gnoland is
+listening). Run each under its own user — for example with systemd units
+(`User=tmkms` / `User=gnoland`), or manually:
+
+```sh
+# signer (as the tmkms user)
+sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+
+# validator (as the gnoland user) — genesis already built in B.3, so NO -lazy
+sudo -u gnoland gnoland start \
+  -data-dir /var/lib/gnoland \
+  -genesis /var/lib/gnoland/genesis.json \
+  -chainid "$CHAIN_ID"
+```
+
+## B.7 Verify it's really the HSM signing — and keep it that way
+
+Within a few seconds the node should advance through heights.
+
+- **tmkms log:** `connected to validator successfully`, then ongoing
+  `signed Proposal/Prevote/Precommit …`. **No** `unverified validator
+  peer ID!` line — if you see that, the peer-ID pin in `addr` (B.4) is
+  missing or wrong; tmkms prints what it expected, compare to
+  `$VALIDATOR_PEER_ID`.
+- **gnoland log:** `This node is a validator` with the `gpub1…` from B.3,
+  and `Committed state … height=N` climbing.
+- **Identity check:** the validator address in the `Signed and pushed
+  vote` lines must equal the address from B.3 and the genesis entry.
+- **Kill tmkms** and watch gnoland stop committing; restart it and watch
+  it resume. That is the proof the key lives in the HSM, not the node.
+
+> **Benign log noise.** Even when signing works, gnoland periodically
+> logs `SignerListener: accept failed … i/o timeout` and `already
+> connected, dropping listen request`. The endpoint holds one live signer
+> connection and these are idle re-accept attempts timing out. Watch the
+> committed height, not these lines.
+
+**Keep it safe in production:**
+
+- **The one residual code-level risk — state-file durability.** tmkms
+  writes its state file but, in 0.15.0, does not `fsync` it before
+  signing the next block. A hard power loss in that window can roll the
+  on-disk height *backward*, and signing again from the lower height is a
+  double-sign. Mitigate operationally: run the signer host on reliable
+  power (UPS), keep the state file on durable local storage (not a flaky
+  network mount), and **never** restore an old state file after a crash —
+  if you're unsure of its freshness, treat the validator as needing a
+  fresh, carefully-reconciled state rather than a rollback. (A two-line
+  upstream patch adding the `fsync` closes this; track it if you build
+  tmkms yourself.)
+- **Back up the state file** as part of every maintenance procedure — and
+  understand a backup is for disaster recovery of the *latest* state, not
+  a checkpoint to roll back to.
+- **Drain the audit log.** With forced auditing on (B.1) the HSM stops
+  signing once its audit buffer fills, so run a small auditor that reads
+  and clears the log periodically (e.g. every 30s) and ships it off-box.
+- **Never run `tmkms yubihsm test` against the production key.** It is an
+  unbounded signing oracle that bypasses the double-sign state machine
+  entirely. Test only against a throwaway key on a non-production device.
+- **Don't re-run provisioning over a live key.** tmkms's key-write path
+  has no "refuse if exists" guard, so a re-run of an init/keygen can
+  silently overwrite. Provision once; back up before you ever touch it.
+
+---
+
+# Part C — Testnet/lab with softsign (key on disk)
+
+softsign keeps the consensus key in a **file on the validator host**.
+That is fine for understanding the wiring and for testnets, but the key
+touches disk, so this path is **not for real stake** — use Part B for
+that. Everything about the *connection* (Part A transport, allowlist,
+peer-ID pin, `protocol_version`, verification) is identical; only key
+custody and the genesis bootstrap differ.
+
+You still apply Part A: dedicated `tmkms` user, `0600` secrets, locked
+directories, and the same transport choice. The softsign-specific
+hardening on top:
+
+- **`0600` on `consensus.key` and the state file**, owned by `tmkms`. A
+  readable softsign key *is* the validator's private key.
+- **Swap exposure.** tmkms zeroizes the key on drop but does not `mlock`
+  it, so it can be paged to disk. Disable swap on the signer host, or use
+  encrypted swap, if you care about the key never hitting persistent
+  storage in the clear.
+- **Don't re-run `secrets init` / keygen over an existing key file** —
+  it can overwrite without warning. Back up first.
+
+## C.1 Generate node secrets and export the consensus key
+
+Install tmkms with the softsign feature (it is **not** in the default
+build):
+
+```sh
+cargo install tmkms --version 0.15.0 --features softsign --locked
+```
+
+Generate the gnoland node secrets (this also creates the consensus key
+that softsign will load and that genesis will register):
+
+```sh
+gnoland secrets init -data-dir ./gnoland-data/secrets
+```
+
+gnoland stores the ed25519 private key as base64 of the 64-byte
+`seed‖pubkey`; tmkms softsign wants base64 of just the 32-byte **seed**.
+Reslice and re-encode (no crypto — a byte slice — so plain `python3` is
+fine):
+
+```sh
+python3 - <<'PY' > ./tmkms/secrets/consensus.key
+import json, base64
+v = json.load(open("gnoland-data/secrets/priv_validator_key.json"))["priv_key"]["value"]
+print(base64.b64encode(base64.b64decode(v)[:32]).decode(), end="")
+PY
+chmod 600 ./tmkms/secrets/consensus.key
+```
+
+Then generate the peer-ID and kms-identity values exactly as in B.2
+(`nodeid-hex.go`, `tmkms-identity-keygen.go`).
+
+## C.2 tmkms.toml with the softsign provider
+
+Same shape as B.4, with the provider block swapped for softsign:
+
+```toml
+[[chain]]
+id = "gno-tmkms-test"
+key_format = { type = "hex" }
+state_file = "/abs/path/tmkms/secrets/consensus_state.json"
+
+[[providers.softsign]]
+chain_ids = ["gno-tmkms-test"]
+key_type = "consensus"
+key_format = "base64"
+path = "/abs/path/tmkms/secrets/consensus.key"
+
+[[validator]]
+chain_id = "gno-tmkms-test"
+addr = "tcp://<peer_id>@127.0.0.1:26659"   # or unix:///… on one host
+secret_key = "/abs/path/tmkms/secrets/kms-identity.key"
+protocol_version = "v0.34"
+reconnect = true
+```
+
+## C.3 Configure gnoland and start (lazy genesis is fine here)
+
+Because the consensus key exists on disk *and* is registered locally, you
+can let `-lazy` build genesis from `priv_validator_key.json`. Configure
+the listener as in B.5, then:
+
+```sh
+# terminal 1
 tmkms start -c ./tmkms/tmkms.toml
 
 # terminal 2
-"$GNOLAND" start \
+gnoland start \
   -data-dir ./gnoland-data \
   -genesis ./gnoland-data/genesis.json \
   -chainid "$CHAIN_ID" \
+  -lazy \
   -skip-genesis-sig-verification
 ```
 
-Verify as in step 7 — gnoland should log `This node is a validator`
-with the `gpub1…` from L3, the height should climb, and tmkms should log
-`signed Proposal/Prevote/Precommit …`. The Tendermint Validator app
-signs consensus messages without a per-vote button press (it must, for
-liveness); it enforces its own monotonic HRS on-device, and tmkms's
-`state_file` is still the authoritative gate — keep it.
+- `-skip-genesis-sig-verification` is the standard dev-genesis flag (the
+  default `-lazy` genesis contains example txs signed by test accounts);
+  it is unrelated to tmkms.
+- `-lazy` only generates *missing* files — it will not clobber your tmkms
+  config or secrets — reads the local consensus pubkey to register the
+  genesis validator, then boots using the tmkms listener for signing.
+
+Verify exactly as in B.7.
+
+---
+
+# Part D — Advanced: Ledger hardware signer
+
+A Ledger holds the consensus key **on the device** and never exports it —
+like a YubiHSM, but it is a single signer with no failover, so it suits
+advanced/low-stake setups rather than high-availability mainnet duty (for
+HA use a YubiHSM or threshold signing such as Horcrux). The bootstrap is
+the same "read the pubkey out, seed genesis from it" flow as Part B; only
+the provider and the device handling change.
+
+> **Residual hardware caveat.** In tmkms 0.15.0 the Ledger code path does
+> not check the device's APDU return code on the pubkey and signature
+> responses, so in principle a device/transport error could be accepted
+> as if valid. In practice the `gnogenesis validator add` pubkey→address
+> check (B.3) catches a wrong *pubkey* at setup time, and a malformed
+> *signature* simply fails consensus rather than producing a bad valid
+> one. Use a known-good device and verify the pubkey out-of-band.
+
+## D.1 Prerequisites
+
+- tmkms built with the **`ledgertm`** provider (it is in the default
+  build; to keep softsign too, build `--features ledgertm,softsign`).
+- A Ledger with the **"Tendermint Validator"** app installed (the
+  dedicated ed25519 consensus app — *not* the regular Cosmos app),
+  plugged in, unlocked, with that app **open**. tmkms cannot reach a
+  locked device or a different app.
+
+## D.2 Provider block and bootstrap
+
+Use the B.4 `tmkms.toml` but replace the provider with `ledgertm` — no
+key files, no paths:
+
+```toml
+[[providers.ledgertm]]
+chain_ids = ["gno-tmkms-test"]
+```
+
+Only one `[[providers.ledgertm]]` is allowed and it always signs the
+**consensus** key. Then follow B.2 (node + identity), B.3 (start tmkms,
+read `added consensus Ed25519 key`, `pkconv.go`, `gnogenesis`), B.5
+(listener), and B.6/B.7 (start non-lazy, verify). gnoland should log
+`This node is a validator` with the `gpub1…` from B.3 and climb.
 
 > **Keep the device awake.** If the Ledger locks, sleeps, or the app is
 > backgrounded, signing stops and the node stalls until you reopen the
 > app. Plan for that on anything you care about.
 
-## Where to go next
+---
 
-- **Run the repo's automated proof.** A build-tagged Go test drives a
-  real tmkms binary through the full signing flow:
+# Part E — Prove it with the repo's automated test
 
-  ```sh
-  go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
-  ```
+A build-tagged Go test drives a **real tmkms binary** through the full
+signing flow (softsign and Ledger backends), exercising the gnoland side
+of every path above:
 
-- **Production hardening** — separate signer host, HSM/Ledger backend,
-  TCP firewalling, `consensus.json` backups, Horcrux threshold signing:
-  see [tmkms.md](tmkms.md), especially *Security notes*, *TCP vs UDS*,
-  and the *Operational checklist*.
+```sh
+go test -tags=tmkms_integration -count=1 -v ./tm2/pkg/bft/privval/upstream/...
+```
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| tmkms: `unknown field 'softsign', expected 'ledgertm'` | tmkms built without softsign | `cargo install tmkms --version 0.15.0 --features softsign --locked` |
+| gnoland: `allowed_kms_pubkeys must not be empty` | allowlist unset, or `listen_addr` set before the other fields | Set the four fields with `listen_addr` **last** (B.5) |
+| gnoland exits after ~60s waiting for connection | tmkms not running, can't reach `addr`, or pubkey not in allowlist | Start tmkms first; check `addr` vs `listen_addr`; confirm the hex in `allowed_kms_pubkeys` |
+| `protocol_version` rejected at startup | a value other than `v0.34` | Use `v0.34` on both sides |
+| gnoland panics at boot: `PubKey does not match Signer address` | default `-lazy` genesis has example txs (softsign path) | Add `-skip-genesis-sig-verification` (C.3) |
+| Node never advances past height 1, no signing in tmkms log | `chain_id` mismatch across genesis / config.toml / tmkms.toml | Make all three identical and restart |
+| Signatures produced but rejected by the chain | consensus key in the signer ≠ genesis validator key | Re-seed genesis from the *same* key the signer holds |
+| tmkms: `unverified validator peer ID! (<hex>)` | peer-ID prefix missing from `addr` (TCP) | Pin `tcp://<hex>@host:port` with `$VALIDATOR_PEER_ID` (B.4) |
+| tmkms (Ledger): startup `SigningError` / no pubkey | device locked, asleep, or wrong app | Unlock, open **Tendermint Validator** app, restart tmkms |
+
+---
+
+# Secure-setup checklist
+
+Run down this list before putting real stake behind the validator. Each
+item plainly states why it matters.
+
+**Host & OS**
+- [ ] tmkms runs as a dedicated, no-shell system user — *limits what a
+  compromised signer process can reach.*
+- [ ] Config, state, and key files are `0600`, owned by `tmkms` — *tmkms
+  won't reject world-readable secrets; the OS must.*
+- [ ] All paths in `tmkms.toml` are absolute — *stops a CWD-relative
+  state file from silently becoming a fresh, height-zero one.*
+
+**Transport & auth**
+- [ ] Same host: Unix socket in a directory only tmkms+gnoland can reach —
+  *on UDS, filesystem permissions are the only auth boundary.*
+- [ ] Separate hosts: TCP with the peer-ID pinned in `addr` **and** the
+  signer pubkey in `allowed_kms_pubkeys` — *both halves of mutual auth;
+  without the pin tmkms signs for any impostor on the port.*
+- [ ] Listen port firewalled to the signer host only — *keeps strangers
+  from knocking or probing your signer.*
+- [ ] `allowed_kms_pubkeys` is non-empty — *an empty list is fail-open.*
+
+**Key custody (production)**
+- [ ] Consensus key generated **non-exportable** in a YubiHSM; never run
+  `tmkms yubihsm setup` (leaks secrets to stdout) — *the key can never be
+  stolen off disk or wrapped out.*
+- [ ] HSM auth key has `sign-eddsa` only — no `export-wrapped`, no
+  attestation — *a leaked credential can request signatures but not clone
+  the key.*
+- [ ] Forced audit log on, drained by an auditor — *every op is recorded;
+  misuse can't run unbounded.*
+- [ ] Recovery seed stored offline on paper — *off the validator host.*
+
+**State & operations**
+- [ ] Signer on reliable power; state file on durable storage; never
+  restore a stale state file — *mitigates the one residual code risk
+  (no fsync before sign) that could cause a double-sign.*
+- [ ] State file backed up as part of maintenance — *for recovery, not
+  rollback.*
+- [ ] Never run `tmkms yubihsm test` against the production key — *it's an
+  unbounded oracle that bypasses the double-sign gate.*
+- [ ] `protocol_version = "v0.34"` on both sides; stay on a tmkms release
+  that supports it — *gnoland speaks only v0.34.*
+- [ ] No `state_hook` configured — *the hook subsystem can silently kill
+  startup; seed the state file directly.*

--- a/docs/validators/tmkms-quickstart.md
+++ b/docs/validators/tmkms-quickstart.md
@@ -84,11 +84,21 @@ export CHAIN_ID=gno-tmkms-prod
 
 # Prerequisites — build the helper tools
 
-Every backend below needs two tiny **stdlib-only** Go helpers. Write them
-once, here, and later sections just `go run` them. They have no module
-dependencies, so they run from any directory (Part B.3's `pkconv.go` is
-the one exception — it imports the gno crypto packages and must be run
-from the gno repo root; it's defined where it's used).
+Every backend below needs two tiny **stdlib-only** Go helpers. Define and
+**compile them once**, here; later sections run the resulting binaries.
+They have no module dependencies, so they build and run from any
+directory (Part B.3's `pkconv.go` is the one exception — it imports the
+gno crypto packages and must be run from the gno repo root; it's defined
+where it's used).
+
+> **Running a helper against a service-owned secret.** In Parts B and D
+> the secrets live under `/var/lib` owned by the `tmkms` / `gnoland`
+> users. Run each helper **as the owning user** (`sudo -u tmkms` /
+> `sudo -u gnoland`) so it touches the secret with exactly the privilege
+> it needs — not as root, and without copying the secret into a directory
+> you own. Those users have no home directory, so the Go *toolchain*
+> can't run as them; that is why we compile the helpers as yourself first
+> and only run the finished **binary** under `sudo -u`.
 
 `nodeid-hex.go` — prints a gnoland node's peer ID in the hex form tmkms
 pins in its `addr` (TCP layouts):
@@ -160,6 +170,22 @@ func main() {
 GO
 ```
 
+Compile both as your normal user (the Go toolchain needs its build
+cache), then install them where every user — including the `tmkms` and
+`gnoland` service users — can execute them. Later steps invoke them by
+name, under `sudo -u` when the target is a service-owned `/var/lib`
+secret:
+
+```sh
+go build -o nodeid-hex ./nodeid-hex.go
+go build -o tmkms-identity-keygen ./tmkms-identity-keygen.go
+sudo install -m 0755 nodeid-hex tmkms-identity-keygen /usr/local/bin/
+```
+
+They are one-shot setup tools; remove them with
+`sudo rm /usr/local/bin/{nodeid-hex,tmkms-identity-keygen}` afterward if
+you'd rather not leave them on the box.
+
 ---
 
 # Part A — Host hardening (do this first, for every backend)
@@ -179,9 +205,13 @@ account with no shell and no home limits what a compromised tmkms process
 sudo useradd --system --no-create-home --shell /usr/sbin/nologin tmkms
 ```
 
-If gnoland and tmkms share a host, run gnoland as its own user too (e.g.
-`gnoland`). Two unprivileged users that can only meet over a single
-tightly-permissioned socket is the local isolation you want.
+If gnoland and tmkms share a host, run gnoland under its own dedicated
+user too — two unprivileged users that can only meet over a single
+tightly-permissioned socket is the local isolation you want:
+
+```sh
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin gnoland
+```
 
 ## A.2 Lay out directories with strict permissions
 
@@ -193,6 +223,10 @@ the one thing that can get you slashed. Give them a private home:
 sudo install -d -o tmkms -g tmkms -m 700 /etc/tmkms          # config
 sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms       # state + identity key
 sudo install -d -o tmkms -g tmkms -m 700 /var/lib/tmkms/secrets
+
+# gnoland's own data dir, owned by the gnoland user (it creates the
+# secrets/ and config/ subdirs itself):
+sudo install -d -o gnoland -g gnoland -m 700 /var/lib/gnoland
 ```
 
 Rules that close whole classes of findings at once:
@@ -378,7 +412,7 @@ identity (the peer ID that tmkms pins on TCP), and tmkms needs a
 SecretConnection identity key. Generate the gnoland node secrets:
 
 ```sh
-gnoland secrets init -data-dir /var/lib/gnoland/secrets
+sudo -u gnoland gnoland secrets init -data-dir /var/lib/gnoland/secrets
 ```
 
 In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
@@ -387,31 +421,39 @@ In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
 **Peer ID in hex (TCP layouts).** tmkms pins your validator's peer ID to
 make sure it signs for *your* node and not whoever answers on the port.
 gnoland reports the identity in bech32 (`g1…`); tmkms wants the same 20
-bytes in hex. Run the `nodeid-hex.go` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools):
+bytes in hex. Run the `nodeid-hex` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools) as the gnoland
+user (it owns `node_key.json`):
 
 ```sh
-export VALIDATOR_PEER_ID=$(go run ./nodeid-hex.go /var/lib/gnoland/secrets/node_key.json)
-echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in B.5 (TCP)
+export VALIDATOR_PEER_ID=$(sudo -u gnoland nodeid-hex /var/lib/gnoland/secrets/node_key.json)
+echo "$VALIDATOR_PEER_ID"   # e.g. 243cef06…dcac — pinned into tmkms.toml in B.4 (TCP)
 ```
 
 **tmkms's SecretConnection identity (TCP layouts).** gnoland only accepts
 the connection if this key's public half is in `allowed_kms_pubkeys`. Run
-the `tmkms-identity-keygen.go` helper from
-[Prerequisites](#prerequisites--build-the-helper-tools):
+the `tmkms-identity-keygen` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools) as the tmkms user,
+so the key is written into tmkms's secrets dir already owned by tmkms (no
+`chown` needed):
 
 ```sh
-ALLOW=$(go run ./tmkms-identity-keygen.go /var/lib/tmkms/secrets/kms-identity.key)
-sudo chown tmkms:tmkms /var/lib/tmkms/secrets/kms-identity.key
-echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — copy for B.6
+ALLOW=$(sudo -u tmkms tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
+echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in B.5
 ```
 
 ## B.3 Read the consensus pubkey out of the HSM and register the validator
 
 Because the key never leaves the HSM, you can't push it into genesis —
 you read the **public** half out of tmkms and register *that* as your
-validator identity. Start tmkms once (with the `tmkms.toml` from B.4) and
-it logs the device's consensus pubkey on connect:
+validator identity. Start tmkms once (as the tmkms user, with the
+`tmkms.toml` from B.4); it logs the device's consensus pubkey on startup.
+Read that line, then stop it with `Ctrl-C` (gnoland isn't up yet, so it
+will just retry the connection in the meantime):
+
+```sh
+sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+```
 
 ```
 [keyring:yubihsm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
@@ -483,8 +525,8 @@ use `gnoland start -lazy` here — it would mint a throwaway local key and
 seed genesis with *that* instead of your HSM key:
 
 ```sh
-gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
-gnogenesis validator add \
+sudo -u gnoland gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
+sudo -u gnoland gnogenesis validator add \
   -genesis-path /var/lib/gnoland/genesis.json \
   -address  g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4 \
   -pub-key  gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z... \
@@ -570,9 +612,12 @@ allowlist must be non-empty — gnoland refuses to enable the mode with an
 empty one, because an empty allowlist means *accept any peer that
 completes a handshake* (fail-open).
 
+All `gnoland config` commands write under `/var/lib/gnoland`, so run them
+**as the gnoland user** (`sudo -u gnoland`):
+
 ```sh
 CFG=/var/lib/gnoland/config/config.toml
-gnoland config init -config-path "$CFG"
+sudo -u gnoland gnoland config init -config-path "$CFG"
 ```
 
 > **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
@@ -582,18 +627,18 @@ gnoland config init -config-path "$CFG"
 > stays unset.
 
 ```sh
-gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
-gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
-gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
 # listen_addr LAST — this enables the mode:
-gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
 ```
 
 Verify it stuck (`listen_addr` should be your `$PRIVVAL_LISTEN`, not
 empty):
 
 ```sh
-gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+sudo -u gnoland gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
 ```
 
 ## B.6 Run both as services, in the right order
@@ -742,7 +787,7 @@ to generate**. You still need tmkms's SecretConnection identity key
 with the [Prerequisites](#prerequisites--build-the-helper-tools) helper:
 
 ```sh
-ALLOW=$(go run ./tmkms-identity-keygen.go ./tmkms/secrets/kms-identity.key)
+ALLOW=$(tmkms-identity-keygen ./tmkms/secrets/kms-identity.key)   # operator-owned path, no sudo
 echo "$ALLOW"   # goes into gnoland's allowed_kms_pubkeys (C.3)
 ```
 
@@ -883,44 +928,243 @@ You also need:
   plugged in, unlocked, with that app **open**. tmkms cannot reach a
   locked device or a different app.
 
-## D.2 Provider block and bootstrap
+## D.2 Generate gnoland's node and listener identity
 
-Use a `tmkms.toml` like B.4's, with two changes: the provider is
-`ledgertm` (no key files — the key is on the device), and like Part C
-this uses a same-host **Unix socket** (A.3) instead of TCP, so there is
-no peer-ID pin. Create the socket directory as in A.3
-(`sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland`), then write
-the config exactly as in B.4 (`sudo tee /etc/tmkms/tmkms.toml`) with:
+The consensus key lives on the Ledger, but gnoland still needs its own
+node identity, and tmkms needs a SecretConnection identity key. Generate
+the gnoland node secrets:
 
-```toml
+```sh
+sudo -u gnoland gnoland secrets init -data-dir /var/lib/gnoland/secrets
+```
+
+In tmkms mode gnoland's `priv_validator_key.json` is **not** used to sign
+— the Ledger signs. On this same-host Unix-socket layout there is **no
+peer-ID pin** to generate (the socket's filesystem permissions are the
+auth boundary, A.3). You do still need tmkms's SecretConnection identity
+key — gnoland only enables the listener with a non-empty
+`allowed_kms_pubkeys`. Run the `tmkms-identity-keygen` helper from
+[Prerequisites](#prerequisites--build-the-helper-tools) as the tmkms user,
+so the key is written into tmkms's secrets dir already owned by tmkms (no
+`chown` needed):
+
+```sh
+ALLOW=$(sudo -u tmkms tmkms-identity-keygen /var/lib/tmkms/secrets/kms-identity.key)
+echo "$ALLOW"   # e.g. ed25519:4b6efade…b18a — used in D.5
+```
+
+## D.3 Write `tmkms.toml`
+
+Create the socket directory first — only the gnoland and tmkms users can
+traverse it, and gnoland creates the socket inside it at `0600`:
+
+```sh
+sudo install -d -o gnoland -g tmkms -m 750 /run/gnoland
+```
+
+Write the config with a heredoc, then lock it to `0600` owned by `tmkms`
+(all paths absolute). The provider is `ledgertm` — no key files, the key
+is on the device — and the transport is the Unix socket, so the `addr`
+carries no peer-ID pin:
+
+```sh
+sudo tee /etc/tmkms/tmkms.toml >/dev/null <<TOML
 [[chain]]
 id = "${CHAIN_ID}"
-key_format = { type = "hex" }
-state_file = "/var/lib/tmkms/secrets/consensus_state.json"
+key_format = { type = "hex" }                                # logs the pubkey in hex (D.4)
+state_file = "/var/lib/tmkms/secrets/consensus_state.json"   # absolute! the HRS gate
 
 [[providers.ledgertm]]
 chain_ids = ["${CHAIN_ID}"]
 
 [[validator]]
 chain_id = "${CHAIN_ID}"
-addr = "unix:///run/gnoland/privval.sock"   # same-host UDS; no peer-ID pin (A.3)
+addr = "unix:///run/gnoland/privval.sock"                    # same-host UDS; no peer-ID pin (A.3)
 secret_key = "/var/lib/tmkms/secrets/kms-identity.key"
 protocol_version = "v0.34"
 reconnect = true
+TOML
+
+sudo chown tmkms:tmkms /etc/tmkms/tmkms.toml
+sudo chmod 600 /etc/tmkms/tmkms.toml
 ```
 
 Only one `[[providers.ledgertm]]` is allowed and it always signs the
-**consensus** key. Then follow B.2 (node + identity — on UDS the peer-ID
-hex from `nodeid-hex.go` is unused, but you still need the kms-identity
-key for the allowlist), B.3 (start tmkms, read `added consensus Ed25519
-key`, `pkconv.go`, `gnogenesis`), B.5 (listener — set `listen_addr` to
-the same `unix:///run/gnoland/privval.sock`), and B.6/B.7 (start
-non-lazy, verify). gnoland should log `This node is a validator` with the
-`gpub1…` from B.3 and climb.
+**consensus** key. The fields that carry security weight:
+
+- **`state_file` (absolute).** tmkms's authoritative double-sign
+  (height/round/step) gate. **Never restore a stale copy** — rolling it
+  back to an older height is the classic self-double-sign (see D.6).
+- **`protocol_version = "v0.34"`.** gnoland speaks only the v0.34 privval
+  dialect; tmkms 0.15.0 prints a `deprecated … update to v0.38!` warning,
+  which is expected. Do **not** drop or bump it.
+- **No peer-ID pin / no `state_hook`.** On UDS the socket permissions are
+  the auth boundary (A.3), so `addr` has no `<peer_id>@` prefix; and don't
+  wire a `state_hook` (its stdout is never captured, so a `fail_closed`
+  hook can silently kill startup).
+
+## D.4 Read the consensus pubkey off the device and register the validator
+
+Because the key never leaves the Ledger, you read the **public** half out
+of tmkms and register *that* as your validator identity. Start tmkms once
+(as the tmkms user, with the `tmkms.toml` from D.3); it loads the device
+key and logs its consensus pubkey on startup. Read that line, then stop it
+with `Ctrl-C` (gnoland isn't up yet, so it will just retry the connection
+in the meantime):
+
+```sh
+sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+```
+
+```
+[keyring:ledgertm] added consensus Ed25519 key: 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
+```
+
+The hex string above is an **example** — copy the one *your* device logs.
+
+Convert that hex pubkey to gno's `gpub1…` / `g1…` forms with the
+`pkconv.go` helper. Write the file, then run it **from the gno repo root**
+(so the `github.com/gnolang/gno/...` imports resolve):
+
+```sh
+cat > pkconv.go <<'GO'
+// Converts a raw ed25519 consensus pubkey (hex or base64) to gno's
+// gpub1… / g1… forms.
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+)
+
+func main() {
+	in := strings.TrimSpace(os.Args[1])
+	bz, err := hex.DecodeString(in)
+	if err != nil {
+		if bz, err = base64.StdEncoding.DecodeString(in); err != nil {
+			panic("pubkey must be 32-byte ed25519 in hex or base64")
+		}
+	}
+	if len(bz) != 32 {
+		panic(fmt.Sprintf("expected 32 bytes, got %d", len(bz)))
+	}
+	var pk ed25519.PubKeyEd25519
+	copy(pk[:], bz)
+	fmt.Println("gpub:   ", crypto.PubKeyToBech32(pk))
+	fmt.Println("address:", pk.Address().String())
+}
+GO
+
+# pass the hex YOUR device logged (the value below is just an example):
+go run ./pkconv.go 2C854661478AA1CDC954D11ABA6ABB6DBF469572564C24C61ABFC0622A04D350
+# gpub:    gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z...
+# address: g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4
+```
+
+That `gpub1…` / `g1…` pair is your validator's public identity. Either
+submit it to an existing chain's validator-onboarding path (the
+production case — the chain already exists, so you do **not** generate
+genesis), or bootstrap your own chain by seeding genesis with it. Do
+**not** use `gnoland start -lazy` here — it would mint a throwaway local
+key and seed genesis with *that* instead of your device key:
+
+```sh
+sudo -u gnoland gnogenesis generate -chain-id "$CHAIN_ID" -output-path /var/lib/gnoland/genesis.json
+sudo -u gnoland gnogenesis validator add \
+  -genesis-path /var/lib/gnoland/genesis.json \
+  -address  g1qmptf8uxdg6l0rh07jwvur0kk8my9vrdf5qtp4 \
+  -pub-key  gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9z... \
+  -name     ledger-validator \
+  -power    10
+```
+
+`validator add` checks that the pubkey hashes to the address, catching a
+copy-paste slip right here.
+
+## D.5 Configure gnoland's tmkms listener
+
+Create a default config, then set the four `tmkms_listener` fields. The
+allowlist must be non-empty — gnoland refuses to enable the mode with an
+empty one. On this Unix-socket layout the allowlist is
+belt-and-suspenders (the socket's filesystem permissions are the real
+boundary, A.3), but gnoland still requires it non-empty, so set it with
+`$ALLOW` from D.2.
+
+All `gnoland config` commands write under `/var/lib/gnoland`, so run them
+**as the gnoland user** (`sudo -u gnoland`):
+
+```sh
+export PRIVVAL_LISTEN="unix:///run/gnoland/privval.sock"   # gnoland listens on the socket from D.3
+CFG=/var/lib/gnoland/config/config.toml
+sudo -u gnoland gnoland config init -config-path "$CFG"
+```
+
+> **Ordering gotcha.** `config set` validates the whole `tmkms_listener`
+> block on every write, and a non-empty `listen_addr` is what *enables*
+> that validation. Set `listen_addr` **last** — set it first and the
+> write is rejected because `chain_id` is still empty, and it silently
+> stays unset.
+
+```sh
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.chain_id "$CHAIN_ID"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.protocol_version "v0.34"
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.allowed_kms_pubkeys "$ALLOW"
+# listen_addr LAST — this enables the mode:
+sudo -u gnoland gnoland config set -config-path "$CFG" consensus.priv_validator.tmkms_listener.listen_addr "$PRIVVAL_LISTEN"
+```
+
+Verify it stuck (`listen_addr` should be your socket, not empty):
+
+```sh
+sudo -u gnoland gnoland config get -config-path "$CFG" consensus.priv_validator.tmkms_listener
+```
+
+## D.6 Run both, verify, and keep the device awake
+
+**Order matters.** gnoland blocks at startup for up to
+`wait_for_connection_timeout` (default 60s) waiting for tmkms to dial in.
+Start tmkms first (with `reconnect = true` it retries until gnoland is
+listening). Run each under its own user — for example with systemd units
+(`User=tmkms` / `User=gnoland`), or manually:
+
+```sh
+# signer (as the tmkms user) — Ledger plugged in, unlocked, app open
+sudo -u tmkms tmkms start -c /etc/tmkms/tmkms.toml
+
+# validator (as the gnoland user) — NO -lazy; genesis already holds the
+# device's pubkey from D.4
+sudo -u gnoland gnoland start \
+  -data-dir /var/lib/gnoland \
+  -genesis /var/lib/gnoland/genesis.json \
+  -chainid "$CHAIN_ID"
+```
+
+Within a few seconds the node should advance through heights:
+
+- **tmkms log:** `connected to validator successfully`, then ongoing
+  `signed Proposal/Prevote/Precommit …`.
+- **gnoland log:** `This node is a validator` with the `gpub1…` from D.4,
+  and `Committed state … height=N` climbing.
+- **Identity check:** the validator address in the `Signed and pushed
+  vote` lines must equal the address from D.4 and the genesis entry.
+- **Kill tmkms** and watch gnoland stop committing; restart it and watch
+  it resume — proof the key lives on the device, not the node.
 
 > **Keep the device awake.** If the Ledger locks, sleeps, or the app is
 > backgrounded, signing stops and the node stalls until you reopen the
 > app. Plan for that on anything you care about.
+
+> **State-file durability.** Like every backend, tmkms 0.15.0 does not
+> `fsync` its state file before signing the next block, so a hard power
+> loss can roll the on-disk height backward — a double-sign risk. Keep the
+> signer on reliable power and **never** restore an old state file (the
+> full discussion is in [B.7](#b7-verify-its-really-the-hsm-signing--and-keep-it-that-way)).
 
 ---
 

--- a/docs/validators/tmkms.md
+++ b/docs/validators/tmkms.md
@@ -8,6 +8,12 @@ signer that speaks the upstream Tendermint privval protocol, like
 [tmkms]: https://github.com/iqlusioninc/tmkms
 [Horcrux]: https://github.com/strangelove-ventures/horcrux
 
+> **Just want to stand one up?** See
+> [tmkms-quickstart.md](tmkms-quickstart.md) for a copy-paste, single-host
+> walkthrough that takes you from an empty directory to a node producing
+> tmkms-signed blocks. This page is the reference for the architecture,
+> security model, and production checklist behind that flow.
+
 ## When to use this mode
 
 Gnoland supports three privval setups. Pick one — they're mutually


### PR DESCRIPTION
Required https://github.com/gnolang/gno/pull/5718

## Description

Adds `docs/validators/tmkms-quickstart.md` — a hands-on guide to running a gnoland validator whose consensus key is held by [tmkms], with the OS/config hardening that closes the operational footguns from the tmkms 0.15.0 review. Plus a small cross-link tweak to `tmkms.md`.

Ordered production-first, each step explaining *why* in plain language:

- **Prerequisites:** build `gnoland`/`gnogenesis` and clone gno to `/opt/gno` (used both to build and as `GNOROOT`, since gnoland loads stdlibs from it at chain init); two stdlib-only helper tools.
- **Part A — Host hardening:** one locked-down `gnoland` user runs both gnoland and tmkms; `0600` secrets, absolute paths; transport choice — same-host **Unix socket** (the owner-only `0600` socket is the auth boundary) or firewalled **TCP** (`allowed_kms_pubkeys` + peer-ID pin).
- **Part B — YubiHSM (recommended):** manual `yubihsm-shell` provisioning (never `tmkms yubihsm setup`/`test`), non-exportable key, `sign-eddsa`-only auth, forced audit log; the one residual code risk (state-file fsync) flagged where it applies.
- **Parts C/D — softsign lab / Ledger:** same connection + genesis flow.
- **Part E — Prove it:** the repo's `tmkms_integration` test, plus a why-it-matters checklist.

## Notes for reviewers

- The gnoland side of every path (listener, allowlist, peer-ID pin, `v0.34` pin, signing) is exercised by the repo's real-tmkms test (softsign + Ledger). The **YubiHSM** steps are derived from the review + tmkms/YubiHSM docs and need the physical device to exercise.
- Targets `feat/tmkms-compat/03-listener-integration` (docs for that listener work), **not** `master`.

[tmkms]: https://github.com/iqlusioninc/tmkms