### PR TITLE
docs(valopers): update Register instructions for operator address and consensus pubkey

### DIFF
--- a/examples/gno.land/r/gnops/valopers/filetests/z_1_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/filetests/z_1_filetest.gno
@@ -64,11 +64,13 @@ func main() {
 //     - **on-prem**: For validators running on on-premises infrastructure
 //     - **data-center**: For validators running in dedicated data centers
 //
-// - **Validator Address**
-//   - Your validator node's address
+// - **Operator Address**
+//   - The `g1...` address of your operator account (from your `gnokey` keyring)
+//   - **Must be controlled by the signer** of this transaction — the realm rejects the call if the signer doesn't control that address
 //
-// - **Validator Public Key**
-//   - Your validator node's public key
+// - **Validator Consensus Public Key**
+//   - Your validator node's consensus public key, in the `gpub1...` format
+//   - Retrieve it by running: `gnoland secrets get validator_key`
 //
 // ### ✍️ Required Information for the Description
 //
@@ -80,6 +82,8 @@ func main() {
 // 4. Contact details
 // 5. Why are you interested in validating on **gno.land**?
 // 6. What contributions have you made or are willing to make to **gno.land**?
+// 7. Your node architecture. For example, do you run sentry nodes to shield your validator?
+// 8. How do you handle backups? Describe your backup strategy for keys and node data.
 //
 // ---
 //

--- a/examples/gno.land/r/gnops/valopers/init.gno
+++ b/examples/gno.land/r/gnops/valopers/init.gno
@@ -49,11 +49,13 @@ To add your validator node to the registry, use the [**Register**](` + txlink.Ca
     - **on-prem**: For validators running on on-premises infrastructure
     - **data-center**: For validators running in dedicated data centers
 
-- **Validator Address**
-  - Your validator node's address
+- **Operator Address**
+  - The ` + "`g1...`" + ` address of your operator account (from your ` + "`gnokey`" + ` keyring)
+  - **Must be controlled by the signer** of this transaction — the realm rejects the call if the signer doesn't control that address
 
-- **Validator Public Key**
-  - Your validator node's public key
+- **Validator Consensus Public Key**
+  - Your validator node's consensus public key, in the ` + "`gpub1...`" + ` format
+  - Retrieve it by running: ` + "`gnoland secrets get validator_key`" + `
 
 ### ✍️ Required Information for the Description
 
@@ -65,6 +67,8 @@ Please provide detailed answers to the following questions to ensure transparenc
 4. Contact details
 5. Why are you interested in validating on **gno.land**?
 6. What contributions have you made or are willing to make to **gno.land**?
+7. Your node architecture. For example, do you run sentry nodes to shield your validator?
+8. How do you handle backups? Describe your backup strategy for keys and node data.
 
 ---
 


### PR DESCRIPTION
## Description

Updates the in-realm registration guide embedded in `r/gnops/valopers` (`init.gno`) so it matches the current `Register` function signature and the [test13 VALIDATOR.md](https://github.com/gnolang/gno/blob/chain/test13/misc/deployments/test13.gno.land/VALIDATOR.md#5-register-as-a-validator-candidate) guidance.

### Changes
- **Operator Address** (was "Validator Address"): documents that it is the `g1...` account from the operator's `gnokey` keyring, and that the realm rejects the call if the tx signer doesn't control that address (enforced by the operator-slot squat guard in `valopers.gno`).
- **Validator Consensus Public Key** (was "Validator Public Key"): documents the `gpub1...` format and that it is obtained via `gnoland secrets get validator_key`.
- Adds two questions to the **Required Information for the Description** section:
  - Node architecture (e.g. whether sentry nodes are used to shield the validator).
  - Backup strategy for keys and node data.

This is a documentation-only change to the embedded instructions string — no contract logic is modified.