### PR TITLE
docs: fix Register gas-wanted and add log-level tip (test13)

### DIFF
--- a/misc/deployments/test13.gno.land/VALIDATOR.md
+++ b/misc/deployments/test13.gno.land/VALIDATOR.md
@@ -96,6 +96,11 @@ gnoland start \
 
 `--skip-genesis-sig-verification` is **required**: test13's genesis replays historical transactions whose signatures a fresh node can't re-verify, so the node panics on startup without it.
 
+> **Tip:** the default log level is `debug`, which is very verbose on a long-running node.
+> Consider adding `--log-level info` to the start command for day-to-day operation
+> (options: `debug`, `info`, `warn`, `error`).
+
+
 Let the node sync, and wait until it has caught up to the chain tip before the next step.
 
 ## 5. Register as a validator candidate
@@ -119,7 +124,7 @@ gnokey maketx call \
   --args "<cloud|on-prem|data-center>" \
   --args "<your operator g1... address>" \
   --args "<your gpub1... consensus pubkey>" \
-  --gas-fee 1000000ugnot --gas-wanted 50000000 \
+  --gas-fee 1000000ugnot --gas-wanted 100000000 \
   --chainid test-13 \
   --remote https://rpc.test13.testnets.gno.land \
   --broadcast \


### PR DESCRIPTION
Two small doc fixes based on a real test13 validator onboarding:

1. **`--gas-wanted 50000000` → `100000000`** for the valopers `Register` call — the current
   value is no longer sufficient. Our registration first failed with
   `out of gas, gasWanted: 50000000, gasUsed: 50000169`, and the successful retry consumed
   **81,783,643 gas** (height 741195, tx `NRk+9eIVNf+fEb8THBzHGSWWmYSQfYI9LcVxOGzBgaw=`).
   100M gives comfortable headroom.

2. Added a tip about `--log-level info` — the default `debug` level floods the journal on
   long-running nodes.

Both hit and verified during our own onboarding (active-set validator `coinsspor`).
Related: #5940 · tooling we've built for test13: https://github.com/coinsspor/gnoland-explorer · https://github.com/coinsspor/gnonym