### PR TITLE
fix(misc/gendocs): pin pkgsite to v0.2.0 (v0.3.0 requires go >= 1.26)

### DIFF
--- a/misc/gendocs/Makefile
+++ b/misc/gendocs/Makefile
@@ -1,7 +1,9 @@
 all: clean gen
 
 install:
-	go install golang.org/x/pkgsite/cmd/pkgsite@latest
+	# Pinned: pkgsite v0.3.0+ requires go >= 1.26; CI's toolchain follows
+	# go.mod (go-version-file). Revert to @latest once go.mod is >= 1.26.
+	go install golang.org/x/pkgsite/cmd/pkgsite@v0.2.0
 
 gen:
 	./gendocs.sh


### PR DESCRIPTION
- `deploy-pages` fails on every PR since pkgsite v0.3.0 was tagged: `@latest` now requires go >= 1.26 while CI runs go 1.25.x with `GOTOOLCHAIN=local`.
- Pin to v0.2.0 (go 1.25.5 directive); verified it installs on go 1.25.9.