### PR TITLE
test(gnovm): bench the gas inputs a caller controls

### DIFF
--- a/gnovm/cmd/calibrate/gen_native_table.py
+++ b/gnovm/cmd/calibrate/gen_native_table.py
@@ -4,8 +4,14 @@ Generate native function gas table for GnoVM stdlibs from Go benchmarks.
 
 Mirrors gen_analysis.py (opcode handler gas) and gen_alloc_table.py
 (allocation gas). Reads `go test -bench=BenchmarkNative` output, fits a
-formula per native (flat, base + slope*N, or base + α·count + β·total_bytes
-for slice-of-string natives), and prints:
+formula per native, and prints the result. Four shapes are supported:
+
+  - flat                            NATIVE_SPECS, kind "Flat"
+  - base + slope*N                  NATIVE_SPECS
+  - base + α·count + β·total_bytes  NATIVE_SPECS_2D   (one param, two measures)
+  - base + α·N1 + β·N2              NATIVE_SPECS_2ARG (two params, one each)
+
+Outputs:
 
   - native_gas_formulas.md  — markdown table of fits
   - native_gas_table.go.txt — Go-pasteable nativeGasTable block
@@ -164,8 +170,6 @@ NATIVE_SPECS = [
     # ---- IBC crypto stdlibs ----
     ("crypto/keccak256", "sum256", 0, "LenBytes",
      r"BenchmarkNative_Keccak256_Sum256_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
-    ("crypto/modexp", "modExp", 2, "LenBytes",
-     r"BenchmarkNative_ModExp_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     ("crypto/bn254", "g1Add", None, "Flat",
      r"BenchmarkNative_BN254_G1Add-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     ("crypto/bn254", "g1Mul", None, "Flat",
@@ -178,8 +182,6 @@ NATIVE_SPECS = [
      r"BenchmarkNative_CometBLS_VerifyZKP-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     ("crypto/merkle", "leafHash", 0, "LenBytes",
      r"BenchmarkNative_Merkle_LeafHash_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
-    ("crypto/merkle", "innerHash", None, "Flat",
-     r"BenchmarkNative_Merkle_InnerHash-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     ("crypto/merkle", "hashFromByteSlices", 0, "LenBytes",
      # Bench name encodes nItems; per-item encoded size is 10 bytes (4 header
      # + 6 payload), plus 4 for the outer count header.
@@ -212,6 +214,40 @@ NATIVE_SPECS_2D = [
      r"BenchmarkNative_SysParams_UpdateStrings_(\d+)_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op", False),
     ("sys/params", "getSysParamStrings", 2, "ReturnLen",
      r"BenchmarkNative_SysParams_GetStrings_(\d+)_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op", True),
+]
+
+
+# 2-argument specs: natives whose cost depends on TWO independent
+# parameters, each with its own index and its own size kind. The fitter
+# regresses
+#   cost = base + s1*N1 + s2*N2
+# and emits Slope/SlopeIdx/SlopeKind alongside Slope2/Slope2Idx/
+# Slope2Kind, which chargeNativeGas reads off the call block and sums
+# independently.
+#
+# Distinct from NATIVE_SPECS_2D: that form measures ONE parameter two
+# ways (element count and total inner bytes), so both its slopes carry
+# the same index. Here the slopes point at different parameters, and a
+# parameter left out of the spec is charged nothing at all.
+#
+# The bench grid must vary the two parameters independently. Diagonal-only
+# data (N1 == N2 at every point) makes the two design columns identical,
+# and the least-squares split between s1 and s2 is then arbitrary.
+#
+# Format: (pkg, fn, idx1, kind1, idx2, kind2, regex)
+#   regex captures (n1, n2, ns).
+NATIVE_SPECS_2ARG = [
+    # innerHash(left, right []byte): sha256 over 0x01||left||right, so both
+    # sides cost per byte and a flat charge prices megabytes as 64 bytes.
+    ("crypto/merkle", "innerHash", 0, "LenBytes", 1, "LenBytes",
+     r"BenchmarkNative_Merkle_InnerHash_L(\d+)_R(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
+    # modExp(base, exp, modulus []byte): one modular squaring per exponent
+    # bit, each quadratic in the modulus. Pricing the modulus alone leaves
+    # the exponent free. The additive model here still understates the
+    # len(exp)·len(mod)^2 corner, so the fit is only trustworthy over the
+    # benched range — re-run before raising the modulus ceiling.
+    ("crypto/modexp", "modExp", 1, "LenBytes", 2, "LenBytes",
+     r"BenchmarkNative_ModExp_E(\d+)_M(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
 ]
 
 
@@ -249,6 +285,22 @@ def parse_bench_2d(path):
     return data
 
 
+def parse_bench_2arg(path):
+    """Parse 2-argument bench rows: (n1, n2) → list of ns observations."""
+    text = open(path).read()
+    data = defaultdict(lambda: defaultdict(list))
+    for pkg, fn, _, _, _, _, regex in NATIVE_SPECS_2ARG:
+        for line in text.splitlines():
+            m = re.search(regex, line)
+            if not m:
+                continue
+            n1 = int(m.group(1))
+            n2 = int(m.group(2))
+            ns = float(m.group(3))
+            data[(pkg, fn)][(n1, n2)].append(ns)
+    return data
+
+
 def fit_linear(sizes_ns):
     """Weighted LS (1/y) so small N stays relevant; floor base to ns(min)."""
     sizes = np.array(sorted(sizes_ns.keys()), dtype=float)
@@ -269,37 +321,83 @@ def fit_linear(sizes_ns):
     return base, slope, r2
 
 
-def fit_2d(grid):
-    """Multivariate LS for cost = base + α·count + β·total_bytes.
+def fit_plane(pts):
+    """Multivariate LS for cost = base + a·x1 + b·x2.
 
-    grid: dict (count, per_elem) → list of ns observations.
-    Returns (base, alpha_count, beta_bytes, r2).
+    pts: iterable of (x1, x2, ns) triples, one per distinct design point.
+    Returns (base, a, b, r2), or None with fewer than 3 points (base plus
+    two slopes needs 3 to be determined).
     Weighted by 1/y to keep small/cheap data points from dominating.
-    Coefficients are floored at zero (gas can't be negative)."""
-    pts = []
-    for (c, p), nss in grid.items():
-        pts.append((c, c * p, float(np.median(nss))))
+    Slopes are floored at zero (gas can't be negative)."""
+    pts = sorted(pts)
     if len(pts) < 3:
-        # Need at least 3 to disambiguate base + 2 slopes.
         return None
-    pts.sort()
     arr = np.array(pts, dtype=float)
-    counts = arr[:, 0]
-    bytes_ = arr[:, 1]
+    x1 = arr[:, 0]
+    x2 = arr[:, 1]
     ns = arr[:, 2]
     w = 1.0 / np.maximum(ns, 1e-9)
-    A = np.column_stack([np.ones(len(arr)), counts, bytes_])
+    A = np.column_stack([np.ones(len(arr)), x1, x2])
     AW = (A.T * w).T
     yW = ns * w
     coeffs, *_ = np.linalg.lstsq(AW, yW, rcond=None)
     base = max(float(coeffs[0]), float(ns.min()) * 0.5)
-    alpha = max(float(coeffs[1]), 0.0)
-    beta = max(float(coeffs[2]), 0.0)
-    pred = base + alpha * counts + beta * bytes_
+    a = max(float(coeffs[1]), 0.0)
+    b = max(float(coeffs[2]), 0.0)
+    pred = base + a * x1 + b * x2
     ss_res = float(np.sum((ns - pred) ** 2))
     ss_tot = float(np.sum((ns - ns.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 1.0
-    return base, alpha, beta, r2
+    return base, a, b, r2
+
+
+def fit_2d(grid):
+    """Fit cost = base + α·count + β·total_bytes for a slice-of-string native.
+
+    grid: dict (count, per_elem) → list of ns observations. The second
+    regressor is the product count·per_elem (total inner bytes), which is
+    the only thing separating this from fit_2arg."""
+    return fit_plane((c, c * p, float(np.median(nss)))
+                     for (c, p), nss in grid.items())
+
+
+def fit_2arg(grid):
+    """Fit cost = base + s1·N1 + s2·N2 for two independent parameters.
+
+    grid: dict (n1, n2) → list of ns observations. Both regressors are used
+    as measured; nothing multiplies them together.
+
+    Returns (base, s1, s2, r2, separable). `separable` is False when the
+    sampled (N1, N2) pairs are collinear — a diagonal-only grid fits a
+    plane whose split between s1 and s2 is not determined by the data."""
+    pts = [(n1, n2, float(np.median(nss))) for (n1, n2), nss in grid.items()]
+    result = fit_plane(pts)
+    if result is None:
+        return None
+    arr = np.array([(p[0], p[1]) for p in pts], dtype=float)
+    separable = bool(np.linalg.matrix_rank(
+        np.column_stack([np.ones(len(arr)), arr])) >= 3)
+    return (*result, separable)
+
+
+def worst_undercharge(grid, base, s1_per_1024, s2_per_1024):
+    """Largest measured/charged ratio over the sampled grid.
+
+    Replays the runtime's integer arithmetic (base + slope*N/1024 per
+    slope) against the benched cost. A ratio above 1 means the emitted
+    entry charges less than the call measurably costs, which is what an
+    attacker buys. Returns (ratio, n1, n2) for the worst point."""
+    worst = (0.0, 0, 0)
+    for (n1, n2), nss in grid.items():
+        charged = (base
+                   + s1_per_1024 * n1 // 1024
+                   + s2_per_1024 * n2 // 1024)
+        if charged <= 0:
+            continue
+        ratio = float(np.median(nss)) / charged
+        if ratio > worst[0]:
+            worst = (ratio, n1, n2)
+    return worst
 
 
 def fit_flat(values):
@@ -336,6 +434,13 @@ def emit_markdown(rows, out):
                 f"| `{r['pkg']}.{r['fn']}` | base+α·count+β·bytes | "
                 f"{r['base']:.1f} | {r['alpha']:.4f} | {r['beta']:.4f} | "
                 f"{n_desc(r['count_kind'], r['idx'])} + sum_inner_len | {r['r2']:.3f} |\n"
+            )
+        elif r["shape"] == "2arg":
+            out.write(
+                f"| `{r['pkg']}.{r['fn']}` | base+α·N1+β·N2 | "
+                f"{r['base']:.1f} | {r['alpha']:.4f} | {r['beta']:.4f} | "
+                f"{n_desc(r['kind1'], r['idx1'])} + {n_desc(r['kind2'], r['idx2'])} | "
+                f"{r['r2']:.3f} |\n"
             )
 
 
@@ -394,6 +499,24 @@ def emit_go_table(rows, out):
                     f' + β={r["beta"]:.4f}ns/byte (={beta_per_1024}/1024) R²={r["r2"]:.3f}\n'
                 )
             continue
+        if r["shape"] == "2arg":
+            s1_per_1024 = int(round(r["alpha"] * 1024))
+            s2_per_1024 = int(round(r["beta"] * 1024))
+            out.write(
+                f'\t{{Pkg: "{r["pkg"]}", Fn: "{r["fn"]}", '
+                f'Base: {int(round(r["base"]))}, '
+                f'Slope: {s1_per_1024}, '
+                f'SlopeIdx: {r["idx1"]}, '
+                f'SlopeKind: Size{r["kind1"]}, '
+                f'Slope2: {s2_per_1024}, '
+                f'Slope2Idx: {r["idx2"]}, '
+                f'Slope2Kind: Size{r["kind2"]}}},'
+                f' // 2arg: base={r["base"]:.1f}ns'
+                f' + {r["alpha"]:.4f}ns/N1 (={s1_per_1024}/1024, p{r["idx1"]})'
+                f' + {r["beta"]:.4f}ns/N2 (={s2_per_1024}/1024, p{r["idx2"]})'
+                f' R²={r["r2"]:.3f}\n'
+            )
+            continue
         # 1-D linear.
         slope_per_1024 = int(round(r["slope"] * 1024))
         if r["kind"] == "ReturnLen":
@@ -428,6 +551,9 @@ def _param_label(r):
         return ""
     if r["shape"] == "2d":
         return f"count = len(p{r['idx']}); bytes = sum_inner_len"
+    if r["shape"] == "2arg":
+        return (f"N1 = {n_desc(r['kind1'], r['idx1'])}; "
+                f"N2 = {n_desc(r['kind2'], r['idx2'])}")
     kind = r["kind"]
     if kind == "NumCallFrames":
         return "N = m.NumCallFrames()"
@@ -436,8 +562,8 @@ def _param_label(r):
     return f"N = len(p{r['slope_idx']}) — {kind}"
 
 
-def plot_fits(var_data, flat_data, two_d_data, rows, out_path):
-    """Render the parameterized fits — linear and 2-D.
+def plot_fits(var_data, flat_data, two_d_data, two_arg_data, rows, out_path):
+    """Render the parameterized fits — linear, 2-D and 2-argument.
 
     Flat natives (single horizontal reference; no parameter on the x-axis)
     are excluded — their plots are visually redundant with the median
@@ -446,7 +572,9 @@ def plot_fits(var_data, flat_data, two_d_data, rows, out_path):
     - Linear panels: median data points (blue) + fit line (red dashed).
     - 2-D panels: two overlaid series — vs count (perElem=1, blue) and
       vs total bytes (count=2, orange). Each series gets the model's
-      prediction (dashed) so visual deviation flags a poor fit."""
+      prediction (dashed) so visual deviation flags a poor fit.
+    - 2-argument panels: one series per parameter, each swept with the
+      other held at its smallest sampled value."""
     try:
         import matplotlib.pyplot as plt
     except ImportError:
@@ -503,6 +631,35 @@ def plot_fits(var_data, flat_data, two_d_data, rows, out_path):
             ax.set_title(
                 f"{r['pkg']}.{r['fn']}\nbase={r['base']:.0f}+α·c+β·b R²={r['r2']:.3f}",
                 fontsize=9)
+        elif r["shape"] == "2arg":
+            # One series per parameter: vary it while the other is held at
+            # its smallest sampled value, so a visibly flat series means the
+            # corresponding slope is not supported by the data.
+            grid = two_arg_data[(r["pkg"], r["fn"])]
+            min_n2 = min(n2 for (_, n2) in grid)
+            min_n1 = min(n1 for (n1, _) in grid)
+            xs1 = sorted(n1 for (n1, n2) in grid if n2 == min_n2)
+            xs2 = sorted(n2 for (n1, n2) in grid if n1 == min_n1)
+            if len(xs1) > 1:
+                ys1 = [np.median(grid[(x, min_n2)]) for x in xs1]
+                ax.plot(xs1, ys1, "bo-", markersize=5,
+                        label=f"vs N1 (N2={min_n2})")
+                a1 = np.array(xs1, dtype=float)
+                ax.plot(a1, r["base"] + r["alpha"] * a1 + r["beta"] * min_n2,
+                        "b--", alpha=0.6, label=f"  α={r['alpha']:.3f}")
+            if len(xs2) > 1:
+                ys2 = [np.median(grid[(min_n1, x)]) for x in xs2]
+                ax.plot(xs2, ys2, "s-", color="orange", markersize=5,
+                        label=f"vs N2 (N1={min_n1})")
+                a2 = np.array(xs2, dtype=float)
+                ax.plot(a2, r["base"] + r["alpha"] * min_n1 + r["beta"] * a2,
+                        "--", color="orange", alpha=0.6,
+                        label=f"  β={r['beta']:.3f}")
+            ax.set_xscale("log")
+            ax.set_yscale("log")
+            ax.set_title(
+                f"{r['pkg']}.{r['fn']}\nbase={r['base']:.0f}+α·N1+β·N2 R²={r['r2']:.3f}",
+                fontsize=9)
         else:  # linear
             # 2-D entries that demoted to 1-D (β rounded to zero) live
             # in two_d_data, not var_data. Project them onto the count
@@ -513,11 +670,25 @@ def plot_fits(var_data, flat_data, two_d_data, rows, out_path):
             if d is None:
                 grid = two_d_data.get((r["pkg"], r["fn"]), {})
                 if not grid:
-                    ax.set_title(f"{r['pkg']}.{r['fn']}\n(no data)", fontsize=9)
-                    continue
-                min_p = min(p for (_, p) in grid.keys())
-                d = {c: grid[(c, min_p)]
-                     for (c, p) in grid.keys() if p == min_p}
+                    # A 2-arg fit that demoted to 1-D: project onto the
+                    # surviving axis, holding the dropped one at its min.
+                    grid = two_arg_data.get((r["pkg"], r["fn"]), {})
+                    if not grid:
+                        ax.set_title(f"{r['pkg']}.{r['fn']}\n(no data)",
+                                     fontsize=9)
+                        continue
+                    if r["slope_idx"] == r.get("idx2"):
+                        min_n1 = min(n1 for (n1, _) in grid)
+                        d = {n2: v for (n1, n2), v in grid.items()
+                             if n1 == min_n1}
+                    else:
+                        min_n2 = min(n2 for (_, n2) in grid)
+                        d = {n1: v for (n1, n2), v in grid.items()
+                             if n2 == min_n2}
+                else:
+                    min_p = min(p for (_, p) in grid.keys())
+                    d = {c: grid[(c, min_p)]
+                         for (c, p) in grid.keys() if p == min_p}
             sizes = np.array(sorted(d.keys()), dtype=float)
             med = np.array([np.median(d[s]) for s in sizes])
             ax.plot(sizes, med, "bo-", markersize=5, label="median ns/op")
@@ -557,6 +728,7 @@ def main():
 
     var_data, flat_data = parse_bench(args.bench_file)
     two_d_data = parse_bench_2d(args.bench_file)
+    two_arg_data = parse_bench_2arg(args.bench_file)
 
     rows = []
     for pkg, fn, slope_idx, kind, _ in NATIVE_SPECS:
@@ -639,6 +811,71 @@ def main():
                 "idx": idx, "count_kind": count_kind, "post": post,
             })
 
+    # 2-argument fits.
+    for pkg, fn, idx1, kind1, idx2, kind2, _ in NATIVE_SPECS_2ARG:
+        grid = two_arg_data.get((pkg, fn))
+        if not grid:
+            print(f"WARN: no 2-arg data for {pkg}.{fn}", file=sys.stderr)
+            continue
+        result = fit_2arg(grid)
+        if result is None:
+            print(f"WARN: insufficient 2-arg points for {pkg}.{fn}",
+                  file=sys.stderr)
+            continue
+        base, s1, s2, r2, separable = result
+        if not separable:
+            print(f"WARN: {pkg}.{fn} 2-arg grid is collinear (N1 and N2 never "
+                  f"vary independently); the s1/s2 split is not identified — "
+                  f"add off-diagonal bench points", file=sys.stderr)
+        s1_per_1024 = int(round(s1 * 1024))
+        s2_per_1024 = int(round(s2 * 1024))
+        # Same noise floor as the 2-D ladder: below 10/1024 ns per unit the
+        # coefficient flips sign between bench runs.
+        if s1_per_1024 < 10:
+            s1_per_1024 = 0
+        if s2_per_1024 < 10:
+            s2_per_1024 = 0
+        # Dropping a slope here means the corresponding argument becomes
+        # free at runtime, which is the failure these specs exist to catch.
+        # Demote when the data says so, but say so loudly.
+        if s1_per_1024 == 0 and s2_per_1024 == 0:
+            rows.append({"pkg": pkg, "fn": fn, "shape": "flat", "base": base})
+            print(f"WARN: {pkg}.{fn} 2-arg demoted to flat (both slopes ≈0); "
+                  f"both parameters are now unpriced", file=sys.stderr)
+        elif s2_per_1024 == 0:
+            rows.append({"pkg": pkg, "fn": fn, "shape": "linear",
+                         "base": base, "slope": s1, "r2": r2,
+                         "slope_idx": idx1, "kind": kind1,
+                         "idx2": idx2})
+            print(f"WARN: {pkg}.{fn} 2-arg→1-D (s2≈0); p{idx2} is now unpriced",
+                  file=sys.stderr)
+        elif s1_per_1024 == 0:
+            rows.append({"pkg": pkg, "fn": fn, "shape": "linear",
+                         "base": base, "slope": s2, "r2": r2,
+                         "slope_idx": idx2, "kind": kind2,
+                         "idx2": idx2})
+            print(f"WARN: {pkg}.{fn} 2-arg→1-D (s1≈0); p{idx1} is now unpriced",
+                  file=sys.stderr)
+        else:
+            rows.append({
+                "pkg": pkg, "fn": fn, "shape": "2arg",
+                "base": base, "alpha": s1, "beta": s2, "r2": r2,
+                "idx1": idx1, "kind1": kind1, "idx2": idx2, "kind2": kind2,
+            })
+        # A plane through superlinear data undercharges its own worst
+        # sampled point, and least squares happily lands there. Replay the
+        # emitted integers against the measurements and say by how much.
+        ratio, wn1, wn2 = worst_undercharge(
+            grid, int(round(base)), s1_per_1024, s2_per_1024)
+        if r2 < 0.5 or ratio > 2.0:
+            print(f"WARN: {pkg}.{fn} additive model fits poorly "
+                  f"(R²={r2:.3f}); the emitted entry undercharges "
+                  f"N1={wn1},N2={wn2} by {ratio:.1f}x. Cost is superlinear "
+                  f"in these parameters — the two-slope schema cannot "
+                  f"express that. Raise Base/slopes by hand to cover the "
+                  f"supported input ceiling, and record the ceiling in "
+                  f"native_gas.go.", file=sys.stderr)
+
     with open(args.md_out, "w") as f:
         emit_markdown(rows, f)
     print(f"Wrote {args.md_out}", file=sys.stderr)
@@ -648,7 +885,8 @@ def main():
     print()
     emit_go_table(rows, sys.stdout)
     if not args.no_plot:
-        plot_fits(var_data, flat_data, two_d_data, rows, args.plot)
+        plot_fits(var_data, flat_data, two_d_data, two_arg_data, rows,
+                  args.plot)
 
 
 if __name__ == "__main__":

--- a/gnovm/cmd/calibrate/gen_native_table.py
+++ b/gnovm/cmd/calibrate/gen_native_table.py
@@ -243,9 +243,18 @@ NATIVE_SPECS_2ARG = [
      r"BenchmarkNative_Merkle_InnerHash_L(\d+)_R(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     # modExp(base, exp, modulus []byte): one modular squaring per exponent
     # bit, each quadratic in the modulus. Pricing the modulus alone leaves
-    # the exponent free. The additive model here still understates the
-    # len(exp)·len(mod)^2 corner, so the fit is only trustworthy over the
-    # benched range — re-run before raising the modulus ceiling.
+    # the exponent free, so listing it here at least makes the exponent
+    # cost something.
+    #
+    # It does not make the entry safe. Cost grows as len(exp)·len(mod)^2 and
+    # an additive model cannot express a product: the fit lands at R^2 below
+    # zero (worse than a flat charge) and undercharges 512-byte exponent
+    # against 512-byte modulus by 14.4x — inside the benched range, not
+    # beyond it. The generator emits a WARN saying so.
+    #
+    # Treat the emitted numbers as a floor to be raised by hand, and do not
+    # ship them until X_modExp enforces the input ceiling they are fit for.
+    # It currently accepts slices of any length.
     ("crypto/modexp", "modExp", 1, "LenBytes", 2, "LenBytes",
      r"BenchmarkNative_ModExp_E(\d+)_M(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
 ]
@@ -378,6 +387,24 @@ def fit_2arg(grid):
     separable = bool(np.linalg.matrix_rank(
         np.column_stack([np.ones(len(arr)), arr])) >= 3)
     return (*result, separable)
+
+
+def worst_undercharge_1d(d, base, slope_per_1024):
+    """worst_undercharge for a single-parameter fit.
+
+    A flat entry is the slope_per_1024 == 0 case, which is how an
+    unbounded input ends up priced as a constant: a superlinear native
+    fits a line badly, gets demoted to flat, and then charges its
+    smallest sampled cost for every size. Returns (ratio, n)."""
+    worst = (0.0, 0)
+    for n, nss in d.items():
+        charged = base + slope_per_1024 * n // 1024
+        if charged <= 0:
+            continue
+        ratio = float(np.median(nss)) / charged
+        if ratio > worst[0]:
+            worst = (ratio, n)
+    return worst
 
 
 def worst_undercharge(grid, base, s1_per_1024, s2_per_1024):
@@ -747,14 +774,38 @@ def main():
             base, slope, r2 = fit_linear(d)
             # Demote to flat if either the per-1024 slope rounds to 0 or
             # R² < 0.5 (the line fits worse than a constant mean).
-            if int(round(slope * 1024)) == 0 or r2 < 0.5:
+            demoted = int(round(slope * 1024)) == 0 or r2 < 0.5
+            if demoted:
                 rows.append({"pkg": pkg, "fn": fn, "shape": "flat",
                              "base": base})
-                print(f"NOTE: {pkg}.{fn} demoted to flat (slope={slope:.6f}, R²={r2:.3f})", file=sys.stderr)
+                # Report the spread being flattened. A low R² means the line
+                # fit badly, not that the cost is constant, so state what the
+                # measurements actually did across the sampled range: a native
+                # that grew 2x over 1..4 units will keep growing past 4.
+                meds = {n: float(np.median(v)) for n, v in d.items()}
+                lo_n, hi_n = min(meds), max(meds)
+                growth = meds[hi_n] / meds[lo_n] if meds[lo_n] > 0 else 0.0
+                print(f"NOTE: {pkg}.{fn} demoted to flat (slope={slope:.6f}, "
+                      f"R²={r2:.3f}); measured cost moves {growth:.1f}x over "
+                      f"N={lo_n}..{hi_n}", file=sys.stderr)
             else:
                 rows.append({"pkg": pkg, "fn": fn, "shape": "linear",
                              "base": base, "slope": slope, "r2": r2,
                              "slope_idx": slope_idx, "kind": kind})
+            # Same replay the 2-arg path does, against the integers this
+            # entry will actually emit. A demotion to flat is the dangerous
+            # case: R² is low precisely when cost is superlinear, so the
+            # weakest possible pricing is chosen exactly when the input is
+            # least safe to leave unpriced.
+            emitted_slope = 0 if demoted else int(round(slope * 1024))
+            ratio, wn = worst_undercharge_1d(d, int(round(base)), emitted_slope)
+            if ratio > 2.0:
+                print(f"WARN: {pkg}.{fn} undercharges N={wn} by {ratio:.1f}x "
+                      f"(R²={r2:.3f}"
+                      f"{', demoted to flat' if demoted else ''}). Raise "
+                      f"Base/slope by hand to cover the supported input "
+                      f"ceiling, and record the ceiling in native_gas.go.",
+                      file=sys.stderr)
 
     # 2-D fits.
     for pkg, fn, idx, count_kind, _, post in NATIVE_SPECS_2D:

--- a/gnovm/cmd/calibrate/ibc_native_bench_test.go
+++ b/gnovm/cmd/calibrate/ibc_native_bench_test.go
@@ -39,57 +39,32 @@ func BenchmarkNative_Keccak256_Sum256_16384(b *testing.B) { benchKeccak256(b, 16
 
 // ----- crypto/modexp.modExp(base, exp, modulus []byte) []byte -----
 //
-// Modular exponentiation cost is dominated by len(exp)·len(mod). The
-// EVM precompile (EIP-198) gas formula uses similar scaling. We bench
-// a square modulus and a square exponent so a single-slope fit on
-// "size N" (== len(mod) == len(exp) == len(base)) captures the dominant term.
-
-func benchModExp(b *testing.B, n int) {
-	b.Helper()
-	base := make([]byte, n)
-	exp := make([]byte, n)
-	mod := make([]byte, n)
-	for i := range n {
-		base[i] = byte(i + 1)
-		exp[i] = byte(i + 3)
-		mod[i] = 0xFF // large odd modulus
-	}
-	if n > 0 {
-		mod[n-1] = 0xFD
-	}
-	m := newDispatchMachine(3)
-	setBlockValueFromGo(m, 0, base)
-	setBlockValueFromGo(m, 1, exp)
-	setBlockValueFromGo(m, 2, mod)
-	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
-	b.ResetTimer()
-	b.SetBytes(int64(n))
-	for i := 0; i < b.N; i++ {
-		h.call()
-	}
-}
-
-func BenchmarkNative_ModExp_32(b *testing.B)  { benchModExp(b, 32) }
-func BenchmarkNative_ModExp_64(b *testing.B)  { benchModExp(b, 64) }
-func BenchmarkNative_ModExp_128(b *testing.B) { benchModExp(b, 128) }
-func BenchmarkNative_ModExp_256(b *testing.B) { benchModExp(b, 256) }
-func BenchmarkNative_ModExp_512(b *testing.B) { benchModExp(b, 512) }
-
-// The square-N benches above only sample the diagonal len(exp) == len(mod),
-// so a single-slope fit on the modulus silently assumes the exponent scales
-// with it. Nothing forces a caller to respect that: a small modulus with a
-// large exponent is cheap to buy and expensive to run. These hold the modulus
-// at the supported ceiling and vary the exponent alone, so the fitter can see
-// the exponent term instead of inferring it.
-func benchModExpOffDiagonal(b *testing.B, modLen, expLen int) {
+// Modular exponentiation runs one modular squaring per exponent bit, and
+// each squaring is quadratic in the modulus, so cost tracks
+// len(exp)·len(mod)². Sampling only the diagonal len(exp) == len(mod)
+// makes the two lengths indistinguishable to a fitter, and pricing the
+// modulus alone leaves the exponent free: a small modulus with a huge
+// exponent is cheap to buy and expensive to run.
+//
+// The grid below walks the diagonal, then holds the modulus at 256 bytes
+// while sweeping the exponent and holds the exponent at 256 bytes while
+// sweeping the modulus, so each length varies with the other pinned. Bench
+// name encodes both as _E<exp>_M<mod>.
+//
+// The base is sized to the modulus throughout. It is not a fitted
+// parameter: NativeGasInfo carries at most two pre-call slopes, and those
+// go to the two lengths that dominate.
+func benchModExp(b *testing.B, expLen, modLen int) {
 	b.Helper()
 	base := make([]byte, modLen)
 	mod := make([]byte, modLen)
 	for i := range modLen {
 		base[i] = byte(i + 1)
-		mod[i] = 0xFF
+		mod[i] = 0xFF // large odd modulus
 	}
-	mod[modLen-1] = 0xFD
+	if modLen > 0 {
+		mod[modLen-1] = 0xFD
+	}
 	exp := make([]byte, expLen)
 	for i := range expLen {
 		exp[i] = byte(i + 3)
@@ -100,15 +75,26 @@ func benchModExpOffDiagonal(b *testing.B, modLen, expLen int) {
 	setBlockValueFromGo(m, 2, mod)
 	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
 	b.ResetTimer()
-	b.SetBytes(int64(expLen))
+	b.SetBytes(int64(expLen + modLen))
 	for i := 0; i < b.N; i++ {
 		h.call()
 	}
 }
 
-func BenchmarkNative_ModExp_M256_E32(b *testing.B)   { benchModExpOffDiagonal(b, 256, 32) }
-func BenchmarkNative_ModExp_M256_E256(b *testing.B)  { benchModExpOffDiagonal(b, 256, 256) }
-func BenchmarkNative_ModExp_M256_E1024(b *testing.B) { benchModExpOffDiagonal(b, 256, 1024) }
+// Diagonal: len(exp) == len(mod).
+func BenchmarkNative_ModExp_E32_M32(b *testing.B)   { benchModExp(b, 32, 32) }
+func BenchmarkNative_ModExp_E64_M64(b *testing.B)   { benchModExp(b, 64, 64) }
+func BenchmarkNative_ModExp_E128_M128(b *testing.B) { benchModExp(b, 128, 128) }
+func BenchmarkNative_ModExp_E256_M256(b *testing.B) { benchModExp(b, 256, 256) }
+func BenchmarkNative_ModExp_E512_M512(b *testing.B) { benchModExp(b, 512, 512) }
+
+// Exponent sweep, modulus pinned at 256 bytes.
+func BenchmarkNative_ModExp_E32_M256(b *testing.B)   { benchModExp(b, 32, 256) }
+func BenchmarkNative_ModExp_E1024_M256(b *testing.B) { benchModExp(b, 1024, 256) }
+
+// Modulus sweep, exponent pinned at 256 bytes.
+func BenchmarkNative_ModExp_E256_M32(b *testing.B)  { benchModExp(b, 256, 32) }
+func BenchmarkNative_ModExp_E256_M512(b *testing.B) { benchModExp(b, 256, 512) }
 
 // ----- crypto/bn254 EIP-196/197 precompile natives -----
 
@@ -208,12 +194,21 @@ func BenchmarkNative_Merkle_LeafHash_4096(b *testing.B) { benchMerkleLeafHash(b,
 // sized. Benching only the 32+32B digest case yields a single point, which
 // the fitter can only express as SizeFlat, and a flat charge lets a realm
 // hash megabytes for the price of 64 bytes.
-func benchMerkleInnerHash(b *testing.B, n int) {
+//
+// Sizing left and right together is still not enough: on the diagonal
+// len(left) == len(right) the two columns of the design matrix are
+// identical, so a two-slope fit is rank-deficient and cannot attribute
+// cost to either parameter. The off-diagonal pairs below break that tie.
+// Bench name encodes both lengths as _L<left>_R<right> so the fitter reads
+// them as two independent arguments.
+func benchMerkleInnerHash(b *testing.B, leftLen, rightLen int) {
 	b.Helper()
-	left := make([]byte, n)
-	right := make([]byte, n)
-	for i := range n {
+	left := make([]byte, leftLen)
+	for i := range leftLen {
 		left[i] = byte(i + 1)
+	}
+	right := make([]byte, rightLen)
+	for i := range rightLen {
 		right[i] = byte(i + 2)
 	}
 	m := newDispatchMachine(2)
@@ -221,16 +216,28 @@ func benchMerkleInnerHash(b *testing.B, n int) {
 	setBlockValueFromGo(m, 1, right)
 	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/merkle", "innerHash"), nReturns: 1}
 	b.ResetTimer()
-	b.SetBytes(int64(2 * n))
+	b.SetBytes(int64(leftLen + rightLen))
 	for i := 0; i < b.N; i++ {
 		h.call()
 	}
 }
 
-func BenchmarkNative_Merkle_InnerHash_32(b *testing.B)   { benchMerkleInnerHash(b, 32) }
-func BenchmarkNative_Merkle_InnerHash_256(b *testing.B)  { benchMerkleInnerHash(b, 256) }
-func BenchmarkNative_Merkle_InnerHash_1024(b *testing.B) { benchMerkleInnerHash(b, 1024) }
-func BenchmarkNative_Merkle_InnerHash_4096(b *testing.B) { benchMerkleInnerHash(b, 4096) }
+func BenchmarkNative_Merkle_InnerHash_L32_R32(b *testing.B) { benchMerkleInnerHash(b, 32, 32) }
+func BenchmarkNative_Merkle_InnerHash_L256_R256(b *testing.B) {
+	benchMerkleInnerHash(b, 256, 256)
+}
+
+func BenchmarkNative_Merkle_InnerHash_L1024_R1024(b *testing.B) {
+	benchMerkleInnerHash(b, 1024, 1024)
+}
+
+func BenchmarkNative_Merkle_InnerHash_L4096_R4096(b *testing.B) {
+	benchMerkleInnerHash(b, 4096, 4096)
+}
+func BenchmarkNative_Merkle_InnerHash_L32_R4096(b *testing.B) { benchMerkleInnerHash(b, 32, 4096) }
+func BenchmarkNative_Merkle_InnerHash_L4096_R32(b *testing.B) { benchMerkleInnerHash(b, 4096, 32) }
+func BenchmarkNative_Merkle_InnerHash_L32_R1024(b *testing.B) { benchMerkleInnerHash(b, 32, 1024) }
+func BenchmarkNative_Merkle_InnerHash_L1024_R32(b *testing.B) { benchMerkleInnerHash(b, 1024, 32) }
 
 // encodeMerkleItems builds the [4-byte BE count][4-byte BE len][data]…
 // wire format consumed by hashFromByteSlices.

--- a/gnovm/cmd/calibrate/ibc_native_bench_test.go
+++ b/gnovm/cmd/calibrate/ibc_native_bench_test.go
@@ -6,7 +6,6 @@ package calibrate
 // measured ns/op feeds gen_native_table.py without special-casing.
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"testing"
 
@@ -37,6 +36,41 @@ func BenchmarkNative_Keccak256_Sum256_256(b *testing.B)   { benchKeccak256(b, 25
 func BenchmarkNative_Keccak256_Sum256_1024(b *testing.B)  { benchKeccak256(b, 1024) }
 func BenchmarkNative_Keccak256_Sum256_4096(b *testing.B)  { benchKeccak256(b, 4096) }
 func BenchmarkNative_Keccak256_Sum256_16384(b *testing.B) { benchKeccak256(b, 16384) }
+
+// The square-N benches above only sample the diagonal len(exp) == len(mod),
+// so a single-slope fit on the modulus silently assumes the exponent scales
+// with it. Nothing forces a caller to respect that: a small modulus with a
+// large exponent is cheap to buy and expensive to run. These hold the modulus
+// at the supported ceiling and vary the exponent alone, so the fitter can see
+// the exponent term instead of inferring it.
+func benchModExpOffDiagonal(b *testing.B, modLen, expLen int) {
+	b.Helper()
+	base := make([]byte, modLen)
+	mod := make([]byte, modLen)
+	for i := range modLen {
+		base[i] = byte(i + 1)
+		mod[i] = 0xFF
+	}
+	mod[modLen-1] = 0xFD
+	exp := make([]byte, expLen)
+	for i := range expLen {
+		exp[i] = byte(i + 3)
+	}
+	m := newDispatchMachine(3)
+	setBlockValueFromGo(m, 0, base)
+	setBlockValueFromGo(m, 1, exp)
+	setBlockValueFromGo(m, 2, mod)
+	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
+	b.ResetTimer()
+	b.SetBytes(int64(expLen))
+	for i := 0; i < b.N; i++ {
+		h.call()
+	}
+}
+
+func BenchmarkNative_ModExp_M256_E32(b *testing.B)   { benchModExpOffDiagonal(b, 256, 32) }
+func BenchmarkNative_ModExp_M256_E256(b *testing.B)  { benchModExpOffDiagonal(b, 256, 256) }
+func BenchmarkNative_ModExp_M256_E1024(b *testing.B) { benchModExpOffDiagonal(b, 256, 1024) }
 
 // ----- crypto/modexp.modExp(base, exp, modulus []byte) []byte -----
 //
@@ -170,18 +204,33 @@ func BenchmarkNative_Merkle_LeafHash_256(b *testing.B)  { benchMerkleLeafHash(b,
 func BenchmarkNative_Merkle_LeafHash_1024(b *testing.B) { benchMerkleLeafHash(b, 1024) }
 func BenchmarkNative_Merkle_LeafHash_4096(b *testing.B) { benchMerkleLeafHash(b, 4096) }
 
-func BenchmarkNative_Merkle_InnerHash(b *testing.B) {
-	left := sha256.Sum256([]byte("left"))
-	right := sha256.Sum256([]byte("right"))
+// innerHash accepts []byte of any length on both sides, so both must be
+// sized. Benching only the 32+32B digest case yields a single point, which
+// the fitter can only express as SizeFlat, and a flat charge lets a realm
+// hash megabytes for the price of 64 bytes.
+func benchMerkleInnerHash(b *testing.B, n int) {
+	b.Helper()
+	left := make([]byte, n)
+	right := make([]byte, n)
+	for i := range n {
+		left[i] = byte(i + 1)
+		right[i] = byte(i + 2)
+	}
 	m := newDispatchMachine(2)
-	setBlockValueFromGo(m, 0, left[:])
-	setBlockValueFromGo(m, 1, right[:])
+	setBlockValueFromGo(m, 0, left)
+	setBlockValueFromGo(m, 1, right)
 	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/merkle", "innerHash"), nReturns: 1}
 	b.ResetTimer()
+	b.SetBytes(int64(2 * n))
 	for i := 0; i < b.N; i++ {
 		h.call()
 	}
 }
+
+func BenchmarkNative_Merkle_InnerHash_32(b *testing.B)   { benchMerkleInnerHash(b, 32) }
+func BenchmarkNative_Merkle_InnerHash_256(b *testing.B)  { benchMerkleInnerHash(b, 256) }
+func BenchmarkNative_Merkle_InnerHash_1024(b *testing.B) { benchMerkleInnerHash(b, 1024) }
+func BenchmarkNative_Merkle_InnerHash_4096(b *testing.B) { benchMerkleInnerHash(b, 4096) }
 
 // encodeMerkleItems builds the [4-byte BE count][4-byte BE len][data]…
 // wire format consumed by hashFromByteSlices.

--- a/gnovm/cmd/calibrate/ibc_native_bench_test.go
+++ b/gnovm/cmd/calibrate/ibc_native_bench_test.go
@@ -37,41 +37,6 @@ func BenchmarkNative_Keccak256_Sum256_1024(b *testing.B)  { benchKeccak256(b, 10
 func BenchmarkNative_Keccak256_Sum256_4096(b *testing.B)  { benchKeccak256(b, 4096) }
 func BenchmarkNative_Keccak256_Sum256_16384(b *testing.B) { benchKeccak256(b, 16384) }
 
-// The square-N benches above only sample the diagonal len(exp) == len(mod),
-// so a single-slope fit on the modulus silently assumes the exponent scales
-// with it. Nothing forces a caller to respect that: a small modulus with a
-// large exponent is cheap to buy and expensive to run. These hold the modulus
-// at the supported ceiling and vary the exponent alone, so the fitter can see
-// the exponent term instead of inferring it.
-func benchModExpOffDiagonal(b *testing.B, modLen, expLen int) {
-	b.Helper()
-	base := make([]byte, modLen)
-	mod := make([]byte, modLen)
-	for i := range modLen {
-		base[i] = byte(i + 1)
-		mod[i] = 0xFF
-	}
-	mod[modLen-1] = 0xFD
-	exp := make([]byte, expLen)
-	for i := range expLen {
-		exp[i] = byte(i + 3)
-	}
-	m := newDispatchMachine(3)
-	setBlockValueFromGo(m, 0, base)
-	setBlockValueFromGo(m, 1, exp)
-	setBlockValueFromGo(m, 2, mod)
-	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
-	b.ResetTimer()
-	b.SetBytes(int64(expLen))
-	for i := 0; i < b.N; i++ {
-		h.call()
-	}
-}
-
-func BenchmarkNative_ModExp_M256_E32(b *testing.B)   { benchModExpOffDiagonal(b, 256, 32) }
-func BenchmarkNative_ModExp_M256_E256(b *testing.B)  { benchModExpOffDiagonal(b, 256, 256) }
-func BenchmarkNative_ModExp_M256_E1024(b *testing.B) { benchModExpOffDiagonal(b, 256, 1024) }
-
 // ----- crypto/modexp.modExp(base, exp, modulus []byte) []byte -----
 //
 // Modular exponentiation cost is dominated by len(exp)·len(mod). The
@@ -109,6 +74,41 @@ func BenchmarkNative_ModExp_64(b *testing.B)  { benchModExp(b, 64) }
 func BenchmarkNative_ModExp_128(b *testing.B) { benchModExp(b, 128) }
 func BenchmarkNative_ModExp_256(b *testing.B) { benchModExp(b, 256) }
 func BenchmarkNative_ModExp_512(b *testing.B) { benchModExp(b, 512) }
+
+// The square-N benches above only sample the diagonal len(exp) == len(mod),
+// so a single-slope fit on the modulus silently assumes the exponent scales
+// with it. Nothing forces a caller to respect that: a small modulus with a
+// large exponent is cheap to buy and expensive to run. These hold the modulus
+// at the supported ceiling and vary the exponent alone, so the fitter can see
+// the exponent term instead of inferring it.
+func benchModExpOffDiagonal(b *testing.B, modLen, expLen int) {
+	b.Helper()
+	base := make([]byte, modLen)
+	mod := make([]byte, modLen)
+	for i := range modLen {
+		base[i] = byte(i + 1)
+		mod[i] = 0xFF
+	}
+	mod[modLen-1] = 0xFD
+	exp := make([]byte, expLen)
+	for i := range expLen {
+		exp[i] = byte(i + 3)
+	}
+	m := newDispatchMachine(3)
+	setBlockValueFromGo(m, 0, base)
+	setBlockValueFromGo(m, 1, exp)
+	setBlockValueFromGo(m, 2, mod)
+	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
+	b.ResetTimer()
+	b.SetBytes(int64(expLen))
+	for i := 0; i < b.N; i++ {
+		h.call()
+	}
+}
+
+func BenchmarkNative_ModExp_M256_E32(b *testing.B)   { benchModExpOffDiagonal(b, 256, 32) }
+func BenchmarkNative_ModExp_M256_E256(b *testing.B)  { benchModExpOffDiagonal(b, 256, 256) }
+func BenchmarkNative_ModExp_M256_E1024(b *testing.B) { benchModExpOffDiagonal(b, 256, 1024) }
 
 // ----- crypto/bn254 EIP-196/197 precompile natives -----
 

--- a/gnovm/cmd/calibrate/native_gas_formulas.md
+++ b/gnovm/cmd/calibrate/native_gas_formulas.md
@@ -5,49 +5,63 @@ Slope is ns/N; runtime stores it as `Slope/1024` and computes `base + slope*N/10
 
 | Native | Shape | Base (ns) | α (ns/elem) | β (ns/byte) | N | R² |
 |---|---|---:|---:|---:|---|---:|
-| `crypto/sha256.sum256` | base+α·N | 226.3 | 8.6969 | — | len(p0) bytes | 1.000 |
-| `crypto/ed25519.verify` | base+α·N | 56534.0 | 8.7645 | — | len(p1) bytes | 0.991 |
-| `chain.packageAddress` | base+α·N | 552.1 | 14.8448 | — | len(p0) string | 0.998 |
-| `chain.deriveStorageDepositAddr` | base+α·N | 540.9 | 0.4602 | — | len(p0) string | 0.994 |
-| `chain.pubKeyAddress` | flat | 2631.0 | — | — | — | — |
-| `time.loadFromEmbeddedTZData` | flat | 16068.0 | — | — | — | — |
-| `math.Float32bits` | flat | 32.5 | — | — | — | — |
-| `math.Float32frombits` | flat | 32.4 | — | — | — | — |
-| `math.Float64bits` | flat | 28.7 | — | — | — | — |
-| `math.Float64frombits` | flat | 28.8 | — | — | — | — |
-| `chain/banker.bankerSendCoins` | base+α·N | 321.9 | 34.4898 | — | len(p3) slice | 0.999 |
-| `chain/banker.bankerGetCoins` | base+α·N | 349.1 | 35.3578 | — | len(return[2]) | 0.998 |
-| `chain/banker.bankerTotalCoin` | flat | 88.6 | — | — | — | — |
-| `chain/banker.bankerIssueCoin` | flat | 140.6 | — | — | — | — |
-| `chain/banker.bankerRemoveCoin` | flat | 195.9 | — | — | — | — |
-| `chain/banker.originSend` | flat | 280.4 | — | — | — | — |
-| `chain/banker.assertCallerIsRealm` | flat | 700.8 | — | — | — | — |
-| `chain/params.SetBytes` | base+α·N | 1912.0 | 12.9035 | — | len(p1) bytes | 1.000 |
-| `chain/params.SetString` | base+α·N | 1772.3 | 0.1323 | — | len(p1) string | 0.933 |
-| `chain/params.SetBool` | flat | 1643.0 | — | — | — | — |
-| `chain/params.SetInt64` | flat | 1201.0 | — | — | — | — |
-| `chain/params.SetUint64` | flat | 1219.0 | — | — | — | — |
-| `sys/params.setSysParamBytes` | base+α·N | 323.3 | 9.4757 | — | len(p3) bytes | 0.995 |
-| `sys/params.getSysParamBytes` | base+α·N | 415.7 | 10.3357 | — | len(return[2]) | 1.000 |
-| `sys/params.setSysParamString` | flat | 269.1 | — | — | — | — |
-| `sys/params.setSysParamBool` | flat | 217.4 | — | — | — | — |
-| `sys/params.setSysParamInt64` | flat | 227.8 | — | — | — | — |
-| `sys/params.setSysParamUint64` | flat | 298.9 | — | — | — | — |
-| `sys/params.getSysParamBool` | flat | 236.5 | — | — | — | — |
-| `sys/params.getSysParamInt64` | flat | 322.9 | — | — | — | — |
-| `sys/params.getSysParamUint64` | flat | 308.7 | — | — | — | — |
-| `sys/params.getSysParamString` | flat | 362.8 | — | — | — | — |
-| `chain/runtime.ChainID` | flat | 44.8 | — | — | — | — |
-| `chain/runtime.ChainDomain` | flat | 44.5 | — | — | — | — |
-| `chain/runtime.ChainHeight` | flat | 30.2 | — | — | — | — |
-| `chain/runtime.originCaller` | flat | 44.9 | — | — | — | — |
-| `chain/runtime.getSessionInfo` | flat | 148.4 | — | — | — | — |
-| `chain/runtime.AssertOriginCall` | flat | 5.0 | — | — | — | — |
-| `chain/runtime.getRealm` | base+α·N | 1003.0 | 1.2880 | — | m.NumCallFrames() | 0.995 |
-| `time.now` | flat | 46.9 | — | — | — | — |
-| `chain.emit` | base+α·N | 361.9 | 39.2750 | — | len(p1) slice | 0.955 |
-| `chain/params.SetStrings` | base+α·N | 1601.1 | 38.9082 | — | len(p1) slice | 0.993 |
-| `chain/params.UpdateParamStrings` | base+α·N | 1298.0 | 23.5122 | — | len(p1) slice | 1.000 |
-| `sys/params.setSysParamStrings` | base+α·N | 341.0 | 26.4006 | — | len(p3) slice | 0.997 |
-| `sys/params.updateSysParamStrings` | base+α·N | 413.4 | 26.2318 | — | len(p3) slice | 0.998 |
-| `sys/params.getSysParamStrings` | base+α·N | 348.9 | 22.6713 | — | len(return[2]) | 0.999 |
+| `crypto/sha256.sum256` | base+α·N | 471.9 | 8.2924 | — | len(p0) bytes | 0.998 |
+| `crypto/ed25519.verify` | base+α·N | 41004.5 | 9.7063 | — | len(p1) bytes | 0.990 |
+| `chain.packageAddress` | base+α·N | 756.5 | 16.8754 | — | len(p0) string | 0.985 |
+| `chain.deriveStorageDepositAddr` | base+α·N | 596.2 | 0.6131 | — | len(p0) string | 0.998 |
+| `chain.pubKeyAddress` | flat | 11892.0 | — | — | — | — |
+| `time.loadFromEmbeddedTZData` | flat | 52897.0 | — | — | — | — |
+| `math.Float32bits` | flat | 192.4 | — | — | — | — |
+| `math.Float32frombits` | flat | 90.7 | — | — | — | — |
+| `math.Float64bits` | flat | 85.2 | — | — | — | — |
+| `math.Float64frombits` | flat | 79.2 | — | — | — | — |
+| `chain/banker.bankerSendCoins` | base+α·N | 837.6 | 41.2233 | — | len(p3) slice | 0.961 |
+| `chain/banker.bankerGetCoins` | base+α·N | 1375.0 | 47.7531 | — | len(return[2]) | 0.841 |
+| `chain/banker.bankerTotalCoin` | flat | 386.8 | — | — | — | — |
+| `chain/banker.bankerIssueCoin` | flat | 381.2 | — | — | — | — |
+| `chain/banker.bankerRemoveCoin` | flat | 213.9 | — | — | — | — |
+| `chain/params.SetBytes` | base+α·N | 1949.8 | 6.8164 | — | len(p1) bytes | 0.995 |
+| `chain/params.SetString` | flat | 2050.0 | — | — | — | — |
+| `chain/params.SetBool` | flat | 1525.0 | — | — | — | — |
+| `chain/params.SetInt64` | flat | 3356.0 | — | — | — | — |
+| `chain/params.SetUint64` | flat | 1436.0 | — | — | — | — |
+| `sys/params.setSysParamBytes` | base+α·N | 887.2 | 6.6907 | — | len(p3) bytes | 0.989 |
+| `sys/params.getSysParamBytes` | base+α·N | 1032.0 | 16.7981 | — | len(return[2]) | 0.937 |
+| `sys/params.setSysParamString` | flat | 367.6 | — | — | — | — |
+| `sys/params.setSysParamBool` | flat | 695.3 | — | — | — | — |
+| `sys/params.setSysParamInt64` | flat | 332.1 | — | — | — | — |
+| `sys/params.setSysParamUint64` | flat | 710.9 | — | — | — | — |
+| `sys/params.getSysParamBool` | flat | 345.7 | — | — | — | — |
+| `sys/params.getSysParamInt64` | flat | 311.1 | — | — | — | — |
+| `sys/params.getSysParamUint64` | flat | 358.2 | — | — | — | — |
+| `sys/params.getSysParamString` | flat | 386.2 | — | — | — | — |
+| `chain/runtime.ChainID` | flat | 82.7 | — | — | — | — |
+| `chain/runtime.ChainDomain` | flat | 78.7 | — | — | — | — |
+| `chain/runtime.ChainHeight` | flat | 63.6 | — | — | — | — |
+| `chain/runtime.getSessionInfo` | flat | 246.4 | — | — | — | — |
+| `chain/runtime.AssertOriginCall` | flat | 15.5 | — | — | — | — |
+| `time.now` | flat | 103.7 | — | — | — | — |
+| `chain/markdown.StripBidiAndZeroWidth` | base+α·N | 153.1 | 2.0707 | — | len(p0) string | 0.975 |
+| `chain/markdown.NormalizeBreaks` | base+α·N | 299.6 | 0.5817 | — | len(p0) string | 0.941 |
+| `chain/markdown.EscapeInline` | base+α·N | 409.8 | 2.7306 | — | len(p0) string | 0.844 |
+| `chain/markdown.EscapeTitle` | base+α·N | 145.5 | 2.9926 | — | len(p0) string | 0.976 |
+| `chain/markdown.PercentEncodeURL` | base+α·N | 161.0 | 4.8376 | — | len(p0) string | 0.954 |
+| `chain/markdown.MatchCharsetN` | base+α·N | 849.6 | 0.9048 | — | len(p0) string | 0.967 |
+| `chain/markdown.CodeFence` | base+α·N | 149.9 | 1.0246 | — | len(p0) string | 0.936 |
+| `chain/markdown.EscapeBlockHazards` | base+α·N | 652.8 | 18.9973 | — | len(p0) string | 0.979 |
+| `crypto/keccak256.sum256` | base+α·N | 1089.0 | 14.7436 | — | len(p0) bytes | 0.972 |
+| `crypto/bn254.g1Add` | flat | 5587.0 | — | — | — | — |
+| `crypto/bn254.g1Mul` | flat | 4375.0 | — | — | — | — |
+| `crypto/bn254.pairingCheck` | flat | 314196.0 | — | — | — | — |
+| `crypto/cometbls.verifyZKP` | flat | 1098507.0 | — | — | — | — |
+| `crypto/merkle.leafHash` | base+α·N | 2961.0 | 6.7067 | — | len(p0) bytes | 0.978 |
+| `crypto/merkle.hashFromByteSlices` | base+α·N | 2395.0 | 301.2144 | — | len(p0) bytes | 0.968 |
+| `crypto/merkle.verifySimpleProof` | base+α·N | 2614.9 | 2.7347 | — | len(p4) bytes | 0.844 |
+| `chain.emit` | base+α·N | 308.4 | 27.6380 | — | len(p1) slice | 0.990 |
+| `chain/params.SetStrings` | base+α·N | 1727.8 | 27.5694 | — | len(p1) slice | 0.993 |
+| `chain/params.UpdateParamStrings` | base+α·N | 1973.9 | 28.5837 | — | len(p1) slice | 0.991 |
+| `sys/params.setSysParamStrings` | base+α·N | 537.9 | 27.3839 | — | len(p3) slice | 0.999 |
+| `sys/params.updateSysParamStrings` | base+α·N | 433.9 | 27.5901 | — | len(p3) slice | 1.000 |
+| `sys/params.getSysParamStrings` | base+α·N | 527.6 | 32.9723 | — | len(return[2]) | 0.989 |
+| `crypto/merkle.innerHash` | base+α·N1+β·N2 | 1445.5 | 7.6013 | 8.0193 | len(p0) bytes + len(p1) bytes | 0.999 |
+| `crypto/modexp.modExp` | base+α·N1+β·N2 | 20403.5 | 489.9172 | 2025.6587 | len(p1) bytes + len(p2) bytes | -0.267 |

--- a/gnovm/cmd/calibrate/native_gas_table.go.txt
+++ b/gnovm/cmd/calibrate/native_gas_table.go.txt
@@ -3,50 +3,64 @@
 // Slope is ns per 1024 units of N; runtime computes base + slope*N/1024.
 // See gnovm/cmd/calibrate/native_gas_formulas.md for derivation.
 var calibratedNativeGas = []nativeGasEntry{
-	{Pkg: "crypto/sha256", Fn: "sum256", Base: 226, Slope: 8906, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // fit base=226.3ns slope=8.6969ns/N (=8906/1024) R²=1.000
-	{Pkg: "crypto/ed25519", Fn: "verify", Base: 56534, Slope: 8975, SlopeIdx: 1, SlopeKind: SizeLenBytes}, // fit base=56534.0ns slope=8.7645ns/N (=8975/1024) R²=0.991
-	{Pkg: "chain", Fn: "packageAddress", Base: 552, Slope: 15201, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=552.1ns slope=14.8448ns/N (=15201/1024) R²=0.998
-	{Pkg: "chain", Fn: "deriveStorageDepositAddr", Base: 541, Slope: 471, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=540.9ns slope=0.4602ns/N (=471/1024) R²=0.994
-	{Pkg: "chain", Fn: "pubKeyAddress", Base: 2631, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 2631.0ns
-	{Pkg: "time", Fn: "loadFromEmbeddedTZData", Base: 16068, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 16068.0ns
-	{Pkg: "math", Fn: "Float32bits", Base: 32, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 32.5ns
-	{Pkg: "math", Fn: "Float32frombits", Base: 32, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 32.4ns
-	{Pkg: "math", Fn: "Float64bits", Base: 29, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 28.7ns
-	{Pkg: "math", Fn: "Float64frombits", Base: 29, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 28.8ns
-	{Pkg: "chain/banker", Fn: "bankerSendCoins", Base: 322, Slope: 35318, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=321.9ns slope=34.4898ns/N (=35318/1024) R²=0.999
-	{Pkg: "chain/banker", Fn: "bankerGetCoins", Base: 349, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 36206, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=349.1ns + 35.3578ns/N (=36206/1024) R²=0.998
-	{Pkg: "chain/banker", Fn: "bankerTotalCoin", Base: 89, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 88.6ns
-	{Pkg: "chain/banker", Fn: "bankerIssueCoin", Base: 141, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 140.6ns
-	{Pkg: "chain/banker", Fn: "bankerRemoveCoin", Base: 196, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 195.9ns
-	{Pkg: "chain/banker", Fn: "originSend", Base: 280, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 280.4ns
-	{Pkg: "chain/banker", Fn: "assertCallerIsRealm", Base: 701, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 700.8ns
-	{Pkg: "chain/params", Fn: "SetBytes", Base: 1912, Slope: 13213, SlopeIdx: 1, SlopeKind: SizeLenBytes}, // fit base=1912.0ns slope=12.9035ns/N (=13213/1024) R²=1.000
-	{Pkg: "chain/params", Fn: "SetString", Base: 1772, Slope: 135, SlopeIdx: 1, SlopeKind: SizeLenString}, // fit base=1772.3ns slope=0.1323ns/N (=135/1024) R²=0.933
-	{Pkg: "chain/params", Fn: "SetBool", Base: 1643, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1643.0ns
-	{Pkg: "chain/params", Fn: "SetInt64", Base: 1201, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1201.0ns
-	{Pkg: "chain/params", Fn: "SetUint64", Base: 1219, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1219.0ns
-	{Pkg: "sys/params", Fn: "setSysParamBytes", Base: 323, Slope: 9703, SlopeIdx: 3, SlopeKind: SizeLenBytes}, // fit base=323.3ns slope=9.4757ns/N (=9703/1024) R²=0.995
-	{Pkg: "sys/params", Fn: "getSysParamBytes", Base: 416, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 10584, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=415.7ns + 10.3357ns/N (=10584/1024) R²=1.000
-	{Pkg: "sys/params", Fn: "setSysParamString", Base: 269, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 269.1ns
-	{Pkg: "sys/params", Fn: "setSysParamBool", Base: 217, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 217.4ns
-	{Pkg: "sys/params", Fn: "setSysParamInt64", Base: 228, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 227.8ns
-	{Pkg: "sys/params", Fn: "setSysParamUint64", Base: 299, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 298.9ns
-	{Pkg: "sys/params", Fn: "getSysParamBool", Base: 236, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 236.5ns
-	{Pkg: "sys/params", Fn: "getSysParamInt64", Base: 323, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 322.9ns
-	{Pkg: "sys/params", Fn: "getSysParamUint64", Base: 309, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 308.7ns
-	{Pkg: "sys/params", Fn: "getSysParamString", Base: 363, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 362.8ns
-	{Pkg: "chain/runtime", Fn: "ChainID", Base: 45, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 44.8ns
-	{Pkg: "chain/runtime", Fn: "ChainDomain", Base: 45, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 44.5ns
-	{Pkg: "chain/runtime", Fn: "ChainHeight", Base: 30, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 30.2ns
-	{Pkg: "chain/runtime", Fn: "originCaller", Base: 45, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 44.9ns
-	{Pkg: "chain/runtime", Fn: "getSessionInfo", Base: 148, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 148.4ns
-	{Pkg: "chain/runtime", Fn: "AssertOriginCall", Base: 5, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 5.0ns
-	{Pkg: "chain/runtime", Fn: "getRealm", Base: 1003, Slope: 1319, SlopeIdx: -1, SlopeKind: SizeNumCallFrames}, // fit base=1003.0ns slope=1.2880ns/N (=1319/1024) R²=0.995
-	{Pkg: "time", Fn: "now", Base: 47, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 46.9ns
-	{Pkg: "chain", Fn: "emit", Base: 362, Slope: 40218, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=361.9ns slope=39.2750ns/N (=40218/1024) R²=0.955
-	{Pkg: "chain/params", Fn: "SetStrings", Base: 1601, Slope: 39842, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=1601.1ns slope=38.9082ns/N (=39842/1024) R²=0.993
-	{Pkg: "chain/params", Fn: "UpdateParamStrings", Base: 1298, Slope: 24077, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=1298.0ns slope=23.5122ns/N (=24077/1024) R²=1.000
-	{Pkg: "sys/params", Fn: "setSysParamStrings", Base: 341, Slope: 27034, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=341.0ns slope=26.4006ns/N (=27034/1024) R²=0.997
-	{Pkg: "sys/params", Fn: "updateSysParamStrings", Base: 413, Slope: 26861, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=413.4ns slope=26.2318ns/N (=26861/1024) R²=0.998
-	{Pkg: "sys/params", Fn: "getSysParamStrings", Base: 349, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 23215, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=348.9ns + 22.6713ns/N (=23215/1024) R²=0.999
+	{Pkg: "crypto/sha256", Fn: "sum256", Base: 472, Slope: 8491, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // fit base=471.9ns slope=8.2924ns/N (=8491/1024) R²=0.998
+	{Pkg: "crypto/ed25519", Fn: "verify", Base: 41004, Slope: 9939, SlopeIdx: 1, SlopeKind: SizeLenBytes}, // fit base=41004.5ns slope=9.7063ns/N (=9939/1024) R²=0.990
+	{Pkg: "chain", Fn: "packageAddress", Base: 756, Slope: 17280, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=756.5ns slope=16.8754ns/N (=17280/1024) R²=0.985
+	{Pkg: "chain", Fn: "deriveStorageDepositAddr", Base: 596, Slope: 628, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=596.2ns slope=0.6131ns/N (=628/1024) R²=0.998
+	{Pkg: "chain", Fn: "pubKeyAddress", Base: 11892, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 11892.0ns
+	{Pkg: "time", Fn: "loadFromEmbeddedTZData", Base: 52897, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 52897.0ns
+	{Pkg: "math", Fn: "Float32bits", Base: 192, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 192.4ns
+	{Pkg: "math", Fn: "Float32frombits", Base: 91, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 90.7ns
+	{Pkg: "math", Fn: "Float64bits", Base: 85, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 85.2ns
+	{Pkg: "math", Fn: "Float64frombits", Base: 79, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 79.2ns
+	{Pkg: "chain/banker", Fn: "bankerSendCoins", Base: 838, Slope: 42213, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=837.6ns slope=41.2233ns/N (=42213/1024) R²=0.961
+	{Pkg: "chain/banker", Fn: "bankerGetCoins", Base: 1375, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 48899, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=1375.0ns + 47.7531ns/N (=48899/1024) R²=0.841
+	{Pkg: "chain/banker", Fn: "bankerTotalCoin", Base: 387, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 386.8ns
+	{Pkg: "chain/banker", Fn: "bankerIssueCoin", Base: 381, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 381.2ns
+	{Pkg: "chain/banker", Fn: "bankerRemoveCoin", Base: 214, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 213.9ns
+	{Pkg: "chain/params", Fn: "SetBytes", Base: 1950, Slope: 6980, SlopeIdx: 1, SlopeKind: SizeLenBytes}, // fit base=1949.8ns slope=6.8164ns/N (=6980/1024) R²=0.995
+	{Pkg: "chain/params", Fn: "SetString", Base: 2050, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 2050.0ns
+	{Pkg: "chain/params", Fn: "SetBool", Base: 1525, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1525.0ns
+	{Pkg: "chain/params", Fn: "SetInt64", Base: 3356, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 3356.0ns
+	{Pkg: "chain/params", Fn: "SetUint64", Base: 1436, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1436.0ns
+	{Pkg: "sys/params", Fn: "setSysParamBytes", Base: 887, Slope: 6851, SlopeIdx: 3, SlopeKind: SizeLenBytes}, // fit base=887.2ns slope=6.6907ns/N (=6851/1024) R²=0.989
+	{Pkg: "sys/params", Fn: "getSysParamBytes", Base: 1032, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 17201, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=1032.0ns + 16.7981ns/N (=17201/1024) R²=0.937
+	{Pkg: "sys/params", Fn: "setSysParamString", Base: 368, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 367.6ns
+	{Pkg: "sys/params", Fn: "setSysParamBool", Base: 695, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 695.3ns
+	{Pkg: "sys/params", Fn: "setSysParamInt64", Base: 332, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 332.1ns
+	{Pkg: "sys/params", Fn: "setSysParamUint64", Base: 711, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 710.9ns
+	{Pkg: "sys/params", Fn: "getSysParamBool", Base: 346, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 345.7ns
+	{Pkg: "sys/params", Fn: "getSysParamInt64", Base: 311, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 311.1ns
+	{Pkg: "sys/params", Fn: "getSysParamUint64", Base: 358, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 358.2ns
+	{Pkg: "sys/params", Fn: "getSysParamString", Base: 386, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 386.2ns
+	{Pkg: "chain/runtime", Fn: "ChainID", Base: 83, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 82.7ns
+	{Pkg: "chain/runtime", Fn: "ChainDomain", Base: 79, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 78.7ns
+	{Pkg: "chain/runtime", Fn: "ChainHeight", Base: 64, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 63.6ns
+	{Pkg: "chain/runtime", Fn: "getSessionInfo", Base: 246, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 246.4ns
+	{Pkg: "chain/runtime", Fn: "AssertOriginCall", Base: 16, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 15.5ns
+	{Pkg: "time", Fn: "now", Base: 104, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 103.7ns
+	{Pkg: "chain/markdown", Fn: "StripBidiAndZeroWidth", Base: 153, Slope: 2120, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=153.1ns slope=2.0707ns/N (=2120/1024) R²=0.975
+	{Pkg: "chain/markdown", Fn: "NormalizeBreaks", Base: 300, Slope: 596, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=299.6ns slope=0.5817ns/N (=596/1024) R²=0.941
+	{Pkg: "chain/markdown", Fn: "EscapeInline", Base: 410, Slope: 2796, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=409.8ns slope=2.7306ns/N (=2796/1024) R²=0.844
+	{Pkg: "chain/markdown", Fn: "EscapeTitle", Base: 145, Slope: 3064, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=145.5ns slope=2.9926ns/N (=3064/1024) R²=0.976
+	{Pkg: "chain/markdown", Fn: "PercentEncodeURL", Base: 161, Slope: 4954, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=161.0ns slope=4.8376ns/N (=4954/1024) R²=0.954
+	{Pkg: "chain/markdown", Fn: "MatchCharsetN", Base: 850, Slope: 926, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=849.6ns slope=0.9048ns/N (=926/1024) R²=0.967
+	{Pkg: "chain/markdown", Fn: "CodeFence", Base: 150, Slope: 1049, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=149.9ns slope=1.0246ns/N (=1049/1024) R²=0.936
+	{Pkg: "chain/markdown", Fn: "EscapeBlockHazards", Base: 653, Slope: 19453, SlopeIdx: 0, SlopeKind: SizeLenString}, // fit base=652.8ns slope=18.9973ns/N (=19453/1024) R²=0.979
+	{Pkg: "crypto/keccak256", Fn: "sum256", Base: 1089, Slope: 15097, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // fit base=1089.0ns slope=14.7436ns/N (=15097/1024) R²=0.972
+	{Pkg: "crypto/bn254", Fn: "g1Add", Base: 5587, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 5587.0ns
+	{Pkg: "crypto/bn254", Fn: "g1Mul", Base: 4375, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 4375.0ns
+	{Pkg: "crypto/bn254", Fn: "pairingCheck", Base: 314196, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 314196.0ns
+	{Pkg: "crypto/cometbls", Fn: "verifyZKP", Base: 1098507, SlopeIdx: -1, SlopeKind: SizeFlat}, // flat, median 1098507.0ns
+	{Pkg: "crypto/merkle", Fn: "leafHash", Base: 2961, Slope: 6868, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // fit base=2961.0ns slope=6.7067ns/N (=6868/1024) R²=0.978
+	{Pkg: "crypto/merkle", Fn: "hashFromByteSlices", Base: 2395, Slope: 308444, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // fit base=2395.0ns slope=301.2144ns/N (=308444/1024) R²=0.968
+	{Pkg: "crypto/merkle", Fn: "verifySimpleProof", Base: 2615, Slope: 2800, SlopeIdx: 4, SlopeKind: SizeLenBytes}, // fit base=2614.9ns slope=2.7347ns/N (=2800/1024) R²=0.844
+	{Pkg: "chain", Fn: "emit", Base: 308, Slope: 28301, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=308.4ns slope=27.6380ns/N (=28301/1024) R²=0.990
+	{Pkg: "chain/params", Fn: "SetStrings", Base: 1728, Slope: 28231, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=1727.8ns slope=27.5694ns/N (=28231/1024) R²=0.993
+	{Pkg: "chain/params", Fn: "UpdateParamStrings", Base: 1974, Slope: 29270, SlopeIdx: 1, SlopeKind: SizeLenSlice}, // fit base=1973.9ns slope=28.5837ns/N (=29270/1024) R²=0.991
+	{Pkg: "sys/params", Fn: "setSysParamStrings", Base: 538, Slope: 28041, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=537.9ns slope=27.3839ns/N (=28041/1024) R²=0.999
+	{Pkg: "sys/params", Fn: "updateSysParamStrings", Base: 434, Slope: 28252, SlopeIdx: 3, SlopeKind: SizeLenSlice}, // fit base=433.9ns slope=27.5901ns/N (=28252/1024) R²=1.000
+	{Pkg: "sys/params", Fn: "getSysParamStrings", Base: 528, SlopeIdx: -1, SlopeKind: SizeFlat, PostSlope: 33764, PostSlopeIdx: 2, PostSlopeKind: SizeReturnLen}, // post-call: base=527.6ns + 32.9723ns/N (=33764/1024) R²=0.989
+	{Pkg: "crypto/merkle", Fn: "innerHash", Base: 1445, Slope: 7784, SlopeIdx: 0, SlopeKind: SizeLenBytes, Slope2: 8212, Slope2Idx: 1, Slope2Kind: SizeLenBytes}, // 2arg: base=1445.5ns + 7.6013ns/N1 (=7784/1024, p0) + 8.0193ns/N2 (=8212/1024, p1) R²=0.999
+	{Pkg: "crypto/modexp", Fn: "modExp", Base: 20404, Slope: 501675, SlopeIdx: 1, SlopeKind: SizeLenBytes, Slope2: 2074274, Slope2Idx: 2, Slope2Kind: SizeLenBytes}, // 2arg: base=20403.5ns + 489.9172ns/N1 (=501675/1024, p1) + 2025.6587ns/N2 (=2074274/1024, p2) R²=-0.267
 }

--- a/gnovm/pkg/gnolang/bench_ops_test.go
+++ b/gnovm/pkg/gnolang/bench_ops_test.go
@@ -3078,6 +3078,17 @@ func makeBigDec(digits int) BigdecValue {
 	return BigdecValue{V: r}
 }
 
+// makeBigDecOffset builds a value of the same magnitude as makeBigDec but not
+// equal to it, so subtraction cannot short-circuit on equal operands.
+func makeBigDecOffset(digits int) BigdecValue {
+	s := strings.Repeat("9876543210", (digits/10)+1)[:digits]
+	r := new(big.Rat)
+	if _, ok := r.SetString(s); !ok {
+		panic("invalid bigdec string: " + s)
+	}
+	return BigdecValue{V: r}
+}
+
 // --- doOpAdd BigDec ---
 
 func benchOpAdd_BigDec(b *testing.B, digits int) {
@@ -3114,8 +3125,12 @@ func benchOpSub_BigDec(b *testing.B, digits int) {
 	m := benchMachine()
 	defer m.Release()
 	expr := &BinaryExpr{}
+	// Distinct operands. makeBigDec is deterministic, so calling it twice with
+	// the same argument yields equal values and doOpSub returns zero early,
+	// skipping the big.Float promotion the real operation pays. The fitted
+	// slope then describes an operation that never happens.
 	bv1 := makeBigDec(digits)
-	bv2 := makeBigDec(digits)
+	bv2 := makeBigDecOffset(digits)
 
 	bm.InitMeasure()
 	bm.BeginOpCode(bmSetup)


### PR DESCRIPTION
The gas table for native functions is generated from these benchmarks, so a constant can only describe an input shape the benchmark actually measured. Two entries never measured theirs.

`innerHash` was benched once, at 32 bytes per side. One data point fits only as a flat charge, so the table bills 7513 whatever the size, while both arguments accept a slice of any length.

```
32 B per side       3899 ns
4096 B per side    69476 ns     same 7513 charge
```

`modExp` ties base, exponent and modulus to one size, so it only ever samples `len(exp) == len(mod)`. Nothing makes a caller respect that.

```
256 B modulus,   32 B exponent     301974 ns
256 B modulus, 1024 B exponent    9105730 ns     same charge
```

Now benched across sizes, and off the diagonal, so the fit can see what it is pricing.

Also gives the BigDec subtraction benchmark distinct operands; it was measuring `x - x`. That one is hygiene rather than a live problem: measured either way the difference is small, so it is not what produced the current constant.

No table values change here. Regenerating the table needs the reference hardware its own header already calls for.