### PR TITLE
docs(constitution): finalize genesis tokenomics numbers

### DIFF
--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -115,13 +115,13 @@ this Constitution for Gno.land.
 
 At Gno.land Genesis there will be 1.333 billion $GNOT tokens.
 
- * Airdrop1:               350M - from partial Cosmos governance snapshot 3 years ago
- * Airdrop2:               231M - from recent AtomOne snapshot prior to launch
- * Core Treasury:           40M - for paying for core development
- * Ecosystem Treasury:      60M - for prior and future Gno.land ecosystem development
- * Validator Treasury:      20M - for paying validators 
- * Investors:              300M - for past and future investors
- * NT,LLC:                 332M - for use at NT,LLC discretion
+ * Airdrop1:               350M (26.26%) - from partial Cosmos governance snapshot 3 years ago
+ * Airdrop2:               231M (17.33%) - from recent AtomOne snapshot prior to launch
+ * Core Treasury:           40M  (3.00%) - for paying for core development
+ * Ecosystem Treasury:      60M  (4.50%) - for prior and future Gno.land ecosystem development
+ * Validator Treasury:      20M  (1.50%) - for paying validators 
+ * Investors:              300M (22.51%) - for past and future investors
+ * NT,LLC:                 332M (24.91%) - for use at NT,LLC discretion
 
 $GNOT will not be transferrable initially except for whitelisted addresses.
 Whitelisted addresses include "Ecosystem" and "Investors" funds and any
@@ -129,9 +129,13 @@ additional addresses needed for the operation of the chain, and funding needs or
 payment of investors. Whitelisted funds remain subject to the vesting schedule
 below.
 
-All Genesis $GNOT allocations vest on a common schedule: 7% released on the day
-$GNOT becomes transferrable (aka the mainnet), 7% each subsequent month, and 9%
-in the final month (fully vested 13 months after the mainnet).
+All Genesis $GNOT allocations vest on a common schedule: 4% unlocked on the day
+$GNOT becomes transferrable (aka the mainnet), and a 4% unlock every subsequent
+month for 24 months (fully vested 24 months after the mainnet).
+
+As an exception, 150,000,000 tokens from the Investors allocation are unlocked
+at the mainnet, with the remaining Investors tokens subject to the same vesting
+schedule.
 
 GovDAO is responsible for distributing the $GNOT of the Ecosystem Treasury
 allocation to prior and future Gno.land ecosystem contributors (as well as
@@ -174,7 +178,7 @@ token.
    will require a bond deposit of $GNOT.
  * Every transaction that ends up freeing up persistent state space will
    receive a refund of $GNOT.
- * One billion $GNOT corresponds to 10TB of persistent state space.
+ * 1.333 billion $GNOT corresponds to 13.33TB of persistent state space.
  * The $GNOT will not inflate, thus the total created $GNOT
    will never exceed 1.333 billion $GNOT.
  * The $GNOT Storage Deposit Price (per byte) will never increase.
@@ -323,9 +327,10 @@ Documents and Gno software not already paid for by other means. Recognizing
 and rewarding contributors is essential to the long-term health of Gno.land
 and its ecosystem.
 
-At most 1/4 of the GovDAO 11.9% genesis allocation may be distributed to prior
-contributors by GovDAO Supermajority Decision. Present GovDAO members are not
-eligible for any allocation from the Ecosystem Treasury genesis allocation.
+At most 1/4 of the GovDAO-managed Ecosystem Treasury 4.50% (60M) genesis
+allocation may be distributed to prior contributors by GovDAO Supermajority
+Decision. Present GovDAO members are not eligible for any allocation from the
+Ecosystem Treasury genesis allocation.
 
 All funding decisions from the Ecosystem Treasury require a Supermajority
 Decision by GovDAO. 
@@ -1276,9 +1281,8 @@ and the following:
    the beginning of each month.
 
  * In no case may the total amount of $GNOT sold for all treasuries per month
-   for diversification purposes exceed 50% of the average of ($GNOT inflation
-   rate, and the past month's transaction fee revenue), with priority given to
-   ValTreasury, then to CoreTreasury.
+   for diversification purposes exceed 50% of the past month's transaction fee
+   revenue, with priority given to ValTreasury, then to CoreTreasury.
 
  * All trades for diversification purposes must be performed by audited and
    approved Gno logic for Gno AMM contracts running on Gno.land. No person or

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -364,7 +364,7 @@ example Library Genesis:
 Some of these projects have or are working toward IPFS integration on top of
 BitTorrent; but for the value that global archiving provides not just today but
 also for all possible potential future timelines the number of seeders for many
-of the archival files [still hover in the single digits](https://zrthstr.github.io/libgen_torrent_cardiography/index.html). 
+of the archival files [still hover in the single digits](https://web.archive.org/web/20260228085850/https://zrthstr.github.io/libgen_torrent_cardiography/index.html). 
 
 More recently the US Department of Justice released millions of files of the
 "Epstein Files" many of which have also been made available for sharing (such

--- a/docs/resources/storage-deposit.md
+++ b/docs/resources/storage-deposit.md
@@ -45,7 +45,7 @@ The default value is defined in [`gno.land/pkg/sdk/vm/params.go`](https://github
 
 ```text
 storagePriceDefault = "100ugnot" // cost per byte
-// e.g., 1 GNOT per 10KB (≈ 1B GNOT = 10TB)
+// e.g., 1 GNOT per 10KB (≈ 1.333B GNOT = 13.33TB)
 ```
 
 ### Tracking Storage

--- a/gno.land/pkg/sdk/vm/params.go
+++ b/gno.land/pkg/sdk/vm/params.go
@@ -19,7 +19,7 @@ const (
 	sysCLAPkgDefault               = "gno.land/r/sys/cla"
 	chainDomainDefault             = "gno.land"
 	depositDefault                 = "600000000ugnot"
-	storagePriceDefault            = "100ugnot" // cost per byte (1 gnot per 10KB) 1B GNOT == 10TB
+	storagePriceDefault            = "100ugnot" // cost per byte (1 gnot per 10KB) 1.333B GNOT == 13.33TB
 	storageFeeCollectorNameDefault = "storage_fee_collector"
 
 	// Depth floors calibrated for B+32 at 100M items with 10K cache, batched 1000 muts.


### PR DESCRIPTION
Update allocation, vesting, and supply figures to the finalized genesis numbers across the Constitution, storage docs, and the storage-price comment.

- Genesis Allocation table: add per-pool percentages (sums to 100%).
- Common vesting schedule: 7%/13mo -> 4% at mainnet + 4% each subsequent month for 24 months (fully vested 24 months after mainnet).
- Add Investors carve-out: 150,000,000 unlocked at mainnet, remainder on the common schedule.
- Storage capacity: "1B GNOT = 10TB" -> "1.333B GNOT = 13.33TB" to reflect the finalized 1.333B supply (rate of 1 GNOT = 10KB unchanged); applied in CONSTITUTION.md, storage-deposit.md, and params.go comment.
- Fix outdated Ecosystem Treasury figure (11.9% -> 4.50%, 60M).
- Remove the "$GNOT inflation rate" term from the diversification cap since $GNOT is non-inflationary and finite.