### PR TITLE
fix(gnovm): ignore make(map, n) size hint

### DIFF
--- a/gnovm/pkg/gnolang/alloc.go
+++ b/gnovm/pkg/gnolang/alloc.go
@@ -366,8 +366,11 @@ func (alloc *Allocator) AllocateFunc() {
 	alloc.Allocate(allocFunc)
 }
 
-func (alloc *Allocator) AllocateMap(items int64) {
-	alloc.Allocate(overflow.Addp(allocMap, overflow.Mulp(allocMapItem, items)))
+func (alloc *Allocator) AllocateMap() {
+	// Only the map header is charged; items are charged on insertion via
+	// AllocateMapItem. The make() size hint is intentionally ignored — see
+	// the make() map case in uverse.go.
+	alloc.Allocate(allocMap)
 }
 
 func (alloc *Allocator) AllocateMapItem() {
@@ -595,10 +598,10 @@ func (alloc *Allocator) NewStructWithFields(t Type, fields ...TypedValue) *Struc
 	return alloc.NewStruct(t, tvs)
 }
 
-func (alloc *Allocator) NewMap(t Type, size int) *MapValue {
-	alloc.AllocateMap(int64(size))
+func (alloc *Allocator) NewMap(t Type) *MapValue {
+	alloc.AllocateMap()
 	mv := &MapValue{}
-	mv.MakeMap(size)
+	mv.MakeMap()
 	alloc.stampPkgID(&mv.ObjectInfo, t)
 	return mv
 }

--- a/gnovm/pkg/gnolang/alloc_test.go
+++ b/gnovm/pkg/gnolang/alloc_test.go
@@ -1,6 +1,7 @@
 package gnolang
 
 import (
+	"math"
 	"testing"
 	"unsafe"
 )
@@ -23,6 +24,29 @@ func TestAllocSizes(t *testing.T) {
 	println("TypeValue{}", unsafe.Sizeof(TypeValue{}))
 	println("TypedValue{}", unsafe.Sizeof(TypedValue{}))
 	println("ObjectInfo{}", unsafe.Sizeof(ObjectInfo{}))
+}
+
+// TestNewMapChargesHeaderOnly pins the map allocation model: creating a
+// map charges only the header (allocMap), never a per-hint preallocation
+// cost. Items are charged one allocMapItem each at insertion time. This
+// is what lets GnoVM ignore the make() size hint safely — there is no
+// allocMapItem*hint term to overflow or to double-charge against the
+// per-item charge.
+func TestNewMapChargesHeaderOnly(t *testing.T) {
+	t.Parallel()
+
+	mt := &MapType{Key: IntType, Value: IntType}
+	alloc := NewAllocator(math.MaxInt64)
+
+	alloc.NewMap(mt)
+	if _, b := alloc.Status(); b != allocMap {
+		t.Fatalf("NewMap charged %d bytes, want allocMap=%d", b, allocMap)
+	}
+
+	alloc.AllocateMapItem()
+	if _, b := alloc.Status(); b != allocMap+allocMapItem {
+		t.Fatalf("after one item charged %d bytes, want %d", b, allocMap+allocMapItem)
+	}
 }
 
 func TestBlockGetShallowSize_WithRefNodeSource(t *testing.T) {

--- a/gnovm/pkg/gnolang/bench_gc_test.go
+++ b/gnovm/pkg/gnolang/bench_gc_test.go
@@ -97,7 +97,7 @@ func buildGCGraph(nObjects int) Value {
 	// --- Create MapValues ---
 	for i := 0; i < nMap; i++ {
 		mv := &MapValue{}
-		mv.MakeMap(0)
+		mv.MakeMap()
 		nEntries := 2 + rng.Intn(2) // 2-3 entries
 		// We need a non-nil allocator for MapList.Append since it
 		// calls AllocateMapItem. Use a large-limit allocator.

--- a/gnovm/pkg/gnolang/bench_ops_test.go
+++ b/gnovm/pkg/gnolang/bench_ops_test.go
@@ -1582,7 +1582,7 @@ func benchOpIndex1MapHit(b *testing.B, size int) {
 
 	mt := &MapType{Key: IntType, Value: IntType}
 	mv := &MapValue{}
-	mv.MakeMap(size)
+	mv.MakeMap()
 	for i := range size {
 		kv := TypedValue{T: IntType, N: i2n(int64(i))}
 		pv := mv.GetPointerForKey(m, m.Alloc, m.Store, kv)
@@ -1623,7 +1623,7 @@ func BenchmarkOpIndex1_MapMiss(b *testing.B) {
 
 	mt := &MapType{Key: IntType, Value: IntType}
 	mv := &MapValue{}
-	mv.MakeMap(10)
+	mv.MakeMap()
 	for i := range 10 {
 		kv := TypedValue{T: IntType, N: i2n(int64(i))}
 		pv := mv.GetPointerForKey(m, m.Alloc, m.Store, kv)
@@ -1656,7 +1656,7 @@ func benchOpIndex1_MapStringKey(b *testing.B, keyLen int) {
 
 	mt := &MapType{Key: StringType, Value: IntType}
 	mv := &MapValue{}
-	mv.MakeMap(10)
+	mv.MakeMap()
 	for i := range 10 {
 		k := strings.Repeat("x", keyLen-1) + string(rune('A'+i))
 		kv := TypedValue{T: StringType, V: m.Alloc.NewString(k)}
@@ -1849,7 +1849,7 @@ func BenchmarkOpIndex2_MapHit(b *testing.B) {
 
 	mt := &MapType{Key: IntType, Value: IntType}
 	mv := &MapValue{}
-	mv.MakeMap(10)
+	mv.MakeMap()
 	for i := range 10 {
 		kv := TypedValue{T: IntType, N: i2n(int64(i))}
 		pv := mv.GetPointerForKey(m, m.Alloc, m.Store, kv)
@@ -1886,7 +1886,7 @@ func BenchmarkOpIndex2_MapMiss(b *testing.B) {
 
 	mt := &MapType{Key: IntType, Value: IntType}
 	mv := &MapValue{}
-	mv.MakeMap(10)
+	mv.MakeMap()
 	for i := range 10 {
 		kv := TypedValue{T: IntType, N: i2n(int64(i))}
 		pv := mv.GetPointerForKey(m, m.Alloc, m.Store, kv)

--- a/gnovm/pkg/gnolang/op_expressions.go
+++ b/gnovm/pkg/gnolang/op_expressions.go
@@ -576,7 +576,7 @@ func (m *Machine) doOpMapLit() {
 	m.Alloc.checkConstructionTime(mt)
 	// bt := baseOf(at).(*MapType)
 	// construct new map value.
-	mv := m.Alloc.NewMap(mt, 0)
+	mv := m.Alloc.NewMap(mt)
 	if 0 < ne {
 		kvs := m.PopValues(ne * 2)
 		// TODO: future optimization

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -1137,18 +1137,23 @@ func makeUverseNode() {
 				}
 			case *MapType:
 				switch vargsl {
-				case 0:
+				case 0, 1:
+					// The optional size argument is an advisory hint.
+					// GnoVM ignores it: the map is created empty and
+					// grows on insertion, with each item charged then
+					// (via AllocateMapItem).
+					//
+					// This diverges from Go, which preallocates buckets
+					// sized to the hint (Go only forces a 0 hint when it
+					// is negative or large enough to overflow its size
+					// math). GnoVM skips that on purpose: the hint is not
+					// persisted across state recovery, and honoring it
+					// would either double-charge gas for the items or let
+					// a large hint trigger an unmetered Go-level
+					// preallocation. As in Go, no hint value ever panics.
 					m.PushValue(TypedValue{
 						T: tt,
-						V: m.Alloc.NewMap(tt, 0),
-					})
-					return
-				case 1:
-					lv := vargs.TV.GetPointerAtIndexInt(m, m.Store, 0).Deref()
-					li := int(lv.ConvertGetInt())
-					m.PushValue(TypedValue{
-						T: tt,
-						V: m.Alloc.NewMap(tt, li),
+						V: m.Alloc.NewMap(tt),
 					})
 					return
 				default:

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -768,9 +768,11 @@ type MapListItem struct {
 	Value TypedValue
 }
 
-func (mv *MapValue) MakeMap(c int) {
+// MakeMap initializes mv with no capacity hint: the make() size argument
+// is intentionally not honored (see the make() map case in uverse.go).
+func (mv *MapValue) MakeMap() {
 	mv.List = &MapList{}
-	mv.vmap = make(map[MapKey]*MapListItem, c)
+	mv.vmap = make(map[MapKey]*MapListItem)
 }
 
 func (mv *MapValue) GetLength() int {

--- a/gnovm/tests/files/make19.gno
+++ b/gnovm/tests/files/make19.gno
@@ -1,0 +1,26 @@
+package main
+
+// A map's size argument is an advisory hint, and GnoVM ignores it
+// entirely: the map is created empty and grows on insertion. Any hint —
+// negative, or large enough to overflow internal size accounting — is a
+// no-op that must never panic (unlike a bad slice length). Go also never
+// panics on a bad map hint, though for valid hints it does preallocate.
+
+func main() {
+	neg := -1
+	a := make(map[int]int, neg)
+	println("neg:", len(a))
+
+	huge := int(^uint(0) >> 1) // max int
+	b := make(map[int]int, huge)
+	println("huge:", len(b))
+
+	a[1] = 10
+	b[2] = 20
+	println("usable:", a[1], b[2], len(a), len(b))
+}
+
+// Output:
+// neg: 0
+// huge: 0
+// usable: 10 20 1 1


### PR DESCRIPTION
## Problem

`make(map[K]V, n)` routed the size hint through `Allocator.NewMap` → `AllocateMap`, which charged `allocMap + allocMapItem*n` up front. Two problems:

- **Double-charged gas.** The per-item cost (`allocMapItem`) is *also* charged on every actual insertion via `AllocateMapItem`. A hinted map that gets filled pays `allocMap + 2*allocMapItem*n` — the up-front charge is for `MapListItem`s that don't exist yet and get charged again when inserted.
- **Overflow panic.** A hint large enough that `allocMap + allocMapItem*n` overflows int64 panicked with the internal `"addition overflow"` / `"multiplication overflow"` instead of behaving gracefully.

The hint is also never persisted: on state recovery the map is rebuilt from its actual item count (`realm.go`: `make(map[MapKey]*MapListItem, cv.List.Size)`), so any preallocation benefit is ephemeral anyway.

## Fix

Ignore the size hint entirely. The map is created empty and grows on insertion, with each item charged once (via `AllocateMapItem`). This drops the `items` / `size` / `c` parameters from `AllocateMap` / `NewMap` / `MakeMap` and stops the `make(map, …)` builtin from reading the hint.

Doing it end-to-end removes the double-charge, the overflow, and a third hazard in one stroke: had we only zeroed the gas charge but kept passing the hint to Go's `make`, a large hint (e.g. `make(map, 10e9)`) would trigger a Go-level bucket preallocation of hundreds of GB with no gas charged.

Alternative to #5770, which clamped only the int64-overflow corner while leaving the double-charge and the per-hint accounting in place.

### Note on Go semantics

This deliberately **diverges** from Go. Go's `makemap` *honors* the hint by preallocating buckets for any in-range hint (it only forces a 0 hint when the hint is negative or large enough to overflow its size math). GnoVM forgoes that optimization because the hint isn't persisted and can't be charged for cheaply. The only behavior that matches Go is the edge contract: a bad map hint never panics (unlike `make([]T, n)`).

## Gas impact

`make(map, n)` with `n > 0` now costs less gas (header up front, items on insertion). Maps with no hint or hint `0` — including all map literals, the overwhelmingly common case — are unaffected (old charge was `allocMap + allocMapItem*0 = allocMap`, identical to the new charge). The change only ever lowers map cost, so no transaction that previously fit its gas will now exceed it.

## Changes

Core:
- `alloc.go` — `AllocateMap()` charges only the map header; `NewMap(t Type)` drops the `size` param.
- `values.go` — `MakeMap()` no longer takes a capacity hint.
- `uverse.go` — `make(map, …)` builtin merges `case 0` / `case 1` and ignores the hint (its expression is still evaluated upstream, so no side effects are lost).
- `op_expressions.go` — map-literal construction updated to the new `NewMap` signature.

Tests:
- `alloc_test.go` — new `TestNewMapChargesHeaderOnly` pins the header-only charge plus the per-item insertion charge.
- `gnovm/tests/files/make19.gno` — new filetest: negative and MaxInt hints don't panic and the map stays usable.
- `bench_ops_test.go`, `bench_gc_test.go` — benchmark `MakeMap` call sites updated to the new signature.

## Verification

- `go test ./gno.land/pkg/sdk/vm/ -run Gas` — pass (no gas golden updates needed)
- `go test ./gno.land/pkg/integration/ -run TestTestdata` — pass
- `go test ./gnovm/pkg/gnolang/ -run Files -short` — map filetests pass
