### PR TITLE
fix(tm2): prevent stale query fast-index rebuilds

### DIFF
--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -16,12 +16,10 @@ import (
 // byte-identical to the committed snapshot at its version.
 //
 // Trust contract: index currency is verified by Load (ensureFastIndex rebuilds
-// on a stamp mismatch) and preserved from then on by eager same-batch
+// a missing or older stamp) and preserved from then on by eager same-batch
 // maintenance (Set/Remove/SaveVersion) and by Import dropping the index up
-// front. A tree reached ONLY via LoadVersion — never Load — over a DB whose
-// later versions were committed with the feature off is outside the contract:
-// nothing re-verifies the stamp there. The in-repo store layer always goes
-// through Load.
+// front. Immutable snapshots also require a stamp at least as new as their
+// version, so read-only LoadVersion paths safely fall back without maintenance.
 //
 // Properties:
 //   - Not in the Merkle commitment — an unauthenticated accelerator, like cosmos
@@ -34,11 +32,11 @@ import (
 //   - Maintained in the SAME batch as the tree (Set/Remove stage into ndb.batch,
 //     committed atomically by SaveVersion → Commit), so it can never disagree
 //     with the committed tree, even across a crash.
-//   - ADVISORY on read: a hit is trusted only when its version ≤ the snapshot
-//     version (else the entry is newer than the reader's snapshot); a miss,
-//     a too-new entry, or a corrupt/too-short entry all fall back to the
-//     authoritative tree walk. Index completeness is therefore a performance
-//     property, never a correctness one.
+//   - ADVISORY on read: an immutable snapshot requires stamp ≥ snapshot version,
+//     then trusts a hit only when its version ≤ the snapshot version. A miss,
+//     untrusted stamp, too-new entry, or corrupt/too-short entry falls back to
+//     the authoritative tree walk. Index completeness is therefore a
+//     performance property, never a correctness one.
 
 // fastDBKey builds the fast-index DB key: PrefixFast ‖ userKey.
 func fastDBKey(userKey []byte) []byte {

--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -204,11 +204,9 @@ func (ndb *nodeDB) dropFastIndex() (err error) {
 	return ndb.clearFastIndex()
 }
 
-// ensureFastIndex rebuilds the fast index from the latest root if it is absent
-// or stale (the stamp != the loaded version). Called from Load when the feature
-// is on. The index is advisory, so a stale/missing index is never wrong, only
-// slower; a rebuild error is returned to Load's caller (the loaded tree is still
-// usable, and a retry Load re-attempts the rebuild).
+// ensureFastIndex ensures that the fast index is valid for the loaded tree.
+// A tree loaded from an older version is treated as a stale reader and never
+// updates the shared fast index.
 func (t *MutableTree) ensureFastIndex() error {
 	if !t.ndb.opts.FastIndex {
 		return nil
@@ -217,7 +215,7 @@ func (t *MutableTree) ensureFastIndex() error {
 	if err != nil {
 		return err
 	}
-	if ok && stamp == t.version {
+	if ok && stamp >= t.version {
 		return nil // already complete through the loaded version
 	}
 	return t.rebuildFastIndex()

--- a/tm2/pkg/bptree/fast_index_test.go
+++ b/tm2/pkg/bptree/fast_index_test.go
@@ -279,6 +279,65 @@ func TestFastIndex_EagerStampAvoidsRebuild(t *testing.T) {
 	}
 }
 
+// TestFastIndex_NewerStampDoesNotRebuildOlderRoot ensures a stale reader
+// cannot overwrite a fast index maintained by a newer committed version.
+func TestFastIndex_NewerStampDoesNotRebuildOlderRoot(t *testing.T) {
+	db := memdb.NewMemDB()
+	tr := NewMutableTreeWithDB(db, 256, NewNopLogger(), FastIndexOption(true))
+	key := []byte("key")
+	mustSet(t, tr, key, []byte("authoritative"))
+	v1 := mustSave(t, tr)
+
+	doctorFastEntry(t, tr, db, key, v1, []byte("sentinel"))
+	if err := tr.ndb.setFastIndexVersion(v1 + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.ndb.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tr.ensureFastIndex(); err != nil {
+		t.Fatal(err)
+	}
+	stamp, ok, err := tr.ndb.getFastIndexVersion()
+	if err != nil || !ok || stamp != v1+1 {
+		t.Fatalf("stamp = (%d, %t, %v); want (%d, true, nil)", stamp, ok, err, v1+1)
+	}
+	got, ok := tr.ndb.fastGet(key, v1)
+	if !ok || string(got) != "sentinel" {
+		t.Fatalf("fast entry changed = (%q, %t); want sentinel unchanged", got, ok)
+	}
+}
+
+// TestFastIndex_OlderStampStillRebuildsLatestRoot ensures writer startup still
+// repairs an index whose stamp is behind the authoritative latest root.
+func TestFastIndex_OlderStampStillRebuildsLatestRoot(t *testing.T) {
+	db := memdb.NewMemDB()
+	tr := NewMutableTreeWithDB(db, 256, NewNopLogger(), FastIndexOption(true))
+	mustSet(t, tr, []byte("key"), []byte("v1"))
+	v1 := mustSave(t, tr)
+	mustSet(t, tr, []byte("key"), []byte("v2"))
+	v2 := mustSave(t, tr)
+
+	if err := tr.ndb.setFastIndexVersion(v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.ndb.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.ensureFastIndex(); err != nil {
+		t.Fatal(err)
+	}
+	stamp, ok, err := tr.ndb.getFastIndexVersion()
+	if err != nil || !ok || stamp != v2 {
+		t.Fatalf("stamp = (%d, %t, %v); want (%d, true, nil)", stamp, ok, err, v2)
+	}
+	got, err := tr.Get([]byte("key"))
+	if err != nil || string(got) != "v2" {
+		t.Fatalf("Get = %q, %v; want v2", got, err)
+	}
+}
+
 // TestFastIndex_VersionCheckRejectsNewer: a committed snapshot at S must never
 // see a value written after S, even though the index points at the newer entry.
 func TestFastIndex_VersionCheckRejectsNewer(t *testing.T) {

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -485,10 +485,10 @@ func (t *MutableTree) saveNode(node Node, version int64) error {
 
 // Load loads the latest version from the DB.
 func (t *MutableTree) Load() (int64, error) {
-	if err := t.ndb.discoverVersions(); err != nil {
+	latest, err := t.GetLatestVersion()
+	if err != nil {
 		return 0, err
 	}
-	latest := t.ndb.getLatestVersion()
 	if latest == 0 {
 		return 0, nil
 	}
@@ -524,10 +524,10 @@ func (t *MutableTree) LoadVersion(version int64) (int64, error) {
 	// (matching IAVL behavior which returns latestVersion, not targetVersion).
 	// Refreshing first/latest on a path that later errors is harmless: they
 	// are re-derived counters, not session state.
-	if err := t.ndb.discoverVersions(); err != nil {
+	latestVersion, err := t.GetLatestVersion()
+	if err != nil {
 		return 0, err
 	}
-	latestVersion := t.ndb.getLatestVersion()
 
 	nkBytes, _, err := t.ndb.GetRoot(version)
 	if err != nil {
@@ -563,6 +563,15 @@ func (t *MutableTree) LoadVersion(version int64) (int64, error) {
 	t.lastSaved = root
 	t.poisoned = nil // full session replacement
 	return latestVersion, nil
+}
+
+// GetLatestVersion discovers and returns the latest persisted version without
+// performing fast-index maintenance.
+func (t *MutableTree) GetLatestVersion() (int64, error) {
+	if err := t.ndb.discoverVersions(); err != nil {
+		return 0, err
+	}
+	return t.ndb.getLatestVersion(), nil
 }
 
 // LoadVersionForOverwriting is not supported — it would leak values and nodes.
@@ -656,6 +665,10 @@ func (t *MutableTree) getImmutable(version int64, register bool) (*ImmutableTree
 		return nil, err
 	}
 	imm := t.newImmutable(root, version, true)
+	if imm.fast {
+		stamp, ok, err := t.ndb.getFastIndexVersion()
+		imm.fast = err == nil && ok && stamp >= version
+	}
 	imm.registered = reg
 	return imm, nil
 }

--- a/tm2/pkg/db/immutable.go
+++ b/tm2/pkg/db/immutable.go
@@ -61,12 +61,12 @@ func (idb *ImmutableDB) NewSnapshot() (Snapshot, error) {
 
 // Implements DB.
 func (idb *ImmutableDB) NewBatch() Batch {
-	return nil // XXX
+	return &snapshotNoopBatch{}
 }
 
 // Implements DB.
 func (idb *ImmutableDB) NewBatchWithSize(_ int) Batch {
-	return nil // XXX
+	return &snapshotNoopBatch{}
 }
 
 // Implements DB.

--- a/tm2/pkg/sdk/baseapp_test.go
+++ b/tm2/pkg/sdk/baseapp_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/sdk/testutils"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/gno/tm2/pkg/store"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
 	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
 	"github.com/gnolang/gno/tm2/pkg/store/iavl"
 )
@@ -964,7 +965,11 @@ func TestSimulateConcurrentNoPanic(t *testing.T) {
 		}))
 	}
 
-	app := setupBaseApp(t, anteOpt, routerOpt)
+	db := memdb.NewMemDB()
+	app := NewBaseApp(t.Name(), defaultLogger(), db, baseKey, mainKey, anteOpt, routerOpt)
+	app.MountStoreWithDB(baseKey, dbadapter.StoreConstructor, db)
+	app.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	require.NoError(t, app.LoadLatestVersion())
 	app.InitChain(abci.RequestInitChain{ChainID: "test-chain"})
 
 	tx := newTxCounter(0, 0)

--- a/tm2/pkg/store/bptree/coverage_test.go
+++ b/tm2/pkg/store/bptree/coverage_test.go
@@ -169,6 +169,49 @@ func TestImmutableLoadVersionDoesNotMaintainFastIndex(t *testing.T) {
 	require.Equal(t, []byte("value"), reader.Get(nil, []byte("key")))
 }
 
+func TestImmutableLoadLatestVersionDoesNotMaintainFastIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stale bool
+	}{
+		{name: "missing stamp"},
+		{name: "stale stamp", stale: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := memdb.NewMemDB()
+			opts := types.StoreOptions{}
+			opts.KeepRecent = 100
+			writer := StoreConstructor(db, opts).(*Store)
+			if tc.stale {
+				writer = FastStoreConstructor(db, opts).(*Store)
+			}
+			writer.Set(nil, []byte("key"), []byte("v1"))
+			writer.Commit()
+			if tc.stale {
+				writer = StoreConstructor(db, opts).(*Store)
+				require.NoError(t, writer.LoadLatestVersion())
+				writer.Set(nil, []byte("key"), []byte("v2"))
+				writer.Commit()
+			}
+
+			snapshot, err := db.NewSnapshot()
+			require.NoError(t, err)
+			defer snapshot.Close()
+
+			reader := FastStoreConstructor(
+				dbm.NewSnapshotDB(snapshot),
+				types.StoreOptions{Immutable: true},
+			).(*Store)
+			require.NoError(t, reader.LoadLatestVersion())
+			want := []byte("v1")
+			if tc.stale {
+				want = []byte("v2")
+			}
+			require.Equal(t, want, reader.Get(nil, []byte("key")))
+		})
+	}
+}
+
 func TestCoverage_ImmutableStoreCommitPanics(t *testing.T) {
 	db := memdb.NewMemDB()
 	opts := types.StoreOptions{}

--- a/tm2/pkg/store/bptree/coverage_test.go
+++ b/tm2/pkg/store/bptree/coverage_test.go
@@ -7,6 +7,7 @@ import (
 
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
 	"github.com/gnolang/gno/tm2/pkg/db/memdb"
 	"github.com/gnolang/gno/tm2/pkg/store/types"
 )
@@ -146,6 +147,26 @@ func TestCoverage_LoadVersionImmutable(t *testing.T) {
 
 	val := st2.Get(nil, []byte("lv"))
 	require.Equal(t, []byte("v1"), val)
+}
+
+// TestImmutableLoadVersionDoesNotMaintainFastIndex ensures immutable loads
+// read the requested root without attempting fast-index writes.
+func TestImmutableLoadVersionDoesNotMaintainFastIndex(t *testing.T) {
+	db := memdb.NewMemDB()
+	writer := StoreConstructor(db, types.StoreOptions{}).(*Store)
+	writer.Set(nil, []byte("key"), []byte("value"))
+	writer.Commit()
+
+	snapshot, err := db.NewSnapshot()
+	require.NoError(t, err)
+	defer snapshot.Close()
+
+	opts := types.StoreOptions{Immutable: true}
+	reader := FastStoreConstructor(dbm.NewSnapshotDB(snapshot), opts).(*Store)
+	require.NotPanics(t, func() {
+		require.NoError(t, reader.LoadVersion(1))
+	})
+	require.Equal(t, []byte("value"), reader.Get(nil, []byte("key")))
 }
 
 func TestCoverage_ImmutableStoreCommitPanics(t *testing.T) {

--- a/tm2/pkg/store/bptree/store.go
+++ b/tm2/pkg/store/bptree/store.go
@@ -186,7 +186,9 @@ func (st *Store) LoadVersion(ver int64) error {
 		return nil // version 0 is always "empty"
 	}
 	if st.opts.Immutable {
-		if _, err := st.mtree.Load(); err != nil {
+		// Loads only the requested root without performing writer-only
+		// fast-index maintenance.
+		if _, err := st.mtree.LoadVersion(ver); err != nil {
 			return err
 		}
 		// Long-lived immutable store view, never Closed → load UNREGISTERED so

--- a/tm2/pkg/store/bptree/store.go
+++ b/tm2/pkg/store/bptree/store.go
@@ -162,6 +162,15 @@ func (st *Store) GetStoreOptions() types.StoreOptions     { return st.opts }
 func (st *Store) SetStoreOptions(opts types.StoreOptions) { st.opts = opts }
 
 func (st *Store) LoadLatestVersion() error {
+	if st.opts.Immutable {
+		latestV, err := st.mtree.GetLatestVersion()
+		if err != nil {
+			return err
+		}
+		if latestV != 0 {
+			return st.LoadVersion(latestV)
+		}
+	}
 	// Load discovers versions and loads the latest
 	latestV, err := st.mtree.Load()
 	if err != nil {

--- a/tm2/pkg/store/rootmulti/fast_index_test.go
+++ b/tm2/pkg/store/rootmulti/fast_index_test.go
@@ -1,0 +1,231 @@
+package rootmulti
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+type rootReadBarrierDB struct {
+	dbm.DB
+	armed   atomic.Bool
+	once    sync.Once
+	reached chan struct{}
+	resume  chan struct{}
+	batches atomic.Int64
+}
+
+func (db *rootReadBarrierDB) waitOnRoot(key []byte) {
+	if db.armed.Load() && bytes.HasPrefix(key, []byte("s/_/R")) {
+		db.once.Do(func() {
+			db.armed.Store(false)
+			close(db.reached)
+			<-db.resume
+		})
+	}
+}
+
+func (db *rootReadBarrierDB) Get(key []byte) ([]byte, error) {
+	db.waitOnRoot(key)
+	return db.DB.Get(key)
+}
+
+func (db *rootReadBarrierDB) NewSnapshot() (dbm.Snapshot, error) {
+	snapshot, err := db.DB.NewSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return &rootReadBarrierSnapshot{Snapshot: snapshot, db: db}, nil
+}
+
+func (db *rootReadBarrierDB) NewBatch() dbm.Batch {
+	db.batches.Add(1)
+	return db.DB.NewBatch()
+}
+
+func (db *rootReadBarrierDB) NewBatchWithSize(size int) dbm.Batch {
+	db.batches.Add(1)
+	return db.DB.NewBatchWithSize(size)
+}
+
+type rootReadBarrierSnapshot struct {
+	dbm.Snapshot
+	db *rootReadBarrierDB
+}
+
+func (s *rootReadBarrierSnapshot) Get(key []byte) ([]byte, error) {
+	s.db.waitOnRoot(key)
+	return s.Snapshot.Get(key)
+}
+
+type noSnapshotDB struct {
+	dbm.DB
+}
+
+func (db *noSnapshotDB) NewSnapshot() (dbm.Snapshot, error) {
+	return nil, fmt.Errorf("snapshots unsupported")
+}
+
+// TestImmutableDedicatedMountWithoutSnapshotSupport ensures the read-only
+// fallback can load a dedicated B+Tree store without constructing a live batch.
+func TestImmutableDedicatedMountWithoutSnapshotSupport(t *testing.T) {
+	db := &noSnapshotDB{DB: memdb.NewMemDB()}
+	ms := NewMultiStore(db)
+	key := types.NewStoreKey("main")
+	ms.MountStoreWithDB(key, storebptree.FastStoreConstructor, db)
+	require.NoError(t, ms.LoadLatestVersion())
+	ms.GetStore(key).Set(nil, []byte("key"), []byte("value"))
+	version := ms.Commit().Version
+
+	require.NotPanics(t, func() {
+		snapshot, release, err := ms.MultiImmutableCacheWrapWithVersion(version)
+		require.NoError(t, err)
+		defer release()
+		require.Equal(t, []byte("value"), snapshot.GetStore(key).Get(nil, []byte("key")))
+	})
+}
+
+// TestImmutableDedicatedMountCannotRebuildFromStaleRoot reproduces the query
+// versus commit TOCTOU and verifies the query stays snapshot-backed and write-free.
+func TestImmutableDedicatedMountCannotRebuildFromStaleRoot(t *testing.T) {
+	db := &rootReadBarrierDB{
+		DB:      memdb.NewMemDB(),
+		reached: make(chan struct{}),
+		resume:  make(chan struct{}),
+	}
+	ms := NewMultiStore(db)
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.PruneNothing})
+	key := types.NewStoreKey("main")
+	ms.MountStoreWithDB(key, storebptree.FastStoreConstructor, db)
+	require.NoError(t, ms.LoadLatestVersion())
+
+	live := ms.GetStore(key)
+	live.Set(nil, []byte("account"), []byte("v1"))
+	v1 := ms.Commit().Version
+	batchesBeforeQuery := db.batches.Load()
+	db.armed.Store(true)
+
+	type queryResult struct {
+		value   []byte
+		release func()
+		err     error
+	}
+	result := make(chan queryResult, 1)
+	go func() {
+		snapshot, release, err := ms.MultiImmutableCacheWrapWithVersion(v1)
+		if err != nil {
+			result <- queryResult{err: err}
+			return
+		}
+		result <- queryResult{
+			value:   snapshot.GetStore(key).Get(nil, []byte("account")),
+			release: release,
+		}
+	}()
+
+	<-db.reached
+	t.Log("query loaded root v1; committing writer root v2 before query continues")
+	queryLiveBatches := db.batches.Load() - batchesBeforeQuery
+	live.Set(nil, []byte("account"), []byte("v2"))
+	v2 := ms.Commit().Version
+	close(db.resume)
+	require.Equal(t, int64(2), v2)
+
+	query := <-result
+	require.NoError(t, query.err)
+	defer query.release()
+	require.Equal(t, []byte("v1"), query.value)
+
+	require.Equal(t, int64(3), ms.Commit().Version)
+	fastValue := live.Get(nil, []byte("account"))
+
+	plain := storebptree.StoreConstructor(
+		dbm.NewPrefixDB(db, []byte("s/_/")),
+		types.StoreOptions{Immutable: true},
+	).(*storebptree.Store)
+	require.NoError(t, plain.LoadVersion(3))
+	treeValue := plain.Get(nil, []byte("account"))
+	t.Logf("query live batches=%d fast=%q tree=%q", queryLiveBatches, fastValue, treeValue)
+
+	require.Equal(t, []byte("v2"), fastValue)
+	require.Equal(t, treeValue, fastValue)
+	require.Zero(t, queryLiveBatches, "immutable query constructed batches against the live dedicated DB")
+}
+
+// TestFastIndexConcurrentSnapshotsKeepTreeParity ensures Pebble-backed query
+// snapshots remain pinned while concurrent commits preserve fast/tree parity.
+func TestFastIndexConcurrentSnapshotsKeepTreeParity(t *testing.T) {
+	db, err := dbm.NewDB("fast-index-race", dbm.PebbleDBBackend, t.TempDir())
+	require.NoError(t, err)
+	ms := NewMultiStore(db)
+	t.Cleanup(func() {
+		require.NoError(t, ms.Close())
+		require.NoError(t, db.Close())
+	})
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.PruneNothing})
+	storeKey := types.NewStoreKey("main")
+	ms.MountStoreWithDB(storeKey, storebptree.FastStoreConstructor, db)
+	require.NoError(t, ms.LoadLatestVersion())
+
+	live := ms.GetStore(storeKey)
+	for i := range 16 {
+		live.Set(nil, []byte{byte(i)}, []byte{0})
+	}
+	seedVersion := ms.Commit().Version
+
+	const readers = 4
+	errs := make(chan error, readers)
+	var wg sync.WaitGroup
+	for range readers {
+		wg.Go(func() {
+			for range 50 {
+				snapshot, release, err := ms.MultiImmutableCacheWrapWithVersion(seedVersion)
+				if err != nil {
+					errs <- err
+					return
+				}
+				for i := range 16 {
+					if got := snapshot.GetStore(storeKey).Get(nil, []byte{byte(i)}); !bytes.Equal(got, []byte{0}) {
+						release()
+						errs <- fmt.Errorf("seed key %d = %x", i, got)
+						return
+					}
+				}
+				release()
+			}
+		})
+	}
+	for version := byte(1); version <= 50; version++ {
+		live.Set(nil, []byte{version % 16}, []byte{version})
+		ms.Commit()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	latest := ms.LastCommitID().Version
+	plain := storebptree.StoreConstructor(
+		dbm.NewPrefixDB(db, []byte("s/_/")),
+		types.StoreOptions{Immutable: true},
+	).(*storebptree.Store)
+	require.NoError(t, plain.LoadVersion(latest))
+	for i := range 16 {
+		require.Equal(t,
+			plain.Get(nil, []byte{byte(i)}),
+			live.Get(nil, []byte{byte(i)}),
+			"key %d fast/tree mismatch", i,
+		)
+	}
+}

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -130,6 +130,9 @@ func (ms *multiStore) MountStoreWithDB(key types.StoreKey, cons types.CommitStor
 	if key == nil {
 		panic("MountIAVLStore() key cannot be nil")
 	}
+	if db != nil && db != ms.db {
+		panic("rootmulti: mounted DB must be nil or the root DB")
+	}
 	if _, ok := ms.storesParams[key]; ok {
 		panic(fmt.Sprintf("Store duplicate store key %v", key))
 	}
@@ -510,6 +513,9 @@ func (ms *multiStore) constructStore(params storeParams) (store types.CommitStor
 	var prefix []byte
 	if params.db != nil {
 		raw = params.db
+		if ms.storeOpts.Immutable {
+			raw = ms.db
+		}
 		prefix = []byte("s/_/")
 	} else {
 		raw = ms.db

--- a/tm2/pkg/store/rootmulti/store_test.go
+++ b/tm2/pkg/store/rootmulti/store_test.go
@@ -43,6 +43,21 @@ func TestStoreMount(t *testing.T) {
 	require.Panics(t, func() { store.MountStoreWithDB(dup1, iavl.StoreConstructor, db) })
 }
 
+// TestStoreMountRejectsSeparateDB ensures dedicated mounts cannot bypass the
+// root DB's atomic commit and query-snapshot boundary.
+func TestStoreMountRejectsSeparateDB(t *testing.T) {
+	rootDB := memdb.NewMemDB()
+	store := NewMultiStore(rootDB)
+
+	require.Panics(t, func() {
+		store.MountStoreWithDB(
+			types.NewStoreKey("separate"),
+			iavl.StoreConstructor,
+			memdb.NewMemDB(),
+		)
+	})
+}
+
 func TestCacheMultiStoreWithVersion(t *testing.T) {
 	t.Parallel()
 

--- a/tm2/pkg/store/types/store.go
+++ b/tm2/pkg/store/types/store.go
@@ -146,8 +146,10 @@ type CommitMultiStore interface {
 	Committer
 	MultiStore
 
-	// Mount a store of type using the given db.
-	// If db == nil, the new store will use the CommitMultiStore db.
+	// MountStoreWithDB mounts a store. If db is non-nil, the store is mounted
+	// using the root DB directly. Otherwise, it is mounted under a
+	// store-specific prefix. A non-nil db must be the same DB used to construct
+	// the CommitMultiStore.
 	MountStoreWithDB(key StoreKey, cons CommitStoreConstructor, db dbm.DB)
 
 	// Panics on a nil key.


### PR DESCRIPTION
## Description

Fixed #6011 by ensuring immutable queries over dedicated mounts use the committed DB snapshot, preventing immutable bptree loads from maintaining the fast index, and refusing to rebuild from a root older than the observed fast-index stamp.

Also makes the snapshot unsupported fallback provide safe no-op batches and explicitly rejects truly separate mounted databases.