### PR TITLE
fix(gnovm): persist function-local declared types referenced by saved values

### DIFF
--- a/gno.land/pkg/integration/testdata/restart_local_type.txtar
+++ b/gno.land/pkg/integration/testdata/restart_local_type.txtar
@@ -1,0 +1,95 @@
+# Regression test: values referencing a function-local declared type must
+# survive persist/reload. Function-local types are declared at runtime (not
+# SetType'd at addpkg like package-level types), so the realm save walk must
+# persist them; otherwise the value serializes a dangling RefType and calling
+# it after a restart panics with "unexpected type with id ...".
+#
+# Three escape routes for the local type S, each in its own realm:
+#   lt1: interface-bound method value (G = i.Get) — the lazy-bind dispatch case
+#   lt2: plain interface-typed package var (X = S{...})
+#   lt3: closure capturing an S value
+loadpkg gno.land/r/test/lt1 $WORK/lt1
+loadpkg gno.land/r/test/lt2 $WORK/lt2
+loadpkg gno.land/r/test/lt3 $WORK/lt3
+
+gnoland start
+
+gnokey maketx call -pkgpath gno.land/r/test/lt1 -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/lt2 -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/lt3 -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnoland restart
+
+gnokey maketx call -pkgpath gno.land/r/test/lt1 -func Call -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '7 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/lt2 -func Call -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '7 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/lt3 -func Call -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '7 int'
+
+-- lt1/lt1.gno --
+package lt1
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+type I interface{ Get() int }
+
+var G func() int
+
+func Bind(cur realm) {
+	type S struct{ T }
+	var i I = S{T{7}}
+	G = i.Get
+}
+
+func Call(cur realm) int {
+	return G()
+}
+
+-- lt2/lt2.gno --
+package lt2
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+type I interface{ Get() int }
+
+var X I
+
+func Bind(cur realm) {
+	type S struct{ T }
+	X = S{T{7}}
+}
+
+func Call(cur realm) int {
+	return X.Get()
+}
+
+-- lt3/lt3.gno --
+package lt3
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+var G func() int
+
+func Bind(cur realm) {
+	type S struct{ T }
+	s := S{T{7}}
+	G = func() int { return s.Get() }
+}
+
+func Call(cur realm) int {
+	return G()
+}

--- a/gno.land/pkg/integration/testdata/restart_local_type2.txtar
+++ b/gno.land/pkg/integration/testdata/restart_local_type2.txtar
@@ -1,0 +1,137 @@
+# Challenge cases for function-local type persistence (see restart_local_type.txtar):
+#   zlta/zltb: cross-realm — zltb's local type S stored in zlta's state (foreign owner)
+#   zltm: map with local-type key (lookup after restart re-mints K from the persisted
+#         TypeValue — pins TypeID stability), recursive local type, and a
+#         reload -> mutate -> re-save -> reload loop across a second restart
+#   zltc/zzltp: local type declared in a pure p/ package function, stored in a realm
+loadpkg gno.land/p/test/zzltp $WORK/zzltp
+loadpkg gno.land/r/test/zlta $WORK/zlta
+loadpkg gno.land/r/test/zltb $WORK/zltb
+loadpkg gno.land/r/test/zltm $WORK/zltm
+loadpkg gno.land/r/test/zltc $WORK/zltc
+
+gnoland start
+
+gnokey maketx call -pkgpath gno.land/r/test/zltb -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltm -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltc -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnoland restart
+
+gnokey maketx call -pkgpath gno.land/r/test/zlta -func Call -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '11 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltm -func Lookup -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'one'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltm -func Sum -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '3 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltm -func Bump -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltc -func Call -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '12 int'
+
+gnoland restart
+
+gnokey maketx call -pkgpath gno.land/r/test/zltm -func Sum -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '4 int'
+
+-- zzltp/zzltp.gno --
+package zzltp
+
+type P struct{ v int }
+
+func (p P) Get() int { return p.v }
+
+func MakeVal() any {
+	type PS struct{ P }
+	return PS{P{12}}
+}
+
+-- zlta/zlta.gno --
+package zlta
+
+type I interface{ Get() int }
+
+var H I
+
+func Set(cur realm, v I) {
+	H = v
+}
+
+func Call(cur realm) int {
+	return H.Get()
+}
+
+-- zltb/zltb.gno --
+package zltb
+
+import "gno.land/r/test/zlta"
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+func Bind(cur realm) {
+	type S struct{ T }
+	zlta.Set(cross(cur), S{T{11}})
+}
+
+-- zltm/zltm.gno --
+package zltm
+
+var (
+	GLookup func() string
+	GSum    func() int
+	GBump   func()
+)
+
+func Bind(cur realm) {
+	type K struct{ k int }
+	m := map[K]string{{1}: "one"}
+	GLookup = func() string { return m[K{1}] }
+
+	type N struct {
+		next *N
+		v    int
+	}
+	head := &N{&N{nil, 2}, 1}
+	GSum = func() int {
+		s := 0
+		for n := head; n != nil; n = n.next {
+			s += n.v
+		}
+		return s
+	}
+	GBump = func() { head.v++ }
+}
+
+func Lookup(cur realm) string { return GLookup() }
+
+func Sum(cur realm) int { return GSum() }
+
+func Bump(cur realm) { GBump() }
+
+-- zltc/zltc.gno --
+package zltc
+
+import "gno.land/p/test/zzltp"
+
+type I interface{ Get() int }
+
+var H I
+
+func Bind(cur realm) {
+	H = zzltp.MakeVal().(I)
+}
+
+func Call(cur realm) int {
+	return H.Get()
+}

--- a/gno.land/pkg/integration/testdata/restart_local_type3.txtar
+++ b/gno.land/pkg/integration/testdata/restart_local_type3.txtar
@@ -1,0 +1,126 @@
+# Round-2 challenge cases for function-local type persistence:
+#   B: TypeValue-only escape — closure constructs the local type per call; the
+#      only persisted trace of S2 is the captured type declaration.
+#   C: type declared inside a closure literal (ParentLoc = FuncLitExpr);
+#      post-restart call re-declares it and persists a fresh value.
+#   D: same local type name in two different functions (distinct ParentLoc).
+#   E: Bind called twice (fresh *DeclaredType instance, same TypeID — SetType
+#      idempotency across transactions).
+#   F (negative): local type declared in a maketx run script cannot escape —
+#      an existing guard rejects persisting values of types defined in the
+#      ephemeral run package, so no dangling e/-pkgpath type is possible.
+loadpkg gno.land/r/test/zlth $WORK/zlth
+loadpkg gno.land/r/test/zltsh $WORK/zltsh
+
+gnoland start
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func Bind -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout 'OK!'
+
+! gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1 $WORK/script/script.gno
+stderr 'cannot persist object of type defined in the private realm'
+
+gnoland restart
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func CallB -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '7 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func CallC -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '5 int'
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func CallD -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '3 int'
+
+gnoland restart
+
+gnokey maketx call -pkgpath gno.land/r/test/zltsh -func CallX -gas-fee 1000000ugnot -gas-wanted 20000000 -broadcast -chainid=tendermint_test test1
+stdout '5 int'
+
+-- zlth/zlth.gno --
+package zlth
+
+type Getter interface{ Get() int }
+
+var H Getter
+
+func Set(cur realm, v Getter) {
+	H = v
+}
+
+func Call(cur realm) int {
+	return H.Get()
+}
+
+-- zltsh/zltsh.gno --
+package zltsh
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+type Getter interface{ Get() int }
+
+var (
+	G      func() any
+	GG     func() any
+	D1, D2 any
+	X      any
+)
+
+func mk1() any {
+	type S struct{ T }
+	return S{T{1}}
+}
+
+func mk2() any {
+	type S struct{ T }
+	return S{T{2}}
+}
+
+func Bind(cur realm) {
+	type S2 struct{ T }
+	G = func() any { return S2{T{7}} }
+
+	GG = func() any {
+		type C struct{ T }
+		return C{T{5}}
+	}
+
+	D1, D2 = mk1(), mk2()
+}
+
+func CallB(cur realm) int {
+	return G().(Getter).Get()
+}
+
+// CallC re-declares C at runtime inside the closure and persists a fresh
+// value of it in a post-restart transaction.
+func CallC(cur realm) int {
+	X = GG()
+	return X.(Getter).Get()
+}
+
+func CallD(cur realm) int {
+	return D1.(Getter).Get() + D2.(Getter).Get()
+}
+
+func CallX(cur realm) int {
+	return X.(Getter).Get()
+}
+
+-- script/script.gno --
+package main
+
+import "gno.land/r/test/zlth"
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+func main(cur realm) {
+	type S struct{ T }
+	zlth.Set(cross(cur), S{T{21}})
+}

--- a/gnovm/adr/pr5894_local_type_persist.md
+++ b/gnovm/adr/pr5894_local_type_persist.md
@@ -1,0 +1,72 @@
+# ADR: Persist function-local declared types referenced by saved values
+
+## Context
+
+Package-level declared types are written to the type store (`/t/<TypeID>`) at
+addpkg (`saveNewPackageValuesAndTypes`). Function-local declared types
+(`type S ...` inside a function body) are created at runtime and were never
+`SetType`'d. Any persisted `TypedValue` whose `.T` is such a type serializes
+as `RefType{"pkg[loc].Name"}` — a dangling pointer into the type store. The
+same process never notices (the live type sits in `cacheTypes`); after a node
+restart, loading the object hits `fillTypesOfValue` → `GetType` → miss →
+`panic("unexpected type with id ...")`. The state is permanently unreadable.
+
+Escape routes that reproduce on master: an interface-typed package var
+(`X = S{...}`) and a closure capture (heap-item slot typed `S`). A third
+route — interface-bound method values (`G = i.Get`) — does *not* reproduce on
+master because the eager bind resolves promotion at bind time and persists
+only the embedded package-level receiver; it starts carrying the local type
+once #5737's call-time dispatch lands (which persists the interface-boxed
+operand). That makes this PR a prerequisite for #5737, but the fix is a
+standalone correction of live corruption.
+
+## Decision
+
+1. **`localTypeSaver` walk in `saveObject`** (realm.go): before `SetObject`,
+   walk the object's typed slots and `SetType` every reachable `DeclaredType`
+   with a non-zero `ParentLoc`, recursing through `Base` (visited-guarded for
+   recursive types). `saveObject` is the single choke point all persistence
+   routes go through (tx finalize and addpkg both reach it via
+   `FinalizeRealmTransaction`), so the walk covers every route. Dedup is
+   centralized in `SetType`'s per-tx `cacheTypes` early-return; the walk stays
+   stateless apart from cycle protection. Per-slot cost is a few pointer hops:
+   package-level `DeclaredType` prunes immediately without descending `Base`,
+   and `SetObject` already performs two full structural walks
+   (`copyValueWithRefs`, amino marshal), so this shallower third walk is noise.
+2. **`copyTypeWithRefs` preserves `ParentLoc`**: `ParentLoc` is part of the
+   TypeID for local types (`pkg[loc].Name`); dropping it in the persist copy
+   (as before) would store the type record under a different ID than the one
+   values reference.
+3. **`debugAssert` invariant in `SetObject`** (store.go): walk the
+   persist-copy; a bracketed `RefType` not in `cacheTypes` panics at save
+   time, so a future missed route fails loudly inside the (buffered,
+   rolled-back) transaction instead of committing unreadable state. The type
+   walker panics on unknown type kinds for the same reason; known-but-not-
+   currently-persistable kinds (`tupleType`) are walked, structurally-empty
+   kinds (`blockType` etc.) are pruned.
+
+## Alternatives considered
+
+- **`SetType` at declaration time (`OpTypeDecl`)**: persists types whose
+  values never escape — store bloat and gas for dead types; also detaches the
+  write from the save path that defines what actually needs resolving.
+- **`containsLocal` bit propagated at type construction** (compiler-style
+  `HasTParam` pattern): O(1) save-time check, but every Type construction
+  site (preprocess + runtime) must participate and the bit must survive amino
+  round trips. The saver's query is cold (once per dirty object per tx,
+  dwarfed by amino encode), so the walk wins on blast radius.
+- **Resolve lazily on reload**: impossible — after restart nothing can
+  reconstruct the type; the source of truth is gone.
+
+## Consequences
+
+- Saves reaching a local type now write `/t/` entries and pay their encode
+  gas; type-record bytes gain `ParentLoc`. Deterministic, but a state/gas
+  change — coordinate like other consensus-affecting fixes.
+- `BoundMethodValue.Receiver` in the saver and the lt1 txtar case are
+  currently vacuous (eager bind flattens the receiver); they become live with
+  #5737.
+- Tests: `restart_local_type*.txtar` are the true reproducers (fail on
+  master); `zrealm_localtype0/1.gno` filetests pass on master and act as
+  save-side guards via `-tags debugAssert` (`make test.debugAssert`, not yet
+  in CI) plus a golden pinning the on-the-wire bracketed `RefType`.

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1199,9 +1199,10 @@ func (lts *localTypeSaver) saveType(t Type) {
 		lts.saveType(ct.Key)
 		lts.saveType(ct.Value)
 	case *tupleType:
-		// Tuples are transient (multi-value expressions on the stack) and
-		// not currently persistable; walked rather than pruned so a future
-		// persistable route cannot silently skip local-type persistence.
+		// Currently unreachable: tuple types are transient (multi-value
+		// expressions) and never persisted. Walked anyway — correct if they
+		// ever become persistable, whereas pruning would silently
+		// reintroduce dangling local-type refs.
 		for _, et := range ct.Elts {
 			lts.saveType(et)
 		}

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1167,7 +1167,7 @@ func (lts *localTypeSaver) saveType(t Type) {
 	}
 	switch ct := t.(type) {
 	case *DeclaredType:
-		if ct.ParentLoc.IsZero() {
+		if !ct.IsFuncLocal() {
 			// Package-level: persisted at addpkg, and a package-scope type
 			// declaration cannot reference a function-local type — prune.
 			return

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1111,8 +1111,7 @@ type localTypeSaver struct {
 }
 
 // saveObjectTypes walks the object's typed slots. Child objects are walked by
-// their own saveObject call during the save traversal, so like
-// assertObjectIsPublic this does not recurse into values.
+// their own saveObject call during the save traversal.
 func (lts *localTypeSaver) saveObjectTypes(oo Object) {
 	switch v := oo.(type) {
 	case *HeapItemValue:
@@ -1200,6 +1199,9 @@ func (lts *localTypeSaver) saveType(t Type) {
 		lts.saveType(ct.Key)
 		lts.saveType(ct.Value)
 	case *tupleType:
+		// Tuples are transient (multi-value expressions on the stack) and
+		// not currently persistable; walked rather than pruned so a future
+		// persistable route cannot silently skip local-type persistence.
 		for _, et := range ct.Elts {
 			lts.saveType(et)
 		}

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -1074,6 +1074,10 @@ func (rlm *Realm) saveObject(store Store, oo Object) {
 		}
 	}
 
+	// Persist any function-local declared types the object references,
+	// so the RefTypes minted for them by copyValueWithRefs resolve on reload.
+	(&localTypeSaver{store: store}).saveObjectTypes(oo)
+
 	// set object to store.
 	// NOTE: also sets the hash to object.
 	// sumDiff routing: foreign-owned objects accrue to the owner
@@ -1085,6 +1089,140 @@ func (rlm *Realm) saveObject(store Store, oo Object) {
 	} else {
 		fr := rlm.touchForeignRealm(store, oid.PkgID)
 		fr.sumDiff += delta
+	}
+}
+
+//----------------------------------------
+// localTypeSaver
+
+// localTypeSaver persists function-local declared types (DeclaredType with
+// ParentLoc set) referenced by a to-be-persisted object. Package-level types
+// are SetType'd at addpkg (saveNewPackageValuesAndTypes), but function-local
+// types are declared at runtime, and this save-time walk is the only place
+// the store learns a persisted value references one; without it the value
+// serializes a dangling RefType and reloading panics with
+// "unexpected type with id ...".
+type localTypeSaver struct {
+	store Store
+	// visited guards recursion through local type Bases (e.g.
+	// `type S struct{ next *S }`); allocated lazily since local types are
+	// rare. Cross-save dedup comes from SetType's per-tx cacheTypes guard.
+	visited map[TypeID]struct{}
+}
+
+// saveObjectTypes walks the object's typed slots. Child objects are walked by
+// their own saveObject call during the save traversal, so like
+// assertObjectIsPublic this does not recurse into values.
+func (lts *localTypeSaver) saveObjectTypes(oo Object) {
+	switch v := oo.(type) {
+	case *HeapItemValue:
+		lts.saveTV(&v.Value)
+	case *ArrayValue:
+		for i := range v.List {
+			lts.saveTV(&v.List[i])
+		}
+	case *StructValue:
+		for i := range v.Fields {
+			lts.saveTV(&v.Fields[i])
+		}
+	case *MapValue:
+		for head := v.List.Head; head != nil; head = head.Next {
+			lts.saveTV(&head.Key)
+			lts.saveTV(&head.Value)
+		}
+	case *FuncValue:
+		lts.saveType(v.Type)
+		for i := range v.Captures {
+			lts.saveTV(&v.Captures[i])
+		}
+	case *BoundMethodValue:
+		// Methods are declared at package scope, so v.Func's signature cannot
+		// reference a function-local type; only the receiver can.
+		lts.saveTV(&v.Receiver)
+	case *Block:
+		for i := range v.Values {
+			lts.saveTV(&v.Values[i])
+		}
+		lts.saveTV(&v.Blank)
+	case *PackageValue:
+		// package-level types are persisted at addpkg.
+	default:
+		panic(fmt.Sprintf("localTypeSaver.saveObjectTypes: unhandled object type %T", v))
+	}
+}
+
+func (lts *localTypeSaver) saveTV(tv *TypedValue) {
+	if tv.T != nil {
+		lts.saveType(tv.T)
+	}
+	// A TypeValue slot (e.g. a captured local type declaration) holds the
+	// type as a value; its slot type is just TypeType.
+	if tvv, ok := tv.V.(TypeValue); ok {
+		lts.saveType(tvv.Type)
+	}
+}
+
+func (lts *localTypeSaver) saveType(t Type) {
+	if t == nil {
+		return
+	}
+	switch ct := t.(type) {
+	case *DeclaredType:
+		if ct.ParentLoc.IsZero() {
+			// Package-level: persisted at addpkg, and a package-scope type
+			// declaration cannot reference a function-local type — prune.
+			return
+		}
+		tid := ct.TypeID()
+		if _, ok := lts.visited[tid]; ok {
+			return
+		}
+		if lts.visited == nil {
+			lts.visited = make(map[TypeID]struct{})
+		}
+		lts.visited[tid] = struct{}{}
+		lts.store.SetType(ct)
+		// Function-local types cannot declare methods, so only the Base can
+		// reference further local types.
+		lts.saveType(ct.Base)
+	case FieldType:
+		lts.saveType(ct.Type)
+	case *FuncType:
+		for _, param := range ct.Params {
+			lts.saveType(param)
+		}
+		for _, result := range ct.Results {
+			lts.saveType(result)
+		}
+	case *SliceType, *ArrayType, *PointerType:
+		lts.saveType(ct.Elem())
+	case *MapType:
+		lts.saveType(ct.Key)
+		lts.saveType(ct.Value)
+	case *tupleType:
+		for _, et := range ct.Elts {
+			lts.saveType(et)
+		}
+	case *InterfaceType:
+		for _, method := range ct.Methods {
+			lts.saveType(method)
+		}
+	case *StructType:
+		for _, field := range ct.Fields {
+			lts.saveType(field)
+		}
+	case heapItemType:
+		// The wrapped HeapItemValue is its own object; its saveObject call
+		// walks the inner type.
+	case RefType:
+		// A RefType round-tripped from the store, so it is persisted by
+		// definition.
+	case PrimitiveType, *TypeType, *PackageType, blockType:
+		// Cannot reference a function-local declared type.
+	default:
+		// Fail loudly so a future type kind cannot silently skip local-type
+		// persistence and reintroduce dangling RefTypes on reload.
+		panic(fmt.Sprintf("localTypeSaver.saveType: unhandled type %T", ct))
 	}
 }
 
@@ -1571,9 +1709,11 @@ func copyTypeWithRefs(typ Type) Type {
 		// cacheTypes, so SetType's early-return always fires for them.
 		dt := &DeclaredType{
 			PkgPath: ct.PkgPath,
-			Name:    ct.Name,
-			Base:    copyTypeWithRefs(ct.Base),
-			Methods: copyMethods(ct.Methods),
+			// ParentLoc is part of the TypeID for function-local types.
+			ParentLoc: ct.ParentLoc,
+			Name:      ct.Name,
+			Base:      copyTypeWithRefs(ct.Base),
+			Methods:   copyMethods(ct.Methods),
 		}
 		return dt
 	case *PackageType:

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -615,6 +615,15 @@ func (ds *defaultStore) SetObject(oo Object) int64 {
 	oid := oo.GetObjectID()
 	// replace children/fields with Ref.
 	o2 := copyValueWithRefs(oo)
+	if debugAssert {
+		// Invariant: every function-local declared type referenced by the
+		// persist-copy must have been SetType'd within this transaction (the
+		// save path runs localTypeSaver just before SetObject), so it must be
+		// in cacheTypes. A miss means some save path minted a RefType the
+		// store cannot resolve on reload — the object would be persisted
+		// permanently unreadable.
+		ds.assertNoDanglingLocalTypeRef(o2)
+	}
 	// marshal to binary.
 	bz := amino.MustMarshalAny(o2)
 	gas := overflow.Mulp(ds.gasConfig.GasAminoEncode, store.Gas(len(bz)))
@@ -860,6 +869,97 @@ func (ds *defaultStore) SetType(tt Type) {
 	}
 	// save type to cache.
 	ds.cacheTypes[tid] = tt
+}
+
+// assertNoDanglingLocalTypeRef (debugAssert only) walks a persist-copy
+// produced by copyValueWithRefs and panics if it references a function-local
+// declared type (RefType whose TypeID carries a location) that is not in
+// cacheTypes. See the SetObject call site for the invariant.
+func (ds *defaultStore) assertNoDanglingLocalTypeRef(val Value) {
+	switch cv := val.(type) {
+	case *ArrayValue:
+		for i := range cv.List {
+			ds.assertNoDanglingLocalTypeRefTV(&cv.List[i])
+		}
+	case *StructValue:
+		for i := range cv.Fields {
+			ds.assertNoDanglingLocalTypeRefTV(&cv.Fields[i])
+		}
+	case *MapValue:
+		for cur := cv.List.Head; cur != nil; cur = cur.Next {
+			ds.assertNoDanglingLocalTypeRefTV(&cur.Key)
+			ds.assertNoDanglingLocalTypeRefTV(&cur.Value)
+		}
+	case *FuncValue:
+		ds.assertNoDanglingLocalTypeRefType(cv.Type)
+		for i := range cv.Captures {
+			ds.assertNoDanglingLocalTypeRefTV(&cv.Captures[i])
+		}
+	case *BoundMethodValue:
+		ds.assertNoDanglingLocalTypeRef(cv.Func)
+		ds.assertNoDanglingLocalTypeRefTV(&cv.Receiver)
+	case *Block:
+		for i := range cv.Values {
+			ds.assertNoDanglingLocalTypeRefTV(&cv.Values[i])
+		}
+		ds.assertNoDanglingLocalTypeRefTV(&cv.Blank)
+	case *HeapItemValue:
+		ds.assertNoDanglingLocalTypeRefTV(&cv.Value)
+	case TypeValue:
+		ds.assertNoDanglingLocalTypeRefType(cv.Type)
+	default:
+		// Scalars carry no type refs; PointerValue/SliceValue bases and
+		// RefValue children are separate objects with their own SetObject.
+	}
+}
+
+func (ds *defaultStore) assertNoDanglingLocalTypeRefTV(tv *TypedValue) {
+	ds.assertNoDanglingLocalTypeRefType(tv.T)
+	ds.assertNoDanglingLocalTypeRef(tv.V)
+}
+
+func (ds *defaultStore) assertNoDanglingLocalTypeRefType(t Type) {
+	switch ct := t.(type) {
+	case RefType:
+		// RefTypes only wrap declared types ("path.Name" or "path[loc].Name",
+		// see refOrCopyType), so a bracket identifies a function-local type.
+		if strings.Contains(ct.ID.String(), "[") {
+			if _, exists := ds.cacheTypes[ct.ID]; !exists {
+				panic(fmt.Sprintf(
+					"dangling function-local type ref %s in persisted value", ct.ID))
+			}
+		}
+	case *DeclaredType:
+		ds.assertNoDanglingLocalTypeRefType(ct.Base)
+	case FieldType:
+		ds.assertNoDanglingLocalTypeRefType(ct.Type)
+	case *FuncType:
+		for _, param := range ct.Params {
+			ds.assertNoDanglingLocalTypeRefType(param)
+		}
+		for _, result := range ct.Results {
+			ds.assertNoDanglingLocalTypeRefType(result)
+		}
+	case *SliceType, *ArrayType, *PointerType:
+		ds.assertNoDanglingLocalTypeRefType(ct.Elem())
+	case *MapType:
+		ds.assertNoDanglingLocalTypeRefType(ct.Key)
+		ds.assertNoDanglingLocalTypeRefType(ct.Value)
+	case *tupleType:
+		for _, et := range ct.Elts {
+			ds.assertNoDanglingLocalTypeRefType(et)
+		}
+	case *InterfaceType:
+		for _, method := range ct.Methods {
+			ds.assertNoDanglingLocalTypeRefType(method)
+		}
+	case *StructType:
+		for _, field := range ct.Fields {
+			ds.assertNoDanglingLocalTypeRefType(field)
+		}
+	default:
+		// nil, primitives, TypeType, PackageType, blockType, heapItemType.
+	}
 }
 
 // Convenience

--- a/gnovm/pkg/gnolang/types.go
+++ b/gnovm/pkg/gnolang/types.go
@@ -1528,6 +1528,9 @@ func declareWith(pkgPath string, parent BlockNode, name Name, b Type) *DeclaredT
 	case *PackageNode, *FileNode:
 		// keep blank.
 	case *FuncDecl, *FuncLitExpr:
+		// Non-zero (setNodeLocations stamps every block node before
+		// preprocessing). IsFuncLocal relies on this: any case added
+		// here for a non-package scope must set a non-zero ploc.
 		ploc = parent.GetLocation()
 	default:
 		panic(fmt.Sprintf("expected type expr but got %T", parent))
@@ -2017,8 +2020,15 @@ func DeclaredTypeID(pkgPath string, loc Location, name Name) TypeID {
 	}
 }
 
+// IsFuncLocal reports whether dt was declared inside a function body.
+// declareWith sets ParentLoc non-zero iff the parent is a
+// FuncDecl/FuncLitExpr; package/file-scope declarations leave it zero.
+func (dt *DeclaredType) IsFuncLocal() bool {
+	return !dt.ParentLoc.IsZero()
+}
+
 func (dt *DeclaredType) String() string {
-	if dt.ParentLoc.IsZero() {
+	if !dt.IsFuncLocal() {
 		return fmt.Sprintf("%s.%s", dt.PkgPath, dt.Name)
 	} else {
 		return fmt.Sprintf("%s[%s].%s", dt.PkgPath, dt.ParentLoc.String(), dt.Name)

--- a/gnovm/tests/files/zrealm_localtype0.gno
+++ b/gnovm/tests/files/zrealm_localtype0.gno
@@ -1,0 +1,104 @@
+// PKGPATH: gno.land/r/test
+package test
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+type I interface{ Get() int }
+
+var X I
+
+func main(cur realm) {
+	type S struct{ T }
+	X = S{T{7}}
+	println(X.Get())
+}
+
+// Output:
+// 7
+
+// Realm:
+// finalizerealm["gno.land/r/test"]
+// c[08ada09dee16d791fd406d629fe29bb0ed084a30:7](214)={
+//     "Fields": [
+//         {
+//             "N": "BwAAAAAAAAA=",
+//             "T": {
+//                 "@type": "/gno.PrimitiveType",
+//                 "value": "32"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7",
+//         "LastObjectSize": "214",
+//         "ModTime": "0",
+//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "RefCount": "1"
+//     }
+// }
+// c[08ada09dee16d791fd406d629fe29bb0ed084a30:6](331)={
+//     "Fields": [
+//         {
+//             "T": {
+//                 "@type": "/gno.RefType",
+//                 "ID": "gno.land/r/test.T"
+//             },
+//             "V": {
+//                 "@type": "/gno.RefValue",
+//                 "Hash": "cf9fac1f1c39731a1e061643ebc8ceed19ab5402",
+//                 "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:7"
+//             }
+//         }
+//     ],
+//     "ObjectInfo": {
+//         "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6",
+//         "LastObjectSize": "331",
+//         "ModTime": "0",
+//         "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//         "RefCount": "1"
+//     }
+// }
+// u[08ada09dee16d791fd406d629fe29bb0ed084a30:3](197)=
+//     @@ -2,9 +2,19 @@
+//          "ObjectInfo": {
+//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3",
+//              "LastObjectSize": "190",
+//     -        "ModTime": "0",
+//     +        "ModTime": "5",
+//              "OwnerID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "RefCount": "1"
+//          },
+//     -    "Value": {}
+//     +    "Value": {
+//     +        "T": {
+//     +            "@type": "/gno.RefType",
+//     +            "ID": "gno.land/r/test[gno.land/r/test/zrealm_localtype0.gno:12:1-16:2].S"
+//     +        },
+//     +        "V": {
+//     +            "@type": "/gno.RefValue",
+//     +            "Hash": "c75d0f3cbea1c4b70684326f94a5fa635f52e2f4",
+//     +            "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:6"
+//     +        }
+//     +    }
+//      }
+// u[08ada09dee16d791fd406d629fe29bb0ed084a30:2](5)=
+//     @@ -4,7 +4,7 @@
+//              "ID": "08ada09dee16d791fd406d629fe29bb0ed084a30:2",
+//              "IsEscaped": true,
+//              "LastObjectSize": "709",
+//     -        "ModTime": "0",
+//     +        "ModTime": "7",
+//              "RefCount": "2"
+//          },
+//          "Parent": null,
+//     @@ -58,7 +58,7 @@
+//                  },
+//                  "V": {
+//                      "@type": "/gno.RefValue",
+//     -                "Hash": "77f76390147dcb12d9de104eb549c3a959934c1c",
+//     +                "Hash": "f5719b6a2df0ed50f03dafcc81e82da22ce74b71",
+//                      "ObjectID": "08ada09dee16d791fd406d629fe29bb0ed084a30:3"
+//                  }
+//              },

--- a/gnovm/tests/files/zrealm_localtype1.gno
+++ b/gnovm/tests/files/zrealm_localtype1.gno
@@ -1,0 +1,90 @@
+// PKGPATH: gno.land/r/test
+package test
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+var (
+	M1  any // map with local-type key
+	M2  any // map with local-type value
+	SL  any // slice of local type
+	P   any // pointer to local type
+	RN  any // recursive local type
+	NB  any // nested local types
+	MI  any // primitive-based local type
+	FT  any // local func type
+	G   func() int
+	ARR any // byte-based local type array
+)
+
+func main(cur realm) {
+	// 1 map key
+	type K struct{ k int }
+	m := map[K]string{{1}: "one"}
+	M1 = m
+	println(m[K{1}])
+	// 2 map value
+	type V struct{ v int }
+	mv := map[string]V{"a": {2}}
+	M2 = mv
+	println(mv["a"].v)
+	// 3 slice of local type
+	type S struct{ x int }
+	sl := []S{{1}, {2}}
+	SL = sl
+	println(sl[0].x + sl[1].x)
+	// 4 pointer to local type
+	p := &S{5}
+	P = p
+	println(p.x)
+	// 5 recursive local type
+	type N struct {
+		next *N
+		v    int
+	}
+	n := &N{&N{nil, 2}, 1}
+	RN = n
+	sum := 0
+	for ; n != nil; n = n.next {
+		sum += n.v
+	}
+	println(sum)
+	// 6 nested local types
+	type A struct{ v int }
+	type B struct{ a A }
+	b := B{A{6}}
+	NB = b
+	println(b.a.v)
+	// 7 primitive base
+	type MyInt int
+	MI = MyInt(42)
+	println(int(MI.(MyInt)))
+	// 8 local func type
+	type F func() int
+	var f F = func() int { return 8 }
+	FT = f
+	println(f())
+	// 9 closure over var of local interface type
+	type LI interface{ Get() int }
+	var li LI = T{9}
+	G = func() int { return li.Get() }
+	println(G())
+	// 10 byte-based local type array
+	type MB byte
+	arr := [3]MB{1, 2, 3}
+	ARR = arr
+	println(int(arr[0]) + int(arr[1]) + int(arr[2]))
+}
+
+// Output:
+// one
+// 2
+// 3
+// 5
+// 3
+// 6
+// 42
+// 8
+// 9
+// 6

--- a/gnovm/tests/files/zrealm_localtype2.gno
+++ b/gnovm/tests/files/zrealm_localtype2.gno
@@ -1,0 +1,48 @@
+// PKGPATH: gno.land/r/test
+package test
+
+type T struct{ x int }
+
+func (t T) Get() int { return t.x }
+
+type Getter interface{ Get() int }
+
+var (
+	G      func() any
+	GG     func() any
+	D1, D2 any
+)
+
+func mk1() any {
+	type S struct{ T }
+	return S{T{1}}
+}
+
+func mk2() any {
+	type S struct{ T }
+	return S{T{2}}
+}
+
+func main(cur realm) {
+	// B: TypeValue-only escape — closure constructs the local type per call;
+	// no S2-typed value exists at save time, only the captured type.
+	type S2 struct{ T }
+	G = func() any { return S2{T{7}} }
+	println(G().(Getter).Get())
+
+	// C: type declared inside a closure literal (ParentLoc = FuncLitExpr)
+	GG = func() any {
+		type C struct{ T }
+		return C{T{5}}
+	}
+	println(GG().(Getter).Get())
+
+	// D: same local type name in two different functions
+	D1, D2 = mk1(), mk2()
+	println(D1.(Getter).Get(), D2.(Getter).Get())
+}
+
+// Output:
+// 7
+// 5
+// 1 2


### PR DESCRIPTION
- Function-local declared types are never `SetType`'d (only package-level types are, at addpkg), so persisting a value referencing one writes a dangling `RefType`; after a node restart every access panics with `unexpected type with id ...` — the realm state is permanently unreadable. Reproduces on master via interface-typed package vars and closure captures.
- Fix: a `localTypeSaver` walk in `saveObject` persists reachable function-local types before `SetObject`; `copyTypeWithRefs` preserves `ParentLoc` so the local type's TypeID survives the persist/reload round trip.
- Defense-in-depth: a `debugAssert`-gated invariant in `SetObject` panics at save time on any dangling function-local type ref, so a missed route fails loudly inside the rolled-back tx instead of committing unreadable state.
- Tests: restart txtars are the true reproducers (fail on master) — interface var / closure / bound method value, cross-realm, p/-package local type, map-key TypeID stability, reload→mutate→resave across two restarts; `zrealm_localtype*` filetests guard the save side under `-tags debugAssert` and pin the on-the-wire `RefType` shape.
- Also unblocks #5737, whose call-time method dispatch persists the interface-boxed operand and newly hits this hole. ADR: `gnovm/adr/pr5894_local_type_persist.md`.
