### PR TITLE
feat(gov/dao): named sentinel errors for VoteOnProposal

### DIFF
--- a/examples/gno.land/r/gov/dao/proxy.gno
+++ b/examples/gno.land/r/gov/dao/proxy.gno
@@ -21,6 +21,51 @@ var allowedDAOs []string
 // proposals contains all the proposals in history.
 var proposals *Proposals = NewProposals()
 
+// Named, exported sentinel errors for VoteOnProposal failure modes (see
+// #3104 / #5998). These are declared here, at the dao package's stable
+// entry point, rather than in a specific implementation (e.g.
+// gno.land/r/gov/dao/v3/impl), because UpdateImpl can swap the underlying
+// implementation behind VoteOnProposal at any time: a sentinel declared in
+// v3/impl would stop matching via errors.Is as soon as a v4 implementation
+// (with its own, distinct sentinel values) took over, even if the error
+// message stayed identical. Callers should check errors.Is(err,
+// dao.ErrAlreadyVoted) etc. against these values, not against an
+// implementation package's own copy.
+var (
+	ErrMemberNotFound    = errors.New("member not found")
+	ErrProposalNotFound  = errors.New("proposal not found")
+	ErrNotAllowedToVote  = errors.New("member on specified tier is not allowed to vote on this proposal")
+	ErrAlreadyVoted      = errors.New("already voted on proposal")
+	ErrInvalidVoteOption = errors.New("voting can only be YES, NO, or ABSTAIN")
+
+	// ErrProposalClosed is the sentinel to check with errors.Is(err,
+	// dao.ErrProposalClosed); the concrete error returned is a
+	// *ProposalClosedError, which also carries whether the proposal was
+	// accepted or denied.
+	ErrProposalClosed = errors.New("proposal closed")
+
+	// ErrDirectCallRequired is returned when VoteOnProposal is invoked by
+	// a realm rather than directly by a user (or a maketx run script).
+	ErrDirectCallRequired = errors.New("proposal voting must be done directly by a user")
+)
+
+// ProposalClosedError indicates a vote was attempted on a proposal that
+// has already been accepted or denied. It implements Is(error) bool (the
+// extension point documented by the errors package) so
+// errors.Is(err, ErrProposalClosed) matches regardless of which outcome
+// the proposal reached.
+type ProposalClosedError struct {
+	Accepted bool
+}
+
+func (e *ProposalClosedError) Error() string {
+	return ufmt.Sprintf("proposal closed. Accepted: %v", e.Accepted)
+}
+
+func (e *ProposalClosedError) Is(target error) bool {
+	return target == ErrProposalClosed
+}
+
 // Render calls directly to Render's DAO implementation.
 // This allows to have this realm as the main entry point for everything.
 func Render(cur realm, p string) string {

--- a/examples/gno.land/r/gov/dao/proxy.gno
+++ b/examples/gno.land/r/gov/dao/proxy.gno
@@ -66,6 +66,17 @@ func (e *ProposalClosedError) Is(target error) bool {
 	return target == ErrProposalClosed
 }
 
+// NewProposalClosedError returns a *ProposalClosedError. Implementations
+// (e.g. gno.land/r/gov/dao/v3/impl) must construct it through this
+// constructor rather than a struct literal: gno only allows a realm to
+// allocate its own types, so `&ProposalClosedError{...}` written in a
+// different realm's source panics with "cannot allocate
+// gno.land/r/gov/dao.ProposalClosedError in realm ...". Calling this
+// function keeps the allocation in dao's own code.
+func NewProposalClosedError(accepted bool) *ProposalClosedError {
+	return &ProposalClosedError{Accepted: accepted}
+}
+
 // Render calls directly to Render's DAO implementation.
 // This allows to have this realm as the main entry point for everything.
 func Render(cur realm, p string) string {

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
@@ -12,6 +12,40 @@ import (
 
 var ErrMemberNotFound = errors.New("member not found")
 
+// Named, exported sentinel errors for VoteOnProposal failure modes (see
+// #3104), so callers can distinguish why a vote failed via errors.Is()
+// instead of parsing the error message. Message text is unchanged from
+// before, to avoid breaking existing callers/tests that check it.
+var (
+	ErrProposalNotFound  = errors.New("proposal not found")
+	ErrNotAllowedToVote  = errors.New("member on specified tier is not allowed to vote on this proposal")
+	ErrAlreadyVoted      = errors.New("already voted on proposal")
+	ErrInvalidVoteOption = errors.New("voting can only be YES, NO, or ABSTAIN")
+
+	// ErrProposalClosed is the sentinel to check with errors.Is(err,
+	// ErrProposalClosed); the concrete error returned is a
+	// *ProposalClosedError, which also carries whether the proposal was
+	// accepted or denied.
+	ErrProposalClosed = errors.New("proposal closed")
+)
+
+// ProposalClosedError indicates a vote was attempted on a proposal that
+// has already been accepted or denied. It implements Is(error) bool (the
+// extension point documented by the errors package) so
+// errors.Is(err, ErrProposalClosed) matches regardless of which outcome
+// the proposal reached.
+type ProposalClosedError struct {
+	Accepted bool
+}
+
+func (e *ProposalClosedError) Error() string {
+	return ufmt.Sprintf("proposal closed. Accepted: %v", e.Accepted)
+}
+
+func (e *ProposalClosedError) Is(target error) bool {
+	return target == ErrProposalClosed
+}
+
 type GovDAO struct {
 	pss    ProposalsStatuses
 	render *render
@@ -83,20 +117,20 @@ func (g *GovDAO) VoteOnProposal(_ int, rlm realm, r dao.VoteRequest) error {
 
 	status := g.pss.GetStatus(r.ProposalID)
 	if status == nil {
-		return errors.New("proposal not found")
+		return ErrProposalNotFound
 	}
 
 	if status.Denied || status.Accepted {
-		return errors.New(ufmt.Sprintf("proposal closed. Accepted: %v", status.Accepted))
+		return &ProposalClosedError{Accepted: status.Accepted}
 	}
 
 	if !status.IsAllowed(tie) {
-		return errors.New("member on specified tier is not allowed to vote on this proposal")
+		return ErrNotAllowedToVote
 	}
 
 	mVoted, _ := status.AllVotes.GetMember(caller)
 	if mVoted != nil {
-		return errors.New("already voted on proposal")
+		return ErrAlreadyVoted
 	}
 
 	switch r.Option {
@@ -110,7 +144,7 @@ func (g *GovDAO) VoteOnProposal(_ int, rlm realm, r dao.VoteRequest) error {
 		status.AllVotes.SetMember(tie, caller, mem)
 		status.AbstainVotes.SetMember(tie, caller, mem)
 	default:
-		return errors.New("voting can only be YES, NO, or ABSTAIN")
+		return ErrInvalidVoteOption
 	}
 
 	return nil

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
@@ -10,42 +10,6 @@ import (
 	"gno.land/r/gov/dao/v3/memberstore"
 )
 
-var ErrMemberNotFound = errors.New("member not found")
-
-// Named, exported sentinel errors for VoteOnProposal failure modes (see
-// #3104), so callers can distinguish why a vote failed via errors.Is()
-// instead of parsing the error message. Message text is unchanged from
-// before, to avoid breaking existing callers/tests that check it.
-var (
-	ErrProposalNotFound  = errors.New("proposal not found")
-	ErrNotAllowedToVote  = errors.New("member on specified tier is not allowed to vote on this proposal")
-	ErrAlreadyVoted      = errors.New("already voted on proposal")
-	ErrInvalidVoteOption = errors.New("voting can only be YES, NO, or ABSTAIN")
-
-	// ErrProposalClosed is the sentinel to check with errors.Is(err,
-	// ErrProposalClosed); the concrete error returned is a
-	// *ProposalClosedError, which also carries whether the proposal was
-	// accepted or denied.
-	ErrProposalClosed = errors.New("proposal closed")
-)
-
-// ProposalClosedError indicates a vote was attempted on a proposal that
-// has already been accepted or denied. It implements Is(error) bool (the
-// extension point documented by the errors package) so
-// errors.Is(err, ErrProposalClosed) matches regardless of which outcome
-// the proposal reached.
-type ProposalClosedError struct {
-	Accepted bool
-}
-
-func (e *ProposalClosedError) Error() string {
-	return ufmt.Sprintf("proposal closed. Accepted: %v", e.Accepted)
-}
-
-func (e *ProposalClosedError) Is(target error) bool {
-	return target == ErrProposalClosed
-}
-
 type GovDAO struct {
 	pss    ProposalsStatuses
 	render *render
@@ -106,31 +70,31 @@ func (g *GovDAO) PostCreateProposal(_ int, rlm realm, r dao.ProposalRequest, pid
 
 func (g *GovDAO) VoteOnProposal(_ int, rlm realm, r dao.VoteRequest) error {
 	if !g.isValidCall(0, rlm) {
-		return errors.New("proposal voting must be done directly by a user")
+		return dao.ErrDirectCallRequired
 	}
 
 	caller := unsafe.OriginCaller()
 	mem, tie := getMembers(cross(rlm)).GetMember(caller)
 	if mem == nil {
-		return ErrMemberNotFound
+		return dao.ErrMemberNotFound
 	}
 
 	status := g.pss.GetStatus(r.ProposalID)
 	if status == nil {
-		return ErrProposalNotFound
+		return dao.ErrProposalNotFound
 	}
 
 	if status.Denied || status.Accepted {
-		return &ProposalClosedError{Accepted: status.Accepted}
+		return &dao.ProposalClosedError{Accepted: status.Accepted}
 	}
 
 	if !status.IsAllowed(tie) {
-		return ErrNotAllowedToVote
+		return dao.ErrNotAllowedToVote
 	}
 
 	mVoted, _ := status.AllVotes.GetMember(caller)
 	if mVoted != nil {
-		return ErrAlreadyVoted
+		return dao.ErrAlreadyVoted
 	}
 
 	switch r.Option {
@@ -144,7 +108,7 @@ func (g *GovDAO) VoteOnProposal(_ int, rlm realm, r dao.VoteRequest) error {
 		status.AllVotes.SetMember(tie, caller, mem)
 		status.AbstainVotes.SetMember(tie, caller, mem)
 	default:
-		return ErrInvalidVoteOption
+		return dao.ErrInvalidVoteOption
 	}
 
 	return nil

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao.gno
@@ -85,7 +85,7 @@ func (g *GovDAO) VoteOnProposal(_ int, rlm realm, r dao.VoteRequest) error {
 	}
 
 	if status.Denied || status.Accepted {
-		return &dao.ProposalClosedError{Accepted: status.Accepted}
+		return dao.NewProposalClosedError(status.Accepted)
 	}
 
 	if !status.IsAllowed(tie) {

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -350,8 +350,12 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 	nm1 := testutils.TestAddress("errtest-nm1")
 
 	testing.SetOriginCaller(m1)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao/v3/impl"))
+	proposalRequest := NewAddMemberRequest(cur, nm1, memberstore.T2, portfolio)
+
+	testing.SetOriginCaller(m1)
 	testing.SetRealm(testing.NewUserRealm(m1))
-	pid := dao.MustCreateProposal(cross(cur), NewAddMemberRequest(cur, nm1, memberstore.T2, portfolio))
+	pid := dao.MustCreateProposal(cross(cur), proposalRequest)
 
 	// A member on a tier not allowed to vote on this proposal (T3 members
 	// aren't allowed to vote on a T2-add proposal).

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -373,18 +373,24 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	urequire.True(t, errors.Is(err, ErrAlreadyVoted), "expected ErrAlreadyVoted, got: "+errString(err))
 
-	// Reach supermajority to close the proposal, then vote again.
+	// Reach supermajority (for denial, mirroring the proven voting
+	// sequence in TestCreateProposalAndVote) to close the proposal, then
+	// vote again.
 	testing.SetOriginCaller(m11)
-	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.NoVote, pid))
 	testing.SetOriginCaller(m2)
-	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.NoVote, pid))
 	testing.SetOriginCaller(m3)
-	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.NoVote, pid))
+	testing.SetOriginCaller(m111)
+	dao.MustVoteOnProposalSimple(cross(cur), int64(pid), "NO")
+	testing.SetOriginCaller(m1111)
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.NoVote, pid))
 
 	accepted := dao.ExecuteProposal(cross(cur), pid)
-	urequire.Equal(t, true, accepted)
+	urequire.Equal(t, false, accepted)
 
-	testing.SetOriginCaller(m111)
+	testing.SetOriginCaller(m6) // m6 hasn't voted, but the proposal is now closed
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	urequire.True(t, errors.Is(err, ErrProposalClosed), "expected ErrProposalClosed, got: "+errString(err))
 
@@ -392,7 +398,7 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 	// assert the concrete type directly.
 	closedErr, ok := err.(*ProposalClosedError)
 	urequire.True(t, ok, "expected *ProposalClosedError")
-	urequire.Equal(t, true, closedErr.Accepted)
+	urequire.Equal(t, false, closedErr.Accepted)
 }
 
 // errString returns err.Error(), or "<nil>" if err is nil, for building

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -329,4 +330,72 @@ func TestAbstainVote(cur realm, t *testing.T) {
 
 func contains(s, substr string) bool {
 	return strings.Index(s, substr) >= 0
+}
+
+// TestVoteOnProposalErrors verifies that VoteOnProposal returns errors an
+// external caller can distinguish programmatically with errors.Is, rather
+// than only a human-readable message (see #3104).
+func TestVoteOnProposalErrors(cur realm, t *testing.T) {
+	loadMembers(cur)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao/v3/impl"))
+
+	// Voting on a proposal ID that was never created.
+	testing.SetOriginCaller(m1)
+	err := dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, dao.ProposalID(999)))
+	urequire.True(t, errors.Is(err, ErrProposalNotFound), "expected ErrProposalNotFound, got: "+errString(err))
+
+	// Create a proposal to exercise the remaining cases against.
+	portfolio := "# portfolio"
+	nm1 := testutils.TestAddress("errtest-nm1")
+
+	testing.SetOriginCaller(m1)
+	testing.SetRealm(testing.NewUserRealm(m1))
+	pid := dao.MustCreateProposal(cross(cur), NewAddMemberRequest(cur, nm1, memberstore.T2, portfolio))
+
+	// A member on a tier not allowed to vote on this proposal (T3 members
+	// aren't allowed to vote on a T2-add proposal).
+	testing.SetOriginCaller(m4) // m4 is T3
+	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	urequire.True(t, errors.Is(err, ErrNotAllowedToVote), "expected ErrNotAllowedToVote, got: "+errString(err))
+
+	// An invalid vote option.
+	testing.SetOriginCaller(m1)
+	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.VoteOption("INVALID"), pid))
+	urequire.True(t, errors.Is(err, ErrInvalidVoteOption), "expected ErrInvalidVoteOption, got: "+errString(err))
+
+	// A vote that succeeds, then a second vote from the same member.
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	urequire.True(t, errors.Is(err, ErrAlreadyVoted), "expected ErrAlreadyVoted, got: "+errString(err))
+
+	// Reach supermajority to close the proposal, then vote again.
+	testing.SetOriginCaller(m11)
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	testing.SetOriginCaller(m2)
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	testing.SetOriginCaller(m3)
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+
+	accepted := dao.ExecuteProposal(cross(cur), pid)
+	urequire.Equal(t, true, accepted)
+
+	testing.SetOriginCaller(m111)
+	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	urequire.True(t, errors.Is(err, ErrProposalClosed), "expected ErrProposalClosed, got: "+errString(err))
+
+	// errors.As isn't available in gno's stdlib errors package yet, so
+	// assert the concrete type directly.
+	closedErr, ok := err.(*ProposalClosedError)
+	urequire.True(t, ok, "expected *ProposalClosedError")
+	urequire.Equal(t, true, closedErr.Accepted)
+}
+
+// errString returns err.Error(), or "<nil>" if err is nil, for building
+// assertion failure messages.
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
 }

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -343,7 +343,7 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 	// Voting on a proposal ID that was never created.
 	testing.SetOriginCaller(m1)
 	err := dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, dao.ProposalID(999)))
-	urequire.True(t, errors.Is(err, ErrProposalNotFound), "expected ErrProposalNotFound, got: "+errString(err))
+	urequire.True(t, errors.Is(err, dao.ErrProposalNotFound), "expected ErrProposalNotFound, got: "+errString(err))
 
 	// Create a proposal to exercise the remaining cases against.
 	portfolio := "# portfolio"
@@ -361,17 +361,17 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 	// aren't allowed to vote on a T2-add proposal).
 	testing.SetOriginCaller(m4) // m4 is T3
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
-	urequire.True(t, errors.Is(err, ErrNotAllowedToVote), "expected ErrNotAllowedToVote, got: "+errString(err))
+	urequire.True(t, errors.Is(err, dao.ErrNotAllowedToVote), "expected ErrNotAllowedToVote, got: "+errString(err))
 
 	// An invalid vote option.
 	testing.SetOriginCaller(m1)
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.VoteOption("INVALID"), pid))
-	urequire.True(t, errors.Is(err, ErrInvalidVoteOption), "expected ErrInvalidVoteOption, got: "+errString(err))
+	urequire.True(t, errors.Is(err, dao.ErrInvalidVoteOption), "expected ErrInvalidVoteOption, got: "+errString(err))
 
 	// A vote that succeeds, then a second vote from the same member.
 	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
-	urequire.True(t, errors.Is(err, ErrAlreadyVoted), "expected ErrAlreadyVoted, got: "+errString(err))
+	urequire.True(t, errors.Is(err, dao.ErrAlreadyVoted), "expected ErrAlreadyVoted, got: "+errString(err))
 
 	// Reach supermajority (for denial, mirroring the proven voting
 	// sequence in TestCreateProposalAndVote) to close the proposal, then
@@ -392,13 +392,47 @@ func TestVoteOnProposalErrors(cur realm, t *testing.T) {
 
 	testing.SetOriginCaller(m6) // m6 hasn't voted, but the proposal is now closed
 	err = dao.VoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
-	urequire.True(t, errors.Is(err, ErrProposalClosed), "expected ErrProposalClosed, got: "+errString(err))
+	urequire.True(t, errors.Is(err, dao.ErrProposalClosed), "expected ErrProposalClosed, got: "+errString(err))
 
 	// errors.As isn't available in gno's stdlib errors package yet, so
 	// assert the concrete type directly.
-	closedErr, ok := err.(*ProposalClosedError)
+	closedErr, ok := err.(*dao.ProposalClosedError)
 	urequire.True(t, ok, "expected *ProposalClosedError")
 	urequire.Equal(t, false, closedErr.Accepted)
+}
+
+// TestSentinelsAreDisjoint verifies that each VoteOnProposal sentinel error
+// matches itself via errors.Is and nothing else -- and that a
+// *ProposalClosedError only matches ErrProposalClosed among the sentinels,
+// not the other way around. Without this, e.g. a ProposalClosedError.Is
+// implementation that always returns true (or accidentally collapsing all
+// sentinels onto one underlying value) would go unnoticed even though
+// TestVoteOnProposalErrors passes, since that test only checks each error
+// against the one sentinel it expects.
+func TestSentinelsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	sentinels := []error{
+		dao.ErrMemberNotFound,
+		dao.ErrProposalNotFound,
+		dao.ErrNotAllowedToVote,
+		dao.ErrAlreadyVoted,
+		dao.ErrInvalidVoteOption,
+		dao.ErrProposalClosed,
+		dao.ErrDirectCallRequired,
+	}
+
+	for i, a := range sentinels {
+		for j, b := range sentinels {
+			urequire.Equal(t, i == j, errors.Is(a, b))
+		}
+	}
+
+	closed := error(&dao.ProposalClosedError{Accepted: true})
+	for _, s := range sentinels {
+		urequire.Equal(t, s == dao.ErrProposalClosed, errors.Is(closed, s))
+	}
+	urequire.False(t, errors.Is(dao.ErrProposalClosed, closed))
 }
 
 // errString returns err.Error(), or "<nil>" if err is nil, for building

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -428,7 +428,7 @@ func TestSentinelsAreDisjoint(t *testing.T) {
 		}
 	}
 
-	closed := error(dao.NewProposalClosedError(true))
+	closed := dao.NewProposalClosedError(true)
 	for _, s := range sentinels {
 		urequire.Equal(t, s == dao.ErrProposalClosed, errors.Is(closed, s))
 	}

--- a/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/impl/govdao_test.gno
@@ -428,7 +428,7 @@ func TestSentinelsAreDisjoint(t *testing.T) {
 		}
 	}
 
-	closed := error(&dao.ProposalClosedError{Accepted: true})
+	closed := error(dao.NewProposalClosedError(true))
 	for _, s := range sentinels {
 		urequire.Equal(t, s == dao.ErrProposalClosed, errors.Is(closed, s))
 	}


### PR DESCRIPTION
Fixes #3104 (partially -- see note below).

VoteOnProposal returned ad-hoc errors.New(...) strings for each distinct failure mode (proposal not found, proposal closed, wrong tier, already voted, invalid option), so callers could only tell them apart by parsing the message text, not via errors.Is.

Adds named, exported sentinel errors for each case (matching the existing ErrMemberNotFound convention), e.g.:

```go
if errors.Is(err, dao.ErrAlreadyVoted) { ... }
```

For the closed-proposal case, which carries dynamic content (whether the proposal was accepted or denied), added a ProposalClosedError type implementing Is(error) bool -- the extension point documented by gnos errors package -- so errors.Is(err, ErrProposalClosed) matches regardless of outcome. errors.As isnt available in gnos stdlib yet, so callers that need the Accepted field use a plain type assertion.

All error message text (.Error()) is unchanged from before, so existing callers checking the panic message via MustVoteOnProposal are unaffected. Added a dedicated test (TestVoteOnProposalErrors) exercising errors.Is for each case.

**Scope note:** this covers 3 of the 4 acceptance criteria in #3104 (voting closed, not a member -- already handled via ErrMemberNotFound, already voted). "Cannot pay gas fees" isnt addressed: gas/fee failures happen at the transaction/ante-handler level before VoteOnProposal ever runs, so its not something this realm function can detect or report on.