### PR TITLE
privval: add HashiCorp Vault backed signer

### DIFF
--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/vault"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/upstream"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
@@ -33,13 +34,21 @@ type PrivValidatorConfig struct {
 	// listens for tmkms / Horcrux to dial in). Mutually exclusive with RemoteSigner;
 	// see upstream_config.go.
 	TmkmsListener *TmkmsListenerConfig `json:"tmkms_listener" toml:"tmkms_listener" comment:"Configuration for upstream-Tendermint-protocol signer (tmkms / Horcrux). Empty listen_addr disables this mode."`
+
+	// Vault configures a signer that loads the validator key from a
+	// HashiCorp Vault KV v2 secret instead of a local file. Signing still
+	// happens locally, in-process; Vault is only used as the durable key
+	// store. Mutually exclusive with RemoteSigner and TmkmsListener.
+	Vault *vault.Config `json:"vault" toml:"vault" comment:"Configuration for loading the validator key from HashiCorp Vault"`
 }
 
 // PrivValidatorConfig validation errors.
 var (
-	errInvalidSignStatePath   = errors.New("invalid private validator sign state file path")
-	errInvalidLocalSignerPath = errors.New("invalid private validator local signer file path")
-	errNilRemoteSignerConfig  = errors.New("remote signer configuration cannot be nil")
+	errInvalidSignStatePath     = errors.New("invalid private validator sign state file path")
+	errInvalidLocalSignerPath   = errors.New("invalid private validator local signer file path")
+	errNilRemoteSignerConfig    = errors.New("remote signer configuration cannot be nil")
+	errNilVaultConfig           = errors.New("vault configuration cannot be nil")
+	errMultipleSignerSourcesSet = errors.New("only one of remote_signer, tmkms_listener, or vault may be configured")
 )
 
 // DefaultPrivValidatorConfig returns a default configuration for the PrivValidator.
@@ -49,6 +58,7 @@ func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 		LocalSigner:   "priv_validator_key.json",
 		RemoteSigner:  rsclient.DefaultRemoteSignerClientConfig(),
 		TmkmsListener: DefaultTmkmsListenerConfig(),
+		Vault:         vault.DefaultConfig(),
 	}
 }
 
@@ -97,9 +107,22 @@ func (cfg *PrivValidatorConfig) ValidateBasic() error {
 		}
 	}
 
+	// Verify the Vault configuration is not nil.
+	if cfg.Vault == nil {
+		return errNilVaultConfig
+	}
+
+	// Validate the Vault configuration.
+	if err := cfg.Vault.ValidateBasic(); err != nil {
+		return err
+	}
+
 	// Mutual exclusion: at most one external-signer mode may be enabled.
 	if cfg.RemoteSigner.ServerAddress != "" && cfg.TmkmsListener.IsEnabled() {
 		return errBothExternalSignersEnabled
+	}
+	if cfg.Vault.IsEnabled() && (cfg.RemoteSigner.ServerAddress != "" || cfg.TmkmsListener.IsEnabled()) {
+		return errMultipleSignerSourcesSet
 	}
 
 	return nil
@@ -123,6 +146,11 @@ func NewSignerFromConfig(
 			clientPrivKey,
 			clientLogger,
 		)
+	}
+
+	// If Vault is configured, load the key from there.
+	if config.Vault.IsEnabled() {
+		return vault.NewSignerFromConfig(ctx, config.Vault)
 	}
 
 	// Otherwise, use a local signer.
@@ -149,9 +177,12 @@ func NewPrivValidatorFromConfig(
 ) (types.PrivValidator, error) {
 	// Mutual exclusion is also enforced in ValidateBasic, but defend in
 	// depth here in case callers skip validation.
-	if config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != "" &&
-		config.TmkmsListener.IsEnabled() {
+	remoteSignerEnabled := config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != ""
+	if remoteSignerEnabled && config.TmkmsListener.IsEnabled() {
 		return nil, errBothExternalSignersEnabled
+	}
+	if config.Vault.IsEnabled() && (remoteSignerEnabled || config.TmkmsListener.IsEnabled()) {
+		return nil, errMultipleSignerSourcesSet
 	}
 
 	// tmkms-compat path. tmkms holds HRS authority; we don't wrap the

--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -18,9 +18,10 @@ import (
 )
 
 // PrivValidatorConfig defines the configuration for the PrivValidator, with a local
-// signer (file-based key), a gnokms remote signer (tm2-native protocol), or a tmkms
+// signer (file-based key), a gnokms remote signer (tm2-native protocol), a tmkms
 // listener (upstream Tendermint privval protocol — the validator listens for tmkms
-// to dial in). At most one of RemoteSigner or TmkmsListener may be enabled.
+// to dial in), or HashiCorp Vault. At most one of RemoteSigner, TmkmsListener, or
+// Vault may be enabled.
 type PrivValidatorConfig struct {
 	// File path configuration.
 	RootDir     string `json:"home" toml:"home"`

--- a/tm2/pkg/bft/privval/config_test.go
+++ b/tm2/pkg/bft/privval/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	rsserver "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/server"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/vault"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 	"github.com/gnolang/gno/tm2/pkg/log"
@@ -420,5 +421,92 @@ func TestNewPrivValidatorFromConfig(t *testing.T) {
 		}
 		require.NoError(t, err, "port must be released after Init failure")
 		require.NoError(t, rebound.Close())
+	})
+}
+
+// enabledVaultConfig returns a minimally-valid, enabled Vault config for use
+// in the mutual-exclusion tests below. It doesn't need to point at a real
+// Vault server: these tests only exercise validation, not signer
+// construction.
+func enabledVaultConfig() *vault.Config {
+	return &vault.Config{
+		SecretPath: "gno/validator-key",
+	}
+}
+
+func TestPrivValidatorConfig_VaultValidateBasic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil vault config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.Vault = nil
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errNilVaultConfig)
+	})
+
+	t.Run("vault with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.Vault = enabledVaultConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("vault with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.Vault = enabledVaultConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-vault-test.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("vault alone", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.Vault = enabledVaultConfig()
+
+		require.NoError(t, cfg.ValidateBasic())
+	})
+}
+
+func TestPrivValidatorConfig_VaultNewPrivValidator(t *testing.T) {
+	t.Parallel()
+
+	var (
+		privKey = ed25519.GenPrivKey()
+		logger  = log.NewNoopLogger()
+	)
+
+	t.Run("vault with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.Vault = enabledVaultConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
+	})
+
+	t.Run("vault with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.Vault = enabledVaultConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-vault-test2.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
 	})
 }

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -80,7 +80,7 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 	// Parse and validate the FileKey from the JSON bytes.
 	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+		return nil, fmt.Errorf("unable to load FileKey from %v: %w", filePath, err)
 	}
 
 	return fk, nil

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -77,11 +77,23 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 		return nil, err
 	}
 
-	// Unmarshal the JSON bytes into a FileKey using amino.
-	fk := &FileKey{}
-	err = amino.UnmarshalJSON(rawJSONBytes, fk)
+	// Parse and validate the FileKey from the JSON bytes.
+	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+	}
+
+	return fk, nil
+}
+
+// ParseFileKey unmarshals and validates a FileKey from raw amino JSON bytes.
+// This is exposed so that alternative key sources (e.g. a secrets manager)
+// can reuse the same encoding and validation rules as the on-disk FileKey.
+func ParseFileKey(rawJSONBytes []byte) (*FileKey, error) {
+	// Unmarshal the JSON bytes into a FileKey using amino.
+	fk := &FileKey{}
+	if err := amino.UnmarshalJSON(rawJSONBytes, fk); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal FileKey: %w", err)
 	}
 
 	// Validate the FileKey.

--- a/tm2/pkg/bft/privval/signer/vault/client.go
+++ b/tm2/pkg/bft/privval/signer/vault/client.go
@@ -18,9 +18,10 @@ type kvAPI interface {
 // kvAPI is implemented by *vaultapi.KVv2.
 var _ kvAPI = (*vaultapi.KVv2)(nil)
 
-// newClient builds a real Vault KV v2 client. Address and Token, if set in
-// cfg, override the Vault SDK's own environment/file-based resolution chain
-// (VAULT_ADDR, VAULT_TOKEN, ~/.vault-token).
+// newClient builds a real Vault KV v2 client. Address and the resolved
+// token (see Config.resolveToken), if set, override the Vault SDK's own
+// environment/file-based resolution chain (VAULT_ADDR, VAULT_TOKEN,
+// ~/.vault-token).
 func newClient(cfg *Config) (kvAPI, error) {
 	vconfig := vaultapi.DefaultConfig()
 	if cfg.Address != "" {
@@ -32,8 +33,8 @@ func newClient(cfg *Config) (kvAPI, error) {
 		return nil, fmt.Errorf("unable to create Vault client: %w", err)
 	}
 
-	if cfg.Token != "" {
-		c.SetToken(cfg.Token)
+	if token := cfg.resolveToken(); token != "" {
+		c.SetToken(token)
 	}
 
 	return c.KVv2(cfg.mountPath()), nil

--- a/tm2/pkg/bft/privval/signer/vault/client.go
+++ b/tm2/pkg/bft/privval/signer/vault/client.go
@@ -1,0 +1,40 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// kvAPI is the subset of the Vault KV v2 client used by the signer. It is
+// defined as an interface so tests can substitute a mock implementation
+// without making real Vault API calls or requiring a running Vault server.
+type kvAPI interface {
+	Get(ctx context.Context, secretPath string) (*vaultapi.KVSecret, error)
+	Put(ctx context.Context, secretPath string, data map[string]interface{}, opts ...vaultapi.KVOption) (*vaultapi.KVSecret, error)
+}
+
+// kvAPI is implemented by *vaultapi.KVv2.
+var _ kvAPI = (*vaultapi.KVv2)(nil)
+
+// newClient builds a real Vault KV v2 client. Address and Token, if set in
+// cfg, override the Vault SDK's own environment/file-based resolution chain
+// (VAULT_ADDR, VAULT_TOKEN, ~/.vault-token).
+func newClient(cfg *Config) (kvAPI, error) {
+	vconfig := vaultapi.DefaultConfig()
+	if cfg.Address != "" {
+		vconfig.Address = cfg.Address
+	}
+
+	c, err := vaultapi.NewClient(vconfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create Vault client: %w", err)
+	}
+
+	if cfg.Token != "" {
+		c.SetToken(cfg.Token)
+	}
+
+	return c.KVv2(cfg.mountPath()), nil
+}

--- a/tm2/pkg/bft/privval/signer/vault/config.go
+++ b/tm2/pkg/bft/privval/signer/vault/config.go
@@ -1,0 +1,73 @@
+package vault
+
+// Config defines the configuration options for a Signer backed by
+// HashiCorp Vault's KV v2 secrets engine. This is used to marshal/unmarshal
+// the configuration to/from TOML and configure the signer using the gnoland
+// CLI tool.
+type Config struct {
+	// Address is the Vault server address (e.g. "https://vault.example.com:8200").
+	// If empty, the client falls back to the standard Vault SDK resolution
+	// chain (the VAULT_ADDR environment variable, then http://127.0.0.1:8200).
+	Address string `json:"address" toml:"address" comment:"Vault server address. Leave empty to use the VAULT_ADDR environment variable / SDK default"`
+
+	// Token is the Vault token used to authenticate. If empty, the client
+	// falls back to the standard Vault SDK resolution chain (the VAULT_TOKEN
+	// environment variable, or the ~/.vault-token file written by `vault login`).
+	Token string `json:"token" toml:"token" comment:"Vault token. Leave empty to use the VAULT_TOKEN environment variable / ~/.vault-token"`
+
+	// MountPath is the mount path of the KV v2 secrets engine holding the
+	// secret. Defaults to "secret" (the standard KV v2 mount) if empty.
+	MountPath string `json:"mount_path" toml:"mount_path" comment:"Mount path of the KV v2 secrets engine. Defaults to \"secret\" if empty"`
+
+	// SecretPath is the path (within MountPath) of the secret holding the
+	// validator's private key, encoded the same way as the on-disk
+	// priv_validator_key.json file. If empty, the Vault signer is disabled.
+	SecretPath string `json:"secret_path" toml:"secret_path" comment:"Path (within mount_path) of the secret holding the validator key. If set, the local signer is disabled"`
+
+	// CreateIfMissing, when true, generates a new random validator key and
+	// writes it to SecretPath if no secret exists there yet. When false
+	// (the default), a missing secret is treated as a fatal configuration
+	// error, to avoid silently minting a validator identity that was never
+	// intended.
+	CreateIfMissing bool `json:"create_if_missing" toml:"create_if_missing" comment:"Generate and store a new validator key in Vault if the secret does not exist yet"`
+}
+
+// DefaultConfig returns a default, disabled configuration for the Vault signer.
+func DefaultConfig() *Config {
+	return &Config{
+		Address:         "",
+		Token:           "",
+		MountPath:       "secret",
+		SecretPath:      "", // Empty to disable the Vault signer by default.
+		CreateIfMissing: false,
+	}
+}
+
+// TestConfig returns a configuration for testing the Vault signer.
+func TestConfig() *Config {
+	return DefaultConfig()
+}
+
+// IsEnabled reports whether the Vault signer is configured for use.
+func (cfg *Config) IsEnabled() bool {
+	return cfg != nil && cfg.SecretPath != ""
+}
+
+// ValidateBasic performs basic validation (checking param bounds, etc.) and
+// returns an error if any check fails.
+func (cfg *Config) ValidateBasic() error {
+	// No cross-field constraints beyond SecretPath gating IsEnabled: Address,
+	// Token, MountPath, and CreateIfMissing are all meaningful at their zero
+	// value (falling back to the Vault SDK's own resolution chain).
+	return nil
+}
+
+// mountPath returns the configured mount path, defaulting to "secret" (the
+// standard KV v2 mount) if unset.
+func (cfg *Config) mountPath() string {
+	if cfg.MountPath == "" {
+		return "secret"
+	}
+
+	return cfg.MountPath
+}

--- a/tm2/pkg/bft/privval/signer/vault/config.go
+++ b/tm2/pkg/bft/privval/signer/vault/config.go
@@ -1,5 +1,7 @@
 package vault
 
+import "os"
+
 // Config defines the configuration options for a Signer backed by
 // HashiCorp Vault's KV v2 secrets engine. This is used to marshal/unmarshal
 // the configuration to/from TOML and configure the signer using the gnoland
@@ -10,10 +12,17 @@ type Config struct {
 	// chain (the VAULT_ADDR environment variable, then http://127.0.0.1:8200).
 	Address string `json:"address" toml:"address" comment:"Vault server address. Leave empty to use the VAULT_ADDR environment variable / SDK default"`
 
-	// Token is the Vault token used to authenticate. If empty, the client
-	// falls back to the standard Vault SDK resolution chain (the VAULT_TOKEN
-	// environment variable, or the ~/.vault-token file written by `vault login`).
-	Token string `json:"token" toml:"token" comment:"Vault token. Leave empty to use the VAULT_TOKEN environment variable / ~/.vault-token"`
+	// Token is the Vault token used to authenticate. Storing it directly
+	// here means it lands in config.toml in plaintext; prefer leaving this
+	// empty and using the standard VAULT_TOKEN environment variable (or
+	// TokenEnv below), or the ~/.vault-token file written by `vault login`.
+	Token string `json:"token" toml:"token" comment:"Vault token. Prefer VAULT_TOKEN / token_env over this where possible"`
+
+	// TokenEnv, if set, names an environment variable to read the Vault
+	// token from at startup, taking precedence over Token (but not over
+	// the standard VAULT_TOKEN handling already performed by the Vault
+	// SDK, which is consulted if both Token and TokenEnv are empty).
+	TokenEnv string `json:"token_env" toml:"token_env" comment:"Name of an environment variable to read the Vault token from (takes precedence over 'token')"`
 
 	// MountPath is the mount path of the KV v2 secrets engine holding the
 	// secret. Defaults to "secret" (the standard KV v2 mount) if empty.
@@ -37,6 +46,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Address:         "",
 		Token:           "",
+		TokenEnv:        "",
 		MountPath:       "secret",
 		SecretPath:      "", // Empty to disable the Vault signer by default.
 		CreateIfMissing: false,
@@ -70,4 +80,17 @@ func (cfg *Config) mountPath() string {
 	}
 
 	return cfg.MountPath
+}
+
+// resolveToken returns the Vault token to use explicitly, if one was
+// configured: the value of the TokenEnv environment variable if TokenEnv is
+// set, otherwise the literal Token field. If both are empty, it returns ""
+// and the caller should leave the Vault client's token unset so the SDK's
+// own resolution chain (VAULT_TOKEN, ~/.vault-token, etc.) applies.
+func (cfg *Config) resolveToken() string {
+	if cfg.TokenEnv != "" {
+		return os.Getenv(cfg.TokenEnv)
+	}
+
+	return cfg.Token
 }

--- a/tm2/pkg/bft/privval/signer/vault/signer.go
+++ b/tm2/pkg/bft/privval/signer/vault/signer.go
@@ -1,0 +1,140 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// dataFieldName is the key under which the validator's FileKey JSON blob is
+// stored in the Vault KV v2 secret's data map.
+const dataFieldName = "priv_validator_key_json"
+
+// Signer implements types.Signer using a validator key stored in HashiCorp
+// Vault's KV v2 secrets engine. The key material is fetched once at
+// construction time and kept in memory for the lifetime of the process;
+// signing itself happens locally, the same way the local file signer does.
+// Vault is used purely as a durable, access-controlled key store, not as a
+// remote signing oracle — unlike the tmkms/gnokms remote-signer modes, the
+// private key does leave Vault and reside in this process's memory.
+type Signer struct {
+	key *local.FileKey
+}
+
+// Signer type implements types.Signer.
+var _ types.Signer = (*Signer)(nil)
+
+// PubKey implements types.Signer.
+func (s *Signer) PubKey() crypto.PubKey {
+	return s.key.PubKey
+}
+
+// Sign implements types.Signer.
+func (s *Signer) Sign(signBytes []byte) ([]byte, error) {
+	return s.key.PrivKey.Sign(signBytes)
+}
+
+// Close implements types.Signer.
+func (s *Signer) Close() error {
+	return nil
+}
+
+// Signer type implements fmt.Stringer.
+var _ fmt.Stringer = (*Signer)(nil)
+
+// String implements fmt.Stringer.
+func (s *Signer) String() string {
+	return fmt.Sprintf("{Type: VaultSigner, Addr: %s}", s.key.Address)
+}
+
+// Config validation errors.
+var (
+	errSecretPathRequired = errors.New("vault signer: secret_path is required")
+	errMissingDataField   = errors.New("vault signer: secret is missing the " + dataFieldName + " field")
+	errInvalidDataField   = errors.New("vault signer: " + dataFieldName + " field is not a string")
+)
+
+// NewSignerFromConfig fetches the validator key from Vault according to cfg
+// and returns a ready-to-use Signer. If the secret does not exist and
+// cfg.CreateIfMissing is true, a new random key is generated and written to
+// cfg.SecretPath before being returned.
+func NewSignerFromConfig(ctx context.Context, cfg *Config) (*Signer, error) {
+	if !cfg.IsEnabled() {
+		return nil, errSecretPathRequired
+	}
+
+	client, err := newClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newSigner(ctx, client, cfg)
+}
+
+// newSigner contains the constructor logic decoupled from the concrete
+// Vault client, so it can be exercised in tests against a mock kvAPI.
+func newSigner(ctx context.Context, client kvAPI, cfg *Config) (*Signer, error) {
+	secret, err := client.Get(ctx, cfg.SecretPath)
+	if err != nil {
+		if cfg.CreateIfMissing && errors.Is(err, vaultapi.ErrSecretNotFound) {
+			return createAndStoreKey(ctx, client, cfg)
+		}
+
+		return nil, fmt.Errorf("unable to read secret %q from Vault: %w", cfg.SecretPath, err)
+	}
+
+	// A deleted (but not destroyed) KV v2 version returns a nil Data map
+	// rather than an error; treat it the same as "not found".
+	if secret == nil || secret.Data == nil {
+		if cfg.CreateIfMissing {
+			return createAndStoreKey(ctx, client, cfg)
+		}
+
+		return nil, fmt.Errorf("unable to read secret %q from Vault: %w", cfg.SecretPath, vaultapi.ErrSecretNotFound)
+	}
+
+	raw, ok := secret.Data[dataFieldName]
+	if !ok {
+		return nil, errMissingDataField
+	}
+
+	rawStr, ok := raw.(string)
+	if !ok {
+		return nil, errInvalidDataField
+	}
+
+	key, err := local.ParseFileKey([]byte(rawStr))
+	if err != nil {
+		return nil, fmt.Errorf("invalid validator key in secret %q: %w", cfg.SecretPath, err)
+	}
+
+	return &Signer{key: key}, nil
+}
+
+// createAndStoreKey generates a new random validator FileKey, writes it to
+// Vault under cfg.SecretPath (using the same amino-JSON encoding as the
+// local file signer), and returns a Signer wrapping the generated key.
+func createAndStoreKey(ctx context.Context, client kvAPI, cfg *Config) (*Signer, error) {
+	key := local.GenerateFileKey()
+
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal newly generated validator key: %w", err)
+	}
+
+	data := map[string]interface{}{
+		dataFieldName: string(jsonBytes),
+	}
+
+	if _, err := client.Put(ctx, cfg.SecretPath, data); err != nil {
+		return nil, fmt.Errorf("unable to write secret %q to Vault: %w", cfg.SecretPath, err)
+	}
+
+	return &Signer{key: key}, nil
+}

--- a/tm2/pkg/bft/privval/signer/vault/vault_test.go
+++ b/tm2/pkg/bft/privval/signer/vault/vault_test.go
@@ -1,0 +1,166 @@
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockKV is an in-memory fake implementing kvAPI, used so tests never make
+// real Vault API calls or require a running Vault server.
+type mockKV struct {
+	// secrets maps secret path -> stored data map.
+	secrets map[string]map[string]interface{}
+
+	getErr error
+	putErr error
+}
+
+func newMockKV() *mockKV {
+	return &mockKV{secrets: map[string]map[string]interface{}{}}
+}
+
+func (m *mockKV) Get(_ context.Context, secretPath string) (*vaultapi.KVSecret, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	data, ok := m.secrets[secretPath]
+	if !ok {
+		return nil, vaultapi.ErrSecretNotFound
+	}
+
+	return &vaultapi.KVSecret{Data: data}, nil
+}
+
+func (m *mockKV) Put(
+	_ context.Context,
+	secretPath string,
+	data map[string]interface{},
+	_ ...vaultapi.KVOption,
+) (*vaultapi.KVSecret, error) {
+	if m.putErr != nil {
+		return nil, m.putErr
+	}
+
+	m.secrets[secretPath] = data
+
+	return &vaultapi.KVSecret{Data: data}, nil
+}
+
+func TestNewSigner_ExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	key := local.GenerateFileKey()
+	jsonBytes, err := amino.MarshalJSONIndent(key, "", "  ")
+	require.NoError(t, err)
+
+	client := newMockKV()
+	client.secrets["gno/validator-key"] = map[string]interface{}{
+		dataFieldName: string(jsonBytes),
+	}
+
+	cfg := &Config{SecretPath: "gno/validator-key"}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	assert.True(t, signer.PubKey().Equals(key.PubKey))
+
+	sig, err := signer.Sign([]byte("hello"))
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().VerifyBytes([]byte("hello"), sig))
+
+	assert.NoError(t, signer.Close())
+	assert.Contains(t, signer.String(), "VaultSigner")
+}
+
+func TestNewSigner_MissingSecret_NoCreate(t *testing.T) {
+	t.Parallel()
+
+	client := newMockKV()
+	cfg := &Config{SecretPath: "does/not/exist", CreateIfMissing: false}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_MissingSecret_CreateIfMissing(t *testing.T) {
+	t.Parallel()
+
+	client := newMockKV()
+	cfg := &Config{SecretPath: "gno/new-validator-key", CreateIfMissing: true}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	stored, ok := client.secrets["gno/new-validator-key"]
+	require.True(t, ok)
+
+	rawStr, ok := stored[dataFieldName].(string)
+	require.True(t, ok)
+
+	parsed, err := local.ParseFileKey([]byte(rawStr))
+	require.NoError(t, err)
+	assert.True(t, signer.PubKey().Equals(parsed.PubKey))
+}
+
+func TestNewSigner_MalformedSecret(t *testing.T) {
+	t.Parallel()
+
+	client := newMockKV()
+	client.secrets["gno/bad-key"] = map[string]interface{}{
+		dataFieldName: "{not valid json",
+	}
+
+	cfg := &Config{SecretPath: "gno/bad-key"}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_MissingDataField(t *testing.T) {
+	t.Parallel()
+
+	client := newMockKV()
+	client.secrets["gno/wrong-field"] = map[string]interface{}{
+		"some_other_field": "value",
+	}
+
+	cfg := &Config{SecretPath: "gno/wrong-field"}
+
+	signer, err := newSigner(context.Background(), client, cfg)
+	require.ErrorIs(t, err, errMissingDataField)
+	assert.Nil(t, signer)
+}
+
+func TestConfig_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&Config{}).IsEnabled())
+	assert.False(t, (*Config)(nil).IsEnabled())
+	assert.True(t, (&Config{SecretPath: "x"}).IsEnabled())
+}
+
+func TestConfig_MountPath(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "secret", (&Config{}).mountPath())
+	assert.Equal(t, "custom", (&Config{MountPath: "custom"}).mountPath())
+}
+
+func TestNewSignerFromConfig_Disabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSignerFromConfig(context.Background(), DefaultConfig())
+	require.ErrorIs(t, err, errSecretPathRequired)
+}

--- a/tm2/pkg/bft/privval/signer/vault/vault_test.go
+++ b/tm2/pkg/bft/privval/signer/vault/vault_test.go
@@ -158,6 +158,19 @@ func TestConfig_MountPath(t *testing.T) {
 	assert.Equal(t, "custom", (&Config{MountPath: "custom"}).mountPath())
 }
 
+func TestConfig_ResolveToken(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", (&Config{}).resolveToken())
+	assert.Equal(t, "literal", (&Config{Token: "literal"}).resolveToken())
+
+	t.Setenv("VAULT_TEST_TOKEN", "from-env")
+	assert.Equal(t, "from-env", (&Config{
+		Token:    "literal",
+		TokenEnv: "VAULT_TEST_TOKEN",
+	}).resolveToken())
+}
+
 func TestNewSignerFromConfig_Disabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds a signer that loads the validator private key from HashiCorp Vault (KV v2 secrets engine) instead of a local file. Signing happens in-process — Vault is used purely as a durable, access-controlled key store, mirroring the existing local-file signer pattern and the same approach as #5956 / #5958.

Closes #3234