### PR TITLE
fix(p2p): use errors.Is instead of errors.As for errTransportClosed sentinel

### DIFF
--- a/tm2/pkg/bft/mempool/reactor_test.go
+++ b/tm2/pkg/bft/mempool/reactor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/p2p"
 	p2pcfg "github.com/gnolang/gno/tm2/pkg/p2p/config"
 	p2pTypes "github.com/gnolang/gno/tm2/pkg/p2p/types"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -197,12 +198,17 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	ensureNoTxs(t, reactors[1], 100*time.Millisecond)
 }
 
-// Deflapped: this used to hit the errTransportClosed data race in
-// switch.go's runAcceptLoop (see the accompanying fix), which -race would
-// intermittently catch. Verified clean over 200 runs with -race after
-// the fix; no longer marked Flappy.
-func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
+// NOTE: still marked Flappy. The errTransportClosed data race fixed in
+// switch.go's runAcceptLoop (see the accompanying fix) was one real source
+// of flakiness here (confirmed via 200 isolated -race runs), but running
+// the full mempool package under -race still intermittently leaks a
+// goroutine (MConnection recvRoutine/sendRoutine not shutting down
+// promptly) that isolated -run reps didn't surface. Needs further
+// investigation before this can be safely deflapped.
+func TestFlappyBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 	t.Parallel()
+
+	testutils.FilterStability(t, testutils.Flappy)
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -227,10 +233,11 @@ func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 	leaktest.CheckTimeout(t, 10*time.Second)()
 }
 
-// Deflapped: same root cause as TestBroadcastTxForPeerStopsWhenPeerStops
-// above. Verified clean over 100 runs with -race after the fix.
-func TestBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
+// NOTE: still marked Flappy; see TestFlappyBroadcastTxForPeerStopsWhenPeerStops above.
+func TestFlappyBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
 	t.Parallel()
+
+	testutils.FilterStability(t, testutils.Flappy)
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/tm2/pkg/bft/mempool/reactor_test.go
+++ b/tm2/pkg/bft/mempool/reactor_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/p2p"
 	p2pcfg "github.com/gnolang/gno/tm2/pkg/p2p/config"
 	p2pTypes "github.com/gnolang/gno/tm2/pkg/p2p/types"
-	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -198,10 +197,12 @@ func TestReactorNoBroadcastToSender(t *testing.T) {
 	ensureNoTxs(t, reactors[1], 100*time.Millisecond)
 }
 
-func TestFlappyBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
+// Deflapped: this used to hit the errTransportClosed data race in
+// switch.go's runAcceptLoop (see the accompanying fix), which -race would
+// intermittently catch. Verified clean over 200 runs with -race after
+// the fix; no longer marked Flappy.
+func TestBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 	t.Parallel()
-
-	testutils.FilterStability(t, testutils.Flappy)
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -226,10 +227,10 @@ func TestFlappyBroadcastTxForPeerStopsWhenPeerStops(t *testing.T) {
 	leaktest.CheckTimeout(t, 10*time.Second)()
 }
 
-func TestFlappyBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
+// Deflapped: same root cause as TestBroadcastTxForPeerStopsWhenPeerStops
+// above. Verified clean over 100 runs with -race after the fix.
+func TestBroadcastTxForPeerStopsWhenReactorStops(t *testing.T) {
 	t.Parallel()
-
-	testutils.FilterStability(t, testutils.Flappy)
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/tm2/pkg/p2p/switch.go
+++ b/tm2/pkg/p2p/switch.go
@@ -634,7 +634,7 @@ func (sw *MultiplexSwitch) runAcceptLoop(ctx context.Context) {
 			// Upper context as been canceled/timeout
 			sw.Logger.Debug("switch context close received")
 			return // exit
-		case errors.As(err, &errTransportClosed):
+		case errors.Is(err, errTransportClosed):
 			// Underlaying transport as been closed
 			sw.Logger.Warn("cannot accept connection on closed transport, exiting")
 			return // exit

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -921,4 +922,63 @@ func TestSwitchAcceptLoopTransportClosed(t *testing.T) {
 	case <-done:
 		assert.True(t, transportClosed)
 	}
+}
+
+// TestSwitchAcceptLoopUnrelatedSentinel verifies the accept loop only exits
+// on errTransportClosed, not on a different sentinel from the same var
+// block (errDuplicateConnection). errors.Is and errors.As agree on
+// errTransportClosed itself (see TestSwitchAcceptLoopTransportClosed
+// above), so that test alone doesn't distinguish the two: this is the case
+// they disagree on -- errors.As matched (and mutated) the sentinel on any
+// same-underlying-type error, while errors.Is only matches the exact
+// value.
+func TestSwitchAcceptLoopUnrelatedSentinel(t *testing.T) {
+	// No t.Parallel: the assertions read the package-level sentinel.
+	original := errTransportClosed
+	t.Cleanup(func() { errTransportClosed = original })
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	var accepts atomic.Int64
+
+	mockTransport := &mockTransport{
+		acceptFn: func(ctx context.Context, _ PeerBehavior) (PeerConn, error) {
+			// Block once the loop has proven it survives the unrelated sentinel.
+			if accepts.Add(1) > 3 {
+				<-ctx.Done()
+
+				return nil, ctx.Err()
+			}
+
+			return nil, errDuplicateConnection
+		},
+	}
+
+	sw := NewMultiplexSwitch(mockTransport)
+
+	done := make(chan struct{})
+
+	go func() {
+		sw.runAcceptLoop(ctx)
+		close(done)
+	}()
+
+	require.Eventually(
+		t,
+		func() bool { return accepts.Load() > 3 },
+		2*time.Second,
+		10*time.Millisecond,
+		"accept loop exited on an error that is not errTransportClosed",
+	)
+
+	cancelFn()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "accept loop did not exit on context cancellation")
+	}
+
+	assert.Equal(t, "transport is closed", errTransportClosed.Error())
 }


### PR DESCRIPTION
Part of the #202 deflap effort.

runAcceptLoop matched the transport-closed sentinel with `errors.As(err, &errTransportClosed)`. `errTransportClosed` is a package-level sentinel value (`errors.New(...)`), not a typed error to extract into -- `errors.As` writes into its target on a match, so this was concurrently mutating the shared sentinel from every switch instance's accept loop while other goroutines read it in `Transport.Accept()`. Confirmed as a genuine data race with `-race`:

```
WARNING: DATA RACE
Read at 0x... by goroutine N: p2p.(*MultiplexTransport).Accept()
    tm2/pkg/p2p/transport.go:103
Previous write at 0x... by goroutine M: errors.As()
    tm2/pkg/p2p/switch.go:637
```

Reproduced via: `STABILITY_FILTER=flappy go test ./tm2/pkg/bft/mempool/... -run TestFlappyBroadcastTxForPeerStopsWhenPeerStops -count=200 -race`

`errors.Is` is the correct comparison for a sentinel value and never writes to it.

Added TestSwitchAcceptLoopUnrelatedSentinel: TestSwitchAcceptLoopTransportClosed alone doesn't distinguish errors.Is from errors.As, since both match errTransportClosed itself. The new test uses a different sentinel from the same var block (errDuplicateConnection), which the two comparisons disagree on.

**Scope note:** this fixes one real, reproducible data race, but does not fully deflap `TestFlappyBroadcastTxForPeerStopsWhenPeerStops`/`TestFlappyBroadcastTxForPeerStopsWhenReactorStops`. Isolated `-count=200/100 -race` runs were clean after this fix, but running the full mempool package under `-race` still leaks an `MConnection` `recvRoutine`/`sendRoutine` goroutine that isolated runs didn't surface -- likely a shutdown-timing issue unrelated to this bug, and reproducible often enough (most runs, not rare/intermittent) that it looks like a real, separate bug rather than occasional flakiness. Leaving both tests marked Flappy; flagging this here as a data point for whoever picks up that part of #202 next.
