### PR TITLE
feat(gnofaucet): add gas-fee and gas-wanted flags

### DIFF
--- a/contribs/gnofaucet/serve.go
+++ b/contribs/gnofaucet/serve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/gnolang/faucet"
@@ -22,7 +21,7 @@ import (
 
 const (
 	defaultGasFee        = "1000000ugnot"
-	defaultGasWanted     = "100000"
+	defaultGasWanted     = 100000
 	defaultRemote        = "http://127.0.0.1:26657"
 	defaultListenAddress = "0.0.0.0:5050"
 )
@@ -53,6 +52,9 @@ type serveCfg struct {
 	mnemonic      string
 	maxSendAmount string
 	numAccounts   uint64
+
+	gasFee    string
+	gasWanted int64
 
 	remote            string
 	trustedProxyCount int
@@ -124,6 +126,20 @@ func (c *serveCfg) RegisterFlags(fs *flag.FlagSet) {
 		"max-send-amount",
 		"10000000ugnot",
 		"the static max send amount (native currency)",
+	)
+
+	fs.StringVar(
+		&c.gasFee,
+		"gas-fee",
+		defaultGasFee,
+		"the static gas fee for faucet transactions",
+	)
+
+	fs.Int64Var(
+		&c.gasWanted,
+		"gas-wanted",
+		defaultGasWanted,
+		"the static gas wanted for faucet transactions",
 	)
 
 	fs.IntVar(
@@ -198,15 +214,16 @@ func serveFaucet(
 		return errors.New("ratelimit-cleanup-timeout must be >= ratelimit-interval, otherwise cleanup defeats the rate limit")
 	}
 
-	// Parse static gas values.
-	// It is worth noting that this is temporary,
-	// and will be removed once gas estimation is enabled
-	// on gno.land
-	gasFee := std.MustParseCoin(defaultGasFee)
-
-	gasWanted, err := strconv.ParseInt(defaultGasWanted, 10, 64)
+	// Validate the static gas values. The fee only needs to parse as a coin —
+	// a zero fee is valid on chains with no minimum gas price — but gas wanted
+	// must be positive, since a non-positive limit always fails out-of-gas.
+	gasFee, err := std.ParseCoin(cfg.gasFee)
 	if err != nil {
-		return fmt.Errorf("invalid gas wanted, %w", err)
+		return fmt.Errorf("invalid gas fee, %w", err)
+	}
+
+	if cfg.gasWanted <= 0 {
+		return errors.New("gas wanted must be greater than zero")
 	}
 
 	// Parse the send amount
@@ -235,7 +252,7 @@ func serveFaucet(
 	// Create a new faucet with
 	// static gas estimation
 	f, err := faucet.NewFaucet(
-		static.New(gasFee, gasWanted),
+		static.New(gasFee, cfg.gasWanted),
 		cli,
 		faucetOpts...,
 	)

--- a/contribs/gnofaucet/serve_test.go
+++ b/contribs/gnofaucet/serve_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"flag"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServeFaucet_CleanupShorterThanRateLimit(t *testing.T) {
@@ -19,4 +21,93 @@ func TestServeFaucet_CleanupShorterThanRateLimit(t *testing.T) {
 	err := serveFaucet(context.Background(), cfg, nil)
 
 	assert.ErrorContains(t, err, "ratelimit-cleanup-timeout must be >= ratelimit-interval")
+}
+
+func TestServeFaucet_InvalidGasValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		gasFee      string
+		gasWanted   int64
+		expectedErr string
+	}{
+		{
+			name:        "malformed gas fee",
+			gasFee:      "invalid",
+			gasWanted:   100000,
+			expectedErr: "invalid gas fee",
+		},
+		{
+			name:        "zero gas wanted",
+			gasFee:      "1000000ugnot",
+			gasWanted:   0,
+			expectedErr: "gas wanted must be greater than zero",
+		},
+		{
+			name:        "negative gas wanted",
+			gasFee:      "1000000ugnot",
+			gasWanted:   -100,
+			expectedErr: "gas wanted must be greater than zero",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &serveCfg{
+				rateLimitInterval:     time.Hour,
+				rateLimitCleanTimeout: 24 * time.Hour,
+				gasFee:                testCase.gasFee,
+				gasWanted:             testCase.gasWanted,
+			}
+
+			err := serveFaucet(context.Background(), cfg, nil)
+
+			assert.ErrorContains(t, err, testCase.expectedErr)
+		})
+	}
+}
+
+func TestServeCfg_GasFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		args              []string
+		expectedGasFee    string
+		expectedGasWanted int64
+	}{
+		{
+			name:              "defaults",
+			args:              nil,
+			expectedGasFee:    "1000000ugnot",
+			expectedGasWanted: 100000,
+		},
+		{
+			name: "explicit values",
+			args: []string{
+				"-gas-fee", "2000000ugnot",
+				"-gas-wanted", "2000000",
+			},
+			expectedGasFee:    "2000000ugnot",
+			expectedGasWanted: 2000000,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &serveCfg{}
+			fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+			cfg.RegisterFlags(fs)
+
+			require.NoError(t, fs.Parse(testCase.args))
+
+			assert.Equal(t, testCase.expectedGasFee, cfg.gasFee)
+			assert.Equal(t, testCase.expectedGasWanted, cfg.gasWanted)
+		})
+	}
 }


### PR DESCRIPTION
  ## Summary

Adds `--gas-fee` and `--gas-wanted` flags to `gnofaucet serve` (inherited by both the `captcha` and `github` subcommands), letting operators override gas values that were previously hardcoded constants.

  ## Why

The faucet hardcoded `gasWanted` at `100000`. On a chain where a single bank send costs more than that — e.g. test13-derived state, where a send meters ~1.6M gas — every drip fails out-of-gas at delivery, with no way to raise the limit. Defaults are unchanged, so existing deployments behave exactly as before.