### PR TITLE
feat(vm): hard-cap chain.emit attr values (panic instead of silent truncation)

### DIFF
--- a/gnovm/cmd/calibrate/native_machine_bench_test.go
+++ b/gnovm/cmd/calibrate/native_machine_bench_test.go
@@ -246,9 +246,9 @@ func BenchmarkNative_Banker_OriginSend(b *testing.B) {
 // Bench grid is 2-D: (nAttrs, perElemBytes). The fitter regresses
 // cost = base + α·nAttrs + β·totalBytes. Constant-byte benches isolate
 // the count slope (α); constant-count benches isolate the byte slope (β).
-// emit truncates each value to MaxEventAttrLen=1024, so per-element
-// payloads above that cap don't grow the marshal cost — we keep the
-// bytes-grid at ≤1024/element so β reflects real marshal work.
+// emit hard-caps each value at MaxEventAttrLen (4096) and panics above it;
+// the bytes-grid stays at ≤1024/element — well under the cap — so β
+// reflects real marshal work without tripping the panic.
 
 func benchChainEmit(b *testing.B, nAttrs, perElemBytes int) {
 	b.Helper()
@@ -279,8 +279,8 @@ func BenchmarkNative_Chain_Emit_100_1(b *testing.B) { benchChainEmit(b, 100, 1) 
 // 128 = MaxEventPairs * 2 — the new hard cap from emit_event.go.
 func BenchmarkNative_Chain_Emit_128_1(b *testing.B) { benchChainEmit(b, 128, 1) }
 
-// Bytes axis (nAttrs=2). 1024 is MaxEventAttrLen; above that emit truncates
-// silently so additional bytes don't grow the marshal slope.
+// Bytes axis (nAttrs=2). Grid tops out at 1024/element, well under
+// MaxEventAttrLen (4096, the hard cap above which emit panics).
 func BenchmarkNative_Chain_Emit_2_50(b *testing.B)   { benchChainEmit(b, 2, 50) }
 func BenchmarkNative_Chain_Emit_2_500(b *testing.B)  { benchChainEmit(b, 2, 500) }
 func BenchmarkNative_Chain_Emit_2_1024(b *testing.B) { benchChainEmit(b, 2, 1024) }

--- a/gnovm/stdlibs/chain/emit_event.go
+++ b/gnovm/stdlibs/chain/emit_event.go
@@ -21,20 +21,20 @@ const (
 	// vector itself, and so downstream amino+JSON encoding is bounded.
 	MaxEventPairs = 64
 
-	// MaxEventAttrLen caps each attribute's byte length. Strings longer
-	// than this (or the type string) are truncated to MaxEventAttrLen +
-	// EventTruncMarker, deterministically. Sized to hold a realistic
-	// binary payload after hex/base64 expansion (~2 KB of raw bytes once
-	// hex-encoded as 0x... doubles the length) — e.g. an IBC packet
-	// acknowledgement, membership proof, or packet-data chunk emitted by
-	// an on-chain bridge realm — while still bounding the downstream
-	// amino+JSON encoding amplification per attr at ~4 KB.
+	// MaxEventAttrLen caps each attribute's byte length. The event type,
+	// every key, AND every value that exceeds this makes emit panic — it
+	// fails loudly instead of silently truncating. A silent cap would be a
+	// hidden invariant: each realm would have to pre-check its own value
+	// lengths to guarantee protocol correctness, and a truncated value
+	// (e.g. a hex-encoded IBC ack or membership proof) would corrupt
+	// downstream consumers with no on-chain signal.
+	//
+	// Sized to hold a realistic binary payload after hex/base64 expansion
+	// (~2 KB of raw bytes once hex-encoded as 0x... doubles the length) —
+	// e.g. an IBC packet acknowledgement, membership proof, or packet-data
+	// chunk emitted by an on-chain bridge realm — while still bounding the
+	// downstream amino+JSON encoding amplification per attr at ~4 KB.
 	MaxEventAttrLen = 4096
-
-	// EventTruncMarker is appended to truncated strings; its 3 bytes are
-	// added on top of MaxEventAttrLen, so a truncated string is exactly
-	// MaxEventAttrLen + len(EventTruncMarker) bytes long.
-	EventTruncMarker = "..."
 )
 
 func X_emit(m *gno.Machine, typ string, attrs []string) {
@@ -62,22 +62,6 @@ func X_emit(m *gno.Machine, typ string, attrs []string) {
 	ctx.EventLogger.EmitEvent(evt)
 }
 
-// truncateValue returns s if len(s) <= MaxEventAttrLen, otherwise the first
-// MaxEventAttrLen bytes followed by EventTruncMarker. Used only for attr
-// VALUES — keys and typ are hard-capped (panic on overflow) since they're
-// identifiers that downstream consumers filter on; silent truncation would
-// alias unrelated keys.
-//
-// Truncation is byte-wise, not rune-aware: an attr ending in a multi-byte
-// UTF-8 sequence may be cut mid-rune. Acceptable for opaque event payloads
-// consumed off-chain.
-func truncateValue(s string) string {
-	if len(s) <= MaxEventAttrLen {
-		return s
-	}
-	return s[:MaxEventAttrLen] + EventTruncMarker
-}
-
 // currentPkgPath retrieves the current package's pkgPath.
 // It's not a native binding; but is used within this package to clarify usage.
 func currentPkgPath(m *gno.Machine) (pkgPath string) {
@@ -91,13 +75,16 @@ func attrKeysAndValues(m *gno.Machine, attrs []string) ([]EventAttribute, error)
 	}
 	eventAttrs := make([]EventAttribute, attrLen/2)
 	for i := 0; i < attrLen-1; i += 2 {
-		key := attrs[i]
+		key, value := attrs[i], attrs[i+1]
 		if len(key) > MaxEventAttrLen {
 			m.PanicString("event attribute key is too long")
 		}
+		if len(value) > MaxEventAttrLen {
+			m.PanicString("event attribute value is too long")
+		}
 		eventAttrs[i/2] = EventAttribute{
 			Key:   key,
-			Value: truncateValue(attrs[i+1]),
+			Value: value,
 		}
 	}
 	return eventAttrs, nil

--- a/gnovm/stdlibs/chain/emit_event_test.go
+++ b/gnovm/stdlibs/chain/emit_event_test.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
@@ -118,6 +119,41 @@ func TestEmit(t *testing.T) {
 				},
 			},
 			expectPanic: false,
+		},
+		{
+			// A value exactly at the cap is kept verbatim — never truncated.
+			name:      "ValueAtCap",
+			eventType: "test",
+			attrs:     []string{"key1", strings.Repeat("v", MaxEventAttrLen)},
+			expectedEvents: []Event{
+				{
+					Type:    "test",
+					PkgPath: pkgPath,
+					Attributes: []EventAttribute{
+						{Key: "key1", Value: strings.Repeat("v", MaxEventAttrLen)},
+					},
+				},
+			},
+			expectPanic: false,
+		},
+		{
+			// A value over the cap panics rather than silently truncating.
+			name:        "ValueTooLong",
+			eventType:   "test",
+			attrs:       []string{"key1", strings.Repeat("v", MaxEventAttrLen+1)},
+			expectPanic: true,
+		},
+		{
+			name:        "KeyTooLong",
+			eventType:   "test",
+			attrs:       []string{strings.Repeat("k", MaxEventAttrLen+1), "value1"},
+			expectPanic: true,
+		},
+		{
+			name:        "TypeTooLong",
+			eventType:   strings.Repeat("t", MaxEventAttrLen+1),
+			attrs:       []string{"key1", "value1"},
+			expectPanic: true,
 		},
 	}
 


### PR DESCRIPTION
:warning: This change is state-breaking, but probably very few realms emit events with truncated attributes.

## Summary

Make `chain.emit` **hard-cap** attribute values: a value longer than `MaxEventAttrLen` now **panics**, exactly like keys and the event type already do. Previously oversized values were **silently truncated** to `value[:MaxEventAttrLen] + "..."`.

This removes `truncateValue` and `EventTruncMarker` and replaces the truncation call in `attrKeysAndValues` with a length check + `m.PanicString`. The cap value itself (`MaxEventAttrLen = 4096`, from #5857) is unchanged — this PR only changes *what happens at the cap*.

## Motivation

#5629 introduced the per-attribute byte cap. Keys and the event type panic on overflow, but **values were silently truncated**. Silent truncation is the wrong default for a consensus VM:

- **It's a hidden invariant.** To guarantee protocol correctness, every realm now has to pre-check the length of every value it emits — otherwise the VM quietly rewrites its data. That obligation is invisible at the call site.
- **It corrupts data with no signal.** Event values frequently carry hex/base64-encoded binary payloads (IBC packet data, acknowledgements, Merkle proofs, …). A truncated ack or proof does not verify downstream, but nothing on-chain indicates truncation happened — the failure surfaces far away, off-chain, as "the proof is wrong."
- **Fail loudly > silent invariant.** A panic at emit time tells the realm author immediately and deterministically that the value is too large, instead of shipping corrupted events.

This makes the value path consistent with the key/type path: all three are hard caps.

> Quoting the review feedback that prompted this: *"would also be good to not silently truncate event values… make it a hard cap… otherwise every realm has to check if their values are a valid length to ensure protocol correctness. Always better to fail loudly rather than have a silent invariant."*

## Changes

- `gnovm/stdlibs/chain/emit_event.go`
  - `attrKeysAndValues`: panic `"event attribute value is too long"` when a value exceeds `MaxEventAttrLen` (mirrors the existing key check).
  - Remove `truncateValue` and the `EventTruncMarker` constant (no longer used).
  - Update the `MaxEventAttrLen` doc comment to describe the panic semantics, while keeping the IBC/hex sizing rationale from #5857.
- `gnovm/stdlibs/chain/emit_event_test.go`
  - Add cap-path coverage that #5629 left unverified: a value **at** the cap is kept verbatim (proves no truncation at the boundary); values, keys, and the type **over** the cap panic.
- `gnovm/cmd/calibrate/native_machine_bench_test.go`
  - Comment-only: two comments described emit as "truncating" above the cap; updated to "panics", and corrected the stale `MaxEventAttrLen=1024` references to 4096. No bench input exceeds the cap, so the calibration grid is unchanged.

## Test plan

- [x] `go test ./gnovm/stdlibs/chain/ -run TestEmit` — passes (incl. new `ValueAtCap` / `ValueTooLong` / `KeyTooLong` / `TypeTooLong`)
- [x] `go vet ./gnovm/stdlibs/chain/ ./gnovm/cmd/calibrate/` — OK

## Note

This is a **behavior change**: emitting a >`MaxEventAttrLen` value now aborts the tx instead of producing a truncated event. Realms that previously relied on truncation must chunk or shorten their values. Since the cap shipped recently (#5629) and was just widened to 4096 (#5857), the blast radius should be minimal — flagging it for the consensus-relevance reason.
