### PR TITLE
feat(gnogenesis): add -skip-signature-check to genesis verify

### DIFF
--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -88,6 +88,16 @@ func execVerify(cfg *verifyCfg, io commands.IO) error {
 			// Basic tx validation ensures there is at least 1 signer
 			signer := tx.Tx.GetSignatures()[0]
 
+			// Zero-value placeholder signatures carry no public key —
+			// nothing to verify against.
+			if signer.PubKey == nil {
+				return fmt.Errorf(
+					"%w #%d, missing signer public key",
+					errInvalidTxSignature,
+					index,
+				)
+			}
+
 			// Grab the signature bytes of the tx.
 			// Genesis transactions are signed with
 			// account number and sequence set to 0

--- a/contribs/gnogenesis/internal/verify/verify.go
+++ b/contribs/gnogenesis/internal/verify/verify.go
@@ -31,6 +31,8 @@ const (
 
 type verifyCfg struct {
 	common.Cfg
+
+	skipSignatureCheck bool
 }
 
 // NewVerifyCmd creates the genesis verify subcommand
@@ -53,6 +55,13 @@ func NewVerifyCmd(io commands.IO) *commands.Command {
 
 func (c *verifyCfg) RegisterFlags(fs *flag.FlagSet) {
 	c.Cfg.RegisterFlags(fs)
+
+	fs.BoolVar(&c.skipSignatureCheck, "skip-signature-check", false,
+		"skip per-tx signature verification. Genesis-mode txs can carry "+
+			"signatures that intentionally don't verify (post-sign caller "+
+			"overrides, valoper-seed placeholder signatures); nodes accept "+
+			"them under --skip-genesis-sig-verification. Every other check "+
+			"still runs.")
 }
 
 func execVerify(cfg *verifyCfg, io commands.IO) error {
@@ -82,6 +91,10 @@ func execVerify(cfg *verifyCfg, io commands.IO) error {
 		for index, tx := range state.Txs {
 			if validateErr := tx.Tx.ValidateBasic(); validateErr != nil {
 				return fmt.Errorf("invalid transacton, %w", validateErr)
+			}
+
+			if cfg.skipSignatureCheck {
+				continue
 			}
 
 			// Genesis txs can only be signed by 1 account.

--- a/contribs/gnogenesis/internal/verify/verify_test.go
+++ b/contribs/gnogenesis/internal/verify/verify_test.go
@@ -163,6 +163,103 @@ func TestGenesis_Verify(t *testing.T) {
 		}
 	})
 
+	t.Run("skip signature check", func(t *testing.T) {
+		// Genesis-mode txs can carry signatures that intentionally don't
+		// verify: a caller_override patches the caller post-sign (e.g. a
+		// names.Enable admin call), and valoper-seed emits zero-value
+		// placeholder signatures. Nodes accept both under
+		// --skip-genesis-sig-verification; -skip-signature-check is the
+		// verify-time equivalent, keeping every other check active.
+		t.Parallel()
+
+		testTable := []struct {
+			name         string
+			signaturesFn func(tx *std.Tx, chainID string) []std.Signature
+		}{
+			{
+				name: "mutated tx body (caller_override)",
+				signaturesFn: func(tx *std.Tx, chainID string) []std.Signature {
+					// Sign with a chain ID that differs from the genesis
+					// chain ID — same mismatch class as a post-sign
+					// caller patch: valid signature shape, wrong payload.
+					signer := ed25519.GenPrivKey()
+					signBytes, err := tx.GetSignBytes(chainID+"wrong", 0, 0)
+					require.NoError(t, err)
+					signature, err := signer.Sign(signBytes)
+					require.NoError(t, err)
+
+					return []std.Signature{
+						{
+							PubKey:    signer.PubKey(),
+							Signature: signature,
+						},
+					}
+				},
+			},
+			{
+				name: "zero-value placeholder signature (valoper-seed)",
+				signaturesFn: func(tx *std.Tx, _ string) []std.Signature {
+					return make([]std.Signature, len(tx.GetSigners()))
+				},
+			},
+		}
+
+		for _, testCase := range testTable {
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				tempFile, cleanup := testutils.NewTestFile(t)
+				t.Cleanup(cleanup)
+
+				g := getValidTestGenesis()
+
+				sender := ed25519.GenPrivKey()
+				sendMsg := bank.MsgSend{
+					FromAddress: sender.PubKey().Address(),
+					ToAddress:   sender.PubKey().Address(),
+					Amount:      std.NewCoins(std.NewCoin("ugnot", 10)),
+				}
+
+				tx := std.Tx{
+					Msgs: []std.Msg{sendMsg},
+					Fee: std.Fee{
+						GasWanted: 1000000,
+						GasFee:    std.NewCoin("ugnot", 20),
+					},
+				}
+				tx.Signatures = testCase.signaturesFn(&tx, g.ChainID)
+
+				appState := g.AppState.(gnoland.GnoGenesisState)
+				appState.Txs = []gnoland.TxWithMetadata{
+					{
+						Tx: tx,
+					},
+				}
+				g.AppState = appState
+
+				require.NoError(t, g.SaveAs(tempFile.Name()))
+
+				// Without the flag, verification must fail.
+				cmd := NewVerifyCmd(commands.NewTestIO())
+				args := []string{
+					"--genesis-path",
+					tempFile.Name(),
+				}
+				require.Error(t, cmd.ParseAndRun(context.Background(), args))
+
+				// With the flag, every non-signature check still runs
+				// and the genesis is accepted.
+				cmd = NewVerifyCmd(commands.NewTestIO())
+				args = []string{
+					"--genesis-path",
+					tempFile.Name(),
+					"--skip-signature-check",
+				}
+				require.NoError(t, cmd.ParseAndRun(context.Background(), args))
+			})
+		}
+	})
+
 	t.Run("missing signer public key", func(t *testing.T) {
 		// Zero-value placeholder signatures (e.g. valoper-seed output)
 		// carry no public key. Verification must reject them with a

--- a/contribs/gnogenesis/internal/verify/verify_test.go
+++ b/contribs/gnogenesis/internal/verify/verify_test.go
@@ -163,6 +163,58 @@ func TestGenesis_Verify(t *testing.T) {
 		}
 	})
 
+	t.Run("missing signer public key", func(t *testing.T) {
+		// Zero-value placeholder signatures (e.g. valoper-seed output)
+		// carry no public key. Verification must reject them with a
+		// proper error, not dereference the nil PubKey.
+		t.Parallel()
+
+		tempFile, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		g := getValidTestGenesis()
+
+		sender := ed25519.GenPrivKey()
+		sendMsg := bank.MsgSend{
+			FromAddress: sender.PubKey().Address(),
+			ToAddress:   sender.PubKey().Address(),
+			Amount:      std.NewCoins(std.NewCoin("ugnot", 10)),
+		}
+
+		tx := std.Tx{
+			Msgs: []std.Msg{sendMsg},
+			Fee: std.Fee{
+				GasWanted: 1000000,
+				GasFee:    std.NewCoin("ugnot", 20),
+			},
+		}
+		// One zero-value signature per signer: passes ValidateBasic's
+		// len(Signatures) == len(GetSigners()) requirement, carries no
+		// key material.
+		tx.Signatures = make([]std.Signature, len(tx.GetSigners()))
+
+		appState := g.AppState.(gnoland.GnoGenesisState)
+		appState.Txs = []gnoland.TxWithMetadata{
+			{
+				Tx: tx,
+			},
+		}
+		g.AppState = appState
+
+		require.NoError(t, g.SaveAs(tempFile.Name()))
+
+		// Create the command
+		cmd := NewVerifyCmd(commands.NewTestIO())
+		args := []string{
+			"--genesis-path",
+			tempFile.Name(),
+		}
+
+		// Run the command
+		cmdErr := cmd.ParseAndRun(context.Background(), args)
+		assert.ErrorIs(t, cmdErr, errInvalidTxSignature)
+	})
+
 	t.Run("invalid balances", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

Lets `gnogenesis verify` validate a genesis whose txs carry signatures that are **unverifiable by design**:

- **Post-sign caller overrides** — admin-gated genesis calls (e.g. `r/sys/names.Enable`) are signed with a build key, then have `msg.caller` patched to the admin address. The signature no longer matches the tx body on purpose.
- **Placeholder signatures** — `gnogenesis fork valoper-seed` emits `valopers.Register` txs with zero-value signatures (it's an offline generator with no key material).

Nodes accept both under `--skip-genesis-sig-verification`, but `verify` had no equivalent: it failed on the first caller-override tx, and **panicked** (nil pointer dereference) on placeholder signatures. The new `-skip-signature-check` flag skips only the per-tx signature loop — `ValidateBasic`, genesis structure, balance validation, and the valoper coverage check still run.

## Changes

- Return a proper `invalid tx signature` error instead of panicking when a signer carries no public key — [`7f33e71`](https://github.com/gnolang/gno/commit/7f33e7142b6cd4abc4d34caebe06ad97b7f55e3b)
- Add the `-skip-signature-check` flag — [`859dcb8`](https://github.com/gnolang/gno/commit/859dcb88c37a704e8382e097a51054051d8926b6)