### PR TITLE
perf(vm): lazily clone the type-check cache per transaction

### DIFF
--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -398,9 +398,32 @@ func (vm *VMKeeper) newGnoTransactionStore(ctx sdk.Context) gno.TransactionStore
 	return vm.gnoStore.BeginTransaction(base, iavl, gctx, gasMeter)
 }
 
+// typeCheckCacheHolder lazily clones the shared type-check cache the
+// first time a transaction actually needs it. Only AddPackage and Run
+// type-check; the common transactions (MsgCall, query eval) never do,
+// so they no longer pay for the per-tx maps.Clone. The clone is created
+// at most once per transaction and shared across a tx's messages, so
+// behaviour is identical to eager cloning.
+//
+// A holder belongs to a single transaction's context and, like the rest
+// of per-tx execution (store, allocator, gas meter), assumes one
+// goroutine drives that transaction. get() is therefore not internally
+// synchronized.
+type typeCheckCacheHolder struct {
+	base   gno.TypeCheckCache // shared, treated as read-only
+	cloned gno.TypeCheckCache // per-tx working copy; nil until first get
+}
+
+func (h *typeCheckCacheHolder) get() gno.TypeCheckCache {
+	if h.cloned == nil {
+		h.cloned = maps.Clone(h.base)
+	}
+	return h.cloned
+}
+
 func (vm *VMKeeper) MakeGnoTransactionStore(ctx sdk.Context) sdk.Context {
 	return ctx.
-		WithValue(vmkContextKeyTypeCheckCache, maps.Clone(vm.typeCheckCache)).
+		WithValue(vmkContextKeyTypeCheckCache, &typeCheckCacheHolder{base: vm.typeCheckCache}).
 		WithValue(vmkContextKeyStore, vm.newGnoTransactionStore(ctx))
 }
 
@@ -409,7 +432,7 @@ func (vm *VMKeeper) CommitGnoTransactionStore(ctx sdk.Context) {
 }
 
 func (vm *VMKeeper) getTypeCheckCache(ctx sdk.Context) gno.TypeCheckCache {
-	return ctx.Value(vmkContextKeyTypeCheckCache).(gno.TypeCheckCache)
+	return ctx.Value(vmkContextKeyTypeCheckCache).(*typeCheckCacheHolder).get()
 }
 
 func (vm *VMKeeper) getGnoTransactionStore(ctx sdk.Context) gno.TransactionStore {


### PR DESCRIPTION
## Summary

`MakeGnoTransactionStore` ran `maps.Clone(vm.typeCheckCache)` on **every** transaction (via the `BeginTxHook`), but only `AddPackage` and `Run` ever consume that cache — `MsgCall` and query eval, the common case, never type-check. Every such transaction paid for a full clone of the shared cache (~stdlib package count) and discarded it unused.

This stores a small holder that clones **lazily on first access** instead:

```go
type typeCheckCacheHolder struct {
    base   gno.TypeCheckCache // shared, treated as read-only
    cloned gno.TypeCheckCache // per-tx working copy; nil until first get
}

func (h *typeCheckCacheHolder) get() gno.TypeCheckCache {
    if h.cloned == nil {
        h.cloned = maps.Clone(h.base)
    }
    return h.cloned
}
```

Transactions that never type-check skip the clone entirely; `AddPackage`/`Run` still get exactly one clone, shared across a tx's messages.

## Why it's safe (no consensus / gas / behavior change)

- **Off the metered path.** The clone happens before the gas meter is wired to the preprocess allocator (`SetPreprocessAllocator` / `SetGasMeter` run afterward), so it never consumed tx gas in either the old or new code. No gas goldens change.
- **Single-clone-per-tx preserved.** `BeginTxHook` fires once per transaction, so all messages in a tx share one holder → one clone, identical to the previous eager behavior.
- **Isolation preserved.** Each tx gets a distinct holder over a read-only `base` (`vm.typeCheckCache`, only written at init/restart); the consumer writes to the clone, never `base`.
- **Concurrency.** A holder belongs to one tx's context and, like the rest of per-tx execution (store, allocator, gas meter), assumes a single driving goroutine; documented on the type. Verified with `go test -race`.

## Impact

Pure node-side work reduction: eliminates one `maps.Clone` of the shared type-check cache for every non-type-checking transaction (the majority). No user-visible or consensus-visible effect.

## Changed files

- `gno.land/pkg/sdk/vm/keeper.go` — lazy holder + accessor (20 lines).

## Verification

- `go test ./gno.land/pkg/sdk/vm/` ✅
- `go test -race ./gno.land/pkg/sdk/vm/` ✅
- `gofmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)