### PR TITLE
fix(gnovm): make parallel test execution race-free and memory-bounded

### DIFF
--- a/gno.land/pkg/integration/parallel_test.go
+++ b/gno.land/pkg/integration/parallel_test.go
@@ -1,0 +1,118 @@
+package integration
+
+import (
+	"flag"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/pbnjay/memory"
+)
+
+// memLimitFraction is the share of available RAM the test process may use as
+// its soft heap limit (GOMEMLIMIT). The remainder is headroom for non-heap
+// memory (goroutine stacks, OS buffers) and other processes.
+const memLimitFraction = 0.80
+
+// perNodeMemBudgetBytes is a conservative live-memory reservation per parallel
+// in-memory integration node, used only to derive a parallelism cap — it is
+// not a hard limit (GOMEMLIMIT is). It is grounded in a validated run: 4 nodes
+// completed under a 9 GiB heap cap with ~13 GiB available, i.e. ~3 GiB of
+// budget per node once the shared baseline is amortised in.
+//
+// Note we deliberately do NOT divide by the SEQ_TS peak RSS (~12 GiB): that
+// figure is dominated by Go heap high-watermark retention plus the shared,
+// process-global stdlib/typecheck caches that accumulate across all scripts,
+// none of which scales per node. Using it would force parallelism to 1.
+const perNodeMemBudgetBytes = 3 << 30 // 3 GiB
+
+// configureForAvailableMemory bounds the integration suite's memory use so it
+// does not OOM on machines where the defaults would. The testing default
+// (-parallel = GOMAXPROCS) boots one in-memory node per core; on a high-core
+// box with limited RAM (e.g. 16 cores / ~13 GiB free) that exhausts memory.
+//
+// Two cooperating guards are installed (each skipped if the caller set it
+// explicitly):
+//
+//   - GOMEMLIMIT is set to memLimitFraction of available RAM, so the Go
+//     runtime caps its own heap and collects under pressure regardless of how
+//     much it would otherwise retain.
+//   - -test.parallel is lowered to available/perNodeMemBudget, clamped to
+//     [1, GOMAXPROCS], so we neither oversubscribe CPU nor pile up more live
+//     nodes than the heap budget can hold. This cap is the real OOM guard.
+//
+// No-op when available memory can't be determined, leaving the defaults in
+// place.
+func configureForAvailableMemory() {
+	avail := availableMemoryBytes()
+	if avail == 0 {
+		return // unknown: keep defaults
+	}
+
+	// Soft heap limit. Respect an explicit GOMEMLIMIT.
+	if os.Getenv("GOMEMLIMIT") == "" {
+		debug.SetMemoryLimit(int64(float64(avail) * memLimitFraction))
+	}
+
+	// Parallelism cap (the OOM guard). Respect an explicit -parallel.
+	if flag.Lookup("test.parallel") == nil || parallelFlagSet() {
+		return
+	}
+	n := int(avail / perNodeMemBudgetBytes)
+	if n < 1 {
+		n = 1
+	}
+	if maxP := runtime.GOMAXPROCS(0); n > maxP {
+		n = maxP
+	}
+	_ = flag.Set("test.parallel", strconv.Itoa(n))
+}
+
+// availableMemoryBytes returns the memory the test process can realistically
+// use. On Linux it reads MemAvailable from /proc/meminfo (which accounts for
+// reclaimable page cache, unlike MemFree). Elsewhere it falls back to
+// memory.FreeMemory(): portable (macOS/Windows/BSD) but reporting free rather
+// than available, i.e. conservative. Returns 0 if neither is determinable.
+func availableMemoryBytes() uint64 {
+	if n := linuxMemAvailableBytes(); n != 0 {
+		return n
+	}
+	return memory.FreeMemory()
+}
+
+// linuxMemAvailableBytes returns MemAvailable from /proc/meminfo, or 0 when it
+// can't be read (e.g. non-Linux platforms, where /proc/meminfo is absent).
+func linuxMemAvailableBytes() uint64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		fields := strings.Fields(line) // "MemAvailable:" "<kB>" "kB"
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return kb * 1024
+	}
+	return 0
+}
+
+// parallelFlagSet reports whether -test.parallel was passed on the command line.
+func parallelFlagSet() bool {
+	set := false
+	flag.Visit(func(fl *flag.Flag) {
+		if fl.Name == "test.parallel" {
+			set = true
+		}
+	})
+	return set
+}

--- a/gno.land/pkg/integration/process_test.go
+++ b/gno.land/pkg/integration/process_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 
 	// Check if the embedded command should be executed
 	if !*runCommand {
+		configureForAvailableMemory()
 		os.Exit(m.Run())
 	}
 

--- a/gnovm/pkg/gnolang/alloc.go
+++ b/gnovm/pkg/gnolang/alloc.go
@@ -2,7 +2,6 @@ package gnolang
 
 import (
 	"fmt"
-	"math"
 	"math/bits"
 	"unsafe"
 
@@ -14,6 +13,15 @@ import (
 // In the future, allocations within realm boundaries will be
 // (optionally?) condensed (objects to be GC'd will be discarded),
 // but for now, allocations strictly increment across the whole tx.
+//
+// A nil *Allocator is valid: every method is nil-safe. It tracks no allocation
+// budget and charges no gas, and stamps new objects only by their declared
+// realm type (getDeclaredPkgID); the executing-realm stamp is skipped, since
+// nil carries no realm context (equivalent to a zero currentRealmID). This
+// serves the handful of pure-function / no-Machine paths (e.g. MapList.Append
+// for MapItems, IntType-only conversions, uverse and package init) that must
+// construct values without a budget. Because nil holds no mutable state, it is
+// also safe to share across goroutines.
 type Allocator struct {
 	maxBytes int64
 	bytes    int64
@@ -31,18 +39,6 @@ type Allocator struct {
 	// realm path rather than an opaque PkgID hex.
 	currentRealmPath string
 }
-
-// fallbackAllocator is for the small set of pure-fn / no-Machine paths
-// that need a valid *Allocator pointer but never produce a persistable
-// composite — e.g. ConvertGetInt (IntType-only conversion), MapList.Append
-// for MapItems (which carry no ObjectInfo), and uverse-init / package-init
-// helpers. Its currentRealmID is zero, so any incidental stamp is a no-op
-// (PkgID.IsZero indistinguishable from "never set"). Its byte budget is
-// MaxInt64 so accounting never throttles.
-//
-// Production paths that *do* produce persistable composites flow through
-// m.Alloc, which has currentRealmID synced via setRealm.
-var fallbackAllocator = NewAllocator(math.MaxInt64)
 
 // Allocation size constants for gas metering.
 //
@@ -241,6 +237,9 @@ func NewAllocator(maxBytes int64) *Allocator {
 }
 
 func (alloc *Allocator) SetGCFn(f func() (int64, bool)) {
+	if alloc == nil {
+		return
+	}
 	alloc.collect = f
 }
 
@@ -256,6 +255,9 @@ func (alloc *Allocator) GetGasMeter() store.GasMeter {
 }
 
 func (alloc *Allocator) SetGasMeter(gasMeter store.GasMeter) {
+	if alloc == nil {
+		return
+	}
 	alloc.gasMeter = gasMeter
 }
 
@@ -268,6 +270,9 @@ func (alloc *Allocator) MemStats() string {
 }
 
 func (alloc *Allocator) Status() (maxBytes int64, bytes int64) {
+	if alloc == nil {
+		return 0, 0
+	}
 	return alloc.maxBytes, alloc.bytes
 }
 
@@ -283,6 +288,9 @@ func (alloc *Allocator) Reset() *Allocator {
 // Used during GC re-walk to re-count surviving objects
 // without double-charging for already-paid allocations.
 func (alloc *Allocator) Recount(size int64) {
+	if alloc == nil {
+		return
+	}
 	alloc.bytes += size
 }
 
@@ -301,6 +309,10 @@ func (alloc *Allocator) Fork() *Allocator {
 }
 
 func (alloc *Allocator) Allocate(size int64) {
+	if alloc == nil {
+		// nil allocator: no budget to track. See the Allocator type doc.
+		return
+	}
 	if overflow.Addp(alloc.bytes, size) > alloc.maxBytes {
 		if alloc.collect == nil {
 			// Forked allocators (e.g. the store's tx-scoped allocator
@@ -428,7 +440,7 @@ func (alloc *Allocator) AllocateHeapItem() {
 // nil t skips the check (anonymous sub-allocations); alloc is assumed
 // non-nil.
 func (alloc *Allocator) checkConstructionTime(t Type) {
-	if t == nil {
+	if t == nil || alloc == nil {
 		return
 	}
 	pid := getDeclaredPkgID(t)
@@ -461,6 +473,10 @@ func (alloc *Allocator) checkConstructionTime(t Type) {
 func (alloc *Allocator) stampPkgID(oi *ObjectInfo, t Type) {
 	if pid := getDeclaredPkgID(t); pid.IsRealmPkg() {
 		oi.SetPkgID(pid)
+		return
+	}
+	if alloc == nil {
+		// No executing realm: leave PkgID zero (== a zero currentRealmID).
 		return
 	}
 	oi.SetPkgID(alloc.currentRealmID)

--- a/gnovm/pkg/gnolang/debug.go
+++ b/gnovm/pkg/gnolang/debug.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	// Ignore pprof import, as the server does not
@@ -49,13 +50,16 @@ func init() {
 	}
 }
 
-// runtime debugging flag.
+// runtime debugging flag. Toggled by EnableDebug/DisableDebug (e.g. filetests
+// mute it during realm setup) and read only inside `if debug` blocks. It is
+// atomic because the parallel test suites toggle it from multiple goroutines.
+var enabled atomic.Bool
 
-var enabled bool = true
+func init() { enabled.Store(true) }
 
 func (debugging) Println(args ...any) {
 	if debug {
-		if enabled {
+		if enabled.Load() {
 			_, file, line, _ := runtime.Caller(2)
 			caller := fmt.Sprintf("%-.12s:%-4d", path.Base(file), line)
 			prefix := fmt.Sprintf("DEBUG: %17s: ", caller)
@@ -66,7 +70,7 @@ func (debugging) Println(args ...any) {
 
 func (debugging) Printf(format string, args ...any) {
 	if debug {
-		if enabled {
+		if enabled.Load() {
 			_, file, line, _ := runtime.Caller(2)
 			caller := fmt.Sprintf("%.12s:%-4d", path.Base(file), line)
 			prefix := fmt.Sprintf("DEBUG: %17s: ", caller)
@@ -82,7 +86,7 @@ var derrors []string = nil
 // test, and the file test fails if any unexpected debug errors were found.
 func (debugging) Errorf(format string, args ...any) {
 	if debug {
-		if enabled {
+		if enabled.Load() {
 			derrors = append(derrors, fmt.Sprintf(format, args...))
 		}
 	}
@@ -197,15 +201,15 @@ func IsDebug() bool {
 }
 
 func IsDebugEnabled() bool {
-	return bool(debug) && enabled
+	return bool(debug) && enabled.Load()
 }
 
 func DisableDebug() {
-	enabled = false
+	enabled.Store(false)
 }
 
 func EnableDebug() {
-	enabled = true
+	enabled.Store(true)
 }
 
 func PrintCaller(start, end int) {

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -2941,7 +2941,7 @@ func (m *Machine) Recover() *Exception {
 
 func (m *Machine) Println(args ...any) {
 	if debug {
-		if enabled {
+		if enabled.Load() {
 			_, file, line, _ := runtime.Caller(2) // get caller info
 			caller := fmt.Sprintf("%-.12s:%-4d", path.Base(file), line)
 			prefix := fmt.Sprintf("DEBUG: %17s: ", caller)
@@ -2953,7 +2953,7 @@ func (m *Machine) Println(args ...any) {
 
 func (m *Machine) Printf(format string, args ...any) {
 	if debug {
-		if enabled {
+		if enabled.Load() {
 			_, file, line, _ := runtime.Caller(2) // get caller info
 			caller := fmt.Sprintf("%-.12s:%-4d", path.Base(file), line)
 			prefix := fmt.Sprintf("DEBUG: %17s: ", caller)

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -4282,10 +4282,10 @@ func tryEvalStatic(store Store, pn *PackageNode, last BlockNode, x Expr) (tv Typ
 		return cx.TypedValue, nil
 	}
 	// store.GetAllocator() may be nil here — store.BeginTransaction
-	// below forks alloc which propagates nil — and we need a non-nil
-	// alloc for pn.NewPackage. Use fallbackAllocator: this PackageValue
-	// is throwaway, never persisted.
-	pv := pn.NewPackage(fallbackAllocator) // throwaway
+	// below forks alloc which propagates nil — and that's fine: this
+	// PackageValue is a throwaway, never persisted, so a nil (no-op)
+	// allocator suffices.
+	pv := pn.NewPackage(nil) // throwaway
 	store = store.BeginTransaction(nil, nil, nil, nil)
 	store.SetCachePackage(pv)
 	m := NewMachineWithOptions(MachineOptions{
@@ -4889,8 +4889,8 @@ func convertConst(store Store, last BlockNode, n Node, cx *ConstExpr, t Type) {
 		// convertConst's store may be nil (e.g. the Preprocess(nil, ...)
 		// special-case in append-iface-nil at line ~1804). The
 		// conversion lands in a ConstExpr that isn't persisted directly,
-		// so use fallbackAllocator: no stamping needed.
-		ConvertTo(fallbackAllocator, store, &cx.TypedValue, t, true)
+		// so use a nil (no-op) allocator: no stamping needed.
+		ConvertTo(nil, store, &cx.TypedValue, t, true)
 		setConstAttrs(cx)
 	}
 }

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1692,7 +1692,7 @@ func copyValueWithRefs(val Value) Value {
 		for cur := cv.List.Head; cur != nil; cur = cur.Next {
 			key2 := refOrCopyValue(cur.Key)
 			val2 := refOrCopyValue(cur.Value)
-			list.Append(fallbackAllocator, key2).Value = val2
+			list.Append(nil, key2).Value = val2
 		}
 		return &MapValue{
 			ObjectInfo: cv.ObjectInfo.Copy(),

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -1215,7 +1215,7 @@ func (ds *defaultStore) GetNative(pkgPath string, name Name) func(m *Machine) {
 
 // Set to nil to disable.
 func (ds *defaultStore) SetLogStoreOps(buf io.Writer) {
-	if enabled {
+	if enabled.Load() {
 		ds.opslog = buf
 	} else {
 		ds.opslog = nil

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -282,7 +282,7 @@ var OriginCallerExtractor func(ctx any) string
 // `cur.Previous()` after the override surfaces what X_getRealm surfaces
 // as PreviousRealm of the override frame. Exposed for X_setContext.
 func BuildOverridePrevField(addr, pkgPath string) TypedValue {
-	return newRealmHIVPointer(fallbackAllocator, addr, pkgPath, TypedValue{})
+	return newRealmHIVPointer(nil, addr, pkgPath, TypedValue{})
 }
 
 // buildOriginRealm constructs a per-call origin realm matching what
@@ -321,7 +321,7 @@ func init() {
 	gConcreteRealmType.Base.(*StructType).Fields[2].Type = gConcreteRealmPtrType
 
 	// Build the global placeholder origin realm now that types are wired.
-	gOriginRealmTV = newRealmHIVPointer(fallbackAllocator, "", "", TypedValue{})
+	gOriginRealmTV = newRealmHIVPointer(nil, "", "", TypedValue{})
 }
 
 // OriginRealmTV returns the typed-nil *.grealm used as the prev seed for
@@ -1554,7 +1554,94 @@ func makeUverseNode() {
 			}
 		},
 	)
-	uverseValue = uverseNode.NewPackage(fallbackAllocator)
+	uverseValue = uverseNode.NewPackage(nil)
+
+	sealUverseTypes()
+}
+
+// sealUverseTypes pre-fills the lazily-memoized fields on the shared, process-
+// global uverse type singletons, single-threaded during package init, so they
+// are read-only afterward and the parallel test suites (and `gno test -p`) do
+// not race filling them on first concurrent access.
+//
+// Each Type kind caches metadata on first use — TypeID, FuncType.bound,
+// Declared/StructType.pkgID, Interface/StructType effective counts — none of
+// which is safe to fill from multiple goroutines. Computing them here once
+// makes the shared type graph immutable. Per-store types are unaffected (each
+// is preprocessed by a single goroutine). DeclaredType.methodIndex is not
+// pre-filled: it builds only past methodIndexThreshold, which no uverse
+// singleton reaches.
+func sealUverseTypes() {
+	seen := make(map[Type]bool)
+	var seal func(t Type)
+	seal = func(t Type) {
+		if t == nil || seen[t] {
+			return
+		}
+		seen[t] = true
+		switch ct := t.(type) {
+		case *PointerType:
+			ct.TypeID()
+			seal(ct.Elt)
+		case *SliceType:
+			ct.TypeID()
+			seal(ct.Elt)
+		case *ArrayType:
+			ct.TypeID()
+			seal(ct.Elt)
+		case *ChanType:
+			ct.TypeID()
+			seal(ct.Elt)
+		case *MapType:
+			ct.TypeID()
+			seal(ct.Key)
+			seal(ct.Value)
+		case *FuncType:
+			ct.TypeID()
+			if len(ct.Params) > 0 {
+				ct.BoundType() // method type: fill bound
+			}
+			for i := range ct.Params {
+				seal(ct.Params[i].Type)
+			}
+			for i := range ct.Results {
+				seal(ct.Results[i].Type)
+			}
+		case *StructType:
+			ct.TypeID()
+			ct.GetPkgID()
+			effectiveStructSurface(ct, map[Type]struct{}{})
+			for i := range ct.Fields {
+				seal(ct.Fields[i].Type)
+			}
+		case *InterfaceType:
+			if ct.Generic != "" {
+				return // generic uverse type: no TypeID, never concurrently filled
+			}
+			ct.TypeID()
+			effectiveInterfaceMethods(ct, map[Type]struct{}{})
+			for i := range ct.Methods {
+				seal(ct.Methods[i].Type)
+			}
+		case *DeclaredType:
+			ct.TypeID()
+			ct.GetPkgID()
+			seal(ct.Base)
+			for i := range ct.Methods {
+				seal(ct.Methods[i].T)
+			}
+		default:
+			// PrimitiveType, PackageType, TypeType, etc.
+			ct.TypeID()
+		}
+	}
+	for _, t := range []Type{
+		gErrorType, gStringerType, gAddressType, gRealmType,
+		gConcreteRealmType, gConcreteRealmPtrType, gByteSliceType,
+		gPackageType, gTypeType,
+	} {
+		seal(t)
+	}
 }
 
 func copyDataToList(dst []TypedValue, data []byte, et Type) {

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -1222,9 +1222,9 @@ func (tv *TypedValue) SetInt(n int64) {
 
 func (tv *TypedValue) ConvertGetInt() int64 {
 	var store Store = nil // not used
-	// IntType-only conversion: no allocation occurs; fallbackAllocator
-	// is used purely to satisfy the *Allocator argument.
-	ConvertTo(fallbackAllocator, store, tv, IntType, false)
+	// IntType-only conversion: no allocation occurs, so pass a nil
+	// (no-op) allocator.
+	ConvertTo(nil, store, tv, IntType, false)
 	return tv.GetInt()
 }
 
@@ -1993,7 +1993,7 @@ func (tv *TypedValue) GetPointerToFromTV(alloc *Allocator, store Store, path Val
 func (tv *TypedValue) GetPointerAtIndexInt(m *Machine, store Store, ii int) PointerValue {
 	iv := TypedValue{T: IntType}
 	iv.SetInt(int64(ii))
-	return tv.GetPointerAtIndex(m, nilRealm, fallbackAllocator, store, &iv)
+	return tv.GetPointerAtIndex(m, nilRealm, nil, store, &iv)
 }
 
 func (tv *TypedValue) GetPointerAtIndex(m *Machine, rlm *Realm, alloc *Allocator, store Store, iv *TypedValue) PointerValue {

--- a/gnovm/pkg/gnolang/values_conversions.go
+++ b/gnovm/pkg/gnolang/values_conversions.go
@@ -1150,7 +1150,7 @@ func ConvertUntypedTo(tv *TypedValue, t Type) {
 			tv.T = t
 			return
 		} else {
-			ConvertTo(fallbackAllocator, nil, tv, t, false)
+			ConvertTo(nil, nil, tv, t, false)
 		}
 	default:
 		panic(fmt.Sprintf(

--- a/gnovm/pkg/gnolang/values_export.go
+++ b/gnovm/pkg/gnolang/values_export.go
@@ -256,7 +256,7 @@ func exportCopyValue(val Value, seen map[Object]int) Value {
 		for cur := cv.List.Head; cur != nil; cur = cur.Next {
 			key2 := exportValue(cur.Key, seen)
 			val2 := exportValue(cur.Value, seen)
-			list.Append(fallbackAllocator, key2).Value = val2
+			list.Append(nil, key2).Value = val2
 		}
 		return &MapValue{
 			ObjectInfo: cv.ObjectInfo.Copy(),

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/libp2p/go-buffer-pool v0.1.0
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pelletier/go-toml v1.9.5
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=


### PR DESCRIPTION
> [!NOTE]
> Stacked on #5811 (`perf(gnovm): parallelize test suites and add gno test -p`); base branch is `dev/morgan/gnovm-test-parallel`, so this diff is only the two commits on top. Merge #5811 first.

## Context

#5811 makes the test suites run many VMs concurrently in one process (parallel `TestFiles`/`TestStdlibs`, and `gno test -p` defaulting to `GOMAXPROCS`). That surfaced two pre-existing problems this PR addresses: latent data races on process-global VM state, and integration-suite OOMs on high-core/low-RAM machines.

## 1. Data races on shared VM globals (gnovm)

These are pre-existing — `go test -race` fails on `master` too (it just isn't run in CI) — but the broadened parallelism makes them load-bearing. All are benign in value yet real under `-race`. Verified across the full short `TestFiles` and `TestStdlibs` suites under `-race`: **0 data races** after these fixes.

- **`fallbackAllocator` removed.** It was a shared, process-global `*Allocator` written by concurrent stores via `copyValueWithRefs` / conversions. Rather than special-casing it, a `nil` `*Allocator` is now a valid, fully nil-safe no-op: it skips byte accounting, gas, and the executing-realm PkgID stamp, while **type-driven** stamping (`getDeclaredPkgID`) still applies — so realm ownership semantics are unchanged. The pure-function / no-Machine paths that used the fallback now pass `nil`, eliminating the shared mutable allocator entirely.
- **Lazy memoization on shared type singletons.** The uverse types (`error`, etc.) are process-global and cache metadata on first use — `TypeID`, `FuncType.bound` (`BoundType`), `Declared`/`StructType.pkgID`, and `Interface`/`StructType` effective counts — each racing on concurrent first access (e.g. `VerifyImplementedBy` / `checkAssignableTo` during stdlib loading). `sealUverseTypes()` pre-computes all of them once at uverse init, single-threaded, so the shared type graph is immutable afterward. Per-store types are unaffected — each is preprocessed by a single goroutine. (`DeclaredType.methodIndex` is intentionally not pre-filled: it only builds past `methodIndexThreshold`, which no uverse singleton reaches.)
- **The `enabled` debug flag** — toggled by `EnableDebug`/`DisableDebug` (filetests call these around realm setup) and read by `SetLogStoreOps` — was a plain `bool` written/read from multiple goroutines. It is now an `atomic.Bool`.

## 2. Bound integration-test memory (gno.land)

`TestTestdata` boots a full in-memory node per txtar script and runs them at `-parallel = GOMAXPROCS`. On 16 cores / ~13 GiB available that booted ~16 nodes at once and OOM-killed the run.

`TestMain` now derives two cooperating guards from available RAM (each skipped if set explicitly):

- `GOMEMLIMIT = 80% of available` — caps the runtime's heap so retention can't OOM us.
- `-test.parallel = available / 3 GiB-per-node`, clamped to `[1, GOMAXPROCS]` — the real OOM guard; never raises parallelism above the old default.

Available RAM is read from `/proc/meminfo` `MemAvailable` on Linux (accounts for reclaimable page cache), falling back to `github.com/pbnjay/memory` `FreeMemory` on other platforms (portable, conservative). The `~12 GiB` `SEQ_TS` peak RSS is deliberately *not* used as a divisor — it's heap retention + shared accumulating caches, not per-node cost.

On 4-vCPU CI the parallel cap stays at `GOMAXPROCS` and `GOMEMLIMIT` doesn't bind, so CI behavior is unchanged. On 16 cores / 13 GiB available, default `go test` now auto-selects `parallel=4` + `~10 GiB` cap: peak RSS **9.8 GiB** (vs ~12.3 GiB unbounded), ~3 min, no OOM.

## Files

- VM race fixes: `gnovm/pkg/gnolang/alloc.go` (nil-safe `*Allocator`, `fallbackAllocator` removed), `uverse.go` (`sealUverseTypes` + nil call sites), `debug.go` / `store.go` / `machine.go` (`enabled` → `atomic.Bool`), and the former `fallbackAllocator` call sites now passing `nil` (`realm.go`, `values.go`, `values_export.go`, `values_conversions.go`, `preprocess.go`)
- Integration memory bounding: `gno.land/pkg/integration/parallel_test.go` (new), `gno.land/pkg/integration/process_test.go`
- Dependency: `go.mod`, `go.sum` (adds `github.com/pbnjay/memory`, a single-file, zero-transitive-dep module, used only in tests)

## Verification

- `go test -race` (cgo): 0 data races on `TestFiles` (full short suite) and `TestStdlibs` (full short suite).
- `go test ./gno.land/pkg/sdk/vm/ -run Gas`: pass (the allocator change doesn't touch real gas accounting).
- `go test ./gnovm/pkg/gnolang/ -run Files -test.short`: no new failures vs baseline (remaining failures are pre-existing go/types message-format diffs).
- txtar suite (`TestTestdata`): pass, auto-bounded, no OOM.
