### PR TITLE
fix(gnovm): update root-level filetest goldens

### DIFF
--- a/gnovm/cmd/gno/testdata/test/output_sync_root_filetest.txtar
+++ b/gnovm/cmd/gno/testdata/test/output_sync_root_filetest.txtar
@@ -1,0 +1,37 @@
+# Test Output instruction updated for a root-level filetest.
+
+gno test -v . -update-golden-tests
+
+stdout 'hey'
+stdout '^hru\?'
+
+stderr '=== RUN   ./x_filetest.gno'
+stderr '--- PASS: ./x_filetest.gno \(elapsed: \d+\.\d\ds, gas: \d+(, storage: .+)?\)'
+stderr 'ok      \. 	\d+\.\d\ds'
+
+cmp x_filetest.gno x_filetest.gno.golden
+
+-- x_filetest.gno --
+package main
+
+func main() {
+	println("hey")
+	println("hru?")
+}
+
+// Output:
+// hey
+-- x_filetest.gno.golden --
+package main
+
+func main() {
+	println("hey")
+	println("hru?")
+}
+
+// Output:
+// hey
+// hru?
+-- gnomod.toml --
+module = "gno.test/p/integ/output_sync_root_filetest"
+gno = "0.9"

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -416,7 +416,7 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 		filter := splitRegexp(opts.RunFlag)
 		for _, testFile := range ftfiles {
 			testFileName := testFile.Name
-			testFilePath := filepath.Join(fsDir, "filetests", testFileName)
+			testFilePath := filetestPath(fsDir, testFileName)
 			// XXX consider this
 			testName := fsDir + "/" + testFileName
 			// testName := "file/" + testFileName
@@ -457,6 +457,14 @@ func Test(mpkg *std.MemPackage, fsDir string, opts *TestOptions) error {
 	}
 
 	return errs
+}
+
+func filetestPath(fsDir, testFileName string) string {
+	path := filepath.Join(fsDir, "filetests", testFileName)
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	return filepath.Join(fsDir, testFileName)
 }
 
 // enableDebugger attaches the interactive debugger to m. Source files are


### PR DESCRIPTION
## Description

Fixes `gno test -update-golden-tests` for root-level `*_filetest.gno` files.

golden updates always tries to write to `file tests/<name?`, even when the filetest was loaded from the package root. That made root-level file tests run successfully but fail during update with `no such file or directory`.

**Before**
<img width="1171" height="462" alt="스크린샷 2026-06-30 오전 10 51 07" src="https://github.com/user-attachments/assets/992f10e1-b08b-43df-9e40-32f05b620178" />

**After**
<img width="1197" height="462" alt="스크린샷 2026-06-30 오전 10 52 01" src="https://github.com/user-attachments/assets/c7773eaf-a2ac-48c5-8c39-a9164a11d5c9" />
