### PR TITLE
fix(gnovm): reject oversized fixed-size array length at preprocess time

### DIFF
--- a/gnovm/pkg/gnolang/alloc.go
+++ b/gnovm/pkg/gnolang/alloc.go
@@ -341,6 +341,18 @@ func (alloc *Allocator) AllocatePointer() {
 	alloc.Allocate(allocPointer)
 }
 
+// arrayItemAllocSize is the per-element allocation cost of a fixed-size array
+// of element type et, matching defaultArrayValue's dispatch: byte arrays back
+// onto AllocateDataArray (1 byte/elem), everything else onto AllocateListArray
+// (allocArrayItem/elem). Kept here next to that dispatch so the preprocessor's
+// checkArrayLenFits guard can't silently drift from the allocator.
+func arrayItemAllocSize(et Type) int64 {
+	if et.Kind() == Uint8Kind {
+		return 1
+	}
+	return allocArrayItem
+}
+
 func (alloc *Allocator) AllocateDataArray(size int64) {
 	alloc.Allocate(overflow.Addp(allocArray, size))
 }

--- a/gnovm/pkg/gnolang/alloc.go
+++ b/gnovm/pkg/gnolang/alloc.go
@@ -345,7 +345,7 @@ func (alloc *Allocator) AllocatePointer() {
 // of element type et, matching defaultArrayValue's dispatch: byte arrays back
 // onto AllocateDataArray (1 byte/elem), everything else onto AllocateListArray
 // (allocArrayItem/elem). Kept here next to that dispatch so the preprocessor's
-// checkArrayLenFits guard can't silently drift from the allocator.
+// checkArrayAllocFits guard can't silently drift from the allocator.
 func arrayItemAllocSize(et Type) int64 {
 	if et.Kind() == Uint8Kind {
 		return 1

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2423,6 +2423,9 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						idx := int64(0)
 						for _, elt := range n.Elts {
 							if elt.Key == nil {
+								if idx == math.MaxInt64 {
+									panic(fmt.Sprintf("array index %d out of bounds [0:0]", idx))
+								}
 								idx++
 							} else {
 								k := evalConst(store, last, elt.Key).ConvertGetInt()

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2436,6 +2436,9 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						// update type
 						// (dontcare)
 						// at.Vrd = false
+						// Reject an oversized [...]T{idx: v} array, whose length
+						// is only known here, at compile time (see checkArrayLenFits).
+						checkArrayLenFits(at.Elt, int64(idx))
 						at.Len = idx
 						// Mutating Len invalidates the cached typeid.
 						at.typeid = ""
@@ -2653,6 +2656,10 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					cx := evalConst(store, last, n.Len)
 					convertConst(store, last, n, cx, IntType)
 					n.Len = cx
+					// Reject an oversized fixed-size array at compile time (see
+					// checkArrayLenFits). This covers [N]T and [N]T{...}; the
+					// [...]T{idx: v} form is measured later and checked there.
+					checkArrayLenFits(evalStaticType(store, last, n.Elt), cx.GetInt())
 				}
 				// NOTE: For all TypeExprs, the node is not replaced
 				// with *constTypeExprs (as *ConstExprs are) because
@@ -4865,6 +4872,25 @@ func isNamedConversion(xt, t Type) bool {
 		}
 	}
 	return false
+}
+
+// checkArrayLenFits rejects a fixed-size array of element type et and the given
+// length whose backing allocation would overflow int64, mirroring the runtime
+// allocator's allocMustFit guard (AllocateListArray/AllocateDataArray). Go's
+// compiler rejects such an array at compile time ("larger than address space");
+// go/types does not, so without this it would only fail at allocation time.
+// Called for every fixed-size array form: [N]T, [N]T{...}, and [...]T{idx: v}.
+func checkArrayLenFits(et Type, length int64) {
+	if length <= 0 {
+		return // negative lengths are rejected earlier (go/types).
+	}
+	per := int64(allocArrayItem)
+	if et.Kind() == Uint8Kind {
+		per = 1 // byte arrays use AllocateDataArray (1 byte/elem).
+	}
+	if length > (math.MaxInt64-allocArray)/per {
+		panic(fmt.Sprintf("type [%d]%s larger than address space", length, et.String()))
+	}
 }
 
 // like checkOrConvertType(last, x, nil)

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2422,6 +2422,11 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					if at.Vrd {
 						idx := int64(0)
 						for _, elt := range n.Elts {
+							// The implied length is the largest index + 1; an index of
+							// MaxInt64 overflows that to MaxInt64+1. Reject it as out of
+							// bounds (matching Go, whose largest valid index here is
+							// MaxInt64-1) so idx can't wrap negative past
+							// checkArrayAllocFits below.
 							if elt.Key == nil {
 								if idx == math.MaxInt64 {
 									panic(fmt.Sprintf("array index %d out of bounds [0:0]", idx))
@@ -2432,11 +2437,6 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 								if idx > k {
 									panic("array lit key out of order")
 								}
-								// The implied length is k+1. MaxInt64 is the only key
-								// whose length overflows int64; Go rejects that key as
-								// an out-of-bounds index (the largest key that forms a
-								// valid length is MaxInt64-1). Match Go, and stop k+1
-								// from wrapping negative past checkArrayLenFits below.
 								if k == math.MaxInt64 {
 									panic(fmt.Sprintf("array index %d out of bounds [0:0]", k))
 								}
@@ -2447,8 +2447,8 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						// (dontcare)
 						// at.Vrd = false
 						// Reject an oversized [...]T{idx: v} array, whose length
-						// is only known here, at compile time (see checkArrayLenFits).
-						checkArrayLenFits(at.Elt, idx)
+						// is only known here, at compile time (see checkArrayAllocFits).
+						checkArrayAllocFits(at.Elt, idx)
 						at.Len = int(idx)
 						// Mutating Len invalidates the cached typeid.
 						at.typeid = ""
@@ -2667,9 +2667,9 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					convertConst(store, last, n, cx, IntType)
 					n.Len = cx
 					// Reject an oversized fixed-size array at compile time (see
-					// checkArrayLenFits). This covers [N]T and [N]T{...}; the
+					// checkArrayAllocFits). This covers [N]T and [N]T{...}; the
 					// [...]T{idx: v} form is measured and checked elsewhere.
-					checkArrayLenFits(evalStaticType(store, last, n.Elt), cx.GetInt())
+					checkArrayAllocFits(evalStaticType(store, last, n.Elt), cx.GetInt())
 				}
 				// NOTE: For all TypeExprs, the node is not replaced
 				// with *constTypeExprs (as *ConstExprs are) because
@@ -4884,13 +4884,13 @@ func isNamedConversion(xt, t Type) bool {
 	return false
 }
 
-// checkArrayLenFits rejects a fixed-size array of element type et and the given
+// checkArrayAllocFits rejects a fixed-size array of element type et and the given
 // length whose backing allocation would overflow int64, mirroring the runtime
 // allocator's allocMustFit guard (AllocateListArray/AllocateDataArray). Go's
 // compiler rejects such an array at compile time ("larger than address space");
 // go/types does not, so without this it would only fail at allocation time.
 // Called for every fixed-size array form: [N]T, [N]T{...}, and [...]T{idx: v}.
-func checkArrayLenFits(et Type, length int64) {
+func checkArrayAllocFits(et Type, length int64) {
 	if length <= 0 {
 		return // negative lengths are rejected earlier (go/types).
 	}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2665,7 +2665,7 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 					n.Len = cx
 					// Reject an oversized fixed-size array at compile time (see
 					// checkArrayLenFits). This covers [N]T and [N]T{...}; the
-					// [...]T{idx: v} form is measured later and checked there.
+					// [...]T{idx: v} form is measured and checked elsewhere.
 					checkArrayLenFits(evalStaticType(store, last, n.Elt), cx.GetInt())
 				}
 				// NOTE: For all TypeExprs, the node is not replaced

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -2420,17 +2420,24 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 				// If variadic array lit, measure.
 				if at, ok := clt.(*ArrayType); ok {
 					if at.Vrd {
-						idx := 0
+						idx := int64(0)
 						for _, elt := range n.Elts {
 							if elt.Key == nil {
 								idx++
 							} else {
-								k := int(evalConst(store, last, elt.Key).ConvertGetInt())
-								if idx <= k {
-									idx = k + 1
-								} else {
+								k := evalConst(store, last, elt.Key).ConvertGetInt()
+								if idx > k {
 									panic("array lit key out of order")
 								}
+								// The implied length is k+1. MaxInt64 is the only key
+								// whose length overflows int64; Go rejects that key as
+								// an out-of-bounds index (the largest key that forms a
+								// valid length is MaxInt64-1). Match Go, and stop k+1
+								// from wrapping negative past checkArrayLenFits below.
+								if k == math.MaxInt64 {
+									panic(fmt.Sprintf("array index %d out of bounds [0:0]", k))
+								}
+								idx = k + 1
 							}
 						}
 						// update type
@@ -2438,12 +2445,12 @@ func preprocess1(store Store, ctx BlockNode, n Node) Node {
 						// at.Vrd = false
 						// Reject an oversized [...]T{idx: v} array, whose length
 						// is only known here, at compile time (see checkArrayLenFits).
-						checkArrayLenFits(at.Elt, int64(idx))
-						at.Len = idx
+						checkArrayLenFits(at.Elt, idx)
+						at.Len = int(idx)
 						// Mutating Len invalidates the cached typeid.
 						at.typeid = ""
 						// update node
-						cx := constInt(n, int64(idx))
+						cx := constInt(n, idx)
 						unconst(n.Type).(*ArrayTypeExpr).Len = cx
 					}
 				}
@@ -4884,10 +4891,7 @@ func checkArrayLenFits(et Type, length int64) {
 	if length <= 0 {
 		return // negative lengths are rejected earlier (go/types).
 	}
-	per := int64(allocArrayItem)
-	if et.Kind() == Uint8Kind {
-		per = 1 // byte arrays use AllocateDataArray (1 byte/elem).
-	}
+	per := arrayItemAllocSize(et)
 	if length > (math.MaxInt64-allocArray)/per {
 		panic(fmt.Sprintf("type [%d]%s larger than address space", length, et.String()))
 	}

--- a/gnovm/pkg/gnolang/preprocess_alloc_test.go
+++ b/gnovm/pkg/gnolang/preprocess_alloc_test.go
@@ -359,3 +359,54 @@ func TestPreprocessAlloc_BeginTransactionPropagates(t *testing.T) {
 	require.Same(t, preAlloc, got,
 		"forked tx-store must share the SAME *Allocator pointer (gas counters and bytes are shared across the tx)")
 }
+
+// TestCheckArrayLenFits exercises the preprocess-time array-length guard
+// directly. The make20/21/22 filetests only cover the wildly-oversized
+// MaxInt64 case end-to-end; the cases that matter for the threshold math —
+// the exact boundary, and the per-element divergence between the byte
+// (1 byte/elem) and non-byte (allocArrayItem/elem) paths — can't be written
+// as filetests because a boundary-length array would attempt a real
+// allocation. They are checked here instead.
+func TestCheckArrayLenFits(t *testing.T) {
+	// Thresholds derived the same way the guard does, so the boundary cases
+	// double as change-detectors for the formula.
+	perItem := int64(allocArrayItem) // non-byte: a full TypedValue slot.
+	thrItem := (math.MaxInt64 - allocArray) / perItem
+	thrByte := int64(math.MaxInt64-allocArray) / 1 // byte: 1 byte/elem.
+
+	tests := []struct {
+		name    string
+		et      Type
+		length  int64
+		wantMsg string // "" => must not panic
+	}{
+		{"zero length", IntType, 0, ""},
+		{"negative length", IntType, -1, ""},
+		{"small array", IntType, 1 << 20, ""},
+		{"non-byte at boundary", IntType, thrItem, ""},
+		{"non-byte just over boundary", IntType, thrItem + 1, "larger than address space"},
+		{"non-byte maxint64", IntType, math.MaxInt64, "type [9223372036854775807]int larger than address space"},
+		{"byte at boundary", Uint8Type, thrByte, ""},
+		{"byte just over boundary", Uint8Type, thrByte + 1, "larger than address space"},
+		{"byte maxint64", Uint8Type, math.MaxInt64, "type [9223372036854775807]uint8 larger than address space"},
+		// 1<<62 overflows the non-byte (allocArrayItem/elem) accounting but
+		// still fits the byte (1/elem) path: the two branches must diverge.
+		{"cross-branch rejected as non-byte", IntType, 1 << 62, "larger than address space"},
+		{"cross-branch accepted as byte", Uint8Type, 1 << 62, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantMsg == "" {
+				require.NotPanics(t, func() { checkArrayLenFits(tt.et, tt.length) })
+				return
+			}
+			defer func() {
+				r := recover()
+				require.NotNil(t, r, "expected a panic")
+				require.Contains(t, fmt.Sprint(r), tt.wantMsg)
+			}()
+			checkArrayLenFits(tt.et, tt.length)
+		})
+	}
+}

--- a/gnovm/pkg/gnolang/preprocess_alloc_test.go
+++ b/gnovm/pkg/gnolang/preprocess_alloc_test.go
@@ -360,14 +360,14 @@ func TestPreprocessAlloc_BeginTransactionPropagates(t *testing.T) {
 		"forked tx-store must share the SAME *Allocator pointer (gas counters and bytes are shared across the tx)")
 }
 
-// TestCheckArrayLenFits exercises the preprocess-time array-length guard
+// TestCheckArrayAllocFits exercises the preprocess-time array-length guard
 // directly. The make20/21/22 filetests only cover the wildly-oversized
 // MaxInt64 case end-to-end; the cases that matter for the threshold math —
 // the exact boundary, and the per-element divergence between the byte
 // (1 byte/elem) and non-byte (allocArrayItem/elem) paths — can't be written
 // as filetests because a boundary-length array would attempt a real
 // allocation. They are checked here instead.
-func TestCheckArrayLenFits(t *testing.T) {
+func TestCheckArrayAllocFits(t *testing.T) {
 	// Thresholds derived the same way the guard does, so the boundary cases
 	// double as change-detectors for the formula.
 	perItem := int64(allocArrayItem) // non-byte: a full TypedValue slot.
@@ -398,7 +398,7 @@ func TestCheckArrayLenFits(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.wantMsg == "" {
-				require.NotPanics(t, func() { checkArrayLenFits(tt.et, tt.length) })
+				require.NotPanics(t, func() { checkArrayAllocFits(tt.et, tt.length) })
 				return
 			}
 			defer func() {
@@ -406,7 +406,62 @@ func TestCheckArrayLenFits(t *testing.T) {
 				require.NotNil(t, r, "expected a panic")
 				require.Contains(t, fmt.Sprint(r), tt.wantMsg)
 			}()
-			checkArrayLenFits(tt.et, tt.length)
+			checkArrayAllocFits(tt.et, tt.length)
+		})
+	}
+}
+
+// TestEllipsisArrayIndexOverflow pins the variadic-array measurement guards
+// that reject an [...]T literal whose implied length would overflow int64.
+// This guard lives in preprocess1's measurement loop — a path the
+// checkArrayAllocFits test above never reaches (it emits "array index ... out
+// of bounds", not "larger than address space") — so it needs its own coverage.
+// Mirrors the make23 (keyed) and make26 (unkeyed trailing element) filetests.
+func TestEllipsisArrayIndexOverflow(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			// Keyed MaxInt64 implies length MaxInt64+1 (make23).
+			"keyed maxint64",
+			"[...]int{9223372036854775807: 1}",
+			"array index 9223372036854775807 out of bounds",
+		},
+		{
+			// Trailing unkeyed element after a MaxInt64-1 key reaches index
+			// MaxInt64, overflowing the running length (make26).
+			"unkeyed trailing element",
+			"[...]int{9223372036854775806: 1, 2}",
+			"array index 9223372036854775807 out of bounds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, _ := newPreprocessAllocTestStore(t, 64*1024*1024, stypes.NewInfiniteGasMeter())
+			defer st.SetPreprocessAllocator(nil)
+
+			pkgPath := "gno.land/r/test/ellipsis"
+			m := NewMachineWithOptions(MachineOptions{
+				PkgPath: pkgPath,
+				Store:   st,
+				Output:  io.Discard,
+				Alloc:   NewAllocator(64 * 1024 * 1024),
+			})
+			defer m.Release()
+
+			mpkg := &std.MemPackage{
+				Type: MPUserProd,
+				Name: "ellipsis",
+				Path: pkgPath,
+				Files: []*std.MemFile{{Name: "a.gno", Body: fmt.Sprintf(
+					"package ellipsis\nfunc main() { _ = %s }\n", tt.expr)}},
+			}
+			panicked, val := runMemPackageRecover(m, mpkg)
+			require.True(t, panicked, "expected preprocess to reject overflowing length")
+			require.Contains(t, fmt.Sprint(val), tt.want, "got: %v", val)
 		})
 	}
 }

--- a/gnovm/tests/files/make20.gno
+++ b/gnovm/tests/files/make20.gno
@@ -1,0 +1,13 @@
+package main
+
+// An oversized fixed-size array is a compile-time error in Go ("larger than
+// address space"). go/types does not catch it, so the gnovm preprocessor
+// rejects it here instead of letting it leak to a runtime allocation panic.
+
+func main() {
+	var arr [9223372036854775807]int
+	_ = arr
+}
+
+// Error:
+// main/make20.gno:8:10-34: type [9223372036854775807]int larger than address space

--- a/gnovm/tests/files/make21.gno
+++ b/gnovm/tests/files/make21.gno
@@ -1,0 +1,13 @@
+package main
+
+// Same compile-time rejection as make20, but for a byte array, which is
+// sized via the AllocateDataArray (1 byte/elem) path rather than the
+// AllocateListArray (TypedValue/elem) path.
+
+func main() {
+	var arr [9223372036854775807]byte
+	_ = arr
+}
+
+// Error:
+// main/make21.gno:8:10-35: type [9223372036854775807]uint8 larger than address space

--- a/gnovm/tests/files/make22.gno
+++ b/gnovm/tests/files/make22.gno
@@ -1,0 +1,14 @@
+package main
+
+// An oversized ellipsis array [...]T{idx: v} is sized by its largest keyed
+// index, known only after the elements are measured. It must be rejected at
+// compile time too (Go: "larger than address space"), not leak to a runtime
+// allocation panic like the explicit [N]T forms in make20/make21.
+
+func main() {
+	x := [...]int{9223372036854775806: 1}
+	_ = x
+}
+
+// Error:
+// main/make22.gno:9:7-39: type [9223372036854775807]int larger than address space

--- a/gnovm/tests/files/make23.gno
+++ b/gnovm/tests/files/make23.gno
@@ -1,0 +1,15 @@
+package main
+
+// An ellipsis-array key of MaxInt64 implies a length of MaxInt64+1, which
+// overflows int64. Go rejects this key as an out-of-bounds array index (the
+// largest key that forms a valid length is MaxInt64-1, used by make22), rather
+// than as the "larger than address space" size error of make20/21/22. gno must
+// reject it at compile time too, not wrap to a negative length.
+
+func main() {
+	x := [...]int{9223372036854775807: 1}
+	_ = x
+}
+
+// Error:
+// main/make23.gno:10:7-39: array index 9223372036854775807 out of bounds [0:0]

--- a/gnovm/tests/files/make24.gno
+++ b/gnovm/tests/files/make24.gno
@@ -1,0 +1,17 @@
+package main
+
+// A key one past MaxInt64 cannot be represented as an int index at all, so it
+// is rejected at key conversion ("bigint overflows target kind") before the
+// ellipsis-array measurement runs. This is why the MaxInt64 guard in make23
+// only needs to handle k == MaxInt64: any larger key never reaches it.
+
+func main() {
+	x := [...]int{9223372036854775808: 1}
+	_ = x
+}
+
+// Error:
+// main/make24.gno:9:7-39: bigint overflows target kind
+
+// TypeCheckError:
+// main/make24.gno:9:16: 9223372036854775808 (untyped int constant) overflows int

--- a/gnovm/tests/files/make25.gno
+++ b/gnovm/tests/files/make25.gno
@@ -1,0 +1,17 @@
+package main
+
+// A negative ellipsis-array key is rejected at key validation ("index must not
+// be negative") before the measurement loop runs, so the loop only ever sees
+// non-negative keys. Pinned alongside make23/make24 to document the full set of
+// out-of-range keys handled upstream of the MaxInt64 length guard.
+
+func main() {
+	x := [...]int{-1: 1}
+	_ = x
+}
+
+// Error:
+// main/make25.gno:9:7-22: invalid argument: index must not be negative: (-1 <untyped> bigint)
+
+// TypeCheckError:
+// main/make25.gno:9:16: invalid argument: index -1 (constant of type int) must not be negative

--- a/gnovm/tests/files/make26.gno
+++ b/gnovm/tests/files/make26.gno
@@ -1,0 +1,16 @@
+package main
+
+// A trailing element after a near-max key overflows the measured length. The
+// key MaxInt64-1 sets the running index to MaxInt64, then the unkeyed element
+// `2` takes index MaxInt64 and pushes the implied length to MaxInt64+1, which
+// wraps int64 negative. Like make23, Go rejects the overflowing element as an
+// out-of-bounds index; gno must reject it at compile time, not silently accept
+// a negative array length.
+
+func main() {
+	x := [...]int{9223372036854775806: 1, 2}
+	_ = x
+}
+
+// Error:
+// main/make26.gno:11:7-42: array index 9223372036854775807 out of bounds [0:0]


### PR DESCRIPTION
follow up #5723.

- Oversized fixed-size arrays (`[N]T`, `[N]T{...}`, `[...]T{idx: v}`) only failed at runtime as a recoverable allocation panic; now rejected at preprocess time like Go (`larger than address space`), via a shared `checkArrayLenFits` mirroring the allocator overflow threshold (go/types misses it — it is a gc-backend check).
- `[...]T` ellipsis keys: a `MaxInt64` key (length `k+1` overflows int64) is rejected as an out-of-bounds index matching Go; larger keys (`bigint overflows target kind`) and negative keys are already caught upstream at key conversion.
- The byte-vs-`TypedValue` per-element size now comes from a shared `arrayItemAllocSize` in `alloc.go`, co-located with the allocator dispatch it mirrors so the preprocess check cannot drift.
- Tests: filetests make20–25 (each array form plus the key-boundary regimes) and a `TestCheckArrayLenFits` unit test; verified with `Files -test.short`, Gas, and integration testdata suites.
