### PR TITLE
fix(gnodev): disable `PeerExchange`

### DIFF
--- a/contribs/gnodev/pkg/dev/node.go
+++ b/contribs/gnodev/pkg/dev/node.go
@@ -91,6 +91,10 @@ func DefaultNodeConfig(rootdir, domain string) *NodeConfig {
 	tmc.Consensus.SkipTimeoutCommit = false // avoid time drifting, see issue #1507
 	tmc.Consensus.WALDisabled = true
 	tmc.Consensus.CreateEmptyBlocks = false
+	// The dev node is in-memory and single-validator, so it never peers. Disable
+	// peer exchange to avoid persisting an address book under rootdir, which fails
+	// when rootdir is read-only (e.g. `go tool gnodev` against the module cache).
+	tmc.P2P.PeerExchange = false
 
 	defaultDeployer := crypto.MustAddressFromString(integration.DefaultAccount_Address)
 	balances := []gnoland.Balance{


### PR DESCRIPTION
`gnodev` is always in-memory and single-validator, so it never peers. Yet `DefaultNodeConfig` inherited `P2P.PeerExchange=true` from `TestConfig`, and that flag is the sole trigger for persisting an address book at `<rootdir>/config/addrbook.json` (introduced in #5861).

Node init therefore fails with "unable to create address book directory: permission denied" whenever rootdir is read-only -- e.g. running `go tool gnodev`, where the gno root resolves to the read-only Go module cache.

Disable peer exchange for the in-memory node: it removes the pointless addrbook write (and discovery reactor) with no functional loss.