### PR TITLE
fix(auth): enforce block gas price in `DeliverTx`

### DIFF
--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -1182,6 +1182,11 @@ func TestGasPriceUpdate(t *testing.T) {
 	// CheckTx failed because gas price increased
 	r = app.CheckTx(abci.RequestCheckTx{Tx: txBytes2})
 	assert.False(t, r.IsOK(), fmt.Sprintf("%v", r))
+	header = &bft.Header{ChainID: "test-chain", Height: 2}
+	app.BeginBlock(abci.RequestBeginBlock{Header: header})
+	res = app.DeliverTx(abci.RequestDeliverTx{Tx: txBytes2})
+	require.False(t, res.IsOK(), "DeliverTx accepted the previous block gas price: %v", res)
+	require.Contains(t, res.Log, "as block gas price")
 
 	// Case 3:
 	// A previously failed CheckTx successed after block gas price reduced.
@@ -1190,15 +1195,13 @@ func TestGasPriceUpdate(t *testing.T) {
 	r = app.CheckTx(abci.RequestCheckTx{Tx: txBytes2})
 	assert.False(t, r.IsOK(), fmt.Sprintf("%v", r))
 	// Replayed a Block, the gas price decrease
-	header = &bft.Header{ChainID: "test-chain", Height: 2}
-	app.BeginBlock(abci.RequestBeginBlock{Header: header})
 	// Delvier Tx consumes less than that target block gas 600000.
 
 	tx200 := newCounterTx(20000)
 	tx200.Fee = std.Fee{
 		GasWanted: 2000000,
 		GasFee: sdk.Coin{
-			Amount: 200000,
+			Amount: 300000,
 			Denom:  "ugnot",
 		},
 	}
@@ -1252,9 +1255,9 @@ func TestGasPriceUpdate(t *testing.T) {
 	require.Equal(t, "100ugnot", gp.Price.String())
 }
 
-// TestGasPriceMinimumIsCheckTxOnly verifies that the production ante handler
-// enforces the block gas price minimum in CheckTx, but not in DeliverTx.
-func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
+// TestBlockGasPriceMinimumIsEnforcedInDeliverTx verifies that the production
+// ante handler rejects a block gas price bypass in both transaction paths.
+func TestBlockGasPriceMinimumIsEnforcedInDeliverTx(t *testing.T) {
 	app, err := NewAppWithOptions(TestAppOptions(memdb.NewMemDB()))
 	require.NoError(t, err)
 	baseApp := app.(*sdk.BaseApp)
@@ -1326,7 +1329,7 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 
 	tx.Signatures = []std.Signature{
 		{
-			PubKey:   privKey.PubKey(),
+			PubKey:    privKey.PubKey(),
 			Signature: sig,
 		},
 	}
@@ -1356,14 +1359,14 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 		},
 	})
 
-	// This documents the current bug: DeliverTx does not enforce the minimum.
 	deliverRes := baseApp.DeliverTx(abci.RequestDeliverTx{Tx: txBytes})
-	require.True(
+	require.False(
 		t,
 		deliverRes.IsOK(),
-		"DeliverTx failed: %+v",
+		"DeliverTx should reject a transaction below the block gas price: %+v",
 		deliverRes,
 	)
+	require.Contains(t, deliverRes.Log, "as block gas price")
 }
 
 func TestGasPriceEmptyBlockUpdate(t *testing.T) {
@@ -1483,8 +1486,14 @@ func newGasPriceTestApp(t *testing.T, storedGasPrice ...std.GasPrice) abci.Appli
 
 			// Override auth params.
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(readCtx))
-			// Continue on with default auth ante handler.
-			if ctx.IsCheckTx() {
+			// Continue on with the production fee-check ordering.
+			if !simulate {
+				res := auth.EnsureSufficientBlockGasPrice(ctx, tx.Fee)
+				if !res.IsOK() {
+					return ctx, res, true
+				}
+			}
+			if ctx.IsCheckTx() && !simulate {
 				res := auth.EnsureSufficientMempoolFees(ctx, tx.Fee)
 				if !res.IsOK() {
 					return ctx, res, true
@@ -1597,7 +1606,7 @@ func replayBlock(t *testing.T, app *sdk.BaseApp, gas int64, hight int64) {
 	tx.Fee = std.Fee{
 		GasWanted: 2000000,
 		GasFee: sdk.Coin{
-			Amount: 1000,
+			Amount: 1_000_000,
 			Denom:  "ugnot",
 		},
 	}

--- a/tm2/adr/pr5954_enforce_block_gas_price_in_delivertx.md
+++ b/tm2/adr/pr5954_enforce_block_gas_price_in_delivertx.md
@@ -1,0 +1,73 @@
+# PR5954: Enforce the block gas price in DeliverTx
+
+## Status
+
+Proposed
+
+## Context
+
+The dynamic block gas price check ran inside `EnsureSufficientMempoolFees`,
+which the auth ante handler called only during CheckTx. A proposer could bypass
+its mempool and include a transaction below the consensus `LastGasPrice`; the
+transaction would then execute during DeliverTx.
+
+That function also checked validator-local `MinGasPrices`. Those values are
+node configuration and cannot safely affect DeliverTx, because validators with
+different local settings must produce the same consensus result.
+
+`InitialGasPrice` is stored under `GasPriceKey` during `InitChain`. `EndBlock`
+updates that value, and `LastGasPrice` returns the current consensus gas price.
+
+## Decision
+
+Split the checks by responsibility:
+
+* `EnsureSufficientBlockGasPrice` compares the transaction gas price with
+  `LastGasPrice` during both CheckTx and DeliverTx. It continues to use
+  `std.GasPrice.IsGTE` and treats a zero or inactive block price as before.
+* `EnsureSufficientMempoolFees` checks only validator-local `MinGasPrices` and
+  remains CheckTx-only.
+* Simulation skips both checks.
+
+The ante wrapper installed by `NewAppWithOptions` loads `LastGasPrice` into
+`GasPriceContextKey` for every `runTx` invocation (CheckTx, ReCheckTx, and
+DeliverTx). Because `EndBlock` updates the stored price only after all
+DeliverTx executions, every transaction in a block observes the same block gas
+price.
+
+## Alternatives considered
+
+* Keep a single CheckTx-only validation function: rejected because it leaves
+  the proposer mempool bypass open.
+* Apply `MinGasPrices` in DeliverTx: rejected because node-local configuration
+  would make transaction results validator-dependent.
+* Add an activation height or migration: rejected because this change starts
+  from a fresh testnet genesis.
+
+## Consequences
+
+A transaction accepted by CheckTx can fail in DeliverTx if the consensus block
+gas price rises before inclusion. Transactions below the current block price
+fail in ante processing before message execution or fee deduction.
+
+After a price increase is committed, ReCheckTx uses the updated
+`LastGasPrice` and may evict transactions admitted under the previous price.
+
+A transaction rejected during DeliverTx still occupies bytes in the proposed
+block without paying a fee. This matches existing handling of other ante
+failures, such as insufficient funds; it is not a new block-processing policy.
+
+Deployment on existing chains is out of scope. Before enabling this change on a
+live network, the need for an activation height or migration must be
+re-evaluated.
+
+The gas price calculation itself—including fixed-scale rescaling, the canonical
+denominator, and the increase/decrease curve—is unchanged.
+
+## Validation
+
+The existing CheckTx-only regression test is renamed to
+`TestBlockGasPriceMinimumIsEnforcedInDeliverTx`, and its DeliverTx assertion is
+reversed to require rejection. `TestGasPriceUpdate` also verifies that
+transactions priced for the previous block are rejected after the block gas
+price increases.

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -421,7 +421,7 @@ func DeductFees(bk BankKeeperI, ctx sdk.Context, acc std.Account, collector cryp
 // EnsureSufficientBlockGasPrice verifies that the transaction fee meets the
 // consensus block gas price.
 func EnsureSufficientBlockGasPrice(ctx sdk.Context, fee std.Fee) sdk.Result {
-	blockGasPrice := ctx.Value(GasPriceContextKey{}).(std.GasPrice)
+	blockGasPrice, _ := ctx.Value(GasPriceContextKey{}).(std.GasPrice)
 	feeGasPrice := std.GasPrice{Gas: fee.GasWanted, Price: fee.GasFee}
 	if blockGasPrice.Price.IsValid() && !blockGasPrice.Price.IsZero() {
 		ok, err := feeGasPrice.IsGTE(blockGasPrice)

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -58,9 +58,14 @@ func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer Signature
 			return ctx, res, true
 		}
 
-		// Ensure that the provided fees meet a minimum threshold for the validator,
-		// if this is a CheckTx. This is only for local mempool purposes, and thus
-		// is only run upon checktx.
+		if !simulate {
+			res := EnsureSufficientBlockGasPrice(ctx, tx.Fee)
+			if !res.IsOK() {
+				return ctx, res, true
+			}
+		}
+
+		// Validator minimum fees are local mempool policy, not consensus rules.
 		if ctx.IsCheckTx() && !simulate {
 			res := EnsureSufficientMempoolFees(ctx, tx.Fee)
 			if !res.IsOK() {
@@ -413,23 +418,11 @@ func DeductFees(bk BankKeeperI, ctx sdk.Context, acc std.Account, collector cryp
 	return sdk.Result{}
 }
 
-// EnsureSufficientMempoolFees verifies that the given transaction has supplied
-// enough fees to cover a proposer's minimum fees. A result object is returned
-// indicating success or failure.
-//
-// Contract: This should only be called during CheckTx as it cannot be part of
-// consensus.
-func EnsureSufficientMempoolFees(ctx sdk.Context, fee std.Fee) sdk.Result {
-	minGasPrices := ctx.MinGasPrices()
+// EnsureSufficientBlockGasPrice verifies that the transaction fee meets the
+// consensus block gas price.
+func EnsureSufficientBlockGasPrice(ctx sdk.Context, fee std.Fee) sdk.Result {
 	blockGasPrice := ctx.Value(GasPriceContextKey{}).(std.GasPrice)
-	feeGasPrice := std.GasPrice{
-		Gas: fee.GasWanted,
-		Price: std.Coin{
-			Amount: fee.GasFee.Amount,
-			Denom:  fee.GasFee.Denom,
-		},
-	}
-	// check the block gas price
+	feeGasPrice := std.GasPrice{Gas: fee.GasWanted, Price: fee.GasFee}
 	if blockGasPrice.Price.IsValid() && !blockGasPrice.Price.IsZero() {
 		ok, err := feeGasPrice.IsGTE(blockGasPrice)
 		if err != nil {
@@ -445,6 +438,15 @@ func EnsureSufficientMempoolFees(ctx sdk.Context, fee std.Fee) sdk.Result {
 			))
 		}
 	}
+	return sdk.Result{}
+}
+
+// EnsureSufficientMempoolFees verifies that the transaction fee meets the
+// validator's local minimum gas prices. It must only be called during CheckTx.
+func EnsureSufficientMempoolFees(ctx sdk.Context, fee std.Fee) sdk.Result {
+	minGasPrices := ctx.MinGasPrices()
+	feeGasPrice := std.GasPrice{Gas: fee.GasWanted, Price: fee.GasFee}
+
 	// check min gas price set by the node.
 	if len(minGasPrices) == 0 {
 		// no minimum gas price (not recommended)

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -768,9 +768,6 @@ func TestEnsureSufficientMempoolFees(t *testing.T) {
 		{std.NewFee(200000, std.NewCoin("stake", 2)), true},
 		{std.NewFee(200000, std.NewCoin("atom", 5)), false},
 	}
-	// Do not set the block gas price
-	ctx = ctx.WithValue(GasPriceContextKey{}, std.GasPrice{})
-
 	for i, tc := range testCases {
 		res := EnsureSufficientMempoolFees(ctx, tc.input)
 		require.Equal(
@@ -828,53 +825,104 @@ func TestCustomSignatureVerificationGasConsumer(t *testing.T) {
 	checkValidTx(t, anteHandler, ctx, tx, false)
 }
 
-func TestEnsureBlockGasPrice(t *testing.T) {
-	p1, err := std.ParseGasPrice("3ugnot/10gas") // 0.3ugnot
-	require.NoError(t, err)
-
-	p2, err := std.ParseGasPrice("400ugnot/2000gas") // 0.2ugnot
+func TestEnsureSufficientBlockGasPrice(t *testing.T) {
+	blockGasPrice, err := std.ParseGasPrice("400ugnot/2000gas") // 0.2ugnot
 	require.NoError(t, err)
 
 	userFeeCases := []struct {
-		minGasPrice   std.GasPrice
 		blockGasPrice std.GasPrice
 		input         std.Fee
 		expectedOK    bool
 	}{
-		// user's gas wanted and gas fee: 0.1ugnot to 0.5ugnot
-		// validator's minGasPrice: 0.3 ugnot
-		// block gas price: 0.2ugnot
-
-		{p1, p2, std.NewFee(100, std.NewCoin("ugnot", 10)), false},
-		{p1, p2, std.NewFee(100, std.NewCoin("ugnot", 20)), false},
-		{p1, p2, std.NewFee(100, std.NewCoin("ugnot", 30)), true},
-		{p1, p2, std.NewFee(100, std.NewCoin("ugnot", 40)), true},
-		{p1, p2, std.NewFee(100, std.NewCoin("ugnot", 50)), true},
-
-		// validator's minGasPrice: 0.2 ugnot
-		// block gas price2: 0.3ugnot
-		{p2, p1, std.NewFee(100, std.NewCoin("ugnot", 10)), false},
-		{p2, p1, std.NewFee(100, std.NewCoin("ugnot", 20)), false},
-		{p2, p1, std.NewFee(100, std.NewCoin("ugnot", 30)), true},
-		{p2, p1, std.NewFee(100, std.NewCoin("ugnot", 40)), true},
-		{p2, p1, std.NewFee(100, std.NewCoin("ugnot", 50)), true},
+		{blockGasPrice, std.NewFee(100, std.NewCoin("ugnot", 10)), false},
+		{blockGasPrice, std.NewFee(100, std.NewCoin("ugnot", 20)), true},
+		{blockGasPrice, std.NewFee(100, std.NewCoin("ugnot", 30)), true},
+		{blockGasPrice, std.NewFee(100, std.NewCoin("uatom", 30)), false},
+		{std.GasPrice{}, std.NewFee(100, std.NewCoin("ugnot", 0)), true},
 	}
 
-	// setup
 	env := setupTestEnv()
-	ctx := env.ctx
-	// validator min gas price // 0.3 ugnot per gas
 	for i, c := range userFeeCases {
-		ctx = ctx.WithMinGasPrices(
-			[]std.GasPrice{c.minGasPrice},
-		)
-		ctx = ctx.WithValue(GasPriceContextKey{}, c.blockGasPrice)
+		ctx := env.ctx.WithValue(GasPriceContextKey{}, c.blockGasPrice)
 
-		res := EnsureSufficientMempoolFees(ctx, c.input)
+		res := EnsureSufficientBlockGasPrice(ctx, c.input)
 		require.Equal(
 			t, c.expectedOK, res.IsOK(),
 			"unexpected result; case #%d, input: %v, log: %v", i, c.input, res.Log,
 		)
+	}
+}
+
+func TestAnteHandlerGasPriceRejectedExecutionPaths(t *testing.T) {
+	env := setupTestEnv()
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer, defaultAnteOptions())
+	blockGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("ugnot", 2)}
+	localGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("ugnot", 3)}
+
+	tests := []struct {
+		name          string
+		mode          sdk.RunTxMode
+		blockGasPrice std.GasPrice
+		minGasPrices  []std.GasPrice
+		fee           std.Fee
+		expectedErr   abci.Error
+	}{
+		{"below block price in CheckTx", sdk.RunTxModeCheck, blockGasPrice, nil, std.NewFee(100, std.NewCoin("ugnot", 10)), std.InsufficientFeeError{}},
+		{"below block price in DeliverTx", sdk.RunTxModeDeliver, blockGasPrice, nil, std.NewFee(100, std.NewCoin("ugnot", 10)), std.InsufficientFeeError{}},
+		{"different denomination in CheckTx", sdk.RunTxModeCheck, blockGasPrice, nil, std.NewFee(100, std.NewCoin("uatom", 30)), std.InsufficientFeeError{}},
+		{"different denomination in DeliverTx", sdk.RunTxModeDeliver, blockGasPrice, nil, std.NewFee(100, std.NewCoin("uatom", 30)), std.InsufficientFeeError{}},
+		{"local price rejects CheckTx", sdk.RunTxModeCheck, blockGasPrice, []std.GasPrice{localGasPrice}, std.NewFee(100, std.NewCoin("ugnot", 20)), std.InsufficientFeeError{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := env.ctx.WithMode(test.mode).
+				WithMinGasPrices(test.minGasPrices).
+				WithValue(GasPriceContextKey{}, test.blockGasPrice)
+			tx := std.Tx{Fee: test.fee}
+			_, res, abort := anteHandler(ctx, tx, false)
+			require.True(t, abort)
+			require.IsType(t, test.expectedErr, sdk.ABCIError(res.Error))
+		})
+	}
+}
+
+func TestAnteHandlerGasPriceSuccessfulExecutionPaths(t *testing.T) {
+	blockGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("atom", 2)}
+	localGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("atom", 3)}
+
+	tests := []struct {
+		name        string
+		mode        sdk.RunTxMode
+		simulate    bool
+		blockPrice  std.GasPrice
+		localPrices []std.GasPrice
+		fee         std.Fee
+	}{
+		{"equal block price in CheckTx", sdk.RunTxModeCheck, false, blockGasPrice, nil, std.NewFee(50_000, std.NewCoin("atom", 10_000))},
+		{"equal block price in DeliverTx", sdk.RunTxModeDeliver, false, blockGasPrice, nil, std.NewFee(50_000, std.NewCoin("atom", 10_000))},
+		{"above block price in CheckTx", sdk.RunTxModeCheck, false, blockGasPrice, nil, std.NewFee(50_000, std.NewCoin("atom", 10_001))},
+		{"above block price in DeliverTx", sdk.RunTxModeDeliver, false, blockGasPrice, nil, std.NewFee(50_000, std.NewCoin("atom", 10_001))},
+		{"local price does not reject DeliverTx", sdk.RunTxModeDeliver, false, blockGasPrice, []std.GasPrice{localGasPrice}, std.NewFee(50_000, std.NewCoin("atom", 10_000))},
+		{"disabled block price in CheckTx", sdk.RunTxModeCheck, false, std.GasPrice{}, nil, std.NewFee(50_000, std.NewCoin("atom", 1))},
+		{"disabled block price in DeliverTx", sdk.RunTxModeDeliver, false, std.GasPrice{}, nil, std.NewFee(50_000, std.NewCoin("atom", 1))},
+		{"simulation skips both prices", sdk.RunTxModeSimulate, true, blockGasPrice, []std.GasPrice{localGasPrice}, std.NewFee(50_000, std.NewCoin("atom", 1))},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := setupTestEnv()
+			ctx := env.ctx.WithMode(test.mode).
+				WithMinGasPrices(test.localPrices).
+				WithValue(GasPriceContextKey{}, test.blockPrice)
+			priv, _, addr := tu.KeyTestPubAddr()
+			acc := env.acck.NewAccountWithAddress(ctx, addr)
+			acc.SetCoins(tu.NewTestCoins())
+			env.acck.SetAccount(ctx, acc)
+			tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)}, []crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, test.fee)
+			anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer, defaultAnteOptions())
+			checkValidTx(t, anteHandler, ctx, tx, test.simulate)
+		})
 	}
 }
 
@@ -896,11 +944,11 @@ func TestInvalidUserFee(t *testing.T) {
 		[]std.GasPrice{minGasPrice},
 	)
 	ctx = ctx.WithValue(GasPriceContextKey{}, blockGasPrice)
-	res1 := EnsureSufficientMempoolFees(ctx, userFee1)
+	res1 := EnsureSufficientBlockGasPrice(ctx, userFee1)
 	require.False(t, res1.IsOK())
 	assert.Contains(t, res1.Log, "GasPrice.Gas cannot be zero;")
 
-	res2 := EnsureSufficientMempoolFees(ctx, userFee2)
+	res2 := EnsureSufficientBlockGasPrice(ctx, userFee2)
 	require.False(t, res2.IsOK())
 	assert.Contains(t, res2.Log, "Gas price denominations should be equal;")
 }

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -887,6 +887,18 @@ func TestAnteHandlerGasPriceRejectedExecutionPaths(t *testing.T) {
 	}
 }
 
+func TestAnteHandlerAllowsDeliverTxWithoutBlockGasPrice(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+	priv, _, addr := tu.KeyTestPubAddr()
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	acc.SetCoins(tu.NewTestCoins())
+	env.acck.SetAccount(ctx, acc)
+	tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)}, []crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, tu.NewTestFee())
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer, defaultAnteOptions())
+	checkValidTx(t, anteHandler, ctx, tx, false)
+}
+
 func TestAnteHandlerGasPriceSuccessfulExecutionPaths(t *testing.T) {
 	blockGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("atom", 2)}
 	localGasPrice := std.GasPrice{Gas: 10, Price: std.NewCoin("atom", 3)}

--- a/tm2/pkg/sdk/auth/test_common.go
+++ b/tm2/pkg/sdk/auth/test_common.go
@@ -38,7 +38,6 @@ func setupTestEnv() testEnv {
 	prmk.Register("dummybank", bankk)
 
 	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms, &bft.Header{Height: 1, ChainID: "test-chain-id"}, log.NewNoopLogger())
-	ctx = ctx.WithValue(GasPriceContextKey{}, std.GasPrice{})
 
 	acck.SetParams(ctx, DefaultParams()) // Setup default params
 

--- a/tm2/pkg/sdk/auth/test_common.go
+++ b/tm2/pkg/sdk/auth/test_common.go
@@ -38,6 +38,7 @@ func setupTestEnv() testEnv {
 	prmk.Register("dummybank", bankk)
 
 	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms, &bft.Header{Height: 1, ChainID: "test-chain-id"}, log.NewNoopLogger())
+	ctx = ctx.WithValue(GasPriceContextKey{}, std.GasPrice{})
 
 	acck.SetParams(ctx, DefaultParams()) // Setup default params
 


### PR DESCRIPTION
Depends on #5916 

## Problem

The consensus block gas was checked only during `CheckTx` as part of `EnsureSufficientMemPoolFees`.

A proposer could bypass its local mempool and include a tx below the current block gas price, which would then be accepted during `DeliverTx`.

## Fix

- Split the consensus block gas price check from the validator-local minimum fee check
- Enforce the consensus block gas price during both `CheckTx` and `DeliverTx`
- Keep validator local `MinGasPrices` enforcement limited to `CheckTx`
- Skip both checks during simulation and allow contexts where no block gas price is configured