### PR TITLE
fix(auth): increase dynamic gas price precision

### DIFF
--- a/contribs/gnogenesis/internal/params/params_set.go
+++ b/contribs/gnogenesis/internal/params/params_set.go
@@ -73,6 +73,9 @@ func execParamsSet(cfg *paramsCfg, io commands.IO, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to set params %q: %w", key, err)
 	}
+	if err := gnoland.ValidateGenState(appstate); err != nil {
+		return fmt.Errorf("unable to validate genesis state: %w", err)
+	}
 
 	// Override AppState with the updated one
 	genesis.AppState = appstate

--- a/contribs/gnogenesis/internal/params/params_set_test.go
+++ b/contribs/gnogenesis/internal/params/params_set_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -187,7 +188,7 @@ func TestParamsSetCmd(t *testing.T) {
 		cmd := newParamsSetCmd(cfg, io)
 
 		newGas := std.GasPrice{
-			Gas: 2000, Price: std.MustParseCoin("400ugnot"),
+			Gas: auth.BlockGasPriceScale, Price: std.MustParseCoin("2000ugnot"),
 		}
 
 		args := []string{"auth.initial_gasprice", newGas.String()}
@@ -198,6 +199,22 @@ func TestParamsSetCmd(t *testing.T) {
 		require.NoError(t, err)
 		state := updated.AppState.(gnoland.GnoGenesisState)
 		assert.Equal(t, newGas, state.Auth.Params.InitialGasPrice)
+	})
+
+	t.Run("reject noncanonical gas price", func(t *testing.T) {
+		t.Parallel()
+		tempGenesis, cleanup := testutils.NewTestFile(t)
+		t.Cleanup(cleanup)
+
+		genesis := common.DefaultGenesis()
+		require.NoError(t, genesis.SaveAs(tempGenesis.Name()))
+
+		cfg := &paramsCfg{}
+		cfg.GenesisPath = tempGenesis.Name()
+		cmd := newParamsSetCmd(cfg, commands.NewTestIO())
+
+		err := cmd.ParseAndRun(context.Background(), []string{"auth.initial_gasprice", "400ugnot/2000gas"})
+		assert.ErrorContains(t, err, "gas must be 1000000")
 	})
 
 	t.Run("invalid type", func(t *testing.T) {

--- a/docs/resources/gas-fees.md
+++ b/docs/resources/gas-fees.md
@@ -59,11 +59,11 @@ prices when usage is high and decreasing them when usage is low.
 ### How Gas Price Works
 
 The gas price is returned as a `GasPrice` object with two fields:
-- `gas` - the gas units (e.g., 1000)
-- `price` - the price for those gas units (e.g., "100ugnot")
+- `gas` - the gas units (`1000000` for the consensus dynamic price)
+- `price` - the price for those gas units (e.g., "100000ugnot")
 
-Together, these represent a **rate**. For example, `{gas: 1000, price: "100ugnot"}`
-means the minimum rate is 100 ugnot per 1000 gas units, which simplifies to
+Together, these represent a **rate**. For example, `{gas: 1000000, price: "100000ugnot"}`
+means the minimum rate is 100000 ugnot per 1000000 gas units, which simplifies to
 0.1 ugnot per gas unit.
 
 To calculate the minimum fee manually:
@@ -74,8 +74,8 @@ To calculate the minimum fee manually:
 
 **Example:**
 ```bash
-# Query returns: {gas: 1000, price: "100ugnot"}
-# Rate = 100 ÷ 1000 = 0.1 ugnot/gas
+# Query returns: {gas: 1000000, price: "100000ugnot"}
+# Rate = 100000 ÷ 1000000 = 0.1 ugnot/gas
 
 # If you want --gas-wanted 2000000:
 # Minimum fee = 2,000,000 × 0.1 = 200,000 ugnot
@@ -143,7 +143,7 @@ Output:
 ```
 GAS WANTED: 2000000
 GAS USED:   268994
-INFO:       estimated gas usage: 268994, gas fee: 282ugnot, current gas price: 1ugnot/1000gas
+INFO:       estimated gas usage: 268994, gas fee: 282ugnot, current gas price: 1000ugnot/1000000gas
 ```
 
 Use the `estimated gas usage` and `gas fee` values as your `-gas-wanted` and `-gas-fee`
@@ -182,4 +182,3 @@ To minimize gas costs, consider these optimization strategies:
 > out of gas), the transaction won't be submitted and you won't be charged.
 > However, a transaction that passes simulation can still fail on-chain, in
 > which case you will be charged.
-

--- a/docs/resources/gas-fees.md
+++ b/docs/resources/gas-fees.md
@@ -143,11 +143,11 @@ Output:
 ```
 GAS WANTED: 2000000
 GAS USED:   268994
-INFO:       estimated gas usage: 268994, gas fee: 282ugnot, current gas price: 1000ugnot/1000000gas
+INFO:       estimated gas usage: 268994 (suggested, with 5% margin: 282444), gas fee: 297ugnot, current gas price: 1000ugnot/1000000gas
 ```
 
-Use the `estimated gas usage` and `gas fee` values as your `-gas-wanted` and `-gas-fee`
-for the actual transaction.
+Use the suggested gas-wanted and `gas fee` values as your `-gas-wanted` and
+`-gas-fee` for the actual transaction.
 
 ## Gas Optimization Tips
 

--- a/docs/users/interact-with-gnokey.md
+++ b/docs/users/interact-with-gnokey.md
@@ -1158,8 +1158,8 @@ If everything went correctly, we should get an output similar to the following:
 ```bash
 height: 0
 data: {
-  "gas": 1000,
-  "price": "100ugnot"
+  "gas": 1000000,
+  "price": "100000ugnot"
 }
 ```
 

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -1230,7 +1230,8 @@ func TestGasPriceUpdate(t *testing.T) {
 	var gp std.GasPrice
 	err = amino.Unmarshal(qr.Value, &gp)
 	require.NoError(t, err)
-	require.Equal(t, "108ugnot", gp.Price.String())
+	require.Equal(t, "108506ugnot", gp.Price.String())
+	require.Equal(t, auth.BlockGasPriceScale, gp.Gas)
 
 	// Case 5,
 	// require matching expected GasPrice after low gas blocks ( decrease below initial gas price case)
@@ -1242,14 +1243,14 @@ func TestGasPriceUpdate(t *testing.T) {
 	qr = app.Query(query)
 	err = amino.Unmarshal(qr.Value, &gp)
 	require.NoError(t, err)
-	require.Equal(t, "102ugnot", gp.Price.String())
+	require.Equal(t, "101866ugnot", gp.Price.String())
 
 	replayBlock(t, baseApp, 500000, 9)
 
 	qr = app.Query(query)
 	err = amino.Unmarshal(qr.Value, &gp)
 	require.NoError(t, err)
-	require.Equal(t, "100ugnot", gp.Price.String())
+	require.Equal(t, "100000ugnot", gp.Price.String())
 }
 
 // TestGasPriceMinimumIsCheckTxOnly verifies that the production ante handler
@@ -1301,7 +1302,10 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 	qr := baseApp.Query(query)
 	require.True(t, qr.IsOK(), "query failed: %v", qr.ResponseBase.Error)
 	require.NoError(t, amino.Unmarshal(qr.Value, &storedPrice))
-	require.Equal(t, initialPrice, storedPrice)
+	require.Equal(t, std.GasPrice{
+		Gas:   auth.BlockGasPriceScale,
+		Price: std.Coin{Amount: 100_000, Denom: "ugnot"},
+	}, storedPrice)
 
 	msgs := []std.Msg{
 		bank.NewMsgSend(
@@ -1326,7 +1330,7 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 
 	tx.Signatures = []std.Signature{
 		{
-			PubKey:   privKey.PubKey(),
+			PubKey:    privKey.PubKey(),
 			Signature: sig,
 		},
 	}
@@ -1395,7 +1399,10 @@ func TestGasPriceEmptyBlockUpdate(t *testing.T) {
 		qr := app.Query(query)
 		require.True(t, qr.IsOK(), "%v", qr.ResponseBase.Error)
 		require.NoError(t, amino.Unmarshal(qr.Value, &gasPrice))
-		require.Equal(t, startingPrice, gasPrice)
+		require.Equal(t, std.GasPrice{
+			Gas:   auth.BlockGasPriceScale,
+			Price: std.Coin{Amount: 10_000, Denom: "ugnot"},
+		}, gasPrice)
 
 		tx := newCounterTx(1)
 		tx.Fee = std.Fee{
@@ -1415,8 +1422,8 @@ func TestGasPriceEmptyBlockUpdate(t *testing.T) {
 		qr = app.Query(query)
 		require.True(t, qr.IsOK(), "%v", qr.ResponseBase.Error)
 		require.NoError(t, amino.Unmarshal(qr.Value, &gasPrice))
-		require.Equal(t, int64(9), gasPrice.Price.Amount)
-		require.Equal(t, startingPrice.Gas, gasPrice.Gas)
+		require.Equal(t, int64(8750), gasPrice.Price.Amount)
+		require.Equal(t, auth.BlockGasPriceScale, gasPrice.Gas)
 		require.Equal(t, startingPrice.Price.Denom, gasPrice.Price.Denom)
 		require.True(t, app.CheckTx(abci.RequestCheckTx{Tx: txBytes}).IsOK())
 		require.NotEqual(t, genesisHash, emptyBlockHash)

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -1261,8 +1261,8 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 	baseApp := app.(*sdk.BaseApp)
 
 	initialPrice := std.GasPrice{
-		Gas:   1000,
-		Price: std.Coin{Amount: 100, Denom: "ugnot"},
+		Gas:   auth.BlockGasPriceScale,
+		Price: std.Coin{Amount: 100_000, Denom: "ugnot"},
 	}
 
 	gen := gnoGenesisState(t)
@@ -1302,10 +1302,7 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 	qr := baseApp.Query(query)
 	require.True(t, qr.IsOK(), "query failed: %v", qr.ResponseBase.Error)
 	require.NoError(t, amino.Unmarshal(qr.Value, &storedPrice))
-	require.Equal(t, std.GasPrice{
-		Gas:   auth.BlockGasPriceScale,
-		Price: std.Coin{Amount: 100_000, Denom: "ugnot"},
-	}, storedPrice)
+	require.Equal(t, initialPrice, storedPrice)
 
 	msgs := []std.Msg{
 		bank.NewMsgSend(
@@ -1372,12 +1369,12 @@ func TestGasPriceMinimumIsCheckTxOnly(t *testing.T) {
 
 func TestGasPriceEmptyBlockUpdate(t *testing.T) {
 	startingPrice := std.GasPrice{
-		Gas:   1000,
-		Price: std.Coin{Amount: 10, Denom: "ugnot"},
+		Gas:   auth.BlockGasPriceScale,
+		Price: std.Coin{Amount: 10_000, Denom: "ugnot"},
 	}
 	floorPrice := std.GasPrice{
-		Gas:   1000,
-		Price: std.Coin{Amount: 1, Denom: "ugnot"},
+		Gas:   auth.BlockGasPriceScale,
+		Price: std.Coin{Amount: 1000, Denom: "ugnot"},
 	}
 
 	run := func() []byte {
@@ -1399,10 +1396,7 @@ func TestGasPriceEmptyBlockUpdate(t *testing.T) {
 		qr := app.Query(query)
 		require.True(t, qr.IsOK(), "%v", qr.ResponseBase.Error)
 		require.NoError(t, amino.Unmarshal(qr.Value, &gasPrice))
-		require.Equal(t, std.GasPrice{
-			Gas:   auth.BlockGasPriceScale,
-			Price: std.Coin{Amount: 10_000, Denom: "ugnot"},
-		}, gasPrice)
+		require.Equal(t, startingPrice, gasPrice)
 
 		tx := newCounterTx(1)
 		tx.Fee = std.Fee{
@@ -1574,8 +1568,8 @@ func gnoGenesisState(t *testing.T) GnoGenesisState {
       "params": {
         "gas_price_change_compressor": "8",
         "initial_gasprice": {
-          "gas": "1000",
-          "price": "100ugnot"
+          "gas": "1000000",
+          "price": "100000ugnot"
         },
         "max_memo_bytes": "65536",
         "sig_verify_cost_ed25519": "590",

--- a/gno.land/pkg/gnoland/genesis.go
+++ b/gno.land/pkg/gnoland/genesis.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
-const initGasPrice = "1ugnot/1000gas"
+const initGasPrice = "1000ugnot/1000000gas"
 
 // LoadGenesisBalancesFile loads genesis balances from the provided file path.
 func LoadGenesisBalancesFile(path string) (Balances, error) {

--- a/gno.land/pkg/integration/node_testing.go
+++ b/gno.land/pkg/integration/node_testing.go
@@ -105,7 +105,7 @@ func TestingMinimalNodeConfig(gnoroot string) *gnoland.InMemoryNodeConfig {
 func DefaultTestingGenesisConfig(gnoroot string, self crypto.PubKey, tmconfig *tmcfg.Config) *bft.GenesisDoc {
 	authGen := auth.DefaultGenesisState()
 	authGen.Params.UnrestrictedAddrs = []crypto.Address{crypto.MustAddressFromString(DefaultAccount_Address)}
-	authGen.Params.InitialGasPrice = std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	authGen.Params.InitialGasPrice = std.GasPrice{Gas: auth.BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}}
 	genState := gnoland.DefaultGenState()
 	genState.Balances = []gnoland.Balance{
 		{

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -14,7 +14,7 @@ stdout '"coins": "10000000000000ugnot"'
 # the actual gas the real tx would consume.
 gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -chainid tendermint_test -simulate only test1
 stdout 'GAS USED:\s+2756592'
-stdout 'INFO:       estimated gas usage: 2756592 \(suggested, with 5% margin: 2894422\), gas fee: 2894ugnot, current gas price: 1ugnot/1000gas'
+stdout 'INFO:       estimated gas usage: 2756592 \(suggested, with 5% margin: 2894422\), gas fee: 3039ugnot, current gas price: 1000ugnot/1000000gas'
 
 ## No fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
@@ -37,7 +37,7 @@ stdout '"coins": "9999999790206ugnot"'
 # Tx Call -simulate only, estimate gas used and gas fee.
 gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -chainid tendermint_test -simulate only test1
 stdout 'GAS USED:\s+1212011'
-stdout 'INFO:       estimated gas usage: 1212011 \(suggested, with 5% margin: 1272612\), gas fee: 1273ugnot, current gas price: 1ugnot/1000gas'
+stdout 'INFO:       estimated gas usage: 1212011 \(suggested, with 5% margin: 1272612\), gas fee: 1336ugnot, current gas price: 1000ugnot/1000000gas'
 
 ## No additional fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr

--- a/gno.land/pkg/integration/testdata/simulate_gas.txtar
+++ b/gno.land/pkg/integration/testdata/simulate_gas.txtar
@@ -14,15 +14,15 @@ stdout 'GAS USED:   \d+' # same as simulate only
 
 # simulate only (again) with default 5% margin
 gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only test1
+stdout 'gas fee: 1264ugnot'
+
+# simulate only with no gas fee margin. base gas fee is 1204ugnot
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=0 test1
 stdout 'gas fee: 1204ugnot'
 
-# simulate only with no gas fee margin. base gas fee is 1147ugnot
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=0 test1
-stdout 'gas fee: 1147ugnot'
-
-# the 5% margin was 57ugnot (1204 - 1147). the 10% margin should be about 114ugnot, total of 1261
+# the 5% margin is 60ugnot; the 10% margin is 120ugnot.
 gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=10 test1
-stdout 'gas fee: 1261ugnot,'
+stdout 'gas fee: 1324ugnot,'
 
 # -gas-fee-margin should be a number
 ! gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=zzz test1

--- a/tm2/adr/pr5955_gas_price_fixed_scale.md
+++ b/tm2/adr/pr5955_gas_price_fixed_scale.md
@@ -1,0 +1,54 @@
+# PR5955: Canonical fixed-scale block gas price
+
+## Context
+
+The dynamic block gas price was stored as `1ugnot/1000gas` at its default
+floor. The controller's minimum upward tick therefore changed the floor
+numerator from `1` to `2`, raising the rate by 100% even when block use differed
+from the target by one gas. Ethereum's 12.5% bound is a maximum full/empty-block
+adjustment, not a price-resolution requirement; representation precision and
+controller rate must remain separate.
+
+## Decision
+
+Store every nonzero consensus dynamic block gas price with the fixed gas
+denominator `1_000_000`. This change targets a fresh testnet, so genesis and
+configuration must provide that representation exactly; runtime and legacy
+state are not rescaled. Thus the unchanged default rate is
+`1000ugnot/1000000gas`, and one numerator atom is 0.1% of that floor. The
+existing proportional formula, target ratio, compressor, two integer
+divisions, and minimum one-atom change remain unchanged.
+
+Genesis and governance validation reject nonzero prices with another scale,
+non-positive amounts, invalid denominations, and governance denomination
+changes. `gnogenesis params set` validates the resulting genesis state before
+saving it. Disabled pricing uses the combined zero gas and zero amount form.
+The keeper changes only the numerator and clamps decreases to the initial
+floor. `std.GasPrice` remains general-purpose and fee validation continues to
+use its cross-multiplication. Gnokey first adds its 5% suggested-gas buffer,
+then estimates the fee for that `GasWanted` with multiply-first ceil division
+using `big.Int` before applying the existing configurable fee margin.
+
+## Alternatives considered
+
+- Remainder consensus state would preserve sub-atom changes but add state and
+  migration complexity.
+- A new public fixed-point price type would duplicate `std.GasPrice` and widen
+  the API change.
+- Runtime ceil conversion would silently change configured rates and add
+  migration behavior that a fresh chain does not need.
+- Changing target ratio, compressor, or the controller curve would mix pricing
+  policy with this representation-only change.
+
+## Consequences
+
+The `auth/gasprice` JSON shape is unchanged, but consumers must treat `gas` as
+data rather than assume `1000`; the default response becomes
+`{gas: 1000000, price: "1000ugnot"}`. External wallets and explorers need only
+preserve ratio-based handling. The numerator remains an `int64`; a controller
+increase beyond that range deterministically panics rather than wrapping or
+introducing a configurable economic cap. Parameter edits through `gnogenesis`
+are saved only when the complete resulting genesis state is valid.
+
+Future target-ratio, compressor, curve, and telemetry changes are separate
+work.

--- a/tm2/pkg/crypto/keys/client/broadcast.go
+++ b/tm2/pkg/crypto/keys/client/broadcast.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -224,8 +225,7 @@ func estimateGasFee(cli client.ABCIClient, bres *ctypes.ResultBroadcastTxCommit,
 	if gp.Gas == 0 {
 		s = fmt.Sprintf("estimated gas usage: %d (suggested, with 5%% margin: %d)\n", gasUsed, suggested)
 	} else {
-		fee := gasUsed/gp.Gas + 1
-		fee = overflow.Mulp(fee, gp.Price.Amount)
+		fee := requiredGasFee(suggested, gp)
 		// fee buffer to cover the sudden change of gas price
 		feeBuffer := overflow.Mulp(fee, int64(gasFeeMargin)) / 100
 		fee = overflow.Addp(fee, feeBuffer)
@@ -237,6 +237,18 @@ func estimateGasFee(cli client.ABCIClient, bres *ctypes.ResultBroadcastTxCommit,
 		bres.DeliverTx.Info = bres.DeliverTx.Info + ", " + s
 	}
 	return nil
+}
+
+func requiredGasFee(gasWanted int64, gp std.GasPrice) int64 {
+	fee, remainder := new(big.Int), new(big.Int)
+	fee.QuoRem(new(big.Int).Mul(big.NewInt(gasWanted), big.NewInt(gp.Price.Amount)), big.NewInt(gp.Gas), remainder)
+	if remainder.Sign() != 0 {
+		fee.Add(fee, big.NewInt(1))
+	}
+	if !fee.IsInt64() {
+		panic("gas fee is out of int64 range")
+	}
+	return fee.Int64()
 }
 
 func SimulateTx(cli client.ABCIClient, tx []byte) (*ctypes.ResultBroadcastTxCommit, error) {

--- a/tm2/pkg/crypto/keys/client/maketx_test.go
+++ b/tm2/pkg/crypto/keys/client/maketx_test.go
@@ -25,6 +25,7 @@ func TestRequiredGasFee(t *testing.T) {
 		{"small gas with large denominator", 1, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 1},
 		{"exact division", 2000, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 2},
 		{"remainder division", 2001, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 3},
+		{"equivalent rate", 2001, std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1}}, 3},
 		{"large multiply", 3_000_000_000, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1_000_000}}, 3_000_000_000},
 	}
 	for _, tt := range tests {

--- a/tm2/pkg/crypto/keys/client/maketx_test.go
+++ b/tm2/pkg/crypto/keys/client/maketx_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/store"
 )
 
+func TestRequiredGasFee(t *testing.T) {
+	tests := []struct {
+		name      string
+		gasWanted int64
+		gasPrice  std.GasPrice
+		want      int64
+	}{
+		{"small gas with large denominator", 1, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 1},
+		{"exact division", 2000, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 2},
+		{"remainder division", 2001, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1000}}, 3},
+		{"large multiply", 3_000_000_000, std.GasPrice{Gas: 1_000_000, Price: std.Coin{Amount: 1_000_000}}, 3_000_000_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, requiredGasFee(tt.gasWanted, tt.gasPrice))
+		})
+	}
+}
+
 func TestHandleDeliverResultCallsOnFailure(t *testing.T) {
 	called := false
 	cfg := &BaseCfg{BaseOptions: BaseOptions{OnTxFailure: func(commands.IO, std.Tx, *ctypes.ResultBroadcastTxCommit) {

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -878,6 +878,18 @@ func TestEnsureBlockGasPrice(t *testing.T) {
 	}
 }
 
+func TestEnsureBlockGasPriceCanonicalThreshold(t *testing.T) {
+	env := setupTestEnv()
+	old := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	canonical := std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}}
+
+	for _, blockPrice := range []std.GasPrice{old, canonical} {
+		ctx := env.ctx.WithValue(GasPriceContextKey{}, blockPrice)
+		require.False(t, EnsureSufficientMempoolFees(ctx, std.NewFee(1001, std.NewCoin("ugnot", 1))).IsOK())
+		require.True(t, EnsureSufficientMempoolFees(ctx, std.NewFee(1001, std.NewCoin("ugnot", 2))).IsOK())
+	}
+}
+
 func TestInvalidUserFee(t *testing.T) {
 	minGasPrice, err := std.ParseGasPrice("3ugnot/10gas") // 0.3ugnot
 	require.NoError(t, err)

--- a/tm2/pkg/sdk/auth/consts.go
+++ b/tm2/pkg/sdk/auth/consts.go
@@ -32,6 +32,9 @@ const (
 
 	// key for gas price
 	GasPriceKey = "gasPrice"
+	// BlockGasPriceScale is the canonical gas denominator for the consensus
+	// dynamic block gas price.
+	BlockGasPriceScale int64 = 1_000_000
 	// param key for global account number
 	GlobalAccountNumberKey = "globalAccountNumber"
 

--- a/tm2/pkg/sdk/auth/handler_test.go
+++ b/tm2/pkg/sdk/auth/handler_test.go
@@ -73,10 +73,10 @@ func TestQueryGasPrice(t *testing.T) {
 	require.Nil(t, res.Error) // no gasprice is set and no error returned anyway
 	require.NotNil(t, res)
 	gp := std.GasPrice{
-		Gas: 100,
+		Gas: BlockGasPriceScale,
 		Price: std.Coin{
-			Denom:  "token",
-			Amount: 10,
+			Denom:  "ugnot",
+			Amount: 1000,
 		},
 	}
 	env.gk.SetGasPrice(env.ctx, gp)
@@ -86,7 +86,7 @@ func TestQueryGasPrice(t *testing.T) {
 	require.Nil(t, res.Error)
 	require.NotNil(t, res)
 	require.NoError(t, amino.UnmarshalJSON(res.Data, &gp2))
-	require.True(t, gp == gp2)
+	require.Equal(t, gp, gp2)
 }
 
 func TestQuerySessions(t *testing.T) {

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -347,7 +347,9 @@ func (gk GasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {
 	if (gp == std.GasPrice{}) {
 		return
 	}
-	gp = canonicalBlockGasPrice(gp)
+	if err := validateBlockGasPrice(gp); err != nil {
+		panic(err)
+	}
 	stor := ctx.Store(gk.key)
 	bz, err := amino.Marshal(gp)
 	if err != nil {
@@ -395,19 +397,22 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // cap nothing (yet); when decreasing we floor the result at the initial gas price. This is just a starting
 // point. Down the line, the solution might not be even representable by one simple formula
 func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
+	if err := validateBlockGasPrice(lastGasPrice); err != nil {
+		panic(err)
+	}
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
 		return lastGasPrice
 	}
-	lastGasPrice = canonicalBlockGasPrice(lastGasPrice)
-
 	// This is also a configuration to indicate that there is no need to change the last gas price.
 	if params.TargetGasRatio == 0 {
 		return lastGasPrice
 	}
-	initialGasPrice := canonicalBlockGasPrice(params.InitialGasPrice)
-	if lastGasPrice.Price.Denom != initialGasPrice.Price.Denom {
-		panic(fmt.Sprintf("block gas price denomination %q does not match initial gas price denomination %q", lastGasPrice.Price.Denom, initialGasPrice.Price.Denom))
+	if err := validateBlockGasPrice(params.InitialGasPrice); err != nil {
+		panic(err)
+	}
+	if lastGasPrice.Price.Denom != params.InitialGasPrice.Price.Denom {
+		panic(fmt.Sprintf("block gas price denomination %q does not match initial gas price denomination %q", lastGasPrice.Price.Denom, params.InitialGasPrice.Price.Denom))
 	}
 	// Note: gasUsed == 0 (empty block) is deliberately handled by the decrease
 	// branch below, so the price can decay during idle periods.
@@ -423,14 +428,11 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	targetGasInt := new(big.Int).Set(num)
 
 	lastPriceInt := big.NewInt(lastGasPrice.Price.Amount)
-	initPriceInt := big.NewInt(initialGasPrice.Price.Amount)
+	initPriceInt := big.NewInt(params.InitialGasPrice.Price.Amount)
 
-	// if used gas is right on target, only apply a newly raised floor
+	// if used gas is right on target, no need to change
 	gasUsedInt := big.NewInt(gasUsed)
 	if targetGasInt.Cmp(gasUsedInt) == 0 {
-		if lastPriceInt.Cmp(initPriceInt) < 0 {
-			return initialGasPrice
-		}
 		return lastGasPrice
 	}
 
@@ -450,7 +452,7 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	} else { // gas used is less than the target
 		// decrease gas price down to initial gas price
 		if lastPriceInt.Cmp(initPriceInt) == -1 {
-			return initialGasPrice
+			return params.InitialGasPrice
 		}
 		num.Sub(targetGasInt, gasUsedInt)
 		num.Mul(num, lastPriceInt)
@@ -462,9 +464,9 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// value of GasPricesChangeCompressor (see issue #5906).
 		diff := maxBig(num, bigOne)
 		num.Sub(lastPriceInt, diff)
+		// gas price should not be less than the initial gas price,
+		num = maxBig(num, initPriceInt)
 	}
-	// Gas price should not be less than the initial gas price in either branch.
-	num = maxBig(num, initPriceInt)
 
 	if !num.IsInt64() {
 		panic("The min gas price is out of int64 range")
@@ -503,7 +505,9 @@ func (gk GasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice {
 	if err != nil {
 		panic(err)
 	}
-	gp = canonicalBlockGasPrice(gp)
+	if err := validateBlockGasPrice(gp); err != nil {
+		panic(err)
+	}
 	logTelemetry(gp,
 		attribute.KeyValue{
 			Key:   "func",
@@ -512,44 +516,18 @@ func (gk GasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice {
 	return gp
 }
 
-func canonicalBlockGasPrice(gp std.GasPrice) std.GasPrice {
-	if gp.Price.Amount == 0 {
-		return gp
-	}
-	if gp.Price.Amount < 0 {
-		panic("block gas price amount must be positive")
-	}
-	if gp.Gas <= 0 {
-		panic("nonzero block gas price gas must be positive")
-	}
-
-	amount := new(big.Int).Mul(big.NewInt(gp.Price.Amount), big.NewInt(BlockGasPriceScale))
-	quotient, remainder := new(big.Int), new(big.Int)
-	quotient.QuoRem(amount, big.NewInt(gp.Gas), remainder)
-	if remainder.Sign() != 0 {
-		quotient.Add(quotient, big.NewInt(1))
-	}
-	if !quotient.IsInt64() {
-		panic("The min gas price is out of int64 range")
-	}
-
-	gp.Gas = BlockGasPriceScale
-	gp.Price.Amount = quotient.Int64()
-	return gp
-}
-
 func logTelemetry(gp std.GasPrice, kv attribute.KeyValue) {
 	if !telemetry.MetricsEnabled() {
 		return
 	}
-	attrs := []attribute.KeyValue{
-		attribute.String("coin_denom", gp.Price.Denom),
-		attribute.Int64("gas_denominator", gp.Gas),
-		kv,
+	a := attribute.KeyValue{
+		Key:   "Coin",
+		Value: attribute.StringValue(gp.Price.String()),
 	}
+	attrs := []attribute.KeyValue{a, kv}
 	metrics.BlockGasPriceAmount.Record(
 		context.Background(),
-		gp.Price.Amount,
+		gp.Gas,
 		metric.WithAttributes(attrs...),
 	)
 }

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -347,6 +347,7 @@ func (gk GasPriceKeeper) SetGasPrice(ctx sdk.Context, gp std.GasPrice) {
 	if (gp == std.GasPrice{}) {
 		return
 	}
+	gp = canonicalBlockGasPrice(gp)
 	stor := ctx.Store(gk.key)
 	bz, err := amino.Marshal(gp)
 	if err != nil {
@@ -398,10 +399,15 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	if lastGasPrice.Price.Amount == 0 {
 		return lastGasPrice
 	}
+	lastGasPrice = canonicalBlockGasPrice(lastGasPrice)
 
 	// This is also a configuration to indicate that there is no need to change the last gas price.
 	if params.TargetGasRatio == 0 {
 		return lastGasPrice
+	}
+	initialGasPrice := canonicalBlockGasPrice(params.InitialGasPrice)
+	if lastGasPrice.Price.Denom != initialGasPrice.Price.Denom {
+		panic(fmt.Sprintf("block gas price denomination %q does not match initial gas price denomination %q", lastGasPrice.Price.Denom, initialGasPrice.Price.Denom))
 	}
 	// Note: gasUsed == 0 (empty block) is deliberately handled by the decrease
 	// branch below, so the price can decay during idle periods.
@@ -416,14 +422,19 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	num.Div(num, big.NewInt(int64(100)))
 	targetGasInt := new(big.Int).Set(num)
 
-	// if used gas is right on target, no need to change
+	lastPriceInt := big.NewInt(lastGasPrice.Price.Amount)
+	initPriceInt := big.NewInt(initialGasPrice.Price.Amount)
+
+	// if used gas is right on target, only apply a newly raised floor
 	gasUsedInt := big.NewInt(gasUsed)
 	if targetGasInt.Cmp(gasUsedInt) == 0 {
+		if lastPriceInt.Cmp(initPriceInt) < 0 {
+			return initialGasPrice
+		}
 		return lastGasPrice
 	}
 
 	c := params.GasPricesChangeCompressor
-	lastPriceInt := big.NewInt(lastGasPrice.Price.Amount)
 
 	bigOne := big.NewInt(1)
 	if gasUsedInt.Cmp(targetGasInt) == 1 { // gas used is more than the target
@@ -438,9 +449,8 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// XXX should we cap it with a max gas price?
 	} else { // gas used is less than the target
 		// decrease gas price down to initial gas price
-		initPriceInt := big.NewInt(params.InitialGasPrice.Price.Amount)
 		if lastPriceInt.Cmp(initPriceInt) == -1 {
-			return params.InitialGasPrice
+			return initialGasPrice
 		}
 		num.Sub(targetGasInt, gasUsedInt)
 		num.Mul(num, lastPriceInt)
@@ -452,9 +462,9 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// value of GasPricesChangeCompressor (see issue #5906).
 		diff := maxBig(num, bigOne)
 		num.Sub(lastPriceInt, diff)
-		// gas price should not be less than the initial gas price,
-		num = maxBig(num, initPriceInt)
 	}
+	// Gas price should not be less than the initial gas price in either branch.
+	num = maxBig(num, initPriceInt)
 
 	if !num.IsInt64() {
 		panic("The min gas price is out of int64 range")
@@ -493,6 +503,7 @@ func (gk GasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice {
 	if err != nil {
 		panic(err)
 	}
+	gp = canonicalBlockGasPrice(gp)
 	logTelemetry(gp,
 		attribute.KeyValue{
 			Key:   "func",
@@ -501,18 +512,44 @@ func (gk GasPriceKeeper) LastGasPrice(ctx sdk.Context) std.GasPrice {
 	return gp
 }
 
+func canonicalBlockGasPrice(gp std.GasPrice) std.GasPrice {
+	if gp.Price.Amount == 0 {
+		return gp
+	}
+	if gp.Price.Amount < 0 {
+		panic("block gas price amount must be positive")
+	}
+	if gp.Gas <= 0 {
+		panic("nonzero block gas price gas must be positive")
+	}
+
+	amount := new(big.Int).Mul(big.NewInt(gp.Price.Amount), big.NewInt(BlockGasPriceScale))
+	quotient, remainder := new(big.Int), new(big.Int)
+	quotient.QuoRem(amount, big.NewInt(gp.Gas), remainder)
+	if remainder.Sign() != 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	if !quotient.IsInt64() {
+		panic("The min gas price is out of int64 range")
+	}
+
+	gp.Gas = BlockGasPriceScale
+	gp.Price.Amount = quotient.Int64()
+	return gp
+}
+
 func logTelemetry(gp std.GasPrice, kv attribute.KeyValue) {
 	if !telemetry.MetricsEnabled() {
 		return
 	}
-	a := attribute.KeyValue{
-		Key:   "Coin",
-		Value: attribute.StringValue(gp.Price.String()),
+	attrs := []attribute.KeyValue{
+		attribute.String("coin_denom", gp.Price.Denom),
+		attribute.Int64("gas_denominator", gp.Gas),
+		kv,
 	}
-	attrs := []attribute.KeyValue{a, kv}
 	metrics.BlockGasPriceAmount.Record(
 		context.Background(),
-		gp.Gas,
+		gp.Price.Amount,
 		metric.WithAttributes(attrs...),
 	)
 }

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -92,70 +92,34 @@ func TestAccountKeeperParams(t *testing.T) {
 func TestGasPrice(t *testing.T) {
 	env := setupTestEnv()
 	gp := std.GasPrice{
-		Gas: 100,
+		Gas: BlockGasPriceScale,
 		Price: std.Coin{
-			Denom:  "token",
-			Amount: 10,
+			Denom:  "ugnot",
+			Amount: 1000,
 		},
 	}
 	env.gk.SetGasPrice(env.ctx, gp)
-	gp2 := env.gk.LastGasPrice(env.ctx)
-	require.Equal(t, std.GasPrice{
-		Gas:   BlockGasPriceScale,
-		Price: std.Coin{Denom: "token", Amount: 100_000},
-	}, gp2)
-}
+	require.Equal(t, gp, env.gk.LastGasPrice(env.ctx))
 
-func TestLastGasPriceCanonicalizesLegacyState(t *testing.T) {
-	env := setupTestEnv()
-	legacy := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
-	bz, err := amino.Marshal(legacy)
+	noncanonical := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	require.Panics(t, func() { env.gk.SetGasPrice(env.ctx, noncanonical) })
+
+	bz, err := amino.Marshal(noncanonical)
 	require.NoError(t, err)
 	env.ctx.Store(env.gk.key).Set(env.ctx.GasContext(), []byte(GasPriceKey), bz)
-
-	require.Equal(t, std.GasPrice{
-		Gas:   BlockGasPriceScale,
-		Price: std.Coin{Amount: 1000, Denom: "ugnot"},
-	}, env.gk.LastGasPrice(env.ctx))
+	require.Panics(t, func() { env.gk.LastGasPrice(env.ctx) })
 }
 
-func TestCanonicalBlockGasPrice(t *testing.T) {
-	tests := []struct {
-		name string
-		in   std.GasPrice
-		want std.GasPrice
-	}{
-		{"default floor", std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}}},
-		{"exact", std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 10, Denom: "ugnot"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 10_000, Denom: "ugnot"}}},
-		{"ceil", std.GasPrice{Gas: 3, Price: std.Coin{Amount: 1, Denom: "foo"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 333_334, Denom: "foo"}}},
-		{"disabled", std.GasPrice{Gas: 0, Price: std.Coin{Denom: "ugnot"}}, std.GasPrice{Gas: 0, Price: std.Coin{Denom: "ugnot"}}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, canonicalBlockGasPrice(tt.in))
-		})
-	}
+func TestGasPriceEquivalentRates(t *testing.T) {
+	legacy := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	canonical := std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}}
 
-	t.Run("invalid gas", func(t *testing.T) {
-		require.PanicsWithValue(t, "nonzero block gas price gas must be positive", func() {
-			canonicalBlockGasPrice(std.GasPrice{Price: std.Coin{Amount: 1, Denom: "ugnot"}})
-		})
-	})
-	t.Run("overflow", func(t *testing.T) {
-		require.PanicsWithValue(t, "The min gas price is out of int64 range", func() {
-			canonicalBlockGasPrice(std.GasPrice{Gas: 1, Price: std.Coin{Amount: math.MaxInt64, Denom: "ugnot"}})
-		})
-	})
-	t.Run("rate preservation", func(t *testing.T) {
-		old := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
-		canonical := canonicalBlockGasPrice(old)
-		gte, err := old.IsGTE(canonical)
-		require.NoError(t, err)
-		require.True(t, gte)
-		gte, err = canonical.IsGTE(old)
-		require.NoError(t, err)
-		require.True(t, gte)
-	})
+	gte, err := legacy.IsGTE(canonical)
+	require.NoError(t, err)
+	require.True(t, gte)
+	gte, err = canonical.IsGTE(legacy)
+	require.NoError(t, err)
+	require.True(t, gte)
 }
 
 func TestMax(t *testing.T) {
@@ -235,21 +199,12 @@ func TestCalcBlockGasPrice(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		zeroPrice := price(0)
+		zeroPrice := std.GasPrice{}
 		require.Equal(t, zeroPrice, gk.calcBlockGasPrice(zeroPrice, targetGas+1, maxGas, params))
 
 		disabledParams := params
 		disabledParams.TargetGasRatio = 0
-		oldFormat := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 10, Denom: "ugnot"}}
-		require.Equal(t, price(10_000), gk.calcBlockGasPrice(oldFormat, targetGas+1, maxGas, disabledParams))
-	})
-
-	t.Run("raised floor clamps every branch", func(t *testing.T) {
-		raised := params
-		raised.InitialGasPrice = price(2000)
-		for _, gasUsed := range []int64{targetGas - 1, targetGas, targetGas + 1} {
-			require.Equal(t, price(2000), gk.calcBlockGasPrice(price(1000), gasUsed, maxGas, raised))
-		}
+		require.Equal(t, price(10_000), gk.calcBlockGasPrice(price(10_000), targetGas+1, maxGas, disabledParams))
 	})
 
 	t.Run("denom mismatch", func(t *testing.T) {
@@ -286,6 +241,7 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 		gasUsed  []int64
 		expected []int64
 	}{
+		{"consecutive increases", []int64{targetGas + 1}, []int64{10_001, 10_002, 10_003}},
 		{"below then above target", []int64{targetGas - 1, targetGas + 1}, []int64{9999, 10_000, 9999, 10_000}},
 		{"above then below target", []int64{targetGas + 1, targetGas - 1}, []int64{10_001, 10_000, 10_001, 10_000}},
 	} {
@@ -294,6 +250,7 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 			for i, expected := range tt.expected {
 				next = gk.calcBlockGasPrice(next, tt.gasUsed[i%len(tt.gasUsed)], maxGas, params)
 				require.Equal(t, expected, next.Price.Amount)
+				require.Equal(t, BlockGasPriceScale, next.Gas)
 			}
 		})
 	}
@@ -311,10 +268,24 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 			for _, expected := range tt.expected {
 				next = gk.calcBlockGasPrice(next, tt.gasUsed, maxGas, params)
 				require.Equal(t, expected, next.Price.Amount)
+				require.Equal(t, BlockGasPriceScale, next.Gas)
 			}
 			require.Greater(t, next.Price.Amount, params.InitialGasPrice.Price.Amount)
 		})
 	}
+
+	t.Run("floor arrival and stability", func(t *testing.T) {
+		next := price
+		for range 100 {
+			next = gk.calcBlockGasPrice(next, 0, maxGas, params)
+			require.Equal(t, BlockGasPriceScale, next.Gas)
+			if next == params.InitialGasPrice {
+				break
+			}
+		}
+		require.Equal(t, params.InitialGasPrice, next)
+		require.Equal(t, next, gk.calcBlockGasPrice(next, 0, maxGas, params))
+	})
 }
 
 func TestNewAccountWithUncheckedNumber(t *testing.T) {

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/store"
@@ -99,7 +100,62 @@ func TestGasPrice(t *testing.T) {
 	}
 	env.gk.SetGasPrice(env.ctx, gp)
 	gp2 := env.gk.LastGasPrice(env.ctx)
-	require.True(t, gp == gp2)
+	require.Equal(t, std.GasPrice{
+		Gas:   BlockGasPriceScale,
+		Price: std.Coin{Denom: "token", Amount: 100_000},
+	}, gp2)
+}
+
+func TestLastGasPriceCanonicalizesLegacyState(t *testing.T) {
+	env := setupTestEnv()
+	legacy := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+	bz, err := amino.Marshal(legacy)
+	require.NoError(t, err)
+	env.ctx.Store(env.gk.key).Set(env.ctx.GasContext(), []byte(GasPriceKey), bz)
+
+	require.Equal(t, std.GasPrice{
+		Gas:   BlockGasPriceScale,
+		Price: std.Coin{Amount: 1000, Denom: "ugnot"},
+	}, env.gk.LastGasPrice(env.ctx))
+}
+
+func TestCanonicalBlockGasPrice(t *testing.T) {
+	tests := []struct {
+		name string
+		in   std.GasPrice
+		want std.GasPrice
+	}{
+		{"default floor", std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}}},
+		{"exact", std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 10, Denom: "ugnot"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 10_000, Denom: "ugnot"}}},
+		{"ceil", std.GasPrice{Gas: 3, Price: std.Coin{Amount: 1, Denom: "foo"}}, std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 333_334, Denom: "foo"}}},
+		{"disabled", std.GasPrice{Gas: 0, Price: std.Coin{Denom: "ugnot"}}, std.GasPrice{Gas: 0, Price: std.Coin{Denom: "ugnot"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, canonicalBlockGasPrice(tt.in))
+		})
+	}
+
+	t.Run("invalid gas", func(t *testing.T) {
+		require.PanicsWithValue(t, "nonzero block gas price gas must be positive", func() {
+			canonicalBlockGasPrice(std.GasPrice{Price: std.Coin{Amount: 1, Denom: "ugnot"}})
+		})
+	})
+	t.Run("overflow", func(t *testing.T) {
+		require.PanicsWithValue(t, "The min gas price is out of int64 range", func() {
+			canonicalBlockGasPrice(std.GasPrice{Gas: 1, Price: std.Coin{Amount: math.MaxInt64, Denom: "ugnot"}})
+		})
+	})
+	t.Run("rate preservation", func(t *testing.T) {
+		old := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1, Denom: "ugnot"}}
+		canonical := canonicalBlockGasPrice(old)
+		gte, err := old.IsGTE(canonical)
+		require.NoError(t, err)
+		require.True(t, gte)
+		gte, err = canonical.IsGTE(old)
+		require.NoError(t, err)
+		require.True(t, gte)
+	})
 }
 
 func TestMax(t *testing.T) {
@@ -145,16 +201,10 @@ func TestCalcBlockGasPrice(t *testing.T) {
 	params := Params{
 		TargetGasRatio:            70,
 		GasPricesChangeCompressor: 10,
-		InitialGasPrice: std.GasPrice{
-			Gas:   1000,
-			Price: std.Coin{Amount: 1, Denom: "ugnot"},
-		},
+		InitialGasPrice:           std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}},
 	}
 	price := func(amount int64) std.GasPrice {
-		return std.GasPrice{
-			Gas:   1000,
-			Price: std.Coin{Amount: amount, Denom: "ugnot"},
-		}
+		return std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: amount, Denom: "ugnot"}}
 	}
 
 	tests := []struct {
@@ -163,14 +213,12 @@ func TestCalcBlockGasPrice(t *testing.T) {
 		gasUsed  int64
 		expected int64
 	}{
-		{"at target", 10, targetGas, 10},
-		{"one below target", 10, targetGas - 1, 9},
-		{"one above target", 10, targetGas + 1, 11},
-		{"low usage", 10, 420_000_000, 9},
-		{"empty block", 10, 0, 9},
-		{"floor below target", 1, targetGas - 1, 1},
-		{"floor empty block", 1, 0, 1},
-		{"floor one above target", 1, targetGas + 1, 2},
+		{"at target", 1000, targetGas, 1000},
+		{"one below target", 1000, targetGas - 1, 1000},
+		{"one above target", 1000, targetGas + 1, 1001},
+		{"full block", 1000, maxGas, 1042},
+		{"empty block", 10_000, 0, 9000},
+		{"floor empty block", 1000, 0, 1000},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -180,8 +228,8 @@ func TestCalcBlockGasPrice(t *testing.T) {
 	}
 
 	t.Run("calculated deltas", func(t *testing.T) {
-		params := Params{TargetGasRatio: 50, GasPricesChangeCompressor: 2}
-		start := std.GasPrice{Gas: 7, Price: std.Coin{Amount: 100, Denom: "atom"}}
+		params := Params{TargetGasRatio: 50, GasPricesChangeCompressor: 2, InitialGasPrice: price(1)}
+		start := price(100)
 		require.Equal(t, int64(125), gk.calcBlockGasPrice(start, 7500, 10000, params).Price.Amount)
 		require.Equal(t, int64(75), gk.calcBlockGasPrice(start, 2500, 10000, params).Price.Amount)
 	})
@@ -192,7 +240,22 @@ func TestCalcBlockGasPrice(t *testing.T) {
 
 		disabledParams := params
 		disabledParams.TargetGasRatio = 0
-		require.Equal(t, price(10), gk.calcBlockGasPrice(price(10), targetGas+1, maxGas, disabledParams))
+		oldFormat := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 10, Denom: "ugnot"}}
+		require.Equal(t, price(10_000), gk.calcBlockGasPrice(oldFormat, targetGas+1, maxGas, disabledParams))
+	})
+
+	t.Run("raised floor clamps every branch", func(t *testing.T) {
+		raised := params
+		raised.InitialGasPrice = price(2000)
+		for _, gasUsed := range []int64{targetGas - 1, targetGas, targetGas + 1} {
+			require.Equal(t, price(2000), gk.calcBlockGasPrice(price(1000), gasUsed, maxGas, raised))
+		}
+	})
+
+	t.Run("denom mismatch", func(t *testing.T) {
+		mismatch := params
+		mismatch.InitialGasPrice = std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "other"}}
+		require.Panics(t, func() { gk.calcBlockGasPrice(price(1000), targetGas, maxGas, mismatch) })
 	})
 
 	t.Run("int64 overflow", func(t *testing.T) {
@@ -211,14 +274,11 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 	params := Params{
 		TargetGasRatio:            70,
 		GasPricesChangeCompressor: 10,
-		InitialGasPrice: std.GasPrice{
-			Gas:   1000,
-			Price: std.Coin{Amount: 1, Denom: "ugnot"},
-		},
+		InitialGasPrice:           std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Amount: 1000, Denom: "ugnot"}},
 	}
 	price := std.GasPrice{
-		Gas:   1000,
-		Price: std.Coin{Amount: 10, Denom: "ugnot"},
+		Gas:   BlockGasPriceScale,
+		Price: std.Coin{Amount: 10_000, Denom: "ugnot"},
 	}
 
 	for _, tt := range []struct {
@@ -226,8 +286,8 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 		gasUsed  []int64
 		expected []int64
 	}{
-		{"below then above target", []int64{targetGas - 1, targetGas + 1}, []int64{9, 10, 9, 10}},
-		{"above then below target", []int64{targetGas + 1, targetGas - 1}, []int64{11, 10, 11, 10}},
+		{"below then above target", []int64{targetGas - 1, targetGas + 1}, []int64{9999, 10_000, 9999, 10_000}},
+		{"above then below target", []int64{targetGas + 1, targetGas - 1}, []int64{10_001, 10_000, 10_001, 10_000}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			next := price
@@ -239,20 +299,20 @@ func TestCalcBlockGasPriceRatchet(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name    string
-		gasUsed int64
+		name     string
+		gasUsed  int64
+		expected []int64
 	}{
-		{"low usage", 420_000_000},
-		{"empty blocks", 0},
+		{"low usage", 420_000_000, []int64{9200, 8464, 7787}},
+		{"empty blocks", 0, []int64{9000, 8100, 7290}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			next := price
-			for block := int64(1); block <= 9; block++ {
+			for _, expected := range tt.expected {
 				next = gk.calcBlockGasPrice(next, tt.gasUsed, maxGas, params)
-				require.Equal(t, int64(10)-block, next.Price.Amount)
+				require.Equal(t, expected, next.Price.Amount)
 			}
-			next = gk.calcBlockGasPrice(next, tt.gasUsed, maxGas, params)
-			require.Equal(t, int64(1), next.Price.Amount)
+			require.Greater(t, next.Price.Amount, params.InitialGasPrice.Price.Amount)
 		})
 	}
 }

--- a/tm2/pkg/sdk/auth/params.go
+++ b/tm2/pkg/sdk/auth/params.go
@@ -118,11 +118,24 @@ func (p Params) Validate() error {
 	if p.FeeCollector.IsZero() {
 		return fmt.Errorf("invalid fee collector, cannot be empty")
 	}
-	if p.InitialGasPrice.Gas < 0 {
-		return fmt.Errorf("invalid initial gas price: gas must be non-negative, got %d", p.InitialGasPrice.Gas)
+	if err := validateBlockGasPrice(p.InitialGasPrice); err != nil {
+		return fmt.Errorf("invalid initial gas price: %w", err)
 	}
-	if p.InitialGasPrice.Price.Amount < 0 {
-		return fmt.Errorf("invalid initial gas price: price amount must be non-negative, got %d", p.InitialGasPrice.Price.Amount)
+	return nil
+}
+
+func validateBlockGasPrice(gp std.GasPrice) error {
+	if gp.Gas == 0 && gp.Price.Amount == 0 {
+		return nil
+	}
+	if gp.Gas != BlockGasPriceScale {
+		return fmt.Errorf("gas must be %d, got %d", BlockGasPriceScale, gp.Gas)
+	}
+	if gp.Price.Amount <= 0 {
+		return fmt.Errorf("price amount must be positive, got %d", gp.Price.Amount)
+	}
+	if err := std.ValidateDenom(gp.Price.Denom); err != nil {
+		return err
 	}
 	return nil
 }
@@ -191,6 +204,9 @@ func (ak AccountKeeper) WillSetParam(ctx sdk.Context, key string, value any) {
 		gp, err := std.ParseGasPrice(s)
 		if err != nil {
 			panic(fmt.Sprintf("invalid initial_gasprice: %v", err))
+		}
+		if params.InitialGasPrice.Price.Denom != "" && gp.Price.Denom != params.InitialGasPrice.Price.Denom {
+			panic(fmt.Sprintf("initial_gasprice denomination %q does not match current denomination %q", gp.Price.Denom, params.InitialGasPrice.Price.Denom))
 		}
 		params.InitialGasPrice = gp
 	case "p:unrestricted_addrs":

--- a/tm2/pkg/sdk/auth/params_test.go
+++ b/tm2/pkg/sdk/auth/params_test.go
@@ -133,6 +133,23 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+
+	valid := DefaultParams()
+	valid.InitialGasPrice = std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Denom: "ugnot", Amount: 1000}}
+	require.NoError(t, valid.Validate())
+
+	for name, gasPrice := range map[string]std.GasPrice{
+		"noncanonical equivalent scale": {Gas: 1000, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+		"zero gas with amount":          {Gas: 0, Price: std.Coin{Denom: "ugnot", Amount: 1}},
+		"zero amount with scale":        {Gas: BlockGasPriceScale, Price: std.Coin{Denom: "ugnot", Amount: 0}},
+		"invalid denomination":          {Gas: BlockGasPriceScale, Price: std.Coin{Denom: "X", Amount: 1}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			params := valid
+			params.InitialGasPrice = gasPrice
+			require.Error(t, params.Validate())
+		})
+	}
 }
 
 func TestNewParams(t *testing.T) {
@@ -178,6 +195,9 @@ func TestNewParams(t *testing.T) {
 
 func TestWillSetParam(t *testing.T) {
 	env := setupTestEnv()
+	params := DefaultParams()
+	params.InitialGasPrice = std.GasPrice{Gas: BlockGasPriceScale, Price: std.Coin{Denom: "ugnot", Amount: 1000}}
+	require.NoError(t, env.acck.SetParams(env.ctx, params))
 
 	tests := []struct {
 		name        string
@@ -340,8 +360,20 @@ func TestWillSetParam(t *testing.T) {
 		{
 			name:        "valid initial_gasprice",
 			key:         "p:initial_gasprice",
-			value:       "1ugnot/1gas",
+			value:       "2000ugnot/1000000gas",
 			shouldPanic: false,
+		},
+		{
+			name:        "invalid initial_gasprice scale",
+			key:         "p:initial_gasprice",
+			value:       "1ugnot/1000gas",
+			shouldPanic: true,
+		},
+		{
+			name:        "invalid initial_gasprice denomination change",
+			key:         "p:initial_gasprice",
+			value:       "1000uatom/1000000gas",
+			shouldPanic: true,
 		},
 		{
 			name:        "wrong type for initial_gasprice",

--- a/tm2/pkg/telemetry/metrics/metrics.go
+++ b/tm2/pkg/telemetry/metrics/metrics.go
@@ -253,7 +253,7 @@ func Init(config config.Config) error {
 
 	if BlockGasPriceAmount, err = meter.Int64Histogram(
 		gasPriceKey,
-		metric.WithDescription("block gas price amount numerator"),
+		metric.WithDescription("block gas price"),
 		metric.WithUnit("token"),
 	); err != nil {
 		return fmt.Errorf("unable to create histogram, %w", err)

--- a/tm2/pkg/telemetry/metrics/metrics.go
+++ b/tm2/pkg/telemetry/metrics/metrics.go
@@ -253,7 +253,7 @@ func Init(config config.Config) error {
 
 	if BlockGasPriceAmount, err = meter.Int64Histogram(
 		gasPriceKey,
-		metric.WithDescription("block gas price"),
+		metric.WithDescription("block gas price amount numerator"),
 		metric.WithUnit("token"),
 	); err != nil {
 		return fmt.Errorf("unable to create histogram, %w", err)


### PR DESCRIPTION
Depends on #5916. Related to #5906.

## Why

The dynamic gas price was represented at its default floor as `1ugnot/1000gas`. Because the controller changes the integer numerator by at least one unit, the smallest upward tick at that floor was `1 -> 2`, or 100%.

This PR keeps the same economic floor while representing it as `1000ugnot/1000000gas`. A one-unit numerator tick is therefore 0.1% at the floor. The target ratio, compressor, and proportional update formula remain unchanged.

This targets a fresh testnet. It does not migrate or rescale legacy runtime state.

## Changes

### Dynamic gas price

- Add a fixed `1_000_000` denominator for the consensus dynamic gas price.
- Change the default genesis price to the economically equivalent `1000ugnot/1000000gas`. (still concerned bout UX)
- Update only the numerator during block-price adjustments while preserving the denominator and denomination.
- Preserve empty-block decay, symmetric minimum one-unit changes, and the initial-price floor from #5916.
- Reject noncanonical scales, invalid amounts and denominations, and governance denomination changes before they reach consensus execution.

### Genesis tooling

- Validate the complete resulting genesis state before `gnogenesis params set` writes it.
- Reject noncanonical dynamic gas-price values during genesis editing.

### Fee estimation

- Calculate required fees as `ceil(gasWanted * priceAmount / gasDenominator)` using `big.Int` intermediates.
- Calculate the fee for the suggested gas-wanted value before applying the existing configurable fee margin.
- Update simulation golden outputs for the new calculation.

### Tests

- Cover fixed-scale validation, governance rejection, equivalent-rate fee thresholds, numerator-only updates, alternating price changes, empty-block decay, floor arrival and stability, and fee rounding with large products.
- Cover canonical and noncanonical `gnogenesis params set` inputs.
- Update `simulate_gas` and `gnokey_gasfee` integration goldens.

## Compatibility

The `auth/gasprice` JSON schema is unchanged, but its raw values now use the fixed denominator. Clients must interpret `price / gas` as a rate instead of assuming that `gas` is `1000`.

## AI assistance

This change was planned and reviewed with AI assistance; the human author reviewed and owns the contribution.

