### PR TITLE
fix(gnovm): meter GC traversal of large primitive-keyed maps

### DIFF
--- a/gnovm/pkg/gnolang/garbage_collector.go
+++ b/gnovm/pkg/gnolang/garbage_collector.go
@@ -199,6 +199,20 @@ func GCVisitorFn(gcCycle int64, alloc *Allocator, visitCount *int64) Visitor {
 
 		*visitCount++ // Count operations for gas calculation
 
+		// A map's O(N) MapList traversal (in VisitAssociated, below) is
+		// otherwise unmetered for entries whose key AND value are unboxed
+		// primitives — their data lives in TypedValue.N, so V == nil and vis
+		// is never called for them. Count one visit per such entry to reflect
+		// the real traversal cost. Boxed keys/values are already counted when
+		// vis reaches them, so they are not double-charged here.
+		if mv, ok := v.(*MapValue); ok {
+			for cur := mv.List.Head; cur != nil; cur = cur.Next {
+				if cur.Key.V == nil && cur.Value.V == nil {
+					*visitCount++
+				}
+			}
+		}
+
 		// Add object size to alloc.
 		size := v.GetShallowSize()
 

--- a/gnovm/pkg/gnolang/gc_map_visit_test.go
+++ b/gnovm/pkg/gnolang/gc_map_visit_test.go
@@ -1,0 +1,99 @@
+package gnolang
+
+import (
+	"math"
+	"testing"
+)
+
+// Regression: the GC visit count for a large primitive-keyed/valued map must
+// reflect its O(N) MapList traversal. Before the fix, map[int]int entries
+// (data in TypedValue.N, V == nil) contributed 0 to visitCount, so an N-entry
+// map was charged as ~1 visit.
+func TestGCPrimitiveMapVisitCount(t *testing.T) {
+	const N = 1000
+	mv := &MapValue{List: &MapList{}}
+	mv.vmap = make(map[MapKey]*MapListItem, N)
+	for i := 0; i < N; i++ {
+		item := &MapListItem{Key: TypedValue{T: IntType}, Value: TypedValue{T: IntType}}
+		item.Key.SetInt(int64(i))
+		item.Value.SetInt(int64(i))
+		if mv.List.Head == nil {
+			mv.List.Head, mv.List.Tail = item, item
+		} else {
+			item.Prev = mv.List.Tail
+			mv.List.Tail.Next = item
+			mv.List.Tail = item
+		}
+		mv.List.Size++
+	}
+
+	var visitCount int64
+	alloc := NewAllocator(math.MaxInt64)
+	vis := GCVisitorFn(1, alloc, &visitCount)
+	vis(mv)
+
+	// The map object itself is 1 visit; each of the N fully-primitive entries
+	// must now contribute a visit (the metered O(N) walk).
+	if visitCount < int64(N) {
+		t.Fatalf("visitCount = %d, want >= %d (primitive-map O(N) walk must be metered)", visitCount, N)
+	}
+	t.Logf("N=%d visitCount=%d gcVisitGas=%d", N, visitCount, gcVisitGas(visitCount))
+}
+
+// The fix must add ZERO visits for maps with any boxed key or value — only
+// fully-unboxed entries (both Key.V and Value.V nil) are counted. This pins
+// the no-over-metering / no-gas-change invariant for object & mixed maps.
+func TestGCMapVisitNoOverchargeBoxed(t *testing.T) {
+	mk := func(boxKey, boxVal bool) *MapValue {
+		const N = 100
+		mv := &MapValue{List: &MapList{}}
+		mv.vmap = make(map[MapKey]*MapListItem, N)
+		for i := 0; i < N; i++ {
+			var k, v TypedValue
+			if boxKey {
+				k = TypedValue{T: StringType, V: StringValue("k")}
+			} else {
+				k = TypedValue{T: IntType}
+				k.SetInt(int64(i))
+			}
+			if boxVal {
+				v = TypedValue{T: StringType, V: StringValue("v")}
+			} else {
+				v = TypedValue{T: IntType}
+				v.SetInt(int64(i))
+			}
+			item := &MapListItem{Key: k, Value: v}
+			if mv.List.Head == nil {
+				mv.List.Head, mv.List.Tail = item, item
+			} else {
+				item.Prev = mv.List.Tail
+				mv.List.Tail.Next = item
+				mv.List.Tail = item
+			}
+			mv.List.Size++
+		}
+		return mv
+	}
+	// The fix adds exactly the number of entries with Key.V==nil && Value.V==nil.
+	added := func(mv *MapValue) int {
+		n := 0
+		for cur := mv.List.Head; cur != nil; cur = cur.Next {
+			if cur.Key.V == nil && cur.Value.V == nil {
+				n++
+			}
+		}
+		return n
+	}
+	if n := added(mk(true, false)); n != 0 {
+		t.Fatalf("boxed-key map: fix would add %d visits, want 0 (over-metering)", n)
+	}
+	if n := added(mk(false, true)); n != 0 {
+		t.Fatalf("boxed-value map: fix would add %d visits, want 0 (over-metering)", n)
+	}
+	if n := added(mk(true, true)); n != 0 {
+		t.Fatalf("boxed key+value map: fix would add %d visits, want 0 (over-metering)", n)
+	}
+	if n := added(mk(false, false)); n != 100 {
+		t.Fatalf("fully-primitive map: fix adds %d visits, want 100", n)
+	}
+}


### PR DESCRIPTION
Fixes #5883.

## Problem
GC visit accounting undercharged the O(N) traversal of a fully-primitive map (`map[int]int` etc.). `MapValue.VisitAssociated` walks the `MapList` in O(N), but the visit counter (`GCVisitorFn`) only increments when `vis` is called on a **boxed** key/value object. For `map[int]int` both `TypedValue.V` are nil (data lives in `.N`), so `vis` is never called for the entries — an N-entry map counted as ~1 visit and `gcVisitGas` charged the ~29-gas flat minimum for an O(N) traversal.

## Fix
When visiting a `MapValue`, count one visit per entry whose key **and** value are both unboxed (`Key.V == nil && Value.V == nil`) — exactly the entries that otherwise contribute zero. Boxed keys/values are already counted when `vis` reaches them, so object/mixed-keyed maps are unaffected (no gas change). Deterministic (walks `MapList` in insertion order, not the Go `vmap`).

## Test
`gnovm/pkg/gnolang/gc_map_visit_test.go`: a 1000-entry `map[int]int` now yields `visitCount = 1001` (was 1); `gcVisitGas` 40040 (was 29). Verified red→green (fails on unfixed code).

## Verification (consensus-gas change)
- `go build ./gnovm/...` + `go vet` + `gofmt` clean.
- `./gno.land/pkg/sdk/vm -run Gas`, full `./gno.land/pkg/integration -run TestTestdata` (txtar), `./gnovm/pkg/gnolang -run Files -test.short` — **all green**. Object/mixed maps get +0, so no gas goldens shift.
- Adversarially reviewed across 14 map types (`map[int]int/bool/string`, `map[[1]int]int`, `map[int]*S`, slice/struct/interface values, nested, `interface{}` holding primitive-vs-pointer): fully-unboxed entries counted, boxed never double-counted; overflow-safe (~9 orders of magnitude headroom).

## Note
A fully-primitive map is list-walked twice per GC (once to count, once in `VisitAssociated`). Kept surgical to avoid changing gas for object maps; a single-walk form would need threading the count through the `Visitor` signature — happy to adjust if you'd prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)