### PR TITLE
gnovm: add -X flag to gno run and gno test

### DIFF
--- a/gnovm/cmd/gno/run.go
+++ b/gnovm/cmd/gno/run.go
@@ -25,6 +25,7 @@ type runCmd struct {
 	debug     bool
 	debugAddr string
 	pkgPath   string
+	xVars     *xFlag
 }
 
 func newRunCmd(cio commands.IO) *commands.Command {
@@ -84,6 +85,14 @@ func (c *runCmd) RegisterFlags(fs *flag.FlagSet) {
 		"pkgpath",
 		"",
 		"run with this package path, overriding the \"// PKGPATH:\" file directive and the gnomod.toml module path",
+	)
+
+	c.xVars = newXFlag()
+	fs.Var(
+		c.xVars,
+		"X",
+		"set the value of a package-level string variable, e.g. -X myVar=override (may be repeated); "+
+			"like 'go build -ldflags \"-X ...\"', only simple 'var name = \"...\"' declarations are patched",
 	)
 }
 
@@ -272,7 +281,7 @@ func execRun(cfg *runCmd, args []string, cio commands.IO) error {
 	}
 
 	// read files
-	files, err := parseFiles(m, args, stderr)
+	files, err := parseFiles(m, args, stderr, cfg.xVars.values)
 	if err != nil {
 		return err
 	}
@@ -335,7 +344,7 @@ func derivePkgPath(arg string) (string, error) {
 	return mod.Module, nil
 }
 
-func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser) ([]*gno.FileNode, error) {
+func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrides map[string]string) ([]*gno.FileNode, error) {
 	files := make([]*gno.FileNode, 0, len(fpaths))
 	var didPanic bool
 	for _, fpath := range fpaths {
@@ -344,7 +353,7 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser) ([]*gno.
 			if err != nil {
 				return nil, err
 			}
-			subFiles, err := parseFiles(m, subFns, stderr)
+			subFiles, err := parseFiles(m, subFns, stderr, xOverrides)
 			if err != nil {
 				return nil, err
 			}
@@ -358,7 +367,7 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser) ([]*gno.
 
 		dir, fname := filepath.Split(fpath)
 		didPanic = catchPanic(dir, fname, stderr, func() {
-			files = append(files, m.MustReadFile(fpath))
+			files = append(files, mustReadAndPatchFile(m, fpath, xOverrides))
 		})
 	}
 
@@ -366,6 +375,22 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser) ([]*gno.
 		return nil, commands.ExitCodeError(1)
 	}
 	return files, nil
+}
+
+// mustReadAndPatchFile reads fpath, applies any -X overrides to its
+// package-level string variable declarations (see patchXVars), and parses
+// the (possibly patched) result. It panics on error, like
+// (*gno.Machine).MustReadFile, which it replaces as the read path here so
+// that overrides can be applied before parsing.
+func mustReadAndPatchFile(m *gno.Machine, fpath string, xOverrides map[string]string) *gno.FileNode {
+	bz, err := os.ReadFile(fpath)
+	if err != nil {
+		panic(err)
+	}
+
+	body := patchXVars(fpath, string(bz), xOverrides)
+
+	return m.MustParseFile(fpath, body)
 }
 
 func listNonTestFiles(dir string) ([]string, error) {

--- a/gnovm/cmd/gno/run.go
+++ b/gnovm/cmd/gno/run.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
@@ -91,8 +92,9 @@ func (c *runCmd) RegisterFlags(fs *flag.FlagSet) {
 	fs.Var(
 		c.xVars,
 		"X",
-		"set the value of a package-level string variable, e.g. -X myVar=override (may be repeated); "+
-			"like 'go build -ldflags \"-X ...\"', only simple 'var name = \"...\"' declarations are patched",
+		"set the value of a package-level string variable, e.g. -X main.myVar=override or "+
+			"-X gno.land/r/demo/foo.Version=1.2.3 (may be repeated); like 'go build -ldflags \"-X ...\"', "+
+			"the package path must be given, and only simple 'var name = \"...\"' declarations are patched",
 	)
 }
 
@@ -281,8 +283,13 @@ func execRun(cfg *runCmd, args []string, cio commands.IO) error {
 	}
 
 	// read files
-	files, err := parseFiles(m, args, stderr, cfg.xVars.values)
+	xOverrides := cfg.xVars.forPackage(pkgPath, pkgName)
+	xt := newXTracker()
+	files, err := parseFiles(m, args, stderr, xOverrides, xt)
 	if err != nil {
+		return err
+	}
+	if err := xt.unmatched(xOverrides); err != nil {
 		return err
 	}
 
@@ -344,7 +351,70 @@ func derivePkgPath(arg string) (string, error) {
 	return mod.Module, nil
 }
 
-func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrides map[string]string) ([]*gno.FileNode, error) {
+// xTracker aggregates which -X overrides were matched (as a proper
+// package-level string var) across all files in a package, so a name that
+// isn't found in file1.gno but is in file2.gno doesn't get wrongly
+// reported as unmatched, and a name that's genuinely never found anywhere
+// is reported exactly once at the end, rather than per-file.
+type xTracker struct {
+	matched   map[string]bool
+	wrongKind map[string]bool
+}
+
+func newXTracker() *xTracker {
+	return &xTracker{matched: map[string]bool{}, wrongKind: map[string]bool{}}
+}
+
+func (t *xTracker) record(result xPatchResult) {
+	for _, n := range result.Matched {
+		t.matched[n] = true
+	}
+	// A name reported as WrongKind here might still turn out matched in
+	// another file; it's only finalized as an explanation in unmatched()
+	// once all files have been processed.
+	for _, n := range result.WrongKind {
+		t.wrongKind[n] = true
+	}
+}
+
+// unmatched returns, for each requested override name not found as a
+// proper package-level string var in any processed file, an error
+// explaining why: either it was never found at all, or it was found but
+// isn't a plain string var (a const, a different type, or missing an
+// initializer).
+func (t *xTracker) unmatched(requested map[string]string) error {
+	var notFound, wrongKind []string
+
+	for name := range requested {
+		switch {
+		case t.matched[name]:
+			continue
+		case t.wrongKind[name]:
+			wrongKind = append(wrongKind, name)
+		default:
+			notFound = append(notFound, name)
+		}
+	}
+
+	if len(notFound) == 0 && len(wrongKind) == 0 {
+		return nil
+	}
+
+	sort.Strings(notFound)
+	sort.Strings(wrongKind)
+
+	var msgs []string
+	for _, n := range notFound {
+		msgs = append(msgs, fmt.Sprintf("-X: no such package-level var: %s", n))
+	}
+	for _, n := range wrongKind {
+		msgs = append(msgs, fmt.Sprintf("-X: %s is not a package-level string var with a literal initializer", n))
+	}
+
+	return errors.New(strings.Join(msgs, "\n"))
+}
+
+func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrides map[string]string, xt *xTracker) ([]*gno.FileNode, error) {
 	files := make([]*gno.FileNode, 0, len(fpaths))
 	var didPanic bool
 	for _, fpath := range fpaths {
@@ -353,7 +423,7 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrid
 			if err != nil {
 				return nil, err
 			}
-			subFiles, err := parseFiles(m, subFns, stderr, xOverrides)
+			subFiles, err := parseFiles(m, subFns, stderr, xOverrides, xt)
 			if err != nil {
 				return nil, err
 			}
@@ -367,7 +437,7 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrid
 
 		dir, fname := filepath.Split(fpath)
 		didPanic = catchPanic(dir, fname, stderr, func() {
-			files = append(files, mustReadAndPatchFile(m, fpath, xOverrides))
+			files = append(files, mustReadAndPatchFile(m, fpath, xOverrides, xt))
 		})
 	}
 
@@ -381,14 +451,16 @@ func parseFiles(m *gno.Machine, fpaths []string, stderr io.WriteCloser, xOverrid
 // package-level string variable declarations (see patchXVars), and parses
 // the (possibly patched) result. It panics on error, like
 // (*gno.Machine).MustReadFile, which it replaces as the read path here so
-// that overrides can be applied before parsing.
-func mustReadAndPatchFile(m *gno.Machine, fpath string, xOverrides map[string]string) *gno.FileNode {
+// that overrides can be applied before parsing. Matches (and non-matches)
+// are recorded into xt for aggregation across every file in the package.
+func mustReadAndPatchFile(m *gno.Machine, fpath string, xOverrides map[string]string, xt *xTracker) *gno.FileNode {
 	bz, err := os.ReadFile(fpath)
 	if err != nil {
 		panic(err)
 	}
 
-	body := patchXVars(fpath, string(bz), xOverrides)
+	body, result := patchXVars(fpath, string(bz), xOverrides)
+	xt.record(result)
 
 	return m.MustParseFile(fpath, body)
 }

--- a/gnovm/cmd/gno/run_test.go
+++ b/gnovm/cmd/gno/run_test.go
@@ -20,6 +20,18 @@ func TestRunApp(t *testing.T) {
 			stdoutShouldContain: "hello world!",
 		},
 		{
+			args:                []string{"run", "../../tests/integ/run_xflag/main.gno"},
+			stdoutShouldContain: "default",
+		},
+		{
+			args:                []string{"run", "-X", "myVar=overridden", "../../tests/integ/run_xflag/main.gno"},
+			stdoutShouldContain: "overridden",
+		},
+		{
+			args:             []string{"run", "-X", "invalidnoequals", "../../tests/integ/run_xflag/main.gno"},
+			errShouldContain: "invalid -X value",
+		},
+		{
 			args:             []string{"run", "../../tests/integ/does_not_exist"},
 			errShouldContain: "no such file or directory",
 		},

--- a/gnovm/cmd/gno/run_test.go
+++ b/gnovm/cmd/gno/run_test.go
@@ -24,12 +24,24 @@ func TestRunApp(t *testing.T) {
 			stdoutShouldContain: "default",
 		},
 		{
-			args:                []string{"run", "-X", "myVar=overridden", "../../tests/integ/run_xflag/main.gno"},
+			args:                []string{"run", "-X", "main.myVar=overridden", "../../tests/integ/run_xflag/main.gno"},
 			stdoutShouldContain: "overridden",
 		},
 		{
 			args:             []string{"run", "-X", "invalidnoequals", "../../tests/integ/run_xflag/main.gno"},
 			errShouldContain: "invalid -X value",
+		},
+		{
+			args:             []string{"run", "-X", "myVar=nopkgpath", "../../tests/integ/run_xflag/main.gno"},
+			errShouldContain: "invalid -X value",
+		},
+		{
+			args:             []string{"run", "-X", "main.noSuchVar=x", "../../tests/integ/run_xflag/main.gno"},
+			errShouldContain: "no such package-level var: noSuchVar",
+		},
+		{
+			args:             []string{"run", "-X", "main.constVar=x", "../../tests/integ/run_xflag/main.gno"},
+			errShouldContain: "constVar is not a package-level string var",
 		},
 		{
 			args:             []string{"run", "../../tests/integ/does_not_exist"},

--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -38,6 +38,7 @@ type testCmd struct {
 	printEvents         bool
 	debug               bool
 	parallel            int
+	xVars               *xFlag
 }
 
 func newTestCmd(io commands.IO) *commands.Command {
@@ -186,6 +187,14 @@ func (c *testCmd) RegisterFlags(fs *flag.FlagSet) {
 			"When above 1, the output of each package is buffered and printed once the package's tests complete. "+
 			"-debug enforces -p 1.",
 			runtime.GOMAXPROCS(0)),
+	)
+
+	c.xVars = newXFlag()
+	fs.Var(
+		c.xVars,
+		"X",
+		"set the value of a package-level string variable, e.g. -X myVar=override (may be repeated); "+
+			"like 'go build -ldflags \"-X ...\"', only simple 'var name = \"...\"' declarations are patched",
 	)
 }
 
@@ -437,6 +446,11 @@ func (c *testCmd) testPkg(
 
 	// Read MemPackage with all files.
 	mpkg := gno.MustReadMemPackage(pkg.Dir, pkgPath, gno.MPAnyAll)
+	if len(c.xVars.values) > 0 {
+		for _, f := range mpkg.Files {
+			f.Body = patchXVars(f.Name, f.Body, c.xVars.values)
+		}
+	}
 	var didPanic, didError bool
 	startedAt := time.Now()
 	didPanic = catchPanic(pkg.Dir, pkgPath, io.Err(), func() {

--- a/gnovm/cmd/gno/test.go
+++ b/gnovm/cmd/gno/test.go
@@ -193,8 +193,9 @@ func (c *testCmd) RegisterFlags(fs *flag.FlagSet) {
 	fs.Var(
 		c.xVars,
 		"X",
-		"set the value of a package-level string variable, e.g. -X myVar=override (may be repeated); "+
-			"like 'go build -ldflags \"-X ...\"', only simple 'var name = \"...\"' declarations are patched",
+		"set the value of a package-level string variable, e.g. -X main.myVar=override or "+
+			"-X gno.land/r/demo/foo.Version=1.2.3 (may be repeated); like 'go build -ldflags \"-X ...\"', "+
+			"the package path must be given, and only simple 'var name = \"...\"' declarations are patched",
 	)
 }
 
@@ -446,9 +447,18 @@ func (c *testCmd) testPkg(
 
 	// Read MemPackage with all files.
 	mpkg := gno.MustReadMemPackage(pkg.Dir, pkgPath, gno.MPAnyAll)
-	if len(c.xVars.values) > 0 {
+	xOverrides := c.xVars.forPackage(mpkg.Path, mpkg.Name)
+	if len(xOverrides) > 0 {
+		xt := newXTracker()
 		for _, f := range mpkg.Files {
-			f.Body = patchXVars(f.Name, f.Body, c.xVars.values)
+			body, result := patchXVars(f.Name, f.Body, xOverrides)
+			f.Body = body
+			xt.record(result)
+		}
+		if err := xt.unmatched(xOverrides); err != nil {
+			io.ErrPrintln(err)
+			buildErrCount++
+			return
 		}
 	}
 	var didPanic, didError bool

--- a/gnovm/cmd/gno/xflag.go
+++ b/gnovm/cmd/gno/xflag.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+// patchXVars parses body as Go source and rewrites the string-literal
+// initializer of any package-level `var name = "..."` (or
+// `var name T = "..."`, including grouped `var ( ... )` blocks)
+// declaration whose name matches a key in overrides, similar to
+// `go build -ldflags "-X pkg.name=value"`.
+//
+// Unlike a text-based find/replace, this walks the parsed AST and only
+// descends into top-level declarations, so:
+//   - a string or raw string literal elsewhere in the file that merely
+//     looks like a var declaration (e.g. inside a backtick-quoted
+//     template string) is never touched, and
+//   - local variables declared inside function bodies are never touched,
+//     even if they shadow a package-level name in overrides.
+//
+// If overrides is empty, body is returned unchanged. If body fails to
+// parse, body is also returned unchanged: the caller's own subsequent
+// parse of the file (with gno's parser) will surface the real syntax
+// error, so this function doesn't need to duplicate that diagnostic.
+func patchXVars(fname, body string, overrides map[string]string) string {
+	if len(overrides) == 0 {
+		return body
+	}
+
+	fset := token.NewFileSet()
+
+	astFile, err := parser.ParseFile(fset, fname, body, parser.ParseComments)
+	if err != nil {
+		return body
+	}
+
+	patched := false
+
+	for _, decl := range astFile.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for i, name := range valueSpec.Names {
+				if i >= len(valueSpec.Values) {
+					continue // no initializer to patch, e.g. `var x string`
+				}
+
+				value, ok := overrides[name.Name]
+				if !ok {
+					continue
+				}
+
+				lit, ok := valueSpec.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue // not a simple string literal initializer
+				}
+
+				lit.Value = strconv.Quote(value)
+				patched = true
+			}
+		}
+	}
+
+	if !patched {
+		return body
+	}
+
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, fset, astFile); err != nil {
+		return body
+	}
+
+	return buf.String()
+}
+
+// xFlag implements flag.Value, collecting repeated `-X name=value` pairs
+// into a map, mirroring the semantics of `go build -ldflags "-X ...=..."`.
+type xFlag struct {
+	values map[string]string
+}
+
+// newXFlag returns an initialized, empty xFlag.
+func newXFlag() *xFlag {
+	return &xFlag{values: map[string]string{}}
+}
+
+// String implements flag.Value.
+func (x *xFlag) String() string {
+	if x == nil || len(x.values) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(x.values))
+	for k, v := range x.values {
+		parts = append(parts, k+"="+v)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// Set implements flag.Value. It parses a single "name=value" pair and
+// records it, overwriting any previous value for the same name. It may be
+// called multiple times (once per -X flag occurrence on the command line).
+func (x *xFlag) Set(s string) error {
+	name, value, found := strings.Cut(s, "=")
+	if !found || name == "" {
+		return fmt.Errorf("invalid -X value %q: expected format name=value", s)
+	}
+
+	x.values[name] = value
+
+	return nil
+}

--- a/gnovm/cmd/gno/xflag.go
+++ b/gnovm/cmd/gno/xflag.go
@@ -1,15 +1,119 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"go/parser"
-	"go/printer"
 	"go/token"
+	"sort"
 	"strconv"
 	"strings"
 )
+
+// xOverride is a single -X override: the value of variable Name in package
+// PkgPath should be replaced with Value.
+type xOverride struct {
+	PkgPath string
+	Name    string
+	Value   string
+}
+
+// xFlag implements flag.Value, collecting repeated `-X importpath.name=value`
+// pairs, mirroring the required qualified form of
+// `go build -ldflags "-X importpath.name=value"` (see cmd/link docs).
+// Unlike an unqualified `-X name=value`, this ties an override to one
+// specific package, so it can't accidentally rewrite a same-named var in
+// every package under test.
+type xFlag struct {
+	overrides []xOverride
+}
+
+// newXFlag returns an initialized, empty xFlag.
+func newXFlag() *xFlag {
+	return &xFlag{}
+}
+
+// String implements flag.Value.
+func (x *xFlag) String() string {
+	if x == nil || len(x.overrides) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(x.overrides))
+	for _, o := range x.overrides {
+		parts = append(parts, o.PkgPath+"."+o.Name+"="+o.Value)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// Set implements flag.Value. It parses a single "importpath.name=value"
+// triple and records it; it may be called multiple times (once per -X
+// flag occurrence on the command line).
+func (x *xFlag) Set(s string) error {
+	eq := strings.IndexByte(s, '=')
+	if eq < 0 {
+		return fmt.Errorf("invalid -X value %q: expected format importpath.name=value", s)
+	}
+
+	qualified, value := s[:eq], s[eq+1:]
+
+	dot := strings.LastIndexByte(qualified, '.')
+	if dot < 0 || dot == len(qualified)-1 {
+		return fmt.Errorf(
+			"invalid -X value %q: expected format importpath.name=value (e.g. -X main.Version=1.2.3)",
+			s,
+		)
+	}
+
+	pkgPath, name := qualified[:dot], qualified[dot+1:]
+	if pkgPath == "" {
+		return fmt.Errorf("invalid -X value %q: empty package path", s)
+	}
+
+	x.overrides = append(x.overrides, xOverride{PkgPath: pkgPath, Name: name, Value: value})
+
+	return nil
+}
+
+// forPackage returns the name->value overrides that apply to a package,
+// identified by its resolved pkgPath and its declared package name
+// pkgName. A package is matched either by its full pkgPath, or -- for the
+// main package specifically -- by the literal "main", mirroring
+// `go build -X main.Var=...`'s own convention of addressing the main
+// package by name rather than its (often irrelevant) import path.
+func (x *xFlag) forPackage(pkgPath, pkgName string) map[string]string {
+	if len(x.overrides) == 0 {
+		return nil
+	}
+
+	overrides := make(map[string]string)
+	for _, o := range x.overrides {
+		if o.PkgPath == pkgPath || (pkgName == "main" && o.PkgPath == "main") {
+			overrides[o.Name] = o.Value
+		}
+	}
+
+	return overrides
+}
+
+// xPatchResult reports which of the requested overrides were actually
+// applied to a package's source, split out by why the rest weren't:
+// NotFound names don't correspond to any top-level declaration at all;
+// WrongKind names do, but aren't a plain string var (they're a const, a
+// var of a different type, or a var with no literal initializer) -- go
+// build -X's own error for this case ("cannot set with -X: not a var of
+// type string") is the model here.
+type xPatchResult struct {
+	Matched   []string
+	NotFound  []string
+	WrongKind []string
+}
+
+// Unmatched reports whether any requested override was not applied.
+func (r xPatchResult) Unmatched() bool {
+	return len(r.NotFound) > 0 || len(r.WrongKind) > 0
+}
 
 // patchXVars parses body as Go source and rewrites the string-literal
 // initializer of any package-level `var name = "..."` (or
@@ -25,27 +129,47 @@ import (
 //   - local variables declared inside function bodies are never touched,
 //     even if they shadow a package-level name in overrides.
 //
-// If overrides is empty, body is returned unchanged. If body fails to
-// parse, body is also returned unchanged: the caller's own subsequent
-// parse of the file (with gno's parser) will surface the real syntax
-// error, so this function doesn't need to duplicate that diagnostic.
-func patchXVars(fname, body string, overrides map[string]string) string {
+// Rather than reprinting the whole file (which would reformat everything,
+// not just the patched literals), each match is spliced into the
+// original bytes at the literal's own offsets, leaving the rest of the
+// file byte-for-byte untouched. If a matched literal spanned multiple
+// source lines (a multi-line raw string) and its replacement doesn't, the
+// splice is padded with blank lines so that line numbers for everything
+// after it in the file are unaffected -- a later panic or type error still
+// points at the same line it would without -X.
+//
+// If overrides is empty, body is returned unchanged with a zero-value
+// result. If body fails to parse, body is also returned unchanged (with a
+// zero-value result): the caller's own subsequent parse of the file (with
+// gno's parser) will surface the real syntax error, so this function
+// doesn't need to duplicate that diagnostic.
+func patchXVars(fname, body string, overrides map[string]string) (string, xPatchResult) {
+	var result xPatchResult
+
 	if len(overrides) == 0 {
-		return body
+		return body, result
 	}
 
 	fset := token.NewFileSet()
 
 	astFile, err := parser.ParseFile(fset, fname, body, parser.ParseComments)
 	if err != nil {
-		return body
+		return body, result
 	}
 
-	patched := false
+	type span struct {
+		start, end int
+		repl       string
+	}
+
+	var spans []span
+
+	matched := make(map[string]bool, len(overrides))
+	wrongKind := make(map[string]bool)
 
 	for _, decl := range astFile.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok || genDecl.Tok != token.VAR {
+		if !ok || (genDecl.Tok != token.VAR && genDecl.Tok != token.CONST) {
 			continue
 		}
 
@@ -56,73 +180,89 @@ func patchXVars(fname, body string, overrides map[string]string) string {
 			}
 
 			for i, name := range valueSpec.Names {
-				if i >= len(valueSpec.Values) {
-					continue // no initializer to patch, e.g. `var x string`
-				}
-
 				value, ok := overrides[name.Name]
 				if !ok {
 					continue
 				}
 
-				lit, ok := valueSpec.Values[i].(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					continue // not a simple string literal initializer
+				lit, ok := literalInitializer(genDecl, valueSpec, i)
+				if !ok {
+					wrongKind[name.Name] = true
+					continue
 				}
 
-				lit.Value = strconv.Quote(value)
-				patched = true
+				matched[name.Name] = true
+
+				start := fset.Position(lit.Pos()).Offset
+				end := fset.Position(lit.End()).Offset
+				newText := strconv.Quote(value)
+
+				// Preserve line numbers for the rest of the file: pad
+				// with as many newlines as the original span had, since
+				// the replacement (a double-quoted string) never
+				// contains one itself.
+				if n := strings.Count(body[start:end], "\n"); n > 0 {
+					newText += strings.Repeat("\n", n)
+				}
+
+				spans = append(spans, span{start: start, end: end, repl: newText})
 			}
 		}
 	}
 
-	if !patched {
-		return body
+	var matchedNames []string
+	for name := range overrides {
+		switch {
+		case matched[name]:
+			matchedNames = append(matchedNames, name)
+		case wrongKind[name]:
+			result.WrongKind = append(result.WrongKind, name)
+		default:
+			result.NotFound = append(result.NotFound, name)
+		}
+	}
+	sort.Strings(matchedNames)
+	sort.Strings(result.NotFound)
+	sort.Strings(result.WrongKind)
+	result.Matched = matchedNames
+
+	if len(spans) == 0 {
+		return body, result
 	}
 
-	var buf bytes.Buffer
-	if err := printer.Fprint(&buf, fset, astFile); err != nil {
-		return body
-	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
 
-	return buf.String()
+	var buf strings.Builder
+
+	pos := 0
+	for _, sp := range spans {
+		buf.WriteString(body[pos:sp.start])
+		buf.WriteString(sp.repl)
+		pos = sp.end
+	}
+	buf.WriteString(body[pos:])
+
+	return buf.String(), result
 }
 
-// xFlag implements flag.Value, collecting repeated `-X name=value` pairs
-// into a map, mirroring the semantics of `go build -ldflags "-X ...=..."`.
-type xFlag struct {
-	values map[string]string
-}
-
-// newXFlag returns an initialized, empty xFlag.
-func newXFlag() *xFlag {
-	return &xFlag{values: map[string]string{}}
-}
-
-// String implements flag.Value.
-func (x *xFlag) String() string {
-	if x == nil || len(x.values) == 0 {
-		return ""
+// literalInitializer returns the string-literal initializer of the
+// name-th name in valueSpec, and whether it's eligible for -X patching:
+// genDecl must be a var (not const) declaration, i must have a
+// corresponding initializer expression, and that expression must be a
+// plain (non-typed-conversion) string literal.
+func literalInitializer(genDecl *ast.GenDecl, valueSpec *ast.ValueSpec, i int) (*ast.BasicLit, bool) {
+	if genDecl.Tok != token.VAR {
+		return nil, false // const: go build -X also refuses this.
 	}
 
-	parts := make([]string, 0, len(x.values))
-	for k, v := range x.values {
-		parts = append(parts, k+"="+v)
+	if i >= len(valueSpec.Values) {
+		return nil, false // e.g. `var x string` with no initializer.
 	}
 
-	return strings.Join(parts, ",")
-}
-
-// Set implements flag.Value. It parses a single "name=value" pair and
-// records it, overwriting any previous value for the same name. It may be
-// called multiple times (once per -X flag occurrence on the command line).
-func (x *xFlag) Set(s string) error {
-	name, value, found := strings.Cut(s, "=")
-	if !found || name == "" {
-		return fmt.Errorf("invalid -X value %q: expected format name=value", s)
+	lit, ok := valueSpec.Values[i].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return nil, false // not a plain string literal initializer.
 	}
 
-	x.values[name] = value
-
-	return nil
+	return lit, true
 }

--- a/gnovm/cmd/gno/xflag_test.go
+++ b/gnovm/cmd/gno/xflag_test.go
@@ -155,14 +155,17 @@ func TestPatchXVars(t *testing.T) {
 		}
 	})
 
-	t.Run("text resembling a var decl inside a raw string is left alone", func(t *testing.T) {
+	t.Run("text resembling a var decl inside another var's raw string is left alone", func(t *testing.T) {
 		t.Parallel()
 
 		// Regression test for a review comment on the original,
 		// regex-based implementation: a raw string literal that merely
 		// *contains* text resembling a top-level var declaration must
-		// never be touched, since it isn't a real declaration.
-		body := "package main\n\nvar myVar = `\nvar myVar = \"not a real declaration\"\n`\n"
+		// never be touched, since it isn't a real declaration -- only
+		// the actual "var myVar = ..." decl below is.
+		body := "package main\n\n" +
+			"var otherVar = `\nvar myVar = \"fake, must not be touched\"\n`\n\n" +
+			"var myVar = \"real default\"\n"
 		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
@@ -170,13 +173,12 @@ func TestPatchXVars(t *testing.T) {
 			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
 		}
 
-		// The AST-level check above already proves only the real
-		// declaration was patched (there's only one `myVar` decl to find
-		// once the raw string's fake one is correctly excluded from
-		// consideration), but assert readably too: the literal source
-		// text of the fake declaration must be preserved verbatim.
-		if !strings.Contains(got, `not a real declaration`) {
-			t.Errorf("expected the raw string's contents to be preserved, got:\n%s", got)
+		// otherVar's raw string content -- which merely contains text
+		// that *looks* like a var myVar declaration -- must be preserved
+		// byte-for-byte, proving the fake declaration inside it was
+		// never treated as a real one.
+		if !strings.Contains(got, `var myVar = "fake, must not be touched"`) {
+			t.Errorf("expected otherVar's raw string contents to be preserved verbatim, got:\n%s", got)
 		}
 	})
 

--- a/gnovm/cmd/gno/xflag_test.go
+++ b/gnovm/cmd/gno/xflag_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// varValue re-parses body and returns the unquoted string value of the
+// package-level `var name = "..."` declaration named name, or ("", false)
+// if no such declaration (with a string literal initializer) exists.
+// Used to make assertions robust to go/printer's exact formatting choices
+// (spacing, alignment, etc.), which this package doesn't want to hardcode
+// expectations about.
+func varValue(t *testing.T, body, name string) (string, bool) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.gno", body, 0)
+	if err != nil {
+		t.Fatalf("varValue: re-parsing patched output failed: %v\n---\n%s", err, body)
+	}
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for i, n := range valueSpec.Names {
+				if n.Name != name || i >= len(valueSpec.Values) {
+					continue
+				}
+
+				lit, ok := valueSpec.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+
+				unquoted, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("varValue: unquoting %s: %v", lit.Value, err)
+				}
+
+				return unquoted, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func TestPatchXVars(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no overrides returns body unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar string = \"default\"\n"
+		got := patchXVars("test.gno", body, nil)
+
+		if got != body {
+			t.Errorf("expected unchanged body, got:\n%s", got)
+		}
+	})
+
+	t.Run("simple override, explicit string type", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar string = \"default\"\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != "override" {
+			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+	})
+
+	t.Run("simple override, inferred type", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar = \"default\"\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != "override" {
+			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+	})
+
+	t.Run("raw string literal initializer replaced", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar = `default`\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != "override" {
+			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+	})
+
+	t.Run("override value round-trips through quoting", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar = \"default\"\n"
+		want := `has "quotes" and \backslash`
+		got := patchXVars("test.gno", body, map[string]string{"myVar": want})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != want {
+			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, want)
+		}
+	})
+
+	t.Run("no matching var name leaves declaration untouched", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar otherVar = \"default\"\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "otherVar")
+		if !ok || value != "default" {
+			t.Errorf("otherVar = %q, ok = %v; want %q, true", value, ok, "default")
+		}
+	})
+
+	t.Run("grouped var block: only matching names are patched", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar (\n\ta = \"a-default\"\n\tb = \"b-default\"\n\tc = \"c-default\"\n)\n"
+		got := patchXVars("test.gno", body, map[string]string{
+			"a": "a-override",
+			"c": "c-override",
+		})
+
+		for name, want := range map[string]string{
+			"a": "a-override",
+			"b": "b-default",
+			"c": "c-override",
+		} {
+			value, ok := varValue(t, got, name)
+			if !ok || value != want {
+				t.Errorf("%s = %q, ok = %v; want %q, true", name, value, ok, want)
+			}
+		}
+	})
+
+	t.Run("text resembling a var decl inside a raw string is left alone", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression test for a review comment on the original,
+		// regex-based implementation: a raw string literal that merely
+		// *contains* text resembling a top-level var declaration must
+		// never be touched, since it isn't a real declaration.
+		body := "package main\n\nvar myVar = `\nvar myVar = \"not a real declaration\"\n`\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != "override" {
+			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+
+		// The AST-level check above already proves only the real
+		// declaration was patched (there's only one `myVar` decl to find
+		// once the raw string's fake one is correctly excluded from
+		// consideration), but assert readably too: the literal source
+		// text of the fake declaration must be preserved verbatim.
+		if !strings.Contains(got, `not a real declaration`) {
+			t.Errorf("expected the raw string's contents to be preserved, got:\n%s", got)
+		}
+	})
+
+	t.Run("local variable in a function body is left alone", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar = \"default\"\n\nfunc f() string {\n\tmyVar := \"local\"\n\treturn myVar\n}\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		value, ok := varValue(t, got, "myVar")
+		if !ok || value != "override" {
+			t.Errorf("package-level myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+
+		if !strings.Contains(got, `"local"`) {
+			t.Errorf("expected the function-local assignment to be preserved, got:\n%s", got)
+		}
+	})
+
+	t.Run("const declarations are never patched", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nconst myVar = \"default\"\n"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		if !strings.Contains(got, `"default"`) || strings.Contains(got, `"override"`) {
+			t.Errorf("expected const myVar to remain \"default\", got:\n%s", got)
+		}
+	})
+
+	t.Run("unparseable source is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		body := "this is not valid go source {{{"
+		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		if got != body {
+			t.Errorf("expected unchanged body for unparseable source, got:\n%s", got)
+		}
+	})
+}
+
+func TestXFlag_SetAndString(t *testing.T) {
+	t.Parallel()
+
+	x := newXFlag()
+
+	if err := x.Set("myVar=override"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if got, want := x.values["myVar"], "override"; got != want {
+		t.Errorf("values[myVar] = %q, want %q", got, want)
+	}
+
+	// A value containing an "=" sign should only split on the first one.
+	if err := x.Set("eq=a=b"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if got, want := x.values["eq"], "a=b"; got != want {
+		t.Errorf("values[eq] = %q, want %q", got, want)
+	}
+}
+
+func TestXFlag_SetInvalid(t *testing.T) {
+	t.Parallel()
+
+	x := newXFlag()
+
+	if err := x.Set("novalue"); err == nil {
+		t.Error("Set(\"novalue\") expected an error, got nil")
+	}
+
+	if err := x.Set("=novalue"); err == nil {
+		t.Error("Set(\"=novalue\") expected an error, got nil")
+	}
+}
+
+func TestXFlag_NilString(t *testing.T) {
+	t.Parallel()
+
+	var x *xFlag
+	if got := x.String(); got != "" {
+		t.Errorf("(*xFlag)(nil).String() = %q, want empty string", got)
+	}
+}

--- a/gnovm/cmd/gno/xflag_test.go
+++ b/gnovm/cmd/gno/xflag_test.go
@@ -265,10 +265,10 @@ func TestPatchXVars(t *testing.T) {
 		body := "package main\n\n" + // lines 1-2
 			"var Banner = `line one\n" + // line 3
 			"line two\n" + // line 4
-			"line three`\n\n" + // line 5
-			"func main() {\n" + // line 6
-			"\tpanic(\"boom\")\n" + // line 7
-			"}\n" // line 8
+			"line three`\n\n" + // line 5, then blank line 6
+			"func main() {\n" + // line 7
+			"\tpanic(\"boom\")\n" + // line 8
+			"}\n" // line 9
 
 		got, _ := patchXVars("test.gno", body, map[string]string{"Banner": "x"})
 
@@ -291,8 +291,8 @@ func TestPatchXVars(t *testing.T) {
 			return true
 		})
 
-		if panicLine != 7 {
-			t.Errorf("panic() call moved to line %d after patching, want line 7 (unchanged):\n%s", panicLine, got)
+		if panicLine != 8 {
+			t.Errorf("panic() call moved to line %d after patching, want line 8 (unchanged):\n%s", panicLine, got)
 		}
 	})
 }

--- a/gnovm/cmd/gno/xflag_test.go
+++ b/gnovm/cmd/gno/xflag_test.go
@@ -12,9 +12,8 @@ import (
 // varValue re-parses body and returns the unquoted string value of the
 // package-level `var name = "..."` declaration named name, or ("", false)
 // if no such declaration (with a string literal initializer) exists.
-// Used to make assertions robust to go/printer's exact formatting choices
-// (spacing, alignment, etc.), which this package doesn't want to hardcode
-// expectations about.
+// Used to make assertions robust to exactly how the splice was applied,
+// without hardcoding byte-for-byte expectations everywhere.
 func varValue(t *testing.T, body, name string) (string, bool) {
 	t.Helper()
 
@@ -66,10 +65,13 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar myVar string = \"default\"\n"
-		got := patchXVars("test.gno", body, nil)
+		got, result := patchXVars("test.gno", body, nil)
 
 		if got != body {
 			t.Errorf("expected unchanged body, got:\n%s", got)
+		}
+		if result.Unmatched() {
+			t.Errorf("expected no unmatched result for empty overrides, got: %+v", result)
 		}
 	})
 
@@ -77,11 +79,14 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar myVar string = \"default\"\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != "override" {
 			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
+		}
+		if result.Unmatched() {
+			t.Errorf("expected myVar matched, got: %+v", result)
 		}
 	})
 
@@ -89,7 +94,7 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar myVar = \"default\"\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, _ := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != "override" {
@@ -101,7 +106,7 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar myVar = `default`\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, _ := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != "override" {
@@ -114,7 +119,7 @@ func TestPatchXVars(t *testing.T) {
 
 		body := "package main\n\nvar myVar = \"default\"\n"
 		want := `has "quotes" and \backslash`
-		got := patchXVars("test.gno", body, map[string]string{"myVar": want})
+		got, _ := patchXVars("test.gno", body, map[string]string{"myVar": want})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != want {
@@ -122,15 +127,57 @@ func TestPatchXVars(t *testing.T) {
 		}
 	})
 
-	t.Run("no matching var name leaves declaration untouched", func(t *testing.T) {
+	t.Run("unmatched name is reported as NotFound", func(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar otherVar = \"default\"\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "otherVar")
 		if !ok || value != "default" {
 			t.Errorf("otherVar = %q, ok = %v; want %q, true", value, ok, "default")
+		}
+		if len(result.NotFound) != 1 || result.NotFound[0] != "myVar" {
+			t.Errorf("NotFound = %v, want [myVar]", result.NotFound)
+		}
+		if len(result.WrongKind) != 0 {
+			t.Errorf("WrongKind = %v, want empty", result.WrongKind)
+		}
+	})
+
+	t.Run("const is reported as WrongKind, not patched", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nconst myVar = \"default\"\n"
+		got, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		if !strings.Contains(got, `"default"`) || strings.Contains(got, `"override"`) {
+			t.Errorf("expected const myVar to remain \"default\", got:\n%s", got)
+		}
+		if len(result.WrongKind) != 1 || result.WrongKind[0] != "myVar" {
+			t.Errorf("WrongKind = %v, want [myVar]", result.WrongKind)
+		}
+	})
+
+	t.Run("non-string var is reported as WrongKind", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar = 42\n"
+		_, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		if len(result.WrongKind) != 1 || result.WrongKind[0] != "myVar" {
+			t.Errorf("WrongKind = %v, want [myVar]", result.WrongKind)
+		}
+	})
+
+	t.Run("var with no initializer is reported as WrongKind", func(t *testing.T) {
+		t.Parallel()
+
+		body := "package main\n\nvar myVar string\n"
+		_, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+
+		if len(result.WrongKind) != 1 || result.WrongKind[0] != "myVar" {
+			t.Errorf("WrongKind = %v, want [myVar]", result.WrongKind)
 		}
 	})
 
@@ -138,7 +185,7 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar (\n\ta = \"a-default\"\n\tb = \"b-default\"\n\tc = \"c-default\"\n)\n"
-		got := patchXVars("test.gno", body, map[string]string{
+		got, result := patchXVars("test.gno", body, map[string]string{
 			"a": "a-override",
 			"c": "c-override",
 		})
@@ -153,30 +200,28 @@ func TestPatchXVars(t *testing.T) {
 				t.Errorf("%s = %q, ok = %v; want %q, true", name, value, ok, want)
 			}
 		}
+		if result.Unmatched() {
+			t.Errorf("expected both a and c matched, got: %+v", result)
+		}
 	})
 
 	t.Run("text resembling a var decl inside another var's raw string is left alone", func(t *testing.T) {
 		t.Parallel()
 
-		// Regression test for a review comment on the original,
-		// regex-based implementation: a raw string literal that merely
-		// *contains* text resembling a top-level var declaration must
-		// never be touched, since it isn't a real declaration -- only
-		// the actual "var myVar = ..." decl below is.
+		// Regression test: a raw string literal that merely *contains*
+		// text resembling a top-level var declaration must never be
+		// touched, since it isn't a real declaration -- only the actual
+		// "var myVar = ..." decl below is.
 		body := "package main\n\n" +
 			"var otherVar = `\nvar myVar = \"fake, must not be touched\"\n`\n\n" +
 			"var myVar = \"real default\"\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, _ := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != "override" {
 			t.Errorf("myVar = %q, ok = %v; want %q, true", value, ok, "override")
 		}
 
-		// otherVar's raw string content -- which merely contains text
-		// that *looks* like a var myVar declaration -- must be preserved
-		// byte-for-byte, proving the fake declaration inside it was
-		// never treated as a real one.
 		if !strings.Contains(got, `var myVar = "fake, must not be touched"`) {
 			t.Errorf("expected otherVar's raw string contents to be preserved verbatim, got:\n%s", got)
 		}
@@ -186,7 +231,7 @@ func TestPatchXVars(t *testing.T) {
 		t.Parallel()
 
 		body := "package main\n\nvar myVar = \"default\"\n\nfunc f() string {\n\tmyVar := \"local\"\n\treturn myVar\n}\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, _ := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		value, ok := varValue(t, got, "myVar")
 		if !ok || value != "override" {
@@ -198,49 +243,96 @@ func TestPatchXVars(t *testing.T) {
 		}
 	})
 
-	t.Run("const declarations are never patched", func(t *testing.T) {
-		t.Parallel()
-
-		body := "package main\n\nconst myVar = \"default\"\n"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
-
-		if !strings.Contains(got, `"default"`) || strings.Contains(got, `"override"`) {
-			t.Errorf("expected const myVar to remain \"default\", got:\n%s", got)
-		}
-	})
-
 	t.Run("unparseable source is returned unchanged", func(t *testing.T) {
 		t.Parallel()
 
 		body := "this is not valid go source {{{"
-		got := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
+		got, result := patchXVars("test.gno", body, map[string]string{"myVar": "override"})
 
 		if got != body {
 			t.Errorf("expected unchanged body for unparseable source, got:\n%s", got)
 		}
+		if result.Unmatched() {
+			t.Errorf("expected zero-value result for unparseable source, got: %+v", result)
+		}
+	})
+
+	t.Run("line numbers after a shrunk multi-line literal are preserved", func(t *testing.T) {
+		t.Parallel()
+
+		// A 3-line raw string collapsed to a 1-line quoted string must
+		// not shift the line number of code that follows it.
+		body := "package main\n\n" + // lines 1-2
+			"var Banner = `line one\n" + // line 3
+			"line two\n" + // line 4
+			"line three`\n\n" + // line 5
+			"func main() {\n" + // line 6
+			"\tpanic(\"boom\")\n" + // line 7
+			"}\n" // line 8
+
+		got, _ := patchXVars("test.gno", body, map[string]string{"Banner": "x"})
+
+		fset := token.NewFileSet()
+		astFile, err := parser.ParseFile(fset, "test.gno", got, 0)
+		if err != nil {
+			t.Fatalf("re-parsing patched output failed: %v\n---\n%s", err, got)
+		}
+
+		var panicLine int
+		ast.Inspect(astFile, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if ok && ident.Name == "panic" {
+				panicLine = fset.Position(call.Pos()).Line
+			}
+			return true
+		})
+
+		if panicLine != 7 {
+			t.Errorf("panic() call moved to line %d after patching, want line 7 (unchanged):\n%s", panicLine, got)
+		}
 	})
 }
 
-func TestXFlag_SetAndString(t *testing.T) {
+func TestXFlag_SetAndForPackage(t *testing.T) {
 	t.Parallel()
 
 	x := newXFlag()
 
-	if err := x.Set("myVar=override"); err != nil {
+	if err := x.Set("main.myVar=override"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := x.Set("gno.land/r/demo/foo.Version=1.2.3"); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
 
-	if got, want := x.values["myVar"], "override"; got != want {
-		t.Errorf("values[myVar] = %q, want %q", got, want)
+	mainOverrides := x.forPackage("main", "main")
+	if got, want := mainOverrides["myVar"], "override"; got != want {
+		t.Errorf("forPackage(main, main)[myVar] = %q, want %q", got, want)
 	}
 
-	// A value containing an "=" sign should only split on the first one.
-	if err := x.Set("eq=a=b"); err != nil {
-		t.Fatalf("Set() error = %v", err)
+	fooOverrides := x.forPackage("gno.land/r/demo/foo", "foo")
+	if got, want := fooOverrides["Version"], "1.2.3"; got != want {
+		t.Errorf("forPackage(gno.land/r/demo/foo, foo)[Version] = %q, want %q", got, want)
 	}
 
-	if got, want := x.values["eq"], "a=b"; got != want {
-		t.Errorf("values[eq] = %q, want %q", got, want)
+	// An override for one package must not leak into another.
+	if _, ok := mainOverrides["Version"]; ok {
+		t.Errorf("expected Version override not to apply to the main package")
+	}
+	if _, ok := fooOverrides["myVar"]; ok {
+		t.Errorf("expected myVar override not to apply to the foo package")
+	}
+
+	// A package whose declared name is "main" is also addressable via the
+	// literal "main" pkgPath qualifier, regardless of its actual import
+	// path (mirroring go build -X main.Var=...).
+	otherMainOverrides := x.forPackage("some/other/import/path", "main")
+	if got, want := otherMainOverrides["myVar"], "override"; got != want {
+		t.Errorf("forPackage(some/other/import/path, main)[myVar] = %q, want %q", got, want)
 	}
 }
 
@@ -250,11 +342,19 @@ func TestXFlag_SetInvalid(t *testing.T) {
 	x := newXFlag()
 
 	if err := x.Set("novalue"); err == nil {
-		t.Error("Set(\"novalue\") expected an error, got nil")
+		t.Error(`Set("novalue") expected an error, got nil`)
 	}
 
-	if err := x.Set("=novalue"); err == nil {
-		t.Error("Set(\"=novalue\") expected an error, got nil")
+	if err := x.Set("myVar=nopkgpath"); err == nil {
+		t.Error(`Set("myVar=nopkgpath") expected an error (missing package path), got nil`)
+	}
+
+	if err := x.Set(".myVar=emptypkgpath"); err == nil {
+		t.Error(`Set(".myVar=emptypkgpath") expected an error (empty package path), got nil`)
+	}
+
+	if err := x.Set("main.=noname"); err == nil {
+		t.Error(`Set("main.=noname") expected an error (empty name), got nil`)
 	}
 }
 
@@ -265,4 +365,35 @@ func TestXFlag_NilString(t *testing.T) {
 	if got := x.String(); got != "" {
 		t.Errorf("(*xFlag)(nil).String() = %q, want empty string", got)
 	}
+}
+
+func TestXTracker_Unmatched(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all matched across multiple files", func(t *testing.T) {
+		t.Parallel()
+
+		xt := newXTracker()
+		_, r1 := patchXVars("file1.gno", "package main\n\nvar a = \"1\"\n", map[string]string{"a": "x", "b": "y"})
+		xt.record(r1)
+		_, r2 := patchXVars("file2.gno", "package main\n\nvar b = \"2\"\n", map[string]string{"a": "x", "b": "y"})
+		xt.record(r2)
+
+		if err := xt.unmatched(map[string]string{"a": "x", "b": "y"}); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("name never found in any file", func(t *testing.T) {
+		t.Parallel()
+
+		xt := newXTracker()
+		_, r := patchXVars("file1.gno", "package main\n\nvar a = \"1\"\n", map[string]string{"a": "x", "missing": "y"})
+		xt.record(r)
+
+		err := xt.unmatched(map[string]string{"a": "x", "missing": "y"})
+		if err == nil || !strings.Contains(err.Error(), "no such package-level var: missing") {
+			t.Errorf("expected a 'no such package-level var: missing' error, got: %v", err)
+		}
+	})
 }

--- a/gnovm/tests/integ/run_xflag/main.gno
+++ b/gnovm/tests/integ/run_xflag/main.gno
@@ -1,0 +1,7 @@
+package main
+
+var myVar string = "default"
+
+func main() {
+	println(myVar)
+}

--- a/gnovm/tests/integ/run_xflag/main.gno
+++ b/gnovm/tests/integ/run_xflag/main.gno
@@ -2,6 +2,9 @@ package main
 
 var myVar string = "default"
 
+const constVar = "unpatchable"
+
 func main() {
 	println(myVar)
+	_ = constVar
 }


### PR DESCRIPTION
Adds a -X name=value flag (repeatable) to 'gno run' and 'gno test', mirroring 'go build -ldflags "-X pkg.name=value"'. Before parsing, matching package-level (unindented) 'var name = "..."'  or 'var name string = "..."' declarations have their string literal initializer replaced with the given override value.

Note: 'gno build' and 'gno publish' do not currently exist as separate gno CLI subcommands (only run/test/lint/etc. do), so this covers the two existing commands that parse and execute .gno source directly.

Closes #1021