### PR TITLE
WIP feat(gnovm): per-package language-semantics pinning seam (dormant)

### DIFF
--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1318,10 +1318,9 @@ type PackageNode struct {
 
 	// LangVersion is the gno language version this package's semantics
 	// are pinned to (see semantics.go / [PackageNode.Semantics]).
-	// WIP: NOT serialized yet — defaults to GnoVerLatest, so it is a
-	// dormant no-op today. Sound per-package pinning requires persisting
-	// this with the realm package (a consensus-visible stored-form
-	// change) before a second version is registered.
+	// WIP: defaults to GnoVerLatest (dormant no-op). The real design
+	// sources this at load from the package's already-persisted
+	// gnomod.toml — NOT a new serialized field. See semantics.go header.
 	LangVersion string
 
 	// pkgID is the lazy-cached PkgID derived from PkgPath.

--- a/gnovm/pkg/gnolang/nodes.go
+++ b/gnovm/pkg/gnolang/nodes.go
@@ -1316,6 +1316,14 @@ type PackageNode struct {
 	PkgName  Name
 	*FileSet // provides .GetDeclFor*()
 
+	// LangVersion is the gno language version this package's semantics
+	// are pinned to (see semantics.go / [PackageNode.Semantics]).
+	// WIP: NOT serialized yet — defaults to GnoVerLatest, so it is a
+	// dormant no-op today. Sound per-package pinning requires persisting
+	// this with the realm package (a consensus-visible stored-form
+	// change) before a second version is registered.
+	LangVersion string
+
 	// pkgID is the lazy-cached PkgID derived from PkgPath.
 	// Not serialized.
 	pkgID PkgID
@@ -1338,9 +1346,10 @@ func PackageNodeLocation(path string) Location {
 
 func NewPackageNode(name Name, path string, fset *FileSet) *PackageNode {
 	pn := &PackageNode{
-		PkgPath: path,
-		PkgName: name,
-		FileSet: fset,
+		PkgPath:     path,
+		PkgName:     name,
+		FileSet:     fset,
+		LangVersion: GnoVerLatest, // WIP dormant default; see semantics.go
 	}
 	pn.SetLocation(PackageNodeLocation(path))
 	pn.InitStaticBlock(pn, nil)

--- a/gnovm/pkg/gnolang/semantics.go
+++ b/gnovm/pkg/gnolang/semantics.go
@@ -1,0 +1,74 @@
+package gnolang
+
+// Per-package language semantics (WIP plumbing — see doc/adr, dormant).
+//
+// GOAL (not yet realized here): pin VM semantics to the gno language
+// version a package declared at deploy time, so a later conformance fix
+// (a "class-3" behavior change) applies only to packages that (re)deploy
+// under the new version — deployed code keeps the semantics it was
+// written and audited against. This is the gno analogue of Solidity's
+// pragma / Go's -lang: the mechanism that lets the VM evolve without
+// silently re-meaning already-deployed contracts.
+//
+// WHAT THIS FILE ESTABLISHES: the seam only. A Semantics value is
+// resolved from a package's language version and is the single place
+// future version-conditional behavior will branch. Today exactly one
+// version (GnoVerLatest) is registered and every field is current
+// behavior, so consulting Semantics changes nothing — it is dormant.
+//
+// WHAT IS DELIBERATELY NOT DONE YET (the real follow-up work):
+//   - PERSISTENCE. PackageNode.LangVersion below is NOT serialized. For
+//     pinning to be sound the version MUST be persisted with the realm
+//     package (PackageValue / the amino stored form) and restored on
+//     reload — otherwise a reloaded old package would default to the
+//     latest semantics, defeating the pin. That stored-form change is
+//     consensus-visible and must land before any second version is
+//     registered here.
+//   - PER-FRAME DISPATCH across a mixed call stack (v1 package calling a
+//     v2 package): Semantics must be scoped per executing package, with
+//     defined conversion rules at the boundary.
+//   - GAS is out of scope: the gas schedule is a chain-wide resource,
+//     height-versioned, never per-package (see 3b).
+
+// Semantics captures the version-conditional behavior switches the VM
+// consults. It is derived from a package's declared language version.
+// All fields describe CURRENT behavior; new fields get a default equal
+// to today's behavior so that omitting the version is a no-op.
+type Semantics struct {
+	// Version is the gno language version these semantics correspond to
+	// (e.g. GnoVerLatest). Informational; feature switches are the
+	// operative part.
+	Version string
+
+	// (No feature switches yet. When the first class-3 conformance fix
+	// needs to be version-gated, add a bool here — false = pre-fix
+	// behavior for older-version packages, true = fixed behavior for
+	// packages on the version that introduced the fix. The registry in
+	// SemanticsForVersion is where each version sets them.)
+}
+
+// SemanticsForVersion returns the Semantics for a gno language version,
+// and whether that version is supported. Today only GnoVerLatest is
+// registered; an unknown version returns ok=false so callers can reject
+// rather than silently run under an undefined semantics.
+func SemanticsForVersion(version string) (Semantics, bool) {
+	switch version {
+	case GnoVerLatest:
+		return Semantics{Version: GnoVerLatest}, true
+	default:
+		return Semantics{}, false
+	}
+}
+
+// Semantics returns the resolved semantics for this package. It never
+// fails: an unset or unrecognized LangVersion falls back to GnoVerLatest
+// (the only registered version), keeping the seam dormant until a second
+// version and its persistence are wired.
+func (pn *PackageNode) Semantics() Semantics {
+	v := pn.LangVersion
+	if s, ok := SemanticsForVersion(v); ok {
+		return s
+	}
+	s, _ := SemanticsForVersion(GnoVerLatest)
+	return s
+}

--- a/gnovm/pkg/gnolang/semantics.go
+++ b/gnovm/pkg/gnolang/semantics.go
@@ -47,17 +47,34 @@ type Semantics struct {
 	// SemanticsForVersion is where each version sets them.)
 }
 
+// semanticsByVersion is the registry of supported language versions.
+// A map (not a switch) so a second version — and, in tests, a synthetic
+// one — is a single entry. Production ships exactly one entry until the
+// persistence follow-up lands (see file header).
+var semanticsByVersion = map[string]Semantics{
+	GnoVerLatest: {Version: GnoVerLatest},
+}
+
 // SemanticsForVersion returns the Semantics for a gno language version,
-// and whether that version is supported. Today only GnoVerLatest is
-// registered; an unknown version returns ok=false so callers can reject
-// rather than silently run under an undefined semantics.
+// and whether that version is supported. An unknown version returns
+// ok=false so callers can reject rather than silently run under an
+// undefined semantics.
 func SemanticsForVersion(version string) (Semantics, bool) {
-	switch version {
-	case GnoVerLatest:
-		return Semantics{Version: GnoVerLatest}, true
-	default:
-		return Semantics{}, false
+	s, ok := semanticsByVersion[version]
+	return s, ok
+}
+
+// registerSemanticsForTest adds a synthetic version to the registry and
+// returns a cleanup func. Test-only: it exists so the per-package
+// dispatch can be exercised (a real second version can't be committed
+// before the persistence follow-up). Not exported — callers live in the
+// same package's _test.go.
+func registerSemanticsForTest(s Semantics) (cleanup func()) {
+	if _, exists := semanticsByVersion[s.Version]; exists {
+		panic("registerSemanticsForTest: version already registered: " + s.Version)
 	}
+	semanticsByVersion[s.Version] = s
+	return func() { delete(semanticsByVersion, s.Version) }
 }
 
 // Semantics returns the resolved semantics for this package. It never

--- a/gnovm/pkg/gnolang/semantics.go
+++ b/gnovm/pkg/gnolang/semantics.go
@@ -16,17 +16,39 @@ package gnolang
 // version (GnoVerLatest) is registered and every field is current
 // behavior, so consulting Semantics changes nothing — it is dormant.
 //
+// SOURCE OF THE VERSION — NO NEW PERSISTED FIELD NEEDED. The gno
+// language version is ALREADY persisted with every package: addpkg
+// writes gnomod.toml into the stored MemPackage (vm keeper), and the
+// store can read it back at load via GetMemFile(path, "gnomod.toml").
+// So the real design is to SOURCE PackageNode.LangVersion from that
+// existing stored gnomod.toml at package load — not to add a new
+// serialized field. This keeps the consensus-visible stored form
+// unchanged (the version is already inside the hashed MemPackage), the
+// same way EVM freezes semantics into the immutable deployed artifact.
+// (LangVersion below is a WIP non-serialized default until that wiring
+// lands; it is dormant, so the default is a no-op today.)
+//
 // WHAT IS DELIBERATELY NOT DONE YET (the real follow-up work):
-//   - PERSISTENCE. PackageNode.LangVersion below is NOT serialized. For
-//     pinning to be sound the version MUST be persisted with the realm
-//     package (PackageValue / the amino stored form) and restored on
-//     reload — otherwise a reloaded old package would default to the
-//     latest semantics, defeating the pin. That stored-form change is
-//     consensus-visible and must land before any second version is
-//     registered here.
+//   - LOAD-TIME WIRING: populate LangVersion by reading the stored
+//     gnomod.toml when a package is loaded, instead of defaulting.
+//   - STOP FORCING LATEST AT DEPLOY: addpkg currently overwrites
+//     gm.Gno = GnoVerLatest (vm keeper). That is harmless with one
+//     version but DEFEATS future pinning — an old package must keep its
+//     deploy-time version in its stored gnomod so it still runs under
+//     old semantics after the VM advances. Must record the real
+//     deploy-time version instead.
 //   - PER-FRAME DISPATCH across a mixed call stack (v1 package calling a
 //     v2 package): Semantics must be scoped per executing package, with
-//     defined conversion rules at the boundary.
+//     defined conversion rules at the boundary. NOTE: only semantics
+//     changes that are INVISIBLE across the import/call boundary are
+//     pinnable this way; a change observable at the boundary (shared
+//     type identity / value representation / serialization) is
+//     shared-substrate and must go through a re-genesis epoch, not a pin.
+//   - Path versioning (xxx/yy/v2) is ORTHOGONAL: it lets an author ship
+//     new CODE that dependents opt into by import path. It does NOT pin
+//     semantics — an unchanged deployed package at its old path still
+//     runs on whatever VM is live, so it cannot protect that package
+//     from a VM behavior change. Pinning is what does that.
 //   - GAS is out of scope: the gas schedule is a chain-wide resource,
 //     height-versioned, never per-package (see 3b).
 

--- a/gnovm/pkg/gnolang/semantics_test.go
+++ b/gnovm/pkg/gnolang/semantics_test.go
@@ -1,0 +1,29 @@
+package gnolang
+
+import "testing"
+
+func TestSemanticsForVersion(t *testing.T) {
+	t.Parallel()
+	if s, ok := SemanticsForVersion(GnoVerLatest); !ok || s.Version != GnoVerLatest {
+		t.Fatalf("latest version must be registered, got %+v ok=%v", s, ok)
+	}
+	if _, ok := SemanticsForVersion("0.0"); ok {
+		t.Fatalf("unregistered version must report ok=false")
+	}
+}
+
+func TestPackageNodeSemanticsDefaultsDormant(t *testing.T) {
+	t.Parallel()
+	pn := NewPackageNode("main", "main", nil)
+	if pn.LangVersion != GnoVerLatest {
+		t.Fatalf("new package must default to latest, got %q", pn.LangVersion)
+	}
+	if pn.Semantics().Version != GnoVerLatest {
+		t.Fatalf("semantics must resolve to latest")
+	}
+	// Unrecognized version falls back to latest (dormant, never fails).
+	pn.LangVersion = "0.0"
+	if pn.Semantics().Version != GnoVerLatest {
+		t.Fatalf("unknown version must fall back to latest")
+	}
+}

--- a/gnovm/pkg/gnolang/semantics_test.go
+++ b/gnovm/pkg/gnolang/semantics_test.go
@@ -7,7 +7,7 @@ func TestSemanticsForVersion(t *testing.T) {
 	if s, ok := SemanticsForVersion(GnoVerLatest); !ok || s.Version != GnoVerLatest {
 		t.Fatalf("latest version must be registered, got %+v ok=%v", s, ok)
 	}
-	if _, ok := SemanticsForVersion("0.0"); ok {
+	if _, ok := SemanticsForVersion("nonesuch"); ok {
 		t.Fatalf("unregistered version must report ok=false")
 	}
 }
@@ -21,9 +21,47 @@ func TestPackageNodeSemanticsDefaultsDormant(t *testing.T) {
 	if pn.Semantics().Version != GnoVerLatest {
 		t.Fatalf("semantics must resolve to latest")
 	}
-	// Unrecognized version falls back to latest (dormant, never fails).
-	pn.LangVersion = "0.0"
+	pn.LangVersion = "nonesuch" // unregistered → dormant fallback, never fails
 	if pn.Semantics().Version != GnoVerLatest {
 		t.Fatalf("unknown version must fall back to latest")
+	}
+}
+
+// TestPerPackageSemanticsDispatch is the load-bearing instrument: it
+// proves the seam actually routes by each package's OWN version, not a
+// global/constant. Since production registers a single version, it
+// registers a SYNTHETIC second version and asserts two packages pinned
+// to different versions resolve to different Semantics. Without this the
+// dormant seam would be unfalsifiable (a stub always returning latest
+// would pass every other test).
+func TestPerPackageSemanticsDispatch(t *testing.T) {
+	// not parallel: mutates the package-global registry.
+	const synthetic = "test-v99"
+	cleanup := registerSemanticsForTest(Semantics{Version: synthetic})
+	defer cleanup()
+
+	pkgLatest := NewPackageNode("a", "gno.land/p/a", nil) // defaults to latest
+	pkgSynthetic := NewPackageNode("b", "gno.land/p/b", nil)
+	pkgSynthetic.LangVersion = synthetic
+
+	// Each package resolves to ITS OWN version — the whole point of
+	// per-package pinning.
+	if got := pkgLatest.Semantics().Version; got != GnoVerLatest {
+		t.Fatalf("latest-pinned package resolved to %q, want %q", got, GnoVerLatest)
+	}
+	if got := pkgSynthetic.Semantics().Version; got != synthetic {
+		t.Fatalf("synthetic-pinned package resolved to %q, want %q", got, synthetic)
+	}
+	if pkgLatest.Semantics().Version == pkgSynthetic.Semantics().Version {
+		t.Fatal("two packages on different versions resolved to the SAME semantics — dispatch is not per-package")
+	}
+
+	// After cleanup the synthetic version is gone → falls back to latest.
+	cleanup()
+	if _, ok := SemanticsForVersion(synthetic); ok {
+		t.Fatal("synthetic version leaked past cleanup")
+	}
+	if got := pkgSynthetic.Semantics().Version; got != GnoVerLatest {
+		t.Fatalf("after deregistration, unknown version must fall back to latest, got %q", got)
 	}
 }


### PR DESCRIPTION
**WIP / dormant plumbing — not for merge as-is; opening to socialize the design.**

## What

Establishes the seam for **per-package language-semantics pinning**: pinning the VM's behavior to the gno language version a package declared at deploy time. The goal is to let the VM evolve — fix conformance bugs that change deployed-code behavior ("class-3" changes) — *without silently re-meaning already-deployed contracts*. Deployed code keeps the semantics it was written and audited against; only (re)deploys under a newer version get the new behavior. This is the gno analogue of Solidity's `pragma` and Go's `-lang`.

## What's in this PR (dormant)

- `Semantics` type + `SemanticsForVersion` registry — the single place future version-conditional behavior branches. Exactly one version registered (`GnoVerLatest`), **no feature switches yet**.
- `PackageNode.LangVersion` (+ `Semantics()` accessor) — the preprocess-time seam, defaulting to `GnoVerLatest`.
- Consulted nowhere → **zero behavior change**. The full filetest suite passes unchanged; that's the neutrality proof.

## Explicitly NOT done (the real follow-up work)

- **Persistence.** `LangVersion` is not serialized. Sound pinning requires persisting the version with the realm package (`PackageValue` / amino stored form) and restoring it on reload — a **consensus-visible** stored-form change that must land *before* any second version is registered, else reloaded old packages default to the latest semantics and the pin is defeated.
- **Per-frame dispatch** across a mixed call stack (v1 package calling v2), with boundary conversion rules.
- **Gas is out of scope** — chain-wide, height-versioned, never per-package.

## Why open it now

To agree on the abstraction and the persistence/consensus plan before wiring it, and so the seam exists ahead of the first post-launch semantics change that needs it. Independent of the conformance-corpus work; the corpus is used out-of-band to prove byte-identical behavior.

## Refinement (2026-07-11): source the version from persisted gnomod.toml, no new field

Design correction after reviewing how the version is stored and how this compares to path versioning:

- **No new persisted/consensus field is needed.** The gno language version is *already* persisted per package: `addpkg` writes `gnomod.toml` into the stored `MemPackage` (vm keeper), and the store reads it back via `GetMemFile(path, "gnomod.toml")`. So `PackageNode.LangVersion` should be **sourced at load from that existing stored gnomod.toml**, not added as a separate serialized field. The stored form is unchanged (the version is already inside the hashed MemPackage) — the same way EVM freezes semantics into the immutable deployed artifact; Gno, running source, needs the stored version to recreate that.
- **Required follow-up wiring** (replaces "persist a new field"): (1) populate `LangVersion` at package load from the stored gnomod; (2) **stop `addpkg` forcing `gm.Gno = GnoVerLatest`** — harmless with one version, but it defeats future pinning (an old package must keep its deploy-time version so it still runs under old semantics after the VM advances).
- **Path versioning (`xxx/yy/v2`) is orthogonal, not a substitute.** It lets an author ship new *code* that dependents opt into by import path. It does not pin *semantics*: an unchanged deployed package at its old path still runs on whatever VM is live, so path versioning cannot protect it from a VM behavior change. Pinning is what does that.
- **Pinnability boundary.** Only semantics changes invisible across the import/call boundary are per-package-pinnable. A change observable at the boundary (shared type identity / value representation / serialization) is shared-substrate and must go through a re-genesis epoch, not a pin. Corollary: a future v2 feature-switch that alters a cross-boundary value is a design error — reject it or escalate to an epoch.

## User's-eye view (what an upgrade feels like)

Cast: `p/demo/mathx` (library, has the buggy multi-assignment inside `Step`), `r/demo/wallet` (realm, imports mathx, calls `Step`, stores the result), and the chain (ships the fix). Say buggy `Step(2,3)` returns `(3,6)`; fixed it returns `(3,5)`.

- **T0** — mathx deployed, its stored `gnomod.toml` records `gno=0.9`. wallet (also `0.9`) calls `Step`, stores `6`. Consistent with the buggy world.
- **T1 — chain upgrades to `0.10` (bug fixed).** mathx's stored version is still `0.9`, so the VM keeps running its `Step` under 0.9 → still `(3,6)`; wallet still gets `6`. **Nothing changes for deployed code — no silent value shift, no broken state, no tx that passed now failing.** That's the whole point: *upgrades don't ambush you.* A new author who deploys under `0.10` gets the correct `(3,5)` immediately.
- **T2 — wallet's author wants the fix.** The buggy line is *inside mathx*, and `Step` executes under **mathx's** pin — so bumping wallet's own version does nothing to the value. The author must repoint wallet's import to a **new mathx deployed under 0.10** (new path), then redeploy. Now `Step` returns `5`. wallet's **old stored `6` stays** (immutable history); correcting it is a separate, deliberate **state migration** the author chooses to run — on their schedule, never the chain's.

Contrast (no pinning): at T1 deployed mathx would suddenly return `(3,5)`, wallet would silently compute `5` against a history built on `6`, and its state would go inconsistent with nobody having asked. That ambush is exactly what pinning prevents. Cost of the safety: the bug lives on in the 0.9 mathx forever, and adopting the fix is an explicit redeploy + migrate.

**One-line takeaway:** an upgrade never changes what already-deployed code does; to get a fix you redeploy against the fixed version (a new path) and decide what to do with old data yourself.

This is the standard web3 idiom (immutable artifact → new version → migrate; cf. Ethereum redeploy/proxy) refined with a per-package *semantics* pin — closest to Solidity's pragma / compiler-version frozen into bytecode.