### PR TITLE
docs: update testnet from test11 to test13

### DIFF
--- a/docs/resources/gnoland-networks.md
+++ b/docs/resources/gnoland-networks.md
@@ -6,7 +6,7 @@
 |-------------------|------------------------------------------|--------------|
 | Betanet (current) | https://rpc.gno.land:443                 | `gnoland1`   |
 | Staging           | https://rpc.staging.gno.land:443         | `staging`    |
-| Test11            | https://rpc.test11.testnets.gno.land:443 | `test11`     |
+| Test13            | https://rpc.test13.testnets.gno.land:443 | `test-13`    |
 
 ### WebSocket endpoints
 
@@ -132,15 +132,15 @@ is the `gnoweb` render of the Staging testnet.
     [`misc/loop`](https://github.com/gnolang/gno/tree/master/misc/loop) folder in the
     monorepo
 
-### Test11
+### Test13
 
-The latest Gno.land testnet, released on the 12th of Februrary, 2025.
+The latest Gno.land testnet, released on the 15th of June, 2026.
 
 - **Persistence of state:**
   - State is fully persisted unless there are breaking changes in a new release,
     where persistence partly depends on implementing a migration strategy
 - **Timeliness of code:**
-  - Pre-deployed packages and realms are at release tag [chain/test11.0](https://github.com/gnolang/gno/releases/tag/chain%2Ftest11.0)
+  - Pre-deployed packages and realms are at release tag [chain/test13](https://github.com/gnolang/gno/releases/tag/chain%2Ftest13)
 - **Intended purpose**
   - Running a full node, testing validator coordination, deploying stable Gno
     dApps, creating tools that require persisted state & transaction history
@@ -148,6 +148,14 @@ The latest Gno.land testnet, released on the 12th of Februrary, 2025.
 ### TestX
 
 These testnets are deprecated and currently serve as archives of previous progress.
+
+### Test12 (archive)
+
+Test12 is the testnet released on the 16th of April, 2026.
+
+### Test11 (archive)
+
+Test11 is the testnet released on the 12th of February, 2025.
 
 ### Test10 (archive)
 


### PR DESCRIPTION
`rpc.test11.testnets.gno.land:443` is dead, causing the `docs` CI linter to fail on any PR that touches the repo.

Changes:
- Replace Test11 with Test13 in the RPC table
- Update the "latest testnet" section from Test11 to Test13 (released 2026-06-15, tag `chain/test13`)
- Archive Test11 and add a Test12 archive entry (released 2026-04-16, tag `chain/test12`)

Fixes the `docs` CI failure visible on #5655 and likely on other open PRs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)