### PR TITLE
chore(docs): gnolang-networks.md: Change to Topaz

### DIFF
--- a/docs/resources/gnoland-networks.md
+++ b/docs/resources/gnoland-networks.md
@@ -6,7 +6,7 @@
 |-------------------|------------------------------------------|--------------|
 | Betanet (current) | https://rpc.gno.land:443                 | `gnoland1`   |
 | Staging           | https://rpc.staging.gno.land:443         | `staging`    |
-| Test13            | https://rpc.test13.testnets.gno.land:443 | `test-13`    |
+| Topaz / Test14    | https://rpc.topaz.testnets.gno.land:443  | `topaz-1`    |
 
 ### WebSocket endpoints
 


### PR DESCRIPTION
Test13 has been sunsetted. Topaz / Test14 is live. Update `gnolang-networks.md` .