### PR TITLE
perf(gnovm): load package file blocks lazily

### DIFF
--- a/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
@@ -4,7 +4,7 @@
 
 env ADDPKG_GAS=4_800_000
 env SETUP_GAS=3_200_000
-env EXACT_GAS=2012646
+env EXACT_GAS=1986776
 
 gnoland start
 

--- a/gnovm/adr/pr5902_lazy_file_blocks.md
+++ b/gnovm/adr/pr5902_lazy_file_blocks.md
@@ -1,0 +1,85 @@
+# Lazy package file-block loading
+
+## Context
+
+When a `PackageValue` is loaded from the store, `defaultStore.fillPackage`
+called `pv.deriveFBlocksMap(ds)`, which iterated every file in `pv.FNames` and
+materialized its file block — reading and amino-decoding each one up front. A
+transaction that enters only a few functions of a package (or imports a large
+multi-file package and touches a fraction of it) therefore paid to hydrate file
+blocks it never used.
+
+The eager derivation was added in #4376 (`fix(gnovm): fill package value for
+GetPackage and GetObject`), itself the accepted fix for a gnoswap production
+panic — `"file block missing for file \"pool_type.gno\""` (#4527). That panic
+came from `FuncValue.GetParent` reading `pv.fBlocksMap[fv.FileName]` directly and
+panicking on a miss when a package was loaded with an unpopulated map. #4376
+resolved it by guaranteeing every load path fully populated `fBlocksMap`.
+
+The machinery to load a file block on demand (`PackageValue.GetFileBlock`, which
+resolves `pv.FBlocks[i]` from a `RefValue` and caches it) already existed and
+predates the eager map.
+
+## Decision
+
+Load file blocks lazily.
+
+1. `fillPackage` no longer calls `deriveFBlocksMap` for multi-file packages; it
+   leaves `fBlocksMap` empty. File blocks are materialized on first use.
+2. `FuncValue.GetParent` (nil-`Parent` case) now calls
+   `pv.GetFileBlock(store, fv.FileName)` instead of reading `fBlocksMap`
+   directly and panicking. This resolves the exact site of the #4527 panic: a
+   package loaded with an empty map no longer panics — it lazily loads from the
+   `FBlocks` `RefValue`. The panic's root cause is *handled*, not reintroduced.
+3. Eager derivation is kept on the package **creation** path
+   (`RunMemPackage` → `machine.go`), where blocks are freshly built, not read
+   from the store.
+4. **Single-file guard**: `fillPackage` still eagerly derives when
+   `len(pv.FNames) <= 1`. A package with no unused file to skip loads its one
+   block on first call anyway, so laziness there only shifts *when* gas is
+   charged — for no benefit. Keeping the eager path preserves master's gas for
+   single-file packages (the common trivial call), confining the change to the
+   multi-file case it actually optimizes.
+
+### Determinism
+
+Gas becomes path-dependent but remains deterministic: a transaction loads
+exactly the file blocks its execution touches, identically on every node.
+`PackageValue` instances are per-message (`BeginTransaction` allocates a fresh
+`cacheObjects`; the keeper calls `ClearObjectCache` per message; `Write` commits
+only `cacheNodes`), so a partially-materialized `fBlocksMap` never leaks across
+transactions. The single-file guard branches on `len(pv.FNames)`, a serialized
+field, so it is identical on every node.
+
+## Alternatives considered
+
+- **Pure lazy, no single-file guard** (rejected). Simpler, but single-file
+  packages incur a small gas shift (+196 on trivial calls) and churn five gas
+  goldens for zero benefit — there is nothing to skip in a one-file package. The
+  guard removes a pointless regression and shrinks the golden footprint to one
+  file.
+- **Keep eager derivation** (status quo, rejected). No perf win; multi-file
+  transactions keep paying to hydrate unused file blocks.
+- **Cache materialized file blocks across transactions** (rejected). Would make
+  gas depend on in-memory cache state, so a long-running node and a
+  freshly-restarted node replaying the same transaction could charge different
+  gas — a consensus fork. Per-message isolation is preserved instead.
+
+## Consequences
+
+- Multi-file transactions load and decode fewer objects. Measured:
+  `BenchmarkPackageLoadFromStore` shows a 12-file package touched at one file
+  drop from 2123 to 1213 allocs (−43%) and 102 KB to 57 KB (−44%); the
+  single-file guard case is byte-identical to master (no regression). At the
+  keeper level, loading the real deployed gnoswap `r/gnoswap/pool` realm graph
+  (25-package closure, fetched from test13) from the store costs ~2.37M gas less.
+- Single-file packages are unchanged vs master, including master's pre-existing
+  behaviour of charging the one file block's allocation at `GetPackage` time
+  (before the tx allocator's gas meter is wired). This change preserves that
+  historical accounting rather than tightening it; closing that metering gap is
+  out of scope for a perf change.
+- Gas goldens: only `stdlib_restart_compare` (multi-file `strconv`/`strings`)
+  changes; the other gas goldens return to master's values.
+- `FuncValue.Parent` for a store-loaded package is materialized on first
+  `GetParent` (unchanged timing); `FBlocks` entries remain `RefValue` after
+  load, so persisted bytes and the realm-finalization crawl are unaffected.

--- a/gnovm/adr/pr5902_lazy_file_blocks.md
+++ b/gnovm/adr/pr5902_lazy_file_blocks.md
@@ -9,12 +9,27 @@ transaction that enters only a few functions of a package (or imports a large
 multi-file package and touches a fraction of it) therefore paid to hydrate file
 blocks it never used.
 
-The eager derivation was added in #4376 (`fix(gnovm): fill package value for
-GetPackage and GetObject`), itself the accepted fix for a gnoswap production
-panic — `"file block missing for file \"pool_type.gno\""` (#4527). That panic
-came from `FuncValue.GetParent` reading `pv.fBlocksMap[fv.FileName]` directly and
-panicking on a miss when a package was loaded with an unpopulated map. #4376
-resolved it by guaranteeing every load path fully populated `fBlocksMap`.
+Eager derivation has existed on the `GetPackage` load path since gno's early
+history, but `GetObject` returned a raw, unfilled `PackageValue` — and
+`FuncValue.GetParent` read `pv.fBlocksMap[fv.FileName]` directly, panicking on
+a miss. That inconsistency between the two load paths caused a gnoswap
+production panic, `"file block missing for file \"pool_type.gno\""` (#4527).
+#4376 (`fix(gnovm): fill package value for GetPackage and GetObject`) fixed it
+by unifying both paths onto `loadObjectSafe` → `fillPackage`, so every load got
+the same eager fill. The unification is right and this PR keeps it —
+`fillPackage` remains the single fill point; what changes is the shared policy
+(eager → lazy), which is only safe because `GetParent` becomes miss-tolerant
+(see Decision).
+
+Why only some callers hit that map: a *plain* top-level function is persisted
+with `Parent` already pointing at its file block (`PrepareNewValues` sets it at
+creation; `copyValueWithRefs` writes it as a `RefValue`), so `GetParent`
+resolves it by ObjectID directly. A *method*, however, lives in
+`DeclaredType.Methods` — a shared, context-free type definition that must not
+carry a transaction-scoped `*Block` pointer — so it is persisted with
+`Parent == nil` and `DeclaredType.GetValueAt` fills a per-dispatch copy via
+`GetParent`, which is the only consumer of `fBlocksMap`. That is why #4527
+fired on method dispatch.
 
 The machinery to load a file block on demand (`PackageValue.GetFileBlock`, which
 resolves `pv.FBlocks[i]` from a `RefValue` and caches it) already existed and

--- a/gnovm/pkg/gnolang/bench_fileblocks_test.go
+++ b/gnovm/pkg/gnolang/bench_fileblocks_test.go
@@ -1,0 +1,74 @@
+package gnolang
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	storetypes "github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+// BenchmarkPackageLoadFromStore measures loading a persisted N-file package
+// from the store and touching a single file's block — the shape of a
+// transaction that enters one function of an imported package. Each iteration
+// uses a fresh transaction store (empty object cache) so the load cost is paid
+// every time, mirroring per-message isolation on chain.
+//
+// This benchmarks the path this change optimizes: on master, GetPackage
+// eagerly materializes all N file blocks (deriveFBlocksMap in fillPackage); with
+// lazy loading, only the one touched block is materialized. Compare across
+// versions with benchstat:
+//
+//	git stash && go test ./gnovm/pkg/gnolang/ -run x -bench BenchmarkPackageLoadFromStore -benchmem -count=6 > old.txt
+//	git stash pop && go test ./gnovm/pkg/gnolang/ -run x -bench BenchmarkPackageLoadFromStore -benchmem -count=6 > new.txt
+//	benchstat old.txt new.txt
+//
+// The single-file case (files=1) is the guard case: it must not regress, since
+// there is no unused file to skip.
+func BenchmarkPackageLoadFromStore(b *testing.B) {
+	for _, nFiles := range []int{1, 4, 12} {
+		b.Run(fmt.Sprintf("files=%d", nFiles), func(b *testing.B) {
+			const pkgPath = "gno.vm/t/bench"
+			db := memdb.NewMemDB()
+			tm2Store := dbadapter.StoreConstructor(db, storetypes.StoreOptions{})
+			st := NewStore(nil, tm2Store, tm2Store)
+
+			// Create and persist the package once.
+			wrapped := tm2Store.CacheWrap()
+			txSt := st.BeginTransaction(wrapped, wrapped, nil, nil)
+			files := make([]*std.MemFile, nFiles)
+			for i := range files {
+				files[i] = &std.MemFile{
+					Name: fmt.Sprintf("f%d.gno", i),
+					Body: fmt.Sprintf("package bench\n\nfunc F%d() int { return %d }", i, i),
+				}
+			}
+			m := NewMachineWithOptions(MachineOptions{
+				PkgPath: pkgPath,
+				Store:   txSt,
+				Output:  io.Discard,
+			})
+			m.RunMemPackage(&std.MemPackage{
+				Type:  MPUserProd,
+				Name:  "bench",
+				Path:  pkgPath,
+				Files: files,
+			}, true)
+			txSt.Write()
+			wrapped.Write()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				cw := tm2Store.CacheWrap()
+				txSt2 := st.BeginTransaction(cw, cw, nil, nil)
+				pv := txSt2.GetPackage(pkgPath, false)
+				// Touch one file, as entering one function would.
+				_ = pv.GetFileBlock(txSt2, "f0.gno")
+			}
+		})
+	}
+}

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -615,8 +615,20 @@ func (ds *defaultStore) fillPackage(pv *PackageValue) {
 	if pv.PkgID.IsZero() {
 		pv.PkgID = PkgIDFromPkgPath(pv.PkgPath)
 	}
-	// Rederive pv.fBlocksMap.
-	pv.deriveFBlocksMap(ds)
+	// pv.fBlocksMap is left empty: file blocks load lazily via
+	// GetFileBlock when a function in that file is first called
+	// (see FuncValue.GetParent). Loading a package therefore no longer
+	// reads every file block up front — a call materializes only the
+	// file blocks it touches.
+	//
+	// Preserve historical hydration and gas accounting when there is no
+	// unused file to skip. A package with <= 1 file loads that one block on
+	// first call anyway, so laziness buys nothing there — only a gas shift;
+	// keep the eager path for them (this also keeps master's gas for the
+	// rare import that reads only package-level vars).
+	if len(pv.FNames) <= 1 {
+		pv.deriveFBlocksMap(ds)
+	}
 }
 
 // NOTE: unlike GetObject(), SetObject() is also used to persist updated

--- a/gnovm/pkg/gnolang/store_test.go
+++ b/gnovm/pkg/gnolang/store_test.go
@@ -70,6 +70,94 @@ func TestTransactionStore(t *testing.T) {
 	assert.Equal(t, stA, helloA)
 }
 
+// TestGetPackageLazyFileBlocks locks in the lazy file-block behavior:
+// loading a multi-file package from the store must NOT eagerly materialize
+// its file blocks; a block is materialized only when a function in that
+// file is first accessed. Guards against re-introducing eager loading in
+// fillPackage.
+func TestGetPackageLazyFileBlocks(t *testing.T) {
+	db := memdb.NewMemDB()
+	tm2Store := dbadapter.StoreConstructor(db, storetypes.StoreOptions{})
+	st := NewStore(nil, tm2Store, tm2Store)
+
+	// Create and persist a three-file package.
+	wrapped := tm2Store.CacheWrap()
+	txSt := st.BeginTransaction(wrapped, wrapped, nil, nil)
+	m := NewMachineWithOptions(MachineOptions{
+		PkgPath: "gno.vm/t/multi",
+		Store:   txSt,
+		Output:  io.Discard,
+	})
+	m.RunMemPackage(&std.MemPackage{
+		Type: MPUserProd,
+		Name: "multi",
+		Path: "gno.vm/t/multi",
+		Files: []*std.MemFile{
+			{Name: "a.gno", Body: "package multi\nfunc FA() int { return 1 }"},
+			{Name: "b.gno", Body: "package multi\nfunc FB() int { return 2 }"},
+			{Name: "c.gno", Body: "package multi\nfunc FC() int { return 3 }"},
+		},
+	}, true)
+	txSt.Write()
+	wrapped.Write()
+
+	// Load the package fresh in a new transaction: its file blocks come
+	// back from the store as RefValues.
+	txSt2 := st.BeginTransaction(tm2Store.CacheWrap(), tm2Store.CacheWrap(), nil, nil)
+	pv := txSt2.GetPackage("gno.vm/t/multi", false)
+	require.NotNil(t, pv)
+	require.Len(t, pv.FNames, 3)
+
+	// fillPackage must leave fBlocksMap empty — no file block loaded yet.
+	assert.Empty(t, pv.fBlocksMap, "fillPackage should not eagerly materialize file blocks")
+
+	// Touching one file materializes only that file's block.
+	assert.NotNil(t, pv.GetFileBlock(txSt2, "a.gno"))
+	assert.Len(t, pv.fBlocksMap, 1, "only the touched file's block should be materialized")
+	_, ok := pv.fBlocksMap["a.gno"]
+	assert.True(t, ok, "the materialized block should be a.gno")
+}
+
+// TestGetPackageSingleFileEagerHydration locks in the single-file guard in
+// fillPackage: a package with <= 1 file has no unused file to skip, so it is
+// hydrated eagerly on load (preserving master's gas), not lazily. Complements
+// TestGetPackageLazyFileBlocks, which covers the multi-file lazy path.
+func TestGetPackageSingleFileEagerHydration(t *testing.T) {
+	db := memdb.NewMemDB()
+	tm2Store := dbadapter.StoreConstructor(db, storetypes.StoreOptions{})
+	st := NewStore(nil, tm2Store, tm2Store)
+
+	// Create and persist a single-file package.
+	wrapped := tm2Store.CacheWrap()
+	txSt := st.BeginTransaction(wrapped, wrapped, nil, nil)
+	m := NewMachineWithOptions(MachineOptions{
+		PkgPath: "gno.vm/t/single",
+		Store:   txSt,
+		Output:  io.Discard,
+	})
+	m.RunMemPackage(&std.MemPackage{
+		Type: MPUserProd,
+		Name: "single",
+		Path: "gno.vm/t/single",
+		Files: []*std.MemFile{
+			{Name: "a.gno", Body: "package single\nfunc FA() int { return 1 }"},
+		},
+	}, true)
+	txSt.Write()
+	wrapped.Write()
+
+	// Load the package fresh in a new transaction.
+	txSt2 := st.BeginTransaction(tm2Store.CacheWrap(), tm2Store.CacheWrap(), nil, nil)
+	pv := txSt2.GetPackage("gno.vm/t/single", false)
+	require.NotNil(t, pv)
+	require.Len(t, pv.FNames, 1)
+
+	// fillPackage must hydrate the one block eagerly (no unused file to skip).
+	assert.Len(t, pv.fBlocksMap, 1, "single-file package should be eagerly hydrated in fillPackage")
+	_, ok := pv.fBlocksMap["a.gno"]
+	assert.True(t, ok, "the hydrated block should be a.gno")
+}
+
 func TestTransactionStore_blockedMethods(t *testing.T) {
 	// These methods should panic as they modify store settings, which should
 	// only be changed in the root store.

--- a/gnovm/pkg/gnolang/store_test.go
+++ b/gnovm/pkg/gnolang/store_test.go
@@ -158,6 +158,91 @@ func TestGetPackageSingleFileEagerHydration(t *testing.T) {
 	assert.True(t, ok, "the hydrated block should be a.gno")
 }
 
+// readRecordingStore wraps a tm2 store and counts reads per key, so tests
+// can assert which objects were (not) fetched from the underlying store.
+type readRecordingStore struct {
+	storetypes.Store
+	reads map[string]int
+}
+
+func (rs *readRecordingStore) Get(gctx *storetypes.GasContext, key []byte) []byte {
+	rs.reads[string(key)]++
+	return rs.Store.Get(gctx, key)
+}
+
+// TestLazyFileBlocksSkipUnusedStoreReads showcases the lazy win end-to-end at
+// the store boundary (where I/O gas is charged): loading a multi-file package
+// and calling into one file must never read the other files' block objects
+// from the underlying store. Under eager fillPackage (pre-lazy), GetPackage
+// read all three. The method call also exercises the #4527 panic site:
+// DeclaredType.GetValueAt fills the method's nil Parent via
+// FuncValue.GetParent, which now lazily loads the file block.
+func TestLazyFileBlocksSkipUnusedStoreReads(t *testing.T) {
+	db := memdb.NewMemDB()
+	tm2Store := dbadapter.StoreConstructor(db, storetypes.StoreOptions{})
+	st := NewStore(nil, tm2Store, tm2Store)
+
+	// Create and persist a three-file package.
+	wrapped := tm2Store.CacheWrap()
+	txSt := st.BeginTransaction(wrapped, wrapped, nil, nil)
+	m := NewMachineWithOptions(MachineOptions{
+		PkgPath: "gno.land/r/lazyread",
+		Store:   txSt,
+		Output:  io.Discard,
+	})
+	m.RunMemPackage(&std.MemPackage{
+		Type: MPUserProd,
+		Name: "lazyread",
+		Path: "gno.land/r/lazyread",
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: GenGnoModLatest("gno.land/r/lazyread")},
+			{Name: "a.gno", Body: "package lazyread\ntype T struct{}\nfunc (T) MA() int { return 7 }\nfunc FA() int { return T{}.MA() }"},
+			{Name: "b.gno", Body: "package lazyread\nfunc FB() int { return 2 }"},
+			{Name: "c.gno", Body: "package lazyread\nfunc FC() int { return 3 }"},
+		},
+	}, true)
+	txSt.Write()
+	wrapped.Write()
+
+	// Reload in a fresh transaction through a read-recording base store.
+	spy := &readRecordingStore{Store: tm2Store.CacheWrap(), reads: map[string]int{}}
+	txSt2 := st.BeginTransaction(spy, spy, nil, nil)
+	pv := txSt2.GetPackage("gno.land/r/lazyread", false)
+	require.NotNil(t, pv)
+	require.Len(t, pv.FNames, 3)
+
+	// The file-block store keys, from the package's RefValue slots.
+	blockKey := map[string]string{}
+	for i, fname := range pv.FNames {
+		ref, ok := pv.FBlocks[i].(RefValue)
+		require.True(t, ok, "file block %q should still be a RefValue after load", fname)
+		blockKey[fname] = backendObjectKey(ref.ObjectID)
+	}
+
+	// Loading the package must not read any file block from the store.
+	for fname, key := range blockKey {
+		assert.Zero(t, spy.reads[key], "GetPackage should not read %s's file block", fname)
+	}
+
+	// Call into a.gno: FA calls the method T.MA, whose dispatch copies the
+	// method FuncValue and fills its nil Parent via GetParent →
+	// GetFileBlock, reading a.gno's block from the store on demand.
+	m2 := NewMachineWithOptions(MachineOptions{
+		PkgPath: "gno.land/r/lazyread",
+		Store:   txSt2,
+		Output:  io.Discard,
+	})
+	m2.SetActivePackage(pv)
+	res := m2.Eval(m2.MustParseExpr("FA()"))
+	require.Len(t, res, 1)
+	assert.Equal(t, int64(7), res[0].GetInt()) // FA() → T{}.MA() → 7, per a.gno above
+
+	// Only a.gno's block was read; the unused files' blocks never were.
+	assert.Positive(t, spy.reads[blockKey["a.gno"]], "the called method's file block should be read")
+	assert.Zero(t, spy.reads[blockKey["b.gno"]], "unused file block b.gno must not be read")
+	assert.Zero(t, spy.reads[blockKey["c.gno"]], "unused file block c.gno must not be read")
+}
+
 func TestTransactionStore_blockedMethods(t *testing.T) {
 	// These methods should panic as they modify store settings, which should
 	// only be changed in the root store.

--- a/gnovm/pkg/gnolang/values.go
+++ b/gnovm/pkg/gnolang/values.go
@@ -633,10 +633,11 @@ func (fv *FuncValue) GetParent(store Store) *Block {
 			return nil
 		}
 		pv := fv.GetPackage(store)
-		fb, ok := pv.fBlocksMap[fv.FileName]
-		if !ok {
-			panic(fmt.Sprintf("file block missing for file %q", fv.FileName))
-		}
+		// Lazily materialize this function's file block. fillPackage no
+		// longer pre-populates fBlocksMap, so on a package loaded from
+		// the store the entry may be absent here; GetFileBlock loads it
+		// from the FBlocks RefValue on demand and caches it.
+		fb := pv.GetFileBlock(store, fv.FileName)
 		fv.Parent = fb
 		return fb
 	case RefValue:


### PR DESCRIPTION
## Summary

`fillPackage` materialized **every** file block of a package each time the
package was loaded from the store (`deriveFBlocksMap`). A transaction that
enters only a few functions of a package — or imports a large multi-file
package and touches a fraction of it — thus paid to read and amino-decode file
blocks it never used.

This leaves `fBlocksMap` empty on load and lets `FuncValue.GetParent`
materialize a file block on demand, via the already-lazy `GetFileBlock`, when a
function in that file is first called. `deriveFBlocksMap` is kept on the
package-**creation** path (`RunMemPackage`), where blocks are freshly built.

```go
// fillPackage (store.go): eager pre-load is gone for multi-file packages
-	// Rederive pv.fBlocksMap.
-	pv.deriveFBlocksMap(ds)
+	// Single-file packages have no unused file to skip: keep eager hydration
+	// (preserves master's gas). Multi-file packages load lazily.
+	if len(pv.FNames) <= 1 {
+		pv.deriveFBlocksMap(ds)
+	}

// FuncValue.GetParent (values.go), nil-Parent case:
-	fb, ok := pv.fBlocksMap[fv.FileName]
-	if !ok { panic(fmt.Sprintf("file block missing for file %q", fv.FileName)) }
+	fb := pv.GetFileBlock(store, fv.FileName) // lazily loads from the FBlocks RefValue
```

### Single-file guard

Lazy loading only helps a package that has unused files to skip. A single-file
package loads its one block on first call regardless, so laziness there merely
shifts *when* gas is charged — a small delta for no benefit. `fillPackage`
therefore keeps the eager path when `len(FNames) <= 1`. Single-file gas returns
to master's values, and the change is confined to the multi-file case it
optimizes. (Note: this preserves master's pre-existing behaviour of charging
that one block's allocation at `GetPackage` time; it does not tighten it.)

## Impact (measured)

`BenchmarkPackageLoadFromStore` — load an N-file package from a fresh
transaction store and touch one file (`benchstat` master vs this branch):

| files | eager (master) | lazy (this PR) | saving |
|---|---|---|---|
| 1 (guard) | 330 allocs / 17.5 KB | 330 allocs / 17.5 KB | none — no regression |
| 4 | 819 allocs / 39 KB | 573 allocs / 28 KB | −30% allocs |
| 12 | 2123 allocs / 102 KB | 1213 allocs / 57 KB | −43% allocs, −44% mem |

At the keeper level, **loading the real deployed gnoswap `r/gnoswap/pool` realm
graph from the store** (25-package closure, fetched from test13) — the same
class of from-store load as the `PoolGetSlot0Tick` call in the #4527 incident —
costs **~2.37M gas less** (30.97M → 28.60M). This measures package-graph
loading (what this PR changes), not an executed swap; a swap loads the same
graph plus more, so its from-store saving is at least this.

## Determinism

Gas is path-dependent but deterministic — a transaction loads exactly the file
blocks its execution touches, identically on every node. `PackageValue`s are
per-message (`BeginTransaction` allocates a fresh `cacheObjects`; the keeper
calls `ClearObjectCache` per message; `Write` commits only `cacheNodes`), so a
partially-materialized `fBlocksMap` never leaks across transactions. The
single-file guard branches on `len(FNames)`, a serialized field, so it is
identical on every node. `restart_gas` / `stdlib_restart_compare` (gas equal
before and after a node restart) pass with regenerated values.

## Relationship to #4527 / #4376

The eager `deriveFBlocksMap` in `fillPackage` was added by #4376 to fix the
gnoswap `"file block missing for file"` panic (#4527), which fired when
`GetParent` read an unpopulated `fBlocksMap`. This PR converts that exact panic
site to a lazy `GetFileBlock` load, so the root cause is **handled, not
reintroduced** — see the ADR.

## Changed files

- **Code** — `gnovm/pkg/gnolang/store.go` (lazy `fillPackage` + single-file
  guard), `gnovm/pkg/gnolang/values.go` (lazy `GetParent`).
- **Tests** — `gnovm/pkg/gnolang/store_test.go` (lazy multi-file + eager
  single-file), `gnovm/pkg/gnolang/bench_fileblocks_test.go` (load benchmark).
- **ADR** — `gnovm/adr/pr5902_lazy_file_blocks.md`.
- **Golden** — `gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar`
  (multi-file `strconv`/`strings`); the other gas goldens return to master's
  values under the guard.

## Verification

- `go test ./gno.land/pkg/sdk/vm/ -run Gas` ✅
- `go test ./gno.land/pkg/integration/ -run TestTestdata` (gas goldens) ✅
- `go test ./gnovm/pkg/gnolang/ -run Files -test.short` ✅
- `go test -race ./gnovm/pkg/gnolang/ -run TestGetPackage` ✅

---

_AI-assisted (Claude Code): implementation, review, and the gnoswap/benchmark measurements._
