### PR TITLE
fix(p2p): re-resolve FQDN-based persistent peers on every redial attempt

### DIFF
--- a/tm2/pkg/bft/blockchain/reactor_test.go
+++ b/tm2/pkg/bft/blockchain/reactor_test.go
@@ -22,7 +22,6 @@ import (
 	p2pTesting "github.com/gnolang/gno/tm2/pkg/internal/p2p"
 	"github.com/gnolang/gno/tm2/pkg/log"
 	"github.com/gnolang/gno/tm2/pkg/p2p"
-	p2pTypes "github.com/gnolang/gno/tm2/pkg/p2p/types"
 	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -262,11 +261,11 @@ func TestFlappyBadBlockStopsPeer(t *testing.T) {
 	lastReactorPair := newBlockchainReactor(log.NewNoopLogger(), genDoc, privVals, 0)
 	reactorPairs = append(reactorPairs, lastReactorPair)
 
-	persistentPeers := make([]*p2pTypes.NetAddress, 0, len(transports))
+	persistentPeers := make([]string, 0, len(transports))
 
 	for _, tr := range transports {
 		addr := tr.NetAddress()
-		persistentPeers = append(persistentPeers, &addr)
+		persistentPeers = append(persistentPeers, addr.String())
 	}
 
 	for i, opt := range options {

--- a/tm2/pkg/bft/node/node.go
+++ b/tm2/pkg/bft/node/node.go
@@ -539,9 +539,13 @@ func NewNode(config *cfg.Config,
 	}
 
 	// Setup MultiplexSwitch.
-	peerAddrs, errs := p2pTypes.NewNetAddressFromStrings(
-		splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " "),
-	)
+	persistentPeerStrs := splitAndTrimEmpty(config.P2P.PersistentPeers, ",", " ")
+
+	// Validate for logging purposes. WithPersistentPeers re-parses these
+	// strings itself (and keeps the raw form around to re-resolve
+	// FQDN-based peers on every reconnect attempt, see #2580), so this
+	// pass only surfaces malformed addresses early.
+	_, errs := p2pTypes.NewNetAddressFromStrings(persistentPeerStrs)
 	for _, err = range errs {
 		p2pLogger.Error("invalid persistent peer address", "err", err)
 	}
@@ -556,7 +560,7 @@ func NewNode(config *cfg.Config,
 
 	// Prepare the misc switch options
 	opts := []p2p.SwitchOption{
-		p2p.WithPersistentPeers(peerAddrs),
+		p2p.WithPersistentPeers(persistentPeerStrs),
 		p2p.WithPrivatePeers(privatePeerIDs),
 		p2p.WithMaxInboundPeers(config.P2P.MaxNumInboundPeers),
 		p2p.WithMaxOutboundPeers(config.P2P.MaxNumOutboundPeers),

--- a/tm2/pkg/p2p/switch.go
+++ b/tm2/pkg/p2p/switch.go
@@ -71,8 +71,13 @@ type MultiplexSwitch struct {
 
 	peers           PeerSet  // currently active peer set (live connections)
 	persistentPeers sync.Map // ID -> *NetAddress; peers whose connections are constant
-	privatePeers    sync.Map // ID -> nothing; lookup table of peers who are not shared
-	transport       Transport
+	// persistentPeerAddrStrs holds the original "id@host:port" strings behind
+	// persistentPeers (ID -> string), so FQDN-based persistent peers can be
+	// re-resolved on each reconnect attempt in redialFn instead of reusing a
+	// possibly-stale resolved IP forever (see #2580).
+	persistentPeerAddrStrs sync.Map
+	privatePeers           sync.Map // ID -> nothing; lookup table of peers who are not shared
+	transport              Transport
 
 	dialQueue  *dial.Queue
 	dialNotify chan struct{}
@@ -402,12 +407,39 @@ func (sw *MultiplexSwitch) runRedialLoop(ctx context.Context) {
 		)
 
 		// Gather addresses of persistent peers that are missing or
-		// not already in the dial queue
+		// not already in the dial queue. For peers configured via FQDN,
+		// re-resolve on every redial attempt rather than reusing the
+		// address resolved when the peer was first registered — otherwise
+		// a persistent peer's IP change (e.g. a sentry node behind a
+		// changing address) is never picked up (see #2580).
 		sw.persistentPeers.Range(func(key, value any) bool {
 			var (
-				id   = key.(types.ID)
-				addr = value.(*types.NetAddress)
+				id      = key.(types.ID)
+				cached  = value.(*types.NetAddress)
+				addr    = cached
+				rawAddr string
+				hasRaw  bool
 			)
+
+			if raw, ok := sw.persistentPeerAddrStrs.Load(id); ok {
+				rawAddr, hasRaw = raw.(string), true
+			}
+
+			if hasRaw {
+				if resolved, err := types.NewNetAddressFromString(rawAddr); err == nil {
+					addr = resolved
+					// Cache the freshly-resolved address so isPersistentPeer
+					// and other lookups reflect the latest known IP too.
+					sw.persistentPeers.Store(id, addr)
+				} else {
+					sw.Logger.Warn(
+						"unable to re-resolve persistent peer address, using last known address",
+						"id", id,
+						"raw_addr", rawAddr,
+						"err", err,
+					)
+				}
+			}
 
 			if !peers.Has(id) && !sw.dialQueue.Has(addr) {
 				peersToDial = append(peersToDial, addr)

--- a/tm2/pkg/p2p/switch_option.go
+++ b/tm2/pkg/p2p/switch_option.go
@@ -28,11 +28,24 @@ func WithReactor(name string, reactor Reactor) SwitchOption {
 	}
 }
 
-// WithPersistentPeers sets the p2p switch's persistent peer set
-func WithPersistentPeers(peerAddrs []*types.NetAddress) SwitchOption {
+// WithPersistentPeers sets the p2p switch's persistent peer set from raw
+// "id@host:port" address strings. The original strings are retained
+// alongside the resolved addresses so FQDN-based persistent peers can be
+// re-resolved on each reconnect attempt (see redialFn in switch.go) instead
+// of reusing a possibly-stale resolved IP forever (see #2580). Invalid
+// addresses are skipped; callers that want to surface parse errors (e.g.
+// for logging) should validate persistentPeerAddrs themselves beforehand,
+// such as with types.NewNetAddressFromStrings.
+func WithPersistentPeers(persistentPeerAddrs []string) SwitchOption {
 	return func(sw *MultiplexSwitch) {
-		for _, addr := range peerAddrs {
+		for _, raw := range persistentPeerAddrs {
+			addr, err := types.NewNetAddressFromString(raw)
+			if err != nil {
+				continue
+			}
+
 			sw.persistentPeers.Store(addr.ID, addr)
+			sw.persistentPeerAddrStrs.Store(addr.ID, raw)
 		}
 	}
 }

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -745,7 +745,7 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 		)
 
 		sw := NewMultiplexSwitch(
-			nil,
+			&mockTransport{},
 			WithPersistentPeers([]string{rawAddr}),
 		)
 		sw.peers = ps

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -735,19 +735,6 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 			freshAddr = peer.SocketAddr() // the current, correct address
 			rawAddr   = freshAddr.String()
 
-			dialedAddrs []types.NetAddress
-
-			mockTransport = &mockTransport{
-				dialFn: func(
-					_ context.Context,
-					address types.NetAddress,
-					_ PeerBehavior,
-				) (PeerConn, error) {
-					dialedAddrs = append(dialedAddrs, address)
-
-					return nil, errors.New("stop after recording the dial attempt")
-				},
-			}
 			ps = &mockSet{
 				hasFn: func(types.ID) bool {
 					// The peer is never connected, so it's always a
@@ -758,7 +745,7 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 		)
 
 		sw := NewMultiplexSwitch(
-			mockTransport,
+			nil,
 			WithPersistentPeers([]string{rawAddr}),
 		)
 		sw.peers = ps
@@ -778,15 +765,7 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 		)
 		defer cancelFn()
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
-			sw.runRedialLoop(ctx)
-		}()
+		go sw.runRedialLoop(ctx)
 
 		deadline := time.After(5 * time.Second)
 
@@ -796,7 +775,7 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 			case <-deadline:
 				break loop
 			default:
-				if len(dialedAddrs) > 0 {
+				if sw.dialQueue.Has(freshAddr) {
 					cancelFn()
 
 					break loop
@@ -804,18 +783,15 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 			}
 		}
 
-		wg.Wait()
-
-		require.NotEmpty(t, dialedAddrs)
-		assert.True(
+		require.True(
 			t,
-			dialedAddrs[0].Equals(*freshAddr),
-			"redial should use the freshly re-resolved address, not the stale cached one",
+			sw.dialQueue.Has(freshAddr),
+			"redial should queue the freshly re-resolved address",
 		)
 		assert.False(
 			t,
-			dialedAddrs[0].Equals(staleAddr),
-			"redial must not reuse the stale cached IP",
+			sw.dialQueue.Has(&staleAddr),
+			"redial must not queue the stale cached IP",
 		)
 	})
 }

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -39,12 +39,36 @@ func TestMultiplexSwitch_Options(t *testing.T) {
 		t.Parallel()
 
 		peers := generateNetAddr(t, 10)
-
-		sw := NewMultiplexSwitch(nil, WithPersistentPeers(peers))
-
-		for _, p := range peers {
-			assert.True(t, sw.isPersistentPeer(p.ID))
+		peerStrs := make([]string, len(peers))
+		for i, p := range peers {
+			peerStrs[i] = p.String()
 		}
+
+		sw := NewMultiplexSwitch(nil, WithPersistentPeers(peerStrs))
+
+		for i, p := range peers {
+			assert.True(t, sw.isPersistentPeer(p.ID))
+
+			// The raw address string must be retained too, so it can be
+			// re-resolved on redial (see #2580).
+			raw, ok := sw.persistentPeerAddrStrs.Load(p.ID)
+			require.True(t, ok)
+			assert.Equal(t, peerStrs[i], raw)
+		}
+	})
+
+	t.Run("persistent peers, invalid address skipped", func(t *testing.T) {
+		t.Parallel()
+
+		peers := generateNetAddr(t, 2)
+
+		sw := NewMultiplexSwitch(nil, WithPersistentPeers([]string{
+			"not-a-valid-address",
+			peers[0].String(),
+		}))
+
+		assert.True(t, sw.isPersistentPeer(peers[0].ID))
+		assert.False(t, sw.isPersistentPeer(peers[1].ID))
 	})
 
 	t.Run("private peers", func(t *testing.T) {
@@ -578,16 +602,16 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 
 		// Make sure the peers are the
 		// switch persistent peers
-		addrs := make([]*types.NetAddress, 0, len(peers))
+		addrStrs := make([]string, 0, len(peers))
 
 		for _, p := range peers {
-			addrs = append(addrs, p.SocketAddr())
+			addrStrs = append(addrStrs, p.SocketAddr().String())
 		}
 
 		// Create the switch
 		sw := NewMultiplexSwitch(
 			nil,
-			WithPersistentPeers(addrs),
+			WithPersistentPeers(addrStrs),
 		)
 
 		// Set the peer set
@@ -644,16 +668,16 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 
 		// Make sure the peers are the
 		// switch persistent peers
-		addrs := make([]*types.NetAddress, 0, len(peers))
+		addrStrs := make([]string, 0, len(peers))
 
 		for _, p := range peers {
-			addrs = append(addrs, p.SocketAddr())
+			addrStrs = append(addrStrs, p.SocketAddr().String())
 		}
 
 		// Create the switch
 		sw := NewMultiplexSwitch(
 			mockTransport,
-			WithPersistentPeers(addrs),
+			WithPersistentPeers(addrStrs),
 		)
 
 		// Set the peer set
@@ -701,6 +725,98 @@ func TestMultiplexSwitch_RedialLoop(t *testing.T) {
 
 		require.True(t, sw.dialQueue.Has(missingAddr))
 		assert.Equal(t, missingAddr, sw.dialQueue.Peek().Address)
+	})
+
+	t.Run("re-resolves stale persistent peer address on redial", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			peer      = mock.GeneratePeers(t, 1)[0]
+			freshAddr = peer.SocketAddr() // the current, correct address
+			rawAddr   = freshAddr.String()
+
+			dialedAddrs []types.NetAddress
+
+			mockTransport = &mockTransport{
+				dialFn: func(
+					_ context.Context,
+					address types.NetAddress,
+					_ PeerBehavior,
+				) (PeerConn, error) {
+					dialedAddrs = append(dialedAddrs, address)
+
+					return nil, errors.New("stop after recording the dial attempt")
+				},
+			}
+			ps = &mockSet{
+				hasFn: func(types.ID) bool {
+					// The peer is never connected, so it's always a
+					// redial candidate.
+					return false
+				},
+			}
+		)
+
+		sw := NewMultiplexSwitch(
+			mockTransport,
+			WithPersistentPeers([]string{rawAddr}),
+		)
+		sw.peers = ps
+
+		// Simulate the address having changed since it was first resolved
+		// (e.g. a sentry node's IP changing behind an FQDN): before this
+		// fix, a stale cached IP like this would be dialed forever. Plant
+		// it directly and make sure redialFn prefers the freshly
+		// re-resolved address from the raw "id@host:port" string instead.
+		staleAddr := *freshAddr
+		staleAddr.IP = net.ParseIP("203.0.113.1") // TEST-NET-3, guaranteed to differ
+		sw.persistentPeers.Store(freshAddr.ID, &staleAddr)
+
+		ctx, cancelFn := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancelFn()
+
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			sw.runRedialLoop(ctx)
+		}()
+
+		deadline := time.After(5 * time.Second)
+
+	loop:
+		for {
+			select {
+			case <-deadline:
+				break loop
+			default:
+				if len(dialedAddrs) > 0 {
+					cancelFn()
+
+					break loop
+				}
+			}
+		}
+
+		wg.Wait()
+
+		require.NotEmpty(t, dialedAddrs)
+		assert.True(
+			t,
+			dialedAddrs[0].Equals(*freshAddr),
+			"redial should use the freshly re-resolved address, not the stale cached one",
+		)
+		assert.False(
+			t,
+			dialedAddrs[0].Equals(staleAddr),
+			"redial must not reuse the stale cached IP",
+		)
 	})
 }
 


### PR DESCRIPTION
Fixes #2580.

Persistent peer addresses configured via FQDN (e.g. `persistent_peers = "id@sentry.internal:26656"`) were resolved to an IP exactly once, at switch construction / node startup. `NetAddress` only stores ID/IP/Port -- the original hostname is discarded after that first resolution -- so the periodic redial loop kept reusing that IP forever. If the peers IP changed (e.g. a sentry node behind a changing address, common with DHCP/cloud/container orchestration), the validator would keep dialing the old, dead IP indefinitely and never reconnect.

`WithPersistentPeers` now takes raw `id@host:port` strings instead of pre-resolved `*NetAddress` values, and keeps the original strings around (`persistentPeerAddrStrs`, ID -> string) alongside the resolved addresses. `redialFn` re-resolves from the raw string on every redial attempt instead of reusing the cached address; if re-resolution fails (e.g. a transient DNS hiccup), it logs a warning and falls back to the last known-good address rather than failing the redial outright.

This intentionally does not touch the `NetAddress` struct itself (its also used for PEX/gossip wire encoding), keeping the fix local to the switchs own persistent-peer bookkeeping and avoiding any wire compatibility concerns.

Added a test ("re-resolves stale persistent peer address on redial") that plants a stale cached address and verifies redialFn queues the freshly re-resolved one instead.

**Note on `-race`:** running the full `tm2/pkg/p2p` package under `-race` shows two data races (`TestMultiplexSwitch_AcceptLoop` vs its mock transport, and `TestMultiplexSwitch_Peers`/`TestMultiplexSwitch_Broadcast` racing on shared state when run in parallel). Confirmed both are pre-existing on master (same races, same tests) and unrelated to this change.