### PR TITLE
feat(vm): bundle governance params into one KV read

### DIFF
--- a/gno.land/adr/prxxxx_vm_params_bundle.md
+++ b/gno.land/adr/prxxxx_vm_params_bundle.md
@@ -1,0 +1,201 @@
+# ADR: Bundle VM governance parameters into one KV read
+
+## Status
+
+Proposed.
+
+## Context
+
+Every transaction loads the VM module parameters before applying their governed
+store-gas configuration. The parameters were stored only as one JSON-encoded KV
+entry per `Params` field, and `ParamsKeeper.GetStruct` therefore performed one
+store read per field. Later reads in the same transaction were cache hits, but
+the first load paid for every key.
+
+The original investigation measured 13 fields on the former IAVL-backed main
+store. The current `master` baseline differs in two important ways:
+
+- `Params` has 14 fields after `PreprocessGasPerByte` was added.
+- The main store is B+32 with a fast index. The ante handler loads VM params
+  before installing their governed fixed depths, so the first load uses the
+  B+ tree's live depth estimate, not `FixedGetReadDepth100`.
+
+For a tree containing `N` entries, the current B+ estimator uses
+`d100 = max(100, bits.Len64(N) * 20)`. With `ReadCostFlat = 59,000`, replacing
+14 cold field reads with one cold bundle read removes the flat component
+
+`13 * d100 * 59,000 / 100`.
+
+For `DefaultParams`, the 14 JSON field values occupy 162 bytes while the amino
+binary struct occupies 144 bytes, removing another `18 * 17 = 306` read gas.
+The resulting parameter-load saving is 767,306 gas at the one-read depth floor
+and approximately 4,142,106 gas around 100 million entries (`d100 = 540`). It
+is no longer the size-independent 7,080,255 gas measured on the older
+13-field/IAVL baseline.
+
+There was also a gas-meter lifecycle defect in the old path. `gnoland` loaded
+VM params while BaseApp's temporary pre-ante meter was active, then the auth
+ante handler replaced that meter with the transaction meter. The storage reads
+were visible in a trace but were discarded from the reported `GasUsed`. The
+bundle alone therefore produced no end-to-end gas reduction against the
+unmodified binary, even though it reduced physical reads.
+
+This change fixes that lifecycle at the same activation point as the bundle.
+It is consensus-affecting: transaction gas changes can change out-of-gas
+outcomes, and adding the bundle changes the application hash.
+
+## Decision
+
+Store an amino-binary encoding of the complete `vm.Params` value under the
+chain-internal root params key `_vm_params`.
+
+The key is deliberately unprefixed. A key such as `vm:_params` would be
+addressable through the generic governance parameter writer and would invoke
+`VMKeeper.WillSetParam` recursively. The unprefixed key follows the existing
+`_realmmeta_` precedent: only chain code can address it, and it is not exposed
+as a module parameter.
+
+### Reads
+
+`VMKeeper.GetParams` reads and decodes `_vm_params` when present. The bundle is
+authoritative. A malformed present bundle fails loudly instead of falling back
+to potentially stale individual values.
+
+When the bundle is absent, `GetParams` falls back to `GetStruct("vm:p")` so an
+upgraded binary can decode legacy state. The three specialized chain-domain and
+system-package getters try the bundle first and otherwise perform their
+original single-leaf read; they do not fan out over the whole legacy struct.
+
+The fallback is value-compatible, not gas-compatible: probing the absent bundle
+costs one additional cold read. This is why the binary rollout itself still
+requires the coordinated upgrade described below.
+
+### Gas-meter lifecycle
+
+`auth.NewAnteHandler` now installs the bounded transaction meter and its
+out-of-gas recovery before invoking the optional `AnteOptions.PrepareGasMeter`
+callback. The callback receives that final meter, loads VM params once, and
+applies the resulting depth configuration to the returned context. Existing
+callers that do not provide the callback retain the previous behavior. Genesis
+and replay modes continue to use the meter semantics selected by `SetGasMeter`
+(including their existing infinite-meter paths).
+
+This is a coordinated repricing, not merely an optimization. On the measured
+`foo20` GRC20 transfer at the current test tree depth, the unmodified master
+reported `6,148,884` gas for both layouts because the parameter-load charge was
+discarded. With the lifecycle fix, the correctly metered legacy layout reports
+`7,803,638` gas (14 reads, `1,654,754` gas) and the bundled layout reports
+`6,269,332` gas (one read, `120,448` gas). The bundle therefore saves exactly
+`1,534,306` gas against the correctly metered legacy schedule, while appearing
+`120,448` gas more expensive than unmodified master because master was
+undercharging that one read.
+
+### Writes and synchronization
+
+`SetParams` validates and amino-encodes the struct before changing state, then
+writes both representations. The individual keys remain available to the
+generic params query and governance paths; the bundle is written last.
+
+Single-field governance changes pass through `VMKeeper.WillSetParam` immediately
+before `ParamsKeeper` writes the individual leaf. The hook constructs and
+validates the complete candidate value, then rewrites an already-active bundle.
+Both writes live in BaseApp's transaction cache and commit or roll back
+together. `CommitGnoTransactionStore` is not involved: it flushes Gno object
+state, while BaseApp owns params-store commit.
+
+On legacy state, `WillSetParam` does not create the bundle. Bundle creation is a
+state-schema migration and must not happen as an incidental side effect of an
+otherwise ordinary governance proposal.
+
+### Migration and coordinated activation
+
+`VMKeeper.InitGenesis` calls `SetParams`, so fresh chains and the repository's
+supported export/replay hardfork flow create the bundle before replaying any
+transactions. This is the explicit migration path in this change.
+
+For a live chain, operators must use the governance halt and minimum-version
+mechanism (`node:p:halt_height` and `node:p:halt_min_version`) and activate this
+binary only after the coordinated halt. Old and new binaries must not execute
+the same post-upgrade block:
+
+- even without a bundle, the new binary charges the additional absent-key
+  probe;
+- on bundle-active state, the new binary rewrites the bundle when a VM
+  parameter changes while the old binary writes only the individual leaf,
+  producing different app hashes.
+
+On legacy same-database state, neither a fallback read nor an ordinary
+single-parameter governance change activates the bundle. Such activation is
+unsupported by this change and requires the deterministic migration described
+below.
+
+This change does not add an in-place same-database migration hook because the
+current B+ main store is itself supported only for fresh chains and
+export/import forks. If a future release needs an in-place rollout, it must add
+a deterministic one-time migration at the scheduled upgrade height before any
+transaction executes. It must not write the bundle during process startup or
+as read-repair in `GetParams`, because those paths are not consensus state
+transitions and queries must remain read-only.
+
+Historical replay under `GasReplayMode="source"` bypasses the new metering as
+designed. Strict replay uses the new gas schedule and may report gas deltas.
+
+## Alternatives considered
+
+### Cache params in keeper memory
+
+An in-memory cache could remove all persistent reads after startup, but it adds
+mutable keeper state, invalidation requirements, and replay/query concurrency
+risk. A state-backed bundle retains ordinary transaction-cache semantics.
+
+### Move params out of the depth-estimated store
+
+This attacks the gas multiplier but changes the storage/gas model for more than
+VM configuration and requires a broader migration.
+
+### Stop charging depth for configuration reads
+
+Special-casing config keys would make the gas layer aware of module semantics.
+Bundling instead reduces the real storage work and the corresponding gas.
+
+### Store only the bundle
+
+Removing individual keys would simplify synchronization, but it would break the
+generic params query and governance writers. Keeping both representations
+preserves those interfaces.
+
+### Use `vm:_params`
+
+This keeps the key visually within the module namespace but exposes the raw
+blob to generic module-parameter writes unless a new internal-write sentinel is
+added. An unprefixed internal key is simpler and safer.
+
+## Consequences
+
+- A transaction with an active bundle pays one cold VM-parameter read instead
+  of 14; repeated `GetParams` and specialized getter calls hit the per-tx cache.
+- Genesis and every active-bundle governance parameter update write one extra
+  key. Governance updates remain more expensive than before but are rare.
+- Individual parameter queries and governance writes remain compatible.
+- The bundle adds a committed key and therefore changes genesis/app hashes.
+- Binary amino encoding is deterministic for this flat, map-free struct.
+  Appending a field lets an upgraded decoder read older bundles, but an older
+  decoder rejects a newer bundle containing the unknown field. Any schema
+  extension therefore requires a coordinated binary upgrade, and existing
+  fields must not be reordered or repurposed.
+- The regression test disables per-byte gas and pins read depth to one operation
+  so it directly proves that all current VM parameter call sites collapse to
+  one cold read. A separate fallback assertion dynamically tracks the number of
+  `Params` fields.
+- The VM gas regression performs the same cold GRC20 transfer against active
+  bundle and legacy layouts. It asserts one versus 14 parameter reads,
+  identical non-parameter gas, equal live B+ depth, and the exact saving
+  derived from the 13 removed reads plus the encoding-byte delta. In its
+  isolated harness (`d100 = 200`), total gas falls from 6,652,703 to
+  5,118,397: a 1,534,306 gas saving for unchanged transfer work. A matching
+  gnodev run verifies the final BaseApp `GasUsed` numbers recorded above.
+
+## AI assistance
+
+This change was implemented with AI assistance. The human author is responsible
+for reviewing and owning the contribution.

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -129,6 +129,15 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 	// Set AnteHandler
 	authOptions := auth.AnteOptions{
 		VerifyGenesisSignatures: !cfg.SkipGenesisSigVerification,
+		PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+			// Charge VM parameter loading to the final transaction meter,
+			// then apply the governed store-gas configuration to all later
+			// ante and message operations. The auth ante handler invokes
+			// this callback after its basic fee and gas-wanted checks.
+			gasCfg := store.DefaultGasConfig()
+			vmk.GetParams(ctx).ApplyToGasConfig(&gasCfg)
+			return ctx.WithGasConfig(gasCfg)
+		},
 	}
 	authAnteHandler := auth.NewAnteHandler(
 		acck, bankk, auth.DefaultSigVerificationGasConsumer, authOptions)
@@ -143,16 +152,6 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 			// the gas meter (see tm2/pkg/sdk/auth/params.go) so this
 			// read costs nothing.
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
-			// Apply VM gas config so all store operations (account
-			// reads/writes in ante, message handlers, etc.) use the
-			// governed depth parameters. vmk.GetParams DOES meter (vm
-			// params are user-tunable consensus state and we want a
-			// real gas signal on changes), so this read uses the ctx's
-			// current (default) gasCfg until it's replaced below.
-			gasCfg := store.DefaultGasConfig()
-			vmk.GetParams(ctx).ApplyToGasConfig(&gasCfg)
-			ctx = ctx.WithGasConfig(gasCfg)
-
 			// During genesis (block height 0), automatically create accounts for signers
 			// if they don't exist. This allows packages with custom creators to be loaded.
 			if ctx.BlockHeight() == 0 {

--- a/gno.land/pkg/integration/testdata/addpkg_import_testdep_gas.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_import_testdep_gas.txtar
@@ -12,7 +12,7 @@
 # On the pre-split single-blob layout, depb's mempackage included its _test.gno,
 # so type-checking useb decoded those extra bytes and useb cost MORE than usea.
 #
-# Measured: on this branch usea == useb == 2796401 (equal => the win; includes the
+# Measured: on this branch usea == useb == 2916849 (equal => the win; includes the
 # PreprocessGasPerByte addpkg charge). On master (pre-split, pre-charge) usea == 3172364
 # but useb == 3212984 -- importing depb costs +40620 gas for its _test.gno bytes. The
 # split removes that import penalty.
@@ -26,9 +26,9 @@ gnokey maketx addpkg -pkgdir $WORK/depa -pkgpath gno.land/p/demo/depa -gas-fee 1
 gnokey maketx addpkg -pkgdir $WORK/depb -pkgpath gno.land/p/demo/depb -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test test1
 
 gnokey maketx addpkg -pkgdir $WORK/usea -pkgpath gno.land/p/demo/usea -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2796401'
+stdout 'GAS USED:\s+2916849'
 gnokey maketx addpkg -pkgdir $WORK/useb -pkgpath gno.land/p/demo/useb -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2796401'
+stdout 'GAS USED:\s+2916849'
 
 -- depa/gnomod.toml --
 module = "gno.land/p/demo/depa"

--- a/gno.land/pkg/integration/testdata/gc.txtar
+++ b/gno.land/pkg/integration/testdata/gc.txtar
@@ -7,7 +7,7 @@ gnoland start -no-parallel
 
 
 gnokey maketx call -pkgpath gno.land/r/gc -func Alloc -gas-fee 17000000ugnot -gas-wanted 170_000_000 -simulate skip -chainid tendermint_test test1
-stdout 'GAS USED:   151133803'
+stdout 'GAS USED:   151254251'
 
 -- r/gc/gc.gno --
 package gc

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -13,8 +13,8 @@ stdout '"coins": "10000000000000ugnot"'
 # gas-wanted/gas-fee on the simulate call are generous; simulate reports
 # the actual gas the real tx would consume.
 gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -chainid tendermint_test -simulate only test1
-stdout 'GAS USED:\s+2546359'
-stdout 'INFO:       estimated gas usage: 2546359 \(suggested, with 5% margin: 2673677\), gas fee: 2674ugnot, current gas price: 1ugnot/1000gas'
+stdout 'GAS USED:\s+2666807'
+stdout 'INFO:       estimated gas usage: 2666807 \(suggested, with 5% margin: 2800148\), gas fee: 2800ugnot, current gas price: 1ugnot/1000gas'
 
 ## No fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
@@ -25,33 +25,33 @@ stdout '"coins": "10000000000000ugnot"'
 # This is the documented simulate->broadcast workflow; the values on this
 # line MUST match the simulate output above (modulo a small gas-wanted
 # headroom).
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_674_000 -gas-fee 2674ugnot -chainid tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_800_000 -gas-fee 2800ugnot -chainid tendermint_test test1
 stdout 'OK'
 stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":206900\}.*\]'
 
 ## fee + storage deposit were charged; sequence number increased.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
-stdout '"coins": "9999999790426ugnot"'
+stdout '"coins": "9999999790300ugnot"'
 
 # Tx Call -simulate only, estimate gas used and gas fee.
 gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -chainid tendermint_test -simulate only test1
-stdout 'GAS USED:\s+1024011'
-stdout 'INFO:       estimated gas usage: 1024011 \(suggested, with 5% margin: 1075212\), gas fee: 1076ugnot, current gas price: 1ugnot/1000gas'
+stdout 'GAS USED:\s+1144459'
+stdout 'INFO:       estimated gas usage: 1144459 \(suggested, with 5% margin: 1201682\), gas fee: 1202ugnot, current gas price: 1ugnot/1000gas'
 
 ## No additional fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
-stdout '"coins": "9999999790426ugnot"'
+stdout '"coins": "9999999790300ugnot"'
 
 # Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_076_000 -gas-fee 1076ugnot -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_202_000 -gas-fee 1202ugnot -chainid tendermint_test test1
 stdout 'OK'
 
 ## fee is charged and sequence number increased
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "2"'
-stdout '"coins": "9999999789350ugnot"'
+stdout '"coins": "9999999789098ugnot"'
 
 -- hello/gnomod.toml --
 module = "gno.land/r/hello"

--- a/gno.land/pkg/integration/testdata/restart_gas.txtar
+++ b/gno.land/pkg/integration/testdata/restart_gas.txtar
@@ -10,15 +10,15 @@
 gnoland start
 
 gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2633729'
+stdout 'GAS USED: +2754177'
 
 gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2634798'
+stdout 'GAS USED: +2755246'
 
 gnoland restart
 
 gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2636075'
+stdout 'GAS USED: +2756523'
 
 -- bar/gnomod.toml --
 module = "bar"

--- a/gno.land/pkg/integration/testdata/simulate_gas.txtar
+++ b/gno.land/pkg/integration/testdata/simulate_gas.txtar
@@ -14,15 +14,15 @@ stdout 'GAS USED:   \d+' # same as simulate only
 
 # simulate only (again) with default 5% margin
 gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only test1
-stdout 'gas fee: 1006ugnot'
+stdout 'gas fee: 1132ugnot'
 
-# simulate only with no gas fee margin. base gas fee is 959ugnot
+# simulate only with no gas fee margin. base gas fee is 1079ugnot
 gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=0 test1
-stdout 'gas fee: 959ugnot'
+stdout 'gas fee: 1079ugnot'
 
-# the 5% margin was 47ugnot (1006 - 959). the 10% margin should be about 95ugnot, total of 1054
+# the 5% margin was 53ugnot (1132 - 1079). the 10% margin should be about 107ugnot, total of 1186
 gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=10 test1
-stdout 'gas fee: 1054ugnot,'
+stdout 'gas fee: 1186ugnot,'
 
 # -gas-fee-margin should be a number
 ! gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=zzz test1

--- a/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
@@ -14,7 +14,7 @@
 
 env ADDPKG_GAS=10_000_000
 env CALL_GAS=10_000_000
-env EXACT_GAS=2551422
+env EXACT_GAS=2671870
 
 gnoland start
 

--- a/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
@@ -4,7 +4,7 @@
 
 env ADDPKG_GAS=4_800_000
 env SETUP_GAS=3_200_000
-env EXACT_GAS=2012646
+env EXACT_GAS=2133094
 
 gnoland start
 

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -96,7 +96,12 @@ import (
 // unchanged; only the genesis params encoding shifted. (Value re-derived
 // after merging master, so it reflects the bptree store + #5890 + #5891 +
 // this param together.)
-const expectedCrossrealm38Hash = "058910b2a1aa0f2c900990843643b5e13d8b8dfa3be8aa7f9dc7d169c1e7cb15"
+//
+// Hash bumped by the VM params bundle PR: InitGenesis now stores the same
+// parameters in one additional amino-binary `_vm_params` key. The individual
+// keys and scenario behavior are unchanged; this is the intentional state-
+// schema/app-hash change documented in prxxxx_vm_params_bundle.md.
+const expectedCrossrealm38Hash = "18c8ba7c2c8f153356ab4364df9fe837fdda6a0eeb71853555d95ae90c1b7120"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/gas_test.go
+++ b/gno.land/pkg/sdk/vm/gas_test.go
@@ -28,7 +28,7 @@ func TestAddPkgDeliverTxInsuffGas(t *testing.T) {
 	ctx, tx, vmHandler := setupAddPkg(isValidTx)
 
 	ctx = ctx.WithMode(sdk.RunTxModeDeliver)
-	tx.Fee.GasWanted = 3000000
+	tx.Fee.GasWanted = 2_000_000
 	gctx := auth.SetGasMeter(ctx, tx.Fee.GasWanted)
 	gctx, _ = gctx.CacheContext()
 
@@ -111,7 +111,7 @@ func TestAddPkgDeliverTxFailedNoGas(t *testing.T) {
 	ctx, tx, vmHandler := setupAddPkg(isValidTx)
 
 	ctx = ctx.WithMode(sdk.RunTxModeDeliver)
-	tx.Fee.GasWanted = 500000
+	tx.Fee.GasWanted = 300_000
 	gctx := auth.SetGasMeter(ctx, tx.Fee.GasWanted)
 	gctx, _ = gctx.CacheContext()
 

--- a/gno.land/pkg/sdk/vm/genesis.go
+++ b/gno.land/pkg/sdk/vm/genesis.go
@@ -53,6 +53,9 @@ func (vm *VMKeeper) InitGenesis(ctx sdk.Context, gs GenesisState) {
 	if err := ValidateGenesis(gs); err != nil {
 		panic(err)
 	}
+	// Besides the legacy per-field keys, SetParams writes the bundled VM
+	// params representation. For export/import hardforks, InitGenesis is the
+	// explicit migration and activation point for the lower read-gas schedule.
 	if err := vm.SetParams(ctx, gs.Params); err != nil {
 		panic(err)
 	}

--- a/gno.land/pkg/sdk/vm/params.go
+++ b/gno.land/pkg/sdk/vm/params.go
@@ -231,7 +231,16 @@ func (vm *VMKeeper) SetParams(ctx sdk.Context, params Params) error {
 	if err := params.Validate(); err != nil {
 		return err
 	}
+	bundle, err := amino.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal vm params bundle: %w", err)
+	}
+
+	// Keep the individual keys for the generic params query/governance paths.
+	// Write the bundle last so a successful SetParams always leaves both
+	// representations synchronized.
 	vm.prmk.SetStruct(ctx, "vm:p", params) // prmk is root.
+	vm.prmk.SetBytes(ctx, paramsBundleKey, bundle)
 	return nil
 }
 
@@ -250,14 +259,42 @@ func (p Params) applyLegacyDefaults() Params {
 	return p
 }
 
-func (vm *VMKeeper) GetParams(ctx sdk.Context) Params {
+// getParamsBundle returns the VM parameters from the bundled representation.
+// A missing bundle is value-compatible legacy state, but probing for it is an
+// additional read compared with the old binary. The binary and state migration
+// must therefore still be activated by a coordinated chain upgrade.
+func (vm *VMKeeper) getParamsBundle(ctx sdk.Context) (Params, bool) {
+	var bundle []byte
+	if vm.prmk.GetBytes(ctx, paramsBundleKey, &bundle) {
+		params := Params{}
+		if err := amino.Unmarshal(bundle, &params); err != nil {
+			panic(fmt.Errorf("unmarshal vm params bundle: %w", err))
+		}
+		return params.applyLegacyDefaults(), true
+	}
+	return Params{}, false
+}
+
+func (vm *VMKeeper) getParams(ctx sdk.Context) (Params, bool) {
+	if params, ok := vm.getParamsBundle(ctx); ok {
+		return params, true
+	}
 	params := Params{}
 	vm.prmk.GetStruct(ctx, "vm:p", &params) // prmk is root.
-	return params.applyLegacyDefaults()
+	return params.applyLegacyDefaults(), false
+}
+
+func (vm *VMKeeper) GetParams(ctx sdk.Context) Params {
+	params, _ := vm.getParams(ctx)
+	return params
 }
 
 const (
 	moduleParamPrefix = "vm"
+	// paramsBundleKey deliberately has no module prefix. It is chain-internal
+	// state, not a governance-addressable parameter; an unprefixed key also
+	// avoids recursively invoking VMKeeper.WillSetParam from SetBytes.
+	paramsBundleKey = "_vm_params"
 
 	sysUsersPkgParamPath = moduleParamPrefix + ":p:sysnames_pkgpath"
 	sysCLAPkgParamPath   = moduleParamPrefix + ":p:syscla_pkgpath"
@@ -265,25 +302,34 @@ const (
 )
 
 func (vm *VMKeeper) getChainDomainParam(ctx sdk.Context) string {
+	if params, ok := vm.getParamsBundle(ctx); ok {
+		return params.ChainDomain
+	}
 	chainDomain := chainDomainDefault // default
 	vm.prmk.GetString(ctx, chainDomainParamPath, &chainDomain)
 	return chainDomain
 }
 
 func (vm *VMKeeper) getSysNamesPkgParam(ctx sdk.Context) string {
+	if params, ok := vm.getParamsBundle(ctx); ok {
+		return params.SysNamesPkgPath
+	}
 	sysNamesPkg := sysNamesPkgDefault
 	vm.prmk.GetString(ctx, sysUsersPkgParamPath, &sysNamesPkg)
 	return sysNamesPkg
 }
 
 func (vm *VMKeeper) getSysCLAPkgParam(ctx sdk.Context) string {
+	if params, ok := vm.getParamsBundle(ctx); ok {
+		return params.SysCLAPkgPath
+	}
 	sysCLAPkg := sysCLAPkgDefault
 	vm.prmk.GetString(ctx, sysCLAPkgParamPath, &sysCLAPkg)
 	return sysCLAPkg
 }
 
 func (vm *VMKeeper) WillSetParam(ctx sdk.Context, key string, value any) {
-	params := vm.GetParams(ctx)
+	params, bundled := vm.getParams(ctx)
 	switch key {
 	case "p:sysnames_pkgpath":
 		params.SysNamesPkgPath = sdkparams.MustParamString("sysnames_pkgpath", value)
@@ -327,5 +373,18 @@ func (vm *VMKeeper) WillSetParam(ctx sdk.Context, key string, value any) {
 	}
 	if err := params.Validate(); err != nil {
 		panic("invalid param: " + err.Error())
+	}
+
+	// ParamsKeeper invokes this hook immediately before writing the changed
+	// individual key. Updating an already-active bundle here keeps the two
+	// writes atomic in BaseApp's transaction cache. Do not create a bundle on
+	// legacy state: its presence changes transaction gas and must only be
+	// introduced by an explicit upgrade migration.
+	if bundled {
+		bundle, err := amino.Marshal(params)
+		if err != nil {
+			panic(fmt.Errorf("marshal vm params bundle: %w", err))
+		}
+		vm.prmk.SetBytes(ctx, paramsBundleKey, bundle)
 	}
 }

--- a/gno.land/pkg/sdk/vm/params_bundle_test.go
+++ b/gno.land/pkg/sdk/vm/params_bundle_test.go
@@ -1,0 +1,198 @@
+package vm
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func readParamsBundle(t *testing.T, env testEnv, ctx sdk.Context) (Params, bool) {
+	t.Helper()
+
+	var bundle []byte
+	if !env.prmk.GetBytes(ctx, paramsBundleKey, &bundle) {
+		return Params{}, false
+	}
+	var params Params
+	require.NoError(t, amino.Unmarshal(bundle, &params))
+	return params, true
+}
+
+func TestParamsBundleSetParamsSynchronizesRepresentations(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	params := DefaultParams()
+	params.ChainDomain = "example.com"
+	params.PreprocessGasPerByte = 2_500
+	params.StorageFeeCollector = crypto.AddressFromPreimage([]byte("new-storage-fee-collector"))
+	require.NoError(t, env.vmk.SetParams(ctx, params))
+
+	bundled, ok := readParamsBundle(t, env, ctx)
+	require.True(t, ok)
+	assert.Equal(t, params, bundled)
+
+	var chainDomain string
+	require.True(t, env.prmk.GetString(ctx, chainDomainParamPath, &chainDomain))
+	assert.Equal(t, params.ChainDomain, chainDomain)
+
+	var preprocessGasPerByte int64
+	require.True(t, env.prmk.GetInt64(ctx, "vm:p:preprocess_gas_per_byte", &preprocessGasPerByte))
+	assert.Equal(t, params.PreprocessGasPerByte, preprocessGasPerByte)
+
+	var storageFeeCollector string
+	require.True(t, env.prmk.GetString(ctx, "vm:p:storage_fee_collector", &storageFeeCollector))
+	assert.Equal(t, params.StorageFeeCollector.String(), storageFeeCollector)
+}
+
+func TestParamsBundleReadPreferenceAndLegacyFallback(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	bundled := DefaultParams()
+	bundled.ChainDomain = "bundle.example"
+	bundled.SysNamesPkgPath = "gno.land/r/sys/bundlenames"
+	bundled.SysCLAPkgPath = "gno.land/r/sys/bundlecla"
+	require.NoError(t, env.vmk.SetParams(ctx, bundled))
+
+	legacy := bundled
+	legacy.ChainDomain = "legacy.example"
+	legacy.SysNamesPkgPath = "gno.land/r/sys/legacynames"
+	legacy.SysCLAPkgPath = "gno.land/r/sys/legacycla"
+	env.prmk.SetStruct(ctx, "vm:p", legacy) // bypass SetParams to make the representations diverge
+
+	assert.Equal(t, bundled, env.vmk.GetParams(ctx))
+	assert.Equal(t, bundled.ChainDomain, env.vmk.getChainDomainParam(ctx))
+	assert.Equal(t, bundled.SysNamesPkgPath, env.vmk.getSysNamesPkgParam(ctx))
+	assert.Equal(t, bundled.SysCLAPkgPath, env.vmk.getSysCLAPkgParam(ctx))
+
+	env.prmk.SetBytes(ctx, paramsBundleKey, nil)
+	assert.Equal(t, legacy, env.vmk.GetParams(ctx))
+	assert.Equal(t, legacy.ChainDomain, env.vmk.getChainDomainParam(ctx))
+	assert.Equal(t, legacy.SysNamesPkgPath, env.vmk.getSysNamesPkgParam(ctx))
+	assert.Equal(t, legacy.SysCLAPkgPath, env.vmk.getSysCLAPkgParam(ctx))
+}
+
+func TestParamsBundleGovernanceSyncAndMigrationGate(t *testing.T) {
+	t.Run("active bundle stays synchronized", func(t *testing.T) {
+		env := setupTestEnv()
+		ctx := env.ctx
+		expected := DefaultParams()
+
+		env.prmk.SetString(ctx, chainDomainParamPath, "example.com")
+		expected.ChainDomain = "example.com"
+		assert.Equal(t, expected, env.vmk.GetParams(ctx))
+		bundled, ok := readParamsBundle(t, env, ctx)
+		require.True(t, ok)
+		assert.Equal(t, expected, bundled)
+
+		env.prmk.SetInt64(ctx, "vm:p:preprocess_gas_per_byte", 2_500)
+		expected.PreprocessGasPerByte = 2_500
+		assert.Equal(t, expected, env.vmk.GetParams(ctx))
+		bundled, ok = readParamsBundle(t, env, ctx)
+		require.True(t, ok)
+		assert.Equal(t, expected, bundled)
+
+		before, ok := readParamsBundle(t, env, ctx)
+		require.True(t, ok)
+		assert.Panics(t, func() {
+			env.prmk.SetString(ctx, chainDomainParamPath, "not/a/domain")
+		})
+		after, ok := readParamsBundle(t, env, ctx)
+		require.True(t, ok)
+		assert.Equal(t, before, after)
+		var chainDomain string
+		require.True(t, env.prmk.GetString(ctx, chainDomainParamPath, &chainDomain))
+		assert.Equal(t, expected.ChainDomain, chainDomain)
+	})
+
+	t.Run("legacy governance write does not activate bundle", func(t *testing.T) {
+		env := setupTestEnv()
+		ctx := env.ctx
+		env.prmk.SetBytes(ctx, paramsBundleKey, nil)
+
+		env.prmk.SetString(ctx, chainDomainParamPath, "example.com")
+		_, ok := readParamsBundle(t, env, ctx)
+		assert.False(t, ok)
+		assert.Equal(t, "example.com", env.vmk.GetParams(ctx).ChainDomain)
+
+		params := env.vmk.GetParams(ctx)
+		require.NoError(t, env.vmk.SetParams(ctx, params))
+		migrated, ok := readParamsBundle(t, env, ctx)
+		require.True(t, ok)
+		assert.Equal(t, params, migrated)
+	})
+}
+
+func TestParamsBundleInitGenesisMigratesLegacyState(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+
+	legacy := DefaultParams()
+	legacy.ChainDomain = "legacy.example"
+	legacy.PreprocessGasPerByte = 0
+	env.prmk.SetBytes(ctx, paramsBundleKey, nil)
+	env.prmk.SetStruct(ctx, "vm:p", legacy)
+
+	exported := env.vmk.ExportGenesis(ctx)
+	assert.Equal(t, preprocessGasPerByteDefault, exported.Params.PreprocessGasPerByte)
+	env.vmk.InitGenesis(ctx, exported)
+
+	bundled, ok := readParamsBundle(t, env, ctx)
+	require.True(t, ok)
+	assert.Equal(t, exported.Params, bundled)
+	assert.Equal(t, exported.Params, env.vmk.GetParams(ctx))
+}
+
+func TestParamsBundleMalformedStatePanics(t *testing.T) {
+	env := setupTestEnv()
+	ctx := env.ctx
+	env.prmk.SetBytes(ctx, paramsBundleKey, []byte{0xff})
+
+	assert.Panics(t, func() { env.vmk.GetParams(ctx) })
+	assert.Panics(t, func() { env.vmk.getChainDomainParam(ctx) })
+}
+
+func TestParamsBundleColdReadGas(t *testing.T) {
+	newMeteredContext := func(env testEnv) (sdk.Context, store.GasMeter) {
+		cfg := store.DefaultGasConfig()
+		cfg.FixedGetReadDepth100 = 100
+		cfg.ReadCostPerByte = 0
+		meter := store.NewInfiniteGasMeter()
+		ctx, _ := env.ctx.WithGasMeter(meter).WithGasConfig(cfg).CacheContext()
+		return ctx, meter
+	}
+	readAllCallSites := func(env testEnv, ctx sdk.Context) {
+		env.vmk.GetParams(ctx)
+		env.vmk.getChainDomainParam(ctx)
+		env.vmk.getSysNamesPkgParam(ctx)
+		env.vmk.getSysCLAPkgParam(ctx)
+		env.vmk.GetParams(ctx)
+	}
+
+	t.Run("bundle", func(t *testing.T) {
+		env := setupTestEnv()
+		ctx, meter := newMeteredContext(env)
+		readAllCallSites(env, ctx)
+
+		assert.Equal(t, store.DefaultGasConfig().ReadCostFlat, meter.GasConsumed(),
+			"all VM param call sites must collapse to one cold bundle read")
+	})
+
+	t.Run("legacy fallback", func(t *testing.T) {
+		env := setupTestEnv()
+		env.prmk.SetBytes(env.ctx, paramsBundleKey, nil)
+		ctx, meter := newMeteredContext(env)
+		readAllCallSites(env, ctx)
+
+		wantReads := int64(1 + reflect.TypeFor[Params]().NumField())
+		assert.Equal(t, wantReads*store.DefaultGasConfig().ReadCostFlat, meter.GasConsumed(),
+			"legacy fallback reads the absent bundle key plus every individual field once")
+	})
+}

--- a/gno.land/pkg/sdk/vm/params_bundle_transfer_gas_test.go
+++ b/gno.land/pkg/sdk/vm/params_bundle_transfer_gas_test.go
@@ -1,0 +1,262 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	authm "github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	bankm "github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	paramsm "github.com/gnolang/gno/tm2/pkg/sdk/params"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	"github.com/stretchr/testify/require"
+)
+
+type paramsGasTestEnv struct {
+	ctx   sdk.Context
+	vmk   *VMKeeper
+	prmk  paramsm.ParamsKeeper
+	acck  authm.AccountKeeper
+	bankk bankm.BankKeeper
+	ms    store.CommitMultiStore
+}
+
+func newParamsGasTestEnv(t *testing.T, db *memdb.MemDB, genesis bool) paramsGasTestEnv {
+	t.Helper()
+
+	baseKey := store.NewStoreKey("baseCapKey")
+	mainKey := store.NewStoreKey("mainCapKey")
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(baseKey, dbadapter.StoreConstructor, db)
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	require.NoError(t, ms.LoadLatestVersion())
+
+	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms,
+		&bft.Header{ChainID: "params-bundle-gas-test", Height: 42},
+		log.NewNoopLogger(),
+	)
+	prmk := paramsm.NewParamsKeeper(mainKey)
+	acck := authm.NewAccountKeeper(mainKey, prmk.ForModule(authm.ModuleName), std.ProtoBaseAccount, std.ProtoBaseSessionAccount)
+	bankk := bankm.NewBankKeeper(acck, prmk.ForModule(bankm.ModuleName))
+	vmk := NewVMKeeper(baseKey, mainKey, acck, bankk, prmk)
+	prmk.Register(authm.ModuleName, acck)
+	prmk.Register(bankm.ModuleName, bankk)
+	prmk.Register(ModuleName, vmk)
+
+	if genesis {
+		acck.SetParams(ctx, authm.DefaultParams())
+		bankk.SetParams(ctx, bankm.DefaultParams())
+		require.NoError(t, vmk.SetParams(ctx, DefaultParams()))
+	}
+
+	mcw := ms.MultiCacheWrap()
+	vmk.Initialize(log.NewNoopLogger(), mcw)
+	if genesis {
+		stdlibCtx := vmk.MakeGnoTransactionStore(ctx.WithMultiStore(mcw))
+		vmk.LoadStdlibCached(stdlibCtx, filepath.Join("..", "..", "..", "..", "gnovm", "stdlibs"))
+		vmk.CommitGnoTransactionStore(stdlibCtx)
+	}
+	mcw.MultiWrite()
+	vmk.PopulateStdlibCache()
+
+	return paramsGasTestEnv{ctx: ctx, vmk: vmk, prmk: prmk, acck: acck, bankk: bankk, ms: ms}
+}
+
+var paramsGasImportPattern = regexp.MustCompile(`"(gno\.land/[pr]/[\w/.\-]+)"`)
+
+func deployParamsGasPackage(t *testing.T, env paramsGasTestEnv, ctx sdk.Context, deployer crypto.Address, pkgPath string, files []*std.MemFile) {
+	t.Helper()
+
+	deployed := make(map[string]bool)
+	var deployDependencies func(string)
+	deployDependencies = func(importPath string) {
+		if deployed[importPath] {
+			return
+		}
+		deployed[importPath] = true
+
+		rel := strings.TrimPrefix(importPath, "gno.land/")
+		info, err := os.Stat(filepath.Join(examplesDir(), rel))
+		if err != nil || !info.IsDir() {
+			return
+		}
+		dependencyFiles := loadExamplePackage(importPath)
+		for _, file := range dependencyFiles {
+			for _, match := range paramsGasImportPattern.FindAllStringSubmatch(file.Body, -1) {
+				deployDependencies(match[1])
+			}
+		}
+		require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(deployer, importPath, dependencyFiles)))
+	}
+
+	for _, file := range files {
+		for _, match := range paramsGasImportPattern.FindAllStringSubmatch(file.Body, -1) {
+			deployDependencies(match[1])
+		}
+	}
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(deployer, pkgPath, files)))
+}
+
+type paramsGasMeter struct {
+	store.GasMeter
+	counts map[string]int64
+	gas    map[string]int64
+}
+
+func newParamsGasMeter() *paramsGasMeter {
+	return &paramsGasMeter{
+		GasMeter: store.NewGasMeter(1_000_000_000),
+		counts:   make(map[string]int64),
+		gas:      make(map[string]int64),
+	}
+}
+
+func (m *paramsGasMeter) ConsumeGas(amount int64, descriptor string) {
+	m.counts[descriptor]++
+	m.gas[descriptor] += amount
+	m.GasMeter.ConsumeGas(amount, descriptor)
+}
+
+type coldTransferGas struct {
+	total          int64
+	params         int64
+	paramReadCount int64
+	paramReadGas   int64
+}
+
+func measureColdGRC20Transfer(t *testing.T, db *memdb.MemDB, legacy bool, caller crypto.Address, pkgPath string) coldTransferGas {
+	t.Helper()
+
+	env := newParamsGasTestEnv(t, db, false)
+	cache := env.ms.MultiCacheWrap()
+	ctx := env.ctx.WithMultiStore(cache)
+	if legacy {
+		// The old implementation had no bundle lookup. Warm only the known-
+		// absent compatibility key without a meter so every other store access
+		// remains cold while this baseline charges the former 14-field path.
+		_, ok := env.vmk.getParamsBundle(ctx.WithGasMeter(nil))
+		require.False(t, ok)
+	}
+
+	meter := newParamsGasMeter()
+	ctx = ctx.WithGasMeter(meter)
+	params := env.vmk.GetParams(ctx)
+	paramGas := meter.GasConsumed()
+	paramReadCount := meter.counts["DepthReadFlat"]
+	paramReadGas := meter.gas["DepthReadFlat"]
+
+	gasConfig := store.DefaultGasConfig()
+	params.ApplyToGasConfig(&gasConfig)
+	ctx = ctx.WithGasConfig(gasConfig)
+	callCtx := env.vmk.MakeGnoTransactionStore(ctx)
+	_, err := env.vmk.Call(callCtx, NewMsgCall(caller, nil, pkgPath, "Transfer", nil))
+	require.NoError(t, err)
+
+	return coldTransferGas{
+		total:          meter.GasConsumed(),
+		params:         paramGas,
+		paramReadCount: paramReadCount,
+		paramReadGas:   paramReadGas,
+	}
+}
+
+func TestParamsBundleColdGRC20TransferGas(t *testing.T) {
+	db := memdb.NewMemDB()
+	env := newParamsGasTestEnv(t, db, true)
+	deployer := crypto.AddressFromPreimage([]byte("params-bundle-gas-deployer"))
+	env.acck.SetAccount(env.ctx, env.acck.NewAccountWithAddress(env.ctx, deployer))
+	require.NoError(t, env.bankk.SetCoins(env.ctx, deployer,
+		std.NewCoins(std.NewCoin("ugnot", 1_000_000_000_000)),
+	))
+
+	const pkgPath = "gno.land/r/test/paramsbundlegrc20"
+	files := []*std.MemFile{
+		{Name: "gnomod.toml", Body: "module = \"" + pkgPath + "\"\ngno = \"0.9\"\n"},
+		{Name: "token.gno", Body: `package paramsbundlegrc20
+
+import (
+	"chain"
+	"gno.land/p/demo/tokens/grc20"
+)
+
+var ledger *grc20.PrivateLedger
+
+func init(cur realm) {
+	_, ledger = grc20.NewToken(0, cur, "Bundle Gas", "BGS", 0)
+	checkErr(ledger.Mint(chain.PackageAddress("holder"), 1000))
+}
+
+func Transfer(cur realm) {
+	checkErr(ledger.Transfer(
+		chain.PackageAddress("holder"),
+		chain.PackageAddress("recipient"),
+		1,
+	))
+}
+
+func checkErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+`},
+	}
+	deployCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	deployParamsGasPackage(t, env, deployCtx, deployer, pkgPath, files)
+	env.vmk.CommitGnoTransactionStore(deployCtx)
+	env.ms.Commit()
+
+	bundled := measureColdGRC20Transfer(t, db, false, deployer, pkgPath)
+
+	// Produce the same committed token state with the legacy params layout.
+	legacyStore := store.NewCommitMultiStore(db)
+	legacyBaseKey := store.NewStoreKey("baseCapKey")
+	legacyMainKey := store.NewStoreKey("mainCapKey")
+	legacyStore.MountStoreWithDB(legacyBaseKey, dbadapter.StoreConstructor, db)
+	legacyStore.MountStoreWithDB(legacyMainKey, storebptree.FastStoreConstructor, db)
+	require.NoError(t, legacyStore.LoadLatestVersion())
+	legacyCtx := sdk.NewContext(sdk.RunTxModeDeliver, legacyStore,
+		&bft.Header{ChainID: "params-bundle-gas-test", Height: 42},
+		log.NewNoopLogger(),
+	)
+	paramsm.NewParamsKeeper(legacyMainKey).SetBytes(legacyCtx, paramsBundleKey, nil)
+	legacyStore.Commit()
+
+	legacy := measureColdGRC20Transfer(t, db, true, deployer, pkgPath)
+
+	require.Equal(t, int64(1), bundled.paramReadCount)
+	require.Equal(t, int64(reflect.TypeFor[Params]().NumField()), legacy.paramReadCount)
+	require.Equal(t, legacy.total-legacy.params, bundled.total-bundled.params,
+		"the mint/deploy/transfer inputs and all non-param gas must stay identical")
+
+	perReadGas := bundled.paramReadGas
+	require.Equal(t, perReadGas, legacy.paramReadGas/legacy.paramReadCount,
+		"the live B+ depth must be the same for both layouts")
+
+	params := DefaultParams()
+	bundleBytes := len(amino.MustMarshal(params))
+	legacyBytes := 0
+	rv := reflect.ValueOf(params)
+	for i := range rv.NumField() {
+		legacyBytes += len(amino.MustMarshalJSON(rv.Field(i).Interface()))
+	}
+	wantSaving := int64(reflect.TypeFor[Params]().NumField()-1)*perReadGas +
+		int64(legacyBytes-bundleBytes)*store.DefaultGasConfig().ReadCostPerByte
+	require.Equal(t, wantSaving, legacy.total-bundled.total,
+		"cold transfer saving must equal 13 removed reads plus the encoding-byte delta")
+	t.Logf("cold transfer gas: legacy=%d bundled=%d saving=%d params_reads=%d->%d read_gas=%d",
+		legacy.total, bundled.total, legacy.total-bundled.total,
+		legacy.paramReadCount, bundled.paramReadCount, perReadGas)
+}

--- a/gno.land/pkg/sdk/vm/params_test.go
+++ b/gno.land/pkg/sdk/vm/params_test.go
@@ -252,6 +252,7 @@ func TestGetParamsDefaultsPreprocessGasPerByte(t *testing.T) {
 
 	legacy := DefaultParams()
 	legacy.PreprocessGasPerByte = 0
+	env.prmk.SetBytes(ctx, paramsBundleKey, nil)
 	env.prmk.SetStruct(ctx, "vm:p", legacy) // direct write: no Validate, no hooks
 
 	assert.Equal(t, preprocessGasPerByteDefault, env.vmk.GetParams(ctx).PreprocessGasPerByte)

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -29,11 +29,24 @@ func init() {
 // and also to accept or reject different types of PubKey's. This is where apps can define their own PubKey
 type SignatureVerificationGasConsumer = func(meter store.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
 
+// PrepareGasMeter prepares the transaction context after the basic fee and
+// gas-wanted checks have passed, but before any auth reads or writes occur.
+// The default transaction gas meter is already installed when the callback is
+// invoked. Applications may use it to charge consensus configuration reads to
+// the final transaction meter before applying the configuration to the
+// context.
+type PrepareGasMeter = func(ctx sdk.Context, tx std.Tx) sdk.Context
+
 type AnteOptions struct {
 	// If verifyGenesisSignatures is false, does not check signatures when Height==0.
 	// This is useful for development, and maybe production chains.
 	// Always check your settings and inspect genesis transactions.
 	VerifyGenesisSignatures bool
+
+	// PrepareGasMeter is invoked after basic gas/mempool checks, with the final
+	// transaction gas meter already installed. A nil callback leaves the
+	// default context unchanged.
+	PrepareGasMeter PrepareGasMeter
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -94,6 +107,10 @@ func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer Signature
 				}
 			}
 		}()
+
+		if opts.PrepareGasMeter != nil {
+			newCtx = opts.PrepareGasMeter(newCtx, tx)
+		}
 
 		// Get params from context.
 		params := ctx.Value(AuthParamsContextKey{}).(Params)

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -956,6 +956,73 @@ func TestSetGasMeter_SkipGasMeteringKey(t *testing.T) {
 	})
 }
 
+// TestAnteHandlerPrepareGasMeter verifies that application-specific gas setup
+// runs after the basic fee checks and that charges made by the setup callback
+// remain on the meter returned by the ante handler. This is used by gnoland to
+// charge VM governance-parameter loading before auth account operations.
+func TestAnteHandlerPrepareGasMeter(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	ctx := env.ctx
+	priv, _, addr := tu.KeyTestPubAddr()
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	acc.SetCoins(tu.NewTestCoins())
+	env.acck.SetAccount(ctx, acc)
+	tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)},
+		[]crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, tu.NewTestFee())
+
+	const prepareGas = int64(1234)
+	called := false
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer,
+		AnteOptions{
+			VerifyGenesisSignatures: true,
+			PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+				called = true
+				ctx.GasMeter().ConsumeGas(prepareGas, "prepare-gas-meter")
+				return ctx
+			},
+		})
+
+	newCtx, res, abort := anteHandler(ctx, tx, false)
+	require.False(t, abort)
+	require.True(t, res.IsOK(), res)
+	require.True(t, called)
+	require.GreaterOrEqual(t, newCtx.GasMeter().GasConsumed(), prepareGas)
+}
+
+// TestAnteHandlerPrepareGasMeterOutOfGas verifies that an out-of-gas panic in
+// the preparation callback is recovered by the ante handler with the final
+// meter available to BaseApp.
+func TestAnteHandlerPrepareGasMeterOutOfGas(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	ctx := env.ctx
+	priv, _, addr := tu.KeyTestPubAddr()
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	acc.SetCoins(tu.NewTestCoins())
+	env.acck.SetAccount(ctx, acc)
+	tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)},
+		[]crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, tu.NewTestFee())
+
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer,
+		AnteOptions{
+			VerifyGenesisSignatures: true,
+			PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+				ctx.GasMeter().ConsumeGas(ctx.GasMeter().Limit()+1, "prepare-gas-meter")
+				return ctx
+			},
+		})
+
+	newCtx, res, abort := anteHandler(ctx, tx, false)
+	require.True(t, abort)
+	require.IsType(t, std.OutOfGasError{}, sdk.ABCIError(res.Error))
+	require.Equal(t, tx.Fee.GasWanted, res.GasWanted)
+	require.Greater(t, res.GasUsed, res.GasWanted)
+	require.Equal(t, res.GasUsed, newCtx.GasMeter().GasConsumed())
+}
+
 // TestAnteHandlerGenesisReplaySkip verifies the genesis-replay signature
 // skip: a tx whose signature no longer matches its body (as happens to a
 // --patch-txs-rewritten historical tx) is skipped ONLY when the node ran


### PR DESCRIPTION
## Summary

- Bundle the complete VM governance parameter struct under the internal `_vm_params` key, while retaining the legacy individual keys for queries and governance.
- Keep the bundle synchronized on `SetParams`, active governance updates, genesis, and export/import migration paths.
- Fix the ante gas-meter lifecycle so VM parameter loading is charged to the final transaction meter before the governed store-gas configuration is applied.
- Add unit, VM gas, app-hash, integration gas-fixture, and ADR coverage.

## Root cause

`gnoland` previously loaded VM parameters while BaseApp's temporary pre-ante meter was active. The auth ante handler then replaced that meter with the transaction meter, so the physical parameter reads appeared in traces but were discarded from reported `GasUsed`. Bundling alone therefore reduced reads without reducing the user-visible transaction gas.

`AnteOptions.PrepareGasMeter` now runs after the final meter and its out-of-gas recovery are installed. The VM parameter read is charged once, then its configuration is applied to the returned context.

## Gas impact

Measured with the same GRC20 transfer on gnodev:

- Unmodified master: `6,148,884` gas (parameter charge discarded)
- Correctly metered legacy layout: `7,803,638` gas
- Bundled layout: `6,269,332` gas
- Saving versus correctly metered legacy: `1,534,306` gas

The bundle is `120,448` gas higher than unmodified master because this change also corrects master's discarded one-read charge. This is a consensus gas repricing and requires coordinated activation.

## Upgrade and compatibility

- The bundle is authoritative when present; legacy state remains readable through a fallback.
- Existing individual parameter keys remain available for generic queries and governance.
- Genesis and supported export/import replay create the bundle explicitly.
- Live-chain activation requires the existing halt/minimum-version coordination; old and new binaries must not execute the same post-upgrade block.
- The new gas schedule changes pinned transaction values and is documented in the ADR.

## Validation

- `go test ./tm2/pkg/sdk/auth -count=1`
- `go test ./gno.land/pkg/gnoland -count=1`
- `go test ./gno.land/pkg/sdk/vm/ -count=1`
- `go test -timeout 20m ./gno.land/pkg/integration/ -run TestTestdata -count=1`
- `go test ./gnovm/pkg/gnolang/ -run Files -test.short -count=1`

All passed on the merged branch.

This PR was prepared with AI assistance; human review and ownership remain required.
