### PR TITLE
fix(gnoland): preserve pre-ante gas charges

### DIFF
--- a/gno.land/adr/prxxxx_ante_meter_lifecycle.md
+++ b/gno.land/adr/prxxxx_ante_meter_lifecycle.md
@@ -1,0 +1,57 @@
+# Preserve pre-message governance-parameter gas charges
+
+## Context
+
+`BaseApp.runTx` installs a temporary passthrough meter before the ante handler
+so that block-gas accounting is still protected while a transaction is being
+decoded. The auth ante handler then installs the transaction's gas meter with
+`GasWanted`. Gnoland's custom ante wrapper used to load VM governance
+parameters before entering the auth ante handler. The parameter read therefore
+charged the temporary meter, and replacing that meter discarded the charge from
+the transaction's reported `GasUsed` (although store-gas traces still showed
+the physical reads).
+
+This made reported transaction gas depend on meter lifetime rather than on the
+work performed. It also meant that the governed store-gas configuration was
+applied only after the read that supplied it.
+
+## Decision
+
+Add an optional `auth.AnteOptions.PrepareGasMeter` callback. The auth ante
+handler invokes it after the gas-wanted and mempool-fee checks, after installing
+the final transaction meter, and before auth reads or writes. The existing
+ante-handler recovery remains around the callback so an out-of-gas parameter
+load reports the final meter's consumption.
+
+Gnoland uses the callback to load VM parameters on the transaction meter and
+then applies those parameters to the context's store gas configuration. The
+custom wrapper no longer performs a pre-ante VM parameter read.
+
+## Alternatives considered
+
+1. Keep the pre-ante read and copy its consumed amount into the transaction
+   meter. This would require a second meter protocol, risks double charging,
+   and would still make callback failures difficult to report consistently.
+2. Change `BaseApp` to share one meter between pre-ante and transaction phases.
+   That would couple BaseApp's block-gas safety mechanism to every ante handler
+   and change the SDK contract for applications that intentionally replace a
+   meter.
+3. Keep the read unmetered. This would hide consensus-configuration storage
+   work from transaction gas and allow parameter changes to change execution
+   cost without a corresponding charge.
+
+## Consequences
+
+- VM parameter loading is charged exactly once to the final transaction meter,
+  and out-of-gas errors retain the consumed amount.
+- On the current legacy VM-parameter layout, the callback performs the same
+  fourteen field reads that the old wrapper performed, so integration gas
+  fixtures increase by approximately 1,654,754 gas per VM transaction. The
+  separate parameter-bundle change can reduce this physical work later; this
+  PR fixes meter ownership independently of that optimization.
+- Gas-wanted fixtures and exact gas assertions must include the newly reported
+  work. They were recalibrated with the repository's
+  `gno.land/pkg/integration/update_gas_wanted.sh` workflow and verified by the
+  full integration testdata suite.
+- The callback is optional and existing SDK applications that do not configure
+  it retain their current ante behavior.

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -129,6 +129,15 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 	// Set AnteHandler
 	authOptions := auth.AnteOptions{
 		VerifyGenesisSignatures: !cfg.SkipGenesisSigVerification,
+		PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+			// Charge VM parameter loading to the final transaction meter,
+			// then apply the governed store-gas configuration to all later
+			// ante and message operations. The auth ante handler invokes
+			// this callback after its basic fee and gas-wanted checks.
+			gasCfg := store.DefaultGasConfig()
+			vmk.GetParams(ctx).ApplyToGasConfig(&gasCfg)
+			return ctx.WithGasConfig(gasCfg)
+		},
 	}
 	authAnteHandler := auth.NewAnteHandler(
 		acck, bankk, auth.DefaultSigVerificationGasConsumer, authOptions)
@@ -143,16 +152,6 @@ func NewAppWithOptions(cfg *AppOptions) (abci.Application, error) {
 			// the gas meter (see tm2/pkg/sdk/auth/params.go) so this
 			// read costs nothing.
 			ctx = ctx.WithValue(auth.AuthParamsContextKey{}, acck.GetParams(ctx))
-			// Apply VM gas config so all store operations (account
-			// reads/writes in ante, message handlers, etc.) use the
-			// governed depth parameters. vmk.GetParams DOES meter (vm
-			// params are user-tunable consensus state and we want a
-			// real gas signal on changes), so this read uses the ctx's
-			// current (default) gasCfg until it's replaced below.
-			gasCfg := store.DefaultGasConfig()
-			vmk.GetParams(ctx).ApplyToGasConfig(&gasCfg)
-			ctx = ctx.WithGasConfig(gasCfg)
-
 			// During genesis (block height 0), automatically create accounts for signers
 			// if they don't exist. This allows packages with custom creators to be loaded.
 			if ctx.BlockHeight() == 0 {

--- a/gno.land/pkg/integration/testdata/addpkg.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg.txtar
@@ -4,11 +4,11 @@
 gnoland start
 
 ## deploy realm
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 370001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
 
 ## check output
 stdout OK!
-stdout 'GAS WANTED: 3700000'
+stdout 'GAS WANTED: 5200000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[.*\]'
@@ -16,43 +16,43 @@ stdout 'TX HASH:    '
 stdout 'PKGPATH:    gno.land/r/'$test1_user_addr'/hello'
 
 ## call added realm
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello   -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello   -gas-fee 180001ugnot -gas-wanted 2_900_000 test1
 
 ## check output
 stdout '\("hello world!" string\)'
 stdout OK!
-stdout 'GAS WANTED: 1800000'
+stdout 'GAS WANTED: 2900000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ## call added realm with 1 parmeter
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello1 -args foo   -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello1 -args foo   -gas-fee 180001ugnot -gas-wanted 2_900_000 test1
 
 ## check output
 stdout '\("hello foo!" string\)'
 stdout OK!
-stdout 'GAS WANTED: 1800000'
+stdout 'GAS WANTED: 2900000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ## call added realm with 2 parmeter
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello2 -args hello -args bar  -gas-fee 180001ugnot -gas-wanted 1_800_000 test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func SayHello2 -args hello -args bar  -gas-fee 180001ugnot -gas-wanted 2_900_000 test1
 
 ## check output
 stdout '\("hello bar!" string\)'
 stdout OK!
-stdout 'GAS WANTED: 1800000'
+stdout 'GAS WANTED: 2900000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[\]'
 stdout 'TX HASH:    '
 
 ##  get previous realm
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func PreviousRealm  -gas-fee 190001ugnot -gas-wanted 1_900_000 test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -chainid=tendermint_test -func PreviousRealm  -gas-fee 190001ugnot -gas-wanted 3_000_000 test1
 
 stdout 'UserRealm{ g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 }'
 

--- a/gno.land/pkg/integration/testdata/addpkg_cla.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_cla.txtar
@@ -16,7 +16,7 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 # Give alice more tokens for gas
-gnokey maketx send -send 1000000000ugnot -to $alice_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $alice_user_addr -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid tendermint_test test1
 
 # ============================================================
 # Test 1: CLA enforcement disabled (no required hash set)
@@ -27,7 +27,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$alice_user
 stdout 'true bool'
 
 # Alice should be able to addpkg when CLA is disabled
-gnokey maketx addpkg -pkgdir $WORK/pkg1 -pkgpath gno.land/r/$alice_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/pkg1 -pkgpath gno.land/r/$alice_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test alice
 stdout 'OK!'
 
 # ============================================================
@@ -39,10 +39,10 @@ gnokey maketx run -gas-fee 2800001ugnot -gas-wanted 32_000_000 -chainid=tendermi
 stdout OK!
 
 # Vote and execute proposal 0
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 25_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Alice's signature is now invalid (hasn't signed)
@@ -58,7 +58,7 @@ stderr 'A Contributor License Agreement'
 # ============================================================
 
 # Alice signs the CLA with correct hash
-gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "abc123hash" -gas-fee 560001ugnot -gas-wanted 7_300_000 -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "abc123hash" -gas-fee 8800001ugnot -gas-wanted 8_800_000 -chainid tendermint_test alice
 stdout 'OK!'
 
 # Verify Alice's signature
@@ -93,7 +93,7 @@ stdout 'false bool'
 stderr 'A Contributor License Agreement'
 
 # Alice re-signs with new hash
-gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "newhash456" -gas-fee 560001ugnot -gas-wanted 7_300_000 -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/sys/cla -func Sign -args "newhash456" -gas-fee 8800001ugnot -gas-wanted 8_800_000 -chainid tendermint_test alice
 stdout 'OK!'
 
 # Now Alice can deploy again
@@ -120,7 +120,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/cla.HasValidSignature(\"$test1_user
 stdout 'true bool'
 
 # Any user can deploy when enforcement is disabled (even test1 who never signed)
-gnokey maketx addpkg -pkgdir $WORK/pkg1 -pkgpath gno.land/r/$test1_user_addr/pkg1 -gas-fee 440001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg1 -pkgpath gno.land/r/$test1_user_addr/pkg1 -gas-fee 5500001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- proposer/propose_cla1.gno --

--- a/gno.land/pkg/integration/testdata/addpkg_domain.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_domain.txtar
@@ -7,7 +7,7 @@ stderr 'invalid package path'
 stderr 'invalid domain: anotherdomain.land/r/foobar/bar'
 
 # addpkg with gno.land
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/foobar/bar -gas-fee 4400001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_import_private.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_import_private.txtar
@@ -2,7 +2,7 @@
 gnoland start
 
 # add the private realm
-gnokey maketx addpkg -pkgdir $WORK/private -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/private -pkgpath gno.land/r/foobar/privaterealm -gas-fee 350001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # add bar package located in $WORK directory as gno.land/r/$test1_user_addr/bar

--- a/gno.land/pkg/integration/testdata/addpkg_import_testdep_gas.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_import_testdep_gas.txtar
@@ -12,7 +12,7 @@
 # On the pre-split single-blob layout, depb's mempackage included its _test.gno,
 # so type-checking useb decoded those extra bytes and useb cost MORE than usea.
 #
-# Measured: on this branch usea == useb == 2796401 (equal => the win; includes the
+# Measured: on this branch usea == useb == 4451155 (equal => the win; includes the
 # PreprocessGasPerByte addpkg charge). On master (pre-split, pre-charge) usea == 3172364
 # but useb == 3212984 -- importing depb costs +40620 gas for its _test.gno bytes. The
 # split removes that import penalty.
@@ -26,9 +26,9 @@ gnokey maketx addpkg -pkgdir $WORK/depa -pkgpath gno.land/p/demo/depa -gas-fee 1
 gnokey maketx addpkg -pkgdir $WORK/depb -pkgpath gno.land/p/demo/depb -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test test1
 
 gnokey maketx addpkg -pkgdir $WORK/usea -pkgpath gno.land/p/demo/usea -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2796401'
+stdout 'GAS USED:\s+4451155'
 gnokey maketx addpkg -pkgdir $WORK/useb -pkgpath gno.land/p/demo/useb -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test test1
-stdout 'GAS USED:\s+2796401'
+stdout 'GAS USED:\s+4451155'
 
 -- depa/gnomod.toml --
 module = "gno.land/p/demo/depa"

--- a/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_namespace.txtar
@@ -17,7 +17,7 @@ gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 42_000_000 -chainid=tendermi
 stdout OK!
 
 # give gui user more tokens
-gnokey maketx send -send 1000000000ugnot -to $gui_user_addr  -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $gui_user_addr  -gas-fee 1000000ugnot -gas-wanted 2800000 -chainid tendermint_test test1
 
 # Check if sys/names is disabled
 # qeval -> sys/names.IsEnabled

--- a/gno.land/pkg/integration/testdata/addpkg_outofgas.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_outofgas.txtar
@@ -4,7 +4,7 @@
 gnoland start
 
 # add foo package
-gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 350001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test test1
 
 
 # add bar package - runs out of gas early in store access with gas 60000

--- a/gno.land/pkg/integration/testdata/addpkg_preprocess_alloc_doubling.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_preprocess_alloc_doubling.txtar
@@ -30,7 +30,7 @@ stdout '"coins": "10000000000000ugnot"'
 # Benign tx still works. If the per-tx preAlloc had leaked from the
 # failed tx (e.g., kept on the store across the defer), this would
 # either fail with stale-state errors or charge the prior tx's gas.
-gnokey maketx addpkg -pkgdir $WORK/healthy -pkgpath gno.land/r/healthy -gas-fee 100000ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/healthy -pkgpath gno.land/r/healthy -gas-fee 4400001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
 stdout 'OK'
 
 -- doubling/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/addpkg_private.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_private.txtar
@@ -7,11 +7,11 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # add the public realm first
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 820001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 820001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # add the private realm
-gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 1100001ugnot -gas-wanted 24_000_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/privaterealm -pkgpath gno.land/r/foobar/privaterealm -gas-fee 1100001ugnot -gas-wanted 25_000_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
@@ -23,22 +23,22 @@ stdout OK!
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveTreeAsAValueOfTreeToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveIntToPublicRealm -gas-fee 460001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveIntToPublicRealm -gas-fee 6500001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStringToPublicRealm -gas-fee 460001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStringToPublicRealm -gas-fee 6500001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveSliceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadSliceToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadSliceToPublicRealm -gas-fee 5000001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test $test1_user_addr
 stdout 'private1'
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMapToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadMapToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func ReadMapToPublicRealm -gas-fee 5000001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test $test1_user_addr
 stdout 100
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
@@ -53,7 +53,7 @@ stderr 'cannot persist object of type defined in the private realm gno.land/r/fo
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveEmptySliceOfPrivateStructToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object from the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 7000001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
@@ -68,7 +68,7 @@ stderr 'cannot persist object of type defined in the private realm gno.land/r/fo
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveMixedStructToPublicRealmWithNewPrivateData -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr
 stderr 'cannot persist object of type defined in the private realm gno.land/r/foobar/privaterealm'
 
-gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func EditMixedStructWithPublicRealm -gas-fee 520001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func EditMixedStructWithPublicRealm -gas-fee 7000001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test $test1_user_addr
 stdout 'Read Mixed Struct'
 
 ! gnokey maketx call -pkgpath gno.land/r/foobar/privaterealm -func SaveInterfaceToPublicRealm -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test $test1_user_addr

--- a/gno.land/pkg/integration/testdata/addpkg_private_basic.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_private_basic.txtar
@@ -4,7 +4,7 @@
 gnoland start
 
 # add a public realm
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 20000000 -chainid=tendermint_test $test1_user_addr
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/foobar/publicrealm -gas-fee 10000000ugnot -gas-wanted 4600000 -chainid=tendermint_test $test1_user_addr
 stdout OK!
 
 # update the public realm

--- a/gno.land/pkg/integration/testdata/addpkg_public.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_public.txtar
@@ -14,49 +14,49 @@ stdout OK!
 gnokey maketx addpkg -pkgdir $WORK/normalrealm -pkgpath gno.land/r/foobar/normalrealm -gas-fee 910001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveTreeToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveTreeToPublicRealm -gas-fee 570001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveIntToPublicRealm -gas-fee 410001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveIntToPublicRealm -gas-fee 410001ugnot -gas-wanted 6_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveSliceToPublicRealm -gas-fee 500001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveSliceToPublicRealm -gas-fee 500001ugnot -gas-wanted 7_200_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMapToPublicRealm -gas-fee 500001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMapToPublicRealm -gas-fee 500001ugnot -gas-wanted 7_200_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveStructToPublicRealm -gas-fee 570001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveStructToPublicRealm -gas-fee 570001ugnot -gas-wanted 7_300_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithoutRef -gas-fee 530001ugnot -gas-wanted 6_100_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 600001ugnot -gas-wanted 6_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToStruct -gas-fee 600001ugnot -gas-wanted 6_900_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 640001ugnot -gas-wanted 6_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmWithRefToTree -gas-fee 640001ugnot -gas-wanted 7_200_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 730001ugnot -gas-wanted 7_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveMixedStructToPublicRealmAfterSaving -gas-fee 730001ugnot -gas-wanted 8_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveInterfaceToPublicRealm -gas-fee 610001ugnot -gas-wanted 6_100_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveInterfaceToPublicRealm -gas-fee 610001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveArrayToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveArrayToPublicRealm -gas-fee 580001ugnot -gas-wanted 6_600_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealm -gas-fee 590001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealm -gas-fee 590001ugnot -gas-wanted 6_800_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveNestedToPublicRealmAfterSaving -gas-fee 740001ugnot -gas-wanted 8_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveClosureToPublicRealm -gas-fee 550001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveClosureToPublicRealm -gas-fee 550001ugnot -gas-wanted 7_100_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveValueFromNormalStructToPublicRealm -gas-fee 580001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foobar/normalrealm -func SaveValueFromNormalStructToPublicRealm -gas-fee 580001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data 'gno.land/r/foobar/normalrealm.GetTreePointer()'

--- a/gno.land/pkg/integration/testdata/adduser.txtar
+++ b/gno.land/pkg/integration/testdata/adduser.txtar
@@ -4,15 +4,15 @@ adduser test8
 gnoland start
 
 ## add bar.gno package located in $WORK directory as gno.land/r/foobar/bar
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test8
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/foobar/bar -gas-fee 350001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test test8
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test8 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test8 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'
 stdout 'OK!'
-stdout 'GAS WANTED: 2000000'
+stdout 'GAS WANTED: 3100000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
 

--- a/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
@@ -26,16 +26,16 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Variant A: close BEFORE callee.Store (no taint expected).
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseBeforeStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4900000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseBeforeStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6100000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant B: close AFTER callee.Store, INLINE (no defer wrapper).
 # If this panics with taint, value-based taint is the cause.
 # If this succeeds, the defer mechanism specifically is the issue.
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func InlineCloseAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6300000 -chainid=tendermint_test user1
 
 # Variant C: close AFTER callee.Store, via inline closure call.
-gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func ClosureCallAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4100000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diaggranter -func ClosureCallAfterStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5600000 -chainid=tendermint_test user1
 
 -- diagcallee/gnomod.toml --
 module = "gno.land/r/test/diagcallee"

--- a/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
@@ -12,25 +12,25 @@ stdout 'g18e22n23g462drp4pyszyl6e6mwxkaylthgeeq4'
 gnoland start
 
 # Variant D: defer al.Close() with NO cross call at all. Should succeed.
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseNoCross -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 3100000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseNoCross -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4500000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant E: defer al.Close() + cross call WITHOUT persistence.
 # Callee receives but discards. Does the cross call alone (without
 # persistence) trigger taint on the deferred receiver?
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossNoPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 3100000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossNoPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4500000 -chainid=tendermint_test user1
 
 # Variant F: defer + cross + persist. With the VM fix (Defer.IsBoundMethod
 # threading the receiver through PushFrameCall so the implicit borrow-
 # realm switch fires for deferred method calls), this now SUCCEEDS.
 # Pre-fix behavior was a "cannot directly modify readonly tainted" panic.
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4600000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersist -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5900000 -chainid=tendermint_test user1
 stdout OK!
 
 # Variant G: defer + cross + persist + INLINE al.Close() before defer fires.
 # Diagnostic question: does the inline close succeed AND does the
 # deferred close still panic?
-gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersistAlsoInline -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5100000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/diag2granter -func DeferCloseCrossPersistAlsoInline -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6400000 -chainid=tendermint_test user1
 
 -- diag2callee/gnomod.toml --
 module = "gno.land/r/test/diag2callee"

--- a/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
@@ -23,7 +23,7 @@ gnoland start
 # tx1: granter installs outer recover-defer FIRST, then defer al.Close()
 # (so Close runs first on unwind, then outer recover catches if needed).
 # Callee persists the pointer. Outcome under test.
-gnokey maketx call -pkgpath gno.land/r/test/outerrecovergranter -func GrantWithOuterRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4900000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/outerrecovergranter -func GrantWithOuterRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6100000 -chainid=tendermint_test user1
 
 # tx2: inspect the persisted state. With the fix, Close ran cleanly
 # (no panic) and the persisted struct is closed.

--- a/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
@@ -34,7 +34,7 @@ gnoland start
 # granter creates 500_000 ugnot allowance, callee spends 200_000
 # during the call, granter's defer closes after. Funds move via
 # the inner banker; allowance correctly tracks spent.
-gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 500000 -args 200000 -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 4100000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndSpend -args 500000 -args 200000 -send 500000ugnot -gas-fee 1000000ugnot -gas-wanted 5400000 -chainid=tendermint_test user1
 stdout OK!
 
 # ============================================================
@@ -63,7 +63,7 @@ stderr 'negative amount not allowed'
 # the receiver is propagated through the deferred call's
 # PushFrameCall, the implicit borrow-realm switch fires, m.Realm
 # becomes callee inside Close, and the field write succeeds.
-gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4500000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/granter -func GrantAndStore -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5800000 -chainid=tendermint_test user1
 stdout OK!
 
 -- callee/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
@@ -26,7 +26,7 @@ gnoland start
 # tx1: granter creates allowance with cap 1M, callee persists, granter
 # tries to recover from the Close-time taint panic. Observe: does the
 # tx succeed (recover worked) or fail (taint panic is un-recoverable)?
-gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreWithRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 4900000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreWithRecover -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6100000 -chainid=tendermint_test user1
 stdout '.'  # match anything; we'll inspect the actual outcome below
 
 # tx2: state inspection. Use qeval to read the persisted state without
@@ -45,7 +45,7 @@ stderr 'allowancesender: closed'
 # Close runs in callee's realm context, the field write is allowed,
 # and the kill switch engages. Pre-fix this panicked with
 # "cannot directly modify readonly tainted object".
-gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreDirect -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/recovergranter -func GrantAndStoreDirect -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 6300000 -chainid=tendermint_test user1
 stdout OK!
 
 -- recovercallee/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/append.txtar
+++ b/gno.land/pkg/integration/testdata/append.txtar
@@ -5,18 +5,18 @@ loadpkg gno.land/r/append $WORK
 gnoland start
 
 # Call Append 1
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 270001ugnot -gas-wanted 2_700_000 -args '1' -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 270001ugnot -gas-wanted 4_000_000 -args '1' -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func AppendNil -gas-fee 270001ugnot -gas-wanted 2_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func AppendNil -gas-fee 270001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call Append 2
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 280001ugnot -gas-wanted 2_800_000 -args '2' -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 280001ugnot -gas-wanted 4_100_000 -args '2' -chainid=tendermint_test test1
 stdout OK!
 
 # Call Append 3
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 290001ugnot -gas-wanted 2_900_000 -args '3' -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 290001ugnot -gas-wanted 4_200_000 -args '3' -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
@@ -24,34 +24,34 @@ gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '1-2-3-'
 
 # Call Pop
-gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Pop -gas-fee 290001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test test1
 stdout OK!
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-'
 
 # Call Append 42
-gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 230001ugnot -gas-wanted 2_300_000 -args '42' -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func Append -gas-fee 230001ugnot -gas-wanted 3_700_000 -args '42' -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-42-'
 
-gnokey maketx call -pkgpath gno.land/r/append -func CopyAppend -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func CopyAppend -gas-fee 300001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func PopB -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func PopB -gas-fee 320001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call render
 gnokey query vm/qrender --data 'gno.land/r/append:'
 stdout '2-3-42-'
 
-gnokey maketx call -pkgpath gno.land/r/append -func AppendMoreAndC -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func AppendMoreAndC -gas-fee 330001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/append -func ReassignC -gas-fee 270001ugnot -gas-wanted 2_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/append -func ReassignC -gas-fee 270001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qrender --data 'gno.land/r/append:'

--- a/gno.land/pkg/integration/testdata/assertorigincall.txtar
+++ b/gno.land/pkg/integration/testdata/assertorigincall.txtar
@@ -40,11 +40,11 @@ gnoland start
 stderr 'invalid non-origin call'
 
 ## 2. MsgCall -> myrlm.B: PASS
-gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 2900001ugnot -gas-wanted 2_900_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 3. MsgCall -> myrlm.C: PASS
-gnokey maketx call -pkgpath gno.land/r/myrlm -func C -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func C -gas-fee 2900001ugnot -gas-wanted 2_900_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 4. MsgCall -> r/foo.A -> myrlm.A: PANIC
@@ -52,7 +52,7 @@ stdout 'OK!'
 stderr 'invalid non-origin call'
 
 ## 5. MsgCall -> r/foo.B -> myrlm.B: PASS
-gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 3200001ugnot -gas-wanted 3_200_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 ## 6. MsgCall -> r/foo.C -> myrlm.C: PANIC
@@ -77,7 +77,7 @@ stderr 'invalid non-origin call'
 stderr 'invalid non-origin call'
 
 ## 11. MsgRun -> run.main -> myrlm.B: PASS
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 2_000_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
+gnokey maketx run -gas-fee 3200001ugnot -gas-wanted 3_200_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
 stdout 'OK!'
 
 ## 12. MsgRun -> run.main -> myrlm.C: PANIC
@@ -89,7 +89,7 @@ stderr 'invalid non-origin call'
 stderr 'invalid non-origin call'
 
 ## 14. MsgRun -> run.main -> foo.B: PASS
-gnokey maketx run -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
 stdout 'OK!'
 
 ## 15. MsgRun -> run.main -> foo.C: PANIC
@@ -101,7 +101,7 @@ stderr 'invalid non-origin call'
 stderr 'invalid non-origin call'
 
 ## 17. MsgRun -> run.main -> bar.B: PASS
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 1_500_000 -chainid tendermint_test test1 $WORK/run/bar-b.gno
+gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid tendermint_test test1 $WORK/run/bar-b.gno
 stdout 'OK!'
 
 ## 18. MsgRun -> run.main -> bar.C: PANIC

--- a/gno.land/pkg/integration/testdata/atomicswap.txtar
+++ b/gno.land/pkg/integration/testdata/atomicswap.txtar
@@ -21,7 +21,7 @@ stdout 'coins.*:.*1010000000ugnot'
 #   test2 after Claim       = 1008853454  (unchanged — Claim moves escrow to test3, not from test2)
 #   test3 after NewCoinSwap = 1010000000  (unchanged)
 #   test3 after Claim       = 1010000000 + 12345 (escrow) - 700001 (gas) - 2000 (storage) = 1009310344
-gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func NewCoinSwap -gas-fee 680001ugnot -send 12345ugnot -gas-wanted 7_500_000 -args $test3_user_addr -args '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func NewCoinSwap -gas-fee 680001ugnot -send 12345ugnot -gas-wanted 8_800_000 -args $test3_user_addr -args '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b' -chainid=tendermint_test test2
 stdout '(1 int)'
 stdout ".*$test2_user_addr.*$test3_user_addr.*12345ugnot.*"
 stdout 'OK!'
@@ -34,7 +34,7 @@ stdout 'coins.*:.*1008853454ugnot'
 gnokey query auth/accounts/$test3_user_addr
 stdout 'coins.*:.*1010000000ugnot'
 
-gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func Claim -gas-fee 700001ugnot -gas-wanted 7_400_000 -args '1' -args 'secret' -chainid=tendermint_test test3
+gnokey maketx call -pkgpath gno.land/r/demo/defi/atomicswap -func Claim -gas-fee 700001ugnot -gas-wanted 8_700_000 -args '1' -args 'secret' -chainid=tendermint_test test3
 stdout 'OK!'
 stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":2000\}.*\]'
 

--- a/gno.land/pkg/integration/testdata/banker_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/banker_persistence.txtar
@@ -23,15 +23,15 @@ gnokey maketx call -pkgpath gno.land/r/test/bankera -func Save -send 1000000ugno
 stdout OK!
 
 # tx2: A's balance is 1_000_000. Spend 600_000 via the persisted banker.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 600000 -gas-fee 1000000ugnot -gas-wanted 2200000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 600000 -gas-fee 1000000ugnot -gas-wanted 3700000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx3: A's balance is now 400_000. Spend 300_000.
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 300000 -gas-fee 1000000ugnot -gas-wanted 2200000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 300000 -gas-fee 1000000ugnot -gas-wanted 3700000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx4: A's balance is now 100_000. Spend 99_000 (cuts it close).
-gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 99000 -gas-fee 1000000ugnot -gas-wanted 2200000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankera -func UseSelfAmount -args 99000 -gas-fee 1000000ugnot -gas-wanted 3700000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx5: A has only 1000 left. Try to spend 50_000 — must fail with
@@ -54,11 +54,11 @@ stdout OK!
 
 # tx7: B.UseGivenBanker spends 200_000 from A's address. (A had 1000
 #      left + 500_000 added = 501_000 going into this.)
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 200000 -gas-fee 1000000ugnot -gas-wanted 2600000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 200000 -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx8: A's balance is now 301_000. B drains another 250_000.
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 250000 -gas-fee 1000000ugnot -gas-wanted 2600000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 250000 -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test user1
 stdout OK!
 
 # tx9: A's balance is now 51_000. Try to drain 100_000 — must fail.
@@ -68,7 +68,7 @@ stderr 'insufficient'
 
 # tx10: B confirms the persisted banker still works for any amount
 #       within balance (sanity check after the failed overdraft).
-gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 50000 -gas-fee 1000000ugnot -gas-wanted 2600000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/test/bankerb -func UseGivenBankerAmount -args 50000 -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test user1
 stdout OK!
 
 -- bankera/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/banker_security.txtar
+++ b/gno.land/pkg/integration/testdata/banker_security.txtar
@@ -21,7 +21,7 @@ gnokey query bank/balances/${attacker_user_addr}
 stdout '1000000000ugnot'
 
 ## Deploy the malicious realm that attempts to steal coins
-gnokey maketx addpkg -pkgdir $WORK/malicious -pkgpath gno.land/r/test/malicious -gas-fee 380001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/malicious -pkgpath gno.land/r/test/malicious -gas-fee 380001ugnot -gas-wanted 6_600_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## ============================================
@@ -63,7 +63,7 @@ stderr 'cannot send "100000ugnot", limit "10ugnot" exceeded'
 ## This verifies the banker does work correctly for legitimate use
 ## ============================================
 
-gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 5 -send 10ugnot -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test victim
+gnokey maketx call -pkgpath gno.land/r/test/malicious -func LegitOriginSend -args ${attacker_user_addr} -args 5 -send 10ugnot -gas-fee 4400001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test victim
 stdout OK!
 
 ## ============================================
@@ -71,11 +71,11 @@ stdout OK!
 ## Deploy a "helper" realm that the malicious realm tries to use to steal coins
 ## ============================================
 
-gnokey maketx addpkg -pkgdir $WORK/helper -pkgpath gno.land/r/test/helper -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/helper -pkgpath gno.land/r/test/helper -gas-fee 5300001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## Update malicious realm to have access to helper
-gnokey maketx addpkg -pkgdir $WORK/malicious_v2 -pkgpath gno.land/r/test/malicious_v2 -gas-fee 400001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/malicious_v2 -pkgpath gno.land/r/test/malicious_v2 -gas-fee 5300001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ## Try cross-realm attack - helper realm should not be able to create OriginSend banker
@@ -91,7 +91,7 @@ stderr 'banker with type BankerTypeOriginSend can only be instantiated by the or
 ## This must FAIL at NewBanker: the realm value must be the live cur,
 ## and cur.Previous() is not IsCurrent. Guards the caller-drain hole.
 ## ============================================
-gnokey maketx addpkg -pkgdir $WORK/prevattack -pkgpath gno.land/r/test/prevattack -gas-fee 400001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/prevattack -pkgpath gno.land/r/test/prevattack -gas-fee 5300001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test attacker
 stdout OK!
 
 ! gnokey maketx call -pkgpath gno.land/r/test/prevattack -func Attack -args ${attacker_user_addr} -args 100000 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test victim

--- a/gno.land/pkg/integration/testdata/cpu-cycle-overrun1.txtar
+++ b/gno.land/pkg/integration/testdata/cpu-cycle-overrun1.txtar
@@ -3,20 +3,20 @@ loadpkg gno.land/p/nt/avl/v0
 # start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/cpu_cycle_overrun1 -gas-fee 710001ugnot -gas-wanted 7_100_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/cpu_cycle_overrun1 -gas-fee 710001ugnot -gas-wanted 8_100_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call AddData 3 times
 gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 5600001ugnot -gas-wanted 56_000_000 -chainid=tendermint_test test1
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 7400001ugnot -gas-wanted 74_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 7400001ugnot -gas-wanted 75_000_000 -chainid=tendermint_test test1
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8100001ugnot -gas-wanted 81_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8100001ugnot -gas-wanted 82_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call AddData one more time. The call to Render used to hang. If you commented this out, then the call to Render would return quickly.
 # This bug was fixed by https://github.com/gnolang/gno/pull/4060
-gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8400001ugnot -gas-wanted 84_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/cpu_cycle_overrun1 -func AddData -gas-fee 8400001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call Render

--- a/gno.land/pkg/integration/testdata/crossrealm_assign_recover.txtar
+++ b/gno.land/pkg/integration/testdata/crossrealm_assign_recover.txtar
@@ -28,14 +28,14 @@ adduser attacker
 gnoland start
 
 ## deploy vault realm
-gnokey maketx addpkg -pkgdir $WORK/vault -pkgpath gno.land/r/test/vault -gas-fee 390001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/vault -pkgpath gno.land/r/test/vault -gas-fee 390001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test test1
 
 ## verify initial owner is the DAO address
 gnokey query "vm/qrender" --data "gno.land/r/test/vault:"
 stdout 'owner: g1dao0000000000000000000000000000000000'
 
 ## deploy attack realm
-gnokey maketx addpkg -pkgdir $WORK/attack -pkgpath gno.land/r/test/attack -gas-fee 420001ugnot -gas-wanted 5_600_000 -chainid=tendermint_test attacker
+gnokey maketx addpkg -pkgdir $WORK/attack -pkgpath gno.land/r/test/attack -gas-fee 420001ugnot -gas-wanted 6_200_000 -chainid=tendermint_test attacker
 
 ## FOOTGUN 1: assign+recover via exported non-crossing setter.
 ## Under interrealm v2, borrow rule #1 makes SetOwner's owner=o write a same-

--- a/gno.land/pkg/integration/testdata/escape_oid_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/escape_oid_persistence.txtar
@@ -22,10 +22,10 @@ adduser alice
 gnoland start
 
 ## deploy registry
-gnokey maketx addpkg -pkgdir $WORK/registry -pkgpath gno.land/r/test/escbug/registry -gas-fee 2000000ugnot -gas-wanted 8_000_000 -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/registry -pkgpath gno.land/r/test/escbug/registry -gas-fee 2000000ugnot -gas-wanted 8_200_000 -chainid=tendermint_test alice
 
 ## deploy holder — its init(cur) cross-constructs and cross-registers X
-gnokey maketx addpkg -pkgdir $WORK/holder -pkgpath gno.land/r/test/escbug/holder -gas-fee 2000000ugnot -gas-wanted 8_000_000 -chainid=tendermint_test alice
+gnokey maketx addpkg -pkgdir $WORK/holder -pkgpath gno.land/r/test/escbug/holder -gas-fee 2000000ugnot -gas-wanted 9_000_000 -chainid=tendermint_test alice
 
 ## verify the holder's X reads back correctly right after init
 gnokey query "vm/qrender" --data "gno.land/r/test/escbug/holder:"

--- a/gno.land/pkg/integration/testdata/event_callback.txtar
+++ b/gno.land/pkg/integration/testdata/event_callback.txtar
@@ -4,9 +4,9 @@ loadpkg gno.land/r/demo/cbee $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/cbee -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/cbee -func Foo -gas-fee 210001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 2100000'
+stdout 'GAS WANTED: 3200000'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}\],\"pkg_path\":\"gno.land/r/demo/cbee\"},{\"type\":\"bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land/r/demo/cbee\"}\]'

--- a/gno.land/pkg/integration/testdata/event_defer_callback_loop.txtar
+++ b/gno.land/pkg/integration/testdata/event_defer_callback_loop.txtar
@@ -4,9 +4,9 @@ loadpkg gno.land/r/demo/edcl $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/edcl -func Main -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/edcl -func Main -gas-fee 240001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 2400000'
+stdout 'GAS WANTED: 3500000'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"0\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"1\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"ForLoopEvent\",\"attrs\":\[{\"key\":\"iteration\",\"value\":\"2\"},{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"ForLoopCompletionEvent\",\"attrs\":\[{\"key\":\"count\",\"value\":\"3\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"CallbackEvent\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"CallbackCompletionEvent\",\"attrs\":\[{\"key\":\"key\",\"value\":\"value\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"},{\"type\":\"DeferEvent\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"}\],\"pkg_path\":\"gno.land/r/demo/edcl\"}\]'

--- a/gno.land/pkg/integration/testdata/event_for_statement.txtar
+++ b/gno.land/pkg/integration/testdata/event_for_statement.txtar
@@ -4,17 +4,17 @@ loadpkg gno.land/r/demo/foree $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/foree -func Foo -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/foree -func Foo -gas-fee 210001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 2100000'
+stdout 'GAS WANTED: 3200000'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"testing\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"}\]'
 stdout 'TX HASH:    '
 
-gnokey maketx call -pkgpath gno.land/r/demo/foree -func Bar -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/foree -func Bar -gas-fee 220001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 2200000'
+stdout 'GAS WANTED: 3200000'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
 stdout 'EVENTS:     \[{\"type\":\"Foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"Bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"Foo\",\"attrs\":\[{\"key\":\"k1\",\"value\":\"v1\"},{\"key\":\"k2\",\"value\":\"v2\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"},{\"type\":\"Bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land/r/demo/foree\"}\]'

--- a/gno.land/pkg/integration/testdata/event_normal.txtar
+++ b/gno.land/pkg/integration/testdata/event_normal.txtar
@@ -4,17 +4,17 @@ loadpkg gno.land/r/demo/ee $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/ee -func Foo -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ee -func Foo -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 2000000'
+stdout 'GAS WANTED: 3100000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[{\"type\":\"foo\",\"attrs\":\[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"},{\"key\":\"key3\",\"value\":\"value3\"}\],\"pkg_path\":\"gno.land/r/demo/ee\"},{\"type\":\"bar\",\"attrs\":\[{\"key\":\"bar\",\"value\":\"baz\"}\],\"pkg_path\":\"gno.land/r/demo/ee\"}\]'
 stdout 'TX HASH:    '
 
-gnokey maketx call -pkgpath gno.land/r/demo/ee -func Bar -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ee -func Bar -gas-fee 190001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 stdout OK!
-stdout 'GAS WANTED: 1900000'
+stdout 'GAS WANTED: 2900000'
 stdout 'GAS USED:   \d+'
 stdout 'HEIGHT:     \d+'
 stdout 'EVENTS:     \[{\"type\":\"bar\",\"attrs\":\[{\"key\":\"foo\",\"value\":\"bar\"}\],\"pkg_path\":\"gno.land/r/demo/ee\"}\]'

--- a/gno.land/pkg/integration/testdata/gc.txtar
+++ b/gno.land/pkg/integration/testdata/gc.txtar
@@ -7,7 +7,7 @@ gnoland start -no-parallel
 
 
 gnokey maketx call -pkgpath gno.land/r/gc -func Alloc -gas-fee 17000000ugnot -gas-wanted 170_000_000 -simulate skip -chainid tendermint_test test1
-stdout 'GAS USED:   151133803'
+stdout 'GAS USED:   152788557'
 
 -- r/gc/gc.gno --
 package gc

--- a/gno.land/pkg/integration/testdata/ghverify.txtar
+++ b/gno.land/pkg/integration/testdata/ghverify.txtar
@@ -12,11 +12,11 @@ gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint 
 stdout '\("\[\{\\"id\\":\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\",\\"type\\":\\"0\\",\\"value_type\\":\\"string\\",\\"tasks\\":\[\{\\"gno_address\\":\\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\\",\\"github_handle\\":\\"deelawn\\"\}\]\}\]" string\)'
 
 # a verification request was made but there should be no verified address
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 530001ugnot -gas-wanted 6_800_000 -chainid=tendermint_test test1
 stdout ""
 
 # a verification request was made but there should be no verified handle
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 530001ugnot -gas-wanted 6_800_000 -chainid=tendermint_test test1
 stdout ""
 
 # fail on ingestion with a bad task ID
@@ -28,11 +28,11 @@ gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GnorkleEntrypoint 
 stdout OK!
 
 # get verified github handle by gno address
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 550001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetHandleByAddress -args 'g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5' -gas-fee 7000001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 stdout "deelawn"
 
 # get verified gno address by github handle
-gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 550001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/ghverify -func GetAddressByHandle -args 'deelawn' -gas-fee 7000001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
 stdout "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
 
 gnokey query vm/qrender --data 'gno.land/r/gnoland/ghverify:'

--- a/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_gasfee.txtar
@@ -12,9 +12,9 @@ stdout '"coins": "10000000000000ugnot"'
 # Tx add package -simulate only, estimate gas used and gas fee.
 # gas-wanted/gas-fee on the simulate call are generous; simulate reports
 # the actual gas the real tx would consume.
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 3_500_000 -gas-fee 350001ugnot -chainid tendermint_test -simulate only test1
-stdout 'GAS USED:\s+2546359'
-stdout 'INFO:       estimated gas usage: 2546359 \(suggested, with 5% margin: 2673677\), gas fee: 2674ugnot, current gas price: 1ugnot/1000gas'
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 4_600_000 -gas-fee 350001ugnot -chainid tendermint_test -simulate only test1
+stdout 'GAS USED:\s+4201113'
+stdout 'INFO:       estimated gas usage: 4201113 \(suggested, with 5% margin: 4411169\), gas fee: 4412ugnot, current gas price: 1ugnot/1000gas'
 
 ## No fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
@@ -25,33 +25,33 @@ stdout '"coins": "10000000000000ugnot"'
 # This is the documented simulate->broadcast workflow; the values on this
 # line MUST match the simulate output above (modulo a small gas-wanted
 # headroom).
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 2_674_000 -gas-fee 2674ugnot -chainid tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/hello  -gas-wanted 4_412_000 -gas-fee 4412ugnot -chainid tendermint_test test1
 stdout 'OK'
 stdout 'EVENTS:     \[.*"fee_delta":\{"denom":"ugnot","amount":206900\}.*\]'
 
 ## fee + storage deposit were charged; sequence number increased.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
-stdout '"coins": "9999999790426ugnot"'
+stdout '"coins": "9999999788688ugnot"'
 
 # Tx Call -simulate only, estimate gas used and gas fee.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_800_000 -gas-fee 180001ugnot -chainid tendermint_test -simulate only test1
-stdout 'GAS USED:\s+1024011'
-stdout 'INFO:       estimated gas usage: 1024011 \(suggested, with 5% margin: 1075212\), gas fee: 1076ugnot, current gas price: 1ugnot/1000gas'
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 2_900_000 -gas-fee 2900001ugnot -chainid tendermint_test -simulate only test1
+stdout 'GAS USED:\s+2678789'
+stdout 'INFO:       estimated gas usage: 2678789 \(suggested, with 5% margin: 2812729\), gas fee: 2812ugnot, current gas price: 1ugnot/1000gas'
 
 ## No additional fee was charged, and the sequence number did not change.
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "1"'
-stdout '"coins": "9999999790426ugnot"'
+stdout '"coins": "9999999788688ugnot"'
 
 # Using the simulated gas and estimated gas fee should ensure the transaction executes successfully.
-gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 1_076_000 -gas-fee 1076ugnot -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/hello -func Hello -gas-wanted 2_813_000 -gas-fee 2813ugnot -chainid tendermint_test test1
 stdout 'OK'
 
 ## fee is charged and sequence number increased
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "2"'
-stdout '"coins": "9999999789350ugnot"'
+stdout '"coins": "9999999785875ugnot"'
 
 -- hello/gnomod.toml --
 module = "gno.land/r/hello"

--- a/gno.land/pkg/integration/testdata/gnokey_simulate.txtar
+++ b/gno.land/pkg/integration/testdata/gnokey_simulate.txtar
@@ -27,19 +27,19 @@ stdout '"sequence": "2"'
 # attempt calling hello.SetName correctly.
 # -simulate test and skip should do it successfully, -simulate only should not.
 # -simulate test
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args John -gas-wanted 2_300_000 -gas-fee 230001ugnot -chainid tendermint_test -simulate test test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args John -gas-wanted 3_600_000 -gas-fee 3600001ugnot -chainid tendermint_test -simulate test test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "3"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, John!'
 # -simulate only
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 1_900_000 -gas-fee 190001ugnot -chainid tendermint_test -simulate only test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args Paul -gas-wanted 3_200_000 -gas-fee 3200001ugnot -chainid tendermint_test -simulate only test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "3"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"
 stdout 'Hello, John!'
 # -simulate skip
-gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args George -gas-wanted 2_300_000 -gas-fee 230001ugnot -chainid tendermint_test -simulate skip test1
+gnokey maketx call -pkgpath gno.land/r/hello -func SetName -args George -gas-wanted 4_000_000 -gas-fee 4000001ugnot -chainid tendermint_test -simulate skip test1
 gnokey query auth/accounts/$test1_user_addr
 stdout '"sequence": "4"'
 gnokey query vm/qeval --data "gno.land/r/hello.Hello()"

--- a/gno.land/pkg/integration/testdata/gnoweb_airgapped.txtar
+++ b/gno.land/pkg/integration/testdata/gnoweb_airgapped.txtar
@@ -26,7 +26,7 @@ stdout '}'
 ! stderr '.+' # empty
 
 # Create transaction
-gnokey maketx call -pkgpath "gno.land/r/realm" -func "SetName" -gas-fee 230001ugnot -gas-wanted 2_300_000 -send "" -args "foo" -broadcast=false user1
+gnokey maketx call -pkgpath "gno.land/r/realm" -func "SetName" -gas-fee 230001ugnot -gas-wanted 3_700_000 -send "" -args "foo" -broadcast=false user1
 cp stdout call.tx
 
 # Sign
@@ -35,7 +35,7 @@ cmpenv stdout sign.stdout.golden
 
 gnokey broadcast $WORK/call.tx
 stdout '("foo" string)'
-stdout 'GAS WANTED: 2300000'
+stdout 'GAS WANTED: 3700000'
 
 gnokey query vm/qrender --data '"gno.land/r/realm":'
 stdout '# HELLO foo'

--- a/gno.land/pkg/integration/testdata/govdao_execute_reject_proposal.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_execute_reject_proposal.txtar
@@ -15,7 +15,7 @@ gnokey maketx run -gas-fee 2400001ugnot -gas-wanted 27_000_000 -chainid=tendermi
 stdout OK!
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 22000000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 23000000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Try to execute proposal, it should fail because execution returns an error

--- a/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_add_member.txtar
@@ -18,7 +18,7 @@ stdout 'data: # GovDAO'
 
 # add the proposal (temporarily comment out to debug)
 # First run a debug script to understand the addresses
-gnokey maketx run -gas-fee 110001ugnot -gas-wanted 1_500_000 -chainid=tendermint_test member $WORK/debug/check_addresses.gno
+gnokey maketx run -gas-fee 110001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test member $WORK/debug/check_addresses.gno
 stdout '=== Debug info ==='
 stdout 'Origin caller: g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0'
 stdout 'Current realm: CodeRealm{ g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0, gno.land/e/g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0/run }'
@@ -32,11 +32,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This is a proposal to add `g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0` to \*\*T2\*\*.'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 24_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_change_law.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_change_law.txtar
@@ -21,11 +21,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout '## Prop #0 - Change Law Proposal'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 29_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 -- proposer/create_proposal.gno --

--- a/gno.land/pkg/integration/testdata/govdao_proposal_new_param.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_new_param.txtar
@@ -22,11 +22,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This proposal wants to add a new key to sys/params: vm:bar:baz'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output:

--- a/gno.land/pkg/integration/testdata/govdao_proposal_new_post.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_new_post.txtar
@@ -23,11 +23,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This propoposal is looking to add a new post to gnoland blog'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 29_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 31_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_promote_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_promote_member.txtar
@@ -26,11 +26,11 @@ stdout 'Prop #0 - Member Promotion Proposal'
 stdout 'This is a proposal to promote g16jv3rpz7mkt0gqulxas56se2js7v5vmc6n6e0r from \*\*T3\*\* to \*\*T2\*\*.'
 
 # vote on the proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # vote on the proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 24_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
 stdout OK!
 
 # add the proposal

--- a/gno.land/pkg/integration/testdata/govdao_proposal_treasury_payment.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_treasury_payment.txtar
@@ -23,7 +23,7 @@ gnokey query bank/balances/g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm
 stdout 'data: ""'
 
 # member send 42 ugnot to treasury realm
-gnokey maketx send -send 42ugnot -to g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test member
+gnokey maketx send -send 42ugnot -to g1axf7xdzvhcapsvr0yzadr32wgsgs0064xyysrm -gas-fee 180001ugnot -gas-wanted 3_200_000 -chainid tendermint_test member
 
 # 2/3 verify receiver and treasury balances
 gnokey query bank/balances/${receiver_user_addr}
@@ -41,11 +41,11 @@ stdout 'Reason: integration test payment'
 stdout 'Payment: 42ugnot to g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0'
 
 # vote on the proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 30_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2900001ugnot -gas-wanted 33_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/govdao_proposal_treasury_tokens_update.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_treasury_tokens_update.txtar
@@ -35,11 +35,11 @@ stdout '- gno.land/r/demo/defi/grc20factory.TOKEN2'
 stdout '- gno.land/r/demo/defi/grc20factory.TOKEN3'
 
 # vote on the tokens update proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # call tokens update proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 28_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # verify the balances associated with the tokens update proposal

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_add_remove_controller.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_add_remove_controller.txtar
@@ -31,11 +31,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Add Whitelisted Caller to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 24_000_000 -args 0 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Register a new user as a controller (@test1)

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_register_user.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_register_user.txtar
@@ -25,7 +25,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Register User to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 22000000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 23000000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
@@ -45,11 +45,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:1'
 stdout 'Update Name Alias in \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 20000000 -args 1 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 21000000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 3000000ugnot -gas-wanted 30000000 -args 1 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 3000000ugnot -gas-wanted 31000000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 
 # Check alias is registered
@@ -65,7 +65,7 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:2'
 stdout 'Delete User in \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 20000000 -args 2 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000000ugnot -gas-wanted 21000000 -args 2 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal

--- a/gno.land/pkg/integration/testdata/govdao_proposal_users_remove_controller.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_users_remove_controller.txtar
@@ -28,11 +28,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'Add Whitelisted Caller to \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 24_000_000 -args 0 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test test1
 stdout OK!
 
 # Register a new user as a controller
@@ -48,11 +48,11 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:1'
 stdout 'Remove Whitelisted Caller From \"sys/users\" Realm'
 
 # Vote on proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 # Execute proposal
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 24_000_000 -args 1 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 26_000_000 -args 1 -chainid=tendermint_test test1
 stdout OK!
 
 # Try to register a new user as a non controller

--- a/gno.land/pkg/integration/testdata/govdao_proposal_withdraw_member.txtar
+++ b/gno.land/pkg/integration/testdata/govdao_proposal_withdraw_member.txtar
@@ -25,15 +25,15 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'This is a proposal to remove g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0 from the GovDAO'
 
 # vote on the proposal 1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # vote on the proposal 2
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2000001ugnot -gas-wanted 24_000_000 -args 0 -args YES -chainid=tendermint_test withdrawmember
 stdout OK!
 
 # call proposal execution
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 24_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 25_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # check output

--- a/gno.land/pkg/integration/testdata/governance_param_validation.txtar
+++ b/gno.land/pkg/integration/testdata/governance_param_validation.txtar
@@ -12,10 +12,10 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 ## Deploy a realm and verify it works
-gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/test/hello -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/hello -pkgpath gno.land/r/test/hello -gas-fee 350001ugnot -gas-wanted 4_600_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 stdout 'hello world'
 
 ## Propose setting StoragePrice to an invalid value
@@ -34,7 +34,7 @@ gnokey query params/vm:p:storage_price
 stdout '100ugnot'
 
 ## VM operations should still work
-gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/hello -func SayHello -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout 'hello world'
 
 -- hello/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/grc20_invalid_address.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_invalid_address.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/r/demo/defi/foo20
 gnoland start
 
 # execute Faucet
-gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_600_000 -chainid=tendermint_test test1
 stdout 'OK!'
 
 # execute Transfer for invalid address

--- a/gno.land/pkg/integration/testdata/grc20_registry.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry.txtar
@@ -8,15 +8,15 @@ loadpkg gno.land/r/registry $WORK/registry
 gnoland start
 
 # we call Transfer with foo20, before it's registered
-gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout 'not found'
 
 # add foo20, and foo20wrapper
-gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/foo20 -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/foo20wrapper -pkgpath gno.land/r/foo20wrapper -gas-fee 590001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/foo20 -gas-fee 360001ugnot -gas-wanted 4_900_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo20wrapper -pkgpath gno.land/r/foo20wrapper -gas-fee 590001ugnot -gas-wanted 7_700_000 -chainid=tendermint_test test1
 
 # we call Transfer with foo20, after it's registered
-gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 260001ugnot -gas-wanted 2_600_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/registry -func TransferByName -args 'foo20' -args 'g123456789' -args '42' -gas-fee 260001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 stdout 'same address, success!'
 
 -- registry/registry.gno --

--- a/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
@@ -8,10 +8,10 @@ loadpkg gno.land/r/grc20transfer $WORK
 gnoland start
 
 # run the faucet before transferring the balance
-gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func Faucet -gas-fee 740001ugnot -gas-wanted 7_600_000 -chainid=tendermint_test test1
 
 # check the event after transferring the grc20 token
-gnokey maketx call -pkgpath gno.land/r/grc20transfer -func TransferBy -args 'gno.land/r/demo/defi/foo20.FOO' -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '1000000' -gas-fee 940001ugnot -gas-wanted 9_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/grc20transfer -func TransferBy -args 'gno.land/r/demo/defi/foo20.FOO' -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '1000000' -gas-fee 940001ugnot -gas-wanted 9_700_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'GAS WANTED: [0-9]+'
 stdout 'GAS USED:   [0-9]+'

--- a/gno.land/pkg/integration/testdata/grc721_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc721_emit.txtar
@@ -5,7 +5,7 @@ loadpkg gno.land/r/foo721 $WORK/foo721
 gnoland start
 
 # Mint
-gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 920001ugnot -gas-wanted 9_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Mint -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args 1  -gas-fee 920001ugnot -gas-wanted 9_400_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Mint\",\"attrs\":\[{\"key\":\"token\",\"value\":\"gno.land/r/foo721.FNFT\"},{\"key\":\"to\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # SetTokenURI
@@ -17,15 +17,15 @@ gnokey maketx call -pkgpath gno.land/r/foo721 -func SetMetadata -args 1 -gas-fee
 stdout '\[{\"type\":\"MetadataUpdate\",\"attrs\":\[{\"key\":\"token\",\"value\":\"gno.land/r/foo721.FNFT\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"}.*\]'
 
 # Approve
-gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 890001ugnot -gas-wanted 8_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func Approve -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 890001ugnot -gas-wanted 9_100_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Approval\",\"attrs\":\[{\"key\":\"token\",\"value\":\"gno.land/r/foo721.FNFT\"},{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # SetApprovalForAll
-gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 880001ugnot -gas-wanted 8_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func SetApprovalForAll -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args false  -gas-fee 880001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"ApprovalForAll\",\"attrs\":\[{\"key\":\"token\",\"value\":\"gno.land/r/foo721.FNFT\"},{\"key\":\"owner\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"approved\",\"value\":\"false\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # TransferFrom
-gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 990001ugnot -gas-wanted 9_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo721 -func TransferFrom -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj -args 1  -gas-fee 990001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout '\[{\"type\":\"Transfer\",\"attrs\":\[{\"key\":\"token\",\"value\":\"gno.land/r/foo721.FNFT\"},{\"key\":\"from\",\"value\":\"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5\"},{\"key\":\"to\",\"value\":\"g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj\"},{\"key\":\"tokenId\",\"value\":\"1\"}\],\"pkg_path\":\"gno.land/p/demo/tokens/grc721\"},.*\]'
 
 # Burn

--- a/gno.land/pkg/integration/testdata/improved_coins.txtar
+++ b/gno.land/pkg/integration/testdata/improved_coins.txtar
@@ -2,32 +2,32 @@ loadpkg gno.land/r/demo/coins $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "MakeNewCoins" -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "MakeNewCoins" -gas-fee 210001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 stdout '(300 int64)'
 stdout '(321 int64)'
 stdout '("ugnot" string)'
 stdout '("example" string)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "AddCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "AddCoin" -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout '(300 int64)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "SubCoin" -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "SubCoin" -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout '(123 int64)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "StringZeroCoin" -gas-fee 210001ugnot -gas-wanted 2_100_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "StringZeroCoin" -gas-fee 210001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout '("0ugnot" string)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsZero" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsZero" -gas-fee 190001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout '(true bool)'
 stdout '(false bool)'
 stdout '(false bool)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsPositive" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsPositive" -gas-fee 190001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout '(false bool)'
 stdout '(false bool)'
 stdout '(true bool)'
 
-gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsNegative" -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/coins -func "IsNegative" -gas-fee 190001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout '(true bool)'
 stdout '(false bool)'
 stdout '(false bool)'

--- a/gno.land/pkg/integration/testdata/infinite_loop.txtar
+++ b/gno.land/pkg/integration/testdata/infinite_loop.txtar
@@ -26,7 +26,7 @@ stderr 'gas used .* exceeds tx.s gas wanted .* during operation: CPUCycles'
 stderr 'gas used .* exceeds max block gas .* during operation: CPUCycles'
 
 # maketx addpkg on r2 (successful)
-gnokey maketx addpkg -pkgdir $WORK/r2 -pkgpath gno.land/r/demo/r2 -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/r2 -pkgpath gno.land/r/demo/r2 -gas-fee 4400001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
 stdout OK!
 
 # qeval on the render function

--- a/gno.land/pkg/integration/testdata/interrealm_final.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_final.txtar
@@ -16,33 +16,33 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/bob -pkgpath gno.land/r/test/bob -gas-fee 570001ugnot -gas-wanted 7_700_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/alice -pkgpath gno.land/r/test/alice -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/peter -pkgpath gno.land/p/test/peter -gas-fee 360001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 730001ugnot -gas-wanted 18_000_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bob -pkgpath gno.land/r/test/bob -gas-fee 570001ugnot -gas-wanted 8_400_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/alice -pkgpath gno.land/r/test/alice -gas-fee 530001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/peter -pkgpath gno.land/p/test/peter -gas-fee 360001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 730001ugnot -gas-wanted 21_000_000 -chainid=tendermint_test test1
 
 ## test CASE_rA1
 ## interrealm v2: bob.Do is /r/bob-declared → borrow rule #1 borrows m.Realm = /r/bob.
 ## fn=alice.TopFunc is invoked, /r/alice-declared → borrow rule #1 → /r/alice.
 ## Inside TopFunc, bob.PrivateFunc() → borrow rule #1 → /r/bob, writes succeed.
 ## (Pre-interrealm-v2: stayed in caller's m.Realm throughout, write panicked.)
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA1 -gas-fee 5000000ugnot -gas-wanted 4800000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rA2
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA2 -gas-fee 5000000ugnot -gas-wanted 4400000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rA3
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA3 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rA3 -gas-fee 5000000ugnot -gas-wanted 4400000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rB1
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB1 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB1 -gas-fee 5000000ugnot -gas-wanted 4000000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rB2
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB2 -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_rB2 -gas-fee 5000000ugnot -gas-wanted 4400000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_rB3
@@ -124,7 +124,7 @@ gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pB4 -gas-fee 
 stdout 'OK'
 
 ## test CASE_pC1
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC1 -gas-fee 400001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC1 -gas-fee 5500001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_pC2
@@ -132,7 +132,7 @@ gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC2 -gas-fee 
 stdout 'OK'
 
 ## test CASE_pC3
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC3 -gas-fee 400001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test runner
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CASE_pC3 -gas-fee 5500001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test runner
 stdout 'OK'
 
 ## test CASE_pC4

--- a/gno.land/pkg/integration/testdata/interrealm_mix_call.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_mix_call.txtar
@@ -6,8 +6,8 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 8_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test test1
 gnokey maketx addpkg -pkgdir $WORK/callerrealm -pkgpath gno.land/r/test/callerrealm -gas-fee 700001ugnot -gas-wanted 9_500_000 -chainid=tendermint_test test1
 
 ## validate initial state
@@ -20,38 +20,38 @@ stdout 'obj\.value = 0'
 ## interrealm v2: borrow rule #1 borrows m.Realm = /r/borrowrealm for the duration
 ## of borrowrealm.Mutate(); the write `value++` is now a same-realm
 ## mutation and succeeds. (Pre-interrealm-v2: panicked on readonly taint.)
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingMutation -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingMutation -gas-fee 5000000ugnot -gas-wanted 4700000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 1'
 
 ## execute CrossingMutation
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CrossingMutation -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CrossingMutation -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 2'
 
 ## execute NonCrossingObjectMutation
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingObjectMutation -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func NonCrossingObjectMutation -gas-fee 350001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 1, value = 2'
 
 ## execute ObjectMutationRootedAtCaller
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func ObjectMutationRootedAtCaller -gas-fee 390001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func ObjectMutationRootedAtCaller -gas-fee 390001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/callerrealm:"
 stdout 'obj\.value = 1'
 
 ## execute CallMutateObject
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CallMutateObject -gas-fee 310001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func CallMutateObject -gas-fee 310001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 2, value = 2'
 
 ## execute InspectRealmsCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsCrossing -gas-fee 290001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test test2
 
 ## execute InspectRealmsNonCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsNonCrossing -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func InspectRealmsNonCrossing -gas-fee 290001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test2
 
 ## execute MutateObjectWithBorrowCrossing
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateObjectWithBorrowCrossing -gas-fee 310001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateObjectWithBorrowCrossing -gas-fee 310001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 3, value = 2'
 
@@ -64,7 +64,7 @@ stdout 'Object\.value = 3, value = 2'
 ## object's PkgID — write succeeds. (Pre-interrealm-v2: the object's storage-
 ## owner was deduced as callerrealm from the package var rooting it,
 ## so the cross-call's m.Realm = borrowrealm didn't match, panicked.)
-gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateCrossingObjectRootedAtCaller -gas-fee 5000000ugnot -gas-wanted 50000000 -chainid=tendermint_test test2
+gnokey maketx call -pkgpath gno.land/r/test/callerrealm -func MutateCrossingObjectRootedAtCaller -gas-fee 5000000ugnot -gas-wanted 4600000 -chainid=tendermint_test test2
 gnokey query "vm/qrender" --data "gno.land/r/test/callerrealm:"
 stdout 'obj\.value = 2'
 

--- a/gno.land/pkg/integration/testdata/interrealm_mix_run.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_mix_run.txtar
@@ -7,8 +7,8 @@ loadpkg gno.land/p/nt/ufmt/v0
 gnoland start
 
 ## load packages
-gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 8_300_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/utils -pkgpath gno.land/p/test/utils -gas-fee 360001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/borrowrealm -pkgpath gno.land/r/test/borrowrealm -gas-fee 620001ugnot -gas-wanted 9_100_000 -chainid=tendermint_test test1
 
 ## validate initial state
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
@@ -18,46 +18,46 @@ stdout 'Object\.value = 0, value = 0'
 ## interrealm v2: borrow rule #1 borrows m.Realm = /r/borrowrealm during the call;
 ## `value++` is a same-realm write — succeeds. (Pre-interrealm-v2: panicked
 ## with readonly taint because borrow did not fire on non-crossing.)
-gnokey maketx run runner $WORK/run/non_crossing_mutation.gno -gas-fee 5000000ugnot -gas-wanted 200000000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/non_crossing_mutation.gno -gas-fee 5000000ugnot -gas-wanted 5300000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 1'
 
 ## run crossing_mutation
-gnokey maketx run runner $WORK/run/crossing_mutation.gno -gas-fee 340001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/crossing_mutation.gno -gas-fee 340001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 0, value = 2'
 
 ## run borrowed_object_mutation
-gnokey maketx run runner $WORK/run/borrowed_object_mutation.gno -gas-fee 380001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/borrowed_object_mutation.gno -gas-fee 380001ugnot -gas-wanted 5_100_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 1, value = 2'
 
 ## run object_mutation_rooted_at_caller
-gnokey maketx run runner $WORK/run/object_mutation_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/object_mutation_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test
 
 ## run call_mutate_object
-gnokey maketx run runner $WORK/run/call_mutate_object.gno -gas-fee 340001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/call_mutate_object.gno -gas-fee 340001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 2, value = 2'
 
 ## run inspect_realms_crossing
-gnokey maketx run runner $WORK/run/inspect_realms_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/inspect_realms_crossing.gno -gas-fee 330001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test
 
 ## run inspect_realms_non_crossing
-gnokey maketx run runner $WORK/run/inspect_realms_non_crossing.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/inspect_realms_non_crossing.gno -gas-fee 330001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test
 
 ## run mutate_object_with_borrow_crossing
-gnokey maketx run runner $WORK/run/mutate_object_with_borrow_crossing.gno -gas-fee 340001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_object_with_borrow_crossing.gno -gas-fee 340001ugnot -gas-wanted 4_900_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 3, value = 2'
 
 ## run mutate_crossing_object
-gnokey maketx run runner $WORK/run/mutate_crossing_object.gno -gas-fee 340001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_crossing_object.gno -gas-fee 340001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test
 gnokey query "vm/qrender" --data "gno.land/r/test/borrowrealm:"
 stdout 'Object\.value = 4, value = 2'
 
 ## run mutate_crossing_object_rooted_at_caller
-gnokey maketx run runner $WORK/run/mutate_crossing_object_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test
+gnokey maketx run runner $WORK/run/mutate_crossing_object_rooted_at_caller.gno -gas-fee 330001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test
 
 -- run/non_crossing_mutation.gno --
 package main

--- a/gno.land/pkg/integration/testdata/interrealm_read_only.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_read_only.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/demo/crossrealm $WORK/crossrealm
 loadpkg gno.land/r/demo/main $WORK/main
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/main -func Exec -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/main -func Exec -gas-fee 1000000ugnot -gas-wanted 4400000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- crossrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/interrealm_read_only_declared_type.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_read_only_declared_type.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/demo/crossrealm $WORK/crossrealm
 loadpkg gno.land/r/demo/main $WORK/main
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/main -func Exec -gas-fee 1000000ugnot -gas-wanted 10000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/main -func Exec -gas-fee 1000000ugnot -gas-wanted 3500000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
 -- crossrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/interrealm_v2.txtar
+++ b/gno.land/pkg/integration/testdata/interrealm_v2.txtar
@@ -57,16 +57,16 @@ gnoland start
 ## Setup
 ## ============================================================
 
-gnokey maketx addpkg -pkgdir $WORK/lib -pkgpath gno.land/p/test/v2lib -gas-fee 360001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/lib -pkgpath gno.land/p/test/v2lib -gas-fee 360001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx addpkg -pkgdir $WORK/owned -pkgpath gno.land/r/test/owned -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/owned -pkgpath gno.land/r/test/owned -gas-fee 1000001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx addpkg -pkgdir $WORK/neighbor -pkgpath gno.land/r/test/neighbor -gas-fee 700001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/neighbor -pkgpath gno.land/r/test/neighbor -gas-fee 700001ugnot -gas-wanted 7_500_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 1000001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query "vm/qrender" --data "gno.land/r/test/owned:"

--- a/gno.land/pkg/integration/testdata/issue_1167.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1167.txtar
@@ -4,25 +4,25 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # add contract
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 700001ugnot -gas-wanted 7_000_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 700001ugnot -gas-wanted 8_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 # execute New
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func New -args X -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func New -args X -gas-fee 500001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 # execute Delta for the first time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 560001ugnot -gas-wanted 5_600_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 560001ugnot -gas-wanted 6_500_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '"1,1,1;'
 
 # execute Delta for the second time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 530001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 530001ugnot -gas-wanted 6_300_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '1,1,1;2,2,2;'
 
 # execute Delta for the third time
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 590001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func Delta -args X -gas-fee 590001ugnot -gas-wanted 6_800_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '1,1,1;2,2,2;3,3,3;'
 

--- a/gno.land/pkg/integration/testdata/issue_1543.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1543.txtar
@@ -5,9 +5,9 @@ loadpkg gno.land/r/demo/realm $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 3_100_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func UnFill --args 0 --gas-fee 310001ugnot --gas-wanted 3_100_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 3_100_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 4_600_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func UnFill --args 0 --gas-fee 310001ugnot --gas-wanted 4_500_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 4_500_000 --broadcast -chainid=tendermint_test test1
 
 -- realm.gno --
 package realm

--- a/gno.land/pkg/integration/testdata/issue_1588.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1588.txtar
@@ -3,13 +3,13 @@
 gnoland start
 
 # add contract
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/demo/xx -gas-fee 370001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func DefineFamily -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func DefineFamily -gas-fee 300001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test test1
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/demo/xx -func GetOutcastChildAge -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/xx -func GetOutcastChildAge -gas-fee 220001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test test1
 stdout OK!
 stdout '(10 int)'
 

--- a/gno.land/pkg/integration/testdata/issue_1786.txtar
+++ b/gno.land/pkg/integration/testdata/issue_1786.txtar
@@ -7,7 +7,7 @@ loadpkg gno.land/r/gnoland/wugnot
 gnoland start
 
 # user deposits directly into wugnot (origin call)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot --send "10000ugnot" -func Deposit -gas-fee 900001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot --send "10000ugnot" -func Deposit -gas-fee 900001ugnot -gas-wanted 9_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check user's wugnot balance
@@ -15,7 +15,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"g1jg8mtutu9k
 stdout '10000 int64'
 
 # user withdraws 500 wugnot directly (origin call)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 500 -gas-fee 980001ugnot -gas-wanted 9_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 500 -gas-fee 980001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check user's wugnot balance after withdraw

--- a/gno.land/pkg/integration/testdata/issue_2266.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2266.txtar
@@ -6,9 +6,9 @@ loadpkg gno.land/r/demo/realm $WORK
 gnoland start
 
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 3_100_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 1 --gas-fee 310001ugnot --gas-wanted 3_100_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func UnFill --gas-fee 330001ugnot --gas-wanted 3_300_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 0 --gas-fee 310001ugnot --gas-wanted 4_600_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Fill --args 1 --gas-fee 310001ugnot --gas-wanted 4_500_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func UnFill --gas-fee 330001ugnot --gas-wanted 4_700_000 --broadcast -chainid=tendermint_test test1
 
 
 -- realm.gno --

--- a/gno.land/pkg/integration/testdata/issue_2283.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2283.txtar
@@ -17,7 +17,7 @@ gnoland start
 
 ! gnokey broadcast $WORK/add_feeds.tx
 
-gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 380001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 380001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- imports/imports.gno --

--- a/gno.land/pkg/integration/testdata/issue_2283_cacheTypes.txtar
+++ b/gno.land/pkg/integration/testdata/issue_2283_cacheTypes.txtar
@@ -19,7 +19,7 @@ gnoland start
 
 ! gnokey broadcast $WORK/add_feeds.tx
 
-gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bye -pkgpath gno.land/r/demo/bye -gas-fee 360001ugnot -gas-wanted 4_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- add_feeds.tx --

--- a/gno.land/pkg/integration/testdata/issue_4280.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4280.txtar
@@ -5,8 +5,8 @@ loadpkg gno.land/r/demo/realm $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 270001ugnot --gas-wanted 2_700_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 230001ugnot --gas-wanted 2_300_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 270001ugnot --gas-wanted 4_100_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 230001ugnot --gas-wanted 3_400_000 --broadcast -chainid=tendermint_test test1
 
 
 -- realm.gno --

--- a/gno.land/pkg/integration/testdata/issue_4280a.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4280a.txtar
@@ -5,8 +5,8 @@ loadpkg gno.land/r/demo/realm $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 270001ugnot --gas-wanted 2_700_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 230001ugnot --gas-wanted 2_300_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 270001ugnot --gas-wanted 4_100_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 230001ugnot --gas-wanted 3_400_000 --broadcast -chainid=tendermint_test test1
 
 
 -- realm.gno --

--- a/gno.land/pkg/integration/testdata/issue_4280b.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4280b.txtar
@@ -5,8 +5,8 @@ loadpkg gno.land/r/demo/realm $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 290001ugnot --gas-wanted 2_900_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 250001ugnot --gas-wanted 2_500_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 290001ugnot --gas-wanted 4_300_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --args "a" --gas-fee 250001ugnot --gas-wanted 3_600_000 --broadcast -chainid=tendermint_test test1
 
 
 -- realm.gno --

--- a/gno.land/pkg/integration/testdata/issue_4983.txtar
+++ b/gno.land/pkg/integration/testdata/issue_4983.txtar
@@ -1,14 +1,14 @@
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 360001ugnot -gas-wanted 3_600_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/foo -gas-fee 360001ugnot -gas-wanted 4_700_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/bar -gas-fee 360001ugnot -gas-wanted 4_700_000 -max-deposit 502500ugnot -chainid=tendermint_test test1
 
-gnokey maketx call -pkgpath gno.land/r/foo -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 3_800_000  -chainid=tendermint_test test1
 stdout 'GAS USED: +\d+'
 
 gnoland restart
 
-gnokey maketx call -pkgpath gno.land/r/bar -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 2_500_000  -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/bar -func NewS -args "struct"  -gas-fee 250001ugnot -gas-wanted 3_800_000  -chainid=tendermint_test test1
 stdout 'GAS USED: +\d+'
 
 

--- a/gno.land/pkg/integration/testdata/issue_gnochess_97.txtar
+++ b/gno.land/pkg/integration/testdata/issue_gnochess_97.txtar
@@ -4,13 +4,13 @@ loadpkg gno.land/r/demo/bug97 $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 290001ugnot -gas-wanted 2_900_000 -send '' -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 290001ugnot -gas-wanted 4_200_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall2' -gas-fee 230001ugnot -gas-wanted 2_300_000 -send '' -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall2' -gas-fee 230001ugnot -gas-wanted 3_700_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
-gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 250001ugnot -gas-wanted 2_500_000 -send '' -chainid='tendermint_test' test1
+gnokey maketx call -pkgpath 'gno.land/r/demo/bug97' -func 'RealmCall1' -gas-fee 250001ugnot -gas-wanted 3_900_000 -send '' -chainid='tendermint_test' test1
 stdout 'OK!'
 
 -- bug97.gno --

--- a/gno.land/pkg/integration/testdata/loadpkg_example.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_example.txtar
@@ -4,7 +4,7 @@ loadpkg gno.land/p/nt/ufmt/v0
 ## start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/importtest -gas-fee 520001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/importtest -gas-fee 520001ugnot -gas-wanted 5_900_000 -chainid=tendermint_test test1
 stdout OK!
 
 ## execute Render

--- a/gno.land/pkg/integration/testdata/loadpkg_work.txtar
+++ b/gno.land/pkg/integration/testdata/loadpkg_work.txtar
@@ -5,12 +5,12 @@ loadpkg gno.land/r/foobar/bar $WORK/bar
 gnoland start
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'
 stdout 'OK!'
-stdout 'GAS WANTED: 2000000'
+stdout 'GAS WANTED: 3100000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
 

--- a/gno.land/pkg/integration/testdata/maketx_call_array_len.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_call_array_len.txtar
@@ -6,7 +6,7 @@ loadpkg gno.land/r/test/arrlen $WORK/realm
 gnoland start
 
 # Correct length (32 bytes) should succeed.
-gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/arrlen -func CheckLen -args 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout '("32" string)'
 
 # Oversized input (100 bytes) must be rejected.

--- a/gno.land/pkg/integration/testdata/maketx_call_send.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_call_send.txtar
@@ -15,7 +15,7 @@ gnokey query auth/accounts/g1x4ykzcqksj2hc5qpvr8kd9zaffkd82rvmzqup7
 stdout 'data: null'
 
 # call to realm with -send
-gnokey maketx call -send 42ugnot -pkgpath gno.land/r/foo/call_realm -func GimmeMoney -gas-fee 240001ugnot -gas-wanted 2_500_000 -chainid=tendermint_test test1
+gnokey maketx call -send 42ugnot -pkgpath gno.land/r/foo/call_realm -func GimmeMoney -gas-fee 240001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 stdout '("send: 42ugnot")'
 
 ## user balance after realm send

--- a/gno.land/pkg/integration/testdata/maketx_run.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_run.txtar
@@ -4,12 +4,12 @@ loadpkg gno.land/r/foobar/bar $WORK/bar
 gnoland start
 
 ## execute Render
-gnokey maketx run -gas-fee 150001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -gas-fee 150001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 
 ## compare render
 stdout 'main: --- hello from foo ---'
 stdout 'OK!'
-stdout 'GAS WANTED: 2000000'
+stdout 'GAS WANTED: 3100000'
 stdout 'GAS USED: '
 stdout 'TX HASH: '
 

--- a/gno.land/pkg/integration/testdata/maketx_run_send.txtar
+++ b/gno.land/pkg/integration/testdata/maketx_run_send.txtar
@@ -6,7 +6,7 @@ gnokey query auth/accounts/$test1_user_addr
 stdout '"coins": "10000000000000ugnot"'
 
 ## run script/script.gno with send flag
-gnokey maketx run -send 42ugnot -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1 $WORK/script/script.gno
+gnokey maketx run -send 42ugnot -gas-fee 200001ugnot -gas-wanted 3_300_000 -chainid=tendermint_test test1 $WORK/script/script.gno
 stdout 'send: 42ugnot'
 
 ## user balance after realm send

--- a/gno.land/pkg/integration/testdata/map_delete.txtar
+++ b/gno.land/pkg/integration/testdata/map_delete.txtar
@@ -3,7 +3,7 @@ loadpkg gno.land/r/demo/mapdelete $WORK
 gnoland start
 
 # delete map
-gnokey maketx call -pkgpath gno.land/r/demo/mapdelete -func DeleteMap -args 3 -gas-fee 240001ugnot -gas-wanted 2_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/mapdelete -func DeleteMap -args 3 -gas-fee 240001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 # check deletion

--- a/gno.land/pkg/integration/testdata/mapkey.txtar
+++ b/gno.land/pkg/integration/testdata/mapkey.txtar
@@ -5,9 +5,9 @@ loadpkg gno.land/r/demo/realm $WORK
 # start a new node
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 260001ugnot --gas-wanted 2_600_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Set --args 4 --gas-fee 240001ugnot --gas-wanted 2_400_000 --broadcast -chainid=tendermint_test test1
-gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --gas-fee 220001ugnot --gas-wanted 2_200_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Register --gas-fee 260001ugnot --gas-wanted 3_900_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Set --args 4 --gas-fee 240001ugnot --gas-wanted 3_800_000 --broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/realm --func Render --gas-fee 220001ugnot --gas-wanted 3_300_000 --broadcast -chainid=tendermint_test test1
 stdout '("0key.num:1" string)'
 
 -- realm.gno --

--- a/gno.land/pkg/integration/testdata/moul_authz.txtar
+++ b/gno.land/pkg/integration/testdata/moul_authz.txtar
@@ -7,11 +7,11 @@ stdout 'g1rfznvu6qfa0sc76cplk5wpqexvefqccjunady0'
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/testing/resource -func Edit -args edited -gas-fee 740001ugnot -gas-wanted 7_600_000 -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/resource -func Edit -args edited -gas-fee 740001ugnot -gas-wanted 8_300_000 -chainid tendermint_test alice
 
-gnokey maketx call -pkgpath gno.land/r/testing/admin -func ExecuteAction -args 0 -gas-fee 760001ugnot -gas-wanted 7_600_000 -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/admin -func ExecuteAction -args 0 -gas-fee 760001ugnot -gas-wanted 8_700_000 -chainid tendermint_test alice
 
-gnokey maketx call -pkgpath gno.land/r/testing/resource -func Value -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/testing/resource -func Value -gas-fee 190001ugnot -gas-wanted 3_000_000 -chainid tendermint_test alice
 stdout 'edited'
 
 

--- a/gno.land/pkg/integration/testdata/object_pointer.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer.txtar
@@ -5,17 +5,17 @@ loadpkg gno.land/r/testing/bug_caller $WORK/bug_caller
 gnoland start
 
 # 1. (Working) Init the object, Set a value and Get the value
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func WorkingNew -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func WorkingNew -gas-fee 290001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 290001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 290001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected
 
 # 2. (Also working)
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func BuggedNew -gas-fee 430001ugnot -gas-wanted 4_400_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func BuggedNew -gas-fee 430001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/bug_caller -func Set -args 42 -gas-fee 320001ugnot -gas-wanted 4_100_000 -chainid=tendermint_test test1
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/testing/bug_caller.Get()"
 stdout '42 int' # Works as expected

--- a/gno.land/pkg/integration/testdata/object_pointer_2.txtar
+++ b/gno.land/pkg/integration/testdata/object_pointer_2.txtar
@@ -3,9 +3,9 @@ loadpkg gno.land/r/testing/ext_realm $WORK/ext_realm
 loadpkg gno.land/r/testing/caller_realm $WORK/caller_realm
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func SaveObject -gas-fee 370001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func SaveObject -gas-fee 370001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func Mutate -args "hello" -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/testing/caller_realm -func Mutate -args "hello" -gas-fee 300001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test test1
 stdout 'OK!'
 stdout '("reply from ext realm" string)'
 

--- a/gno.land/pkg/integration/testdata/params.txtar
+++ b/gno.land/pkg/integration/testdata/params.txtar
@@ -13,7 +13,7 @@ gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: $'
 
 # add params to gno.land/r/myrealm
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 380001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/myrealm -gas-fee 380001ugnot -gas-wanted 5_800_000 -chainid=tendermint_test test1
 
 # query after adding the package, but before setting values
 gnokey query params/vm:gno.land/r/myrealm:foo
@@ -24,34 +24,34 @@ gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: $'
 
 ## set foo (string)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo1 -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo1 -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:foo
 stdout 'data: "foo1"'
 
 # override foo
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo2 -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetFoo -args foo2 -gas-fee 300001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:foo
 stdout 'data: "foo2"'
 
 
 # set bar (bool)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args true -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args true -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bar
 stdout 'data: true'
 
 # override bar
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args false -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBar -args false -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bar
 stdout 'data: false'
 
 
 # set baz (int64)
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args 1337 -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args 1337 -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: "1337"'
 
 # override baz
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args -31337 -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetBaz -args -31337 -gas-fee 300001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:baz
 stdout 'data: "-31337"'
 
@@ -64,7 +64,7 @@ stderr 'Data: invalid param key: bank:p:lockTransfer'
 stderr 'Data: invalid param key: bank:p:lockTransfer'
 
 # <key_name>.<type> (e.g., "bank_lockTransfer") is a valid name.
-gnokey maketx call -pkgpath gno.land/r/myrealm -func SetValidString -args ugnot -gas-fee 300001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrealm -func SetValidString -args ugnot -gas-fee 4000001ugnot -gas-wanted 4_000_000 -chainid=tendermint_test test1
 gnokey query params/vm:gno.land/r/myrealm:bank_lockTransfer
 stdout 'data: "ugnot"'
 

--- a/gno.land/pkg/integration/testdata/params_sysparams1.txtar
+++ b/gno.land/pkg/integration/testdata/params_sysparams1.txtar
@@ -4,14 +4,14 @@ gnoland start
 
 # Test sys/params.SetSysParamXXX when called from gno.land/r/sys/params
 
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 350001ugnot -gas-wanted 3_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 350001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test1
 
 ## before set lock transfer
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \[\]\n'
 
 ## lock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 180001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
 
 ## query bank module
 gnokey query params/bank:p:restricted_denoms

--- a/gno.land/pkg/integration/testdata/params_sysparams2.txtar
+++ b/gno.land/pkg/integration/testdata/params_sysparams2.txtar
@@ -4,15 +4,15 @@ gnoland start
 
 # ---- 1 Test sys/params.SetSysParamXXX when called from gno.land/r/sys/params
 
-gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/params -pkgpath gno.land/r/sys/params -gas-fee 1000000ugnot -gas-wanted 7100000 -chainid=tendermint_test test1
 
 ## lock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func SetLockTransfer -args "ugnot" -gas-fee 1000000ugnot -gas-wanted 3200000 -chainid=tendermint_test test1
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \["ugnot"\]'
 
 # unlock transfer
-gnokey maketx call -pkgpath gno.land/r/sys/params -func UnlockTransfer -gas-fee 1000000ugnot -gas-wanted 10000000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/params -func UnlockTransfer -gas-fee 1000000ugnot -gas-wanted 3200000 -chainid=tendermint_test test1
 gnokey query params/bank:p:restricted_denoms
 stdout 'data: \[\]'
 

--- a/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
@@ -34,9 +34,9 @@ gnoland start
 # on height-LastRotationHeight < rotation_period_blocks.
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/disable_throttle.gno
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # member registers their own valoper profile with pubKey P.
@@ -56,7 +56,7 @@ gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -ga
 stdout OK!
 
 # member revokes test2's authority.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func DeleteFromAuthList -gas-fee 4000001ugnot -gas-wanted 8_800_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args $test2_user_addr -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func DeleteFromAuthList -gas-fee 4000001ugnot -gas-wanted 10_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args $test2_user_addr -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # (c) test2 again attempts a rotation; must reject post-revoke.

--- a/gno.land/pkg/integration/testdata/params_valset_cross_realm_auth.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_cross_realm_auth.txtar
@@ -20,7 +20,7 @@ loadpkg gno.land/r/gnops/valopers
 gnoland start
 
 # Deploy the hostile realm.
-gnokey maketx addpkg -pkgdir $WORK/attacker -pkgpath gno.land/r/test/attacker -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/attacker -pkgpath gno.land/r/test/attacker -gas-fee 5000000ugnot -gas-wanted 11_000_000 -broadcast -chainid=tendermint_test test1
 stdout OK!
 
 # Snapshot valset:current — must remain identical after both rejections.

--- a/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
@@ -31,7 +31,7 @@ loadpkg gno.land/r/gnops/valopers
 gnoland start
 
 # Deploy the hostile proxy realm.
-gnokey maketx addpkg -pkgdir $WORK/rotateproxy -pkgpath gno.land/r/test/rotateproxy -gas-fee 5000000ugnot -gas-wanted 50_000_000 -broadcast -chainid=tendermint_test member
+gnokey maketx addpkg -pkgdir $WORK/rotateproxy -pkgpath gno.land/r/test/rotateproxy -gas-fee 5000000ugnot -gas-wanted 15_000_000 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # member registers their valoper profile with pubKey P.

--- a/gno.land/pkg/integration/testdata/params_valset_keeprunning_optout_bypass.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_keeprunning_optout_bypass.txtar
@@ -26,7 +26,7 @@ stdout OK!
 # Add A to valset at power=1 via a normal proposal.
 gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 60_000_000 -broadcast -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
@@ -36,7 +36,7 @@ gnokey query params/node:valset:current
 stdout 'gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aadexfnpsmgjxu72xz9y30aqfrlpny:1'
 
 # Operator A signals opt-out: UpdateKeepRunning(A, false).
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateKeepRunning -gas-fee 4000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args false -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateKeepRunning -gas-fee 4000001ugnot -gas-wanted 16_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args false -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Sanity: a FRESH-add proposal {A, power=2} must reject at create

--- a/gno.land/pkg/integration/testdata/params_valset_keeprunning_race.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_keeprunning_race.txtar
@@ -46,11 +46,11 @@ stdout OK!
 
 # Flip A's KeepRunning to false BEFORE the proposal executes. This is
 # the race the test pins.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateKeepRunning -gas-fee 4000001ugnot -gas-wanted 40_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args false -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateKeepRunning -gas-fee 4000001ugnot -gas-wanted 16_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args false -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Vote YES on the proposal.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Execute. The executor must re-check KeepRunning, see false (no

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_e2e.txtar
@@ -59,14 +59,14 @@ gnokey query vm/qrender --data 'gno.land/r/gov/dao:0'
 stdout 'g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0: add \(power 1\)'
 
 # Vote YES.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 # Execute. v3 callback runs -> SetValsetProposal writes proposed +
 # dirty=true. The execute tx itself is a block; EndBlocker at the
 # end of THAT block reads dirty=true, computes diff, writes
 # valset:current = proposed, emits ValidatorUpdates.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 24_000_000 -args 0 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 26_000_000 -args 0 -chainid=tendermint_test member
 stdout OK!
 
 # Post-EndBlocker state: valset:current must now contain BOTH the
@@ -89,7 +89,7 @@ stdout 'false'
 # self-transfer. If the chain stalled at H+2 because the new
 # validator can't sign, this maketx would time out. A successful
 # OK! proves consensus made progress through the transition.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 890_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_500_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- proposer/create_proposal.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_power_update.txtar
@@ -33,7 +33,7 @@ gnoland start
 gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 35_000_000 -args 0 -chainid=tendermint_test member
@@ -48,7 +48,7 @@ stdout 'gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aad
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/update_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -chainid=tendermint_test member
@@ -64,7 +64,7 @@ stdout 'false'
 
 # Liveness check past H+2 — chain made progress through the
 # power-update transition.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 890_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_500_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- run/add_proposal.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_proposal_remove.txtar
@@ -30,7 +30,7 @@ gnoland start
 gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 85_000_000 -chainid=tendermint_test member $WORK/run/add_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test member
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 35_000_000 -args 0 -chainid=tendermint_test member
@@ -46,7 +46,7 @@ stdout '","gpub1'
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -chainid=tendermint_test member $WORK/run/remove_proposal.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 1 -args YES -chainid=tendermint_test member
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -chainid=tendermint_test member
@@ -67,7 +67,7 @@ stdout 'false'
 
 # Liveness check past H+2 — chain made progress through both the
 # add and the remove validator-set transitions.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 890_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_500_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -chainid=tendermint_test member
 stdout OK!
 
 -- run/add_proposal.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_rotation_during_pending_proposal.txtar
@@ -37,9 +37,9 @@ gnoland start
 # Disable rotation throttle so we can rotate inside the txtar window.
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/disable_throttle.gno
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Step 1: register operator A (= member) with pubKey P.
@@ -58,7 +58,7 @@ stdout OK!
 
 # Step 4: vote and execute proposal X. The v3 executor reads
 # valoperCache[A] at execute time -> sees P' (post-rotation).
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 50_000_000 -args 1 -broadcast -chainid=tendermint_test member
 stdout OK!
@@ -78,7 +78,7 @@ stdout '","gpub1'
 
 # Liveness check: produce another block past H+2 to confirm the chain
 # is still live after the validator-set change.
-gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_000_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -broadcast -chainid=tendermint_test member
+gnokey maketx send -gas-fee 1000000ugnot -gas-wanted 2_500_000 -send 1ugnot -to g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 -- run/disable_throttle.gno --

--- a/gno.land/pkg/integration/testdata/params_valset_rotation_throttle.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_rotation_throttle.txtar
@@ -33,9 +33,9 @@ gnoland start
 # after-Register rotation hits the throttle).
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/set_throttle.gno
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
 gnokey query params/node:valoper:rotation_period_blocks
 stdout '"3"'

--- a/gno.land/pkg/integration/testdata/params_valset_self_rotation_retired_reclaim.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_self_rotation_retired_reclaim.txtar
@@ -33,9 +33,9 @@ gnoland start
 # Disable rotation throttle.
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/disable_throttle.gno
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Register operator A with pubKey P.

--- a/gno.land/pkg/integration/testdata/params_valset_signing_key_reuse.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_signing_key_reuse.txtar
@@ -38,10 +38,10 @@ gnoland start
 gnokey maketx run -gas-fee 4000001ugnot -gas-wanted 40_000_000 -broadcast -chainid=tendermint_test member $WORK/run/disable_throttle.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 22_000_000 -args 0 -broadcast -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 23_000_000 -args 0 -broadcast -chainid=tendermint_test member
 stdout OK!
 
 # Confirm throttle param landed.

--- a/gno.land/pkg/integration/testdata/prevrealm.txtar
+++ b/gno.land/pkg/integration/testdata/prevrealm.txtar
@@ -34,19 +34,19 @@ env RFOO_USER_ADDR=g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469
 
 # Test cases
 ## 1. MsgCall -> myrlm.A: user address
-gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func A -gas-fee 180001ugnot -gas-wanted 3_000_000 -chainid tendermint_test test1
 stdout ${test1_user_addr}
 
 ## 2. MsgCall -> myrealm.B -> myrlm.A: user address
-gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/myrlm -func B -gas-fee 190001ugnot -gas-wanted 3_000_000 -chainid tendermint_test test1
 stdout ${test1_user_addr}
 
 ## 3. MsgCall -> r/foo.A -> myrlm.A: r/foo
-gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func A -gas-fee 220001ugnot -gas-wanted 3_300_000 -chainid tendermint_test test1
 stdout ${RFOO_USER_ADDR}
 
 ## 4. MsgCall -> r/foo.B -> myrlm.B -> r/foo.A: r/foo
-gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func B -gas-fee 230001ugnot -gas-wanted 3_400_000 -chainid tendermint_test test1
 stdout ${RFOO_USER_ADDR}
 
 ## remove due to update to maketx call can only call realm (case 5, 6, 13)
@@ -59,19 +59,19 @@ stdout ${RFOO_USER_ADDR}
 ## stdout ${test1_user_addr}
 
 ## 7. MsgRun -> myrlm.A: user address
-gnokey maketx run -gas-fee 160001ugnot -gas-wanted 2_100_000 -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
+gnokey maketx run -gas-fee 160001ugnot -gas-wanted 3_200_000 -chainid tendermint_test test1 $WORK/run/myrlm-a.gno
 stdout ${test1_user_addr}
 
 ## 8. MsgRun -> myrealm.B -> myrlm.A: user address
-gnokey maketx run -gas-fee 170001ugnot -gas-wanted 1_700_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
+gnokey maketx run -gas-fee 170001ugnot -gas-wanted 3_300_000 -chainid tendermint_test test1 $WORK/run/myrlm-b.gno
 stdout ${test1_user_addr}
 
 ## 9. MsgRun -> r/foo.A -> myrlm.A: r/foo
-gnokey maketx run -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid tendermint_test test1 $WORK/run/foo-a.gno
+gnokey maketx run -gas-fee 220001ugnot -gas-wanted 3_600_000 -chainid tendermint_test test1 $WORK/run/foo-a.gno
 stdout ${RFOO_USER_ADDR}
 
 ## 10. MsgRun -> r/foo.B -> myrlm.B -> r/foo.A: r/foo
-gnokey maketx run -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
+gnokey maketx run -gas-fee 230001ugnot -gas-wanted 3_700_000 -chainid tendermint_test test1 $WORK/run/foo-b.gno
 stdout ${RFOO_USER_ADDR}
 
 ## 11. MsgRun -> p/demo/bar.A -> myrlm.A: user address
@@ -89,7 +89,7 @@ stdout ${RFOO_USER_ADDR}
 ## stdout ${test1_user_addr}
 
 ## 14. MsgRun -> std.PreviousRealm(): user address
-gnokey maketx run -gas-fee 100001ugnot -gas-wanted 1_400_000 -chainid tendermint_test test1 $WORK/run/baz.gno
+gnokey maketx run -gas-fee 100001ugnot -gas-wanted 2_800_000 -chainid tendermint_test test1 $WORK/run/baz.gno
 stdout ${test1_user_addr}
 
 -- r/myrlm/myrlm.gno --

--- a/gno.land/pkg/integration/testdata/ptr_mapkey.txtar
+++ b/gno.land/pkg/integration/testdata/ptr_mapkey.txtar
@@ -2,7 +2,7 @@ loadpkg gno.land/r/demo/ptrmap $WORK
 
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/ptrmap -func AddToMap -args 5 -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/ptrmap -func AddToMap -args 5 -gas-fee 280001ugnot -gas-wanted 4_300_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/demo/ptrmap.GetFromMap()"

--- a/gno.land/pkg/integration/testdata/realm_banker_issued_coin_denom.txtar
+++ b/gno.land/pkg/integration/testdata/realm_banker_issued_coin_denom.txtar
@@ -7,40 +7,40 @@ adduser test2
 gnoland start
 
 ## add realm_banker
-gnokey maketx addpkg -pkgdir $WORK/short -pkgpath gno.land/r/test/realm_banker -gas-fee 370001ugnot -gas-wanted 3_700_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/short -pkgpath gno.land/r/test/realm_banker -gas-fee 370001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
 
 ## add realm_banker with long package_name
-gnokey maketx addpkg -pkgdir $WORK/long -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -gas-fee 450001ugnot -gas-wanted 4_500_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/long -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -gas-fee 450001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test test1
 
 ## add invalid realm_denom
-gnokey maketx addpkg -pkgdir $WORK/invalid_realm_denom -pkgpath gno.land/r/test/invalid_realm_denom -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/invalid_realm_denom -pkgpath gno.land/r/test/invalid_realm_denom -gas-fee 360001ugnot -gas-wanted 5_200_000 -chainid=tendermint_test test1
 
 ## test2 spend all balance
-gnokey maketx send -send "995000000ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test2
+gnokey maketx send -send "995000000ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test2
 
 ## check test2 balance
 gnokey query bank/balances/${test2_user_addr}
 stdout ''
 
 ## mint coin from banker
-gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args ${test2_user_addr} -args "ugnot" -args "31337" -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Mint -args ${test2_user_addr} -args "ugnot" -args "31337" -gas-fee 280001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 
 ## check balance after minting, without patching banker will return '31337ugnot'
 gnokey query bank/balances/${test2_user_addr}
 stdout '31337/gno.land/r/test/realm_banker:ugnot'
 
 ## burn coin
-gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args ${test2_user_addr} -args "ugnot" -args "7" -gas-fee 280001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/realm_banker -func Burn -args ${test2_user_addr} -args "ugnot" -args "7" -gas-fee 280001ugnot -gas-wanted 3_800_000 -chainid=tendermint_test test1
 
 ## check balance after burning
 gnokey query bank/balances/${test2_user_addr}
 stdout '31330/gno.land/r/test/realm_banker:ugnot'
 
 ## transfer 5000000ugnot to test2 for gas-fee of below tx
-gnokey maketx send -send "5000000ugnot" -to ${test2_user_addr} -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
+gnokey maketx send -send "5000000ugnot" -to ${test2_user_addr} -gas-fee 130001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test test1
 
 ## transfer coin
-gnokey maketx send -send "1330/gno.land/r/test/realm_banker:ugnot" -to g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test test2
+gnokey maketx send -send "1330/gno.land/r/test/realm_banker:ugnot" -to g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0 -gas-fee 180001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test2
 
 ## check sender balance
 gnokey query bank/balances/${test2_user_addr}
@@ -51,7 +51,7 @@ gnokey query bank/balances/g1yr0dpfgthph7y6mepdx8afuec4q3ga2lg8tjt0
 stdout '1330/gno.land/r/test/realm_banker:ugnot'
 
 ## mint coin from long named package with banker
-gnokey maketx call -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 320001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890 -func Mint -args "g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7" -args "ugnot" -args "100" -gas-fee 320001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test1
 gnokey query bank/balances/g1cq2ecdq3eyn5qa0fzznpurg87zq3k77g63q6u7
 stdout '"100/gno.land/r/test/package89_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_1234567890:ugnot"'
 

--- a/gno.land/pkg/integration/testdata/restart.txtar
+++ b/gno.land/pkg/integration/testdata/restart.txtar
@@ -4,12 +4,12 @@
 loadpkg gno.land/r/demo/counter $WORK
 gnoland start
 
-gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 230001ugnot -gas-wanted 2_300_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 230001ugnot -gas-wanted 3_700_000 -chainid tendermint_test test1
 stdout '\(1 int\)'
 
 gnoland restart
 
-gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 190001ugnot -gas-wanted 1_900_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/demo/counter -func Incr -gas-fee 190001ugnot -gas-wanted 3_300_000 -chainid tendermint_test test1
 stdout '\(2 int\)'
 
 -- counter.gno --

--- a/gno.land/pkg/integration/testdata/restart_gas.txtar
+++ b/gno.land/pkg/integration/testdata/restart_gas.txtar
@@ -9,16 +9,16 @@
 
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2633729'
+gnokey maketx addpkg -pkgdir $WORK/bar -pkgpath gno.land/r/$test1_user_addr/bar -gas-fee 1000000ugnot -gas-wanted 4700000 -chainid=tendermint_test test1
+stdout 'GAS USED: +4288483'
 
 gnokey maketx addpkg -pkgdir $WORK/foo -pkgpath gno.land/r/$test1_user_addr/foo -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2634798'
+stdout 'GAS USED: +4289552'
 
 gnoland restart
 
 gnokey maketx addpkg -pkgdir $WORK/baz -pkgpath gno.land/r/$test1_user_addr/baz -gas-fee 1000000ugnot -gas-wanted 100000000 -chainid=tendermint_test test1
-stdout 'GAS USED: +2636075'
+stdout 'GAS USED: +4290829'
 
 -- bar/gnomod.toml --
 module = "bar"

--- a/gno.land/pkg/integration/testdata/restart_missing_type.txtar
+++ b/gno.land/pkg/integration/testdata/restart_missing_type.txtar
@@ -10,7 +10,7 @@ loadpkg gno.land/p/nt/avl/v0
 gnoland start
 
 # give gui user more tokens
-gnokey maketx send -send 1000000000ugnot -to $user1_user_addr  -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test test1
+gnokey maketx send -send 1000000000ugnot -to $user1_user_addr  -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid tendermint_test test1
 
 # tx1 out of gas
 gnokey sign -tx-path $WORK/tx1.tx -chainid tendermint_test -account-sequence 0 -account-number 58 user1

--- a/gno.land/pkg/integration/testdata/save_struct.txtar
+++ b/gno.land/pkg/integration/testdata/save_struct.txtar
@@ -3,15 +3,15 @@
 gnoland start
 
 # Deploy the public realm that holds saved data.
-gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/test/publicrealm -gas-fee 360001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/publicrealm -pkgpath gno.land/r/test/publicrealm -gas-fee 360001ugnot -gas-wanted 4_800_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Deploy the caller realm.
-gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 420001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 420001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Call SaveStructToPublicRealm — stores a struct cross-realm.
-gnokey maketx call -pkgpath gno.land/r/test/caller -func SaveStructToPublicRealm -gas-fee 330001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/caller -func SaveStructToPublicRealm -gas-fee 330001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- publicrealm/gnomod.toml --

--- a/gno.land/pkg/integration/testdata/set_fee_collector.txtar
+++ b/gno.land/pkg/integration/testdata/set_fee_collector.txtar
@@ -20,10 +20,10 @@ gnokey maketx run -gas-fee 3400001ugnot -gas-wanted 42_000_000 -chainid=tendermi
 gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 29_000_000 -chainid=tendermint_test test1 $WORK/run/propose_collector1.gno
 stdout '0'
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 0 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check collector1 balance
@@ -31,7 +31,7 @@ gnokey query bank/balances/$collector1_user_addr
 stdout '1000000000ugnot'
 
 ## Make costly tx
-gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
+gnokey maketx run -gas-fee 350001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
 
 ## Check collector1 balance, must have changed
 gnokey query bank/balances/$collector1_user_addr
@@ -43,10 +43,10 @@ stdout '1000350001ugnot'
 gnokey maketx run -gas-fee 2600001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1 $WORK/run/propose_collector2.gno
 stdout '1'
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 19_000_000 -args 1 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 1 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 21_000_000 -args 1 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 23_000_000 -args 1 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check collector1 balance
@@ -58,7 +58,7 @@ gnokey query bank/balances/$collector2_user_addr
 stdout '1000000000ugnot'
 
 ## Make costly tx
-gnokey maketx run -gas-fee 350001ugnot -gas-wanted 3_600_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
+gnokey maketx run -gas-fee 350001ugnot -gas-wanted 5_400_000 -chainid=tendermint_test test1 $WORK/run/costly.gno
 
 ## Check collector1 balance, must not have changed
 gnokey query bank/balances/$collector1_user_addr

--- a/gno.land/pkg/integration/testdata/simulate_gas.txtar
+++ b/gno.land/pkg/integration/testdata/simulate_gas.txtar
@@ -5,24 +5,24 @@ loadpkg gno.land/r/simulate $WORK/simulate
 gnoland start
 
 # simulate only
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test -simulate only test1
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test -simulate only test1
 stdout 'GAS USED:   \d+'
 
 # simulate skip
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test -simulate skip test1
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 180001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test -simulate skip test1
 stdout 'GAS USED:   \d+' # same as simulate only
 
 # simulate only (again) with default 5% margin
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only test1
-stdout 'gas fee: 1006ugnot'
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2900000 -broadcast -chainid=tendermint_test -simulate only test1
+stdout 'gas fee: 2743ugnot'
 
-# simulate only with no gas fee margin. base gas fee is 959ugnot
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=0 test1
-stdout 'gas fee: 959ugnot'
+# simulate only with no gas fee margin. base gas fee is 2613ugnot
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2900000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=0 test1
+stdout 'gas fee: 2613ugnot'
 
-# the 5% margin was 47ugnot (1006 - 959). the 10% margin should be about 95ugnot, total of 1054
-gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=10 test1
-stdout 'gas fee: 1054ugnot,'
+# the 5% margin was 130ugnot (2743 - 2613). the 10% margin should be about 261ugnot, total of 2874
+gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2900000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=10 test1
+stdout 'gas fee: 2874ugnot,'
 
 # -gas-fee-margin should be a number
 ! gnokey maketx call -pkgpath gno.land/r/simulate -func Hello -gas-fee 1000000ugnot -gas-wanted 2000000 -broadcast -chainid=tendermint_test -simulate only -gas-fee-margin=zzz test1

--- a/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
@@ -14,7 +14,7 @@
 
 env ADDPKG_GAS=10_000_000
 env CALL_GAS=10_000_000
-env EXACT_GAS=2551422
+env EXACT_GAS=4206176
 
 gnoland start
 

--- a/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_restart_compare.txtar
@@ -2,9 +2,9 @@
 # Both Convert calls start from lastResult="42" and set it to "42".
 # EXACT_GAS is the expected GAS USED — both calls must match exactly.
 
-env ADDPKG_GAS=4_800_000
-env SETUP_GAS=3_200_000
-env EXACT_GAS=2012646
+env ADDPKG_GAS=5_700_000
+env SETUP_GAS=4_100_000
+env EXACT_GAS=3667400
 
 gnoland start
 

--- a/gno.land/pkg/integration/testdata/stdlib_runtime.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_runtime.txtar
@@ -5,8 +5,8 @@
 
 # Gas budgets — update these together if gas model changes.
 # CALL_GAS must be enough for Convert but NOT enough for ConvertHeavy.
-env ADDPKG_GAS=4_800_000
-env CALL_GAS=3_200_000
+env ADDPKG_GAS=6_500_000
+env CALL_GAS=4_500_000
 
 gnoland start
 

--- a/gno.land/pkg/integration/testdata/storage_deposit.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit.txtar
@@ -9,7 +9,7 @@ gnoland start
 #   STORAGE FEE   == fee_delta
 #   qstorage "storage/deposit" echoes the on-chain values
 #   TOTAL TX COST == gas-fee +/- STORAGE FEE/REFUND
-gnokey maketx addpkg -pkgdir $WORK/realm -pkgpath gno.land/r/foo -gas-fee 380001ugnot -gas-wanted 3_800_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/realm -pkgpath gno.land/r/foo -gas-fee 380001ugnot -gas-wanted 5_200_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
 stdout 'EVENTS:     \[{\"bytes_delta\":5016,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":501600},\"pkg_path\":\"gno.land/r/foo\"}\]'
 stdout 'STORAGE DELTA:  5016 bytes'
 stdout 'STORAGE FEE:    501600ugnot'
@@ -20,7 +20,7 @@ gnokey query vm/qstorage --data gno.land/r/foo
 stdout 'storage: 5016, deposit: 501600'
 
 ## Set an object with a smaller size. Exactly 2 bytes are released when we update the realm record from 'hello' to 'foo'.
-gnokey maketx call -pkgpath gno.land/r/foo -func NewFoo -args "foo"  -gas-fee 260001ugnot -gas-wanted 2_600_000  -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func NewFoo -args "foo"  -gas-fee 260001ugnot -gas-wanted 3_900_000  -chainid=tendermint_test test1
 stdout OK!
 stdout 'EVENTS:     \[{\"bytes_delta\":-2,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":200},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
 stdout 'STORAGE DELTA:  -2 bytes'
@@ -33,7 +33,7 @@ stdout 'storage: 5014, deposit: 501400'
 
 ## remove an object
 
- gnokey maketx call -pkgpath gno.land/r/foo -func Clear -gas-fee 260001ugnot -gas-wanted 2_600_000  -chainid=tendermint_test test1
+ gnokey maketx call -pkgpath gno.land/r/foo -func Clear -gas-fee 260001ugnot -gas-wanted 3_900_000  -chainid=tendermint_test test1
  stdout OK!
  stdout 'EVENTS:     \[{\"bytes_delta\":-27,\"fee_refund\":{\"denom\":\"ugnot\",\"amount\":2700},\"pkg_path\":\"gno.land/r/foo\",\"refund_withheld\":false}\]'
  stdout 'STORAGE DELTA:  -27 bytes'
@@ -48,7 +48,7 @@ stdout 'storage: 5014, deposit: 501400'
  stdout '"coins": "9999998601297ugnot"'
 
 ## test storage deposit for package gno.land/p/foo
-gnokey maketx addpkg -pkgdir $WORK/package -pkgpath gno.land/p/foo -gas-fee 370001ugnot -gas-wanted 3_700_000 -max-deposit 500000ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/package -pkgpath gno.land/p/foo -gas-fee 370001ugnot -gas-wanted 4_900_000 -max-deposit 500000ugnot -chainid=tendermint_test test1
 stdout OK!
 stdout 'EVENTS:     \[{\"bytes_delta\":2940,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":294000},\"pkg_path\":\"gno.land/p/foo\"}\]'
 stdout 'STORAGE DELTA:  2940 bytes'

--- a/gno.land/pkg/integration/testdata/storage_deposit_bank_send.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_bank_send.txtar
@@ -3,13 +3,13 @@
 ## start a new node
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK/contracts -pkgpath gno.land/r/foo -gas-fee 420001ugnot -gas-wanted 5_700_000 -max-deposit 1500000ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/contracts -pkgpath gno.land/r/foo -gas-fee 420001ugnot -gas-wanted 6_500_000 -max-deposit 1500000ugnot -chainid=tendermint_test test1
 stdout OK!
 
 
 # Users are not allowed to withdraw deposits from the realm balance via the realm banker.
 ## Get realm gno.land/r/foo (g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469) balance
-gnokey maketx call -pkgpath gno.land/r/foo -func PkgAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func PkgAddress -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout 'g1evezrh92xaucffmtgsaa3rvmz5s8kedffsg469'
 stdout OK!
 
@@ -21,7 +21,7 @@ stdout 'data: null'
 
 
 ## Get realm gno.land/r/foo storage deposit address  balance (g1nln0nrcd20s6a2736n864ma8lac0zep8hw7th9) balance
-gnokey maketx call -pkgpath gno.land/r/foo -func StorageDepositAddress -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func StorageDepositAddress -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test test1
 stdout 'g1nln0nrcd20s6a2736n864ma8lac0zep8hw7th9'
 stdout OK!
 
@@ -62,7 +62,7 @@ stderr 'insufficient coins error'
 
 
 ## Origin banker send within user's allowed amount
-gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1 -send 1ugnot -gas-fee 240001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/foo -func OriginSend  -args $test1_user_addr -args 1 -send 1ugnot -gas-fee 4200001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
 stdout 'OK'
 
 ## Origin banker send more than user's allowed amount

--- a/gno.land/pkg/integration/testdata/storage_deposit_collector.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_collector.txtar
@@ -28,18 +28,18 @@ gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 29_000_000 -chainid=tendermi
 stdout '0'
 
 ## Vote change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Execute change proposal with unrestricted account test1
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2100001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
 stdout 'OK!'
 
 ## Check storage_collector balance
 gnokey query bank/balances/$storage_collector_user_addr
 stdout '1000000000ugnot'
 
-gnokey maketx addpkg -pkgdir $WORK/bytesbank -pkgpath gno.land/r/bytesbank -gas-fee 370001ugnot -gas-wanted 4_800_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/bytesbank -pkgpath gno.land/r/bytesbank -gas-fee 370001ugnot -gas-wanted 5_500_000 -max-deposit 900000ugnot -chainid=tendermint_test test1
 stdout 'EVENTS:     \[{\"bytes_delta\":\d+,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":\d+},\"pkg_path\":\"gno.land/r/bytesbank\"}]'
 stdout 'STORAGE DELTA:  \d+ bytes'
 stdout 'STORAGE FEE:    \d+ugnot'
@@ -50,7 +50,7 @@ gnokey query vm/qstorage --data gno.land/r/bytesbank
 stdout 'storage: \d+, deposit: \d+'
 
 ## Set an object with a smaller size. Exactly 2 bytes are released when we update the realm record from 'hello' to 'foo'.
-gnokey maketx call -pkgpath gno.land/r/bytesbank -func Credit -args $norman_user_addr -args 500000  -gas-fee 1200001ugnot -gas-wanted 12_000_000  -chainid=tendermint_test alice
+gnokey maketx call -pkgpath gno.land/r/bytesbank -func Credit -args $norman_user_addr -args 500000  -gas-fee 1200001ugnot -gas-wanted 13_000_000  -chainid=tendermint_test alice
 stdout OK!
 stdout 'STORAGE DELTA:  \d+ bytes'
 stdout 'STORAGE FEE:    \d+ugnot'
@@ -61,7 +61,7 @@ stdout 'storage: \d+, deposit: \d+'
 
 ## Norman frees the storage of bytes bank, but storage deposit goes to storage fee collector
 ## instead of him
-gnokey maketx call -pkgpath gno.land/r/bytesbank -func Debit -args 0  -gas-fee 1400001ugnot -gas-wanted 14_000_000  -chainid=tendermint_test norman
+gnokey maketx call -pkgpath gno.land/r/bytesbank -func Debit -args 0  -gas-fee 1400001ugnot -gas-wanted 16_000_000  -chainid=tendermint_test norman
 stdout OK!
 stdout 'STORAGE DELTA:  -\d+ bytes'
 

--- a/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
@@ -13,7 +13,7 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 ## Step 1: Deploy a realm at default StoragePrice (100 ugnot/byte)
-gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/test/storage -gas-fee 1000000ugnot -gas-wanted 20000000 -max-deposit 600000000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/test/storage -gas-fee 1000000ugnot -gas-wanted 4900000 -max-deposit 600000000ugnot -broadcast -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/test/storage.DataLen()"
@@ -23,7 +23,7 @@ stdout '0 int'
 gnokey query vm/qstorage --data gno.land/r/test/storage
 stdout 'storage: 3364, deposit: 336400'
 
-gnokey maketx call -pkgpath gno.land/r/test/storage -func Allocate -args 500000 -gas-fee 1000000ugnot -gas-wanted 100000000 -max-deposit 600000000ugnot -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/storage -func Allocate -args 500000 -gas-fee 1000000ugnot -gas-wanted 13000000 -max-deposit 600000000ugnot -broadcast -chainid=tendermint_test test1
 stdout OK!
 stdout 'STORAGE FEE:'
 
@@ -40,20 +40,20 @@ gnokey query params/vm:p:storage_price
 stdout '100ugnot'
 
 ## Step 2: Propose to change StoragePrice from 100 to 1000 (10x increase)
-gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_price.gno
+gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 27000000 -broadcast -chainid=tendermint_test test1 $WORK/run/propose_price.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -args 0 -args YES -gas-fee 2000000ugnot -gas-wanted 22000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -args 0 -args YES -gas-fee 2000000ugnot -gas-wanted 23000000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -args 0 -gas-fee 2000000ugnot -gas-wanted 22000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -args 0 -gas-fee 2000000ugnot -gas-wanted 23000000 -broadcast -chainid=tendermint_test test1
 stdout 'OK!'
 
 gnokey query params/vm:p:storage_price
 stdout '1000ugnot'
 
 ## Step 3: Free the large allocation
-gnokey maketx call -pkgpath gno.land/r/test/storage -func Free -gas-fee 1000000ugnot -gas-wanted 100000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/test/storage -func Free -gas-fee 1000000ugnot -gas-wanted 15000000 -broadcast -chainid=tendermint_test test1
 stdout OK!
 stdout 'STORAGE REFUND: 50031600ugnot'
 

--- a/gno.land/pkg/integration/testdata/subrealm_run_parity.txtar
+++ b/gno.land/pkg/integration/testdata/subrealm_run_parity.txtar
@@ -21,7 +21,7 @@ gnoland start
 
 ## Enter via MsgRun: the ephemeral run realm crosses into the persistent
 ## subhost realm, which mints a sub of its own cur and crosses on.
-gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 20000000 -chainid=tendermint_test test1 $WORK/run/parity.gno
+gnokey maketx run -gas-fee 1000000ugnot -gas-wanted 4300000 -chainid=tendermint_test test1 $WORK/run/parity.gno
 stdout 'OK!'
 
 ## The sub presents its synthesized identity to the innermost callee...

--- a/gno.land/pkg/integration/testdata/sys_namereg_v1_controller.txtar
+++ b/gno.land/pkg/integration/testdata/sys_namereg_v1_controller.txtar
@@ -49,7 +49,7 @@ stdout OK!
 # captured paths at the first `-`, so a deploy under `gno.land/r/nym-alice123/*`
 # would have lookup-up "nym" instead of "nym-alice123" and failed with
 # "is not authorized to deploy packages to namespace nym".
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 6_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/nym-alice123/hello -gas-fee 1500001ugnot -gas-wanted 15_000_000 -chainid=tendermint_test user1

--- a/gno.land/pkg/integration/testdata/sys_names_pause.txtar
+++ b/gno.land/pkg/integration/testdata/sys_names_pause.txtar
@@ -29,7 +29,7 @@ gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermi
 stdout OK!
 
 # Vote YES + execute.
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1

--- a/gno.land/pkg/integration/testdata/sys_names_pause_addpkg.txtar
+++ b/gno.land/pkg/integration/testdata/sys_names_pause_addpkg.txtar
@@ -37,18 +37,18 @@ gnokey query vm/qeval --data "gno.land/r/sys/names.IsEnabled()"
 stdout 'false bool'
 
 # (1) Pre-Enable bypass: deploy under an arbitrary (non-PA) namespace succeeds.
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/preenable/hello -gas-fee 410001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/preenable/hello -gas-fee 410001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 # Enable namespace enforcement.
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 5_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 6_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data "gno.land/r/sys/names.IsEnabled()"
 stdout 'true bool'
 
 # (2a) Post-Enable: deploy under test1's PA namespace succeeds.
-gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 410001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg -pkgpath gno.land/r/$test1_user_addr/hello -gas-fee 410001ugnot -gas-wanted 5_700_000 -chainid=tendermint_test test1
 stdout OK!
 
 # (2b) Post-Enable: deploy under non-PA namespace fails (no registered name).
@@ -59,7 +59,7 @@ stderr 'is not authorized to deploy packages to namespace'
 gnokey maketx run -gas-fee 5000001ugnot -gas-wanted 50_000_000 -chainid=tendermint_test test1 $WORK/run/propose_pause.gno
 stdout OK!
 
-gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 21_000_000 -args 0 -args YES -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -args YES -chainid=tendermint_test test1
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2300001ugnot -gas-wanted 23_000_000 -args 0 -chainid=tendermint_test test1
@@ -81,7 +81,7 @@ stderr 'is not authorized to deploy packages to namespace'
 # (4) MsgCall against the package deployed pre-pause MUST keep working.
 # The package doc claims pause is scoped to MsgAddPackage; existing
 # realms continue to receive MsgCall traffic normally. This locks that in.
-gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -func Hello -gas-fee 1000000ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/$test1_user_addr/hello -func Hello -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test test1
 stdout OK!
 stdout 'hi from hello'
 
@@ -99,7 +99,7 @@ gnokey query vm/qeval --data "gno.land/r/sys/names.IsPaused()"
 stdout 'false bool'
 
 # (5) After unpause: addpkg under PA succeeds again.
-gnokey maketx addpkg -pkgdir $WORK/pkg_au -pkgpath gno.land/r/$test1_user_addr/after_unpause -gas-fee 410001ugnot -gas-wanted 4_200_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/pkg_au -pkgpath gno.land/r/$test1_user_addr/after_unpause -gas-fee 6000001ugnot -gas-wanted 6_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- run/init_govdao.gno --

--- a/gno.land/pkg/integration/testdata/time_simple.txtar
+++ b/gno.land/pkg/integration/testdata/time_simple.txtar
@@ -3,7 +3,7 @@
 
 gnoland start
 
-gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/time_simple -gas-fee 390001ugnot -gas-wanted 3_900_000 -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/time_simple -gas-fee 390001ugnot -gas-wanted 4_900_000 -chainid=tendermint_test test1
 stdout OK!
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/transfer_unlock.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_unlock.txtar
@@ -10,7 +10,7 @@ gnoland start -lock-transfer
 
 ## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
 ## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
-gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
@@ -39,7 +39,7 @@ gnokey maketx run  -gas-fee 2500001ugnot -gas-wanted 27_000_000  -chainid=tender
 stdout 'OK!'
 
 ## Restricted transfer is unlocked, allowing simple token transfers for regular accounts.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular1
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test regular1
 
 stdout 'OK!'
 

--- a/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
+++ b/gno.land/pkg/integration/testdata/transfer_unrestricted.txtar
@@ -15,11 +15,11 @@ gnoland start -lock-transfer
 
 ## test1 is the DefaultAccount in the integration test. To ensure that the unrestricted account can send tokens even when token transfers are locked,
 ## we included it in the unrestricted account list in the genesis state. By default, the unrestricted account list is empty.
-gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular1_user_addr -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
-gnokey maketx send -send "9999999ugnot" -to $regular2_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test test1
+gnokey maketx send -send "9999999ugnot" -to $regular2_user_addr -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid=tendermint_test test1
 
 stdout 'OK!'
 
@@ -52,12 +52,12 @@ gnokey maketx run  -gas-fee 2600001ugnot -gas-wanted 29_000_000  -chainid=tender
 stdout 'OK!'
 
 ## Token transfers for regular1 accounts is allowed.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular1
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test regular1
 
 stdout 'OK!'
 
 ## Token transfers for regular2 accounts is allowed.
-gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid=tendermint_test regular2
+gnokey maketx send -send "100ugnot" -to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test regular2
 
 stdout 'OK!'
 

--- a/gno.land/pkg/integration/testdata/update_storage_params.txtar
+++ b/gno.land/pkg/integration/testdata/update_storage_params.txtar
@@ -11,7 +11,7 @@ loadpkg gno.land/r/gov/dao/v3/loader $WORK/loader
 gnoland start
 
 ## add a contract
-gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/storage -gas-fee 380001ugnot -gas-wanted 3_800_000  -chainid=tendermint_test test1
+gnokey maketx addpkg -pkgdir $WORK/storage -pkgpath gno.land/r/storage -gas-fee 380001ugnot -gas-wanted 5_200_000  -chainid=tendermint_test test1
 stdout OK!
 
 ## Propose to update default deposit.

--- a/gno.land/pkg/integration/testdata/user_journey.txtar
+++ b/gno.land/pkg/integration/testdata/user_journey.txtar
@@ -40,7 +40,7 @@ stdout 'data: "100000000000ugnot"'
 ################################
 
 # User3 funds user1 (100ugnot) and user2 (4e10ugnot) using the disperse Realm
-gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseUgnotString -args "$user1_user_addr,$user2_user_addr" -args '100,40000000000' -send 40000000100ugnot -gas-fee 530001ugnot -gas-wanted 5_500_000 -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/demo/disperse -func DisperseUgnotString -args "$user1_user_addr,$user2_user_addr" -args '100,40000000000' -send 40000000100ugnot -gas-fee 530001ugnot -gas-wanted 6_600_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 # Verify users' new balances
@@ -52,7 +52,7 @@ gnokey query bank/balances/${user3_user_addr}
 stdout 'data: "\d+ugnot"' # Disperse + Gas used
 
 # User2 sends some more ugnot to user1 (1e10ugnot)
-gnokey maketx send -send 10000000000ugnot -to $user1_user_addr -gas-fee 130001ugnot -gas-wanted 1_300_000 -chainid tendermint_test user2
+gnokey maketx send -send 10000000000ugnot -to $user1_user_addr -gas-fee 130001ugnot -gas-wanted 2_800_000 -chainid tendermint_test user2
 stdout 'OK!'
 
 # Verify users' new balances
@@ -72,13 +72,13 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # user2 make a deposit of 1e7ugnot
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000  -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000000ugnot -gas-fee 900001ugnot -gas-wanted 9_900_000  -chainid=tendermint_test user2
 stdout 'OK!'
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user_addr}\")"
 stdout '10000000 int64'
 
 # user2 transfers 1e7ugnot to user1
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -args ${user1_user_addr} -args 10000000 -gas-fee 690001ugnot -gas-wanted 6_900_000 -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -args ${user1_user_addr} -args 10000000 -gas-fee 690001ugnot -gas-wanted 7_300_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Verify users' new balances
@@ -88,7 +88,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # user1 withdraw 1e7ugnot
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000000 -gas-fee 1000001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 ################################
@@ -99,7 +99,7 @@ stdout 'OK!'
 env DISPERSE_REALM_ADDR=g1yryw6qs8h9anvguu4dfdc0u7zh4gvv8vqf59sj
 
 # user1 creates a new token with 5 decimals and 10 drip ammount for the faucet
-gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func New -args MyAwesomeToken -args MAT -args 5 -args 0 -args 10 -gas-fee 1100001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/demo/defi/grc20factory -func New -args MyAwesomeToken -args MAT -args 5 -args 0 -args 10 -gas-fee 1100001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 # user1 mints 1000 MAT to himself
@@ -154,9 +154,9 @@ stdout '220 int64'
 # genesiscall lines before `gnoland start`.)
 
 # user3 creates a new board and a thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateBoard -args 'user3_awesome_board' -gas-fee 1700001ugnot -gas-wanted 17_000_000 -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateBoard -args 'user3_awesome_board' -gas-fee 1700001ugnot -gas-wanted 19_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My first thread' -args 'Hey Guys!' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My first thread' -args 'Hey Guys!' -gas-fee 1200001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 # user1 tries to reply to the thread without registering
@@ -164,15 +164,15 @@ stdout 'OK!'
 stderr 'please register, otherwise minimum fee 100000000 is required if anonymous'
 
 # user2 posts a reply to the thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hey hey hey!' -gas-fee 1300001ugnot -gas-wanted 13_000_000 -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'Hey hey hey!' -gas-fee 14000001ugnot -gas-wanted 14_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # user2 creates a new thread
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My own thread' -args 'Posting on my own thread' -gas-fee 1200001ugnot -gas-wanted 12_000_000 -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateThread -args 1 -args 'My own thread' -args 'Posting on my own thread' -gas-fee 14000001ugnot -gas-wanted 14_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # user1 replies to user3's thread anonymously
-gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'I prefer not to register' -send 100000000ugnot -gas-fee 1400001ugnot -gas-wanted 14_000_000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/archive/boards -func CreateReply -args 1 -args 1 -args 1 -args 'I prefer not to register' -send 100000000ugnot -gas-fee 16000001ugnot -gas-wanted 16_000_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 ######################
@@ -180,7 +180,7 @@ stdout 'OK!'
 ######################
 
 # Enable `sys/names` to enforce namespace restrictions
-gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 260001ugnot -gas-wanted 5_300_000 -chainid tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/sys/names -func Enable -gas-fee 6500001ugnot -gas-wanted 6_500_000 -chainid tendermint_test test1
 stdout 'OK!'
 
 # user2 publishes a custom home package to its address namespace

--- a/gno.land/pkg/integration/testdata/variadic.txtar
+++ b/gno.land/pkg/integration/testdata/variadic.txtar
@@ -8,17 +8,17 @@ loadpkg gno.land/r/tests/vm/variadic
 gnoland start
 
 # Call variadic func with 2 variadic arguments
-gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Echo -args "mem123" -args "123mem" -gas-fee 220001ugnot -gas-wanted 2_200_000 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Echo -args "mem123" -args "123mem" -gas-fee 220001ugnot -gas-wanted 3_200_000 -chainid=tendermint_test member
 stdout 'OK!'
 stdout '("mem123 123mem" string)'
 
 # Call variadic func with 0 variadic arguments
-gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Echo -gas-fee 200001ugnot -gas-wanted 2_000_000 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Echo -gas-fee 200001ugnot -gas-wanted 3_100_000 -chainid=tendermint_test member
 stdout 'OK!'
 stdout '("" string)'
 
 # Call variadic func with 2 int variadic arguments
-gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Add -args 10 -args 20 -gas-fee 180001ugnot -gas-wanted 1_800_000 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Add -args 10 -args 20 -gas-fee 180001ugnot -gas-wanted 2_900_000 -chainid=tendermint_test member
 stdout 'OK!'
 stdout '(30 int)'
 
@@ -27,6 +27,6 @@ stdout '(30 int)'
 stderr 'unexpected bool value'
 
 # Call variadic func with 0 int variadic arguments
-gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Add -gas-fee 1000000ugnot -gas-wanted 1300000 -chainid=tendermint_test member
+gnokey maketx call -pkgpath gno.land/r/tests/vm/variadic -func Add -gas-fee 3000001ugnot -gas-wanted 3_000_000 -chainid=tendermint_test member
 stdout 'OK!'
 stdout '(0 int)'

--- a/gno.land/pkg/integration/testdata/wugnot.txtar
+++ b/gno.land/pkg/integration/testdata/wugnot.txtar
@@ -21,7 +21,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user
 stdout '0 int64'
 
 # Deposit using user1
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 900001ugnot -gas-wanted 9_000_000 -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 900001ugnot -gas-wanted 9_800_000 -chainid=tendermint_test user1
 stdout 'OK!'
 
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user_addr}\")"
@@ -37,7 +37,7 @@ gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user2_user
 stdout '0 int64'
 
 # Deposit using user2
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 930001ugnot -gas-wanted 9_300_000 -chainid=tendermint_test user2
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send 10000ugnot -gas-fee 930001ugnot -gas-wanted 9_800_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 gnokey query vm/qeval --data "gno.land/r/gnoland/wugnot.BalanceOf(\"${user1_user_addr}\")"
@@ -52,7 +52,7 @@ stdout 'Total supply..: 20000'
 stdout 'Known accounts..: 2'
 
 
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -gas-fee 750001ugnot -gas-wanted 7_500_000 -args ${user3_user_addr} -args '10000' -chainid=tendermint_test user1
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Transfer -gas-fee 750001ugnot -gas-wanted 7_900_000 -args ${user3_user_addr} -args '10000' -chainid=tendermint_test user1
 stdout 'OK!'
 
 gnokey query vm/qrender --data "gno.land/r/gnoland/wugnot:"
@@ -60,7 +60,7 @@ stdout 'Total supply..: 20000'
 stdout 'Known accounts..: 2' # user1 is no longer known, as they transferred all their balance
 
 # XXX: use test3 instead (depends on https://github.com/gnolang/gno/issues/1269#issuecomment-1806386069)
-gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000 -gas-fee 1000001ugnot -gas-wanted 10_000_000 -chainid=tendermint_test user3
+gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Withdraw -args 10000 -gas-fee 1000001ugnot -gas-wanted 11_000_000 -chainid=tendermint_test user3
 stdout 'OK!'
 
 gnokey query vm/qrender --data "gno.land/r/gnoland/wugnot:"

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -747,7 +747,7 @@ func waitForNewBlock(ts *testscript.TestScript, remote string, defaultPK crypto.
 			ToAddress:   addr,
 			Amount:      std.Coins{std.NewCoin(ugnot.Denom, 1)},
 		}},
-		Fee: std.NewFee(890_000, std.NewCoin(ugnot.Denom, 1_000_000)),
+		Fee: std.NewFee(2_500_000, std.NewCoin(ugnot.Denom, 1_000_000)),
 	}
 	signBytes, err := tx.GetSignBytes("tendermint_test", acct.BaseAccount.GetAccountNumber(), acct.BaseAccount.GetSequence())
 	if err != nil {

--- a/tm2/pkg/sdk/auth/ante.go
+++ b/tm2/pkg/sdk/auth/ante.go
@@ -29,11 +29,24 @@ func init() {
 // and also to accept or reject different types of PubKey's. This is where apps can define their own PubKey
 type SignatureVerificationGasConsumer = func(meter store.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
 
+// PrepareGasMeter prepares the transaction context after the basic fee and
+// gas-wanted checks have passed, but before any auth reads or writes occur.
+// The default transaction gas meter is already installed when the callback is
+// invoked. Applications may use it to charge consensus configuration reads to
+// the final transaction meter before applying the configuration to the
+// context.
+type PrepareGasMeter = func(ctx sdk.Context, tx std.Tx) sdk.Context
+
 type AnteOptions struct {
 	// If verifyGenesisSignatures is false, does not check signatures when Height==0.
 	// This is useful for development, and maybe production chains.
 	// Always check your settings and inspect genesis transactions.
 	VerifyGenesisSignatures bool
+
+	// PrepareGasMeter is invoked after basic gas/mempool checks, with the final
+	// transaction gas meter already installed. A nil callback leaves the
+	// default context unchanged.
+	PrepareGasMeter PrepareGasMeter
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -94,6 +107,10 @@ func NewAnteHandler(ak AccountKeeper, bank BankKeeperI, sigGasConsumer Signature
 				}
 			}
 		}()
+
+		if opts.PrepareGasMeter != nil {
+			newCtx = opts.PrepareGasMeter(newCtx, tx)
+		}
 
 		// Get params from context.
 		params := ctx.Value(AuthParamsContextKey{}).(Params)

--- a/tm2/pkg/sdk/auth/ante_test.go
+++ b/tm2/pkg/sdk/auth/ante_test.go
@@ -956,6 +956,73 @@ func TestSetGasMeter_SkipGasMeteringKey(t *testing.T) {
 	})
 }
 
+// TestAnteHandlerPrepareGasMeter verifies that application-specific gas setup
+// runs after the basic fee checks and that charges made by the setup callback
+// remain on the meter returned by the ante handler. This is used by gnoland to
+// charge VM governance-parameter loading before auth account operations.
+func TestAnteHandlerPrepareGasMeter(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	ctx := env.ctx
+	priv, _, addr := tu.KeyTestPubAddr()
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	acc.SetCoins(tu.NewTestCoins())
+	env.acck.SetAccount(ctx, acc)
+	tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)},
+		[]crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, tu.NewTestFee())
+
+	const prepareGas = int64(1234)
+	called := false
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer,
+		AnteOptions{
+			VerifyGenesisSignatures: true,
+			PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+				called = true
+				ctx.GasMeter().ConsumeGas(prepareGas, "prepare-gas-meter")
+				return ctx
+			},
+		})
+
+	newCtx, res, abort := anteHandler(ctx, tx, false)
+	require.False(t, abort)
+	require.True(t, res.IsOK(), res)
+	require.True(t, called)
+	require.GreaterOrEqual(t, newCtx.GasMeter().GasConsumed(), prepareGas)
+}
+
+// TestAnteHandlerPrepareGasMeterOutOfGas verifies that an out-of-gas panic in
+// the preparation callback is recovered by the ante handler with the final
+// meter available to BaseApp.
+func TestAnteHandlerPrepareGasMeterOutOfGas(t *testing.T) {
+	t.Parallel()
+
+	env := setupTestEnv()
+	ctx := env.ctx
+	priv, _, addr := tu.KeyTestPubAddr()
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	acc.SetCoins(tu.NewTestCoins())
+	env.acck.SetAccount(ctx, acc)
+	tx := tu.NewTestTx(t, ctx.ChainID(), []std.Msg{tu.NewTestMsg(addr)},
+		[]crypto.PrivKey{priv}, []uint64{0}, []uint64{0}, tu.NewTestFee())
+
+	anteHandler := NewAnteHandler(env.acck, env.bankk, DefaultSigVerificationGasConsumer,
+		AnteOptions{
+			VerifyGenesisSignatures: true,
+			PrepareGasMeter: func(ctx sdk.Context, tx std.Tx) sdk.Context {
+				ctx.GasMeter().ConsumeGas(ctx.GasMeter().Limit()+1, "prepare-gas-meter")
+				return ctx
+			},
+		})
+
+	newCtx, res, abort := anteHandler(ctx, tx, false)
+	require.True(t, abort)
+	require.IsType(t, std.OutOfGasError{}, sdk.ABCIError(res.Error))
+	require.Equal(t, tx.Fee.GasWanted, res.GasWanted)
+	require.Greater(t, res.GasUsed, res.GasWanted)
+	require.Equal(t, res.GasUsed, newCtx.GasMeter().GasConsumed())
+}
+
 // TestAnteHandlerGenesisReplaySkip verifies the genesis-replay signature
 // skip: a tx whose signature no longer matches its body (as happens to a
 // --patch-txs-rewritten historical tx) is skipped ONLY when the node ran


### PR DESCRIPTION
## Summary

The VM governance-parameter read in gnoland used to run while BaseApp's temporary pre-ante passthrough meter was active. Auth ante then installed the transaction meter, so the physical store reads appeared in gas traces but were omitted from reported transaction gas.

This draft PR:

- adds an optional `auth.AnteOptions.PrepareGasMeter` hook that runs after gas-wanted and fee checks, with the final transaction meter installed;
- moves gnoland's VM parameter load into that hook and applies the governed store gas configuration to the returned context;
- preserves ante out-of-gas recovery and reports the final meter's consumption;
- updates the integration gas budgets and exact assertions using the repository calibration workflow; and
- adds an ADR documenting the lifecycle, alternatives, and consequences.

The legacy VM parameter layout now reports its 14 parameter reads (about 1,654,754 gas per VM transaction in this branch). The separate parameter-bundle optimization can reduce that physical work later; this PR fixes the meter-lifecycle accounting independently.

## Verification

- `go test ./tm2/pkg/sdk/auth -count=1`
- `go test ./gno.land/pkg/sdk/vm/ -run Gas -count=1`
- `go test ./gnovm/pkg/gnolang/ -run Files -test.short -count=1`
- `go test ./gno.land/pkg/gnoland -count=1`
- `go test ./gno.land/pkg/integration -run TestTestdata -count=1`

AI assistance was used for implementation and test calibration; the changes and results should be reviewed by the maintainers.
