### PR TITLE
feat(examples): add parimutuel payout math library

### DIFF
--- a/examples/gno.land/p/demo/parimutuel/doc.gno
+++ b/examples/gno.land/p/demo/parimutuel/doc.gno
@@ -1,0 +1,5 @@
+// Package parimutuel provides payout and implied-probability math for
+// pool-based ("parimutuel") betting and prediction markets: winners
+// split a pool proportional to their stake, optionally after a
+// commission (rake) is taken off the top.
+package parimutuel

--- a/examples/gno.land/p/demo/parimutuel/gnomod.toml
+++ b/examples/gno.land/p/demo/parimutuel/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/demo/parimutuel"
+gno = "0.9"

--- a/examples/gno.land/p/demo/parimutuel/parimutuel.gno
+++ b/examples/gno.land/p/demo/parimutuel/parimutuel.gno
@@ -1,0 +1,77 @@
+package parimutuel
+
+// CalculatePayout returns the payout owed to a single winning bet,
+// proportional to its share of the winning outcome's pool, drawn from
+// the full pool (losers' stakes included).
+//
+// userBet must be part of winningPool (i.e. userBet <= winningPool).
+// winningPool must be <= totalPool and > 0.
+func CalculatePayout(userBet, totalPool, winningPool int64) int64 {
+	assertNonNegative(userBet, "userBet")
+	assertNonNegative(totalPool, "totalPool")
+	if winningPool <= 0 {
+		panic("parimutuel: winningPool must be positive")
+	}
+	if winningPool > totalPool {
+		panic("parimutuel: winningPool cannot exceed totalPool")
+	}
+	if userBet > winningPool {
+		panic("parimutuel: userBet cannot exceed winningPool")
+	}
+	return mulDiv(userBet, totalPool, winningPool)
+}
+
+// CalculatePayoutWithRake is CalculatePayout after deducting a commission
+// (rake) from the total pool before distribution. rakeBps is in basis
+// points: 100 = 1%, 10000 = 100%.
+//
+// If the rake consumes the entire pool (rakeBps == 10000, or rounding
+// leaves netPool at 0), there is nothing left to distribute and this
+// returns 0 rather than delegating to CalculatePayout, whose invariants
+// assume a non-degenerate pool.
+func CalculatePayoutWithRake(userBet, totalPool, winningPool, rakeBps int64) int64 {
+	if rakeBps < 0 || rakeBps > 10000 {
+		panic("parimutuel: rakeBps must be between 0 and 10000")
+	}
+	netPool := totalPool - mulDiv(totalPool, rakeBps, 10000)
+	if netPool <= 0 {
+		return 0
+	}
+	return CalculatePayout(userBet, netPool, winningPool)
+}
+
+// ImpliedProbabilityBps returns the market-implied probability of an
+// outcome, in basis points (10000 = 100%), based on its share of the
+// total pool.
+//
+// Basis points (not float64) are used deliberately: floating-point
+// arithmetic is not guaranteed deterministic across platforms, which
+// matters for consensus-critical code that must produce identical
+// results on every validator.
+func ImpliedProbabilityBps(outcomePool, totalPool int64) int64 {
+	if totalPool <= 0 {
+		panic("parimutuel: totalPool must be positive")
+	}
+	assertNonNegative(outcomePool, "outcomePool")
+	if outcomePool > totalPool {
+		panic("parimutuel: outcomePool cannot exceed totalPool")
+	}
+	return mulDiv(outcomePool, 10000, totalPool)
+}
+
+func assertNonNegative(v int64, name string) {
+	if v < 0 {
+		panic("parimutuel: " + name + " must be non-negative")
+	}
+}
+
+// mulDiv computes (a * b) / c. Amounts are assumed to fit comfortably
+// within int64 for realistic ugnot-denominated pools; for pools that
+// could approach 2^63, callers should pre-scale inputs or use a
+// bignum-backed alternative, which this package does not provide.
+func mulDiv(a, b, c int64) int64 {
+	if c == 0 {
+		panic("parimutuel: division by zero")
+	}
+	return (a * b) / c
+}

--- a/examples/gno.land/p/demo/parimutuel/parimutuel.gno
+++ b/examples/gno.land/p/demo/parimutuel/parimutuel.gno
@@ -1,5 +1,9 @@
 package parimutuel
 
+import (
+	"math/overflow"
+)
+
 // CalculatePayout returns the payout owed to a single winning bet,
 // proportional to its share of the winning outcome's pool, drawn from
 // the full pool (losers' stakes included).
@@ -21,23 +25,46 @@ func CalculatePayout(userBet, totalPool, winningPool int64) int64 {
 	return mulDiv(userBet, totalPool, winningPool)
 }
 
-// CalculatePayoutWithRake is CalculatePayout after deducting a commission
-// (rake) from the total pool before distribution. rakeBps is in basis
-// points: 100 = 1%, 10000 = 100%.
-//
-// If the rake consumes the entire pool (rakeBps == 10000, or rounding
-// leaves netPool at 0), there is nothing left to distribute and this
-// returns 0 rather than delegating to CalculatePayout, whose invariants
-// assume a non-degenerate pool.
-func CalculatePayoutWithRake(userBet, totalPool, winningPool, rakeBps int64) int64 {
+// CalculateRake returns the commission taken from totalPool at rakeBps
+// (basis points, 100 = 1%, 10000 = 100%). Exposed so a caller that
+// needs to account for or display the house cut itself doesn't have to
+// re-derive totalPool * rakeBps / 10000 with its own rounding.
+func CalculateRake(totalPool, rakeBps int64) int64 {
+	assertNonNegative(totalPool, "totalPool")
 	if rakeBps < 0 || rakeBps > 10000 {
 		panic("parimutuel: rakeBps must be between 0 and 10000")
 	}
-	netPool := totalPool - mulDiv(totalPool, rakeBps, 10000)
+	return mulDiv(totalPool, rakeBps, 10000)
+}
+
+// CalculatePayoutWithRake is CalculatePayout after deducting a
+// commission (rake) from the total pool before distribution.
+//
+// Validation is against the pre-rake totalPool, not the post-rake net
+// pool -- winningPool can legitimately exceed the net pool (a rake
+// simply means winners get back slightly less than their full stake),
+// so that is not an error condition and does not panic. If the rake
+// consumes the entire pool (rakeBps == 10000, or rounding leaves
+// netPool at 0), there is nothing left to distribute and this returns
+// 0 directly rather than dividing by a winningPool that may exceed it.
+func CalculatePayoutWithRake(userBet, totalPool, winningPool, rakeBps int64) int64 {
+	assertNonNegative(userBet, "userBet")
+	rake := CalculateRake(totalPool, rakeBps) // also validates totalPool and rakeBps
+	if winningPool <= 0 {
+		panic("parimutuel: winningPool must be positive")
+	}
+	if winningPool > totalPool {
+		panic("parimutuel: winningPool cannot exceed totalPool")
+	}
+	if userBet > winningPool {
+		panic("parimutuel: userBet cannot exceed winningPool")
+	}
+
+	netPool := totalPool - rake
 	if netPool <= 0 {
 		return 0
 	}
-	return CalculatePayout(userBet, netPool, winningPool)
+	return mulDiv(userBet, netPool, winningPool)
 }
 
 // ImpliedProbabilityBps returns the market-implied probability of an
@@ -47,7 +74,10 @@ func CalculatePayoutWithRake(userBet, totalPool, winningPool, rakeBps int64) int
 // Basis points (not float64) are used deliberately: floating-point
 // arithmetic is not guaranteed deterministic across platforms, which
 // matters for consensus-critical code that must produce identical
-// results on every validator.
+// results on every validator. Integer division also means this rounds
+// down, so summing ImpliedProbabilityBps across every outcome in a
+// pool can land a few basis points under 10000 (dust) rather than
+// exactly 10000 -- that is expected, not a bug.
 func ImpliedProbabilityBps(outcomePool, totalPool int64) int64 {
 	if totalPool <= 0 {
 		panic("parimutuel: totalPool must be positive")
@@ -65,13 +95,10 @@ func assertNonNegative(v int64, name string) {
 	}
 }
 
-// mulDiv computes (a * b) / c. Amounts are assumed to fit comfortably
-// within int64 for realistic ugnot-denominated pools; for pools that
-// could approach 2^63, callers should pre-scale inputs or use a
-// bignum-backed alternative, which this package does not provide.
+// mulDiv computes (a * b) / c, panicking on multiplication overflow
+// rather than silently wrapping. c == 0 is not guarded here: every
+// call site already establishes c > 0 before calling this, and integer
+// division by zero already panics natively.
 func mulDiv(a, b, c int64) int64 {
-	if c == 0 {
-		panic("parimutuel: division by zero")
-	}
-	return (a * b) / c
+	return overflow.Mul64p(a, b) / c
 }

--- a/examples/gno.land/p/demo/parimutuel/parimutuel_test.gno
+++ b/examples/gno.land/p/demo/parimutuel/parimutuel_test.gno
@@ -1,0 +1,109 @@
+package parimutuel
+
+import "testing"
+
+func TestCalculatePayoutSingleWinnerTakesAll(t *testing.T) {
+	payout := CalculatePayout(1000, 1000, 1000)
+	if payout != 1000 {
+		t.Fatalf("expected 1000, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutSplitsProportionally(t *testing.T) {
+	payout := CalculatePayout(300, 1000, 400)
+	if payout != 750 {
+		t.Fatalf("expected 750, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutZeroWinningPoolPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on zero winningPool")
+		}
+	}()
+	CalculatePayout(100, 1000, 0)
+}
+
+func TestCalculatePayoutWinningPoolExceedsTotalPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when winningPool > totalPool")
+		}
+	}()
+	CalculatePayout(100, 500, 600)
+}
+
+func TestCalculatePayoutUserBetExceedsWinningPoolPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when userBet > winningPool")
+		}
+	}()
+	CalculatePayout(600, 1000, 500)
+}
+
+func TestCalculatePayoutWithRakeZeroRakeMatchesNoRake(t *testing.T) {
+	withoutRake := CalculatePayout(300, 1000, 400)
+	withZeroRake := CalculatePayoutWithRake(300, 1000, 400, 0)
+	if withoutRake != withZeroRake {
+		t.Fatalf("expected %d, got %d", withoutRake, withZeroRake)
+	}
+}
+
+func TestCalculatePayoutWithRakeReducesPayout(t *testing.T) {
+	payout := CalculatePayoutWithRake(400, 1000, 400, 500)
+	if payout != 950 {
+		t.Fatalf("expected 950, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutWithRakeFullRakeYieldsZero(t *testing.T) {
+	payout := CalculatePayoutWithRake(400, 1000, 400, 10000)
+	if payout != 0 {
+		t.Fatalf("expected 0, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutWithRakeInvalidBpsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on rakeBps > 10000")
+		}
+	}()
+	CalculatePayoutWithRake(100, 1000, 400, 10001)
+}
+
+func TestImpliedProbabilityBpsHalfPool(t *testing.T) {
+	prob := ImpliedProbabilityBps(500, 1000)
+	if prob != 5000 {
+		t.Fatalf("expected 5000, got %d", prob)
+	}
+}
+
+func TestImpliedProbabilityBpsSumsToTotal(t *testing.T) {
+	a := ImpliedProbabilityBps(500, 1000)
+	b := ImpliedProbabilityBps(300, 1000)
+	c := ImpliedProbabilityBps(200, 1000)
+	if a+b+c != 10000 {
+		t.Fatalf("expected probabilities to sum to 10000, got %d", a+b+c)
+	}
+}
+
+func TestImpliedProbabilityBpsZeroTotalPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on zero totalPool")
+		}
+	}()
+	ImpliedProbabilityBps(0, 0)
+}
+
+func TestImpliedProbabilityBpsOutcomeExceedsTotalPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when outcomePool > totalPool")
+		}
+	}()
+	ImpliedProbabilityBps(1200, 1000)
+}

--- a/examples/gno.land/p/demo/parimutuel/parimutuel_test.gno
+++ b/examples/gno.land/p/demo/parimutuel/parimutuel_test.gno
@@ -43,6 +43,16 @@ func TestCalculatePayoutUserBetExceedsWinningPoolPanics(t *testing.T) {
 	CalculatePayout(600, 1000, 500)
 }
 
+func TestCalculatePayoutOverflowingPoolPanics(t *testing.T) {
+	const bigPool = int64(3037000500)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on overflowing pool")
+		}
+	}()
+	CalculatePayout(bigPool, bigPool, bigPool)
+}
+
 func TestCalculatePayoutWithRakeZeroRakeMatchesNoRake(t *testing.T) {
 	withoutRake := CalculatePayout(300, 1000, 400)
 	withZeroRake := CalculatePayoutWithRake(300, 1000, 400, 0)
@@ -74,6 +84,45 @@ func TestCalculatePayoutWithRakeInvalidBpsPanics(t *testing.T) {
 	CalculatePayoutWithRake(100, 1000, 400, 10001)
 }
 
+func TestCalculatePayoutWithRakeWinnerTakesAllDoesNotPanic(t *testing.T) {
+	payout := CalculatePayoutWithRake(1000, 1000, 1000, 500)
+	if payout != 950 {
+		t.Fatalf("expected 950, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutWithRakeWinningPoolAboveNetPoolStillPaysOut(t *testing.T) {
+	payout := CalculatePayoutWithRake(951, 1000, 951, 500)
+	if payout != 950 {
+		t.Fatalf("expected 950, got %d", payout)
+	}
+}
+
+func TestCalculatePayoutWithRakeNegativeTotalPoolPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on negative totalPool")
+		}
+	}()
+	CalculatePayoutWithRake(100, -1000, 400, 0)
+}
+
+func TestCalculateRakeBasic(t *testing.T) {
+	rake := CalculateRake(1000, 500)
+	if rake != 50 {
+		t.Fatalf("expected 50, got %d", rake)
+	}
+}
+
+func TestCalculateRakeInvalidBpsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on rakeBps > 10000")
+		}
+	}()
+	CalculateRake(1000, 10001)
+}
+
 func TestImpliedProbabilityBpsHalfPool(t *testing.T) {
 	prob := ImpliedProbabilityBps(500, 1000)
 	if prob != 5000 {
@@ -81,12 +130,24 @@ func TestImpliedProbabilityBpsHalfPool(t *testing.T) {
 	}
 }
 
-func TestImpliedProbabilityBpsSumsToTotal(t *testing.T) {
+func TestImpliedProbabilityBpsExactSplitSumsToTotal(t *testing.T) {
 	a := ImpliedProbabilityBps(500, 1000)
 	b := ImpliedProbabilityBps(300, 1000)
 	c := ImpliedProbabilityBps(200, 1000)
 	if a+b+c != 10000 {
 		t.Fatalf("expected probabilities to sum to 10000, got %d", a+b+c)
+	}
+}
+
+func TestImpliedProbabilityBpsRoundingLeavesDust(t *testing.T) {
+	a := ImpliedProbabilityBps(1000, 3000)
+	b := ImpliedProbabilityBps(1000, 3000)
+	c := ImpliedProbabilityBps(1000, 3000)
+	if a != 3333 || b != 3333 || c != 3333 {
+		t.Fatalf("expected 3333 each, got %d, %d, %d", a, b, c)
+	}
+	if a+b+c != 9999 {
+		t.Fatalf("expected rounding dust to leave 9999, got %d", a+b+c)
 	}
 }
 
@@ -106,4 +167,14 @@ func TestImpliedProbabilityBpsOutcomeExceedsTotalPanics(t *testing.T) {
 		}
 	}()
 	ImpliedProbabilityBps(1200, 1000)
+}
+
+func TestImpliedProbabilityBpsOverflowingPoolPanics(t *testing.T) {
+	const bigPool = int64(922337203685478)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on overflowing pool")
+		}
+	}()
+	ImpliedProbabilityBps(bigPool, bigPool)
 }


### PR DESCRIPTION
Small p/ package for pool-based payout math, meant to be reusable by any realm that needs it (prediction markets, sports betting, anything pool-based) instead of everyone rewriting the same formula inline.

Three functions:
- CalculatePayout -- proportional payout from a winning pool, drawn from the full pool
- CalculatePayoutWithRake -- same thing but with an optional commission (rake, in basis points) taken off the top first
- ImpliedProbabilityBps -- market-implied probability of an outcome based on its share of the pool

Probability is returned as integer basis points rather than float64 on purpose -- floating point math is not guaranteed to be identical across platforms, and this needs to produce the same result on every validator.

Tests cover the normal paths plus the edge cases (zero pool, bet bigger than the winning pool, rake that eats the whole pool, etc). Worth mentioning: the full-rake test actually caught a real bug while writing this -- 100% rake left netPool at 0, which tripped CalculatePayouts own validation and panicked instead of just returning 0. Fixed by special-casing an exhausted pool in CalculatePayoutWithRake.

Happy to adjust naming or add more cases if anything looks off.