### PR TITLE
fix(gnovm): fold -0 to +0 for float call args

### DIFF
--- a/gno.land/pkg/sdk/vm/convert.go
+++ b/gno.land/pkg/sdk/vm/convert.go
@@ -213,6 +213,15 @@ func convertFloat(value string, precision int) float64 {
 		panic(fmt.Sprintf("error value exceeds float%d precision %q: %v", precision, value, err))
 	}
 
+	// A Go source literal -0.0 is a constant that folds to +0, but ParseFloat
+	// keeps the sign bit, so a "-0.0"/"-0" argument arrives as negative zero.
+	// Clear the sign on zero so the argument matches Go. NaN and Inf are left
+	// untouched: Go accepts them as float arguments and the VM produces them,
+	// so rejecting them only at the maketx call boundary would diverge from Go.
+	if f64 == 0 {
+		f64 = math.Copysign(0, 1)
+	}
+
 	return f64
 }
 

--- a/gno.land/pkg/sdk/vm/convert_goparity_test.go
+++ b/gno.land/pkg/sdk/vm/convert_goparity_test.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"math"
+	"testing"
+)
+
+// TestConvertFloatMatchesGo locks the float call-argument conversion to Go's
+// semantics. A "-0.0"/"-0" argument folds to +0, matching Go, where the source
+// literal -0.0 is a constant that folds to +0. NaN and Inf are accepted, not
+// rejected: Go takes them as float arguments and the VM produces them too. This
+// guards against a future change dropping the -0 fold or rejecting NaN/Inf.
+func TestConvertFloatMatchesGo(t *testing.T) {
+	t.Parallel()
+
+	// Signbit cases: assert the exact zero produced, so -0 is caught.
+	zeros := []struct {
+		in   string
+		want float64 // Go value for the same source
+	}{
+		{"0", 0},
+		{"-0", 0},   // Go folds the -0.0 literal to +0
+		{"-0.0", 0}, // same
+	}
+	for _, prec := range []int{32, 64} {
+		for _, tc := range zeros {
+			got := convertFloat(tc.in, prec)
+			if math.Float64bits(got) != math.Float64bits(tc.want) {
+				t.Errorf("convertFloat(%q, %d) bits = %#x, want %#x (+0)",
+					tc.in, prec, math.Float64bits(got), math.Float64bits(tc.want))
+			}
+			if math.Signbit(got) {
+				t.Errorf("convertFloat(%q, %d) has sign bit set, want +0", tc.in, prec)
+			}
+		}
+	}
+
+	// NaN and Inf must be accepted, never rejected.
+	if got := convertFloat("NaN", 64); !math.IsNaN(got) {
+		t.Errorf("convertFloat(\"NaN\", 64) = %v, want NaN", got)
+	}
+	if got := convertFloat("Inf", 64); !math.IsInf(got, 1) {
+		t.Errorf("convertFloat(\"Inf\", 64) = %v, want +Inf", got)
+	}
+	if got := convertFloat("-Inf", 64); !math.IsInf(got, -1) {
+		t.Errorf("convertFloat(\"-Inf\", 64) = %v, want -Inf", got)
+	}
+}


### PR DESCRIPTION
alternative to #5221

convertFloat parses MsgCall string args via strconv.ParseFloat, which keeps the sign bit, so "-0.0"/"-0" arrive as negative zero. The Go source literal -0.0 folds to +0 at compile time; clear the sign bit on zero so the argument path matches. The float32 underflow case ("-1e-50") hits the same path and is covered by a test.