### PR TITLE
privval: add YubiHSM2 backed signer

### DIFF
--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -18,9 +18,10 @@ import (
 )
 
 // PrivValidatorConfig defines the configuration for the PrivValidator, with a local
-// signer (file-based key), a gnokms remote signer (tm2-native protocol), or a tmkms
+// signer (file-based key), a gnokms remote signer (tm2-native protocol), a tmkms
 // listener (upstream Tendermint privval protocol — the validator listens for tmkms
-// to dial in). At most one of RemoteSigner or TmkmsListener may be enabled.
+// to dial in), or a YubiHSM2 hardware security module. At most one of RemoteSigner,
+// TmkmsListener, or YubiHSM may be enabled.
 type PrivValidatorConfig struct {
 	// File path configuration.
 	RootDir     string `json:"home" toml:"home"`

--- a/tm2/pkg/bft/privval/config.go
+++ b/tm2/pkg/bft/privval/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/yubihsm"
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/upstream"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
@@ -33,13 +34,21 @@ type PrivValidatorConfig struct {
 	// listens for tmkms / Horcrux to dial in). Mutually exclusive with RemoteSigner;
 	// see upstream_config.go.
 	TmkmsListener *TmkmsListenerConfig `json:"tmkms_listener" toml:"tmkms_listener" comment:"Configuration for upstream-Tendermint-protocol signer (tmkms / Horcrux). Empty listen_addr disables this mode."`
+
+	// YubiHSM configures a signer that delegates signing to an Ed25519 key
+	// stored in a YubiHSM2 hardware security module, accessed through a
+	// yubihsm-connector service. The private key never leaves the device.
+	// Mutually exclusive with RemoteSigner and TmkmsListener.
+	YubiHSM *yubihsm.Config `json:"yubihsm" toml:"yubihsm" comment:"Configuration for signing with a YubiHSM2 hardware security module"`
 }
 
 // PrivValidatorConfig validation errors.
 var (
-	errInvalidSignStatePath   = errors.New("invalid private validator sign state file path")
-	errInvalidLocalSignerPath = errors.New("invalid private validator local signer file path")
-	errNilRemoteSignerConfig  = errors.New("remote signer configuration cannot be nil")
+	errInvalidSignStatePath     = errors.New("invalid private validator sign state file path")
+	errInvalidLocalSignerPath   = errors.New("invalid private validator local signer file path")
+	errNilRemoteSignerConfig    = errors.New("remote signer configuration cannot be nil")
+	errNilYubiHSMConfig         = errors.New("yubihsm configuration cannot be nil")
+	errMultipleSignerSourcesSet = errors.New("only one of remote_signer, tmkms_listener, or yubihsm may be configured")
 )
 
 // DefaultPrivValidatorConfig returns a default configuration for the PrivValidator.
@@ -49,6 +58,7 @@ func DefaultPrivValidatorConfig() *PrivValidatorConfig {
 		LocalSigner:   "priv_validator_key.json",
 		RemoteSigner:  rsclient.DefaultRemoteSignerClientConfig(),
 		TmkmsListener: DefaultTmkmsListenerConfig(),
+		YubiHSM:       yubihsm.DefaultConfig(),
 	}
 }
 
@@ -97,9 +107,22 @@ func (cfg *PrivValidatorConfig) ValidateBasic() error {
 		}
 	}
 
+	// Verify the YubiHSM configuration is not nil.
+	if cfg.YubiHSM == nil {
+		return errNilYubiHSMConfig
+	}
+
+	// Validate the YubiHSM configuration.
+	if err := cfg.YubiHSM.ValidateBasic(); err != nil {
+		return err
+	}
+
 	// Mutual exclusion: at most one external-signer mode may be enabled.
 	if cfg.RemoteSigner.ServerAddress != "" && cfg.TmkmsListener.IsEnabled() {
 		return errBothExternalSignersEnabled
+	}
+	if cfg.YubiHSM.IsEnabled() && (cfg.RemoteSigner.ServerAddress != "" || cfg.TmkmsListener.IsEnabled()) {
+		return errMultipleSignerSourcesSet
 	}
 
 	return nil
@@ -123,6 +146,11 @@ func NewSignerFromConfig(
 			clientPrivKey,
 			clientLogger,
 		)
+	}
+
+	// If YubiHSM is enabled, delegate signing to the hardware module.
+	if config.YubiHSM.IsEnabled() {
+		return yubihsm.NewSignerFromConfig(config.YubiHSM)
 	}
 
 	// Otherwise, use a local signer.
@@ -149,9 +177,12 @@ func NewPrivValidatorFromConfig(
 ) (types.PrivValidator, error) {
 	// Mutual exclusion is also enforced in ValidateBasic, but defend in
 	// depth here in case callers skip validation.
-	if config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != "" &&
-		config.TmkmsListener.IsEnabled() {
+	remoteSignerEnabled := config.RemoteSigner != nil && config.RemoteSigner.ServerAddress != ""
+	if remoteSignerEnabled && config.TmkmsListener.IsEnabled() {
 		return nil, errBothExternalSignersEnabled
+	}
+	if config.YubiHSM.IsEnabled() && (remoteSignerEnabled || config.TmkmsListener.IsEnabled()) {
+		return nil, errMultipleSignerSourcesSet
 	}
 
 	// tmkms-compat path. tmkms holds HRS authority; we don't wrap the

--- a/tm2/pkg/bft/privval/config_test.go
+++ b/tm2/pkg/bft/privval/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/local"
 	rsclient "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/client"
 	rsserver "github.com/gnolang/gno/tm2/pkg/bft/privval/signer/remote/server"
+	"github.com/gnolang/gno/tm2/pkg/bft/privval/signer/yubihsm"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 	"github.com/gnolang/gno/tm2/pkg/log"
@@ -420,5 +421,93 @@ func TestNewPrivValidatorFromConfig(t *testing.T) {
 		}
 		require.NoError(t, err, "port must be released after Init failure")
 		require.NoError(t, rebound.Close())
+	})
+}
+
+// enabledYubiHSMConfig returns a minimally-valid, enabled YubiHSM config for
+// use in the mutual-exclusion tests below. It doesn't need to point at a
+// real device: these tests only exercise validation, not signer construction.
+func enabledYubiHSMConfig() *yubihsm.Config {
+	return &yubihsm.Config{
+		ConnectorURL: "127.0.0.1:12345",
+		AuthKeyID:    1,
+		KeyID:        2,
+	}
+}
+
+func TestPrivValidatorConfig_YubiHSMValidateBasic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil yubihsm config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.YubiHSM = nil
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errNilYubiHSMConfig)
+	})
+
+	t.Run("yubihsm with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.YubiHSM = enabledYubiHSMConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("yubihsm with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.YubiHSM = enabledYubiHSMConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-yubihsm-test.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		assert.ErrorIs(t, cfg.ValidateBasic(), errMultipleSignerSourcesSet)
+	})
+
+	t.Run("yubihsm alone", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.YubiHSM = enabledYubiHSMConfig()
+
+		require.NoError(t, cfg.ValidateBasic())
+	})
+}
+
+func TestPrivValidatorConfig_YubiHSMNewPrivValidator(t *testing.T) {
+	t.Parallel()
+
+	var (
+		privKey = ed25519.GenPrivKey()
+		logger  = log.NewNoopLogger()
+	)
+
+	t.Run("yubihsm with remote signer", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.YubiHSM = enabledYubiHSMConfig()
+		cfg.RemoteSigner.ServerAddress = "tcp://127.0.0.1:26659"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
+	})
+
+	t.Run("yubihsm with tmkms listener", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultPrivValidatorConfig()
+		cfg.RootDir = t.TempDir()
+		cfg.YubiHSM = enabledYubiHSMConfig()
+		cfg.TmkmsListener.ListenAddr = "unix:///tmp/tmkms-yubihsm-test2.sock"
+		cfg.TmkmsListener.ChainID = "test-chain"
+
+		_, err := NewPrivValidatorFromConfig(cfg, privKey, logger)
+		assert.ErrorIs(t, err, errMultipleSignerSourcesSet)
 	})
 }

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -77,11 +77,23 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 		return nil, err
 	}
 
-	// Unmarshal the JSON bytes into a FileKey using amino.
-	fk := &FileKey{}
-	err = amino.UnmarshalJSON(rawJSONBytes, fk)
+	// Parse and validate the FileKey from the JSON bytes.
+	fk, err := ParseFileKey(rawJSONBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
+	}
+
+	return fk, nil
+}
+
+// ParseFileKey unmarshals and validates a FileKey from raw amino JSON bytes.
+// This is exposed so that alternative key sources (e.g. a secrets manager)
+// can reuse the same encoding and validation rules as the on-disk FileKey.
+func ParseFileKey(rawJSONBytes []byte) (*FileKey, error) {
+	// Unmarshal the JSON bytes into a FileKey using amino.
+	fk := &FileKey{}
+	if err := amino.UnmarshalJSON(rawJSONBytes, fk); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal FileKey: %w", err)
 	}
 
 	// Validate the FileKey.

--- a/tm2/pkg/bft/privval/signer/local/key.go
+++ b/tm2/pkg/bft/privval/signer/local/key.go
@@ -77,23 +77,11 @@ func LoadFileKey(filePath string) (*FileKey, error) {
 		return nil, err
 	}
 
-	// Parse and validate the FileKey from the JSON bytes.
-	fk, err := ParseFileKey(rawJSONBytes)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
-	}
-
-	return fk, nil
-}
-
-// ParseFileKey unmarshals and validates a FileKey from raw amino JSON bytes.
-// This is exposed so that alternative key sources (e.g. a secrets manager)
-// can reuse the same encoding and validation rules as the on-disk FileKey.
-func ParseFileKey(rawJSONBytes []byte) (*FileKey, error) {
 	// Unmarshal the JSON bytes into a FileKey using amino.
 	fk := &FileKey{}
-	if err := amino.UnmarshalJSON(rawJSONBytes, fk); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal FileKey: %w", err)
+	err = amino.UnmarshalJSON(rawJSONBytes, fk)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal FileKey from %v: %w", filePath, err)
 	}
 
 	// Validate the FileKey.

--- a/tm2/pkg/bft/privval/signer/yubihsm/client.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/client.go
@@ -1,0 +1,33 @@
+package yubihsm
+
+import (
+	"fmt"
+
+	hsm "github.com/certusone/yubihsm-go"
+	"github.com/certusone/yubihsm-go/commands"
+	"github.com/certusone/yubihsm-go/connector"
+)
+
+// hsmAPI is the subset of a YubiHSM2 session used by the signer. It is
+// defined as an interface so tests can substitute a mock implementation
+// without requiring a physical device or a running yubihsm-connector.
+type hsmAPI interface {
+	SendEncryptedCommand(c *commands.CommandMessage) (commands.Response, error)
+	Destroy()
+}
+
+// hsmAPI is implemented by *hsm.SessionManager.
+var _ hsmAPI = (*hsm.SessionManager)(nil)
+
+// newSession opens an authenticated session with the YubiHSM2 device behind
+// cfg's yubihsm-connector.
+func newSession(cfg *Config) (hsmAPI, error) {
+	conn := connector.NewHTTPConnector(cfg.ConnectorURL)
+
+	sm, err := hsm.NewSessionManager(conn, cfg.AuthKeyID, cfg.Password)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open YubiHSM2 session: %w", err)
+	}
+
+	return sm, nil
+}

--- a/tm2/pkg/bft/privval/signer/yubihsm/client.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/client.go
@@ -24,7 +24,7 @@ var _ hsmAPI = (*hsm.SessionManager)(nil)
 func newSession(cfg *Config) (hsmAPI, error) {
 	conn := connector.NewHTTPConnector(cfg.ConnectorURL)
 
-	sm, err := hsm.NewSessionManager(conn, cfg.AuthKeyID, cfg.Password)
+	sm, err := hsm.NewSessionManager(conn, cfg.AuthKeyID, cfg.resolvePassword())
 	if err != nil {
 		return nil, fmt.Errorf("unable to open YubiHSM2 session: %w", err)
 	}

--- a/tm2/pkg/bft/privval/signer/yubihsm/config.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/config.go
@@ -1,22 +1,35 @@
 package yubihsm
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
 // Config defines the configuration options for a Signer backed by a
 // YubiHSM2 hardware security module, accessed via a yubihsm-connector
 // service.
 type Config struct {
 	// ConnectorURL is the address of the yubihsm-connector service that
-	// bridges this process to the physical YubiHSM2 device (e.g.
-	// "http://127.0.0.1:12345"). If empty, the YubiHSM2 signer is disabled.
-	ConnectorURL string `json:"connector_url" toml:"connector_url" comment:"Address of the yubihsm-connector service (e.g. http://127.0.0.1:12345). If set, the local signer is disabled"`
+	// bridges this process to the physical YubiHSM2 device, as a bare
+	// "host:port" (e.g. "127.0.0.1:12345") — the client prepends the
+	// scheme itself, so a URL with "http://" already included will break.
+	// If empty, the YubiHSM2 signer is disabled.
+	ConnectorURL string `json:"connector_url" toml:"connector_url" comment:"Address of the yubihsm-connector service as host:port, e.g. 127.0.0.1:12345 (no scheme). If set, the local signer is disabled"`
 
 	// AuthKeyID is the Object ID of the Authentication Key used to open a
 	// session with the device.
 	AuthKeyID uint16 `json:"auth_key_id" toml:"auth_key_id" comment:"Object ID of the Authentication Key used to open a session with the device"`
 
-	// Password authenticates against AuthKeyID.
-	Password string `json:"password" toml:"password" comment:"Password for the Authentication Key"`
+	// Password authenticates against AuthKeyID. Storing it directly here
+	// means it lands in config.toml in plaintext; prefer PasswordEnv where
+	// possible so the secret isn't persisted to disk alongside the rest of
+	// the (otherwise non-sensitive) node configuration.
+	Password string `json:"password" toml:"password" comment:"Password for the Authentication Key. Prefer password_env over this where possible"`
+
+	// PasswordEnv, if set, names an environment variable to read the
+	// Authentication Key password from at startup, taking precedence over
+	// Password. This keeps the secret out of config.toml.
+	PasswordEnv string `json:"password_env" toml:"password_env" comment:"Name of an environment variable to read the password from (takes precedence over 'password')"`
 
 	// KeyID is the Object ID of the Ed25519 asymmetric key on the device
 	// holding the validator's private key.
@@ -29,6 +42,7 @@ func DefaultConfig() *Config {
 		ConnectorURL: "", // Empty to disable the YubiHSM2 signer by default.
 		AuthKeyID:    0,
 		Password:     "",
+		PasswordEnv:  "",
 		KeyID:        0,
 	}
 }
@@ -45,14 +59,29 @@ func (cfg *Config) IsEnabled() bool {
 
 // Config validation errors.
 var (
-	errZeroAuthKeyID = errors.New("yubihsm signer: auth_key_id cannot be zero when enabled")
-	errZeroKeyID     = errors.New("yubihsm signer: key_id cannot be zero when enabled")
+	errZeroAuthKeyID       = errors.New("yubihsm signer: auth_key_id cannot be zero when enabled")
+	errZeroKeyID           = errors.New("yubihsm signer: key_id cannot be zero when enabled")
+	errConnectorURLMissing = errors.New(
+		"yubihsm signer: connector_url must be set if auth_key_id, key_id, or a password is configured; " +
+			"otherwise the signer silently falls back to the local file signer")
 )
 
 // ValidateBasic performs basic validation (checking param bounds, etc.) and
 // returns an error if any check fails.
 func (cfg *Config) ValidateBasic() error {
-	if !cfg.IsEnabled() {
+	if cfg == nil {
+		return nil
+	}
+
+	// Guard against a partially-filled-but-technically-disabled config: if
+	// any other yubihsm field is set but connector_url isn't, IsEnabled
+	// reports false and the node would silently fall back to the local
+	// file signer instead of the YubiHSM2 the operator clearly intended to
+	// configure. Fail loudly instead.
+	if cfg.ConnectorURL == "" {
+		if cfg.AuthKeyID != 0 || cfg.KeyID != 0 || cfg.Password != "" || cfg.PasswordEnv != "" {
+			return errConnectorURLMissing
+		}
 		return nil
 	}
 
@@ -65,4 +94,15 @@ func (cfg *Config) ValidateBasic() error {
 	}
 
 	return nil
+}
+
+// resolvePassword returns the Authentication Key password to use: the
+// value of the PasswordEnv environment variable if PasswordEnv is set,
+// otherwise the literal Password field.
+func (cfg *Config) resolvePassword() string {
+	if cfg.PasswordEnv != "" {
+		return os.Getenv(cfg.PasswordEnv)
+	}
+
+	return cfg.Password
 }

--- a/tm2/pkg/bft/privval/signer/yubihsm/config.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/config.go
@@ -1,0 +1,68 @@
+package yubihsm
+
+import "errors"
+
+// Config defines the configuration options for a Signer backed by a
+// YubiHSM2 hardware security module, accessed via a yubihsm-connector
+// service.
+type Config struct {
+	// ConnectorURL is the address of the yubihsm-connector service that
+	// bridges this process to the physical YubiHSM2 device (e.g.
+	// "http://127.0.0.1:12345"). If empty, the YubiHSM2 signer is disabled.
+	ConnectorURL string `json:"connector_url" toml:"connector_url" comment:"Address of the yubihsm-connector service (e.g. http://127.0.0.1:12345). If set, the local signer is disabled"`
+
+	// AuthKeyID is the Object ID of the Authentication Key used to open a
+	// session with the device.
+	AuthKeyID uint16 `json:"auth_key_id" toml:"auth_key_id" comment:"Object ID of the Authentication Key used to open a session with the device"`
+
+	// Password authenticates against AuthKeyID.
+	Password string `json:"password" toml:"password" comment:"Password for the Authentication Key"`
+
+	// KeyID is the Object ID of the Ed25519 asymmetric key on the device
+	// holding the validator's private key.
+	KeyID uint16 `json:"key_id" toml:"key_id" comment:"Object ID of the Ed25519 asymmetric key on the device holding the validator key"`
+}
+
+// DefaultConfig returns a default, disabled configuration for the YubiHSM2 signer.
+func DefaultConfig() *Config {
+	return &Config{
+		ConnectorURL: "", // Empty to disable the YubiHSM2 signer by default.
+		AuthKeyID:    0,
+		Password:     "",
+		KeyID:        0,
+	}
+}
+
+// TestConfig returns a configuration for testing the YubiHSM2 signer.
+func TestConfig() *Config {
+	return DefaultConfig()
+}
+
+// IsEnabled reports whether the YubiHSM2 signer is configured for use.
+func (cfg *Config) IsEnabled() bool {
+	return cfg != nil && cfg.ConnectorURL != ""
+}
+
+// Config validation errors.
+var (
+	errZeroAuthKeyID = errors.New("yubihsm signer: auth_key_id cannot be zero when enabled")
+	errZeroKeyID     = errors.New("yubihsm signer: key_id cannot be zero when enabled")
+)
+
+// ValidateBasic performs basic validation (checking param bounds, etc.) and
+// returns an error if any check fails.
+func (cfg *Config) ValidateBasic() error {
+	if !cfg.IsEnabled() {
+		return nil
+	}
+
+	if cfg.AuthKeyID == 0 {
+		return errZeroAuthKeyID
+	}
+
+	if cfg.KeyID == 0 {
+		return errZeroKeyID
+	}
+
+	return nil
+}

--- a/tm2/pkg/bft/privval/signer/yubihsm/signer.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/signer.go
@@ -1,0 +1,117 @@
+package yubihsm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/certusone/yubihsm-go/commands"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+)
+
+// Signer implements types.Signer by delegating public key retrieval and
+// signing to an Ed25519 key stored in a YubiHSM2 hardware security module.
+// Unlike the file/AWS/GCP/Vault-backed signers, the private key never
+// leaves the device: PubKey is fetched once at construction time and
+// cached, and Sign sends the raw sign-bytes to the device (through the
+// yubihsm-connector) for on-device signing.
+type Signer struct {
+	session hsmAPI
+	keyID   uint16
+	pubKey  ed25519.PubKeyEd25519
+}
+
+// Signer type implements types.Signer.
+var _ types.Signer = (*Signer)(nil)
+
+// PubKey implements types.Signer.
+func (s *Signer) PubKey() crypto.PubKey {
+	return s.pubKey
+}
+
+// Sign implements types.Signer.
+func (s *Signer) Sign(signBytes []byte) ([]byte, error) {
+	cmd, err := commands.CreateSignDataEddsaCommand(s.keyID, signBytes)
+	if err != nil {
+		return nil, fmt.Errorf("yubihsm signer: unable to build sign command: %w", err)
+	}
+
+	resp, err := s.session.SendEncryptedCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("yubihsm signer: sign failed: %w", err)
+	}
+
+	sigResp, ok := resp.(*commands.SignDataEddsaResponse)
+	if !ok {
+		return nil, errUnexpectedResponseType
+	}
+
+	return sigResp.Signature, nil
+}
+
+// Close implements types.Signer. It tears down the session with the device.
+func (s *Signer) Close() error {
+	s.session.Destroy()
+
+	return nil
+}
+
+// Signer type implements fmt.Stringer.
+var _ fmt.Stringer = (*Signer)(nil)
+
+// String implements fmt.Stringer.
+func (s *Signer) String() string {
+	return fmt.Sprintf("{Type: YubiHSM2Signer, Addr: %s}", s.pubKey.Address())
+}
+
+// Config validation errors.
+var (
+	errDisabled               = errors.New("yubihsm signer: not enabled")
+	errInvalidPubKeyLen       = errors.New("yubihsm signer: device returned an unexpected public key length")
+	errUnexpectedResponseType = errors.New("yubihsm signer: unexpected response type from device")
+)
+
+// NewSignerFromConfig opens a session with the YubiHSM2 device behind cfg's
+// yubihsm-connector and returns a ready-to-use Signer bound to cfg.KeyID.
+func NewSignerFromConfig(cfg *Config) (*Signer, error) {
+	if !cfg.IsEnabled() {
+		return nil, errDisabled
+	}
+
+	session, err := newSession(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newSigner(session, cfg.KeyID)
+}
+
+// newSigner contains the constructor logic decoupled from the concrete
+// YubiHSM2 session, so it can be exercised in tests against a mock hsmAPI
+// without requiring a physical device.
+func newSigner(session hsmAPI, keyID uint16) (*Signer, error) {
+	cmd, err := commands.CreateGetPubKeyCommand(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("yubihsm signer: unable to build get-pubkey command: %w", err)
+	}
+
+	resp, err := session.SendEncryptedCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("yubihsm signer: unable to retrieve public key: %w", err)
+	}
+
+	pubKeyResp, ok := resp.(*commands.GetPubKeyResponse)
+	if !ok {
+		return nil, errUnexpectedResponseType
+	}
+
+	if len(pubKeyResp.KeyData) != ed25519.PubKeyEd25519Size {
+		return nil, errInvalidPubKeyLen
+	}
+
+	var pubKey ed25519.PubKeyEd25519
+	copy(pubKey[:], pubKeyResp.KeyData)
+
+	return &Signer{session: session, keyID: keyID, pubKey: pubKey}, nil
+}

--- a/tm2/pkg/bft/privval/signer/yubihsm/signer.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/signer.go
@@ -12,10 +12,10 @@ import (
 
 // Signer implements types.Signer by delegating public key retrieval and
 // signing to an Ed25519 key stored in a YubiHSM2 hardware security module.
-// Unlike the file/AWS/GCP/Vault-backed signers, the private key never
-// leaves the device: PubKey is fetched once at construction time and
-// cached, and Sign sends the raw sign-bytes to the device (through the
-// yubihsm-connector) for on-device signing.
+// Unlike the local file signer, the private key never leaves the device:
+// PubKey is fetched once at construction time and cached, and Sign sends
+// the raw sign-bytes to the device (through the yubihsm-connector) for
+// on-device signing.
 type Signer struct {
 	session hsmAPI
 	keyID   uint16
@@ -47,6 +47,10 @@ func (s *Signer) Sign(signBytes []byte) ([]byte, error) {
 		return nil, errUnexpectedResponseType
 	}
 
+	if len(sigResp.Signature) != ed25519.SignatureSize {
+		return nil, errInvalidSignatureLen
+	}
+
 	return sigResp.Signature, nil
 }
 
@@ -68,8 +72,8 @@ func (s *Signer) String() string {
 // Config validation errors.
 var (
 	errDisabled               = errors.New("yubihsm signer: not enabled")
-	errInvalidPubKeyLen       = errors.New("yubihsm signer: device returned an unexpected public key length")
 	errUnexpectedResponseType = errors.New("yubihsm signer: unexpected response type from device")
+	errInvalidSignatureLen    = errors.New("yubihsm signer: device returned an unexpected signature length")
 )
 
 // NewSignerFromConfig opens a session with the YubiHSM2 device behind cfg's
@@ -84,7 +88,16 @@ func NewSignerFromConfig(cfg *Config) (*Signer, error) {
 		return nil, err
 	}
 
-	return newSigner(session, cfg.KeyID)
+	signer, err := newSigner(session, cfg.KeyID)
+	if err != nil {
+		// Constructor failed after the session was opened: tear it down so
+		// we don't leak an authenticated session (and its keepalive
+		// goroutine) holding one of the device's limited session slots.
+		session.Destroy()
+		return nil, err
+	}
+
+	return signer, nil
 }
 
 // newSigner contains the constructor logic decoupled from the concrete
@@ -107,7 +120,11 @@ func newSigner(session hsmAPI, keyID uint16) (*Signer, error) {
 	}
 
 	if len(pubKeyResp.KeyData) != ed25519.PubKeyEd25519Size {
-		return nil, errInvalidPubKeyLen
+		return nil, fmt.Errorf(
+			"yubihsm signer: key_id %d returned a %d-byte public key (algorithm code %d), expected %d bytes for Ed25519; "+
+				"is key_id pointing at an Ed25519 key?",
+			keyID, len(pubKeyResp.KeyData), pubKeyResp.Algorithm, ed25519.PubKeyEd25519Size,
+		)
 	}
 
 	var pubKey ed25519.PubKeyEd25519

--- a/tm2/pkg/bft/privval/signer/yubihsm/yubihsm_test.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/yubihsm_test.go
@@ -1,0 +1,156 @@
+package yubihsm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/certusone/yubihsm-go/commands"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getPubKeyCmdType and signCmdType are the CommandType values used by the
+// real GetPubKey/SignDataEddsa commands, derived from the real constructors
+// (rather than hardcoded protocol byte values) so the mock stays correct if
+// the underlying wire format ever changes.
+var (
+	getPubKeyCmdType = mustCommandType(commands.CreateGetPubKeyCommand(1))
+	signCmdType      = mustCommandType(commands.CreateSignDataEddsaCommand(1, []byte("x")))
+)
+
+func mustCommandType(cmd *commands.CommandMessage, err error) commands.CommandType {
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd.CommandType
+}
+
+// mockSession is a fake implementing hsmAPI, used so tests never require a
+// physical YubiHSM2 device or a running yubihsm-connector.
+type mockSession struct {
+	pubKeyData []byte
+	signature  []byte
+
+	sendErr   error
+	destroyed bool
+}
+
+func (m *mockSession) SendEncryptedCommand(c *commands.CommandMessage) (commands.Response, error) {
+	if m.sendErr != nil {
+		return nil, m.sendErr
+	}
+
+	switch c.CommandType {
+	case getPubKeyCmdType:
+		return &commands.GetPubKeyResponse{KeyData: m.pubKeyData}, nil
+	case signCmdType:
+		return &commands.SignDataEddsaResponse{Signature: m.signature}, nil
+	default:
+		return nil, errors.New("mockSession: unexpected command type")
+	}
+}
+
+func (m *mockSession) Destroy() {
+	m.destroyed = true
+}
+
+func TestNewSigner_ValidDevice(t *testing.T) {
+	t.Parallel()
+
+	session := &mockSession{
+		pubKeyData: make([]byte, 32),
+		signature:  make([]byte, 64),
+	}
+	session.pubKeyData[0] = 0xAB
+	session.signature[0] = 0xCD
+
+	signer, err := newSigner(session, 42)
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+
+	assert.Equal(t, session.pubKeyData, signer.pubKey[:])
+	assert.Contains(t, signer.String(), "YubiHSM2Signer")
+
+	sig, err := signer.Sign([]byte("sign-bytes"))
+	require.NoError(t, err)
+	assert.Equal(t, session.signature, sig)
+
+	assert.NoError(t, signer.Close())
+	assert.True(t, session.destroyed)
+}
+
+func TestNewSigner_SendCommandError(t *testing.T) {
+	t.Parallel()
+
+	session := &mockSession{sendErr: errors.New("connector unreachable")}
+
+	signer, err := newSigner(session, 42)
+	require.Error(t, err)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_InvalidPubKeyLength(t *testing.T) {
+	t.Parallel()
+
+	session := &mockSession{pubKeyData: make([]byte, 16)} // wrong length
+
+	signer, err := newSigner(session, 42)
+	require.ErrorIs(t, err, errInvalidPubKeyLen)
+	assert.Nil(t, signer)
+}
+
+func TestNewSigner_SignError(t *testing.T) {
+	t.Parallel()
+
+	session := &mockSession{
+		pubKeyData: make([]byte, 32),
+		sendErr:    nil,
+	}
+
+	signer, err := newSigner(session, 42)
+	require.NoError(t, err)
+
+	// Now make subsequent calls fail (the Sign call).
+	session.sendErr = errors.New("device error")
+
+	sig, err := signer.Sign([]byte("sign-bytes"))
+	require.Error(t, err)
+	assert.Nil(t, sig)
+}
+
+func TestConfig_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (&Config{}).IsEnabled())
+	assert.False(t, (*Config)(nil).IsEnabled())
+	assert.True(t, (&Config{ConnectorURL: "http://127.0.0.1:12345"}).IsEnabled())
+}
+
+func TestConfig_ValidateBasic(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, (&Config{}).ValidateBasic())
+
+	assert.ErrorIs(t, (&Config{
+		ConnectorURL: "http://127.0.0.1:12345",
+	}).ValidateBasic(), errZeroAuthKeyID)
+
+	assert.ErrorIs(t, (&Config{
+		ConnectorURL: "http://127.0.0.1:12345",
+		AuthKeyID:    1,
+	}).ValidateBasic(), errZeroKeyID)
+
+	assert.NoError(t, (&Config{
+		ConnectorURL: "http://127.0.0.1:12345",
+		AuthKeyID:    1,
+		KeyID:        2,
+	}).ValidateBasic())
+}
+
+func TestNewSignerFromConfig_Disabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSignerFromConfig(DefaultConfig())
+	require.ErrorIs(t, err, errDisabled)
+}

--- a/tm2/pkg/bft/privval/signer/yubihsm/yubihsm_test.go
+++ b/tm2/pkg/bft/privval/signer/yubihsm/yubihsm_test.go
@@ -96,8 +96,26 @@ func TestNewSigner_InvalidPubKeyLength(t *testing.T) {
 	session := &mockSession{pubKeyData: make([]byte, 16)} // wrong length
 
 	signer, err := newSigner(session, 42)
-	require.ErrorIs(t, err, errInvalidPubKeyLen)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key_id 42")
+	assert.Contains(t, err.Error(), "16-byte")
 	assert.Nil(t, signer)
+}
+
+func TestNewSigner_InvalidSignatureLength(t *testing.T) {
+	t.Parallel()
+
+	session := &mockSession{
+		pubKeyData: make([]byte, 32),
+		signature:  make([]byte, 16), // wrong length
+	}
+
+	signer, err := newSigner(session, 42)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign([]byte("sign-bytes"))
+	require.ErrorIs(t, err, errInvalidSignatureLen)
+	assert.Nil(t, sig)
 }
 
 func TestNewSigner_SignError(t *testing.T) {
@@ -124,7 +142,7 @@ func TestConfig_IsEnabled(t *testing.T) {
 
 	assert.False(t, (&Config{}).IsEnabled())
 	assert.False(t, (*Config)(nil).IsEnabled())
-	assert.True(t, (&Config{ConnectorURL: "http://127.0.0.1:12345"}).IsEnabled())
+	assert.True(t, (&Config{ConnectorURL: "127.0.0.1:12345"}).IsEnabled())
 }
 
 func TestConfig_ValidateBasic(t *testing.T) {
@@ -133,19 +151,43 @@ func TestConfig_ValidateBasic(t *testing.T) {
 	assert.NoError(t, (&Config{}).ValidateBasic())
 
 	assert.ErrorIs(t, (&Config{
-		ConnectorURL: "http://127.0.0.1:12345",
+		ConnectorURL: "127.0.0.1:12345",
 	}).ValidateBasic(), errZeroAuthKeyID)
 
 	assert.ErrorIs(t, (&Config{
-		ConnectorURL: "http://127.0.0.1:12345",
+		ConnectorURL: "127.0.0.1:12345",
 		AuthKeyID:    1,
 	}).ValidateBasic(), errZeroKeyID)
 
 	assert.NoError(t, (&Config{
-		ConnectorURL: "http://127.0.0.1:12345",
+		ConnectorURL: "127.0.0.1:12345",
 		AuthKeyID:    1,
 		KeyID:        2,
 	}).ValidateBasic())
+}
+
+func TestConfig_ValidateBasic_PartiallyConfiguredButDisabled(t *testing.T) {
+	t.Parallel()
+
+	// connector_url unset but other fields set: this used to silently read
+	// as "disabled" and fall through to the local file signer. It must now
+	// be rejected instead.
+	assert.ErrorIs(t, (&Config{AuthKeyID: 1}).ValidateBasic(), errConnectorURLMissing)
+	assert.ErrorIs(t, (&Config{KeyID: 1}).ValidateBasic(), errConnectorURLMissing)
+	assert.ErrorIs(t, (&Config{Password: "x"}).ValidateBasic(), errConnectorURLMissing)
+	assert.ErrorIs(t, (&Config{PasswordEnv: "X"}).ValidateBasic(), errConnectorURLMissing)
+}
+
+func TestConfig_ResolvePassword(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "literal", (&Config{Password: "literal"}).resolvePassword())
+
+	t.Setenv("YUBIHSM_TEST_PASSWORD", "from-env")
+	assert.Equal(t, "from-env", (&Config{
+		Password:    "literal",
+		PasswordEnv: "YUBIHSM_TEST_PASSWORD",
+	}).resolvePassword())
 }
 
 func TestNewSignerFromConfig_Disabled(t *testing.T) {


### PR DESCRIPTION
Adds a signer that delegates signing to an Ed25519 key stored in a YubiHSM2 hardware security module, accessed through a yubihsm-connector service. Like a Ledger device, the private key never leaves the hardware — PubKey is cached at startup and Sign forwards raw bytes to the device.

Closes #3236