### PR TITLE
privval: add AWS Secrets Manager backed signer

### DIFF
--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/awssecretsmanager"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/upstream"
@@ -33,22 +34,31 @@ type PrivValidatorConfig struct {
 	// listens for tmkms / Horcrux to dial in). Mutually exclusive with RemoteSigner;
 	// see upstream_config.go.
 	TmkmsListener *TmkmsListenerConfig `json:"tmkms_listener" toml:"tmkms_listener" comment:"Configuration for upstream-Tendermint-protocol signer (tmkms / Horcrux). Empty listen_addr disables this mode."`
+
+	// AWSSecretsManager configures a signer that loads the validator key from
+	// an AWS Secrets Manager secret instead of a local file. Signing still
+	// happens locally, in-process; AWS Secrets Manager is only used as the
+	// durable key store. Mutually exclusive with RemoteSigner and TmkmsListener.
+	AWSSecretsManager *awssecretsmanager.Config `json:"aws_secrets_manager" toml:"aws_secrets_manager" comment:"Configuration for loading the validator key from AWS Secrets Manager"`
 }
 
 // PrivValidatorConfig validation errors.
 var (
-	errInvalidSignStatePath   = errors.New("invalid private validator sign state file path")
-	errInvalidLocalSignerPath = errors.New("invalid private validator local signer file path")
-	errNilRemoteSignerConfig  = errors.New("remote signer configuration cannot be nil")
+	errInvalidSignStatePath     = errors.New("invalid private validator sign state file path")
+	errInvalidLocalSignerPath   = errors.New("invalid private validator local signer file path")
+	errNilRemoteSignerConfig    = errors.New("remote signer configuration cannot be nil")
+	errNilAWSSecretsManagerCfg  = errors.New("aws secrets manager configuration cannot be nil")
+	errMultipleSignerSourcesSet = errors.New("only one of remote_signer, tmkms_listener, or aws_secrets_manager may be configured")
 )
 
 // DefaultPrivValidatorConfig returns a default configuration for the PrivValidator.
 func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 	return &PrivValidatorConfig{
-		SignState:     "priv_validator_state.json",
-		LocalSigner:   "priv_validator_key.json",
-		RemoteSigner:  rsclient.DefaultRemoteSignerClientConfig(),
-		TmkmsListener: DefaultTmkmsListenerConfig(),
+		SignState:         "priv_validator_state.json",
+		LocalSigner:       "priv_validator_key.json",
+		RemoteSigner:      rsclient.DefaultRemoteSignerClientConfig(),
+		TmkmsListener:     DefaultTmkmsListenerConfig(),
+		AWSSecretsManager: awssecretsmanager.DefaultConfig(),
 	}
 }
 
@@ -97,9 +107,22 @@ func (cfg *PrivValidatorConfig) ValidateBasic() error {
 		}
 	}
 
+	// Verify the AWS Secrets Manager configuration is not nil.
+	if cfg.AWSSecretsManager == nil {
+		return errNilAWSSecretsManagerCfg
+	}
+
+	// Validate the AWS Secrets Manager configuration.
+	if err := cfg.AWSSecretsManager.ValidateBasic(); err != nil {
+		return err
+	}
+
 	// Mutual exclusion: at most one external-signer mode may be enabled.
 	if cfg.RemoteSigner.ServerAddress != "" && cfg.TmkmsListener.IsEnabled() {
 		return errBothExternalSignersEnabled
+	}
+	if cfg.AWSSecretsManager.IsEnabled() && (cfg.RemoteSigner.ServerAddress != "" || cfg.TmkmsListener.IsEnabled()) {
+		return errMultipleSignerSourcesSet
 	}
 
 	return nil
@@ -123,6 +146,11 @@ func NewSignerFromConfig(
 			clientPrivKey,
 			clientLogger,
 		)
+	}
+
+	// If AWS Secrets Manager is configured, load the key from there.
+	if config.AWSSecretsManager.IsEnabled() {
+		return awssecretsmanager.NewSignerFromConfig(ctx, config.AWSSecretsManager)
 	}
 
 	// Otherwise, use a local signer.
@@ -149,9 +177,12 @@ func NewPrivValidatorFromConfig(
 ) (types.PrivValidator, error) {
 	// Mutual exclusion is also enforced in ValidateBasic, but defend in
 	// depth here in case callers skip validation.
-	if config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != "" &&
-		config.TmkmsListener.IsEnabled() {
+	remoteSignerEnabled := config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != ""
+	if remoteSignerEnabled && config.TmkmsListener.IsEnabled() {
 		return nil, errBothExternalSignersEnabled
+	}
+	if config.AWSSecretsManager.IsEnabled() && (remoteSignerEnabled || config.TmkmsListener.IsEnabled()) {
+		return nil, errMultipleSignerSourcesSet
 	}
 
 	// tmkms-compat path. tmkms holds HRS authority; we don't wrap the

--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -18,9 +18,10 @@ import (
 )
 
 // PrivValidatorConfig defines the configuration for the PrivValidator, with a local
-// signer (file-based key), a gnokms remote signer (tm2-native protocol), or a tmkms
+// signer (file-based key), a gnokms remote signer (tm2-native protocol), a tmkms
 // listener (upstream Tendermint privval protocol — the validator listens for tmkms
-// to dial in). At most one of RemoteSigner or TmkmsListener may be enabled.
+// to dial in), or AWS Secrets Manager. At most one of RemoteSigner, TmkmsListener,
+// or AWSSecretsManager may be enabled.
 type PrivValidatorConfig struct {
 	// File path configuration.
 	RootDir     string `json:"home" toml:"home"`

--- a/tm2/pkg/bft/privval/config_test.go
+++ b/tm2/pkg/bft/privval/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/awssecretsmanager"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	rsserver "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/server"
@@ -420,5 +421,92 @@ func TestNewPrivValidatorFromConfig(t *testing.T) {
 		}
 		require.NoError(t, err, "port must be released after Init failure")
 		require.NoError(t, rebound.Close())
+	})
+}
+
+// enabledAWSConfig returns a minimally-valid, enabled AWS Secrets Manager
+// config for use in the mutual-exclusion tests below. It doesn't need to
+// point at a real secret: these tests only exercise validation, not signer
+// construction.
+func enabledAWSConfig() *awssecretsmanager.Config {
+	return &awssecretsmanager.Config{
+		SecretID: "test-validator-key",
+	}
+}
+
+func TestPrivValidatorConfig_AWSSecretsManagerValidateBasic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil aws config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.AWSSecretsManager = nil
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errNilAWSSecretsManagerCfg)
+	})
+
+	t.Run("aws with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.AWSSecretsManager = enabledAWSConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("aws with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.AWSSecretsManager = enabledAWSConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-aws-test.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("aws alone", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.AWSSecretsManager = enabledAWSConfig()
+
+		require.NoError(t, cfg.ValidateBasic())
+	})
+}
+
+func TestPrivValidatorConfig_AWSSecretsManagerNewPrivValidator(t *testing.T) {
+	t.Parallel()
+
+	var (
+		privKey = ed25519.GenPrivKey()
+		logger  = log.NewNoopLogger()
+	)
+
+	t.Run("aws with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.AWSSecretsManager = enabledAWSConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
+	})
+
+	t.Run("aws with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.AWSSecretsManager = enabledAWSConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-aws-test2.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
 	})
 }

--- a/tm2/pkg/bft/privval/signer/awssecretsmanager/awssecretsmanager_test.go
+++ b/tm2/pkg/bft/privval/signer/awssecretsmanager/awssecretsmanager_test.go
@@ -1,0 +1,149 @@
+package awssecretsmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSecretsManagerClient is an in-memory fake implementing secretsManagerAPI,
+// used so tests never make real AWS API calls.
+type mockSecretsManagerClient struct {
+	// secrets maps secret ID -> stored SecretString value.
+	secrets map[string]string
+
+	// getErr, if set, is returned by every GetSecretValue call instead of
+	// looking up secrets.
+	getErr error
+
+	// createErr, if set, is returned by every CreateSecret call.
+	createErr error
+}
+
+func newMockClient() *mockSecretsManagerClient {
+	return &mockSecretsManagerClient{secrets: map[string]string{}}
+}
+
+func (m *mockSecretsManagerClient) GetSecretValue(
+	_ context.Context,
+	params *secretsmanager.GetSecretValueInput,
+	_ ...func(*secretsmanager.Options),
+) (*secretsmanager.GetSecretValueOutput, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	value, ok := m.secrets[*params.SecretId]
+	if !ok {
+		msg := "secret not found"
+		return nil, &smtypes.ResourceNotFoundException{Message: &msg}
+	}
+
+	return &secretsmanager.GetSecretValueOutput{SecretString: &value}, nil
+}
+
+func (m *mockSecretsManagerClient) CreateSecret(
+	_ context.Context,
+	params *secretsmanager.CreateSecretInput,
+	_ ...func(*secretsmanager.Options),
+) (*secretsmanager.CreateSecretOutput, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+
+	m.secrets[*params.Name] = *params.SecretString
+
+	return &secretsmanager.CreateSecretOutput{Name: params.Name}, nil
+}
+
+func TestNewSigner_ExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	// Seed the mock store with a validator key encoded the same way the
+	// local file signer would persist it to disk.
+	key := local.GenerateFileKey()
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	require.NoError(t, err)
+
+	client := newMockClient()
+	client.secrets["my-validator-key"] = string(jsonBytes)
+
+	cfg := &Config{SecretID: "my-validator-key"}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	assert.True(t, signer.PubKey().Equals(key.PubKey))
+
+	sig, err := signer.Sign([]byte("hello"))
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().VerifyBytes([]byte("hello"), sig))
+
+	assert.NoError(t, signer.Close())
+	assert.Contains(t, signer.String(), "AWSSecretsManagerSigner")
+}
+
+func TestNewSigner_MissingSecret_NoCreate(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient()
+	cfg := &Config{SecretID: "does-not-exist", CreateIfMissing: false}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_MissingSecret_CreateIfMissing(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient()
+	cfg := &Config{SecretID: "new-validator-key", CreateIfMissing: true}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	// The generated key must have been persisted back to the mock store.
+	stored, ok := client.secrets["new-validator-key"]
+	require.True(t, ok)
+
+	parsed, err := local.ParseFileKey([]byte(stored))
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().Equals(parsed.PubKey))
+}
+
+func TestNewSigner_MalformedSecret(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient()
+	client.secrets["bad-key"] = "{not valid json"
+
+	cfg := &Config{SecretID: "bad-key"}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestConfig_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&Config{}).IsEnabled())
+	assert.False(t, (*Config)(nil).IsEnabled())
+	assert.True(t, (&Config{SecretID: "x"}).IsEnabled())
+}
+
+func TestNewSignerFromConfig_Disabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSignerFromConfig(context.Background(), DefaultConfig())
+	require.ErrorIs(t, err, errSecretIDRequired)
+}

--- a/tm2/pkg/bft/privval/signer/awssecretsmanager/client.go
+++ b/tm2/pkg/bft/privval/signer/awssecretsmanager/client.go
@@ -1,0 +1,46 @@
+package awssecretsmanager
+
+import (
+	"context"
+	"fmt"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// secretsManagerAPI is the subset of the AWS Secrets Manager client used by
+// the signer. It is defined as an interface so tests can substitute a mock
+// implementation without making real AWS API calls or requiring credentials.
+type secretsManagerAPI interface {
+	GetSecretValue(
+		ctx context.Context,
+		params *secretsmanager.GetSecretValueInput,
+		optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.GetSecretValueOutput, error)
+
+	CreateSecret(
+		ctx context.Context,
+		params *secretsmanager.CreateSecretInput,
+		optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.CreateSecretOutput, error)
+}
+
+// secretsManagerAPI is implemented by *secretsmanager.Client.
+var _ secretsManagerAPI = (*secretsmanager.Client)(nil)
+
+// newClient builds a real AWS Secrets Manager client using the standard AWS
+// SDK configuration chain (environment variables, shared config/credentials
+// files, EC2/ECS instance roles, etc.), optionally pinned to a specific region.
+func newClient(ctx context.Context, region string) (secretsManagerAPI, error) {
+	var opts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS SDK configuration: %w", err)
+	}
+
+	return secretsmanager.NewFromConfig(awsCfg), nil
+}

--- a/tm2/pkg/bft/privval/signer/awssecretsmanager/config.go
+++ b/tm2/pkg/bft/privval/signer/awssecretsmanager/config.go
@@ -1,0 +1,53 @@
+package awssecretsmanager
+
+// Config defines the configuration options for a Signer backed by AWS
+// Secrets Manager. This is used to marshal/unmarshal the configuration
+// to/from TOML and configure the signer using the gnoland CLI tool.
+type Config struct {
+	// SecretID is the ARN or name of the AWS Secrets Manager secret holding
+	// the validator's private key, encoded the same way as the on-disk
+	// priv_validator_key.json file. If empty, the AWS Secrets Manager signer
+	// is disabled.
+	SecretID string `json:"secret_id" toml:"secret_id" comment:"ARN or name of the AWS Secrets Manager secret holding the validator key. If set, the local signer is disabled"`
+
+	// Region is the AWS region to use for the Secrets Manager client. If
+	// empty, it is resolved using the standard AWS SDK configuration chain
+	// (environment variables, shared config/credentials files, EC2/ECS
+	// instance metadata, etc.).
+	Region string `json:"region" toml:"region" comment:"AWS region for the Secrets Manager client. Leave empty to use the default AWS SDK region resolution"`
+
+	// CreateIfMissing, when true, generates a new random validator key and
+	// stores it as a new secret under SecretID if the secret does not
+	// already exist. When false (the default), a missing secret is treated
+	// as a fatal configuration error, to avoid silently minting a validator
+	// identity that was never intended.
+	CreateIfMissing bool `json:"create_if_missing" toml:"create_if_missing" comment:"Generate and store a new validator key in Secrets Manager if the secret does not exist yet"`
+}
+
+// DefaultConfig returns a default, disabled configuration for the AWS
+// Secrets Manager signer.
+func DefaultConfig() *Config {
+	return &Config{
+		SecretID:        "", // Empty to disable the AWS Secrets Manager signer by default.
+		Region:          "",
+		CreateIfMissing: false,
+	}
+}
+
+// TestConfig returns a configuration for testing the AWS Secrets Manager signer.
+func TestConfig() *Config {
+	return DefaultConfig()
+}
+
+// IsEnabled reports whether the AWS Secrets Manager signer is configured for use.
+func (cfg *Config) IsEnabled() bool {
+	return cfg != nil && cfg.SecretID != ""
+}
+
+// ValidateBasic performs basic validation (checking param bounds, etc.) and
+// returns an error if any check fails.
+func (cfg *Config) ValidateBasic() error {
+	// No cross-field constraints beyond SecretID gating IsEnabled: Region and
+	// CreateIfMissing are both meaningful at their zero value.
+	return nil
+}

--- a/tm2/pkg/bft/privval/signer/awssecretsmanager/signer.go
+++ b/tm2/pkg/bft/privval/signer/awssecretsmanager/signer.go
@@ -1,0 +1,139 @@
+package awssecretsmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+)
+
+// Signer implements types.Signer using a validator key stored in AWS Secrets
+// Manager. The key material is fetched once at construction time and kept in
+// memory for the lifetime of the process; signing itself happens locally, the
+// same way the local file signer does. AWS Secrets Manager is used purely as
+// a durable, access-controlled key store, not as a remote signing oracle —
+// unlike the tmkms/gnokms remote-signer modes, the private key does leave
+// AWS and reside in this process's memory.
+type Signer struct {
+	key *local.FileKey
+}
+
+// Signer type implements types.Signer.
+var _ types.Signer = (*Signer)(nil)
+
+// PubKey implements types.Signer.
+func (s *Signer) PubKey() crypto.PubKey {
+	return s.key.PubKey
+}
+
+// Sign implements types.Signer.
+func (s *Signer) Sign(signBytes []byte) ([]byte, error) {
+	return s.key.PrivKey.Sign(signBytes)
+}
+
+// Close implements types.Signer.
+func (s *Signer) Close() error {
+	return nil
+}
+
+// Signer type implements fmt.Stringer.
+var _ fmt.Stringer = (*Signer)(nil)
+
+// String implements fmt.Stringer.
+func (s *Signer) String() string {
+	return fmt.Sprintf("{Type: AWSSecretsManagerSigner, Addr: %s}", s.key.Address)
+}
+
+// Config validation errors.
+var (
+	errSecretIDRequired = errors.New("aws secrets manager signer: secret_id is required")
+	errEmptySecretValue = errors.New("aws secrets manager signer: secret has no value")
+)
+
+// NewSignerFromConfig fetches the validator key from AWS Secrets Manager
+// according to cfg and returns a ready-to-use Signer. If the secret does not
+// exist and cfg.CreateIfMissing is true, a new random key is generated and
+// stored under cfg.SecretID before being returned.
+func NewSignerFromConfig(ctx context.Context, cfg *Config) (*Signer, error) {
+	if !cfg.IsEnabled() {
+		return nil, errSecretIDRequired
+	}
+
+	client, err := newClient(ctx, cfg.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	return newSigner(ctx, client, cfg)
+}
+
+// newSigner contains the constructor logic decoupled from the concrete AWS
+// client, so it can be exercised in tests against a mock secretsManagerAPI.
+func newSigner(ctx context.Context, client secretsManagerAPI, cfg *Config) (*Signer, error) {
+	out, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: &cfg.SecretID,
+	})
+	if err != nil {
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) && cfg.CreateIfMissing {
+			return createAndStoreKey(ctx, client, cfg.SecretID)
+		}
+
+		return nil, fmt.Errorf("unable to retrieve secret %q from AWS Secrets Manager: %w", cfg.SecretID, err)
+	}
+
+	raw, err := secretPayload(out)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := local.ParseFileKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid validator key in secret %q: %w", cfg.SecretID, err)
+	}
+
+	return &Signer{key: key}, nil
+}
+
+// secretPayload extracts the raw JSON bytes from a GetSecretValueOutput,
+// preferring SecretString (the common case, and what CreateSecret in this
+// package writes) and falling back to SecretBinary.
+func secretPayload(out *secretsmanager.GetSecretValueOutput) ([]byte, error) {
+	if out.SecretString != nil {
+		return []byte(*out.SecretString), nil
+	}
+
+	if len(out.SecretBinary) > 0 {
+		return out.SecretBinary, nil
+	}
+
+	return nil, errEmptySecretValue
+}
+
+// createAndStoreKey generates a new random validator FileKey, persists it as
+// a new secret under secretID using the same amino-JSON encoding as the local
+// file signer, and returns a Signer wrapping it.
+func createAndStoreKey(ctx context.Context, client secretsManagerAPI, secretID string) (*Signer, error) {
+	key := local.GenerateFileKey()
+
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal newly generated validator key: %w", err)
+	}
+	secretString := string(jsonBytes)
+
+	if _, err := client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         &secretID,
+		SecretString: &secretString,
+	}); err != nil {
+		return nil, fmt.Errorf("unable to create secret %q in AWS Secrets Manager: %w", secretID, err)
+	}
+
+	return &Signer{key: key}, nil
+}

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -80,7 +80,7 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 	// Parse and validate the FileKey from the JSON bytes.
 	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+		return nil, fmt.Errorf("unable to load FileKey from %v: %w", filePath, err)
 	}
 
 	return fk, nil

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -77,11 +77,23 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 		return nil, err
 	}
 
-	// Unmarshal the JSON bytes into a FileKey using amino.
-	fk := &FileKey{}
-	err = amino.UnmarshalJSON(rawJSONBytes, fk)
+	// Parse and validate the FileKey from the JSON bytes.
+	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+	}
+
+	return fk, nil
+}
+
+// ParseFileKey unmarshals and validates a FileKey from raw amino JSON bytes.
+// This is exposed so that alternative key sources (e.g. a secrets manager)
+// can reuse the same encoding and validation rules as the on-disk FileKey.
+func ParseFileKey(rawJSONBytes []byte) (*FileKey, error) {
+	// Unmarshal the JSON bytes into a FileKey using amino.
+	fk := &FileKey{}
+	if err := amino.UnmarshalJSON(rawJSONBytes, fk); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal FileKey: %w", err)
 	}
 
 	// Validate the FileKey.


### PR DESCRIPTION
Adds a signer that loads the validator private key from AWS Secrets Manager (instead of a local file). Signing happens in-process — Secrets Manager is used purely as a durable, access-controlled key store, mirroring the existing local-file signer pattern.

Closes #3232