### PR TITLE
feat: add token-bound-account realm example using realm.Sub()

### DIFF
--- a/examples/gno.land/r/zeycan1/tba/gnomod.toml
+++ b/examples/gno.land/r/zeycan1/tba/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/zeycan1/tba"
+gno = "0.9"

--- a/examples/gno.land/r/zeycan1/tba/tba.gno
+++ b/examples/gno.land/r/zeycan1/tba/tba.gno
@@ -1,0 +1,155 @@
+package tba
+
+import (
+	"strconv"
+	"strings"
+
+	"chain"
+	"chain/banker"
+	"chain/runtime/unsafe"
+
+	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/nt/avl/v0"
+)
+
+const selfPath = "gno.land/r/zeycan1/tba"
+
+type tokenMeta struct {
+	name  string
+	image string
+}
+
+var (
+	nft       *grc721.BasicNFT
+	admin     address
+	nextID    int64 = 1
+	allTokens []grc721.TokenID
+	metaByID  avl.Tree // tokenID string -> *tokenMeta
+)
+
+func init() {
+	admin = address(unsafe.PreviousRealm().Address())
+}
+
+func Setup(cur realm) {
+	if nft != nil {
+		panic("already initialized")
+	}
+	caller := cur.Previous().Address()
+	if caller != admin {
+		panic("only admin can initialize")
+	}
+	nft = grc721.NewBasicNFT(0, cur, "Token Bound Account", "TBA")
+}
+
+func Mint(cur realm, to address, name string, image string) grc721.TokenID {
+	caller := cur.Previous().Address()
+	if caller != admin {
+		panic("only admin can mint")
+	}
+	tid := grc721.TokenID(strconv.FormatInt(nextID, 10))
+	nextID++
+	if err := nft.Mint(to, tid); err != nil {
+		panic(err)
+	}
+	allTokens = append(allTokens, tid)
+	metaByID.Set(string(tid), &tokenMeta{name: name, image: image})
+	return tid
+}
+
+func vaultSubpath(tid grc721.TokenID) string {
+	return "vault/" + string(tid)
+}
+
+func VaultAddress(tid grc721.TokenID) address {
+	return chain.DerivePkgSubAddr(selfPath, vaultSubpath(tid))
+}
+
+func Balance(tid grc721.TokenID) int64 {
+	coins := banker.NewReadonlyBanker().GetCoins(VaultAddress(tid))
+	return coins.AmountOf("ugnot")
+}
+
+func Withdraw(cur realm, tid grc721.TokenID, to address, amount int64) {
+	caller := cur.Previous().Address()
+	owner, err := nft.OwnerOf(tid)
+	if err != nil {
+		panic(err)
+	}
+	if caller != owner {
+		panic("caller is not the current owner of this token")
+	}
+
+	sub := cur.Sub(vaultSubpath(tid))
+	b := banker.NewBanker(banker.BankerTypeRealmSend, sub)
+	b.SendCoins(sub.Address(), to, chain.NewCoins(chain.NewCoin("ugnot", amount)))
+}
+
+func OwnerOf(tid grc721.TokenID) (address, error) {
+	return nft.OwnerOf(tid)
+}
+
+func BalanceOfOwner(owner address) (int64, error) {
+	return nft.BalanceOf(owner)
+}
+
+func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
+	caller := cur.Previous().Address()
+	return nft.TransferFrom(caller, from, to, tid)
+}
+
+func AllTokens() []grc721.TokenID {
+	return allTokens
+}
+
+func TokensOf(owner address) []grc721.TokenID {
+	var out []grc721.TokenID
+	for _, tid := range allTokens {
+		o, err := nft.OwnerOf(tid)
+		if err == nil && o == owner {
+			out = append(out, tid)
+		}
+	}
+	return out
+}
+
+func TokenInfo(tid grc721.TokenID) (name string, image string, owner address, vault address, balance int64, err error) {
+	owner, err = nft.OwnerOf(tid)
+	if err != nil {
+		return "", "", "", "", 0, err
+	}
+	vault = VaultAddress(tid)
+	balance = Balance(tid)
+	if v := metaByID.Get(string(tid)); v != nil {
+		m := v.(*tokenMeta)
+		name = m.name
+		image = m.image
+	}
+	return name, image, owner, vault, balance, nil
+}
+
+func Render(path string) string {
+	if nft == nil {
+		return "# Token Bound Accounts\n\nNot initialized yet. Call Setup() first.\n"
+	}
+	return nft.RenderHome()
+}
+
+// --- Frontend-friendly CSV variants (avoid slice-ref parsing issues) ---
+
+func AllTokensCSV() string {
+	ids := make([]string, len(allTokens))
+	for i, t := range allTokens {
+		ids[i] = string(t)
+	}
+	return strings.Join(ids, ",")
+}
+
+func TokensOfCSV(owner address) string {
+	toks := TokensOf(owner)
+	ids := make([]string, len(toks))
+	for i, t := range toks {
+		ids[i] = string(t)
+	}
+	return strings.Join(ids, ",")
+}

--- a/examples/gno.land/r/zeycan1/tba/tba.gno
+++ b/examples/gno.land/r/zeycan1/tba/tba.gno
@@ -6,13 +6,16 @@ import (
 
 	"chain"
 	"chain/banker"
-	"chain/runtime/unsafe"
 
 	"gno.land/p/demo/tokens/grc721"
 	"gno.land/p/nt/avl/v0"
 )
 
-const selfPath = "gno.land/r/zeycan1/tba"
+// admin is fixed to the deployer's address. Unlike deriving it from
+// unsafe.PreviousRealm() at package init, this stays correct regardless of
+// which key signs the addpkg transaction (e.g. examples/ deployments signed
+// by a genesis key).
+const admin = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
 
 type tokenMeta struct {
 	name  string
@@ -20,17 +23,22 @@ type tokenMeta struct {
 }
 
 var (
-	nft       *grc721.BasicNFT
-	admin     address
+	nft *grc721.BasicNFT
+
+	// realmPath is captured from cur.PkgPath() the first time Setup runs,
+	// i.e. it reflects wherever this code is actually deployed. VaultAddress
+	// and Balance derive from this instead of a hardcoded constant, so a
+	// copy of this file deployed at another path cannot advertise a vault
+	// address it does not control.
+	realmPath string
+
 	nextID    int64 = 1
 	allTokens []grc721.TokenID
 	metaByID  avl.Tree // tokenID string -> *tokenMeta
 )
 
-func init() {
-	admin = address(unsafe.PreviousRealm().Address())
-}
-
+// Setup initializes the realm. Must be called once, by admin, before Mint,
+// Withdraw, or TransferFrom can be used.
 func Setup(cur realm) {
 	if nft != nil {
 		panic("already initialized")
@@ -39,10 +47,16 @@ func Setup(cur realm) {
 	if caller != admin {
 		panic("only admin can initialize")
 	}
+	realmPath = cur.PkgPath()
 	nft = grc721.NewBasicNFT(0, cur, "Token Bound Account", "TBA")
 }
 
+// Mint creates a new token-bound-account NFT and assigns it to `to`.
+// Only admin can mint. Must be called after Setup.
 func Mint(cur realm, to address, name string, image string) grc721.TokenID {
+	if nft == nil {
+		panic("not initialized: call Setup first")
+	}
 	caller := cur.Previous().Address()
 	if caller != admin {
 		panic("only admin can mint")
@@ -61,16 +75,25 @@ func vaultSubpath(tid grc721.TokenID) string {
 	return "vault/" + string(tid)
 }
 
+// VaultAddress returns the on-chain vault address for a given token.
 func VaultAddress(tid grc721.TokenID) address {
-	return chain.DerivePkgSubAddr(selfPath, vaultSubpath(tid))
+	return chain.DerivePkgSubAddr(realmPath, vaultSubpath(tid))
 }
 
+// Balance returns the ugnot balance held in a token's vault.
 func Balance(tid grc721.TokenID) int64 {
 	coins := banker.NewReadonlyBanker().GetCoins(VaultAddress(tid))
 	return coins.AmountOf("ugnot")
 }
 
+// Withdraw sends `amount` ugnot from a token's vault to `to`. Only the
+// current owner of the token may withdraw. Note: the vault is drainable by
+// the current owner up to the moment a transfer lands, since Withdraw and
+// TransferFrom are separate transactions (the same property ERC-6551 has).
 func Withdraw(cur realm, tid grc721.TokenID, to address, amount int64) {
+	if amount <= 0 {
+		panic("amount must be positive")
+	}
 	caller := cur.Previous().Address()
 	owner, err := nft.OwnerOf(tid)
 	if err != nil {
@@ -85,23 +108,33 @@ func Withdraw(cur realm, tid grc721.TokenID, to address, amount int64) {
 	b.SendCoins(sub.Address(), to, chain.NewCoins(chain.NewCoin("ugnot", amount)))
 }
 
+// OwnerOf returns the current owner of a token.
 func OwnerOf(tid grc721.TokenID) (address, error) {
 	return nft.OwnerOf(tid)
 }
 
+// BalanceOfOwner returns how many tokens an address owns.
 func BalanceOfOwner(owner address) (int64, error) {
 	return nft.BalanceOf(owner)
 }
 
-func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
+// TransferFrom transfers a token (and control of its vault) from one owner
+// to another. Panics if the caller is not the owner or an approved operator,
+// so an unauthorized attempt aborts the transaction instead of committing a
+// silent no-op.
+func TransferFrom(cur realm, from, to address, tid grc721.TokenID) {
 	caller := cur.Previous().Address()
-	return nft.TransferFrom(caller, from, to, tid)
+	if err := nft.TransferFrom(caller, from, to, tid); err != nil {
+		panic(err)
+	}
 }
 
+// AllTokens returns every minted token ID.
 func AllTokens() []grc721.TokenID {
 	return allTokens
 }
 
+// TokensOf returns every token ID owned by `owner`.
 func TokensOf(owner address) []grc721.TokenID {
 	var out []grc721.TokenID
 	for _, tid := range allTokens {
@@ -113,6 +146,8 @@ func TokensOf(owner address) []grc721.TokenID {
 	return out
 }
 
+// TokenInfo returns the metadata, owner, vault address, and balance for a
+// token in one call.
 func TokenInfo(tid grc721.TokenID) (name string, image string, owner address, vault address, balance int64, err error) {
 	owner, err = nft.OwnerOf(tid)
 	if err != nil {
@@ -128,11 +163,32 @@ func TokenInfo(tid grc721.TokenID) (name string, image string, owner address, va
 	return name, image, owner, vault, balance, nil
 }
 
+// Render implements the realm's default render function. When path names a
+// specific token id, it shows that token's vault details instead of just
+// the collection header.
 func Render(path string) string {
 	if nft == nil {
 		return "# Token Bound Accounts\n\nNot initialized yet. Call Setup() first.\n"
 	}
-	return nft.RenderHome()
+	if path == "" {
+		return nft.RenderHome()
+	}
+
+	tid := grc721.TokenID(strings.TrimPrefix(path, "token/"))
+	name, image, owner, vault, balance, err := TokenInfo(tid)
+	if err != nil {
+		return "# Token Bound Accounts\n\nToken not found: " + string(tid) + "\n"
+	}
+
+	var b strings.Builder
+	b.WriteString("# " + name + "\n\n")
+	if image != "" {
+		b.WriteString("![" + name + "](" + image + ")\n\n")
+	}
+	b.WriteString("- Owner: " + owner.String() + "\n")
+	b.WriteString("- Vault: " + vault.String() + "\n")
+	b.WriteString("- Balance: " + strconv.FormatInt(balance, 10) + " ugnot\n")
+	return b.String()
 }
 
 // --- Frontend-friendly CSV variants (avoid slice-ref parsing issues) ---

--- a/examples/gno.land/r/zeycan1/tba/tba_test.gno
+++ b/examples/gno.land/r/zeycan1/tba/tba_test.gno
@@ -1,0 +1,131 @@
+package tba
+
+import (
+	"testing"
+
+	"chain"
+
+	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/uassert/v0"
+)
+
+var (
+	aliceAddr = testutils.TestAddress("alice")
+	bobAddr   = testutils.TestAddress("bob")
+)
+
+// setup makes the realm usable from a unit test and mints one token to
+// alice, returning its id. Uses cross(cur) for the crossing calls into
+// Setup/Mint, matching how any external caller invokes them.
+func setup(cur realm, t *testing.T) grc721.TokenID {
+	t.Helper()
+	testing.SetRealm(testing.NewUserRealm(admin))
+	if nft == nil {
+		Setup(cross(cur))
+	}
+	return Mint(cross(cur), aliceAddr, "art", "ipfs://img")
+}
+
+func TestSetupOnlyAdmin(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(bobAddr))
+	uassert.AbortsContains(t, cur, "only admin can initialize", func(cur realm) {
+		Setup(cross(cur))
+	}, "non-admin Setup should abort")
+}
+
+func TestMintOnlyAdmin(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(admin))
+	if nft == nil {
+		Setup(cross(cur))
+	}
+
+	testing.SetRealm(testing.NewUserRealm(bobAddr))
+	uassert.AbortsContains(t, cur, "only admin can mint", func(cur realm) {
+		Mint(cross(cur), bobAddr, "art", "ipfs://img")
+	}, "non-admin Mint should abort")
+}
+
+// TestTransferFromSucceedsForOwner: the owner of a token must be able to
+// transfer it. This is the case that failed in the earlier draft test
+// (address mismatch in the test's own expectations) — re-verified here
+// against the actual owner returned by OwnerOf, not a hardcoded literal.
+func TestTransferFromSucceedsForOwner(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+
+	ownerBefore, err := OwnerOf(tid)
+	uassert.NoError(t, err, "OwnerOf should not error")
+	uassert.Equal(t, aliceAddr.String(), ownerBefore.String(), "alice should own the freshly minted token")
+
+	testing.SetRealm(testing.NewUserRealm(aliceAddr))
+	TransferFrom(cross(cur), aliceAddr, bobAddr, tid)
+
+	ownerAfter, err := OwnerOf(tid)
+	uassert.NoError(t, err, "OwnerOf should not error after transfer")
+	uassert.Equal(t, bobAddr.String(), ownerAfter.String(), "bob should own the token after owner-initiated transfer")
+}
+
+// TestTransferFromAbortsWhenUnauthorized: a caller who is neither the owner
+// nor an approved operator must not be able to move the token. The realm's
+// TransferFrom panics on the underlying error instead of returning it, so
+// the transaction aborts rather than silently committing a no-op.
+func TestTransferFromAbortsWhenUnauthorized(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+
+	testing.SetRealm(testing.NewUserRealm(bobAddr))
+	uassert.AbortsContains(t, cur, "caller is not token owner or approved", func(cur realm) {
+		TransferFrom(cross(cur), aliceAddr, bobAddr, tid)
+	}, "unauthorized transfer should abort")
+
+	owner, err := OwnerOf(tid)
+	uassert.NoError(t, err, "OwnerOf should not error")
+	uassert.Equal(t, aliceAddr.String(), owner.String(), "ownership must be unchanged after a rejected transfer")
+}
+
+func TestWithdrawRejectsNonPositive(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+	testing.IssueCoins(VaultAddress(tid), chain.NewCoins(chain.NewCoin("ugnot", 1000)))
+
+	testing.SetRealm(testing.NewUserRealm(aliceAddr))
+	uassert.AbortsContains(t, cur, "amount must be positive", func(cur realm) {
+		Withdraw(cross(cur), tid, bobAddr, 0)
+	}, "zero-amount withdraw should abort")
+
+	uassert.Equal(t, int64(1000), Balance(tid), "vault balance must be unchanged after a rejected withdraw")
+}
+
+func TestWithdrawOnlyOwner(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+	testing.IssueCoins(VaultAddress(tid), chain.NewCoins(chain.NewCoin("ugnot", 1000)))
+
+	testing.SetRealm(testing.NewUserRealm(bobAddr))
+	uassert.AbortsContains(t, cur, "caller is not the current owner", func(cur realm) {
+		Withdraw(cross(cur), tid, bobAddr, 100)
+	}, "non-owner withdraw should abort")
+
+	uassert.Equal(t, int64(1000), Balance(tid), "vault balance must be unchanged after a rejected withdraw")
+}
+
+func TestWithdrawSucceedsForOwner(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+	testing.IssueCoins(VaultAddress(tid), chain.NewCoins(chain.NewCoin("ugnot", 1000)))
+
+	testing.SetRealm(testing.NewUserRealm(aliceAddr))
+	Withdraw(cross(cur), tid, bobAddr, 400)
+
+	uassert.Equal(t, int64(600), Balance(tid), "vault balance should decrease by the withdrawn amount")
+}
+
+// TestVaultAddressDeterministic: VaultAddress must derive from the realm's
+// actual deploy path (captured in Setup), not a hardcoded constant — this
+// is the fix for the "copy advertises the original realm's vault" issue.
+// We can't deploy a second copy from a unit test, but we can at least
+// confirm VaultAddress is deterministic and non-empty for the realm under
+// test.
+func TestVaultAddressDeterministic(cur realm, t *testing.T) {
+	tid := setup(cur, t)
+	v1 := VaultAddress(tid)
+	v2 := VaultAddress(tid)
+	uassert.Equal(t, v1.String(), v2.String(), "VaultAddress must be deterministic for the same token")
+	uassert.True(t, v1.String() != "", "VaultAddress must not be empty")
+}


### PR DESCRIPTION
Demonstrates the new sub-realm identity primitive (PR #5890) with a practical pattern: each NFT in a GRC721 collection is minted alongside its own deterministic on-chain vault address. Anyone can deposit into the vault directly; only the current NFT owner can withdraw. Transferring the NFT transfers control of the vault with no extra step.

Tested end-to-end on gnodev: mint, deposit, owner-gated withdraw, transfer, and post-transfer access revocation for the previous owner.

## What

Adds a working example realm demonstrating the new `realm.Sub()` 
sub-realm identity primitive (#5890): each NFT in a GRC721 collection 
is minted alongside its own deterministic on-chain vault address. 
Anyone can deposit into the vault directly; only the current NFT owner 
can withdraw. Transferring the NFT transfers control of the vault with 
no extra step required.

## Why

`realm.Sub()` is very new and I couldn't find an existing example that 
uses it for a practical, end-user-facing pattern (the merged tests are 
great for understanding the mechanics, but this shows a full applied 
use case). This pattern is similar to ERC-6551 (Token Bound Accounts) 
on Ethereum, adapted to Gno's sub-realm model.

## Testing

Tested end-to-end on `gnodev`:
- Mint → deposit (plain bank send to the vault address) → owner-gated 
  withdraw → transfer → previous owner correctly loses withdraw access
- A minimal Next.js frontend with Adena wallet integration was also 
  built and tested against this realm (not included in this PR, happy 
  to share separately if useful)

Also asked in a comment on #5890 whether there's a public testnet 
tracking master where this would already be live, since Test13 
predates this feature.

## Notes

Open to feedback on the pattern itself  e.g. whether admin-gated 
minting is the right default for an example, or whether it should be 
public-mint to keep the example simpler.