### PR TITLE
privval: add GCP Secret Manager backed signer

### DIFF
--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/gcpsecretmanager"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/upstream"
@@ -33,22 +34,31 @@ type PrivValidatorConfig struct {
 	// listens for tmkms / Horcrux to dial in). Mutually exclusive with RemoteSigner;
 	// see upstream_config.go.
 	TmkmsListener *TmkmsListenerConfig `json:"tmkms_listener" toml:"tmkms_listener" comment:"Configuration for upstream-Tendermint-protocol signer (tmkms / Horcrux). Empty listen_addr disables this mode."`
+
+	// GCPSecretManager configures a signer that loads the validator key from
+	// a GCP Secret Manager secret instead of a local file. Signing still
+	// happens locally, in-process; GCP Secret Manager is only used as the
+	// durable key store. Mutually exclusive with RemoteSigner and TmkmsListener.
+	GCPSecretManager *gcpsecretmanager.Config `json:"gcp_secret_manager" toml:"gcp_secret_manager" comment:"Configuration for loading the validator key from GCP Secret Manager"`
 }
 
 // PrivValidatorConfig validation errors.
 var (
-	errInvalidSignStatePath   = errors.New("invalid private validator sign state file path")
-	errInvalidLocalSignerPath = errors.New("invalid private validator local signer file path")
-	errNilRemoteSignerConfig  = errors.New("remote signer configuration cannot be nil")
+	errInvalidSignStatePath     = errors.New("invalid private validator sign state file path")
+	errInvalidLocalSignerPath   = errors.New("invalid private validator local signer file path")
+	errNilRemoteSignerConfig    = errors.New("remote signer configuration cannot be nil")
+	errNilGCPSecretManagerCfg   = errors.New("gcp secret manager configuration cannot be nil")
+	errMultipleSignerSourcesSet = errors.New("only one of remote_signer, tmkms_listener, or gcp_secret_manager may be configured")
 )
 
 // DefaultPrivValidatorConfig returns a default configuration for the PrivValidator.
 func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 	return &PrivValidatorConfig{
-		SignState:     "priv_validator_state.json",
-		LocalSigner:   "priv_validator_key.json",
-		RemoteSigner:  rsclient.DefaultRemoteSignerClientConfig(),
-		TmkmsListener: DefaultTmkmsListenerConfig(),
+		SignState:        "priv_validator_state.json",
+		LocalSigner:      "priv_validator_key.json",
+		RemoteSigner:     rsclient.DefaultRemoteSignerClientConfig(),
+		TmkmsListener:    DefaultTmkmsListenerConfig(),
+		GCPSecretManager: gcpsecretmanager.DefaultConfig(),
 	}
 }
 
@@ -97,9 +107,22 @@ func (cfg *PrivValidatorConfig) ValidateBasic() error {
 		}
 	}
 
+	// Verify the GCP Secret Manager configuration is not nil.
+	if cfg.GCPSecretManager == nil {
+		return errNilGCPSecretManagerCfg
+	}
+
+	// Validate the GCP Secret Manager configuration.
+	if err := cfg.GCPSecretManager.ValidateBasic(); err != nil {
+		return err
+	}
+
 	// Mutual exclusion: at most one external-signer mode may be enabled.
 	if cfg.RemoteSigner.ServerAddress != "" && cfg.TmkmsListener.IsEnabled() {
 		return errBothExternalSignersEnabled
+	}
+	if cfg.GCPSecretManager.IsEnabled() && (cfg.RemoteSigner.ServerAddress != "" || cfg.TmkmsListener.IsEnabled()) {
+		return errMultipleSignerSourcesSet
 	}
 
 	return nil
@@ -123,6 +146,11 @@ func NewSignerFromConfig(
 			clientPrivKey,
 			clientLogger,
 		)
+	}
+
+	// If GCP Secret Manager is configured, load the key from there.
+	if config.GCPSecretManager.IsEnabled() {
+		return gcpsecretmanager.NewSignerFromConfig(ctx, config.GCPSecretManager)
 	}
 
 	// Otherwise, use a local signer.
@@ -149,9 +177,12 @@ func NewPrivValidatorFromConfig(
 ) (types.PrivValidator, error) {
 	// Mutual exclusion is also enforced in ValidateBasic, but defend in
 	// depth here in case callers skip validation.
-	if config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != "" &&
-		config.TmkmsListener.IsEnabled() {
+	remoteSignerEnabled := config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != ""
+	if remoteSignerEnabled && config.TmkmsListener.IsEnabled() {
 		return nil, errBothExternalSignersEnabled
+	}
+	if config.GCPSecretManager.IsEnabled() && (remoteSignerEnabled || config.TmkmsListener.IsEnabled()) {
+		return nil, errMultipleSignerSourcesSet
 	}
 
 	// tmkms-compat path. tmkms holds HRS authority; we don't wrap the

--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -18,9 +18,10 @@ import (
 )
 
 // PrivValidatorConfig defines the configuration for the PrivValidator, with a local
-// signer (file-based key), a gnokms remote signer (tm2-native protocol), or a tmkms
+// signer (file-based key), a gnokms remote signer (tm2-native protocol), a tmkms
 // listener (upstream Tendermint privval protocol — the validator listens for tmkms
-// to dial in). At most one of RemoteSigner or TmkmsListener may be enabled.
+// to dial in), or GCP Secret Manager. At most one of RemoteSigner, TmkmsListener,
+// or GCPSecretManager may be enabled.
 type PrivValidatorConfig struct {
 	// File path configuration.
 	RootDir     string `json:"home" toml:"home"`

--- a/tm2/pkg/bft/privval/config_test.go
+++ b/tm2/pkg/bft/privval/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/gcpsecretmanager"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	rsserver "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/server"
@@ -420,5 +421,93 @@ func TestNewPrivValidatorFromConfig(t *testing.T) {
 		}
 		require.NoError(t, err, "port must be released after Init failure")
 		require.NoError(t, rebound.Close())
+	})
+}
+
+// enabledGCPConfig returns a minimally-valid, enabled GCP Secret Manager
+// config for use in the mutual-exclusion tests below. It doesn't need to
+// point at a real secret: these tests only exercise validation, not signer
+// construction.
+func enabledGCPConfig() *gcpsecretmanager.Config {
+	return &gcpsecretmanager.Config{
+		ProjectID: "test-project",
+		SecretID:  "test-validator-key",
+	}
+}
+
+func TestPrivValidatorConfig_GCPSecretManagerValidateBasic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil gcp config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.GCPSecretManager = nil
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errNilGCPSecretManagerCfg)
+	})
+
+	t.Run("gcp with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.GCPSecretManager = enabledGCPConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("gcp with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.GCPSecretManager = enabledGCPConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-gcp-test.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("gcp alone", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.GCPSecretManager = enabledGCPConfig()
+
+		require.NoError(t, cfg.ValidateBasic())
+	})
+}
+
+func TestPrivValidatorConfig_GCPSecretManagerNewPrivValidator(t *testing.T) {
+	t.Parallel()
+
+	var (
+		privKey = ed25519.GenPrivKey()
+		logger  = log.NewNoopLogger()
+	)
+
+	t.Run("gcp with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.GCPSecretManager = enabledGCPConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
+	})
+
+	t.Run("gcp with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.GCPSecretManager = enabledGCPConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-gcp-test2.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
 	})
 }

--- a/tm2/pkg/bft/privval/signer/gcpsecretmanager/client.go
+++ b/tm2/pkg/bft/privval/signer/gcpsecretmanager/client.go
@@ -1,0 +1,75 @@
+package gcpsecretmanager
+
+import (
+	"context"
+	"fmt"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+)
+
+// secretManagerAPI is the subset of the GCP Secret Manager client used by
+// the signer. It is defined as an interface so tests can substitute a mock
+// implementation without making real GCP API calls or requiring credentials.
+//
+// The real *secretmanager.Client methods additionally accept variadic
+// gax.CallOption arguments; gcpClient adapts that away so callers in this
+// package don't need to depend on the gax package directly.
+type secretManagerAPI interface {
+	AccessSecretVersion(
+		ctx context.Context,
+		req *secretmanagerpb.AccessSecretVersionRequest,
+	) (*secretmanagerpb.AccessSecretVersionResponse, error)
+
+	CreateSecret(
+		ctx context.Context,
+		req *secretmanagerpb.CreateSecretRequest,
+	) (*secretmanagerpb.Secret, error)
+
+	AddSecretVersion(
+		ctx context.Context,
+		req *secretmanagerpb.AddSecretVersionRequest,
+	) (*secretmanagerpb.SecretVersion, error)
+}
+
+// gcpClient adapts *secretmanager.Client to the secretManagerAPI interface.
+type gcpClient struct {
+	c *secretmanager.Client
+}
+
+// gcpClient type implements secretManagerAPI.
+var _ secretManagerAPI = (*gcpClient)(nil)
+
+func (g *gcpClient) AccessSecretVersion(
+	ctx context.Context,
+	req *secretmanagerpb.AccessSecretVersionRequest,
+) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	return g.c.AccessSecretVersion(ctx, req)
+}
+
+func (g *gcpClient) CreateSecret(
+	ctx context.Context,
+	req *secretmanagerpb.CreateSecretRequest,
+) (*secretmanagerpb.Secret, error) {
+	return g.c.CreateSecret(ctx, req)
+}
+
+func (g *gcpClient) AddSecretVersion(
+	ctx context.Context,
+	req *secretmanagerpb.AddSecretVersionRequest,
+) (*secretmanagerpb.SecretVersion, error) {
+	return g.c.AddSecretVersion(ctx, req)
+}
+
+// newClient builds a real GCP Secret Manager client using Application
+// Default Credentials (the GOOGLE_APPLICATION_CREDENTIALS environment
+// variable, gcloud user credentials, or the attached service account on
+// GCE/GKE/Cloud Run).
+func newClient(ctx context.Context) (secretManagerAPI, error) {
+	c, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create GCP Secret Manager client: %w", err)
+	}
+
+	return &gcpClient{c: c}, nil
+}

--- a/tm2/pkg/bft/privval/signer/gcpsecretmanager/config.go
+++ b/tm2/pkg/bft/privval/signer/gcpsecretmanager/config.go
@@ -1,0 +1,75 @@
+package gcpsecretmanager
+
+import "fmt"
+
+// Config defines the configuration options for a Signer backed by GCP Secret
+// Manager. This is used to marshal/unmarshal the configuration to/from TOML
+// and configure the signer using the gnoland CLI tool.
+type Config struct {
+	// ProjectID is the GCP project that owns the secret. If empty, the GCP
+	// Secret Manager signer is disabled.
+	ProjectID string `json:"project_id" toml:"project_id" comment:"GCP project ID that owns the secret"`
+
+	// SecretID is the short ID (not the full resource name) of the GCP
+	// Secret Manager secret holding the validator's private key, encoded
+	// the same way as the on-disk priv_validator_key.json file. If empty,
+	// the GCP Secret Manager signer is disabled.
+	SecretID string `json:"secret_id" toml:"secret_id" comment:"Short ID of the GCP Secret Manager secret holding the validator key. If set (together with project_id), the local signer is disabled"`
+
+	// Version is the secret version to read (e.g. "1", or "latest"). If
+	// empty, "latest" is used.
+	Version string `json:"version" toml:"version" comment:"Secret version to read. Defaults to \"latest\" if empty"`
+
+	// CreateIfMissing, when true, generates a new random validator key and
+	// stores it as a new secret (with an initial version) under SecretID if
+	// the secret does not already exist. When false (the default), a
+	// missing secret is treated as a fatal configuration error, to avoid
+	// silently minting a validator identity that was never intended.
+	CreateIfMissing bool `json:"create_if_missing" toml:"create_if_missing" comment:"Generate and store a new validator key in Secret Manager if the secret does not exist yet"`
+}
+
+// DefaultConfig returns a default, disabled configuration for the GCP Secret
+// Manager signer.
+func DefaultConfig() *Config {
+	return &Config{
+		ProjectID:       "", // Empty to disable the GCP Secret Manager signer by default.
+		SecretID:        "",
+		Version:         "latest",
+		CreateIfMissing: false,
+	}
+}
+
+// TestConfig returns a configuration for testing the GCP Secret Manager signer.
+func TestConfig() *Config {
+	return DefaultConfig()
+}
+
+// IsEnabled reports whether the GCP Secret Manager signer is configured for use.
+func (cfg *Config) IsEnabled() bool {
+	return cfg != nil && cfg.ProjectID != "" && cfg.SecretID != ""
+}
+
+// ValidateBasic performs basic validation (checking param bounds, etc.) and
+// returns an error if any check fails.
+func (cfg *Config) ValidateBasic() error {
+	// No cross-field constraints beyond ProjectID+SecretID gating IsEnabled:
+	// Version and CreateIfMissing are both meaningful at their zero value.
+	return nil
+}
+
+// versionName returns the fully-qualified resource name of the secret
+// version to access, e.g. "projects/my-project/secrets/my-secret/versions/latest".
+func (cfg *Config) versionName() string {
+	version := cfg.Version
+	if version == "" {
+		version = "latest"
+	}
+
+	return fmt.Sprintf("projects/%s/secrets/%s/versions/%s", cfg.ProjectID, cfg.SecretID, version)
+}
+
+// secretParent returns the fully-qualified resource name of the parent
+// project, used when creating a new secret.
+func (cfg *Config) secretParent() string {
+	return fmt.Sprintf("projects/%s", cfg.ProjectID)
+}

--- a/tm2/pkg/bft/privval/signer/gcpsecretmanager/gcpsecretmanager_test.go
+++ b/tm2/pkg/bft/privval/signer/gcpsecretmanager/gcpsecretmanager_test.go
@@ -1,0 +1,159 @@
+package gcpsecretmanager
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockClient is an in-memory fake implementing secretManagerAPI, used so
+// tests never make real GCP API calls.
+type mockClient struct {
+	// secrets maps a fully-qualified version resource name -> stored bytes.
+	secrets map[string][]byte
+
+	getErr    error
+	createErr error
+	addErr    error
+}
+
+func newMockClient() *mockClient {
+	return &mockClient{secrets: map[string][]byte{}}
+}
+
+func (m *mockClient) AccessSecretVersion(
+	_ context.Context,
+	req *secretmanagerpb.AccessSecretVersionRequest,
+) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	data, ok := m.secrets[req.Name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "secret not found")
+	}
+
+	return &secretmanagerpb.AccessSecretVersionResponse{
+		Payload: &secretmanagerpb.SecretPayload{Data: data},
+	}, nil
+}
+
+func (m *mockClient) CreateSecret(
+	_ context.Context,
+	req *secretmanagerpb.CreateSecretRequest,
+) (*secretmanagerpb.Secret, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+
+	return &secretmanagerpb.Secret{Name: req.Parent + "/secrets/" + req.SecretId}, nil
+}
+
+func (m *mockClient) AddSecretVersion(
+	_ context.Context,
+	req *secretmanagerpb.AddSecretVersionRequest,
+) (*secretmanagerpb.SecretVersion, error) {
+	if m.addErr != nil {
+		return nil, m.addErr
+	}
+
+	// Register under both a numbered version and "latest", mirroring how a
+	// subsequent AccessSecretVersion(..., "latest") would resolve on GCP.
+	m.secrets[req.Parent+"/versions/1"] = req.Payload.Data
+	m.secrets[req.Parent+"/versions/latest"] = req.Payload.Data
+
+	return &secretmanagerpb.SecretVersion{Name: req.Parent + "/versions/1"}, nil
+}
+
+func TestNewSigner_ExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	key := local.GenerateFileKey()
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	require.NoError(t, err)
+
+	cfg := &Config{ProjectID: "my-project", SecretID: "my-validator-key", Version: "latest"}
+
+	client := newMockClient()
+	client.secrets[cfg.versionName()] = jsonBytes
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	assert.True(t, signer.PubKey().Equals(key.PubKey))
+
+	sig, err := signer.Sign([]byte("hello"))
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().VerifyBytes([]byte("hello"), sig))
+
+	assert.NoError(t, signer.Close())
+	assert.Contains(t, signer.String(), "GCPSecretManagerSigner")
+}
+
+func TestNewSigner_MissingSecret_NoCreate(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient()
+	cfg := &Config{ProjectID: "my-project", SecretID: "does-not-exist", CreateIfMissing: false}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_MissingSecret_CreateIfMissing(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient()
+	cfg := &Config{ProjectID: "my-project", SecretID: "new-validator-key", Version: "latest", CreateIfMissing: true}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	stored, ok := client.secrets[cfg.versionName()]
+	require.True(t, ok)
+
+	parsed, err := local.ParseFileKey(stored)
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().Equals(parsed.PubKey))
+}
+
+func TestNewSigner_MalformedSecret(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{ProjectID: "my-project", SecretID: "bad-key"}
+
+	client := newMockClient()
+	client.secrets[cfg.versionName()] = []byte("{not valid json")
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestConfig_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&Config{}).IsEnabled())
+	assert.False(t, (*Config)(nil).IsEnabled())
+	assert.False(t, (&Config{ProjectID: "p"}).IsEnabled())
+	assert.False(t, (&Config{SecretID: "s"}).IsEnabled())
+	assert.True(t, (&Config{ProjectID: "p", SecretID: "s"}).IsEnabled())
+}
+
+func TestNewSignerFromConfig_Disabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSignerFromConfig(context.Background(), DefaultConfig())
+	require.ErrorIs(t, err, errConfigDisabled)
+}

--- a/tm2/pkg/bft/privval/signer/gcpsecretmanager/signer.go
+++ b/tm2/pkg/bft/privval/signer/gcpsecretmanager/signer.go
@@ -1,0 +1,148 @@
+package gcpsecretmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Signer implements types.Signer using a validator key stored in GCP Secret
+// Manager. The key material is fetched once at construction time and kept in
+// memory for the lifetime of the process; signing itself happens locally,
+// the same way the local file signer does. GCP Secret Manager is used purely
+// as a durable, access-controlled key store, not as a remote signing oracle —
+// unlike the tmkms/gnokms remote-signer modes, the private key does leave
+// GCP and reside in this process's memory.
+type Signer struct {
+	key *local.FileKey
+}
+
+// Signer type implements types.Signer.
+var _ types.Signer = (*Signer)(nil)
+
+// PubKey implements types.Signer.
+func (s *Signer) PubKey() crypto.PubKey {
+	return s.key.PubKey
+}
+
+// Sign implements types.Signer.
+func (s *Signer) Sign(signBytes []byte) ([]byte, error) {
+	return s.key.PrivKey.Sign(signBytes)
+}
+
+// Close implements types.Signer.
+func (s *Signer) Close() error {
+	return nil
+}
+
+// Signer type implements fmt.Stringer.
+var _ fmt.Stringer = (*Signer)(nil)
+
+// String implements fmt.Stringer.
+func (s *Signer) String() string {
+	return fmt.Sprintf("{Type: GCPSecretManagerSigner, Addr: %s}", s.key.Address)
+}
+
+// Config validation errors.
+var (
+	errConfigDisabled   = errors.New("gcp secret manager signer: project_id and secret_id are required")
+	errEmptySecretValue = errors.New("gcp secret manager signer: secret has no value")
+)
+
+// NewSignerFromConfig fetches the validator key from GCP Secret Manager
+// according to cfg and returns a ready-to-use Signer. If the secret does not
+// exist and cfg.CreateIfMissing is true, a new random key is generated and
+// stored under cfg.SecretID (with an initial version) before being returned.
+func NewSignerFromConfig(ctx context.Context, cfg *Config) (*Signer, error) {
+	if !cfg.IsEnabled() {
+		return nil, errConfigDisabled
+	}
+
+	client, err := newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return newSigner(ctx, client, cfg)
+}
+
+// newSigner contains the constructor logic decoupled from the concrete GCP
+// client, so it can be exercised in tests against a mock secretManagerAPI.
+func newSigner(ctx context.Context, client secretManagerAPI, cfg *Config) (*Signer, error) {
+	out, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+		Name: cfg.versionName(),
+	})
+	if err != nil {
+		if cfg.CreateIfMissing && isNotFound(err) {
+			return createAndStoreKey(ctx, client, cfg)
+		}
+
+		return nil, fmt.Errorf("unable to access secret %q from GCP Secret Manager: %w", cfg.versionName(), err)
+	}
+
+	if out.Payload == nil || len(out.Payload.Data) == 0 {
+		return nil, errEmptySecretValue
+	}
+
+	key, err := local.ParseFileKey(out.Payload.Data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid validator key in secret %q: %w", cfg.versionName(), err)
+	}
+
+	return &Signer{key: key}, nil
+}
+
+// isNotFound reports whether err represents a gRPC NotFound status, which
+// GCP Secret Manager returns both when the secret itself doesn't exist and
+// when it exists but has no versions yet.
+func isNotFound(err error) bool {
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.NotFound
+}
+
+// createAndStoreKey generates a new random validator FileKey, creates a new
+// secret for it (with automatic replication) and adds an initial version
+// containing the same amino-JSON encoding as the local file signer, then
+// returns a Signer wrapping the generated key.
+func createAndStoreKey(ctx context.Context, client secretManagerAPI, cfg *Config) (*Signer, error) {
+	key := local.GenerateFileKey()
+
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal newly generated validator key: %w", err)
+	}
+
+	secret, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent:   cfg.secretParent(),
+		SecretId: cfg.SecretID,
+		Secret: &secretmanagerpb.Secret{
+			Replication: &secretmanagerpb.Replication{
+				Replication: &secretmanagerpb.Replication_Automatic_{
+					Automatic: &secretmanagerpb.Replication_Automatic{},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create secret %q in GCP Secret Manager: %w", cfg.SecretID, err)
+	}
+
+	if _, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent: secret.Name,
+		Payload: &secretmanagerpb.SecretPayload{
+			Data: jsonBytes,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("unable to add secret version for %q in GCP Secret Manager: %w", cfg.SecretID, err)
+	}
+
+	return &Signer{key: key}, nil
+}

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -80,7 +80,7 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 	// Parse and validate the FileKey from the JSON bytes.
 	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+		return nil, fmt.Errorf("unable to load FileKey from %v: %w", filePath, err)
 	}
 
 	return fk, nil

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -77,11 +77,23 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 		return nil, err
 	}
 
-	// Unmarshal the JSON bytes into a FileKey using amino.
-	fk := &FileKey{}
-	err = amino.UnmarshalJSON(rawJSONBytes, fk)
+	// Parse and validate the FileKey from the JSON bytes.
+	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+	}
+
+	return fk, nil
+}
+
+// ParseFileKey unmarshals and validates a FileKey from raw amino JSON bytes.
+// This is exposed so that alternative key sources (e.g. a secrets manager)
+// can reuse the same encoding and validation rules as the on-disk FileKey.
+func ParseFileKey(rawJSONBytes []byte) (*FileKey, error) {
+	// Unmarshal the JSON bytes into a FileKey using amino.
+	fk := &FileKey{}
+	if err := amino.UnmarshalJSON(rawJSONBytes, fk); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal FileKey: %w", err)
 	}
 
 	// Validate the FileKey.


### PR DESCRIPTION
Adds a signer that loads the validator private key from GCP Secret Manager (instead of a local file). Signing happens in-process — Secret Manager is used purely as a durable, access-controlled key store, mirroring the existing local-file signer pattern and the same approach as #5956.

Closes #3233