### PR TITLE
WIP: alternative/follow-up to #5739 — flatten embedded interface method sets

### DIFF
--- a/gnovm/pkg/gnolang/op_types.go
+++ b/gnovm/pkg/gnolang/op_types.go
@@ -142,7 +142,9 @@ func (m *Machine) doOpInterfaceType() {
 	// pop methods
 	for i := len(x.Methods) - 1; 0 <= i; i-- {
 		ft := m.PopValue().V.(TypeValue).Type.(FieldType)
-		fillEmbeddedName(&ft, x.Methods[i].Type)
+		// embedded interfaces are named from the resolved type, not the
+		// written spelling, so an alias and its target stay identical.
+		fillEmbeddedInterfaceName(&ft)
 		methods[i] = ft
 	}
 	// push interface type

--- a/gnovm/pkg/gnolang/op_types.go
+++ b/gnovm/pkg/gnolang/op_types.go
@@ -116,9 +116,9 @@ func (m *Machine) doOpStructType() {
 	// allocate (minimum) space for fields
 	fields := make([]FieldType, 0, len(x.Fields))
 	// populate fields
-	for _, ftv := range ftvs {
+	for i, ftv := range ftvs {
 		ft := ftv.V.(TypeValue).Type.(FieldType)
-		fillEmbeddedName(&ft)
+		fillEmbeddedName(&ft, x.Fields[i].Type)
 		fields = append(fields, ft)
 	}
 	// push struct type
@@ -142,7 +142,7 @@ func (m *Machine) doOpInterfaceType() {
 	// pop methods
 	for i := len(x.Methods) - 1; 0 <= i; i-- {
 		ft := m.PopValue().V.(TypeValue).Type.(FieldType)
-		fillEmbeddedName(&ft)
+		fillEmbeddedName(&ft, x.Methods[i].Type)
 		methods[i] = ft
 	}
 	// push interface type

--- a/gnovm/pkg/gnolang/op_types.go
+++ b/gnovm/pkg/gnolang/op_types.go
@@ -142,11 +142,11 @@ func (m *Machine) doOpInterfaceType() {
 	// pop methods
 	for i := len(x.Methods) - 1; 0 <= i; i-- {
 		ft := m.PopValue().V.(TypeValue).Type.(FieldType)
-		// embedded interfaces are named from the resolved type, not the
-		// written spelling, so an alias and its target stay identical.
-		fillEmbeddedInterfaceName(&ft)
 		methods[i] = ft
 	}
+	// flatten embedded interfaces so identity is the method set, not the
+	// embedded-interface (alias) spelling; see flattenInterfaceMethods.
+	methods = flattenInterfaceMethods(methods)
 	// push interface type
 	it := &InterfaceType{
 		PkgPath: m.Package.PkgPath,

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -4136,9 +4136,16 @@ func staticTypeFromAST(store Store, last BlockNode, x Expr) (Type, bool) {
 		validateStructFields(st, "<anonymous struct>")
 		return st, true
 	case *InterfaceTypeExpr:
+		// Build without struct-style embed naming (embed=false), then name
+		// embedded interfaces from the resolved type rather than the written
+		// spelling, so an alias and its target collapse to one identity.
+		methods := buildFieldTypesAST(store, last, x.Methods, false)
+		for i := range methods {
+			fillEmbeddedInterfaceName(&methods[i])
+		}
 		it := &InterfaceType{
 			PkgPath: packageOf(last).PkgPath,
-			Methods: buildFieldTypesAST(store, last, x.Methods, true),
+			Methods: methods,
 			Generic: x.Generic,
 		}
 		validateEmbedDepth(it, "<anonymous interface>")
@@ -4150,8 +4157,9 @@ func staticTypeFromAST(store Store, last BlockNode, x Expr) (Type, bool) {
 
 // buildFieldTypesAST constructs a []FieldType directly from FieldTypeExprs,
 // mirroring doOpFieldType + doOp{Struct,Interface,Func}Type aggregation.
-// embed=true mirrors doOpStructType/doOpInterfaceType which call
-// fillEmbeddedName per field; embed=false mirrors doOpFuncType which does not.
+// embed=true mirrors doOpStructType, which calls fillEmbeddedName per field;
+// embed=false mirrors doOpFuncType (and the interface path, which builds with
+// embed=false and then names embeds via fillEmbeddedInterfaceName).
 func buildFieldTypesAST(store Store, last BlockNode, fxs FieldTypeExprs, embed bool) []FieldType {
 	fts := make([]FieldType, len(fxs))
 	for i := range fxs {

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -4164,7 +4164,7 @@ func buildFieldTypesAST(store Store, last BlockNode, fxs FieldTypeExprs, embed b
 			ft.Tag = Tag(evalConst(store, last, fx.Tag).GetString())
 		}
 		if embed {
-			fillEmbeddedName(&ft)
+			fillEmbeddedName(&ft, fx.Type)
 		}
 		fts[i] = ft
 	}

--- a/gnovm/pkg/gnolang/preprocess.go
+++ b/gnovm/pkg/gnolang/preprocess.go
@@ -4136,16 +4136,12 @@ func staticTypeFromAST(store Store, last BlockNode, x Expr) (Type, bool) {
 		validateStructFields(st, "<anonymous struct>")
 		return st, true
 	case *InterfaceTypeExpr:
-		// Build without struct-style embed naming (embed=false), then name
-		// embedded interfaces from the resolved type rather than the written
-		// spelling, so an alias and its target collapse to one identity.
-		methods := buildFieldTypesAST(store, last, x.Methods, false)
-		for i := range methods {
-			fillEmbeddedInterfaceName(&methods[i])
-		}
 		it := &InterfaceType{
 			PkgPath: packageOf(last).PkgPath,
-			Methods: methods,
+			// flatten embedded interfaces so identity is the method set, not
+			// the embedded-interface (alias) spelling; see
+			// flattenInterfaceMethods.
+			Methods: flattenInterfaceMethods(buildFieldTypesAST(store, last, x.Methods, true)),
 			Generic: x.Generic,
 		}
 		validateEmbedDepth(it, "<anonymous interface>")
@@ -4157,9 +4153,9 @@ func staticTypeFromAST(store Store, last BlockNode, x Expr) (Type, bool) {
 
 // buildFieldTypesAST constructs a []FieldType directly from FieldTypeExprs,
 // mirroring doOpFieldType + doOp{Struct,Interface,Func}Type aggregation.
-// embed=true mirrors doOpStructType, which calls fillEmbeddedName per field;
-// embed=false mirrors doOpFuncType (and the interface path, which builds with
-// embed=false and then names embeds via fillEmbeddedInterfaceName).
+// embed=true mirrors doOpStructType / doOpInterfaceType, which name embedded
+// fields (the interface path then flattens embeds via flattenInterfaceMethods,
+// which discards the embed name); embed=false mirrors doOpFuncType.
 func buildFieldTypesAST(store Store, last BlockNode, fxs FieldTypeExprs, embed bool) []FieldType {
 	fts := make([]FieldType, len(fxs))
 	for i := range fxs {

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2637,8 +2637,13 @@ func defaultTypeOf(t Type) Type {
 	}
 }
 
-func fillEmbeddedName(ft *FieldType) {
+func fillEmbeddedName(ft *FieldType, nameSrc ...Expr) {
 	if ft.Name != "" {
+		return
+	}
+	if n := pickEmbedName(nameSrc); n != "" {
+		ft.Name = n
+		ft.Embedded = true
 		return
 	}
 	switch ct := ft.Type.(type) {
@@ -2690,6 +2695,40 @@ func fillEmbeddedName(ft *FieldType) {
 			ft.Type.String()))
 	}
 	ft.Embedded = true
+}
+
+func pickEmbedName(xs []Expr) Name {
+	var zero Name
+	if len(xs) == 0 {
+		return zero
+	}
+	x := xs[0]
+	for {
+		switch e := x.(type) {
+		case *constTypeExpr:
+			if e.Source == nil {
+				return zero
+			}
+			x = e.Source
+		case *ConstExpr:
+			if e.Source == nil {
+				return zero
+			}
+			x = e.Source
+		case *StarExpr:
+			x = e.X
+		default:
+			goto done
+		}
+	}
+done:
+	switch e := x.(type) {
+	case *NameExpr:
+		return e.Name
+	case *SelectorExpr:
+		return e.Sel
+	}
+	return zero
 }
 
 func IsImplementedBy(it Type, ot Type) bool {

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2668,6 +2668,36 @@ func fillEmbeddedName(ft *FieldType, nameSrc Expr) {
 	ft.Embedded = true
 }
 
+// fillEmbeddedInterfaceName names an embedded-interface field from its
+// resolved type, NOT from the source spelling. This is deliberately the
+// opposite of fillEmbeddedName (used for struct embeds): Go computes
+// interface identity from the flattened method set, so an embedded alias and
+// its target must collapse to one identity — interface{ SAlias } (where
+// type SAlias = Stringer) must equal interface{ Stringer }. Deriving the
+// name from the resolved *DeclaredType keeps both named "Stringer", matching
+// pre-#5739 behavior and Go.
+//
+// TODO(gnovm): this only equalizes alias-vs-target. GnoVM still stores an
+// embedded interface as a single named method entry instead of flattening
+// its method set, so structurally identical interfaces with different
+// spellings still diverge from Go (e.g. interface{ Stringer } !=
+// interface{ Str() string }, which is also broken on master). The complete
+// fix flattens embedded method sets at construction, dropping the embed name
+// from the TypeID entirely; see the follow-up branch scratch/iface-flatten.
+// Embedding an alias to an *anonymous* interface still panics here, as it
+// did pre-#5739 — the flattening follow-up also resolves that.
+func fillEmbeddedInterfaceName(ft *FieldType) {
+	if ft.Name != "" {
+		return
+	}
+	dt, ok := ft.Type.(*DeclaredType)
+	if !ok {
+		panic(fmt.Sprintf("cannot derive embedded interface name for type %s", ft.Type.String()))
+	}
+	ft.Name = dt.Name
+	ft.Embedded = true
+}
+
 func IsImplementedBy(it Type, ot Type) bool {
 	switch cbt := baseOf(it).(type) {
 	case *InterfaceType:

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2637,98 +2637,80 @@ func defaultTypeOf(t Type) Type {
 	}
 }
 
-func fillEmbeddedName(ft *FieldType, nameSrc ...Expr) {
+func fillEmbeddedName(ft *FieldType, nameSrc Expr) {
 	if ft.Name != "" {
 		return
 	}
 	if n := pickEmbedName(nameSrc); n != "" {
 		ft.Name = n
-		ft.Embedded = true
-		return
-	}
-	switch ct := ft.Type.(type) {
-	case *PointerType:
-		// dereference one level
-		switch ct := ct.Elt.(type) {
+	} else {
+		switch ct := ft.Type.(type) {
+		case *PointerType:
+			// dereference one level
+			switch ct := ct.Elt.(type) {
+			case *DeclaredType:
+				ft.Name = ct.Name
+			default:
+				// should not happen,
+				panic("should not happen")
+			}
 		case *DeclaredType:
 			ft.Name = ct.Name
+		case PrimitiveType:
+			switch ct {
+			case BoolType:
+				ft.Name = Name("bool")
+			case StringType:
+				ft.Name = Name("string")
+			case IntType:
+				ft.Name = Name("int")
+			case Int8Type:
+				ft.Name = Name("int8")
+			case Int16Type:
+				ft.Name = Name("int16")
+			case Int32Type:
+				ft.Name = Name("int32")
+			case Int64Type:
+				ft.Name = Name("int64")
+			case UintType:
+				ft.Name = Name("uint")
+			case Uint8Type:
+				ft.Name = Name("uint8")
+			case Uint16Type:
+				ft.Name = Name("uint16")
+			case Uint32Type:
+				ft.Name = Name("uint32")
+			case Uint64Type:
+				ft.Name = Name("uint64")
+			case Float32Type:
+				ft.Name = Name("float32")
+			case Float64Type:
+				ft.Name = Name("float64")
+			}
 		default:
-			// should not happen,
-			panic("should not happen")
+			panic(fmt.Sprintf(
+				"unexpected field type %s",
+				ft.Type.String()))
 		}
-	case *DeclaredType:
-		ft.Name = ct.Name
-	case PrimitiveType:
-		switch ct {
-		case BoolType:
-			ft.Name = Name("bool")
-		case StringType:
-			ft.Name = Name("string")
-		case IntType:
-			ft.Name = Name("int")
-		case Int8Type:
-			ft.Name = Name("int8")
-		case Int16Type:
-			ft.Name = Name("int16")
-		case Int32Type:
-			ft.Name = Name("int32")
-		case Int64Type:
-			ft.Name = Name("int64")
-		case UintType:
-			ft.Name = Name("uint")
-		case Uint8Type:
-			ft.Name = Name("uint8")
-		case Uint16Type:
-			ft.Name = Name("uint16")
-		case Uint32Type:
-			ft.Name = Name("uint32")
-		case Uint64Type:
-			ft.Name = Name("uint64")
-		case Float32Type:
-			ft.Name = Name("float32")
-		case Float64Type:
-			ft.Name = Name("float64")
-		}
-	default:
-		panic(fmt.Sprintf(
-			"unexpected field type %s",
-			ft.Type.String()))
 	}
 	ft.Embedded = true
 }
 
-func pickEmbedName(xs []Expr) Name {
-	var zero Name
-	if len(xs) == 0 {
-		return zero
-	}
-	x := xs[0]
+func pickEmbedName(x Expr) Name {
 	for {
 		switch e := x.(type) {
-		case *constTypeExpr:
-			if e.Source == nil {
-				return zero
-			}
-			x = e.Source
-		case *ConstExpr:
-			if e.Source == nil {
-				return zero
-			}
-			x = e.Source
+		case *constTypeExpr, *ConstExpr:
+			x = unconst(x)
 		case *StarExpr:
 			x = e.X
+		case *NameExpr:
+			return e.Name
+		case *SelectorExpr:
+			return e.Sel
 		default:
-			goto done
+			return ""
 		}
 	}
-done:
-	switch e := x.(type) {
-	case *NameExpr:
-		return e.Name
-	case *SelectorExpr:
-		return e.Sel
-	}
-	return zero
 }
 
 func IsImplementedBy(it Type, ot Type) bool {

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2668,34 +2668,46 @@ func fillEmbeddedName(ft *FieldType, nameSrc Expr) {
 	ft.Embedded = true
 }
 
-// fillEmbeddedInterfaceName names an embedded-interface field from its
-// resolved type, NOT from the source spelling. This is deliberately the
-// opposite of fillEmbeddedName (used for struct embeds): Go computes
-// interface identity from the flattened method set, so an embedded alias and
-// its target must collapse to one identity — interface{ SAlias } (where
-// type SAlias = Stringer) must equal interface{ Stringer }. Deriving the
-// name from the resolved *DeclaredType keeps both named "Stringer", matching
-// pre-#5739 behavior and Go.
+// flattenInterfaceMethods expands embedded-interface entries into their
+// constituent methods, so a freshly-constructed InterfaceType's Methods list
+// holds only concrete methods, never an embedded interface. This makes
+// interface identity the flattened method set, matching Go: the
+// embedded-interface name (e.g. an alias spelling) no longer leaks into the
+// TypeID, so interface{ Stringer } and interface{ Str() string } — and an
+// embedded alias vs its target — share one identity.
 //
-// TODO(gnovm): this only equalizes alias-vs-target. GnoVM still stores an
-// embedded interface as a single named method entry instead of flattening
-// its method set, so structurally identical interfaces with different
-// spellings still diverge from Go (e.g. interface{ Stringer } !=
-// interface{ Str() string }, which is also broken on master). The complete
-// fix flattens embedded method sets at construction, dropping the embed name
-// from the TypeID entirely; see the follow-up branch scratch/iface-flatten.
-// Embedding an alias to an *anonymous* interface still panics here, as it
-// did pre-#5739 — the flattening follow-up also resolves that.
-func fillEmbeddedInterfaceName(ft *FieldType) {
-	if ft.Name != "" {
-		return
+// Each source interface was itself flattened and method-count-capped at its
+// own construction, so the expansion is bounded; validateInterfaceMethods
+// re-checks the cap on the flattened result at the call sites.
+//
+// Identical methods reached via two paths (diamond embedding) are deduped.
+// A genuine same-name/different-signature conflict is rejected by go/types
+// (TypeCheckMemPackage, run before the VM constructs any type on the addpkg
+// path), so reaching the panic here is should-not-happen — consistent with
+// the other construction-time guards in this file (e.g. FieldTypeList.Less).
+func flattenInterfaceMethods(fts []FieldType) []FieldType {
+	out := make([]FieldType, 0, len(fts))
+	seen := make(map[Name]Type, len(fts))
+	add := func(name Name, typ Type) {
+		if prev, ok := seen[name]; ok {
+			if prev.TypeID() != typ.TypeID() {
+				panic(fmt.Sprintf("duplicate method %s with conflicting types in interface", name))
+			}
+			return
+		}
+		seen[name] = typ
+		out = append(out, FieldType{Name: name, Type: typ})
 	}
-	dt, ok := ft.Type.(*DeclaredType)
-	if !ok {
-		panic(fmt.Sprintf("cannot derive embedded interface name for type %s", ft.Type.String()))
+	for i := range fts {
+		if et := embeddedInterface(fts[i].Type); et != nil {
+			for j := range et.Methods {
+				add(et.Methods[j].Name, et.Methods[j].Type)
+			}
+			continue
+		}
+		add(fts[i].Name, fts[i].Type)
 	}
-	ft.Name = dt.Name
-	ft.Embedded = true
+	return out
 }
 
 func IsImplementedBy(it Type, ot Type) bool {

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -2641,76 +2641,31 @@ func fillEmbeddedName(ft *FieldType, nameSrc Expr) {
 	if ft.Name != "" {
 		return
 	}
-	if n := pickEmbedName(nameSrc); n != "" {
-		ft.Name = n
-	} else {
-		switch ct := ft.Type.(type) {
-		case *PointerType:
-			// dereference one level
-			switch ct := ct.Elt.(type) {
-			case *DeclaredType:
-				ft.Name = ct.Name
-			default:
-				// should not happen,
-				panic("should not happen")
-			}
-		case *DeclaredType:
-			ft.Name = ct.Name
-		case PrimitiveType:
-			switch ct {
-			case BoolType:
-				ft.Name = Name("bool")
-			case StringType:
-				ft.Name = Name("string")
-			case IntType:
-				ft.Name = Name("int")
-			case Int8Type:
-				ft.Name = Name("int8")
-			case Int16Type:
-				ft.Name = Name("int16")
-			case Int32Type:
-				ft.Name = Name("int32")
-			case Int64Type:
-				ft.Name = Name("int64")
-			case UintType:
-				ft.Name = Name("uint")
-			case Uint8Type:
-				ft.Name = Name("uint8")
-			case Uint16Type:
-				ft.Name = Name("uint16")
-			case Uint32Type:
-				ft.Name = Name("uint32")
-			case Uint64Type:
-				ft.Name = Name("uint64")
-			case Float32Type:
-				ft.Name = Name("float32")
-			case Float64Type:
-				ft.Name = Name("float64")
-			}
-		default:
-			panic(fmt.Sprintf(
-				"unexpected field type %s",
-				ft.Type.String()))
-		}
-	}
-	ft.Embedded = true
-}
-
-func pickEmbedName(x Expr) Name {
+	// Derive the field name from the source expr, not ft.Type: an alias
+	// (type Int = int) resolves away, so ft.Type would yield "int" instead
+	// of the written "Int". An embedded field is always a (qualified/pointer)
+	// type name, so unwrapping const/pointer layers lands on the NameExpr or
+	// SelectorExpr that carries the name as written.
+	x := nameSrc
 	for {
 		switch e := x.(type) {
 		case *constTypeExpr, *ConstExpr:
 			x = unconst(x)
+			continue
 		case *StarExpr:
 			x = e.X
+			continue
 		case *NameExpr:
-			return e.Name
+			ft.Name = e.Name
 		case *SelectorExpr:
-			return e.Sel
-		default:
-			return ""
+			ft.Name = e.Sel
 		}
+		break
 	}
+	if ft.Name == "" {
+		panic(fmt.Sprintf("cannot derive embedded name for field type %s", ft.Type.String()))
+	}
+	ft.Embedded = true
 }
 
 func IsImplementedBy(it Type, ot Type) bool {

--- a/gnovm/tests/files/alias2.gno
+++ b/gnovm/tests/files/alias2.gno
@@ -1,0 +1,27 @@
+package main
+
+type Int = int
+
+type A = struct{ int }
+type B = struct{ Int }
+
+func main() {
+	var x, y interface{} = A{}, B{}
+	if x == y {
+		mustNot()
+	}
+
+	{
+		type C = int32
+		x = struct{ C }{}
+	}
+	{
+		type C = uint32
+		y = struct{ C }{}
+	}
+	if x == y {
+		mustNot()
+	}
+}
+func mustNot() { panic(badMsg) }
+const badMsg = "FAIL"

--- a/gnovm/tests/files/alias2.gno
+++ b/gnovm/tests/files/alias2.gno
@@ -1,3 +1,7 @@
+// A plain (unqualified) embedded type alias keeps the alias name as the field
+// name: struct{Int} stays distinct from struct{int}, and two same-named aliases
+// of different underlying types stay distinct too. (alias3 covers the qualified
+// selector form pkg.T, plus pointer and interface embeds.)
 package main
 
 type Int = int

--- a/gnovm/tests/files/alias3.gno
+++ b/gnovm/tests/files/alias3.gno
@@ -1,3 +1,8 @@
+// An embedded type alias takes its field name from the name as written, not
+// from the resolved underlying type, across all embed forms: the qualified
+// selector pkg.T (named after T, the selector's final segment), pointer *T,
+// and interface embeds. Otherwise distinct alias embeds collapse to equal
+// TypeIDs.
 package main
 
 import "filetests/extern/aliasdef"

--- a/gnovm/tests/files/alias3.gno
+++ b/gnovm/tests/files/alias3.gno
@@ -1,0 +1,47 @@
+package main
+
+import "filetests/extern/aliasdef"
+
+type Int = int
+
+type B = struct{ Int }
+
+type Stringer interface{ Str() string }
+type SAlias = Stringer
+type I interface{ SAlias }
+
+type T struct{}
+
+func (T) Str() string { return "ok" }
+
+func main() {
+	// a qualified alias embeds as its own name, so struct{aliasdef.Int}
+	// is identical to struct{Int}
+	var x, y interface{} = B{}, struct{ aliasdef.Int }{}
+	if x != y {
+		panic("FAIL: struct{Int} != struct{aliasdef.Int}")
+	}
+
+	// pointer embeds also use the alias name
+	x, y = struct{ *Int }{}, struct{ *int }{}
+	if x == y {
+		panic("FAIL: struct{*Int} == struct{*int}")
+	}
+
+	// the embedded field is accessible by the alias name
+	b := B{7}
+	b.Int++
+	println(b.Int)
+
+	// embedding an alias in an interface still flattens the method set
+	var v interface{} = T{}
+	s, ok := v.(I)
+	if !ok {
+		panic("FAIL: T does not implement interface{SAlias}")
+	}
+	println(s.Str())
+}
+
+// Output:
+// 8
+// ok

--- a/gnovm/tests/files/alias4.gno
+++ b/gnovm/tests/files/alias4.gno
@@ -1,3 +1,5 @@
+// An alias to a defined type (type C = T) embeds under the alias name "C",
+// not the target type's name "T", so struct{C} and struct{T} are distinct.
 package main
 
 type T struct{ V int }

--- a/gnovm/tests/files/alias4.gno
+++ b/gnovm/tests/files/alias4.gno
@@ -1,0 +1,30 @@
+package main
+
+type T struct{ V int }
+
+type C = T // alias to a defined type
+
+type Named struct{ V int } // distinct defined type, same shape as T
+
+func main() {
+	// Embedding the alias C names the field "C", embedding T names it "T",
+	// so the two structs are distinct even though C and T are the same type.
+	var x, y interface{} = struct{ C }{}, struct{ T }{}
+	if x == y {
+		panic("FAIL: struct{C} == struct{T}")
+	}
+
+	// And distinct from embedding an unrelated defined type of the same shape.
+	x, y = struct{ C }{}, struct{ Named }{}
+	if x == y {
+		panic("FAIL: struct{C} == struct{Named}")
+	}
+
+	// The embedded field is accessible by the alias name C, not T.
+	s := struct{ C }{}
+	s.C.V = 9
+	println(s.C.V)
+}
+
+// Output:
+// 9

--- a/gnovm/tests/files/alias5.gno
+++ b/gnovm/tests/files/alias5.gno
@@ -1,14 +1,9 @@
-// An embedded interface is named from its resolved type, not the written
-// spelling, so embedding an alias is identical to embedding its target:
-// interface{ SAlias } == interface{ Stringer }. This is the inverse of the
-// struct rule (alias2-4), because Go computes interface identity from the
-// method set, not the embedded name. Guards against the regression where
-// alias-named embeds got distinct TypeIDs.
-//
-// NOTE: this only equalizes alias-vs-target. Structurally identical
-// interfaces with different spellings still diverge (interface{ Stringer }
-// != interface{ Str() string }); fixing that needs method-set flattening
-// (follow-up, branch scratch/iface-flatten).
+// An embedded interface contributes only its method set to identity, never
+// the written spelling, so embedding an alias is identical to embedding its
+// target: interface{ SAlias } == interface{ Stringer }. This is the inverse
+// of the struct rule (alias2-4), because Go computes interface identity from
+// the method set, not the embedded name. See iface_embed_id.gno for the wider
+// flattening cases (embed-vs-explicit, diamond).
 package main
 
 type Stringer interface{ Str() string }

--- a/gnovm/tests/files/alias5.gno
+++ b/gnovm/tests/files/alias5.gno
@@ -1,0 +1,23 @@
+// An embedded interface is named from its resolved type, not the written
+// spelling, so embedding an alias is identical to embedding its target:
+// interface{ SAlias } == interface{ Stringer }. This is the inverse of the
+// struct rule (alias2-4), because Go computes interface identity from the
+// method set, not the embedded name. Guards against the regression where
+// alias-named embeds got distinct TypeIDs.
+//
+// NOTE: this only equalizes alias-vs-target. Structurally identical
+// interfaces with different spellings still diverge (interface{ Stringer }
+// != interface{ Str() string }); fixing that needs method-set flattening
+// (follow-up, branch scratch/iface-flatten).
+package main
+
+type Stringer interface{ Str() string }
+type SAlias = Stringer
+
+func main() {
+	var x, y interface{} = struct{ A interface{ SAlias } }{}, struct{ A interface{ Stringer } }{}
+	println("alias==canonical:", x == y)
+}
+
+// Output:
+// alias==canonical: true

--- a/gnovm/tests/files/extern/aliasdef/aliasdef.gno
+++ b/gnovm/tests/files/extern/aliasdef/aliasdef.gno
@@ -1,0 +1,3 @@
+package aliasdef
+
+type Int = int

--- a/gnovm/tests/files/iface_embed_id.gno
+++ b/gnovm/tests/files/iface_embed_id.gno
@@ -1,0 +1,70 @@
+// An embedded interface contributes only its method set to identity, never
+// its own (alias) name: anonymous interfaces with the same flattened method
+// set share one TypeID, matching Go. Covers embed-vs-explicit, alias-vs-
+// target, and diamond embedding (the same method reached twice dedups).
+package main
+
+type Stringer interface{ Str() string }
+type SAlias = Stringer
+
+type R interface{ Read() int }
+type W interface{ Write() int }
+type A interface{ R }
+type B interface{ R }
+
+func main() {
+	// embedding a named interface flattens to its methods, so an embed is
+	// identical to spelling the method out
+	var a, b interface{} = struct {
+		X interface{ Stringer }
+	}{}, struct {
+		X interface{ Str() string }
+	}{}
+	if a != b {
+		panic("FAIL: interface{Stringer} != interface{Str() string}")
+	}
+
+	// an embedded alias is identical to embedding its target
+	var c, d interface{} = struct {
+		X interface{ SAlias }
+	}{}, struct {
+		X interface{ Stringer }
+	}{}
+	if c != d {
+		panic("FAIL: interface{SAlias} != interface{Stringer}")
+	}
+
+	// embedding two interfaces vs the union of their methods
+	type RW = interface {
+		Read() int
+		Write() int
+	}
+	var e, f interface{} = struct {
+		X interface {
+			R
+			W
+		}
+	}{}, struct{ X RW }{}
+	if e != f {
+		panic("FAIL: interface{R;W} != interface{Read;Write}")
+	}
+
+	// diamond: interface{A;B} reaches R's method twice; dedups to {Read},
+	// identical to interface{R}
+	var g, h interface{} = struct {
+		X interface {
+			A
+			B
+		}
+	}{}, struct {
+		X interface{ R }
+	}{}
+	if g != h {
+		panic("FAIL: diamond interface{A;B} != interface{R}")
+	}
+
+	println("ok")
+}
+
+// Output:
+// ok


### PR DESCRIPTION
**Status: WIP / draft.** Alternative to, and follow-up on, #5739. Stacked on `fix/alias_2`; until that merges this PR's diff also shows #5739's commits — the net-new change here is the single commit `fix(gnovm): flatten embedded interface method sets for type identity`.

#5739 makes embedded **struct** alias names take the written spelling (correct), and ships a *minimal* interface fix that only re-equalizes an embedded alias with its target (`interface{ SAlias } == interface{ Stringer }`). This PR replaces that minimal interface fix with the deeper one.

- Flattens embedded interfaces into their method set at construction (`doOpInterfaceType`, `staticTypeFromAST`), so the embedded-interface name leaves the `TypeID` entirely. Interface identity becomes the flattened method set, matching Go.
- Fixes a divergence that exists on master independent of #5739: `interface{ Stringer } == interface{ Str() string }` (and embed-of-two vs methods-listed, diamond dedup) — not just the alias case.
- Keeps the runtime embedded-interface handling in `FindEmbeddedFieldType`/`VerifyImplementedBy` for already-persisted (pre-upgrade) state, whose `Methods` are still unflattened.
- Same-name/different-signature conflicts are rejected by go/types before the VM builds the type, so the dedup panic is should-not-happen (consistent with existing construction-time guards).
- Tests: `iface_embed_id.gno` (embed-vs-explicit, alias-vs-target, diamond); `alias5.gno` retained.

**Consensus-breaking**, distinct from #5739's struct break: anonymous-interface `TypeID`s that embed other interfaces change. Must land with a chain upgrade.

Verified: `Files -short`, `sdk/vm -run Gas`, `integration -run TestTestdata` all green.