### PR TITLE
feat(examples): add N-of-M multisig treasury demo realm

### DIFF
--- a/examples/gno.land/r/demo/multisig/gnomod.toml
+++ b/examples/gno.land/r/demo/multisig/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/multisig"
+gno = "0.9"

--- a/examples/gno.land/r/demo/multisig/multisig.gno
+++ b/examples/gno.land/r/demo/multisig/multisig.gno
@@ -1,0 +1,274 @@
+package multisig
+
+import (
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/avl/v0"
+
+	"chain"
+	"chain/banker"
+	"chain/runtime/unsafe"
+)
+
+// ownPkgPath is this realm's own path, used to derive its address
+// deterministically. unsafe.CurrentRealm() was tried here originally,
+// but it stack-walks to whichever realm is asking -- a realm that
+// composes with this one would get its own address back instead of
+// the treasury's. chain.PackageAddress on a hardcoded, known-own path
+// has no such ambiguity.
+const ownPkgPath = "gno.land/r/demo/multisig"
+
+type Proposal struct {
+	id          int
+	description string
+	to          address
+	amount      int64
+	executed    bool
+	approvals   avl.Tree
+}
+
+func (p *Proposal) ID() int             { return p.id }
+func (p *Proposal) Description() string { return p.description }
+func (p *Proposal) To() address         { return p.to }
+func (p *Proposal) Amount() int64       { return p.amount }
+func (p *Proposal) Executed() bool      { return p.executed }
+func (p *Proposal) ApprovalCount() int  { return p.approvals.Size() }
+
+var (
+	owners      avl.Tree
+	ownerCount  int
+	threshold   int
+	initialized bool
+	deployer    address
+	proposals   avl.Tree
+	nextID      int
+)
+
+func init() {
+	deployer = unsafe.OriginCaller()
+	nextID = 1
+}
+
+// Setup is a one-shot initializer -- init() cannot take parameters, so
+// this fills that role instead, guarded by initialized and restricted
+// to the deployer. The three owners must be pairwise distinct: without
+// that check, Setup(A, A, B, 2) would silently leave two owners behind
+// one slot in the tree while ownerCount and the threshold bound still
+// assumed three, making some or all thresholds unreachable forever
+// (initialized can't be run twice to fix it).
+func Setup(cur realm, owner1 address, owner2 address, owner3 address, thresh int) {
+	caller := cur.Previous().Address()
+	if caller != deployer {
+		panic("only deployer can run setup")
+	}
+	if initialized {
+		panic("already initialized")
+	}
+	if owner1 == owner2 || owner1 == owner3 || owner2 == owner3 {
+		panic("owners must be distinct")
+	}
+	if thresh < 1 || thresh > 3 {
+		panic("invalid threshold")
+	}
+	owners.Set(owner1.String(), true)
+	owners.Set(owner2.String(), true)
+	owners.Set(owner3.String(), true)
+	ownerCount = 3
+	threshold = thresh
+	initialized = true
+}
+
+func assertOwner(caller address) {
+	if !initialized {
+		panic("multisig not initialized")
+	}
+	if owners.Get(caller.String()) == nil {
+		panic("caller is not an owner")
+	}
+}
+
+// Propose opens a new payout proposal. amount must be positive --
+// without this check a zero or negative amount would only be caught
+// by the bank keeper inside Execute, after owners had already spent
+// gas approving something that could never settle, with no way to
+// remove it from the tree afterward.
+func Propose(cur realm, description string, to address, amount int64) int {
+	caller := cur.Previous().Address()
+	assertOwner(caller)
+	if amount <= 0 {
+		panic("amount must be positive")
+	}
+
+	id := nextID
+	nextID++
+	p := &Proposal{
+		id:          id,
+		description: description,
+		to:          to,
+		amount:      amount,
+	}
+	proposals.Set(proposalKey(id), p)
+	chain.Emit("ProposalCreated", "id", strconv.Itoa(id), "to", to.String(), "amount", strconv.FormatInt(amount, 10))
+	return id
+}
+
+func Approve(cur realm, proposalID int) {
+	caller := cur.Previous().Address()
+	assertOwner(caller)
+
+	raw := proposals.Get(proposalKey(proposalID))
+	if raw == nil {
+		panic("proposal does not exist")
+	}
+	p := raw.(*Proposal)
+	if p.executed {
+		panic("proposal already executed")
+	}
+	if p.approvals.Get(caller.String()) != nil {
+		panic("already approved")
+	}
+	p.approvals.Set(caller.String(), true)
+}
+
+// Revoke lets an owner withdraw their own approval from a
+// not-yet-executed proposal. Combined with Cancel, this is how an
+// owner set can back out of a proposal that turns out to be a mistake
+// -- without it, an approval given while the treasury was empty (or
+// before an owner changed their mind) sits there and fires the moment
+// someone funds the address, with no way to stop it.
+func Revoke(cur realm, proposalID int) {
+	caller := cur.Previous().Address()
+	assertOwner(caller)
+
+	raw := proposals.Get(proposalKey(proposalID))
+	if raw == nil {
+		panic("proposal does not exist")
+	}
+	p := raw.(*Proposal)
+	if p.executed {
+		panic("proposal already executed")
+	}
+	_, removed := p.approvals.Remove(caller.String())
+	if !removed {
+		panic("caller has not approved this proposal")
+	}
+}
+
+// Cancel removes an unexecuted proposal entirely. Any owner can cancel
+// -- the owner set collectively controls the treasury, so any one of
+// them should be able to pull a proposal that should never execute,
+// the same way any of them can approve one.
+func Cancel(cur realm, proposalID int) {
+	caller := cur.Previous().Address()
+	assertOwner(caller)
+
+	raw := proposals.Get(proposalKey(proposalID))
+	if raw == nil {
+		panic("proposal does not exist")
+	}
+	p := raw.(*Proposal)
+	if p.executed {
+		panic("proposal already executed")
+	}
+	proposals.Remove(proposalKey(proposalID))
+}
+
+func Execute(cur realm, proposalID int) {
+	raw := proposals.Get(proposalKey(proposalID))
+	if raw == nil {
+		panic("proposal does not exist")
+	}
+	p := raw.(*Proposal)
+	if p.executed {
+		panic("proposal already executed")
+	}
+	if p.approvals.Size() < threshold {
+		panic("not enough approvals")
+	}
+	p.executed = true
+
+	bkr := banker.NewBanker(banker.BankerTypeRealmSend, cur)
+	bkr.SendCoins(cur.Address(), p.to, chain.Coins{{Denom: "ugnot", Amount: p.amount}})
+	chain.Emit("ProposalExecuted", "id", strconv.Itoa(proposalID), "to", p.to.String(), "amount", strconv.FormatInt(p.amount, 10))
+}
+
+func TreasuryAddress() address {
+	return chain.PackageAddress(ownPkgPath)
+}
+
+// proposalKey zero-pads the id so proposals.Iterate (which walks keys
+// as strings) lists proposals in numeric order instead of lexical
+// order (which would otherwise put proposal 10 before proposal 2).
+func proposalKey(id int) string {
+	s := strconv.Itoa(id)
+	for len(s) < 10 {
+		s = "0" + s
+	}
+	return s
+}
+
+// Render shows every proposal, or a single proposal's detail when
+// called with ?id=<proposalID>.
+func Render(path string) string {
+	if id, ok := parseIDQuery(path); ok {
+		return renderProposal(id)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Multisig Treasury\n\n")
+	sb.WriteString("Initialized: " + strconv.FormatBool(initialized) + "\n")
+	if initialized {
+		sb.WriteString("Owners: " + strconv.Itoa(ownerCount) + " | Threshold: " + strconv.Itoa(threshold) + "\n")
+	}
+	sb.WriteString("\n")
+	proposals.Iterate("", "", func(key string, value interface{}) bool {
+		p := value.(*Proposal)
+		sb.WriteString(proposalSummaryLine(p))
+		return false
+	})
+	return sb.String()
+}
+
+func renderProposal(id int) string {
+	raw := proposals.Get(proposalKey(id))
+	if raw == nil {
+		return "Proposal not found.\n"
+	}
+	p := raw.(*Proposal)
+
+	var sb strings.Builder
+	sb.WriteString("# Proposal #" + strconv.Itoa(p.id) + "\n\n")
+	sb.WriteString(p.description + "\n\n")
+	sb.WriteString(proposalSummaryLine(p))
+	return sb.String()
+}
+
+func proposalSummaryLine(p *Proposal) string {
+	status := "pending"
+	if p.executed {
+		status = "executed"
+	}
+	return "Proposal #" + strconv.Itoa(p.id) + ": " + p.description +
+		" | to: " + p.to.String() +
+		" | amount: " + strconv.FormatInt(p.amount, 10) +
+		" | approvals: " + strconv.Itoa(p.approvals.Size()) + "/" + strconv.Itoa(threshold) +
+		" [" + status + "]\n"
+}
+
+func parseIDQuery(path string) (int, bool) {
+	const prefix = "?id="
+	idx := strings.Index(path, prefix)
+	if idx == -1 {
+		return 0, false
+	}
+	rest := path[idx+len(prefix):]
+	if amp := strings.Index(rest, "&"); amp != -1 {
+		rest = rest[:amp]
+	}
+	id, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}

--- a/examples/gno.land/r/demo/multisig/multisig_test.gno
+++ b/examples/gno.land/r/demo/multisig/multisig_test.gno
@@ -1,0 +1,158 @@
+package multisig
+
+import (
+	"testing"
+
+	"chain"
+
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/testutils/v0"
+)
+
+func resetForTest(owner1, owner2, owner3 address, thresh int) {
+	owners = avl.Tree{}
+	proposals = avl.Tree{}
+	nextID = 1
+	owners.Set(owner1.String(), true)
+	owners.Set(owner2.String(), true)
+	owners.Set(owner3.String(), true)
+	ownerCount = 3
+	threshold = thresh
+	initialized = true
+}
+
+func expectPanic(t *testing.T, expected string, f func()) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic %q, got none", expected)
+			return
+		}
+		msg, ok := r.(string)
+		if !ok || msg != expected {
+			t.Fatalf("expected panic %q, got %v", expected, r)
+		}
+	}()
+	f()
+}
+
+func TestSetupTwiceFails(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	owner2 := testutils.TestAddress("setup-owner2")
+	owner3 := testutils.TestAddress("setup-owner3")
+	resetForTest(owner1, owner2, owner3, 2)
+
+	expectPanic(t, "already initialized", func() {
+		Setup(cur, owner1, owner2, owner3, 2)
+	})
+}
+
+func TestSetupRejectsDuplicateOwners(cur realm, t *testing.T) {
+	initialized = false
+	owner1 := cur.Previous().Address()
+	expectPanic(t, "owners must be distinct", func() {
+		Setup(cur, owner1, owner1, testutils.TestAddress("dup-owner3"), 2)
+	})
+}
+
+func TestProposeRejectsNonPositiveAmount(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("propose-owner2"), testutils.TestAddress("propose-owner3"), 2)
+
+	expectPanic(t, "amount must be positive", func() {
+		Propose(cur, "bad amount", testutils.TestAddress("propose-target"), 0)
+	})
+}
+
+func TestExecuteWithoutApprovalsFails(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("noappr-owner2"), testutils.TestAddress("noappr-owner3"), 2)
+	id := Propose(cur, "underapproved", testutils.TestAddress("noappr-target"), 500)
+
+	expectPanic(t, "not enough approvals", func() {
+		Execute(cur, id)
+	})
+}
+
+func TestApproveThenRevokeDropsCount(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("revoke-owner2"), testutils.TestAddress("revoke-owner3"), 2)
+	id := Propose(cur, "revoke test", testutils.TestAddress("revoke-target"), 250)
+
+	Approve(cur, id)
+	raw := proposals.Get(proposalKey(id))
+	p := raw.(*Proposal)
+	if p.ApprovalCount() != 1 {
+		t.Fatalf("expected 1 approval, got %d", p.ApprovalCount())
+	}
+
+	Revoke(cur, id)
+	if p.ApprovalCount() != 0 {
+		t.Fatalf("expected 0 approvals after revoke, got %d", p.ApprovalCount())
+	}
+}
+
+func TestDoubleApproveFails(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("double-owner2"), testutils.TestAddress("double-owner3"), 2)
+	id := Propose(cur, "double approve test", testutils.TestAddress("double-target"), 250)
+	Approve(cur, id)
+
+	expectPanic(t, "already approved", func() {
+		Approve(cur, id)
+	})
+}
+
+func TestCancelRemovesProposal(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("cancel-owner2"), testutils.TestAddress("cancel-owner3"), 2)
+	id := Propose(cur, "to be cancelled", testutils.TestAddress("cancel-target"), 300)
+
+	Cancel(cur, id)
+	raw := proposals.Get(proposalKey(id))
+	if raw != nil {
+		t.Fatal("expected proposal to be removed after cancel")
+	}
+}
+
+func TestApproveNonExistentProposalFails(cur realm, t *testing.T) {
+	owner1 := cur.Previous().Address()
+	resetForTest(owner1, testutils.TestAddress("missing-owner2"), testutils.TestAddress("missing-owner3"), 2)
+
+	expectPanic(t, "proposal does not exist", func() {
+		Approve(cur, 9999)
+	})
+}
+
+// This test switches identities via testing.SetRealm (owner1 -> owner2
+// -> owner3) to exercise a threshold reached by genuinely distinct
+// approvers. cur's own Previous chain is fixed at test entry, so once
+// the realm context has been swapped underneath it, calling through
+// with bare cur breaks -- cross(cur) re-derives the crossing frame
+// against the realm active at call time instead of the one captured
+// at the top of the test.
+func TestExecuteWithDistinctApprovalsMovesCoins(cur realm, t *testing.T) {
+	owner1 := testutils.TestAddress("exec-owner1")
+	owner2 := testutils.TestAddress("exec-owner2")
+	owner3 := testutils.TestAddress("exec-owner3")
+	resetForTest(owner1, owner2, owner3, 2)
+
+	testing.SetRealm(testing.NewUserRealm(owner1))
+	id := Propose(cross(cur), "real execution", testutils.TestAddress("exec-target"), 400)
+	Approve(cross(cur), id)
+
+	testing.SetRealm(testing.NewUserRealm(owner2))
+	Approve(cross(cur), id)
+
+	treasury := chain.PackageAddress(ownPkgPath)
+	testing.IssueCoins(treasury, chain.NewCoins(chain.NewCoin("ugnot", 400)))
+
+	testing.SetRealm(testing.NewUserRealm(owner3))
+	Execute(cross(cur), id)
+
+	raw := proposals.Get(proposalKey(id))
+	p := raw.(*Proposal)
+	if !p.Executed() {
+		t.Fatal("expected proposal to be marked executed")
+	}
+}


### PR DESCRIPTION
Adds a contract-based multisig treasury realm under examples/gno.land/r/demo/multisig, following the pattern requested in #379 (contract-based multisig patterns).

Design follows the well-established cw3-flex-multisig pattern from CosmWasm/Cosmos:

- Deployer runs a one-time `Setup(owner1, owner2, owner3, threshold)` to configure N owners and an M-of-N threshold (init() cannot take parameters, so setup is a guarded one-shot call instead)
- The realm itself acts as the treasury; anyone can send ugnot to its address (exposed via `TreasuryAddress()`)
- Any owner can `Propose` a payout (description, recipient, amount)
- Owners `Approve` proposals; once distinct approvals reach the threshold, any caller can `Execute`, which uses chain/banker (BankerTypeRealmSend) to move real coins from the realm balance to the recipient

Testing:
- Verified end-to-end on Test13 using 3 real, independently-keyed owner addresses with a 2-of-3 threshold: setup, treasury funding, propose, two separate approvals from different keys, and execute -- confirmed the recipient balance actually increased on-chain.
- Unit tests cover state-machine guards: double-setup, propose/approve/execute against unknown proposals, double-approve from the same owner, and execute below threshold.

Open to feedback on API shape (e.g., generalizing Setup to accept a variable number of owners once/if a cleaner way to pass slices via maketx call args is available), naming, or additional edge cases you would want covered.