### PR TITLE
fix(gnovm): reject go1.18 generics syntax at deploy-time type check

### DIFF
--- a/gnovm/pkg/gnolang/gotypecheck.go
+++ b/gnovm/pkg/gnolang/gotypecheck.go
@@ -429,6 +429,13 @@ func (gimp *gnoImporter) typeCheckMemPackage(mpkg *std.MemPackage, wtests *bool)
 		return nil, errs
 	}
 
+	// STEP 3: Reject go1.18 generics syntax (type parameters, interface
+	// type sets). go/types accepts them, so without this deploy-time
+	// guard generic declarations slip on chain silently. See checkNoGenerics.
+	if errs = checkNoGenerics(gofset, allgofs); errs != nil {
+		return nil, errs
+	}
+
 	// STEP 3: Prepare for Go type-checking.
 	for _, gof := range allgofs {
 		err := prepareGoGno0p9(gof)

--- a/gnovm/pkg/gnolang/nogenerics.go
+++ b/gnovm/pkg/gnolang/nogenerics.go
@@ -1,0 +1,72 @@
+package gnolang
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+// checkNoGenerics rejects go1.18 generics syntax before go/types runs.
+// Gno targets go1.17 and does not support generics, but modern go/types
+// accepts them — without this guard a package declaring (but not
+// instantiating) generics deploys silently and its declarations are
+// dead weight with undefined Gno semantics. Rejected syntactically:
+//   - type parameters, on a type or func declaration (`type W[P any] ...`);
+//   - interface type-set terms: unions (`A | B`) and approximations (`~T`).
+//
+// Bare non-interface type-set elements (`interface{ int }`) are NOT
+// detectable syntactically (indistinguishable from a legal embedded
+// interface ident) and are left to a future preprocess check.
+//
+// It reports the earliest-positioned offending construct, so the error is
+// deterministic (the message can reach consensus-visible tx results).
+func checkNoGenerics(fset *token.FileSet, gofs []*ast.File) error {
+	var (
+		off  token.Pos
+		what string
+	)
+	note := func(pos token.Pos, kind string) {
+		if !off.IsValid() || pos < off {
+			off, what = pos, kind
+		}
+	}
+	for _, gof := range gofs {
+		ast.Inspect(gof, func(n ast.Node) bool {
+			switch t := n.(type) {
+			case *ast.TypeSpec:
+				if t.TypeParams != nil {
+					note(t.Name.Pos(), "generic type declarations")
+				}
+			case *ast.FuncType:
+				if t.TypeParams != nil {
+					note(t.Pos(), "generic functions")
+				}
+			case *ast.InterfaceType:
+				for _, f := range t.Methods.List {
+					if len(f.Names) != 0 {
+						continue // a method, not a type-set term
+					}
+					switch e := f.Type.(type) {
+					case *ast.BinaryExpr:
+						// `|` in this position is only a type union
+						// (elsewhere it is bitwise-or).
+						if e.Op == token.OR {
+							note(e.Pos(), "interface type unions")
+						}
+					case *ast.UnaryExpr:
+						// `~` is exclusively type-approximation.
+						if e.Op == token.TILDE {
+							note(e.Pos(), "interface approximation (~) terms")
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+	if off.IsValid() {
+		return fmt.Errorf("%s: %s are not supported (Gno targets go1.17)",
+			fset.Position(off), what)
+	}
+	return nil
+}

--- a/gnovm/pkg/gnolang/nogenerics_test.go
+++ b/gnovm/pkg/gnolang/nogenerics_test.go
@@ -1,0 +1,73 @@
+package gnolang
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+func TestCheckNoGenerics(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name, body, wantErr string
+	}{
+		{
+			"GenericTypeDecl",
+			`package hello
+			type empty interface{}
+			type Foo[T empty] int`,
+			"generic type declarations are not supported",
+		},
+		{
+			"GenericFunc",
+			`package hello
+			func Bar[T any]() {}`,
+			"generic functions are not supported",
+		},
+		{
+			"TypeUnion",
+			`package hello
+			type N interface{ int | string }`,
+			"interface type unions are not supported",
+		},
+		{
+			"Approximation",
+			`package hello
+			type N interface{ ~int }`,
+			"interface approximation (~) terms are not supported",
+		},
+		{
+			"PlainInterfaceEmbedOK",
+			`package hello
+			type A interface{ M() }
+			type B interface{ A }
+			var _ B`,
+			"",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mpkg := &std.MemPackage{
+				Type: MPUserProd,
+				Name: "hello",
+				Path: "gno.land/p/demo/hello",
+				Files: []*std.MemFile{
+					{Name: "hello.gno", Body: tc.body},
+				},
+			}
+			_, err := TypeCheckMemPackage(mpkg, TypeCheckOptions{Mode: TCLatestRelaxed})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected accept, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/gnovm/tests/files/type_param0.gno
+++ b/gnovm/tests/files/type_param0.gno
@@ -1,0 +1,16 @@
+// Gno targets go1.17 and rejects go1.18 generics syntax at deploy-time
+// type-checking; see gnovm/pkg/gnolang/nogenerics.go (checkNoGenerics).
+
+package main
+
+type Box[T any] struct{ v T }
+
+func main() {
+	println("unreached")
+}
+
+// Error:
+// main/type_param0.gno:6:6-30: name T not defined in fileset with files [type_param0.gno]
+
+// TypeCheckError:
+// main/type_param0.gno:6:6: generic type declarations are not supported (Gno targets go1.17)


### PR DESCRIPTION
- Packages *declaring* (not instantiating) generics deploy and run silently today: modern go/types accepts them and preprocess never rejects the declarations — `type Foo[T any] int` / `func Bar[T any]()` reach the chain with undefined Gno semantics.
- Add `checkNoGenerics` after Go-AST parse in `typeCheckMemPackage`: syntactic reject of type parameters and interface type-set terms (`A | B`, `~T`), earliest-position deterministic error.

## Relationship to #5826 (type-expansion fan-out bound)

Both PRs introduce the **same** `checkNoGenerics` guard (identical logic; only surrounding comments differ) but for **different reasons** — it sits at the intersection of two independent requirements:

- **This PR (#5921) — conformance.** Gno targets go1.17 and does not implement generics; a package *declaring* them must be rejected at deploy regardless of any DoS concern. Standalone value, permanent semantics (moves into gno's native checker when go/types is removed).
- **#5826 — safety.** go/types' `validType` walk is unmetered and exponential on generic type-set fan-out; #5826 rejects generics as *step 1* of its DoS defense, then bounds the remaining non-generic fan-out. There the guard is transitional scaffolding (deleted with go/types in the removal plan).

**Ordering is free — either can merge first:**
- If **#5921 first**: #5826 rebases and drops its copy of `checkNoGenerics` (its bound logic is what remains).
- If **#5826 first**: this PR rebases to a trivial no-op on the guard itself, retaining only its focused unit tests (which #5826 lacks).

The shared function is intentional duplication for landing independence; whichever merges second deletes one copy. No logic reconciliation needed — the two copies are byte-identical in behavior.