### PR TITLE
fix(tm2): prevent a race between store queries and commits

### DIFF
--- a/tm2/pkg/sdk/baseapp_test.go
+++ b/tm2/pkg/sdk/baseapp_test.go
@@ -1539,6 +1539,54 @@ func TestQuery(t *testing.T) {
 	require.Equal(t, value, res.Value)
 }
 
+// TestStoreQueryConcurrentWithCommit verifies that a latest-height store query
+// can run concurrently with Commit. Run with -race.
+func TestStoreQueryConcurrentWithCommit(t *testing.T) {
+	app := setupBaseApp(t)
+	app.InitChain(abci.RequestInitChain{ChainID: "test-chain"})
+
+	app.BeginBlock(abci.RequestBeginBlock{
+		Header: &bft.Header{ChainID: "test-chain", Height: 1},
+	})
+	app.EndBlock(abci.RequestEndBlock{})
+	app.Commit()
+
+	query := abci.RequestQuery{
+		Path: ".store/main/key",
+		Data: []byte("key"),
+	}
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	var queries atomic.Int64
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		app.Query(query)
+		queries.Add(1)
+		close(ready)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				app.Query(query)
+				queries.Add(1)
+			}
+		}
+	})
+
+	<-ready
+	for height := int64(2); height <= 20; height++ {
+		app.BeginBlock(abci.RequestBeginBlock{
+			Header: &bft.Header{ChainID: "test-chain", Height: height},
+		})
+		app.EndBlock(abci.RequestEndBlock{})
+		app.Commit()
+	}
+	close(done)
+	wg.Wait()
+	require.Greater(t, queries.Load(), int64(1))
+}
+
 func TestGetMaximumBlockGas(t *testing.T) {
 	app := setupBaseApp(t)
 

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -51,17 +51,17 @@ func (rs *refSnapshot) release() {
 // the CommitMultiStore interface.
 type multiStore struct {
 	db           dbm.DB
-	lastCommitID types.CommitID
+	lastCommitID atomic.Pointer[types.CommitID]
 	storeOpts    types.StoreOptions
 	storesParams map[types.StoreKey]storeParams
 	stores       map[types.StoreKey]types.CommitStore
 	keysByName   map[string]types.StoreKey
 
-	// initialVersion, when > 0 and lastCommitID.Version == 0, is the version
+	// initialVersion, when > 0 and LastCommitID().Version == 0, is the version
 	// the next Commit() will produce. Set once via SetInitialVersion (called
 	// from BaseApp.InitChain when GenesisDoc.InitialHeight > 1) and consumed
 	// on the first Commit; not persisted (after the first commit,
-	// lastCommitID.Version is the source of truth).
+	// LastCommitID().Version is the source of truth).
 	initialVersion int64
 
 	// querySnapshot holds the last fully-committed DB snapshot.
@@ -182,7 +182,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 			newStores[key] = store
 		}
 		ms.stores = newStores
-		ms.lastCommitID = types.CommitID{}
+		ms.lastCommitID.Store(&types.CommitID{})
 		return nil
 	}
 
@@ -222,7 +222,8 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 		newStores[key] = store
 	}
 
-	ms.lastCommitID = cInfo.CommitID()
+	commitID := cInfo.CommitID()
+	ms.lastCommitID.Store(&commitID)
 	ms.stores = newStores
 
 	return nil
@@ -233,7 +234,10 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 
 // Implements Committer/CommitStore.
 func (ms *multiStore) LastCommitID() types.CommitID {
-	return ms.lastCommitID
+	if commitID := ms.lastCommitID.Load(); commitID != nil {
+		return *commitID
+	}
+	return types.CommitID{}
 }
 
 // Implements Committer/CommitStore.
@@ -251,10 +255,11 @@ func (ms *multiStore) Commit() types.CommitID {
 	// must land at the chain's InitialHeight so multistore version equals
 	// real chain height. Subsequent commits auto-increment.
 	var version int64
-	if ms.lastCommitID.Version == 0 && ms.initialVersion > 0 {
+	lastVersion := ms.LastCommitID().Version
+	if lastVersion == 0 && ms.initialVersion > 0 {
 		version = ms.initialVersion
 	} else {
-		version = ms.lastCommitID.Version + 1
+		version = lastVersion + 1
 	}
 	commitInfo := commitStores(version, ms.stores)
 
@@ -291,7 +296,7 @@ func (ms *multiStore) Commit() types.CommitID {
 		Version: version,
 		Hash:    commitInfo.Hash(),
 	}
-	ms.lastCommitID = commitID
+	ms.lastCommitID.Store(&commitID)
 	return commitID
 }
 

--- a/tm2/pkg/store/rootmulti/store_test.go
+++ b/tm2/pkg/store/rootmulti/store_test.go
@@ -468,7 +468,7 @@ func TestCommitAtomicBatchWithCacheFlush(t *testing.T) {
 	// batch actually carried IAVL nodes AND rootmulti metadata to persistence.
 	reload := newMultiStoreWithMounts(db)
 	require.NoError(t, reload.LoadLatestVersion())
-	require.Equal(t, cid.Version, reload.lastCommitID.Version)
+	require.Equal(t, cid.Version, reload.LastCommitID().Version)
 	require.Equal(t, []byte("v1"),
 		reload.getStoreByName("store1").Get(nil, []byte("k1")))
 	require.Equal(t, []byte("v2"),


### PR DESCRIPTION
## Description

Concurrent ABCI query connections can execute `.store` queries while the consensus connection commits a block.

When a query omit its height, `BaseApp` obtains the latest height through:
`Query` -> `handleQueryStore` -> `LastBlockHeight` -> `LastCommitID`

At the same time, `root multi.multiStore.Commit` updated `lastCommitID` without synchronization. This caused a data race between the query and commit paths.

This issue was discovered while reviewing #6013, but is independent of the changes for #6011 so handled separately and the fix similar to #5431.

## Changes

`multistore.lastCommitID` is now published through an `atomic.Pointer`.

Both `LoadVersion` and `Commit` atomically publish a complete commit ID, while all reads go through `LastCommitID`. This keeps the synchronization at the shared state owner and preserves concurrent query execution without locking queries for the duration of a commit.

The regression test runs a latest height `.store` query concurrently with multiple commits and is intended to be executed with the race detector.