### PR TITLE
fix(tm2/auth): stop the block gas price from climbing forever or panicking

### DIFF
--- a/tm2/adr/pr5999_block_gas_price_ratchet.md
+++ b/tm2/adr/pr5999_block_gas_price_ratchet.md
@@ -1,0 +1,127 @@
+# PR5999: The block gas price must not ratchet, panic, or halt the node
+
+## Status
+
+Proposed
+
+## Context
+
+`GasPriceKeeper.calcBlockGasPrice` recomputes the minimum gas price at the end of
+every block. It derives a target from the block gas limit,
+`targetGas = MaxGas * TargetGasRatio / 100`, divides by that target in both the
+increase and the decrease branch, and multiplies the price by a ratio that has no
+upper bound. Three shapes of configuration and load break it.
+
+**`Block.MaxGas == -1`, the "no gas bound" sentinel.** Nothing on this path maps
+it to "unbounded", unlike `BaseApp.getMaximumBlockGas` and `NewAnteHandler`.
+`big.Int.Div` floors, so the target is `-1`, every `gasUsed >= 0` compares above
+it and takes the increase branch, and there the intermediate quotient is negative
+so the min-1 floor clamps it to `+1`. The price rises by 1 on every block,
+including idle ones, and the decrease direction is unreachable.
+
+**`Block.MaxGas * TargetGasRatio < 100`**, which at the default ratio of 70 means
+`MaxGas` 0 or 1. The target is 0 and the first non-empty block divides by zero
+inside `EndBlock`, halting the node. `MaxGas == 0` is the other "unbounded"
+spelling: `getMaximumBlockGas` turns it into an infinite gas meter, so blocks do
+consume gas and the division is reached.
+
+Both pass `ValidateConsensusParams`, which only rejects `MaxGas < -1`, and both
+are one JSON field away from a genesis the tooling produces:
+`ConsensusParams.Update` copies a non-nil `Block` whole rather than field by
+field, so a genesis whose `consensus_params.Block` omits `MaxGas` validates with
+`MaxGas == 0` and no default backfill.
+
+**Sustained congestion.** At the shipped parameters (`MaxGas` 3e9, ratio 70,
+compressor 10) a completely full block raises the price by about 4.29%, so from a
+price of 1 the `IsInt64` check fires after 1,002 full blocks and `EndBlock`
+panics on every node at the same height. `Params.Validate` also accepts a
+`TargetGasRatio` of 1 with a `GasPricesChangeCompressor` of 1, which reaches the
+same point after nine full blocks.
+
+A fourth, smaller shape: `Params.Validate` accepts an `InitialGasPrice` of 0, and
+a stored price of 0 is read at the top of `calcBlockGasPrice` as "dynamic pricing
+disabled". A chain whose floor is 0 therefore walks down to 0 and can never rise
+again.
+
+## Decision
+
+Three changes, all inside `calcBlockGasPrice` except the last.
+
+1. **A non-positive target returns the price unchanged.** The guard sits after
+   the target is computed and before either branch is chosen, so a chain with a
+   positive target reaches exactly the code that ran before. It covers the `-1`
+   sentinel and the rounding case in one condition, because both mean the same
+   thing: there is no congestion signal to price against.
+2. **The decrease floor is `max(InitialGasPrice, 1)`.** The price can still decay
+   to the configured floor, but never into the absorbing 0 state.
+3. **The int64 overflow clamps instead of panicking.** The price saturates at
+   `math.MaxInt64` and the node keeps producing blocks. Only the increase branch
+   can produce a non-int64 value: every decrease result lands in
+   `[1, max(lastPrice, initialPrice)]`, both ends of which are already int64.
+4. **`UpdateGasPrice` logs at `ERROR` when the new price is the ceiling.** At that
+   price no transaction wanting more than 1,000 gas can pay the minimum fee, and
+   the skip-when-unchanged write means the price stops moving and the telemetry
+   hook stops firing, so nothing else in the node reports the state.
+
+## Alternatives considered
+
+- **Map `MaxGas` -1 and 0 to "unbounded" here, the way `getMaximumBlockGas`
+  does.** Rejected: an unbounded limit has no target, so the controller has
+  nothing to steer towards. Freezing the price is what "no target" means; picking
+  an arbitrary substitute target would invent a congestion signal.
+- **Reject `MaxGas` 0 and -1 in `ValidateConsensusParams`.** Rejected as the fix
+  for this PR: it makes an existing genesis invalid, and a node should not halt
+  on a configuration the validator accepted. Worth doing separately as a
+  tooling-level guard.
+- **Keep the panic and cap the price at a governance parameter.** A policy
+  ceiling below the int64 one is a real design question, and the `XXX` in the
+  increase branch still asks it. It is not this PR: a policy cap needs a new
+  parameter, a migration and a governance decision, while the int64 ceiling is a
+  property of the type and must be handled either way.
+- **Return an error from `calcBlockGasPrice`.** Rejected: it runs in `EndBlock`,
+  where there is no caller that can do anything but panic.
+
+## Consequences
+
+- A chain with no usable target keeps the price it starts with, which on such a
+  chain is the configured `InitialGasPrice`.
+- A chain under sustained congestion reaches a price no transaction can pay
+  rather than halting. That state is not absorbing: with the mempool rejecting
+  everything, blocks go idle and the price returns to the floor in 407 blocks at
+  the shipped parameters. It is a bounded outage where the previous behavior was
+  a coordinated crash.
+- The change is consensus-visible exactly where the previous code panicked. For
+  every configuration with a positive target, a non-zero initial price and a
+  valid compressor, the function is output-identical to before: a 91,584-case
+  differential against the merge base classifies all 19,585 divergent cases into
+  those three intended causes, with none unexplained, and the merge base panics
+  in all 14,976 cases where the new code does not.
+- A rolling upgrade is safe on gno.land's own configuration. A `MaxGas` 0 chain
+  is already halted on the old binary, so there is no live network to fork; a
+  `MaxGas` -1 chain keeps producing blocks with a climbing price, so mixed
+  binaries there would diverge and it needs a coordinated restart. No
+  configuration in the tree sets -1.
+- Setting `auth:p:initial_gasprice` to a zero-amount price no longer disables
+  dynamic pricing by letting the price decay to 0.
+
+## Tests
+
+`tm2/pkg/sdk/auth/keeper_test.go`:
+
+- `TestCalcBlockGasPriceUnboundedMaxGas`: `MaxGas` -1 does not ratchet on idle
+  blocks; `MaxGas` 0 and 1 do not panic at any usage; the smallest `MaxGas` with
+  a positive target still adjusts the price.
+- `TestCalcBlockGasPriceZeroInitialPrice` and
+  `TestCalcBlockGasPriceFloorAboveOne`: the floor is 1 when the initial price is
+  0, and the initial price itself when that is higher.
+- `TestCalcBlockGasPrice/int64 overflow caps instead of panicking`,
+  `/sustained congestion settles at the cap` and `/decreasing stays in range`:
+  the clamp is reached, keeps the denominator and denom, returns to the floor
+  under a bounded number of idle blocks, and is unreachable from the decrease
+  branch even at an initial price of `math.MaxInt64`.
+- `TestUpdateGasPriceCeilingLogs`: the ceiling is logged, and nothing is logged
+  below it.
+
+Each of these fails against the previous implementation, by panic or by
+assertion, except the floor-above-one case, which guards the floor against a
+future simplification.

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -430,6 +430,29 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	num.Div(num, big.NewInt(int64(100)))
 	targetGasInt := new(big.Int).Set(num)
 
+	// A non-positive target is not a target at all, and both branches below
+	// divide by it. Two ways to get here, both reachable from a genesis that
+	// ValidateConsensusParams accepts:
+	//
+	//   - Block.MaxGas == -1, the "no gas bound" sentinel. Nothing maps it to
+	//     "unbounded" on this path, unlike BaseApp.getMaximumBlockGas and
+	//     NewAnteHandler. big.Int.Div floors, so maxGas*70/100 is -1, every
+	//     gasUsed >= 0 compares above it and takes the increase branch, and
+	//     there the intermediate quotient is negative so the min-1 floor
+	//     clamps it to +1: the price ratchets up by 1 on every block,
+	//     including idle ones, with the decay direction unreachable.
+	//   - maxGas*TargetGasRatio < 100 — with the default ratio of 70 that is
+	//     MaxGas 0 or 1 — makes the target 0 and the division panic. MaxGas 0
+	//     is the other "unbounded" spelling: getMaximumBlockGas turns it into
+	//     an infinite gas meter, so blocks do consume gas and the first
+	//     non-empty block panics in EndBlock.
+	//
+	// In both cases there is no congestion signal to price against, so leave
+	// the price where it is.
+	if targetGasInt.Sign() <= 0 {
+		return lastGasPrice
+	}
+
 	// if used gas is right on target, no need to change
 	gasUsedInt := big.NewInt(gasUsed)
 	if targetGasInt.Cmp(gasUsedInt) == 0 {
@@ -466,8 +489,18 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// value of GasPricesChangeCompressor (see issue #5906).
 		diff := maxBig(num, bigOne)
 		num.Sub(lastPriceInt, diff)
-		// gas price should not be less than the initial gas price,
-		num = maxBig(num, initPriceInt)
+		// gas price should not be less than the initial gas price, and
+		// never below 1 whatever the initial price says. Params.Validate
+		// accepts an InitialGasPrice of 0, and 0 is an absorbing state: the
+		// guard at the top of this function reads a stored price of 0 as
+		// "dynamic pricing disabled" and returns early, so no congestion
+		// level can lift the price again. Combined with the min-1 decrement
+		// above, a chain configured that way walks down to 0 in a handful of
+		// under-target blocks and stays there permanently. gno.land's own
+		// genesis sets 1ugnot/1000gas, so the shipped chain has a floor of 1
+		// already; this stops an operator misconfiguration from silently
+		// disabling the mechanism.
+		num = maxBig(num, maxBig(initPriceInt, bigOne))
 	}
 
 	if !num.IsInt64() {

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -405,8 +405,9 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // We simplify the solution with a one-line formula to explain the idea. However, in reality, we need to treat
 // two scenarios differently. In both cases we move the price by at least 1 unit (instead of rounding the
 // integer division down to 0), otherwise the price ratchets: it can rise but never fall. When increasing we
-// cap nothing (yet); when decreasing we floor the result at the initial gas price. This is just a starting
-// point. Down the line, the solution might not be even representable by one simple formula
+// cap nothing (yet); when decreasing we floor the result at the initial gas price, or at 1 when the initial
+// price is 0. A non-positive block gas limit leaves the price unchanged rather than dividing by it. This is
+// just a starting point. Down the line, the solution might not be even representable by one simple formula
 func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
@@ -494,12 +495,14 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// accepts an InitialGasPrice of 0, and 0 is an absorbing state: the
 		// guard at the top of this function reads a stored price of 0 as
 		// "dynamic pricing disabled" and returns early, so no congestion
-		// level can lift the price again. Combined with the min-1 decrement
-		// above, a chain configured that way walks down to 0 in a handful of
-		// under-target blocks and stays there permanently. gno.land's own
-		// genesis sets 1ugnot/1000gas, so the shipped chain has a floor of 1
-		// already; this stops an operator misconfiguration from silently
-		// disabling the mechanism.
+		// level can lift the price again.
+		//
+		// Genesis alone cannot reach it, because installAuthParams seeds the
+		// stored price from InitialGasPrice, so a zero there disables pricing
+		// from block 1 rather than decaying into it. The reachable shape is a
+		// post-genesis change of auth:p:initial_gasprice to 0 on a chain whose
+		// stored price is non-zero: the min-1 decrement then walks it down to
+		// 0 and it stays there permanently.
 		num = maxBig(num, maxBig(initPriceInt, bigOne))
 	}
 

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -406,9 +406,9 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // We simplify the solution with a one-line formula to explain the idea. However, in reality, we need to treat
 // two scenarios differently. In both cases we move the price by at least 1 unit (instead of rounding the
 // integer division down to 0), otherwise the price ratchets: it can rise but never fall. When increasing we
-// cap at the largest int64 price; when decreasing we floor the result at the initial gas price, or at 1. An
-// unbounded block gas limit leaves the price unchanged. This is just a starting point. Down the line, the
-// solution might not be even representable by one simple formula
+// cap at the largest int64 price; when decreasing we floor the result at the initial gas price, and never
+// below 1. A block gas limit that yields no positive target leaves the price unchanged. This is just a
+// starting point. Down the line, the solution might not be even representable by one simple formula
 func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
@@ -432,8 +432,10 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	num.Div(num, big.NewInt(int64(100)))
 	targetGasInt := new(big.Int).Set(num)
 
-	// An unbounded MaxGas leaves no target to price against, and both branches
-	// below divide by it.
+	// No positive target, so there is no congestion to price against. Either
+	// MaxGas is one of the two unbounded spellings, -1 or 0, or it is too small
+	// for the ratio to reach 1. At 0 the branches below would divide by zero; at
+	// -1 the price would ratchet up by 1 on every block, idle ones included.
 	if targetGasInt.Sign() <= 0 {
 		return lastGasPrice
 	}
@@ -457,7 +459,8 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// increase at least 1
 		diff := maxBig(num, bigOne)
 		num.Add(lastPriceInt, diff)
-		// XXX should we cap it with a max gas price?
+		// XXX should we cap it with a configured max gas price? The clamp below
+		// is only the int64 ceiling, not a policy one.
 	} else { // gas used is less than the target
 		// decrease gas price down to initial gas price
 		initPriceInt := big.NewInt(params.InitialGasPrice.Price.Amount)

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -406,10 +406,9 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // We simplify the solution with a one-line formula to explain the idea. However, in reality, we need to treat
 // two scenarios differently. In both cases we move the price by at least 1 unit (instead of rounding the
 // integer division down to 0), otherwise the price ratchets: it can rise but never fall. When increasing we
-// cap at the largest int64 price; when decreasing we floor the result at the initial gas price, or at 1 when
-// the initial price is 0. A non-positive block gas limit leaves the price unchanged rather than dividing by
-// it. This is just a starting point. Down the line, the solution might not be even representable by one
-// simple formula
+// cap at the largest int64 price; when decreasing we floor the result at the initial gas price, or at 1. An
+// unbounded block gas limit leaves the price unchanged. This is just a starting point. Down the line, the
+// solution might not be even representable by one simple formula
 func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
@@ -433,12 +432,8 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	num.Div(num, big.NewInt(int64(100)))
 	targetGasInt := new(big.Int).Set(num)
 
-	// A non-positive target is not a target at all, and both branches below
-	// divide by it. ValidateConsensusParams accepts two ways to get here:
-	// MaxGas -1, the "no gas bound" sentinel this path never maps to
-	// unbounded, which ratchets the price up by 1 on every block; and
-	// maxGas*TargetGasRatio < 100, which makes the target 0 and panics on the
-	// division. Neither carries a congestion signal, so leave the price as is.
+	// An unbounded MaxGas leaves no target to price against, and both branches
+	// below divide by it.
 	if targetGasInt.Sign() <= 0 {
 		return lastGasPrice
 	}
@@ -479,22 +474,14 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// value of GasPricesChangeCompressor (see issue #5906).
 		diff := maxBig(num, bigOne)
 		num.Sub(lastPriceInt, diff)
-		// Floor at the initial gas price, and never below 1 whatever that
-		// price says. Params.Validate accepts an InitialGasPrice of 0, and 0
-		// is absorbing: the guard at the top of this function reads a stored
-		// price of 0 as "dynamic pricing disabled". Only reachable by setting
-		// auth:p:initial_gasprice to 0 post-genesis, since at genesis
-		// installAuthParams seeds the stored price from it and pricing is off
-		// from block 1 instead.
+		// Never below 1: a stored price of 0 reads as "pricing disabled" above.
 		num = maxBig(num, maxBig(initPriceInt, bigOne))
 	}
 
-	// Cap at the largest representable price instead of panicking. Sustained
-	// congestion otherwise walks the increase branch past int64: at the
-	// shipped parameters a run of full blocks gets there around block 1000,
-	// and every node then panics in EndBlock at the same height.
+	// Clamp rather than panic: sustained congestion would halt every node.
 	if !num.IsInt64() {
-		num = big.NewInt(math.MaxInt64)
+		lastGasPrice.Price.Amount = math.MaxInt64
+		return lastGasPrice
 	}
 
 	lastGasPrice.Price.Amount = num.Int64()

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/big"
 
 	"github.com/gnolang/gno/tm2/pkg/amino"
@@ -405,9 +406,10 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 // We simplify the solution with a one-line formula to explain the idea. However, in reality, we need to treat
 // two scenarios differently. In both cases we move the price by at least 1 unit (instead of rounding the
 // integer division down to 0), otherwise the price ratchets: it can rise but never fall. When increasing we
-// cap nothing (yet); when decreasing we floor the result at the initial gas price, or at 1 when the initial
-// price is 0. A non-positive block gas limit leaves the price unchanged rather than dividing by it. This is
-// just a starting point. Down the line, the solution might not be even representable by one simple formula
+// cap at the largest int64 price; when decreasing we floor the result at the initial gas price, or at 1 when
+// the initial price is 0. A non-positive block gas limit leaves the price unchanged rather than dividing by
+// it. This is just a starting point. Down the line, the solution might not be even representable by one
+// simple formula
 func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed int64, maxGas int64, params Params) std.GasPrice {
 	// If no block gas price is set, there is no need to change the last gas price.
 	if lastGasPrice.Price.Amount == 0 {
@@ -432,24 +434,11 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 	targetGasInt := new(big.Int).Set(num)
 
 	// A non-positive target is not a target at all, and both branches below
-	// divide by it. Two ways to get here, both reachable from a genesis that
-	// ValidateConsensusParams accepts:
-	//
-	//   - Block.MaxGas == -1, the "no gas bound" sentinel. Nothing maps it to
-	//     "unbounded" on this path, unlike BaseApp.getMaximumBlockGas and
-	//     NewAnteHandler. big.Int.Div floors, so maxGas*70/100 is -1, every
-	//     gasUsed >= 0 compares above it and takes the increase branch, and
-	//     there the intermediate quotient is negative so the min-1 floor
-	//     clamps it to +1: the price ratchets up by 1 on every block,
-	//     including idle ones, with the decay direction unreachable.
-	//   - maxGas*TargetGasRatio < 100 — with the default ratio of 70 that is
-	//     MaxGas 0 or 1 — makes the target 0 and the division panic. MaxGas 0
-	//     is the other "unbounded" spelling: getMaximumBlockGas turns it into
-	//     an infinite gas meter, so blocks do consume gas and the first
-	//     non-empty block panics in EndBlock.
-	//
-	// In both cases there is no congestion signal to price against, so leave
-	// the price where it is.
+	// divide by it. ValidateConsensusParams accepts two ways to get here:
+	// MaxGas -1, the "no gas bound" sentinel this path never maps to
+	// unbounded, which ratchets the price up by 1 on every block; and
+	// maxGas*TargetGasRatio < 100, which makes the target 0 and panics on the
+	// division. Neither carries a congestion signal, so leave the price as is.
 	if targetGasInt.Sign() <= 0 {
 		return lastGasPrice
 	}
@@ -490,24 +479,22 @@ func (gk GasPriceKeeper) calcBlockGasPrice(lastGasPrice std.GasPrice, gasUsed in
 		// value of GasPricesChangeCompressor (see issue #5906).
 		diff := maxBig(num, bigOne)
 		num.Sub(lastPriceInt, diff)
-		// gas price should not be less than the initial gas price, and
-		// never below 1 whatever the initial price says. Params.Validate
-		// accepts an InitialGasPrice of 0, and 0 is an absorbing state: the
-		// guard at the top of this function reads a stored price of 0 as
-		// "dynamic pricing disabled" and returns early, so no congestion
-		// level can lift the price again.
-		//
-		// Genesis alone cannot reach it, because installAuthParams seeds the
-		// stored price from InitialGasPrice, so a zero there disables pricing
-		// from block 1 rather than decaying into it. The reachable shape is a
-		// post-genesis change of auth:p:initial_gasprice to 0 on a chain whose
-		// stored price is non-zero: the min-1 decrement then walks it down to
-		// 0 and it stays there permanently.
+		// Floor at the initial gas price, and never below 1 whatever that
+		// price says. Params.Validate accepts an InitialGasPrice of 0, and 0
+		// is absorbing: the guard at the top of this function reads a stored
+		// price of 0 as "dynamic pricing disabled". Only reachable by setting
+		// auth:p:initial_gasprice to 0 post-genesis, since at genesis
+		// installAuthParams seeds the stored price from it and pricing is off
+		// from block 1 instead.
 		num = maxBig(num, maxBig(initPriceInt, bigOne))
 	}
 
+	// Cap at the largest representable price instead of panicking. Sustained
+	// congestion otherwise walks the increase branch past int64: at the
+	// shipped parameters a run of full blocks gets there around block 1000,
+	// and every node then panics in EndBlock at the same height.
 	if !num.IsInt64() {
-		panic("The min gas price is out of int64 range")
+		num = big.NewInt(math.MaxInt64)
 	}
 
 	lastGasPrice.Price.Amount = num.Int64()

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -375,6 +375,13 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 	maxBlockGas := ctx.ConsensusParams().Block.MaxGas
 	lgp := gk.LastGasPrice(ctx)
 	newGasPrice := gk.calcBlockGasPrice(lgp, gasUsed, maxBlockGas, params)
+	// At the ceiling no transaction above 1000 gas wanted can pay the minimum
+	// fee, and the write below is skipped once the price stops moving, so this
+	// is the only signal an operator gets that the chain is refusing work.
+	if newGasPrice.Price.Amount == math.MaxInt64 {
+		ctx.Logger().Error("block gas price is at the int64 ceiling, transactions cannot pay for it",
+			"gasPrice", newGasPrice.String(), "gasUsed", gasUsed, "maxBlockGas", maxBlockGas)
+	}
 	// Skip the write when the price is unchanged — e.g. it already sits at the
 	// floor, the block was exactly at target, or dynamic pricing is disabled
 	// (stored price 0 or TargetGasRatio == 0). Now that empty blocks are no

--- a/tm2/pkg/sdk/auth/keeper.go
+++ b/tm2/pkg/sdk/auth/keeper.go
@@ -379,7 +379,7 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 	// fee, and the write below is skipped once the price stops moving, so this
 	// is the only signal an operator gets that the chain is refusing work.
 	if newGasPrice.Price.Amount == math.MaxInt64 {
-		ctx.Logger().Error("block gas price is at the int64 ceiling, transactions cannot pay for it",
+		gk.Logger(ctx).Error("block gas price is at the int64 ceiling, transactions cannot pay for it",
 			"gasPrice", newGasPrice.String(), "gasUsed", gasUsed, "maxBlockGas", maxBlockGas)
 	}
 	// Skip the write when the price is unchanged — e.g. it already sits at the
@@ -402,6 +402,11 @@ func (gk GasPriceKeeper) UpdateGasPrice(ctx sdk.Context) {
 			Key:   "func",
 			Value: attribute.StringValue("UpdateGasPrice"),
 		})
+}
+
+// Logger returns a module-specific logger.
+func (gk GasPriceKeeper) Logger(ctx sdk.Context) *slog.Logger {
+	return ctx.Logger().With("module", ModuleName)
 }
 
 // calcBlockGasPrice calculates the minGasPrice for the txs to be included in the next block.

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -404,3 +404,91 @@ func TestIterateAccountsChargesGas(t *testing.T) {
 	require.Greater(t, used, store.Gas(0),
 		"IterateAccounts should consume gas through the threaded gctx")
 }
+
+// TestCalcBlockGasPriceUnboundedMaxGas covers the two consensus-param
+// spellings of "no block gas bound". Neither carries a congestion signal, so
+// neither may move the price.
+func TestCalcBlockGasPriceUnboundedMaxGas(t *testing.T) {
+	gk := GasPriceKeeper{}
+	params := Params{
+		TargetGasRatio:            70,
+		GasPricesChangeCompressor: 10,
+		InitialGasPrice: std.GasPrice{
+			Gas:   1000,
+			Price: std.Coin{Amount: 1, Denom: "ugnot"},
+		},
+	}
+	price := func(amount int64) std.GasPrice {
+		return std.GasPrice{Gas: 1000, Price: std.Coin{Amount: amount, Denom: "ugnot"}}
+	}
+
+	// MaxGas == -1 is the sentinel ValidateConsensusParams accepts for "no
+	// gas bounds". targetGas floors to -1, so every gasUsed >= 0 used to take
+	// the increase branch and the min-1 clamp ratcheted the price up by 1 per
+	// block, idle blocks included.
+	t.Run("MaxGas -1 does not ratchet", func(t *testing.T) {
+		next := price(1000)
+		for range 5 {
+			next = gk.calcBlockGasPrice(next, 0, -1, params)
+			require.Equal(t, int64(1000), next.Price.Amount)
+		}
+		// Not even a full block moves it: there is no maximum to be full of.
+		require.Equal(t, int64(1000), gk.calcBlockGasPrice(price(1000), 1_000_000, -1, params).Price.Amount)
+	})
+
+	// maxGas*ratio < 100 makes the target 0 and every branch divides by it.
+	// With the default ratio of 70 that is MaxGas 0 and 1. MaxGas == 0 is
+	// reachable: getMaximumBlockGas maps it to an infinite gas meter, so
+	// blocks consume gas and EndBlock is reached with gasUsed > 0.
+	t.Run("zero target does not panic", func(t *testing.T) {
+		for _, maxGas := range []int64{0, 1} {
+			for _, gasUsed := range []int64{0, 1, 1_000_000} {
+				require.NotPanics(t, func() {
+					got := gk.calcBlockGasPrice(price(10), gasUsed, maxGas, params)
+					require.Equal(t, int64(10), got.Price.Amount)
+				}, "maxGas=%d gasUsed=%d", maxGas, gasUsed)
+			}
+		}
+	})
+
+	// The smallest MaxGas that still yields a target keeps working.
+	t.Run("smallest usable MaxGas still adjusts", func(t *testing.T) {
+		require.Equal(t, int64(9), gk.calcBlockGasPrice(price(10), 0, 2, params).Price.Amount)
+	})
+}
+
+// TestCalcBlockGasPriceZeroInitialPrice pins the floor at 1 even when
+// InitialGasPrice is 0. Params.Validate accepts that value, and a stored price
+// of 0 is absorbing: calcBlockGasPrice reads it as "dynamic pricing disabled"
+// and returns early, so the price could never recover.
+func TestCalcBlockGasPriceZeroInitialPrice(t *testing.T) {
+	gk := GasPriceKeeper{}
+	const (
+		maxGas    = int64(3_000_000_000)
+		targetGas = int64(2_100_000_000)
+	)
+	params := Params{
+		TargetGasRatio:            70,
+		GasPricesChangeCompressor: 10,
+		InitialGasPrice: std.GasPrice{
+			Gas:   1000,
+			Price: std.Coin{Amount: 0, Denom: "ugnot"},
+		},
+	}
+	require.NoError(t, func() error {
+		p := DefaultParams()
+		p.InitialGasPrice = params.InitialGasPrice
+		return p.Validate()
+	}(), "Params.Validate accepts a zero InitialGasPrice, so calc must cope with it")
+
+	next := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 3, Denom: "ugnot"}}
+	for range 10 {
+		next = gk.calcBlockGasPrice(next, 0, maxGas, params)
+		require.GreaterOrEqual(t, next.Price.Amount, int64(1))
+	}
+	require.Equal(t, int64(1), next.Price.Amount)
+
+	// Still responsive: from the floor, a full block raises the price again.
+	up := gk.calcBlockGasPrice(next, targetGas+1, maxGas, params)
+	require.Equal(t, int64(2), up.Price.Amount)
+}

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -436,10 +436,12 @@ func TestCalcBlockGasPriceUnboundedMaxGas(t *testing.T) {
 		require.Equal(t, int64(1000), gk.calcBlockGasPrice(price(1000), 1_000_000, -1, params).Price.Amount)
 	})
 
-	// maxGas*ratio < 100 makes the target 0 and every branch divides by it.
-	// With the default ratio of 70 that is MaxGas 0 and 1. MaxGas == 0 is
-	// reachable: getMaximumBlockGas maps it to an infinite gas meter, so
-	// blocks consume gas and EndBlock is reached with gasUsed > 0.
+	// maxGas*ratio < 100 makes the target 0, and both the increase and the
+	// decrease branch divide by it. With the default ratio of 70 that is
+	// MaxGas 0 and 1. MaxGas == 0 is reachable: getMaximumBlockGas maps it to
+	// an infinite gas meter, so blocks consume gas and EndBlock is reached
+	// with gasUsed > 0. gasUsed == 0 is the exception, matching the target
+	// exactly and returning before either division.
 	t.Run("zero target does not panic", func(t *testing.T) {
 		for _, maxGas := range []int64{0, 1} {
 			for _, gasUsed := range []int64{0, 1, 1_000_000} {

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -448,7 +448,9 @@ func TestCalcBlockGasPriceUnboundedMaxGas(t *testing.T) {
 	})
 
 	// maxGas*ratio < 100 makes the target 0, which both branches divide by. At
-	// the default ratio of 70 that is MaxGas 0 and 1.
+	// the default ratio of 70 that is MaxGas 0 and 1. The gasUsed 0 rows are the
+	// exception: the usage equals the target, so they return before either
+	// division and pass without the guard too.
 	t.Run("zero target does not panic", func(t *testing.T) {
 		for _, maxGas := range []int64{0, 1} {
 			for _, gasUsed := range []int64{0, 1, 1_000_000} {

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"math"
 	"math/big"
 	"testing"
@@ -521,4 +523,25 @@ func TestCalcBlockGasPriceFloorAboveOne(t *testing.T) {
 		next = gk.calcBlockGasPrice(next, 0, maxGas, params)
 		require.Equal(t, initial, next)
 	}
+}
+
+// A chain at the ceiling stops writing the price, so the log is the only thing
+// that tells an operator the mempool is refusing everything.
+func TestUpdateGasPriceCeilingLogs(t *testing.T) {
+	env := setupTestEnv()
+	var buf bytes.Buffer
+	ctx := env.ctx.WithLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+	meter := store.NewGasMeter(math.MaxInt64)
+	meter.ConsumeGas(ctx.ConsensusParams().Block.MaxGas, "full block")
+	ctx = ctx.WithBlockGasMeter(meter)
+
+	env.gk.SetGasPrice(ctx, std.GasPrice{Gas: 1000, Price: std.Coin{Amount: math.MaxInt64 - 10, Denom: "ugnot"}})
+	env.gk.UpdateGasPrice(ctx)
+	require.Equal(t, int64(math.MaxInt64), env.gk.LastGasPrice(ctx).Price.Amount)
+	require.Contains(t, buf.String(), "int64 ceiling")
+
+	buf.Reset()
+	env.gk.SetGasPrice(ctx, std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 1000, Denom: "ugnot"}})
+	env.gk.UpdateGasPrice(ctx)
+	require.NotContains(t, buf.String(), "int64 ceiling", "logged below the ceiling")
 }

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -196,6 +196,8 @@ func TestCalcBlockGasPrice(t *testing.T) {
 	})
 
 	t.Run("int64 overflow caps instead of panicking", func(t *testing.T) {
+		// Starting below the cap, so returning the price unchanged would fail.
+		require.Equal(t, price(math.MaxInt64), gk.calcBlockGasPrice(price(math.MaxInt64-10), targetGas+1, maxGas, params))
 		require.Equal(t, price(math.MaxInt64), gk.calcBlockGasPrice(price(math.MaxInt64), targetGas+1, maxGas, params))
 	})
 
@@ -445,12 +447,8 @@ func TestCalcBlockGasPriceUnboundedMaxGas(t *testing.T) {
 		require.Equal(t, int64(1000), gk.calcBlockGasPrice(price(1000), 1_000_000, -1, params).Price.Amount)
 	})
 
-	// maxGas*ratio < 100 makes the target 0, which both branches divide by.
-	// With the default ratio of 70 that is MaxGas 0 and 1. MaxGas 0 is
-	// reachable: getMaximumBlockGas maps it to an infinite gas meter, so
-	// blocks consume gas and EndBlock runs with gasUsed > 0. gasUsed == 0 is
-	// the exception, matching the target exactly and returning before either
-	// division.
+	// maxGas*ratio < 100 makes the target 0, which both branches divide by. At
+	// the default ratio of 70 that is MaxGas 0 and 1.
 	t.Run("zero target does not panic", func(t *testing.T) {
 		for _, maxGas := range []int64{0, 1} {
 			for _, gasUsed := range []int64{0, 1, 1_000_000} {
@@ -502,4 +500,23 @@ func TestCalcBlockGasPriceZeroInitialPrice(t *testing.T) {
 	// Still responsive: from the floor, a full block raises the price again.
 	up := gk.calcBlockGasPrice(next, targetGas+1, maxGas, params)
 	require.Equal(t, int64(2), up.Price.Amount)
+}
+
+// The decrease floor is the initial gas price, not 1. Every other test in this
+// file sets InitialGasPrice to 1, which makes the two indistinguishable.
+func TestCalcBlockGasPriceFloorAboveOne(t *testing.T) {
+	gk := GasPriceKeeper{}
+	const maxGas = int64(3_000_000_000)
+	initial := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 100, Denom: "ugnot"}}
+	params := Params{
+		TargetGasRatio:            70,
+		GasPricesChangeCompressor: 10,
+		InitialGasPrice:           initial,
+	}
+
+	next := std.GasPrice{Gas: 1000, Price: std.Coin{Amount: 105, Denom: "ugnot"}}
+	for range 5 {
+		next = gk.calcBlockGasPrice(next, 0, maxGas, params)
+		require.Equal(t, initial, next)
+	}
 }

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -195,10 +195,19 @@ func TestCalcBlockGasPrice(t *testing.T) {
 		require.Equal(t, price(10), gk.calcBlockGasPrice(price(10), targetGas+1, maxGas, disabledParams))
 	})
 
-	t.Run("int64 overflow", func(t *testing.T) {
-		require.PanicsWithValue(t, "The min gas price is out of int64 range", func() {
-			gk.calcBlockGasPrice(price(math.MaxInt64), targetGas+1, maxGas, params)
-		})
+	t.Run("int64 overflow caps instead of panicking", func(t *testing.T) {
+		require.Equal(t, price(math.MaxInt64), gk.calcBlockGasPrice(price(math.MaxInt64), targetGas+1, maxGas, params))
+	})
+
+	t.Run("sustained congestion settles at the cap", func(t *testing.T) {
+		p := price(1)
+		for range 2000 {
+			p = gk.calcBlockGasPrice(p, maxGas, maxGas, params)
+		}
+		require.Equal(t, int64(math.MaxInt64), p.Price.Amount)
+
+		// The cap is not absorbing: an idle block still walks the price back.
+		require.Less(t, gk.calcBlockGasPrice(p, 0, maxGas, params).Price.Amount, int64(math.MaxInt64))
 	})
 }
 
@@ -436,12 +445,12 @@ func TestCalcBlockGasPriceUnboundedMaxGas(t *testing.T) {
 		require.Equal(t, int64(1000), gk.calcBlockGasPrice(price(1000), 1_000_000, -1, params).Price.Amount)
 	})
 
-	// maxGas*ratio < 100 makes the target 0, and both the increase and the
-	// decrease branch divide by it. With the default ratio of 70 that is
-	// MaxGas 0 and 1. MaxGas == 0 is reachable: getMaximumBlockGas maps it to
-	// an infinite gas meter, so blocks consume gas and EndBlock is reached
-	// with gasUsed > 0. gasUsed == 0 is the exception, matching the target
-	// exactly and returning before either division.
+	// maxGas*ratio < 100 makes the target 0, which both branches divide by.
+	// With the default ratio of 70 that is MaxGas 0 and 1. MaxGas 0 is
+	// reachable: getMaximumBlockGas maps it to an infinite gas meter, so
+	// blocks consume gas and EndBlock runs with gasUsed > 0. gasUsed == 0 is
+	// the exception, matching the target exactly and returning before either
+	// division.
 	t.Run("zero target does not panic", func(t *testing.T) {
 		for _, maxGas := range []int64{0, 1} {
 			for _, gasUsed := range []int64{0, 1, 1_000_000} {

--- a/tm2/pkg/sdk/auth/keeper_test.go
+++ b/tm2/pkg/sdk/auth/keeper_test.go
@@ -209,9 +209,35 @@ func TestCalcBlockGasPrice(t *testing.T) {
 			p = gk.calcBlockGasPrice(p, maxGas, maxGas, params)
 		}
 		require.Equal(t, int64(math.MaxInt64), p.Price.Amount)
+		require.Equal(t, int64(1000), p.Gas, "the clamp keeps the denominator")
+		require.Equal(t, "ugnot", p.Price.Denom, "the clamp keeps the denom")
 
-		// The cap is not absorbing: an idle block still walks the price back.
-		require.Less(t, gk.calcBlockGasPrice(p, 0, maxGas, params).Price.Amount, int64(math.MaxInt64))
+		// The cap is a pause, not a trap: idle blocks walk the price all the way
+		// back to the floor. A change to the floor, the compressor or the min-1
+		// decrement that stranded the price up here would hang this loop.
+		idle := 0
+		for p.Price.Amount != 1 {
+			p = gk.calcBlockGasPrice(p, 0, maxGas, params)
+			idle++
+			require.Less(t, idle, 1000, "the price does not return to the floor")
+		}
+	})
+
+	// Only the increase branch can leave int64 range, so the clamp is the right
+	// saturation direction. Every decrease result lands in [1, max(last, initial)],
+	// including at the largest initial price Params.Validate accepts.
+	t.Run("decreasing stays in range", func(t *testing.T) {
+		for _, last := range []int64{1, 2, 1000, math.MaxInt64 / 2, math.MaxInt64 - 1, math.MaxInt64} {
+			for _, initial := range []int64{0, 1, 1000, math.MaxInt64} {
+				p := params
+				p.InitialGasPrice = price(initial)
+				got := gk.calcBlockGasPrice(price(last), 0, maxGas, p)
+				require.LessOrEqual(t, got.Price.Amount, max(last, initial),
+					"last=%d initial=%d", last, initial)
+				require.GreaterOrEqual(t, got.Price.Amount, int64(1),
+					"last=%d initial=%d", last, initial)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
On a chain whose [`Block.MaxGas`](https://github.com/gnolang/gno/blob/master/tm2/pkg/bft/types/params.go#L69-L71) is `-1`, the minimum gas price rises by 1 on every block, idle blocks included, and can never come back down. On a chain whose `MaxGas` is 0 or 1, the node panics in `EndBlock` on the first block that uses gas. Both come from [`calcBlockGasPrice`](https://github.com/gnolang/gno/blob/master/tm2/pkg/sdk/auth/keeper.go#L412) deriving its target as `maxGas * TargetGasRatio / 100`, which is `-1` for the "no gas bound" sentinel and 0 for the small values, while nothing on this path maps those spellings to unbounded the way [`getMaximumBlockGas`](https://github.com/gnolang/gno/blob/master/tm2/pkg/sdk/baseapp.go#L300) does.

A non-positive target now returns the price unchanged: there is no bound to measure congestion against.

Two smaller changes ride along. The decrease floor is now `max(InitialGasPrice, 1)`, because [`Params.Validate`](https://github.com/gnolang/gno/blob/master/tm2/pkg/sdk/auth/params.go#L115-L117) accepts a zero initial price and a stored price of 0 reads as "pricing disabled" and can never rise again. The int64 overflow panic is now a clamp at `math.MaxInt64`, which sustained congestion reaches at block 1002 at the shipped parameters. A capped chain cannot price any transaction above 1000 gas wanted, so `UpdateGasPrice` logs it at `ERROR`; 407 idle blocks then walk the price back to the floor.

A sweep of 91584 parameter combinations against master puts every one of the 19585 differing outcomes into those three intended causes and finds no other, and master panics in all 14976 cases where this branch does not. Driving the same block sequence through the full ABCI cycle on both binaries at a block gas limit of 1000000 gives identical app hashes at every height. Tests cover the `-1` ratchet, both divide-by-zero shapes, the floor, the clamp and its descent, and the log. The decisions are recorded in `tm2/adr/pr5999_block_gas_price_ratchet.md`.
