### PR TITLE
feat(tm2): remove secp256k1 support for validators

### DIFF
--- a/examples/gno.land/r/gnops/valopers/pubkey_type_test.gno
+++ b/examples/gno.land/r/gnops/valopers/pubkey_type_test.gno
@@ -1,0 +1,41 @@
+package valopers
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+)
+
+const (
+	testEd25519PubKey   = "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr"
+	testSecp256k1PubKey = "gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj"
+)
+
+func TestPubKeyTypeURL(t *testing.T) {
+	got, err := pubKeyTypeURL(testEd25519PubKey)
+	uassert.NoError(t, err)
+	uassert.Equal(t, "/tm.PubKeyEd25519", got)
+
+	got, err = pubKeyTypeURL(testSecp256k1PubKey)
+	uassert.NoError(t, err)
+	uassert.Equal(t, "/tm.PubKeySecp256k1", got)
+
+	_, err = pubKeyTypeURL("not-a-valid-bech32-pubkey")
+	uassert.Error(t, err)
+}
+
+func TestAssertPubKeyTypeAllowed(t *testing.T) {
+	// Empty allow-list accepts any well-formed type.
+	testing.SetSysParamStrings("node", "valset", "pubkey_types", []string{})
+	uassert.NotPanics(t, cur, func() { assertPubKeyTypeAllowed(testSecp256k1PubKey) })
+
+	// ed25519-only allow-list: ed25519 accepted, secp256k1 rejected.
+	testing.SetSysParamStrings("node", "valset", "pubkey_types", []string{"/tm.PubKeyEd25519"})
+	uassert.NotPanics(t, cur, func() { assertPubKeyTypeAllowed(testEd25519PubKey) })
+	uassert.PanicsWithMessage(t, cur, ErrDisallowedPubKeyType.Error(), func() {
+		assertPubKeyTypeAllowed(testSecp256k1PubKey)
+	})
+
+	// Reset so the non-empty allow-list doesn't leak into other tests.
+	testing.SetSysParamStrings("node", "valset", "pubkey_types", []string{})
+}

--- a/examples/gno.land/r/gnops/valopers/valopers.gno
+++ b/examples/gno.land/r/gnops/valopers/valopers.gno
@@ -43,6 +43,7 @@ var (
 	ErrFrontrunValidator    = errors.New("post-genesis: signing address is already an active validator")
 	ErrRotationThrottled    = errors.New("rotation throttled: try again later")
 	ErrRegistryEntryMissing = errors.New("signing address has no active registry entry (corrupted state)")
+	ErrDisallowedPubKeyType = errors.New("consensus pubkey type is not allowed for validators")
 )
 
 var (
@@ -154,6 +155,9 @@ func Register(cur realm, moniker string, description string, serverType string, 
 	if isValoper(addr) {
 		panic(ErrValoperExists)
 	}
+
+	// Reject disallowed key types early (else the EndBlocker drops it silently).
+	assertPubKeyTypeAllowed(pubKey)
 
 	// Derive the consensus signing address from the pubkey.
 	signingAddr, err := chain.PubKeyAddress(pubKey)
@@ -323,6 +327,9 @@ func UpdateSigningKey(cur realm, addr address, newPubKey string) {
 			panic(ufmt.Sprintf("payment must not be less than %d%s", minFee.Amount, minFee.Denom))
 		}
 	}
+
+	// Reject disallowed key types early (else the EndBlocker drops it silently).
+	assertPubKeyTypeAllowed(newPubKey)
 
 	// Derive the new signing address from the new pubkey.
 	newSigningAddr, err := chain.PubKeyAddress(newPubKey)
@@ -526,6 +533,46 @@ func validatePubKey(pubKey string) error {
 	}
 
 	return nil
+}
+
+// assertPubKeyTypeAllowed panics if pubKey's type is not in the chain's validator allow-list (empty list accepts any).
+func assertPubKeyTypeAllowed(pubKey string) {
+	allowed := sysparams.GetValsetPubKeyTypes()
+	if len(allowed) == 0 {
+		return
+	}
+	typeURL, err := pubKeyTypeURL(pubKey)
+	if err != nil {
+		panic(err)
+	}
+	for _, a := range allowed {
+		if a == typeURL {
+			return
+		}
+	}
+	panic(ErrDisallowedPubKeyType)
+}
+
+// pubKeyTypeURL returns the amino type URL (e.g. "/tm.PubKeyEd25519") of a bech32 consensus pubkey.
+func pubKeyTypeURL(pubKey string) (string, error) {
+	// gpub exceeds bech32's 90-char cap, so decode without the limit.
+	_, data5, err := bech32.DecodeNoLimit(pubKey)
+	if err != nil {
+		return "", err
+	}
+	data, err := bech32.ConvertBits(data5, 5, 8, false)
+	if err != nil {
+		return "", err
+	}
+	// Type URL is the first amino field: 0x0A <len> <typeURL>.
+	if len(data) < 2 || data[0] != 0x0A {
+		return "", errors.New("malformed consensus pubkey: " + pubKey)
+	}
+	n := int(data[1])
+	if n == 0 || len(data) < 2+n {
+		return "", errors.New("malformed consensus pubkey: " + pubKey)
+	}
+	return string(data[2 : 2+n]), nil
 }
 
 // validateServerType checks if the server type is valid.

--- a/examples/gno.land/r/sys/params/valset.gno
+++ b/examples/gno.land/r/sys/params/valset.gno
@@ -33,6 +33,9 @@ const (
 	valsetProposedKey = "proposed"
 	valsetCurrentKey  = "current"
 
+	// pubkey_types: chain-mirrored validator pubkey-type allow-list (read-only here).
+	valsetPubKeyTypesKey = "pubkey_types"
+
 	// Only this realm may write valset:proposed and valset:dirty.
 	// valset:current is chain-managed (see ctx-sentinel in node_params.go).
 	valsetAuthorizedRealm = "gno.land/r/sys/validators/v3"
@@ -119,6 +122,12 @@ func parseEntry(entry string) (validators.Validator, error) {
 		PubKey:      pkStr,
 		VotingPower: power,
 	}, nil
+}
+
+// GetValsetPubKeyTypes returns the validator pubkey-type allow-list mirrored from consensus params (empty means accept any).
+func GetValsetPubKeyTypes() []string {
+	types, _ := prms.GetSysParamStrings(nodeModulePrefix, valsetSubmodule, valsetPubKeyTypesKey)
+	return types
 }
 
 func assertValsetCaller(_ int, rlm realm) {

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -388,6 +388,8 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 
 	ictx := ctx.WithValue(internalWriteCtxKey{}, true)
 	cfg.prmk.SetStrings(ictx, valsetCurrentPath, abci.EncodeValidatorUpdates(abci.ValidatorUpdates(req.Validators)))
+	// Mirror the allow-list into the params store for realms to read (genesis-immutable).
+	cfg.prmk.SetStrings(ictx, valsetPubKeyTypesPath, allowedKeyTypes)
 
 	// load app state. AppState may be nil mostly in some minimal testing setups;
 	// so log a warning when that happens.

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -359,13 +359,6 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 	// that any genesis-time realm reads of sysparams.GetValsetEffective /
 	// GetValsetEntries see the authoritative set instead of empty.
 	//
-	// Note on sentinel scope: internalWriteCtxKey is set on the LOCAL
-	// ictx variable, NOT on app.deliverState.ctx. baseapp.Deliver pulls
-	// a fresh ctx via getContextForTx (tm2/pkg/sdk/baseapp.go:606-611),
-	// so this sentinel does NOT propagate into genesis-tx execution —
-	// a malicious genesis tx cannot manufacture a sentinel-bearing ctx
-	// and write valset:current directly.
-	//
 	// Gate the initial validator set against the pubkey-type allow-list (like the
 	// EndBlocker does for runtime updates); panic to abort boot on a disallowed type.
 	var allowedKeyTypes []string
@@ -386,6 +379,12 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 		}
 	}
 
+	// Note on sentinel scope: internalWriteCtxKey is set on the LOCAL
+	// ictx variable, NOT on app.deliverState.ctx. baseapp.Deliver pulls
+	// a fresh ctx via getContextForTx (tm2/pkg/sdk/baseapp.go:606-611),
+	// so this sentinel does NOT propagate into genesis-tx execution —
+	// a malicious genesis tx cannot manufacture a sentinel-bearing ctx
+	// and write valset:current directly.
 	ictx := ctx.WithValue(internalWriteCtxKey{}, true)
 	cfg.prmk.SetStrings(ictx, valsetCurrentPath, abci.EncodeValidatorUpdates(abci.ValidatorUpdates(req.Validators)))
 	// Mirror the allow-list into the params store for realms to read (genesis-immutable).

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -365,6 +365,27 @@ func (cfg InitChainerConfig) InitChainer(ctx sdk.Context, req abci.RequestInitCh
 	// so this sentinel does NOT propagate into genesis-tx execution —
 	// a malicious genesis tx cannot manufacture a sentinel-bearing ctx
 	// and write valset:current directly.
+	//
+	// Gate the initial validator set against the pubkey-type allow-list (like the
+	// EndBlocker does for runtime updates); panic to abort boot on a disallowed type.
+	var allowedKeyTypes []string
+	if req.ConsensusParams != nil && req.ConsensusParams.Validator != nil {
+		allowedKeyTypes = req.ConsensusParams.Validator.PubKeyTypeURLs
+	}
+	if len(allowedKeyTypes) > 0 {
+		for _, v := range req.Validators {
+			if v.Power == 0 {
+				continue // non-voting entry, never enters the active set
+			}
+			if keyType := amino.GetTypeURL(v.PubKey); !slices.Contains(allowedKeyTypes, keyType) {
+				panic(fmt.Errorf(
+					"genesis validator %s has disallowed pubkey type %s (allowed: %v)",
+					v.Address.String(), keyType, allowedKeyTypes,
+				))
+			}
+		}
+	}
+
 	ictx := ctx.WithValue(internalWriteCtxKey{}, true)
 	cfg.prmk.SetStrings(ictx, valsetCurrentPath, abci.EncodeValidatorUpdates(abci.ValidatorUpdates(req.Validators)))
 

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -19,6 +19,7 @@ import (
 	bftCfg "github.com/gnolang/gno/tm2/pkg/bft/config"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/memdb"
 	"github.com/gnolang/gno/tm2/pkg/events"
@@ -181,6 +182,60 @@ func TestNewApp(t *testing.T) {
 		AppState:   DefaultGenState(),
 	})
 	assert.True(t, resp.IsOK(), "resp is not OK: %v", resp)
+}
+
+// TestInitChainer_GenesisValidatorPubKeyType verifies that the initial
+// validator set seeded from genesis is gated by the consensus-params pubkey
+// allow-list, mirroring the EndBlocker gate for runtime valset updates. A
+// genesis validator whose key type is not allowed (e.g. secp256k1, which is
+// disallowed for validators) must abort InitChain rather than seed a
+// non-compliant validator into the active set.
+func TestInitChainer_GenesisValidatorPubKeyType(t *testing.T) {
+	t.Parallel()
+
+	ed25519Type := amino.GetTypeURL(ed25519.PubKeyEd25519{})
+
+	newInitReq := func(pubKey crypto.PubKey) abci.RequestInitChain {
+		return abci.RequestInitChain{
+			ChainID: "dev",
+			ConsensusParams: &abci.ConsensusParams{
+				Block: defaultBlockParams(),
+				// ed25519 is the only allowed validator key type.
+				Validator: &abci.ValidatorParams{PubKeyTypeURLs: []string{ed25519Type}},
+			},
+			Validators: []abci.ValidatorUpdate{
+				{Address: pubKey.Address(), PubKey: pubKey, Power: 1},
+			},
+			AppState: DefaultGenState(),
+		}
+	}
+
+	t.Run("ed25519 genesis validator accepted", func(t *testing.T) {
+		t.Parallel()
+
+		app, err := NewApp(t.TempDir(), NewTestGenesisAppConfig(), config.DefaultAppConfig(), events.NewEventSwitch(), log.NewNoopLogger(), 0)
+		require.NoError(t, err)
+
+		resp := app.InitChain(newInitReq(ed25519.GenPrivKey().PubKey()))
+		assert.True(t, resp.IsOK(), "resp is not OK: %v", resp)
+	})
+
+	t.Run("secp256k1 genesis validator aborts boot", func(t *testing.T) {
+		t.Parallel()
+
+		app, err := NewApp(t.TempDir(), NewTestGenesisAppConfig(), config.DefaultAppConfig(), events.NewEventSwitch(), log.NewNoopLogger(), 0)
+		require.NoError(t, err)
+
+		// getDummyKey produces a secp256k1 key, which is not in the allow-list.
+		secpKey := getDummyKey(t).PubKey()
+		wantErr := fmt.Sprintf(
+			"genesis validator %s has disallowed pubkey type %s (allowed: %v)",
+			secpKey.Address().String(), amino.GetTypeURL(secpKey), []string{ed25519Type},
+		)
+		assert.PanicsWithError(t, wantErr, func() {
+			app.InitChain(newInitReq(secpKey))
+		})
+	})
 }
 
 // Test whether InitChainer calls to load the stdlibs correctly.

--- a/gno.land/pkg/gnoland/node_params.go
+++ b/gno.land/pkg/gnoland/node_params.go
@@ -31,6 +31,9 @@ const (
 	valsetProposedPath = "node:valset:proposed"
 	valsetCurrentPath  = "node:valset:current"
 
+	// pubkey_types: chain-managed mirror of the consensus-params validator allow-list, so realms can read it.
+	valsetPubKeyTypesPath = "node:valset:pubkey_types"
+
 	// maxValsetEntries caps len(valset:proposed) at WillSetParam time.
 	// v3 enforces 40 at proposal-creation; this is defense-in-depth at
 	// 2.5x to protect against future writers that bypass v3's cap.
@@ -103,6 +106,15 @@ func (nodeParamsKeeper) WillSetParam(ctx sdk.Context, key string, value any) {
 		}
 		if _, err := abci.ParseValidatorUpdates(entries); err != nil {
 			panic(fmt.Sprintf("invalid valset:current (chain-internal corruption): %v", err))
+		}
+	case "valset:pubkey_types":
+		// Chain-only mirror; reject user-routed writes (like valset:current).
+		v, _ := ctx.Value(internalWriteCtxKey{}).(bool)
+		if !v {
+			panic("valset:pubkey_types is chain-managed; not writable via params")
+		}
+		if _, ok := value.([]string); !ok {
+			panic(fmt.Sprintf("valset:pubkey_types must be []string, got %T", value))
 		}
 	default:
 		if strings.HasPrefix(key, "p:") {

--- a/gno.land/pkg/integration/testdata/params_valset_auth.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_auth.txtar
@@ -21,7 +21,7 @@ stderr 'unauthorized: only gno.land/r/sys/validators/v3 may write valset params'
 
 # Confirm the attacker's pubkey did NOT reach valset:current.
 gnokey query params/node:valset:current
-! stdout 'gpub1pgfj7ard'
+! stdout 'gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr'
 
 -- run/exploit.gno --
 package main
@@ -30,6 +30,6 @@ import sysparams "gno.land/r/sys/params"
 
 func main(cur realm) {
 	sysparams.SetValsetProposal(cross(cur), []string{
-		"gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj:1000000",
+		"gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr:1000000",
 	})
 }

--- a/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
@@ -44,7 +44,7 @@ gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 60
 stdout OK!
 
 # (a) test2 NOT on auth list yet: rotation must reject.
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test2
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test test2
 stderr 'caller is not in authorized list'
 
 # member grants test2 the authority to rotate.
@@ -52,7 +52,7 @@ gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func AddToAuthList -gas-f
 stdout OK!
 
 # (b) test2 NOW on auth list: rotation must succeed.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 20_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test test2
 stdout OK!
 
 # member revokes test2's authority.
@@ -60,7 +60,7 @@ gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func DeleteFromAuthList -
 stdout OK!
 
 # (c) test2 again attempts a rotation; must reject post-revoke.
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqv78qzekzh8ysj26zgda53kngk6x9329la0vjhwp75t4ytkymfhzz46a2dz -broadcast -chainid=tendermint_test test2
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqqpjjc4fkcmrkvvkgp56xfeee0t8cmy783qwkadnjsdvp0gsdgqal0uugj -broadcast -chainid=tendermint_test test2
 stderr 'caller is not in authorized list'
 
 -- run/disable_throttle.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_authlist_owner_only.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_authlist_owner_only.txtar
@@ -38,7 +38,7 @@ stderr 'caller is not superuser'
 
 # Attack 2: even without auth-list membership, attacker tries to call
 # UpdateSigningKey directly. Must reject — not in member's auth list.
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test attacker
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test attacker
 stderr 'caller is not in authorized list'
 
 # Attack 3: attacker tries DeleteFromAuthList — same owner check

--- a/gno.land/pkg/integration/testdata/params_valset_cross_realm_auth.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_cross_realm_auth.txtar
@@ -73,6 +73,6 @@ func AttackNotify(cur realm) {
 func AttackRotate(cur realm) {
 	const fakeOp = "g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0"
 	const oldPubKey = "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aadexfnpsmgjxu72xz9y30aqfrlpny"
-	const newPubKey = "gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj"
+	const newPubKey = "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr"
 	v3.RotateValoperSigningKey(cross(cur), address(fakeOp), oldPubKey, newPubKey)
 }

--- a/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
@@ -74,6 +74,6 @@ import (
 // as PreviousRealm — not member. The auth check must reject.
 func WrapRotate(cur realm) {
 	const memberAddr = "g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0"
-	const newPubKey = "gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj"
+	const newPubKey = "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr"
 	valopers.UpdateSigningKey(cross(cur), address(memberAddr), newPubKey)
 }

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
@@ -49,7 +49,7 @@ stdout 'gpub1'
 # first registers a valoper profile (operator = member, signing key
 # = the new pubkey) so v3's valoperCache has the entry the executor
 # will resolve at execution time.
-gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 68_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test member $WORK/proposer/create_proposal.gno
 stdout OK!
 
 # Sanity: proposal is in gov/dao at id 0. The proposal text shows

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
@@ -30,7 +30,7 @@ gnoland start
 
 # === PROPOSAL 0: ADD VALIDATOR AT POWER 1 ===
 
-gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 69_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
@@ -27,7 +27,7 @@ gnoland start
 
 # === PROPOSAL 0: ADD VALIDATOR ===
 
-gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 69_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member

--- a/gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar
@@ -53,7 +53,7 @@ stdout OK!
 
 # Step 3: rotate A from P to P'. This happens BEFORE the proposal X
 # is voted+executed. Throttle is 0 so this is unblocked.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Step 4: vote and execute proposal X. The v3 executor reads
@@ -65,7 +65,7 @@ stdout OK!
 
 # Post-execution invariant: valset:current must contain P' (NEW key).
 gnokey query params/node:valset:current
-stdout 'gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj'
+stdout 'gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr'
 
 # Critical: P (OLD/retired key) must NOT appear in valset:current. A
 # regression where the executor captured the create-time signing key

--- a/gno.land/pkg/integration/testdata/params_valset_rotation_throttle.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_rotation_throttle.txtar
@@ -45,7 +45,7 @@ gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 60
 stdout OK!
 
 # (a) Immediate rotation at height H+1: H+1 - H = 1 < 3, throttle fires.
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stderr 'rotation throttled'
 
 # Burn blocks deterministically: each `gnoland wait-for-new-block`
@@ -58,12 +58,12 @@ gnoland wait-for-new-block
 gnoland wait-for-new-block
 
 # (b) Rotation now succeeds: enough blocks have elapsed.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 20_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Defense-in-depth: a SECOND immediate rotation must fail again, since
 # LastRotationHeight has been advanced by step (b).
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqv78qzekzh8ysj26zgda53kngk6x9329la0vjhwp75t4ytkymfhzz46a2dz -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqqpjjc4fkcmrkvvkgp56xfeee0t8cmy783qwkadnjsdvp0gsdgqal0uugj -broadcast -chainid=tendermint_test member
 stderr 'rotation throttled'
 
 -- run/set_throttle.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_self_rotation_retired_reclaim.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_self_rotation_retired_reclaim.txtar
@@ -47,7 +47,7 @@ stdout OK!
 stderr 'signing address already in registry'
 
 # Real rotation: P -> P'. P is now retired.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 20_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # (b) Reclaim retired key: try to rotate back from P' to P (now retired).
@@ -58,13 +58,13 @@ stderr 'signing address already in registry'
 
 # (c) Self-rotation on the new active key P' must also reject (active
 # entry path of the same Has check).
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stderr 'signing address already in registry'
 
 # Sanity: a rotation to a fresh key P'' must succeed (proves the Has
 # check doesn't reject every rotation; it only rejects keys that
 # WERE registered).
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 19_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pqv78qzekzh8ysj26zgda53kngk6x9329la0vjhwp75t4ytkymfhzz46a2dz -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqqpjjc4fkcmrkvvkgp56xfeee0t8cmy783qwkadnjsdvp0gsdgqal0uugj -broadcast -chainid=tendermint_test member
 stdout OK!
 
 -- run/disable_throttle.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_signing_key_reuse.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_signing_key_reuse.txtar
@@ -54,7 +54,7 @@ stdout OK!
 
 # Step 3: member rotates A from P -> P'. Throttle is now 0 so this
 # succeeds even though height-LastRotationHeight is small.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 20_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -gas-fee 6000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Step 4: test2 attempts to register operator B with the retired pubKey P.
@@ -65,7 +65,7 @@ stderr 'signing address already in registry'
 
 # Defense-in-depth: same attempt with the new, currently-active key P'
 # must also fail (active entry path of the same registry check).
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args opB -args 'operator B profile' -args cloud -args $test2_user_addr -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -broadcast -chainid=tendermint_test test2
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args opB -args 'operator B profile' -args cloud -args $test2_user_addr -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -broadcast -chainid=tendermint_test test2
 stderr 'signing address already in registry'
 
 -- run/disable_throttle.gno --

--- a/gno.land/pkg/integration/testdata/valopers.txtar
+++ b/gno.land/pkg/integration/testdata/valopers.txtar
@@ -6,12 +6,17 @@ adduser regular1
 
 gnoland start
 
+# The chain mirrors the validator pubkey-type allow-list (ed25519-only by
+# default) from consensus params into the params store so realms can read it.
+gnokey query params/node:valset:pubkey_types
+stdout '/tm.PubKeyEd25519'
+
 # Add user as a member for govdao
 gnokey maketx run  -gas-fee 3400001ugnot -gas-wanted 42_000_000 -chainid=tendermint_test test1 $WORK/run/load_user.gno
 
 # add a valoper with a bad operator address (not the caller's). The
 # post-genesis squat guard rejects: OriginCaller (test1) != addr.
-! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args 1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -chainid=tendermint_test test1
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args 1ut590acnamvhkrh4qz6dz9zt9e3hyu499u0gvl -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -chainid=tendermint_test test1
 stderr 'caller must equal operator address'
 
 # add a valoper with a bad pubkey. The operator address (test1's own)
@@ -20,13 +25,18 @@ stderr 'caller must equal operator address'
 ! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 200000000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40zzz -chainid=tendermint_test test1
 stderr 'panic: invalid checksum'
 
-# add a valoper. The address arg is the test1 user's address (=
-# operator) and matches OriginCaller, so the squat guard passes.
-# The pubkey is the consensus signing key; chain.PubKeyAddress(pubKey)
-# derives g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 (= operator addr
-# in this test by coincidence). v3's executor resolves operator ->
-# signing-key via valoperCache at proposal-execute time.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 4000001ugnot -gas-wanted 40_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -chainid=tendermint_test test1
+# A secp256k1 signing key is rejected at registration: it is not in the
+# validator pubkey-type allow-list (ed25519-only), so Register fails fast
+# rather than letting the EndBlocker silently drop the eventual valset update.
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 5000000ugnot -gas-wanted 55_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pgfj7ard9eg82cjtv4u4xetrwqer2dntxyfzxz3pq0skzdkmzu0r9h6gny6eg8c9dc303xrrudee6z4he4y7cs5rnjwmyf40yaj -chainid=tendermint_test test1
+stderr 'consensus pubkey type is not allowed for validators'
+
+# add a valoper with a valid ed25519 signing key. The address arg is the
+# test1 user's address (= operator) and matches OriginCaller, so the squat
+# guard passes. chain.PubKeyAddress(pubKey) derives the signing address
+# g10ddhfxv47lhyhpj426u57ckxwl0qtrk6c9rs5v; v3's executor resolves operator
+# -> signing-key via valoperCache at proposal-execute time.
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 4000001ugnot -gas-wanted 55_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -chainid=tendermint_test test1
 stdout OK!
 
 # see the valoper in the Render

--- a/tm2/adr/pr5949_remove_secp256k1_validators.md
+++ b/tm2/adr/pr5949_remove_secp256k1_validators.md
@@ -54,6 +54,30 @@ The execution-layer check (`validateValidatorUpdates` →
 validator pubkey type absent from the params, so removing secp256k1 from the
 allow-list automatically causes secp256k1 validator updates to be rejected.
 
+### Gating the initial genesis validator set
+
+The params allow-list and the runtime `EndBlocker` gate together cover consensus-params
+validation and runtime valset *updates*, but the **initial** validator set is seeded
+into consensus state directly by the gno.land `InitChainer`
+(`gno.land/pkg/gnoland/app.go`) — it does not pass through `validateValidatorUpdates`.
+Nothing else re-checked those genesis validators against the allow-list, so a genesis
+doc with ed25519-only params could still seed a secp256k1 validator into the active set,
+leaving the "IBC-compatible by construction" guarantee incomplete.
+
+`InitChainer` now scans `req.Validators` against
+`req.ConsensusParams.Validator.PubKeyTypeURLs` before writing `valset:current`, using the
+same allow-list logic as the `EndBlocker` gate. A disallowed genesis validator is fatal:
+as with the existing valoper-coverage assertion, `ResponseInitChain.Error` is silently
+discarded by tm2, so the check **panics** to abort the handshake loudly rather than boot
+a non-compliant chain. When the allow-list is empty (no `Validator` params configured),
+the scan is skipped — matching the `EndBlocker` "accept all" fallback.
+
+This gate lives in the gno.land app layer, not in tm2's `GenesisDoc.Validate` /
+`ValidateAndComplete`, because tm2 genesis validation is deliberately key-type-agnostic
+(mock and secp256k1 keys are used pervasively in tm2/gnogenesis test fixtures for
+non-consensus purposes). The app layer is where the genesis set is actually consumed into
+consensus and where the sibling `EndBlocker` gate already lives.
+
 ## Alternatives considered
 
 **Leave secp256k1 in the allow-list, document that operators should not use it.**
@@ -70,6 +94,14 @@ Would reject secp256k1 validator updates at runtime but still let a genesis doc 
 `ValidateConsensusParams` with secp256k1 listed, leaving misleading params in state.
 Enforcing at the params allow-list is the single authoritative gate. Rejected.
 
+**Gate the initial validator set in tm2 `GenesisDoc.ValidateAndComplete`.**
+Would reject secp256k1 (and mock) genesis validators at the tm2 layer. Rejected: tm2
+genesis validation is intentionally key-type-agnostic — mock/secp256k1 validator keys
+are used across tm2 and gnogenesis test fixtures for non-consensus purposes, and a
+key-type policy there is both too broad and the wrong layer. The gate belongs where the
+genesis set is consumed into consensus (gno.land `InitChainer`), alongside the existing
+runtime `EndBlocker` gate.
+
 ## Key files
 
 | File | Role |
@@ -78,6 +110,9 @@ Enforcing at the params allow-list is the single authoritative gate. Rejected.
 | `tm2/pkg/bft/types/params_test.go` | Validation test asserting secp256k1 validator params are rejected |
 | `tm2/pkg/bft/state/execution.go` | `validateValidatorUpdates` — unchanged; honors the allow-list |
 | `tm2/pkg/bft/types/genesis.go` | Applies `DefaultConsensusParams()` when genesis omits params |
+| `gno.land/pkg/gnoland/app.go` | `InitChainer` — gates the initial genesis validator set against the allow-list (panics on a disallowed key type) |
+| `gno.land/pkg/gnoland/app_test.go` | `TestInitChainer_GenesisValidatorPubKeyType` — accepts ed25519, aborts on secp256k1 |
+| `gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar` | Rotation target switched from a secp256k1 to an ed25519 signing key (secp256k1 no longer publishable to the valset) |
 
 ## Consequences
 
@@ -87,6 +122,9 @@ Enforcing at the params allow-list is the single authoritative gate. Rejected.
   `Validator.PubKeyTypeURLs` now fails `ValidateConsensusParams`.
 - A `ValidatorUpdate` carrying a secp256k1 pubkey is rejected by
   `validateValidatorUpdates` (unsupported for consensus).
+- A genesis doc whose **initial** validator set contains a validator with a disallowed
+  (e.g. secp256k1) pubkey type now aborts `InitChain` (panic), so a chain cannot boot with
+  a non-compliant validator already in the active set.
 - **Backwards compatibility:** an existing chain whose consensus params already list
   secp256k1, or whose active validator set contains a secp256k1 key, is affected —
   its stored params would no longer re-validate and such a validator could not be

--- a/tm2/adr/pr5949_remove_secp256k1_validators.md
+++ b/tm2/adr/pr5949_remove_secp256k1_validators.md
@@ -16,14 +16,15 @@ secp256k1 validator could be added to the set.
 
 ### Why remove it
 
-**secp256k1 validators break IBC.** The IBC Tendermint light client verifies a
-counterparty chain's validator set and their commit signatures. Its consensus
-verification path is built around ed25519 validator keys: the light-client
-signature-verification and validator-set encoding used across the IBC ecosystem do
-not interoperate with secp256k1 consensus keys. A gno.land chain that admitted a
-secp256k1 validator would produce headers that an IBC light client cannot verify,
-making the chain unbridgeable and putting relayers at risk of accepting or rejecting
-headers inconsistently.
+**secp256k1 validators break the IBC GNO light client.** The IBC Tendermint light
+client verifies a counterparty chain's validator set and their commit signatures.
+IBC core does not in principle forbid secp256k1 consensus keys — ed25519 is the
+de-facto interoperable consensus key across the Tendermint/IBC ecosystem, but the
+concrete restriction is in **our Gno IBC light-client implementation**, whose
+signature-verification and validator-set encoding are built around ed25519. A
+gno.land chain that admitted a secp256k1 validator would produce headers that this
+light client cannot verify, making the chain unbridgeable and putting relayers at
+risk of accepting or rejecting headers inconsistently.
 
 Because the validator set is consensus-critical and its accepted key types are fixed
 by the consensus params, this must be enforced at the protocol layer rather than left
@@ -78,6 +79,35 @@ This gate lives in the gno.land app layer, not in tm2's `GenesisDoc.Validate` /
 non-consensus purposes). The app layer is where the genesis set is actually consumed into
 consensus and where the sibling `EndBlocker` gate already lives.
 
+### Rejecting disallowed validator keys at registration (valopers)
+
+The `EndBlocker` gate rejects a disallowed valset *update*, but it does so **silently**:
+`r/gnops/valopers`'s `Register` / `UpdateSigningKey` only validated that the signing key
+was well-formed bech32, not that its *type* is accepted for consensus. So an operator
+could register or rotate to a secp256k1 signing key, see the tx succeed, and only later
+have the `EndBlocker` drop the resulting valset update. Worst case: an operator rotates,
+sees success, swaps its `priv_validator_key.json` to the new key, and — because consensus
+never accepted the update — signs with a key the set doesn't expect and goes dark.
+
+To fail fast, `valopers` now rejects a signing key whose type is not in the allow-list at
+registration/rotation time. Because the allow-list lives in consensus params (which gno
+realms cannot read directly), the chain **mirrors** it into the params store:
+
+- `InitChainer` writes `ConsensusParams.Validator.PubKeyTypeURLs` to the chain-managed
+  `node:valset:pubkey_types` key (alongside `valset:current`). Consensus params are
+  immutable after genesis, so this write-once mirror never drifts.
+- `r/sys/params.GetValsetPubKeyTypes()` exposes the mirror to realms (a thin param read;
+  it deliberately adds **no** new imports to that widely-imported realm).
+- `valopers` reads the allow-list and classifies the bech32 signing key locally (it
+  already imports `crypto/bech32`): the amino type URL is carried verbatim as the first
+  field of the encoded key, so it is recoverable without an amino decoder. An empty
+  allow-list means "accept all", matching the `EndBlocker` fallback.
+
+**Cost.** Decoding the ~103-char `gpub` in the interpreted GnoVM adds ~4–7M gas per
+`Register` / `UpdateSigningKey`; affected txtar fixtures had their `-gas-wanted` raised
+accordingly. This was preferred over adding a native `chain` primitive (which would be
+gas-cheap but requires regenerating stdlib bindings) to keep the change confined to gno.
+
 ## Alternatives considered
 
 **Leave secp256k1 in the allow-list, document that operators should not use it.**
@@ -102,6 +132,14 @@ key-type policy there is both too broad and the wrong layer. The gate belongs wh
 genesis set is consumed into consensus (gno.land `InitChainer`), alongside the existing
 runtime `EndBlocker` gate.
 
+**Expose the allow-list to realms via a native `chain` primitive.**
+A `chain.ValidatorPubKeyTypes()` (and a native pubkey-type classifier) would let
+`valopers` validate keys gas-cheaply. Rejected here to avoid adding public `chain` stdlib
+surface and regenerating native bindings (`go generate`). Instead the allow-list is
+mirrored into the params store and the realm classifies the key in pure gno. The tradeoff
+is gas: the in-gno bech32 decode costs ~4–7M gas per valoper key op. A native primitive
+remains a reasonable future optimization if that cost matters.
+
 ## Key files
 
 | File | Role |
@@ -110,9 +148,12 @@ runtime `EndBlocker` gate.
 | `tm2/pkg/bft/types/params_test.go` | Validation test asserting secp256k1 validator params are rejected |
 | `tm2/pkg/bft/state/execution.go` | `validateValidatorUpdates` — unchanged; honors the allow-list |
 | `tm2/pkg/bft/types/genesis.go` | Applies `DefaultConsensusParams()` when genesis omits params |
-| `gno.land/pkg/gnoland/app.go` | `InitChainer` — gates the initial genesis validator set against the allow-list (panics on a disallowed key type) |
+| `gno.land/pkg/gnoland/app.go` | `InitChainer` — gates the initial genesis validator set against the allow-list (panics on a disallowed key type); mirrors the allow-list to `node:valset:pubkey_types` |
+| `gno.land/pkg/gnoland/node_params.go` | `valsetPubKeyTypesPath` const + chain-only `WillSetParam` gate for the mirror |
 | `gno.land/pkg/gnoland/app_test.go` | `TestInitChainer_GenesisValidatorPubKeyType` — accepts ed25519, aborts on secp256k1 |
-| `gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar` | Rotation target switched from a secp256k1 to an ed25519 signing key (secp256k1 no longer publishable to the valset) |
+| `examples/gno.land/r/sys/params/valset.gno` | `GetValsetPubKeyTypes()` — exposes the mirrored allow-list to realms |
+| `examples/gno.land/r/gnops/valopers/valopers.gno` | `Register`/`UpdateSigningKey` reject a signing key whose type is not allowed |
+| `gno.land/pkg/integration/testdata/*.txtar` | secp256k1 *validator* signing keys swapped to ed25519; `valopers.txtar` asserts secp256k1 registration is rejected and queries the mirror; affected fixtures' `-gas-wanted` raised for the added check |
 
 ## Consequences
 
@@ -125,6 +166,10 @@ runtime `EndBlocker` gate.
 - A genesis doc whose **initial** validator set contains a validator with a disallowed
   (e.g. secp256k1) pubkey type now aborts `InitChain` (panic), so a chain cannot boot with
   a non-compliant validator already in the active set.
+- `r/gnops/valopers.Register` / `UpdateSigningKey` reject a secp256k1 (or otherwise
+  disallowed) signing key at tx time with a clear error, instead of succeeding and having
+  the `EndBlocker` silently drop the eventual valset update. This adds ~4–7M gas to those
+  calls (in-gno bech32 decode of the signing key).
 - **Backwards compatibility:** an existing chain whose consensus params already list
   secp256k1, or whose active validator set contains a secp256k1 key, is affected —
   its stored params would no longer re-validate and such a validator could not be

--- a/tm2/adr/pr5949_remove_secp256k1_validators.md
+++ b/tm2/adr/pr5949_remove_secp256k1_validators.md
@@ -1,0 +1,96 @@
+# PR5949: Remove secp256k1 Support for Validators
+
+## Context
+
+Consensus params carry a `Validator.PubKeyTypeURLs` allow-list that gates which
+public-key types a validator may use. Historically the chain accepted two types:
+
+- `ed25519.PubKeyEd25519`
+- `secp256k1.PubKeySecp256k1`
+
+Both `DefaultValidatorParams()` and the `validatorPubKeyTypeURLs` validation set in
+`tm2/pkg/bft/types/params.go` listed secp256k1, and `ValidateConsensusParams`
+accepted it. At the execution layer, `validateValidatorUpdates` (in
+`tm2/pkg/bft/state/execution.go`) also honored whatever the params allowed, so a
+secp256k1 validator could be added to the set.
+
+### Why remove it
+
+**secp256k1 validators break IBC.** The IBC Tendermint light client verifies a
+counterparty chain's validator set and their commit signatures. Its consensus
+verification path is built around ed25519 validator keys: the light-client
+signature-verification and validator-set encoding used across the IBC ecosystem do
+not interoperate with secp256k1 consensus keys. A gno.land chain that admitted a
+secp256k1 validator would produce headers that an IBC light client cannot verify,
+making the chain unbridgeable and putting relayers at risk of accepting or rejecting
+headers inconsistently.
+
+Because the validator set is consensus-critical and its accepted key types are fixed
+by the consensus params, this must be enforced at the protocol layer rather than left
+to operator convention.
+
+Note this is scoped strictly to **validators**. secp256k1 remains a fully supported
+key type for user accounts and transaction signing (`std`, `crypto/keys`, ledger,
+`SignGenesisTxs`, session accounts); only its use as a consensus/validator key is
+removed.
+
+## Decision
+
+Drop secp256k1 from the validator key-type allow-list and from the defaults, leaving
+ed25519 as the only accepted validator key type.
+
+In `tm2/pkg/bft/types/params.go`:
+
+- `validatorPubKeyTypeURLs` — the set consulted by `ValidateConsensusParams` — now
+  contains only `ed25519.PubKeyEd25519`. A consensus-params / genesis doc that lists
+  secp256k1 for validators is now rejected at validation time.
+- `DefaultValidatorParams()` returns ed25519-only. New genesis docs that do not
+  specify validator params default to ed25519 (via
+  `DefaultConsensusParams().Update(...)` in `genesis.go`).
+- The now-unused secp256k1 import is removed.
+
+The execution-layer check (`validateValidatorUpdates` →
+`ValidatorParams.IsValidPubKeyTypeURL`) needs no change: it already rejects any
+validator pubkey type absent from the params, so removing secp256k1 from the
+allow-list automatically causes secp256k1 validator updates to be rejected.
+
+## Alternatives considered
+
+**Leave secp256k1 in the allow-list, document that operators should not use it.**
+Relies on convention for a consensus-critical, bridge-breaking property. A single
+misconfigured genesis or validator update would silently make the chain
+unbridgeable. Rejected.
+
+**Remove the secp256k1 package entirely.**
+Out of scope and incorrect: secp256k1 is a legitimate account/transaction key type
+and is still used for user keys, ledger, and genesis-tx signing. Rejected.
+
+**Enforce ed25519-only only at the execution layer.**
+Would reject secp256k1 validator updates at runtime but still let a genesis doc pass
+`ValidateConsensusParams` with secp256k1 listed, leaving misleading params in state.
+Enforcing at the params allow-list is the single authoritative gate. Rejected.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `tm2/pkg/bft/types/params.go` | `validatorPubKeyTypeURLs` set, `DefaultValidatorParams`, `ValidateConsensusParams` |
+| `tm2/pkg/bft/types/params_test.go` | Validation test asserting secp256k1 validator params are rejected |
+| `tm2/pkg/bft/state/execution.go` | `validateValidatorUpdates` — unchanged; honors the allow-list |
+| `tm2/pkg/bft/types/genesis.go` | Applies `DefaultConsensusParams()` when genesis omits params |
+
+## Consequences
+
+- New chains default to ed25519-only validators and are IBC-compatible by
+  construction.
+- A genesis doc or consensus-params update that lists `/tm.PubKeySecp256k1` under
+  `Validator.PubKeyTypeURLs` now fails `ValidateConsensusParams`.
+- A `ValidatorUpdate` carrying a secp256k1 pubkey is rejected by
+  `validateValidatorUpdates` (unsupported for consensus).
+- **Backwards compatibility:** an existing chain whose consensus params already list
+  secp256k1, or whose active validator set contains a secp256k1 key, is affected —
+  its stored params would no longer re-validate and such a validator could not be
+  re-added. In practice gno.land validators are ed25519 (the priv-validator keygen
+  path uses ed25519), so no live gno.land validator is impacted. Any chain relying on
+  secp256k1 validators must migrate those validators to ed25519.
+- secp256k1 remains unaffected for accounts, transaction signing, and keys.

--- a/tm2/pkg/bft/types/params.go
+++ b/tm2/pkg/bft/types/params.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
-	"github.com/gnolang/gno/tm2/pkg/crypto/secp256k1"
 	"github.com/gnolang/gno/tm2/pkg/errors"
 )
 
@@ -32,8 +31,7 @@ const (
 )
 
 var validatorPubKeyTypeURLs = map[string]struct{}{
-	amino.GetTypeURL(ed25519.PubKeyEd25519{}):     {},
-	amino.GetTypeURL(secp256k1.PubKeySecp256k1{}): {},
+	amino.GetTypeURL(ed25519.PubKeyEd25519{}): {},
 }
 
 func DefaultConsensusParams() abci.ConsensusParams {
@@ -55,7 +53,6 @@ func DefaultBlockParams() *abci.BlockParams {
 func DefaultValidatorParams() *abci.ValidatorParams {
 	return &abci.ValidatorParams{PubKeyTypeURLs: []string{
 		amino.GetTypeURL(ed25519.PubKeyEd25519{}),
-		amino.GetTypeURL(secp256k1.PubKeySecp256k1{}),
 	}}
 }
 

--- a/tm2/pkg/bft/types/params_test.go
+++ b/tm2/pkg/bft/types/params_test.go
@@ -36,6 +36,8 @@ func TestConsensusParamsValidation(t *testing.T) {
 		9: {makeParams(1, 1024, 0, 10, []string{}), false},
 		// test invalid pubkey type provided
 		10: {makeParams(1, 1024, 0, 10, []string{"potatoes make good pubkeys"}), false},
+		// secp256k1 is not supported for validators
+		11: {makeParams(1, 1024, 0, 10, valSecp256k1), false},
 	}
 	for i, tc := range testCases {
 		if tc.valid {


### PR DESCRIPTION
## Motivation

**secp256k1 validators break the IBC GNO light client.** The IBC Tendermint light client verifies a counterparty chain's validator set and their commit signatures. IBC core does not in principle forbid secp256k1 consensus keys — ed25519 is the de-facto interoperable consensus key across the Tendermint/IBC ecosystem, but the concrete restriction is in **our Gno IBC light-client implementation**, whose signature-verification and validator-set encoding are built around ed25519. A gno.land chain that admitted a secp256k1 validator would produce headers this light client cannot verify, making the chain unbridgeable.

Since the accepted validator key types are fixed by the consensus params, this is enforced at the protocol layer rather than left to operator convention.

## Changes

### 1. Remove secp256k1 from the validator allow-list

- **`tm2/pkg/bft/types/params.go`** — remove `secp256k1.PubKeySecp256k1` from the `validatorPubKeyTypeURLs` allow-list (consulted by `ValidateConsensusParams`) and from `DefaultValidatorParams()`, leaving ed25519 as the only accepted validator key type. Drop the now-unused import.
- **`tm2/pkg/bft/types/params_test.go`** — add a validation case asserting secp256k1 validator params are rejected.

The execution-layer check (`validateValidatorUpdates` → `IsValidPubKeyTypeURL`) needs no change: it already rejects any validator pubkey type absent from the params, so removing secp256k1 automatically rejects secp256k1 validator **updates**.

### 2. Gate the initial genesis validator set

The params allow-list and the `EndBlocker` gate cover params validation and runtime valset *updates*, but the **initial** validator set is seeded into consensus by the gno.land `InitChainer` without passing through that path — so an unchecked genesis could still seed a disallowed key type into the active set.

- **`gno.land/pkg/gnoland/app.go`** — `InitChainer` scans `req.Validators` against the consensus-params allow-list before writing `valset:current`, mirroring the `EndBlocker` gate. A disallowed genesis validator is fatal: it **panics** to abort the handshake (tm2 silently discards `ResponseInitChain.Error`, matching the existing valoper-coverage abort). Empty allow-list → skipped.
- **`gno.land/pkg/gnoland/app_test.go`** — `TestInitChainer_GenesisValidatorPubKeyType`: ed25519 genesis validator boots OK; secp256k1 aborts boot.

This gate lives in the gno.land app layer, **not** tm2's `GenesisDoc.Validate`/`ValidateAndComplete`, because tm2 genesis validation is deliberately key-type-agnostic (mock/secp256k1 keys are used pervasively in tm2/gnogenesis fixtures for non-consensus purposes).

### 3. Reject disallowed validator keys at registration (valopers) — addresses review

`r/gnops/valopers.Register`/`UpdateSigningKey` previously validated only that the signing key was well-formed bech32, not that its *type* is accepted for consensus. So an operator could register/rotate to a secp256k1 key, see the tx succeed, and only later have the `EndBlocker` silently drop the resulting valset update. Worst case: an operator rotates, sees success, swaps its `priv_validator_key.json` to the new key, and — because consensus never accepted the update — signs with a key the set doesn't expect and **goes dark**.

They now reject a disallowed key type at tx time with a clear error. Because the allow-list lives in consensus params (which gno realms cannot read), the chain **mirrors** it into the params store:

- **`gno.land/pkg/gnoland/app.go` / `node_params.go`** — `InitChainer` writes `ConsensusParams.Validator.PubKeyTypeURLs` to the chain-managed `node:valset:pubkey_types` key. Consensus params are genesis-immutable, so this write-once mirror never drifts.
- **`examples/gno.land/r/sys/params/valset.gno`** — `GetValsetPubKeyTypes()` exposes the mirror to realms (a thin param read that deliberately adds **no** new imports to that widely-imported core realm — an earlier version that imported `crypto/bech32` here shifted gas/balances across unrelated tests).
- **`examples/gno.land/r/gnops/valopers/valopers.gno`** — reads the allow-list and classifies the bech32 signing key locally (it already imports `crypto/bech32`). The amino type URL is carried verbatim as the first field of the encoded key (`0x0A <len> <typeURL>`), so it is recoverable in pure gno without an amino decoder. An empty allow-list means "accept all", matching the `EndBlocker` fallback.

**Gas cost.** Decoding the ~103-char `gpub` in the interpreted GnoVM adds ~4–7M gas per `Register`/`UpdateSigningKey`; affected txtar fixtures had their `-gas-wanted` raised. This was preferred over a native `chain` primitive (gas-cheap but requires regenerating stdlib bindings) to keep the change confined to gno. A native primitive remains a reasonable future optimization.

**Tests** — `pubkey_type_test.gno` unit-tests the parser (ed25519/secp256k1/malformed) and the accept/reject path (seeding the allow-list via `testing.SetSysParamStrings`); `valopers.txtar` asserts secp256k1 registration is rejected and queries the mirror.

### 4. Test fixture updates

- **`params_valset_rotation_during_pending_proposal.txtar`** — the rotation target was a secp256k1 key asserted to publish to `valset:current`; no longer possible, so it is now ed25519 (the test's intent — live-resolve of a rotation at execute time — is preserved).
- Across the valset fixtures, secp256k1 **validator signing** keys are swapped to ed25519. secp256k1 **account** keys (e.g. `gnokey add bech32` in `gnokey_multisig.txtar`) are untouched — secp256k1 remains fully valid for accounts.

### 5. Docs

- **`tm2/adr/pr5949_remove_secp256k1_validators.md`** — ADR covering motivation, the three enforcement points (params allow-list, `InitChainer`, valopers), alternatives (incl. why not the tm2 genesis layer and why not a native primitive), and the gas tradeoff.

## Scope

Strictly **validators**. secp256k1 remains fully supported for user accounts and transaction signing (`std`, `crypto/keys`, ledger, `SignGenesisTxs`, session accounts).

## Backwards compatibility

An existing chain whose consensus params list secp256k1, or whose active/genesis validator set contains a secp256k1 key, is affected — such params no longer re-validate, such a validator cannot be re-added, a genesis with one aborts `InitChain`, and valopers rejects one at registration. gno.land validators are ed25519 (the priv-validator keygen path uses ed25519), so no live gno.land validator is impacted. Chains relying on secp256k1 validators must migrate them to ed25519.

## Verification

- `go build ./tm2/... ./gno.land/...`
- `go test ./tm2/pkg/bft/types/ ./tm2/pkg/bft/state/`
- `go test ./gno.land/pkg/gnoland/`
- `go test ./gno.land/pkg/integration/ -run TestTestdata` (full suite)
- `gno test` on `r/sys/params` and `r/gnops/valopers`
- `go test ./internal/validator/ ./internal/verify/` in `contribs/gnogenesis`

<sub>AI-assisted (Claude Code); reviewed by the author.</sub>
