### PR TITLE
feat(examples): add prediction market demo realm

### DIFF
--- a/examples/gno.land/r/demo/predictionmarket/gnomod.toml
+++ b/examples/gno.land/r/demo/predictionmarket/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/predictionmarket"
+gno = "0.9"

--- a/examples/gno.land/r/demo/predictionmarket/predictionmarket.gno
+++ b/examples/gno.land/r/demo/predictionmarket/predictionmarket.gno
@@ -1,0 +1,172 @@
+package predictionmarket
+
+import (
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/avl/v0"
+
+	"chain"
+	"chain/banker"
+	"chain/runtime"
+	"chain/runtime/unsafe"
+)
+
+const (
+	OutcomeHome = 0
+	OutcomeAway = 1
+	OutcomeDraw = 2
+
+	betDenom = "ugnot"
+)
+
+type Bet struct {
+	bettor  address
+	outcome int
+	amount  int64
+}
+
+type Market struct {
+	id          int
+	description string
+	resolved    bool
+	winner      int
+	pools       [3]int64
+	bets        []*Bet
+}
+
+var (
+	markets avl.Tree
+	nextID  int
+	admin   address
+)
+
+func init() {
+	admin = unsafe.OriginCaller()
+	nextID = 1
+}
+
+func CreateMarket(cur realm, description string) int {
+	caller := cur.Previous().Address()
+	if caller != admin {
+		panic("only admin can create markets")
+	}
+	id := nextID
+	nextID++
+	m := &Market{
+		id:          id,
+		description: description,
+		winner:      -1,
+	}
+	markets.Set(strconv.Itoa(id), m)
+	return id
+}
+
+func PlaceBet(cur realm, marketID int, outcome int) {
+	runtime.AssertOriginCall()
+	if !cur.Previous().IsUserCall() {
+		panic("only direct EOA calls can place bets")
+	}
+	if outcome < 0 || outcome > 2 {
+		panic("invalid outcome")
+	}
+
+	raw, exists := markets.Get(strconv.Itoa(marketID))
+	if !exists {
+		panic("market does not exist")
+	}
+	m := raw.(*Market)
+	if m.resolved {
+		panic("market already resolved")
+	}
+
+	sent := unsafe.OriginSend()
+	var amount int64
+	for _, c := range sent {
+		if c.Denom == betDenom {
+			amount = c.Amount
+		}
+	}
+	if amount <= 0 {
+		panic("must attach ugnot to place a bet")
+	}
+
+	caller := cur.Previous().Address()
+	m.pools[outcome] += amount
+	m.bets = append(m.bets, &Bet{bettor: caller, outcome: outcome, amount: amount})
+}
+
+func ResolveMarket(cur realm, marketID int, winningOutcome int) {
+	caller := cur.Previous().Address()
+	if caller != admin {
+		panic("only admin can resolve markets")
+	}
+	if winningOutcome < 0 || winningOutcome > 2 {
+		panic("invalid outcome")
+	}
+	raw, exists := markets.Get(strconv.Itoa(marketID))
+	if !exists {
+		panic("market does not exist")
+	}
+	m := raw.(*Market)
+	if m.resolved {
+		panic("market already resolved")
+	}
+	m.resolved = true
+	m.winner = winningOutcome
+}
+
+func ClaimWinnings(cur realm, marketID int) {
+	caller := cur.Previous().Address()
+	raw, exists := markets.Get(strconv.Itoa(marketID))
+	if !exists {
+		panic("market does not exist")
+	}
+	m := raw.(*Market)
+	if !m.resolved {
+		panic("market not resolved yet")
+	}
+
+	winningPool := m.pools[m.winner]
+	if winningPool == 0 {
+		panic("no winning pool")
+	}
+
+	var totalPool int64
+	for _, p := range m.pools {
+		totalPool += p
+	}
+
+	var payout int64
+	for _, b := range m.bets {
+		if b.bettor == caller && b.outcome == m.winner && b.amount > 0 {
+			payout += (b.amount * totalPool) / winningPool
+			b.amount = 0
+		}
+	}
+	if payout == 0 {
+		panic("nothing to claim")
+	}
+
+	bkr := banker.NewBanker(banker.BankerTypeRealmSend, cur)
+	bkr.SendCoins(cur.Address(), caller, chain.Coins{{Denom: betDenom, Amount: payout}})
+}
+
+func Render(path string) string {
+	var sb strings.Builder
+	sb.WriteString("Prediction Market Realm\nAdmin: " + admin.String() + "\n\n")
+	markets.Iterate("", "", func(key string, value interface{}) bool {
+		m := value.(*Market)
+		status := "open"
+		if m.resolved {
+			status = "resolved, winner: " + strconv.Itoa(m.winner)
+		}
+		sb.WriteString("Market #" + strconv.Itoa(m.id) + ": " + m.description +
+			" | Home: " + strconv.FormatInt(m.pools[OutcomeHome], 10) +
+			" Away: " + strconv.FormatInt(m.pools[OutcomeAway], 10) +
+			" Draw: " + strconv.FormatInt(m.pools[OutcomeDraw], 10) +
+			" [" + status + "]\n")
+		return false
+	})
+	return sb.String()
+}

--- a/examples/gno.land/r/demo/predictionmarket/predictionmarket.gno
+++ b/examples/gno.land/r/demo/predictionmarket/predictionmarket.gno
@@ -1,14 +1,15 @@
 package predictionmarket
 
 import (
+	"math/overflow"
 	"strconv"
 	"strings"
 
 	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ownable/v0"
 
 	"chain"
 	"chain/banker"
-	"chain/runtime"
 	"chain/runtime/unsafe"
 )
 
@@ -20,64 +21,106 @@ const (
 	betDenom = "ugnot"
 )
 
+// Market is a single prediction market. The admin (owner) alone
+// decides when to resolve it and which outcome won -- there is no
+// oracle, dispute window, or betting cutoff. Bettors are trusting the
+// admin completely; this is documented, not hidden, and the admin is
+// blocked from placing bets in their own markets (see PlaceBet) to
+// remove the most obvious form of self-dealing, but nothing prevents
+// an admin from simply resolving in whatever direction benefits them.
+type Market struct {
+	id          int
+	description string
+	allowDraw   bool
+	resolved    bool
+	winner      int
+	noWinners   bool // true if the resolved outcome received no bets; triggers a full refund instead of a proportional payout
+	pools       [3]int64
+	bets        []*Bet
+}
+
 type Bet struct {
 	bettor  address
 	outcome int
 	amount  int64
 }
 
-type Market struct {
-	id          int
-	description string
-	resolved    bool
-	winner      int
-	pools       [3]int64
-	bets        []*Bet
-}
-
 var (
 	markets avl.Tree
 	nextID  int
-	admin   address
+	owner   *ownable.Ownable
 )
 
 func init() {
-	admin = unsafe.OriginCaller()
+	owner = ownable.NewWithAddress(unsafe.OriginCaller())
 	nextID = 1
 }
 
-func CreateMarket(cur realm, description string) int {
-	caller := cur.Previous().Address()
-	if caller != admin {
-		panic("only admin can create markets")
+// TransferOwnership hands off admin control of every market (past and
+// future) to newOwner.
+func TransferOwnership(cur realm, newOwner address) {
+	if err := owner.TransferOwnership(0, cur, newOwner); err != nil {
+		panic(err.Error())
 	}
+}
+
+// marketKey zero-pads the id so markets.Iterate (which walks keys as
+// strings) lists markets in numeric order instead of lexical order
+// (which would otherwise put market 10 before market 2).
+func marketKey(id int) string {
+	s := strconv.Itoa(id)
+	for len(s) < 10 {
+		s = "0" + s
+	}
+	return s
+}
+
+// CreateMarket opens a new market. allowDraw controls whether
+// OutcomeDraw is a valid bet for this specific market -- set it to
+// false for contests that cannot end in a draw.
+func CreateMarket(cur realm, description string, allowDraw bool) int {
+	caller := cur.Previous().Address()
+	owner.AssertOwnedBy(caller)
+
 	id := nextID
 	nextID++
 	m := &Market{
 		id:          id,
 		description: description,
+		allowDraw:   allowDraw,
 		winner:      -1,
 	}
-	markets.Set(strconv.Itoa(id), m)
+	markets.Set(marketKey(id), m)
 	return id
 }
 
+// PlaceBet attaches ugnot (read via unsafe.OriginSend) to a bet on
+// outcome. cur.Previous().IsUserCall() rejects both a direct call from
+// another realm and a gnokey maketx run ephemeral script (which has a
+// non-empty, but not user, pkgPath) -- only a plain EOA transaction
+// gets through. The admin is additionally blocked from betting in any
+// market: they alone decide the resolution, so allowing them to also
+// hold a position would let them resolve in their own favor risk-free.
 func PlaceBet(cur realm, marketID int, outcome int) {
-	runtime.AssertOriginCall()
 	if !cur.Previous().IsUserCall() {
 		panic("only direct EOA calls can place bets")
 	}
-	if outcome < 0 || outcome > 2 {
-		panic("invalid outcome")
+
+	caller := cur.Previous().Address()
+	if owner.OwnedBy(caller) {
+		panic("admin cannot place bets")
 	}
 
-	raw, exists := markets.Get(strconv.Itoa(marketID))
-	if !exists {
+	raw := markets.Get(marketKey(marketID))
+	if raw == nil {
 		panic("market does not exist")
 	}
 	m := raw.(*Market)
 	if m.resolved {
 		panic("market already resolved")
+	}
+	if outcome < OutcomeHome || outcome > OutcomeAway && !(outcome == OutcomeDraw && m.allowDraw) {
+		panic("invalid outcome for this market")
 	}
 
 	sent := unsafe.OriginSend()
@@ -91,35 +134,49 @@ func PlaceBet(cur realm, marketID int, outcome int) {
 		panic("must attach ugnot to place a bet")
 	}
 
-	caller := cur.Previous().Address()
-	m.pools[outcome] += amount
+	m.pools[outcome] = overflow.Add64p(m.pools[outcome], amount)
 	m.bets = append(m.bets, &Bet{bettor: caller, outcome: outcome, amount: amount})
 }
 
+// ResolveMarket locks in winningOutcome. If nobody bet on that
+// outcome, the market is marked noWinners and ClaimWinnings refunds
+// every bettor their original stake instead of computing a
+// proportional payout against an empty winning pool -- otherwise the
+// escrow would be stuck in the realm forever, since there would be no
+// way to divide zero into a payout.
 func ResolveMarket(cur realm, marketID int, winningOutcome int) {
 	caller := cur.Previous().Address()
-	if caller != admin {
-		panic("only admin can resolve markets")
-	}
-	if winningOutcome < 0 || winningOutcome > 2 {
-		panic("invalid outcome")
-	}
-	raw, exists := markets.Get(strconv.Itoa(marketID))
-	if !exists {
+	owner.AssertOwnedBy(caller)
+
+	raw := markets.Get(marketKey(marketID))
+	if raw == nil {
 		panic("market does not exist")
 	}
 	m := raw.(*Market)
 	if m.resolved {
 		panic("market already resolved")
 	}
+	if winningOutcome < OutcomeHome || winningOutcome > OutcomeAway && !(winningOutcome == OutcomeDraw && m.allowDraw) {
+		panic("invalid outcome for this market")
+	}
+
 	m.resolved = true
 	m.winner = winningOutcome
+	if m.pools[winningOutcome] == 0 {
+		m.noWinners = true
+	}
 }
 
+// ClaimWinnings pays out the caller's share of a resolved market. For
+// a normal resolution this is proportional to the caller's stake in
+// the winning pool, drawn from the full pool. For a market marked
+// noWinners (nobody backed the resolved outcome), this instead refunds
+// every one of the caller's bets in full, regardless of which outcome
+// they were on -- a push, not a proportional payout.
 func ClaimWinnings(cur realm, marketID int) {
 	caller := cur.Previous().Address()
-	raw, exists := markets.Get(strconv.Itoa(marketID))
-	if !exists {
+	raw := markets.Get(marketKey(marketID))
+	if raw == nil {
 		panic("market does not exist")
 	}
 	m := raw.(*Market)
@@ -127,21 +184,26 @@ func ClaimWinnings(cur realm, marketID int) {
 		panic("market not resolved yet")
 	}
 
-	winningPool := m.pools[m.winner]
-	if winningPool == 0 {
-		panic("no winning pool")
-	}
-
-	var totalPool int64
-	for _, p := range m.pools {
-		totalPool += p
-	}
-
 	var payout int64
-	for _, b := range m.bets {
-		if b.bettor == caller && b.outcome == m.winner && b.amount > 0 {
-			payout += (b.amount * totalPool) / winningPool
-			b.amount = 0
+	if m.noWinners {
+		for _, b := range m.bets {
+			if b.bettor == caller && b.amount > 0 {
+				payout = overflow.Add64p(payout, b.amount)
+				b.amount = 0
+			}
+		}
+	} else {
+		winningPool := m.pools[m.winner]
+		var totalPool int64
+		for _, p := range m.pools {
+			totalPool = overflow.Add64p(totalPool, p)
+		}
+		for _, b := range m.bets {
+			if b.bettor == caller && b.outcome == m.winner && b.amount > 0 {
+				share := overflow.Mul64p(b.amount, totalPool) / winningPool
+				payout = overflow.Add64p(payout, share)
+				b.amount = 0
+			}
 		}
 	}
 	if payout == 0 {
@@ -152,21 +214,71 @@ func ClaimWinnings(cur realm, marketID int) {
 	bkr.SendCoins(cur.Address(), caller, chain.Coins{{Denom: betDenom, Amount: payout}})
 }
 
+// Render shows every open/resolved market, or a single market's detail
+// when called with ?id=<marketID>.
 func Render(path string) string {
+	if id, ok := parseIDQuery(path); ok {
+		return renderMarket(id)
+	}
+
 	var sb strings.Builder
-	sb.WriteString("Prediction Market Realm\nAdmin: " + admin.String() + "\n\n")
+	sb.WriteString("# Prediction Market Realm\n\n")
+	sb.WriteString("Admin: " + owner.Owner().String() + "\n\n")
 	markets.Iterate("", "", func(key string, value interface{}) bool {
 		m := value.(*Market)
-		status := "open"
-		if m.resolved {
-			status = "resolved, winner: " + strconv.Itoa(m.winner)
-		}
-		sb.WriteString("Market #" + strconv.Itoa(m.id) + ": " + m.description +
-			" | Home: " + strconv.FormatInt(m.pools[OutcomeHome], 10) +
-			" Away: " + strconv.FormatInt(m.pools[OutcomeAway], 10) +
-			" Draw: " + strconv.FormatInt(m.pools[OutcomeDraw], 10) +
-			" [" + status + "]\n")
+		sb.WriteString(marketSummaryLine(m))
 		return false
 	})
 	return sb.String()
+}
+
+func renderMarket(id int) string {
+	raw := markets.Get(marketKey(id))
+	if raw == nil {
+		return "Market not found.\n"
+	}
+	m := raw.(*Market)
+
+	var sb strings.Builder
+	sb.WriteString("# Market #" + strconv.Itoa(m.id) + "\n\n")
+	sb.WriteString(m.description + "\n\n")
+	sb.WriteString(marketSummaryLine(m))
+	return sb.String()
+}
+
+func marketSummaryLine(m *Market) string {
+	status := "open"
+	if m.resolved {
+		if m.noWinners {
+			status = "resolved, no winners (refund)"
+		} else {
+			status = "resolved, winner: " + strconv.Itoa(m.winner)
+		}
+	}
+	line := "Market #" + strconv.Itoa(m.id) + ": " + m.description +
+		" | Home: " + strconv.FormatInt(m.pools[OutcomeHome], 10) +
+		" Away: " + strconv.FormatInt(m.pools[OutcomeAway], 10)
+	if m.allowDraw {
+		line += " Draw: " + strconv.FormatInt(m.pools[OutcomeDraw], 10)
+	}
+	line += " [" + status + "]\n"
+	return line
+}
+
+// parseIDQuery extracts ?id=<n> from path, if present and valid.
+func parseIDQuery(path string) (int, bool) {
+	const prefix = "?id="
+	idx := strings.Index(path, prefix)
+	if idx == -1 {
+		return 0, false
+	}
+	rest := path[idx+len(prefix):]
+	if amp := strings.Index(rest, "&"); amp != -1 {
+		rest = rest[:amp]
+	}
+	id, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
 }

--- a/examples/gno.land/r/demo/predictionmarket/predictionmarket_test.gno
+++ b/examples/gno.land/r/demo/predictionmarket/predictionmarket_test.gno
@@ -1,0 +1,62 @@
+package predictionmarket
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestCreateMarket(cur realm, t *testing.T) {
+	id := CreateMarket(cur, "Test Market: Team A vs Team B")
+	if id != 1 {
+		t.Fatalf("expected market id 1, got %d", id)
+	}
+
+	raw, exists := markets.Get(strconv.Itoa(id))
+	if !exists {
+		t.Fatal("market was not stored")
+	}
+	m := raw.(*Market)
+	if m.description != "Test Market: Team A vs Team B" {
+		t.Fatalf("unexpected description: %s", m.description)
+	}
+	if m.resolved {
+		t.Fatal("new market should not be resolved")
+	}
+}
+
+func TestResolveMarket(cur realm, t *testing.T) {
+	id := CreateMarket(cur, "Test Market: Resolve Flow")
+	ResolveMarket(cur, id, OutcomeHome)
+
+	raw, _ := markets.Get(strconv.Itoa(id))
+	m := raw.(*Market)
+	if !m.resolved {
+		t.Fatal("market should be resolved")
+	}
+	if m.winner != OutcomeHome {
+		t.Fatalf("expected winner %d, got %d", OutcomeHome, m.winner)
+	}
+}
+
+func TestResolveMarketTwiceFails(cur realm, t *testing.T) {
+	id := CreateMarket(cur, "Test Market: Double Resolve")
+	ResolveMarket(cur, id, OutcomeAway)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on double resolve")
+		}
+	}()
+	ResolveMarket(cur, id, OutcomeDraw)
+}
+
+func TestClaimWinningsBeforeResolveFails(cur realm, t *testing.T) {
+	id := CreateMarket(cur, "Test Market: Early Claim")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on claim before resolve")
+		}
+	}()
+	ClaimWinnings(cur, id)
+}

--- a/examples/gno.land/r/demo/predictionmarket/predictionmarket_test.gno
+++ b/examples/gno.land/r/demo/predictionmarket/predictionmarket_test.gno
@@ -1,62 +1,141 @@
 package predictionmarket
 
 import (
-	"strconv"
 	"testing"
+
+	"chain"
+
+	"gno.land/p/nt/ownable/v0"
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/uassert/v0"
 )
 
-func TestCreateMarket(cur realm, t *testing.T) {
-	id := CreateMarket(cur, "Test Market: Team A vs Team B")
-	if id != 1 {
-		t.Fatalf("expected market id 1, got %d", id)
-	}
+var realmAddr = chain.PackageAddress("gno.land/r/demo/predictionmarket")
 
-	raw, exists := markets.Get(strconv.Itoa(id))
-	if !exists {
-		t.Fatal("market was not stored")
-	}
-	m := raw.(*Market)
-	if m.description != "Test Market: Team A vs Team B" {
-		t.Fatalf("unexpected description: %s", m.description)
-	}
-	if m.resolved {
-		t.Fatal("new market should not be resolved")
-	}
+func TestCreateMarketAndPlaceBets(cur realm, t *testing.T) {
+	admin := testutils.TestAddress("admin")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "Test Market", true)
+
+	alice := testutils.TestAddress("alice")
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 1000)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 1000)))
+	PlaceBet(cross(cur), id, OutcomeHome)
+
+	bob := testutils.TestAddress("bob")
+	testing.SetRealm(testing.NewUserRealm(bob))
+	testing.SetOriginCaller(bob)
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 500)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 1500)))
+	PlaceBet(cross(cur), id, OutcomeAway)
+
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	ResolveMarket(cross(cur), id, OutcomeHome)
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	ClaimWinnings(cross(cur), id)
 }
 
-func TestResolveMarket(cur realm, t *testing.T) {
-	id := CreateMarket(cur, "Test Market: Resolve Flow")
-	ResolveMarket(cur, id, OutcomeHome)
+func TestAdminCannotPlaceBet(cur realm, t *testing.T) {
+	admin := testutils.TestAddress("admin-nobet")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "Admin Cannot Bet", true)
 
-	raw, _ := markets.Get(strconv.Itoa(id))
-	m := raw.(*Market)
-	if !m.resolved {
-		t.Fatal("market should be resolved")
-	}
-	if m.winner != OutcomeHome {
-		t.Fatalf("expected winner %d, got %d", OutcomeHome, m.winner)
-	}
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 1000)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 1000)))
+
+	uassert.AbortsWithMessage(t, cur, "admin cannot place bets", func() {
+		PlaceBet(cross(cur), id, OutcomeHome)
+	})
+}
+
+func TestNoWinnersTriggersRefund(cur realm, t *testing.T) {
+	admin := testutils.TestAddress("admin-refund")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "No Winners Test", true)
+
+	alice := testutils.TestAddress("alice-refund")
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 700)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 700)))
+	PlaceBet(cross(cur), id, OutcomeHome)
+
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	ResolveMarket(cross(cur), id, OutcomeAway)
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	uassert.NotPanics(t, cur, func() {
+		ClaimWinnings(cross(cur), id)
+	})
 }
 
 func TestResolveMarketTwiceFails(cur realm, t *testing.T) {
-	id := CreateMarket(cur, "Test Market: Double Resolve")
-	ResolveMarket(cur, id, OutcomeAway)
+	admin := testutils.TestAddress("admin-double")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "Double Resolve Test", true)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic on double resolve")
-		}
-	}()
-	ResolveMarket(cur, id, OutcomeDraw)
+	ResolveMarket(cross(cur), id, OutcomeAway)
+
+	uassert.AbortsWithMessage(t, cur, "market already resolved", func() {
+		ResolveMarket(cross(cur), id, OutcomeDraw)
+	})
 }
 
 func TestClaimWinningsBeforeResolveFails(cur realm, t *testing.T) {
-	id := CreateMarket(cur, "Test Market: Early Claim")
+	admin := testutils.TestAddress("admin-early")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "Early Claim Test", true)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic on claim before resolve")
-		}
-	}()
-	ClaimWinnings(cur, id)
+	uassert.AbortsWithMessage(t, cur, "market not resolved yet", func() {
+		ClaimWinnings(cross(cur), id)
+	})
+}
+
+func TestClaimWinningsOverflowingPoolPanics(cur realm, t *testing.T) {
+	admin := testutils.TestAddress("admin-overflow")
+	owner = ownable.NewWithAddress(admin)
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	id := CreateMarket(cross(cur), "Overflow Test", true)
+
+	alice := testutils.TestAddress("alice-overflow")
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 5_000_000_000)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 5_000_000_000)))
+	PlaceBet(cross(cur), id, OutcomeHome)
+
+	bob := testutils.TestAddress("bob-overflow")
+	testing.SetRealm(testing.NewUserRealm(bob))
+	testing.SetOriginCaller(bob)
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin(betDenom, 5_000_000_000)))
+	testing.IssueCoins(realmAddr, chain.NewCoins(chain.NewCoin(betDenom, 10_000_000_000)))
+	PlaceBet(cross(cur), id, OutcomeAway)
+
+	testing.SetRealm(testing.NewUserRealm(admin))
+	testing.SetOriginCaller(admin)
+	ResolveMarket(cross(cur), id, OutcomeHome)
+
+	testing.SetRealm(testing.NewUserRealm(alice))
+	testing.SetOriginCaller(alice)
+	uassert.AbortsWithMessage(t, cur, "multiplication overflow", func() {
+		ClaimWinnings(cross(cur), id)
+	})
 }


### PR DESCRIPTION
Adds a parimutuel-style prediction market realm under examples/gno.land/r/demo/predictionmarket.

- Uses chain/banker (BankerTypeRealmSend) for escrow and payout
- Uses unsafe.OriginSend() to read the attached bet amount
- Admin creates markets and resolves outcomes; users bet ugnot on Home/Away/Draw and claim winnings proportional to the losing pool
- Tests cover market creation, resolution, double-resolve guard, and early-claim guard

Happy to iterate on naming, structure, or add more edge-case tests based on feedback.