### PR TITLE
feat(vm): raise MaxEventAttrLen from 1024 to 4096 bytes

### DIFF
--- a/gnovm/stdlibs/chain/emit_event.go
+++ b/gnovm/stdlibs/chain/emit_event.go
@@ -23,10 +23,13 @@ const (
 
 	// MaxEventAttrLen caps each attribute's byte length. Strings longer
 	// than this (or the type string) are truncated to MaxEventAttrLen +
-	// EventTruncMarker, deterministically. Chosen to fit any realistic
-	// short payload (addresses, IDs, short messages) while bounding the
-	// downstream encoding amplification per attr at ~1 KB.
-	MaxEventAttrLen = 1024
+	// EventTruncMarker, deterministically. Sized to hold a realistic
+	// binary payload after hex/base64 expansion (~2 KB of raw bytes once
+	// hex-encoded as 0x... doubles the length) — e.g. an IBC packet
+	// acknowledgement, membership proof, or packet-data chunk emitted by
+	// an on-chain bridge realm — while still bounding the downstream
+	// amino+JSON encoding amplification per attr at ~4 KB.
+	MaxEventAttrLen = 4096
 
 	// EventTruncMarker is appended to truncated strings; its 3 bytes are
 	// added on top of MaxEventAttrLen, so a truncated string is exactly


### PR DESCRIPTION
## Summary

Raise `MaxEventAttrLen` in `gnovm/stdlibs/chain/emit_event.go` from **1024** to **4096** bytes.

`MaxEventAttrLen` is the per-attribute byte cap introduced in #5629. Attribute *values* longer than the cap are silently truncated (`value[:MaxEventAttrLen] + "..."`); keys and the event type panic. `MaxEventPairs` is unchanged at 64.

## Motivation — the gno Union/IBC bridge (`onbloc/gno-ibc`)

The 1024-byte cap is too small for any realm that emits **binary payloads**, because event attribute values are strings: binary data must be hex- or base64-encoded first, and hex encoding **doubles** the byte length (`len*2 + 2` for the `0x` prefix). So 1024 hex chars only carry **~511 raw bytes**.

The [`onbloc/gno-ibc`](https://github.com/onbloc/gno-ibc) Union bridge (IBC Union core proxy + UCS03-ZKGM app) emits IBC lifecycle events whose values are exactly these encoded blobs. From its `core/event.gno`:

- It hard-codes the VM cap as its own constant and works around it by **chunking**:
  ```go
  maxEventAttrValueLen      = 1024
  maxPacketDataEventColumns = 50
  MaxPacketDataEventSize    = maxPacketDataEventColumns * maxEventAttrValueLen
  ```
  `packet_data` is split across up to 50 indexed columns (`packet_data[0]`, `packet_data[1]`, …) via `eventAttrColumns`, and relayers must reassemble them off-chain. The chunk size **mirrors this VM cap** — it exists only because a single attribute cannot exceed it.

- Several other binary attributes are emitted **whole, without chunking**, and are therefore subject to silent truncation by the VM today:
  - `acknowledgement` (`WriteAck`, `PacketAck`) — `hexAttr(acknowledgement)`
  - `value` and `path` (`CommitMembershipProof` / `CommitNonMembershipProof`) — Merkle proof material
  - `maker_msg` (`PacketRecv`, `IntentPacketRecv`)

  A Union membership proof `value`, a ZKGM acknowledgement, or a maker message larger than ~511 raw bytes is **silently truncated** to 1024 hex chars + `"..."`. For IBC this corrupts consensus-critical relayed data — a truncated proof or ack does not verify on the counterparty — and the truncation is invisible at emit time.

