### PR TITLE
fix(misc/gendocs): pin pkgsite to v0.2.0 to fix deploy/pages CI

### DIFF
--- a/misc/gendocs/Makefile
+++ b/misc/gendocs/Makefile
@@ -1,7 +1,9 @@
 all: clean gen
 
+# Pin to v0.2.0: v0.3.0+ requires Go >= 1.26, but CI pins GOTOOLCHAIN=local to
+# the go.mod toolchain (currently 1.25.x), so @latest fails to build.
 install:
-	go install golang.org/x/pkgsite/cmd/pkgsite@latest
+	go install golang.org/x/pkgsite/cmd/pkgsite@v0.2.0
 
 gen:
 	./gendocs.sh


### PR DESCRIPTION
pkgsite v0.3.0 requires Go >= 1.26, but the deploy/pages workflow runs with GOTOOLCHAIN=local (set by actions/setup-go) pinned to the go.mod toolchain (1.25.x). Building pkgsite@latest therefore fails with:

  golang.org/x/pkgsite@v0.3.0 requires go >= 1.26.0 (running go 1.25.9;
  GOTOOLCHAIN=local)

Pin to v0.2.0, whose go directive (1.25.5) is satisfied by the current toolchain.