### PR TITLE
fix(gnoweb): In serveEval, use MaxBytesReader to cap the JSON size

### DIFF
--- a/gno.land/pkg/gnoweb/feature/playground/handler.go
+++ b/gno.land/pkg/gnoweb/feature/playground/handler.go
@@ -32,6 +32,10 @@ const (
 	// against memory exhaustion from large or numerous on-chain package files.
 	maxForkCodeSize = 1 << 20 // 1 MiB
 
+	// maxEvalBodyBytes caps the eval request body to guard against memory
+	// exhaustion from oversized JSON payloads.
+	maxEvalBodyBytes = 1 << 20 // 1 MiB
+
 	// defaultCode defines the default code displayed in the code editor.
 	defaultCode = `package main
 
@@ -211,6 +215,8 @@ func (h *Handler) serveEval(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusTooManyRequests, evalResponse{Error: "rate limit exceeded, please slow down"})
 		return
 	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxEvalBodyBytes)
 
 	var req evalRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/gno.land/pkg/gnoweb/feature/playground/handler.go
+++ b/gno.land/pkg/gnoweb/feature/playground/handler.go
@@ -36,6 +36,12 @@ const (
 	// exhaustion from oversized JSON payloads.
 	maxEvalBodyBytes = 1 << 20 // 1 MiB
 
+	// maxEvalPkgPathLen and maxEvalExpressionLen bound the eval request fields
+	// well below maxEvalBodyBytes, rejecting oversized requests before they are
+	// forwarded to the RPC node. Legitimate values are far smaller.
+	maxEvalPkgPathLen    = 1024
+	maxEvalExpressionLen = 64 * 1024
+
 	// defaultCode defines the default code displayed in the code editor.
 	defaultCode = `package main
 
@@ -226,6 +232,11 @@ func (h *Handler) serveEval(w http.ResponseWriter, r *http.Request) {
 
 	if req.PkgPath == "" || req.Expression == "" {
 		writeJSON(w, http.StatusBadRequest, evalResponse{Error: "pkg_path and expression are required"})
+		return
+	}
+
+	if len(req.PkgPath) > maxEvalPkgPathLen || len(req.Expression) > maxEvalExpressionLen {
+		writeJSON(w, http.StatusBadRequest, evalResponse{Error: "pkg_path or expression is too long"})
 		return
 	}
 


### PR DESCRIPTION
In the spirit of "small PRs against the playground2 branch", this PR fixes [this comment from @alexiscolin](https://github.com/gnolang/gno/pull/5774#discussion_r3360675922) . We put new constants like `maxEvalBodyBytes` next to the other constants like `maxForkCodeSize`.

Following the [comment from @moul](https://github.com/gnolang/gno/pull/5421#discussion_r3512098582), we also limit the size of `req.PkgPath` to 1024 and `req.Expression` to 64K. Are these good sizes?