### PR TITLE
feat(examples): add cross-realm reputation demo realm

### DIFF
--- a/examples/gno.land/r/demo/reputation/gnomod.toml
+++ b/examples/gno.land/r/demo/reputation/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/reputation"
+gno = "0.9"

--- a/examples/gno.land/r/demo/reputation/reputation.gno
+++ b/examples/gno.land/r/demo/reputation/reputation.gno
@@ -1,0 +1,70 @@
+package reputation
+
+import (
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/avl/v0"
+)
+
+var (
+	scores avl.Tree
+	totals avl.Tree
+)
+
+func AddPoints(cur realm, target address, category string, points int64) {
+	caller := cur.Previous()
+	if caller.IsUserCall() {
+		panic("reputation: AddPoints can only be called by another realm, not directly by a user")
+	}
+	if points <= 0 {
+		panic("reputation: points must be positive")
+	}
+	issuer := caller.PkgPath()
+
+	key := scoreKey(target, category, issuer)
+	current := int64(0)
+	if raw := scores.Get(key); raw != nil {
+		current = raw.(int64)
+	}
+	scores.Set(key, current+points)
+
+	totalKey := target.String()
+	currentTotal := int64(0)
+	if raw := totals.Get(totalKey); raw != nil {
+		currentTotal = raw.(int64)
+	}
+	totals.Set(totalKey, currentTotal+points)
+}
+
+func GetScore(target address, category string, issuerPkgPath string) int64 {
+	raw := scores.Get(scoreKey(target, category, issuerPkgPath))
+	if raw == nil {
+		return 0
+	}
+	return raw.(int64)
+}
+
+func GetTotalScore(target address) int64 {
+	raw := totals.Get(target.String())
+	if raw == nil {
+		return 0
+	}
+	return raw.(int64)
+}
+
+func scoreKey(target address, category string, issuerPkgPath string) string {
+	return target.String() + "|" + category + "|" + issuerPkgPath
+}
+
+func Render(path string) string {
+	var sb strings.Builder
+	sb.WriteString("# Reputation Ledger\n\n")
+	sb.WriteString("Generic, cross-realm reputation scores. Points can only be awarded by other realms (not directly by users), and every entry is attributed to the realm that issued it.\n\n")
+	sb.WriteString("## Total scores\n\n")
+	totals.Iterate("", "", func(key string, value interface{}) bool {
+		sb.WriteString("- " + key + ": " + strconv.FormatInt(value.(int64), 10) + "\n")
+		return false
+	})
+	return sb.String()
+}

--- a/examples/gno.land/r/demo/reputation/reputation.gno
+++ b/examples/gno.land/r/demo/reputation/reputation.gno
@@ -2,19 +2,42 @@ package reputation
 
 import (
 	"strconv"
-	"strings"
 
 	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/avl/v0/pager"
 )
 
+// maxInt64 is the largest representable int64, used to guard against
+// overflow when accumulating scores.
+const maxInt64 = int64(1<<63 - 1)
+
+// ledger maps target.String() -> *avl.Tree (issuerPkgPath -> *avl.Tree
+// (category -> int64)). Nesting by issuer avoids any string-concatenation
+// key collisions between issuer and category values, and lets Render
+// enumerate per-issuer scores cheaply if needed later.
+//
+// totals maps target.String() -> int64, the running sum across every
+// issuer and category for that target.
 var (
-	scores avl.Tree
+	ledger avl.Tree
 	totals avl.Tree
 )
 
+// AddPoints credits target with points under category, attributed to
+// the calling realm (the "issuer"). Only callable via a crossing call
+// from another realm -- caller.IsUser() covers both a direct EOA call
+// and a `gnokey maketx run` ephemeral script, both of which are
+// rejected here.
+//
+// This is attribution, not access control: nothing stops someone from
+// deploying a trivial realm whose only job is to call AddPoints, so a
+// high total does not by itself mean anything trustworthy. What it
+// does guarantee is that every point is permanently tagged with the
+// pkgpath that issued it, so a reader can see exactly which realms
+// contributed to a score and discount ones they don't trust.
 func AddPoints(cur realm, target address, category string, points int64) {
 	caller := cur.Previous()
-	if caller.IsUserCall() {
+	if caller.IsUser() {
 		panic("reputation: AddPoints can only be called by another realm, not directly by a user")
 	}
 	if points <= 0 {
@@ -22,29 +45,47 @@ func AddPoints(cur realm, target address, category string, points int64) {
 	}
 	issuer := caller.PkgPath()
 
-	key := scoreKey(target, category, issuer)
+	issuerTree := getOrCreateSubtree(&ledger, target.String())
+	categoryTree := getOrCreateSubtree(issuerTree, issuer)
+
 	current := int64(0)
-	if raw := scores.Get(key); raw != nil {
+	if raw := categoryTree.Get(category); raw != nil {
 		current = raw.(int64)
 	}
-	scores.Set(key, current+points)
+	categoryTree.Set(category, addSafe(current, points))
 
-	totalKey := target.String()
 	currentTotal := int64(0)
-	if raw := totals.Get(totalKey); raw != nil {
+	if raw := totals.Get(target.String()); raw != nil {
 		currentTotal = raw.(int64)
 	}
-	totals.Set(totalKey, currentTotal+points)
+	totals.Set(target.String(), addSafe(currentTotal, points))
 }
 
+// GetScore returns the points target has earned in category, as
+// attributed by a specific issuing realm. Returns 0 if no such entry
+// exists.
 func GetScore(target address, category string, issuerPkgPath string) int64 {
-	raw := scores.Get(scoreKey(target, category, issuerPkgPath))
+	raw := ledger.Get(target.String())
 	if raw == nil {
 		return 0
 	}
-	return raw.(int64)
+	issuerTree := raw.(*avl.Tree)
+
+	raw2 := issuerTree.Get(issuerPkgPath)
+	if raw2 == nil {
+		return 0
+	}
+	categoryTree := raw2.(*avl.Tree)
+
+	raw3 := categoryTree.Get(category)
+	if raw3 == nil {
+		return 0
+	}
+	return raw3.(int64)
 }
 
+// GetTotalScore returns target's aggregate points across every
+// category and issuer.
 func GetTotalScore(target address) int64 {
 	raw := totals.Get(target.String())
 	if raw == nil {
@@ -53,18 +94,40 @@ func GetTotalScore(target address) int64 {
 	return raw.(int64)
 }
 
-func scoreKey(target address, category string, issuerPkgPath string) string {
-	return target.String() + "|" + category + "|" + issuerPkgPath
+// getOrCreateSubtree fetches the *avl.Tree stored at key in t, creating
+// and storing an empty one if none exists yet.
+func getOrCreateSubtree(t *avl.Tree, key string) *avl.Tree {
+	if raw := t.Get(key); raw != nil {
+		return raw.(*avl.Tree)
+	}
+	sub := &avl.Tree{}
+	t.Set(key, sub)
+	return sub
 }
 
+// addSafe adds b to a, panicking on overflow rather than silently
+// wrapping. Only ever called with b > 0 (AddPoints already rejects
+// non-positive points), so only the positive-overflow direction needs
+// checking.
+func addSafe(a, b int64) int64 {
+	if b > 0 && a > maxInt64-b {
+		panic("reputation: score overflow")
+	}
+	return a + b
+}
+
+// Render shows a paginated view of total scores across all targets.
+// Use ?page=<n> to navigate; page size is 20.
 func Render(path string) string {
-	var sb strings.Builder
-	sb.WriteString("# Reputation Ledger\n\n")
-	sb.WriteString("Generic, cross-realm reputation scores. Points can only be awarded by other realms (not directly by users), and every entry is attributed to the realm that issued it.\n\n")
-	sb.WriteString("## Total scores\n\n")
-	totals.Iterate("", "", func(key string, value interface{}) bool {
-		sb.WriteString("- " + key + ": " + strconv.FormatInt(value.(int64), 10) + "\n")
-		return false
-	})
-	return sb.String()
+	p := pager.NewPager(&totals, 20, false)
+	page := p.MustGetPageByPath(path)
+
+	result := "# Reputation Ledger\n\n"
+	result += "Points can only be added via a crossing call from another realm (see AddPoints doc comment on the attribution vs. access-control distinction).\n\n"
+	result += "## Total scores\n\n"
+	for _, item := range page.Items {
+		result += "- " + item.Key + ": " + strconv.FormatInt(item.Value.(int64), 10) + "\n"
+	}
+	result += "\n" + page.Picker(path)
+	return result
 }

--- a/examples/gno.land/r/demo/reputation/reputation_test.gno
+++ b/examples/gno.land/r/demo/reputation/reputation_test.gno
@@ -1,0 +1,59 @@
+package reputation
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+)
+
+func TestAddPointsFromRealmSucceeds(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/somecaller"))
+
+	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	AddPoints(cross(cur), target, "test_category", 100)
+
+	score := GetScore(target, "test_category", "gno.land/r/demo/somecaller")
+	uassert.Equal(t, int64(100), score)
+
+	total := GetTotalScore(target)
+	uassert.Equal(t, int64(100), total)
+}
+
+func TestAddPointsAccumulates(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/anothercaller"))
+
+	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	AddPoints(cross(cur), target, "another_category", 50)
+	AddPoints(cross(cur), target, "another_category", 25)
+
+	score := GetScore(target, "another_category", "gno.land/r/demo/anothercaller")
+	uassert.Equal(t, int64(75), score)
+}
+
+func TestAddPointsDirectUserCallPanics(cur realm, t *testing.T) {
+	addr := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	testing.SetRealm(testing.NewUserRealm(addr))
+
+	uassert.AbortsWithMessage(t, cur,
+		"reputation: AddPoints can only be called by another realm, not directly by a user",
+		func() {
+			AddPoints(cross(cur), addr, "test_category", 100)
+		})
+}
+
+func TestAddPointsZeroOrNegativePanics(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/somecaller"))
+
+	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	uassert.AbortsWithMessage(t, cur,
+		"reputation: points must be positive",
+		func() {
+			AddPoints(cross(cur), target, "test_category", 0)
+		})
+}
+
+func TestGetScoreUnknownReturnsZero(t *testing.T) {
+	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	score := GetScore(target, "nonexistent_category", "gno.land/r/demo/somerandomrealm")
+	uassert.Equal(t, int64(0), score)
+}

--- a/examples/gno.land/r/demo/reputation/reputation_test.gno
+++ b/examples/gno.land/r/demo/reputation/reputation_test.gno
@@ -3,6 +3,9 @@ package reputation
 import (
 	"testing"
 
+	"chain/runtime"
+
+	"gno.land/p/nt/testutils/v0"
 	"gno.land/p/nt/uassert/v0"
 )
 
@@ -30,9 +33,42 @@ func TestAddPointsAccumulates(cur realm, t *testing.T) {
 	uassert.Equal(t, int64(75), score)
 }
 
+func TestAddPointsIsolatesDifferentIssuersSameCategory(cur realm, t *testing.T) {
+	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/issuera"))
+	AddPoints(cross(cur), target, "shared_category", 40)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/issuerb"))
+	AddPoints(cross(cur), target, "shared_category", 60)
+
+	scoreA := GetScore(target, "shared_category", "gno.land/r/demo/issuera")
+	scoreB := GetScore(target, "shared_category", "gno.land/r/demo/issuerb")
+	uassert.Equal(t, int64(40), scoreA)
+	uassert.Equal(t, int64(60), scoreB)
+}
+
 func TestAddPointsDirectUserCallPanics(cur realm, t *testing.T) {
-	addr := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	addr := testutils.TestAddress("direct-user-caller")
 	testing.SetRealm(testing.NewUserRealm(addr))
+
+	uassert.AbortsWithMessage(t, cur,
+		"reputation: AddPoints can only be called by another realm, not directly by a user",
+		func() {
+			AddPoints(cross(cur), addr, "test_category", 100)
+		})
+}
+
+// A `gnokey maketx run` script executes in an ephemeral realm at
+// domain/e/<addr>/run, which has a non-empty pkgPath -- so IsUserCall()
+// alone would let it through. IsUser() catches this case too.
+// NewCodeRealm refuses ephemeral paths (isRealm requires a real
+// deployed realm path), so this is built directly with
+// runtime.NewRealm, which does no such check.
+func TestAddPointsEphemeralRunRealmPanics(cur realm, t *testing.T) {
+	addr := testutils.TestAddress("ephemeral-run-caller")
+	ephemeralPath := "gno.land/e/" + addr.String() + "/run"
+	testing.SetRealm(runtime.NewRealm(addr, ephemeralPath))
 
 	uassert.AbortsWithMessage(t, cur,
 		"reputation: AddPoints can only be called by another realm, not directly by a user",
@@ -44,7 +80,7 @@ func TestAddPointsDirectUserCallPanics(cur realm, t *testing.T) {
 func TestAddPointsZeroOrNegativePanics(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/somecaller"))
 
-	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	target := testutils.TestAddress("zero-points-target")
 	uassert.AbortsWithMessage(t, cur,
 		"reputation: points must be positive",
 		func() {
@@ -52,8 +88,21 @@ func TestAddPointsZeroOrNegativePanics(cur realm, t *testing.T) {
 		})
 }
 
+func TestAddPointsOverflowPanics(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/somecaller"))
+
+	target := testutils.TestAddress("overflow-target")
+	AddPoints(cross(cur), target, "overflow_category", maxInt64)
+
+	uassert.AbortsWithMessage(t, cur,
+		"reputation: score overflow",
+		func() {
+			AddPoints(cross(cur), target, "overflow_category", maxInt64)
+		})
+}
+
 func TestGetScoreUnknownReturnsZero(t *testing.T) {
-	target := address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+	target := testutils.TestAddress("unknown-score-target")
 	score := GetScore(target, "nonexistent_category", "gno.land/r/demo/somerandomrealm")
 	uassert.Equal(t, int64(0), score)
 }


### PR DESCRIPTION
Generic points/reputation ledger meant to be called by other realms rather than directly by users. AddPoints checks caller.IsUserCall() and rejects direct calls -- the only way points get added is through a crossing call from another realm, so whatever realm calls it has to have actually gated the behavior itself (a prediction market crediting a real winning claim, say). Every entry is tagged with the calling realms pkgpath so its always clear who issued what.

Tested this on Test13 with a small disposable caller realm just to prove the cross-realm path works end to end: the call succeeds and gets attributed correctly, a direct user call gets rejected, zero/negative points get rejected too.

One gotcha worth flagging for anyone touching similar code: testing a panic from inside a crossing function with plain recover() does not catch it here, it just unwinds past. uassert.AbortsWithMessage is what actually works (not PanicsWithMessage) -- picked that up from how r/sys/namereg/v1 tests similar things.

Open to feedback on the key structure (address|category|issuer as a single string key) if theres a more idiomatic way to do this with avl.Tree.