### PR TITLE
fix(tm2): snapshot-isolate query paths and write-proof bptree fast-index maintenance

### DIFF
--- a/contribs/gnogenesis/internal/fork/source_txs_data_dir.go
+++ b/contribs/gnogenesis/internal/fork/source_txs_data_dir.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -121,6 +122,13 @@ func (s *dataDirTxsSource) Description() string { return "gnoland data directory
 
 func (s *dataDirTxsSource) Close() error {
 	var errs []error
+	// Release the multistore before its backing DB: LoadLatestVersion seeds a
+	// query snapshot that PebbleDB reports as leaked if the DB closes first.
+	if closer, ok := s.cms.(io.Closer); ok {
+		if closeErr := closer.Close(); closeErr != nil {
+			errs = append(errs, closeErr)
+		}
+	}
 	for _, db := range []dbm.DB{s.bsDB, s.stateDB, s.appDB} {
 		if db == nil {
 			continue

--- a/gno.land/pkg/gnoland/app_query_race_test.go
+++ b/gno.land/pkg/gnoland/app_query_race_test.go
@@ -167,7 +167,7 @@ func TestQueryRace_FastIndexParity(t *testing.T) {
 			return nil, err
 		}
 		if res.IsErr() || len(res.Data) == 0 || string(res.Data) == "null" {
-			return nil, fmt.Errorf("account query failed: %v %q", res.Error, res.Log)
+			return nil, fmt.Errorf("account query failed: %w (log: %q)", res.Error, res.Log)
 		}
 		var acct GnoAccount
 		if err := amino.UnmarshalJSON(res.Data, &acct); err != nil {

--- a/gno.land/pkg/gnoland/app_query_race_test.go
+++ b/gno.land/pkg/gnoland/app_query_race_test.go
@@ -272,12 +272,14 @@ func TestQueryRace_FastIndexParity(t *testing.T) {
 	stop.Store(true)
 	hammerGroup.Wait()
 
-	// On the fixed code the query path performs no index maintenance, so the
-	// stamp is never read outside startup: the hook must not have fired. (On
-	// the unfixed code it fires on the first hammer query and the audit below
-	// reports the poisoning.)
+	// The hook fires only on a stamp read through the LIVE DB handle. On the
+	// fixed code the query path never touches the live handle — it loads
+	// read-only from the frozen snapshot (the getImmutable stamp gate reads the
+	// snapshot's stamp, which bypasses this hook), so the hook must not have
+	// fired. (On the unfixed code the query's index maintenance reads the live
+	// stamp, fires the hook, and the audit below reports the poisoning.)
 	require.False(t, hooked.fired.Load(),
-		"query path read the fast-index stamp: query-side index maintenance is back")
+		"query path read the live fast-index stamp: query-side index maintenance is back")
 	require.Positive(t, queryLoads.Load(), "hammer performed no successful queries")
 
 	// Shut the app down and audit the persisted fast index from the raw DB,

--- a/gno.land/pkg/gnoland/app_query_race_test.go
+++ b/gno.land/pkg/gnoland/app_query_race_test.go
@@ -1,0 +1,343 @@
+package gnoland
+
+// Full-app integration regression for https://github.com/gnolang/gno/issues/6011:
+// concurrent query traffic must never corrupt the bptree fast index while the
+// app commits blocks.
+//
+// This exercises the PRODUCTION concurrency topology at the outermost layer
+// the bug is observable from: the real gnoland app (bptree main store with the
+// fast index, pebble, production store wiring and options) wrapped in the real
+// ABCI proxy client creator — block execution with signed bank sends driven
+// through the CONSENSUS connection while goroutines hammer account and .store
+// queries through the READ-ONLY QUERY connection, which has its own mutex and
+// genuinely races the commit drain (tm2/pkg/bft/proxy). The txtar integration
+// framework cannot express this (it is sequential); this is the flow that
+// poisoned topaz-1.
+//
+// The racing interleaving itself is made deterministic the same way the
+// tm2-level regression does it (the stochastic window — a version scan and a
+// stamp read straddling a commit drain — is microseconds wide at this layer,
+// far too narrow to hit reliably in CI time): the app's DB is wrapped so that
+// the first query-path read of the fast-index stamp pauses until the block
+// loop lands exactly one more commit. On the UNFIXED code the query connection
+// reads the stamp during its per-query index maintenance, observes it ahead of
+// the version it scanned, rebuilds the whole index from its outdated root, and
+// permanently poisons the just-committed sender's entry (write-once senders:
+// account i sends only at block i, so its reverted genesis-era entry is never
+// healed) — caught by the end-of-run parity audit. On the fixed code the query
+// path performs no index maintenance at all: the hook must never fire, and the
+// audit must be clean.
+//
+// The test intentionally uses no post-fix API, so it can be run against the
+// unfixed code to demonstrate the failure.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"math/rand"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	bftCfg "github.com/gnolang/gno/tm2/pkg/bft/config"
+	"github.com/gnolang/gno/tm2/pkg/bft/proxy"
+	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
+	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	"github.com/gnolang/gno/tm2/pkg/events"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/sdk"
+	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
+	"github.com/gnolang/gno/tm2/pkg/sdk/config"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// stampHookDB delegates to the wrapped DB; once armed, the first Get of the
+// fast-index stamp key runs onStampGet before returning the (post-hook)
+// value. It stands in for the consensus commit drain landing between a
+// query-path load's version scan and its stamp read — the gno#6011 window.
+type stampHookDB struct {
+	dbm.DB
+	armed      atomic.Bool
+	fired      atomic.Bool
+	onStampGet func()
+}
+
+func (h *stampHookDB) Get(key []byte) ([]byte, error) {
+	if h.armed.Load() && bytes.HasSuffix(key, []byte("fastidx")) &&
+		h.fired.CompareAndSwap(false, true) {
+		h.onStampGet()
+	}
+	return h.DB.Get(key)
+}
+
+func TestQueryRace_FastIndexParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("full-app query/commit race")
+	}
+
+	const (
+		chainID = "dev"
+		blocks  = 40
+	)
+	appDir := t.TempDir()
+
+	// One write-once sender per block, plus a sink receiver touched every block.
+	senders := make([]ed25519.PrivKeyEd25519, blocks)
+	balances := make([]Balance, 0, blocks+1)
+	for i := range senders {
+		senders[i] = ed25519.GenPrivKey()
+		balances = append(balances, Balance{
+			Address: senders[i].PubKey().Address(),
+			Amount:  std.Coins{std.NewCoin("ugnot", 100_000_000)},
+		})
+	}
+	sink := ed25519.GenPrivKey().PubKey().Address()
+	balances = append(balances, Balance{
+		Address: sink,
+		Amount:  std.Coins{std.NewCoin("ugnot", 1)},
+	})
+
+	// The app over a stamp-hooked pebble DB; all other options exactly as
+	// gnoland.NewApp assembles them.
+	rawDB, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, filepath.Join(appDir, bftCfg.DefaultDBDir))
+	require.NoError(t, err)
+	hooked := &stampHookDB{DB: rawDB}
+	appCfg := config.DefaultAppConfig()
+	genesisCfg := NewTestGenesisAppConfig()
+	app, err := NewAppWithOptions(&AppOptions{
+		DB:          hooked,
+		Logger:      log.NewNoopLogger(),
+		EventSwitch: events.NewEventSwitch(),
+		InitChainerConfig: InitChainerConfig{
+			GenesisTxResultHandler: PanicOnFailingTxResultHandler,
+			StdlibDir:              filepath.Join(gnoenv.RootDir(), "gnovm", "stdlibs"),
+		},
+		MinGasPrices:               appCfg.MinGasPrices,
+		SkipGenesisSigVerification: genesisCfg.SkipSigVerification,
+		PruneStrategy:              appCfg.PruneStrategy,
+	})
+	require.NoError(t, err)
+
+	// The real production connection topology: consensus and query connections
+	// with independent mutexes.
+	creator := proxy.NewLocalClientCreator(app)
+	cons, err := creator.NewABCIClient()
+	require.NoError(t, err)
+	require.NoError(t, cons.Start())
+	defer cons.Stop()
+	query, err := creator.NewReadOnlyABCIClient()
+	require.NoError(t, err)
+	require.NoError(t, query.Start())
+	defer query.Stop()
+
+	genState := DefaultGenState()
+	genState.Balances = append(genState.Balances, balances...)
+	_, err = cons.InitChainSync(abci.RequestInitChain{
+		ChainID: chainID,
+		Time:    time.Now(),
+		ConsensusParams: &abci.ConsensusParams{
+			Block: &abci.BlockParams{MaxGas: 100_000_000},
+		},
+		AppState: genState,
+	})
+	require.NoError(t, err)
+	_, err = cons.CommitSync()
+	require.NoError(t, err)
+
+	// queryAccount goes through the QUERY connection — the surface gnokey and
+	// gnoweb use.
+	queryAccount := func(addr crypto.Address) (std.Account, error) {
+		res, err := query.QuerySync(abci.RequestQuery{
+			Path: "auth/accounts/" + crypto.AddressToBech32(addr),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if res.IsErr() || len(res.Data) == 0 || string(res.Data) == "null" {
+			return nil, fmt.Errorf("account query failed: %v %q", res.Error, res.Log)
+		}
+		var acct GnoAccount
+		if err := amino.UnmarshalJSON(res.Data, &acct); err != nil {
+			return nil, err
+		}
+		return &acct, nil
+	}
+
+	// Prefetch account numbers BEFORE arming the hook: the block loop must
+	// never touch the query mutex once the hook can pause a query (the hooked
+	// query holds the query mutex while waiting for the loop to commit).
+	accNums := make([]uint64, blocks)
+	for i := range senders {
+		acct, err := queryAccount(senders[i].PubKey().Address())
+		require.NoError(t, err, "prefetch account %d", i)
+		accNums[i] = acct.GetAccountNumber()
+		require.EqualValues(t, 0, acct.GetSequence())
+	}
+
+	// Hook orchestration: the first query-path stamp read (a) freezes the
+	// hammer so no later query can trigger a healing rebuild on the unfixed
+	// code, and (b) waits for the block loop to land one more commit — placing
+	// the stamp ahead of the version the query already scanned.
+	var (
+		stop        atomic.Bool
+		wantCommit  atomic.Bool
+		committed   = make(chan struct{}, 1)
+		queryLoads  atomic.Int64
+		hammerGroup sync.WaitGroup
+	)
+	hooked.onStampGet = func() {
+		stop.Store(true)
+		wantCommit.Store(true)
+		select {
+		case <-committed:
+		case <-time.After(30 * time.Second):
+			t.Error("hook: no commit arrived within 30s")
+		}
+	}
+	hooked.armed.Store(true)
+
+	for g := range 4 {
+		hammerGroup.Go(func() {
+			rng := rand.New(rand.NewSource(int64(1000 + g)))
+			for !stop.Load() {
+				addr := senders[rng.Intn(len(senders))].PubKey().Address()
+				if g%2 == 0 {
+					if _, err := queryAccount(addr); err == nil {
+						queryLoads.Add(1)
+					}
+					continue
+				}
+				res, err := query.QuerySync(abci.RequestQuery{
+					Path: ".store/main/key",
+					Data: append([]byte("/a/"), addr.Bytes()...),
+				})
+				if err == nil && !res.IsErr() {
+					queryLoads.Add(1)
+				}
+			}
+		})
+	}
+
+	// Blocks: sender i sends once at block i (sequence 0, never touched again).
+	sendAmount := std.Coins{std.NewCoin("ugnot", 1_000_000)}
+	fee := std.NewFee(2_000_000, std.NewCoin("ugnot", 10_000_000))
+	base := app.(*sdk.BaseApp)
+	startHeight := base.LastBlockHeight() + 1
+	for i := range blocks {
+		h := startHeight + int64(i)
+		sender := senders[i]
+		addr := sender.PubKey().Address()
+
+		tx := std.Tx{
+			Msgs: []std.Msg{bank.NewMsgSend(addr, sink, sendAmount)},
+			Fee:  fee,
+		}
+		signBytes, err := tx.GetSignBytes(chainID, accNums[i], 0)
+		require.NoError(t, err)
+		sig, err := sender.Sign(signBytes)
+		require.NoError(t, err)
+		tx.Signatures = []std.Signature{{PubKey: sender.PubKey(), Signature: sig}}
+
+		_, err = cons.BeginBlockSync(abci.RequestBeginBlock{
+			Header: &bft.Header{ChainID: chainID, Height: h, Time: time.Now()},
+		})
+		require.NoError(t, err)
+		resTx, err := cons.DeliverTxSync(abci.RequestDeliverTx{Tx: amino.MustMarshal(tx)})
+		require.NoError(t, err)
+		require.True(t, resTx.IsOK(), "block %d: send failed: %v %q", h, resTx.Error, resTx.Log)
+		_, err = cons.EndBlockSync(abci.RequestEndBlock{})
+		require.NoError(t, err)
+		_, err = cons.CommitSync()
+		require.NoError(t, err)
+
+		// Serve a pending hook request: this commit is the one that lands
+		// between the hooked query's version scan and its stamp read.
+		if wantCommit.CompareAndSwap(true, false) {
+			committed <- struct{}{}
+		}
+	}
+	stop.Store(true)
+	hammerGroup.Wait()
+
+	// On the fixed code the query path performs no index maintenance, so the
+	// stamp is never read outside startup: the hook must not have fired. (On
+	// the unfixed code it fires on the first hammer query and the audit below
+	// reports the poisoning.)
+	require.False(t, hooked.fired.Load(),
+		"query path read the fast-index stamp: query-side index maintenance is back")
+	require.Positive(t, queryLoads.Load(), "hammer performed no successful queries")
+
+	// Shut the app down and audit the persisted fast index from the raw DB,
+	// exactly as issue #6011's diagnostic did: every 'F' entry must match the
+	// authoritative tree walk.
+	require.NoError(t, base.Close())
+	db, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, filepath.Join(appDir, bftCfg.DefaultDBDir))
+	require.NoError(t, err)
+	defer db.Close()
+
+	pdb := dbm.NewPrefixDB(db, []byte("s/_/"))
+	plain := bp.NewMutableTreeWithDB(pdb, 10000, bp.NewNopLogger()) // fast index OFF: authoritative walks
+	_, err = plain.Load()
+	require.NoError(t, err)
+
+	itr, err := pdb.Iterator([]byte{bp.PrefixFast}, []byte{bp.PrefixFast + 1})
+	require.NoError(t, err)
+	defer itr.Close()
+	stale := 0
+	for ; itr.Valid(); itr.Next() {
+		key := append([]byte(nil), itr.Key()[1:]...)
+		payload, cerr := queryRaceVerifyChecksum(itr.Value())
+		if cerr != nil || len(payload) < 8 {
+			t.Fatalf("corrupt F entry %q: %v", key, cerr)
+		}
+		want, err := plain.Get(key)
+		require.NoError(t, err)
+		if want == nil {
+			stale++
+			t.Errorf("STALE-PRESENT F entry for deleted key %q", key)
+			continue
+		}
+		if !bytes.Equal(payload[8:], want) {
+			stale++
+			if stale <= 5 {
+				t.Errorf("STALE F entry key=%q (issue #6011 shape)", key)
+			}
+		}
+	}
+	require.NoError(t, itr.Error())
+	if stale > 0 {
+		t.Fatalf("issue #6011 regressed at the full-app layer: %d stale fast-index entries persisted", stale)
+	}
+}
+
+var queryRaceCRC = crc32.MakeTable(crc32.Castagnoli)
+
+// queryRaceVerifyChecksum re-implements bptree's record framing check
+// (payload ‖ big-endian crc32c) independently of the code under test.
+// Sibling of reproVerifyChecksum in tm2/pkg/store/rootmulti's fastindex
+// tests (test-package helpers are not importable); update both together
+// if the framing changes.
+func queryRaceVerifyChecksum(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("record too short (%d bytes)", len(data))
+	}
+	payload := data[:len(data)-4]
+	want := binary.BigEndian.Uint32(data[len(data)-4:])
+	if got := crc32.Checksum(payload, queryRaceCRC); got != want {
+		return nil, fmt.Errorf("crc mismatch")
+	}
+	return payload, nil
+}

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -3,6 +3,7 @@ package gnoland
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1755,6 +1756,12 @@ func TestPruneStrategyNothing(t *testing.T) {
 
 	// Make sure loading a past version doesn't fail
 	assert.NoError(t, cms.LoadVersion(1))
+
+	// Release the multistore (its query snapshot) before closing the DB —
+	// PebbleDB reports open snapshots as a leak at Close time.
+	if closer, ok := cms.(io.Closer); ok {
+		require.NoError(t, closer.Close())
+	}
 
 	err = db.Close()
 	require.NoError(t, err)

--- a/tm2/adr/pr6018_fastindex_snapshot_isolation.md
+++ b/tm2/adr/pr6018_fastindex_snapshot_isolation.md
@@ -87,10 +87,10 @@ Layered defense — any one of the first three layers stops the incident:
 3. **Snapshot routing** (`rootmulti.constructStore`): immutable multistores
    read `ms.db` — the frozen post-commit SnapshotDB (or ImmutableDB fallback)
    — even for dedicated-db mounts. Constraint: a dedicated `params.db` must
-   be the same physical DB as the multistore's (true for every in-repo
-   mount); a genuinely separate merkleized store DB fails loudly at
-   LoadVersion's commit-id check (a dbadapter mount would not — its CommitID
-   is always zero — so separate physical DBs must not be mounted).
+   be the same physical DB as the multistore's — now ENFORCED at mount time
+   (`MountStoreWithDB` panics otherwise; see Alternatives), closing the
+   dbadapter escape hatch where a separate DB would have loaded with a
+   zero CommitID and served silently-empty state.
    - Companion (hard prerequisite): `ImmutableDB.NewBatch` returns a shared
      read-only no-op batch (Set/Delete discarded, Write panics) instead of
      nil.
@@ -119,7 +119,26 @@ Layered defense — any one of the first three layers stops the incident:
 ## Alternatives considered
 
 - **Per-store snapshots for genuinely-separate dedicated DBs**: rejected;
-  no in-repo mount needs it, and the failure mode without it is loud.
+  no in-repo mount needs it, and the constraint is now enforced — a non-nil
+  mount DB that isn't the multistore's own panics in `MountStoreWithDB`,
+  turning a first-query failure (misrouted reads / silently-empty state) into
+  a startup failure.
+- **Relationship to PR #6013** (notJoon, first fix for the same incident):
+  two pieces adopted with co-author credit. (1) The `MountStoreWithDB`
+  root-DB guard above — a separate mounted DB would bypass the atomic
+  collector drain (writes vanish) and, on this branch, be misrouted away
+  from the query snapshot. (2) The `getImmutable` stamp gate: an immutable
+  snapshot drops fast reads unless the stamp covers its version — read-only
+  re-verification closing the "LoadVersion-only readers are outside the trust
+  contract" caveat that `LoadReadonly` widened (concretely reachable in the
+  post-toggle-restart, pre-first-commit window, where a rebuild sits in the
+  collector while the query snapshot still holds the old on-disk stamp). Its
+  `ensureFastIndex` relaxation (stamp ahead ⇒ skip silently) is rejected:
+  after layers 1–3 only a writer load can observe stamp-ahead, which means an
+  external rewind; skipping boots a node whose old-timeline entries become
+  trusted again once the chain re-passes their versions, and the production
+  nop logger makes a warning invisible. Fail-loud with the stamp-deletion
+  remediation stands.
 - **Serializing queries with the consensus mutex**: rejected; reintroduces
   the query-blocks-consensus latency #5431 removed, and does not fix the
   design gap (write-capable read paths).
@@ -166,6 +185,19 @@ Layered defense — any one of the first three layers stops the incident:
   that ends without a `Commit()` must flush explicitly.
 - Startup rebuilds over CollectingDB still stage the whole index in memory
   until the next drain (unchanged; bounded by index size). Documented cost.
+  This same window — rebuild in the collector while the query snapshot holds
+  the pre-rebuild on-disk stamp — is why the `getImmutable` stamp gate is a
+  correctness fix, not only hardening: without it a query in that window
+  trusts the not-yet-rebuilt stale entries. Follow-up (out of scope): the
+  rebuild is not durable until the first block commit and is lost on a crash
+  before it — a resync or a bounded/streamed rebuild would remove the RAM
+  spike and the durability gap.
+- The `getImmutable` stamp gate costs one point read per immutable snapshot
+  view built via `getImmutable` (custom and `.store` queries, the ABCI proof
+  snapshot, and live-tree `GetVersioned`), and zero on the consensus
+  execution path (`MutableTree.Get`) and on working-tree proof generation
+  (which never consults the index). A read or checksum error on the stamp
+  degrades to the authoritative walk.
 - **Operator remediation for already-poisoned nodes**: the fixes prevent new
   poisoning but cannot detect existing stale entries (their stamp claims
   currency). Delete the fast-index stamp (`s/_/M` ‖ `fastidx` in the app DB)

--- a/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
+++ b/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
@@ -70,10 +70,15 @@ Layered defense — any one of the first three layers stops the incident:
    READS keep working (advisory `fastGet` with its version guard).
 2. **Stale-reader guard** (`ensureFastIndex`): rebuild only when the stamp is
    missing or BEHIND the loaded version. The stamp commits atomically with
-   each version's records, so a stamp AHEAD of the loaded version means the
-   observer is a stale reader racing a newer commit; rebuilding from its
-   older root is exactly the poisoning. Skips log a warning. This also
-   protects direct library users outside the store layer.
+   each version's records, so a stamp AHEAD of the loaded version means
+   either an out-of-contract reader racing a newer commit (rebuilding from
+   its older root is exactly the poisoning) or an externally rewound DB
+   (old-timeline entries may lurk). Both FAIL LOUD instead of proceeding:
+   post-fix the only in-contract caller is the single-threaded startup Load,
+   where the error blocks boot until the operator deletes the stamp (forcing
+   a rebuild) or resyncs — the production store constructors use a nop
+   logger, so a warning would be invisible. This also protects direct
+   library users outside the store layer.
 3. **Snapshot routing** (`rootmulti.constructStore`): immutable multistores
    read `ms.db` — the frozen post-commit SnapshotDB (or ImmutableDB fallback)
    — even for dedicated-db mounts. Constraint: a dedicated `params.db` must
@@ -162,4 +167,6 @@ Layered defense — any one of the first three layers stops the incident:
   to force a full rebuild at the next start, or resync. The same applies
   after any external rollback/DB surgery: rollback tooling must delete the
   stamp, since old-timeline entries become trusted again once the chain
-  re-passes their versions.
+  re-passes their versions. A rewound DB whose stamp is ahead of its latest
+  version now refuses to load (stamp-ahead error) rather than booting
+  silently; the remediation is the same stamp deletion.

--- a/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
+++ b/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
@@ -131,9 +131,13 @@ Layered defense — any one of the first three layers stops the incident:
   `Commit` between the WriteSync and the snapshot refresh (commitInfo durable,
   snapshot one behind) — read-only and no worse than the pre-fix behavior.
   Each `.store` query now pays the same per-query store construction that
-  custom queries already paid (including a `discoverVersions` root scan — a
-  pre-existing cost, now shared; a future optimization could cache the latest
-  version).
+  custom queries already paid. The dominant term is `discoverVersions`' full
+  root scan, O(retained versions) — measured ~200 ms/query at gno.land's
+  default syncable retention (705,600 roots) while the scan ran twice per
+  load; `loadVersionDiscovered` removes the duplicate scan, halving every
+  query path's construction cost relative to master. A follow-up can make
+  immutable loads O(1): the requested version is already known, so only the
+  latest-version lookup needs a cheaper source than a scan.
 - CollectingDB read-your-writes narrowed for BATCH ops: staged batch ops are
   visible to `CollectingDB.Get` only after `batch.Write()` (previously at
   `Set` time). No in-repo consumer read back unwritten batch ops (bptree

--- a/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
+++ b/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
@@ -1,0 +1,161 @@
+# ADR: Query-path snapshot isolation and fast-index write-proofing (gno#6011)
+
+## Status
+
+Proposed (fixes https://github.com/gnolang/gno/issues/6011).
+
+## Context
+
+A topaz-1 node rejected the proposal for block 227783 with an AppHash
+mismatch. Investigation traced it to a persisted bptree fast-index entry that
+held an account value from block 224859 while the authoritative tree carried
+the block-227773 update — under a fast-index stamp that claimed currency at
+227782. The stale entry was served by `MutableTree.Get`'s clean-working-tree
+fast path (PR #5937) during block execution, diverging the node's state.
+
+The root cause is a chain of four interacting design gaps, reproduced both
+deterministically and under natural concurrency
+(`tm2/pkg/store/rootmulti/fastindex_*_test.go`):
+
+1. **Snapshot bypass.** `rootmulti.constructStore` routed mounts with a
+   dedicated db (`params.db != nil`) to that LIVE db even when building the
+   "immutable" query multistore of `MultiImmutableCacheWrapWithVersion`,
+   whose `ims.db` snapshot then only covered rootmulti metadata. gno.land
+   mounts both stores with `cfg.DB`, so every query-path store read bypassed
+   the snapshot. (`Simulate` was already routed through
+   `MultiImmutableCacheWrapWithVersion` — it was a *victim* of this bypass,
+   not a separate unsafe path.)
+2. **Concurrent queries.** The query ABCI connection has an independent mutex
+   (`proxy.NewReadOnlyABCIClient`), so query loads run concurrently with the
+   consensus commit.
+3. **Write-capable query loads.** Immutable multistores skip the CollectingDB
+   wrap, so the throwaway query store held a REAL writable batch over the
+   live DB; `bptree.Store.LoadVersion` (Immutable branch) ran `Load()` →
+   `ensureFastIndex()`, a maintenance path that can WRITE.
+4. **Load TOCTOU.** `Load()` reads "latest" via a `discoverVersions` iterator
+   (a pre-commit point-in-time view) and the fast-index stamp via a later
+   `Get`. When the commit drain for block N landed between the two reads, the
+   query load saw latest = N−1 with stamp = N, concluded the index was stale,
+   and `rebuildFastIndex()` silently rewrote EVERY fast-index entry from
+   root@N−1 — old values, old versions — into the live DB. Later commits
+   re-advanced the stamp, making the poisoning undetectable at restart. Keys
+   updated in block N and never touched again stayed stale; the incident's
+   account was one (entry vk 224859 = its last write before 227772).
+
+Adjacent bugs found during the investigation:
+
+- `batchHandle` (CollectingDB batches) forwarded ops to the shared collector
+  at `Set` time with no-op `Write`/`Close`, so bptree's `DiscardBatch` did not
+  actually discard under production wiring (latent: the affected error paths
+  currently panic the process, which drops the collector).
+- `clearFastIndex` re-opened its chunk iterator from the range start and
+  relied on the chunk commit applying its deletes — under CollectingDB the
+  commit only moves ops to the collector and the iterator reads the
+  underlying DB, so clearing ≥ 65536 existing entries looped forever,
+  re-staging the same keys unboundedly (sampled runs: 262k ops for 70k
+  entries within a second; 68.8M within 30s). This also affected
+  `Import` → `dropFastIndex`.
+- `ImmutableDB.NewBatch()` returned nil, a latent panic for any consumer that
+  constructs batches eagerly (bptree, IAVL's BatchWithFlusher).
+- The restart window: `querySnapshot` was only installed by `Commit()`, so a
+  restarted node's queries fell back to the live DB until its first block.
+
+## Decision
+
+Layered defense — any one of the first three layers stops the incident:
+
+1. **Read-only loads on immutable stores** (`bptree.MutableTree.LoadReadonly`,
+   used by `store/bptree` Immutable branches): query-path loads perform NO
+   fast-index maintenance. Read paths cannot write, on any DB routing. Fast
+   READS keep working (advisory `fastGet` with its version guard).
+2. **Stale-reader guard** (`ensureFastIndex`): rebuild only when the stamp is
+   missing or BEHIND the loaded version. The stamp commits atomically with
+   each version's records, so a stamp AHEAD of the loaded version means the
+   observer is a stale reader racing a newer commit; rebuilding from its
+   older root is exactly the poisoning. Skips log a warning. This also
+   protects direct library users outside the store layer.
+3. **Snapshot routing** (`rootmulti.constructStore`): immutable multistores
+   read `ms.db` — the frozen post-commit SnapshotDB (or ImmutableDB fallback)
+   — even for dedicated-db mounts. Constraint: a dedicated `params.db` must
+   be the same physical DB as the multistore's (true for every in-repo
+   mount); a genuinely separate merkleized store DB fails loudly at
+   LoadVersion's commit-id check (a dbadapter mount would not — its CommitID
+   is always zero — so separate physical DBs must not be mounted).
+   - Companion (hard prerequisite): `ImmutableDB.NewBatch` returns a shared
+     read-only no-op batch (Set/Delete discarded, Write panics) instead of
+     nil.
+   - Companion: `rootmulti.LoadVersion` seeds `querySnapshot` (non-immutable
+     multistores, both the ver==0 and normal exits), giving restarted nodes
+     snapshot isolation before their first commit.
+4. **`.store` query isolation** (`rootmulti.QueryImmutable` +
+   `baseapp.handleQueryStore`): store queries are served from the query
+   snapshot via the extracted `immutableAtVersion`; on error (height ≤ 0
+   pre-first-commit, pruned heights) the handler falls back to the legacy
+   live path, preserving the existing response surface for those corners.
+5. **Real batch discard semantics** (`db/collecting.go`): `batchHandle`
+   buffers ops locally; `Write` moves them into the collector (order
+   preserved, handle reusable); `Close` without `Write` discards — restoring
+   the standard `dbm.Batch` contract that `DiscardBatch` and rollback paths
+   rely on. `GetByteSize` now measures the handle's own buffer (fixes
+   whole-collector readings in flush-threshold loops). Required companion:
+   `rootmulti.Commit` calls `metaBatch.Write()` BEFORE draining, keeping
+   commitInfo/latestVersion in the same atomic WriteSync as store data.
+6. **Terminating index clear** (`clearFastIndex`): each chunk resumes its
+   iterator after the last staged key instead of the range start, making
+   progress independent of whether staged deletes have been applied. This —
+   not layer 5 — is what fixes the ≥64Ki-entry startup hang; `Import` →
+   `dropFastIndex` inherits it.
+
+## Alternatives considered
+
+- **Per-store snapshots for genuinely-separate dedicated DBs**: rejected;
+  no in-repo mount needs it, and the failure mode without it is loud.
+- **Serializing queries with the consensus mutex**: rejected; reintroduces
+  the query-blocks-consensus latency #5431 removed, and does not fix the
+  design gap (write-capable read paths).
+- **Making `MutableTree` thread-safe**: out of scope; the tree's
+  single-writer contract is sound once no other goroutine can reach live
+  mutable state.
+- **Only fixing the TOCTOU (consistent version+stamp read)**: insufficient;
+  the query path had no business writing at all, and other interleavings
+  (e.g. racing an in-progress clear) would remain.
+
+## Consequences
+
+- The natural-concurrency repro (8 query goroutines vs 1900 commits, which
+  persisted hundreds of stale entries per pre-fix run — 290 and 480 in two
+  sampled runs, scheduling-dependent) runs clean, including under `-race`.
+- `.store` queries at pruned or pre-commit heights now take the legacy
+  fallback explicitly; served heights get snapshot isolation. A query for the
+  just-committed height can also hit the fallback in the narrow window inside
+  `Commit` between the WriteSync and the snapshot refresh (commitInfo durable,
+  snapshot one behind) — read-only and no worse than the pre-fix behavior.
+  Each `.store` query now pays the same per-query store construction that
+  custom queries already paid (including a `discoverVersions` root scan — a
+  pre-existing cost, now shared; a future optimization could cache the latest
+  version).
+- CollectingDB read-your-writes narrowed for BATCH ops: staged batch ops are
+  visible to `CollectingDB.Get` only after `batch.Write()` (previously at
+  `Set` time). No in-repo consumer read back unwritten batch ops (bptree
+  serves its own staging from `pendingVals`/node cache; dbadapter and the
+  cache flush write-then-Write); direct Set/Delete visibility is unchanged.
+- Multistore lifecycle: anything that loads a multistore over PebbleDB must
+  release it (`Close`) before closing the DB — previously only required
+  after `Commit`, now also after load (the seeded snapshot). In-repo callers
+  (baseapp, gnogenesis fork, tests) were audited and updated.
+- Non-snapshot backends (goleveldb, boltdb, lmdb, mdbx) keep UNISOLATED
+  query reads over the live DB (ImmutableDB fallback) — but write-proof, and
+  layers 1–2 close the poisoning there too. The default backend (pebbledb)
+  gets full isolation.
+- A statesync/import flow that drops or rebuilds the index through the
+  CollectingDB wiring is durable only after the next rootmulti drain; wiring
+  that ends without a `Commit()` must flush explicitly.
+- Startup rebuilds over CollectingDB still stage the whole index in memory
+  until the next drain (unchanged; bounded by index size). Documented cost.
+- **Operator remediation for already-poisoned nodes**: the fixes prevent new
+  poisoning but cannot detect existing stale entries (their stamp claims
+  currency). Delete the fast-index stamp (`s/_/M` ‖ `fastidx` in the app DB)
+  to force a full rebuild at the next start, or resync. The same applies
+  after any external rollback/DB surgery: rollback tooling must delete the
+  stamp, since old-timeline entries become trusted again once the chain
+  re-passes their versions.

--- a/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
+++ b/tm2/adr/prxxxx_fastindex_snapshot_isolation.md
@@ -15,7 +15,9 @@ fast path (PR #5937) during block execution, diverging the node's state.
 
 The root cause is a chain of four interacting design gaps, reproduced both
 deterministically and under natural concurrency
-(`tm2/pkg/store/rootmulti/fastindex_*_test.go`):
+(`tm2/pkg/store/rootmulti/fastindex_*_test.go`, and end-to-end through the
+real app + ABCI proxy topology in
+`gno.land/pkg/gnoland/app_query_race_test.go`):
 
 1. **Snapshot bypass.** `rootmulti.constructStore` routed mounts with a
    dedicated db (`params.db != nil`) to that LIVE db even when building the
@@ -59,6 +61,9 @@ Adjacent bugs found during the investigation:
   constructs batches eagerly (bptree, IAVL's BatchWithFlusher).
 - The restart window: `querySnapshot` was only installed by `Commit()`, so a
   restarted node's queries fell back to the live DB until its first block.
+- `BaseApp.LastBlockHeight` — every query handler's height-0 resolution, on
+  the concurrent query connection — read `ms.lastCommitID` unsynchronized
+  against Commit/LoadVersion writes; now published via an atomic pointer.
 
 ## Decision
 

--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -16,12 +16,14 @@ import (
 // byte-identical to the committed snapshot at its version.
 //
 // Trust contract: index currency is verified by Load (ensureFastIndex rebuilds
-// on a stamp mismatch) and preserved from then on by eager same-batch
-// maintenance (Set/Remove/SaveVersion) and by Import dropping the index up
-// front. A tree reached ONLY via LoadVersion — never Load — over a DB whose
-// later versions were committed with the feature off is outside the contract:
-// nothing re-verifies the stamp there. The in-repo store layer always goes
-// through Load.
+// a missing or older stamp, and fails loud on a stamp ahead of the loaded
+// version) and preserved from then on by eager same-batch maintenance
+// (Set/Remove/SaveVersion) and by Import dropping the index up front. Immutable
+// snapshots additionally require a stamp ≥ their version (MutableTree.getImmutable),
+// so read-only LoadVersion paths fall back to the authoritative walk without
+// maintenance rather than trusting a too-old index. Only a raw working-tree read
+// (MutableTree.Get after a bare LoadVersion, no getImmutable) remains outside
+// the contract; the in-repo store layer never does this.
 //
 // Properties:
 //   - Not in the Merkle commitment — an unauthenticated accelerator, like cosmos
@@ -34,9 +36,11 @@ import (
 //   - Maintained in the SAME batch as the tree (Set/Remove stage into ndb.batch,
 //     committed atomically by SaveVersion → Commit), so it can never disagree
 //     with the committed tree, even across a crash.
-//   - ADVISORY on read: a hit is trusted only when its version ≤ the snapshot
-//     version (else the entry is newer than the reader's snapshot); a miss,
-//     a too-new entry, or a corrupt/too-short entry all fall back to the
+//   - ADVISORY on read: an immutable snapshot consults the index only when the
+//     stamp is ≥ its version (else the index may be too old for it), and then
+//     trusts a hit only when the entry's version ≤ the snapshot version (else
+//     the entry is newer than the reader's snapshot). A miss, an untrusted
+//     stamp, a too-new entry, or a corrupt/too-short entry all fall back to the
 //     authoritative tree walk. Index completeness is therefore a performance
 //     property, never a correctness one.
 

--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -137,18 +137,23 @@ func (ndb *nodeDB) getFastIndexVersion() (int64, bool, error) {
 const fastRebuildFlush = 1 << 16
 
 // clearFastIndex stages deletion of every existing 'F' entry, flushing in
-// bounded chunks. After each chunk Commits, the deleted keys are gone from the
-// DB, so re-opening the iterator from the range start finds the remaining keys.
+// bounded chunks. Each chunk resumes AFTER the last staged key rather than
+// re-scanning from the range start: progress must not depend on the staged
+// deletes being applied to the DB between chunks — under rootmulti's
+// CollectingDB the chunk Commit only moves them into the shared collector
+// (applied at the block-level drain), and the iterator reads the underlying
+// DB, so a restart-from-start scan would re-see the same keys forever.
 // Leaves a fresh batch for the caller.
 func (ndb *nodeDB) clearFastIndex() error {
-	prefix := []byte{PrefixFast}
+	start := []byte{PrefixFast}
 	end := []byte{PrefixFast + 1}
 	for {
-		itr, err := ndb.db.Iterator(prefix, end)
+		itr, err := ndb.db.Iterator(start, end)
 		if err != nil {
 			return err
 		}
 		n := 0
+		var last []byte
 		for ; itr.Valid() && n < fastRebuildFlush; itr.Next() {
 			k := itr.Key()
 			kc := make([]byte, len(k))
@@ -157,6 +162,7 @@ func (ndb *nodeDB) clearFastIndex() error {
 				itr.Close()
 				return err
 			}
+			last = kc
 			n++
 		}
 		ierr := itr.Error()
@@ -173,6 +179,7 @@ func (ndb *nodeDB) clearFastIndex() error {
 		if n < fastRebuildFlush {
 			return nil
 		}
+		start = append(last, 0) // resume at the immediate successor of the last staged key
 	}
 }
 

--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -205,10 +205,22 @@ func (ndb *nodeDB) dropFastIndex() (err error) {
 }
 
 // ensureFastIndex rebuilds the fast index from the latest root if it is absent
-// or stale (the stamp != the loaded version). Called from Load when the feature
-// is on. The index is advisory, so a stale/missing index is never wrong, only
-// slower; a rebuild error is returned to Load's caller (the loaded tree is still
-// usable, and a retry Load re-attempts the rebuild).
+// or BEHIND the loaded version (stamp < version: versions were committed with
+// the feature off). Called from Load when the feature is on. The index is
+// advisory, so a stale/missing index is never wrong, only slower; a rebuild
+// error is returned to Load's caller (the loaded tree is still usable, and a
+// retry Load re-attempts the rebuild).
+//
+// A stamp AHEAD of the loaded version (stamp > version) must NOT rebuild: the
+// stamp and each version's records commit in one atomic batch, so at rest they
+// are equal — observing a newer stamp means this tree is a stale reader racing
+// a newer commit (or the DB was externally rewound). Rebuilding here would
+// rewrite the whole index from an outdated root — old values under a stamp
+// later commits re-validate — which is exactly the gno#6011 poisoning. Reads
+// stay safe without a rebuild: fastGet distrusts entries newer than the
+// reader's version. NOTE: after external rollback/DB surgery, delete the stamp
+// (PrefixMeta‖"fastidx") to force a rebuild — old-timeline entries would
+// otherwise become trusted again once the chain re-passes their versions.
 func (t *MutableTree) ensureFastIndex() error {
 	if !t.ndb.opts.FastIndex {
 		return nil
@@ -217,8 +229,12 @@ func (t *MutableTree) ensureFastIndex() error {
 	if err != nil {
 		return err
 	}
-	if ok && stamp == t.version {
-		return nil // already complete through the loaded version
+	if ok && stamp >= t.version {
+		if stamp > t.version {
+			t.ndb.logger.Warn("bptree: fast index stamp ahead of loaded version; skipping rebuild",
+				"stamp", stamp, "version", t.version)
+		}
+		return nil // complete through the loaded version
 	}
 	return t.rebuildFastIndex()
 }

--- a/tm2/pkg/bptree/fast_index.go
+++ b/tm2/pkg/bptree/fast_index.go
@@ -218,16 +218,19 @@ func (ndb *nodeDB) dropFastIndex() (err error) {
 // error is returned to Load's caller (the loaded tree is still usable, and a
 // retry Load re-attempts the rebuild).
 //
-// A stamp AHEAD of the loaded version (stamp > version) must NOT rebuild: the
-// stamp and each version's records commit in one atomic batch, so at rest they
-// are equal — observing a newer stamp means this tree is a stale reader racing
-// a newer commit (or the DB was externally rewound). Rebuilding here would
-// rewrite the whole index from an outdated root — old values under a stamp
-// later commits re-validate — which is exactly the gno#6011 poisoning. Reads
-// stay safe without a rebuild: fastGet distrusts entries newer than the
-// reader's version. NOTE: after external rollback/DB surgery, delete the stamp
-// (PrefixMeta‖"fastidx") to force a rebuild — old-timeline entries would
-// otherwise become trusted again once the chain re-passes their versions.
+// A stamp AHEAD of the loaded version (stamp > version) is an ERROR, never a
+// rebuild: the stamp and each version's records commit in one atomic batch, so
+// at rest they are equal. A newer stamp therefore means either (a) this tree
+// is an out-of-contract reader racing a newer commit — rebuilding from its
+// outdated root would rewrite the whole index to old values under a stamp
+// later commits re-validate, exactly the gno#6011 poisoning (in-contract
+// query paths use LoadReadonly and never reach here) — or (b) the DB was
+// externally rewound (partial restore, manual surgery), in which case
+// old-timeline entries may exist that would regain trust as the chain
+// re-passes their versions, and the operator must decide: delete the stamp
+// (PrefixMeta‖"fastidx") to force a rebuild from the surviving root, or
+// resync. Failing loud covers both: (a) gets a hard error instead of a
+// silently degraded load, (b) cannot boot into silent divergence.
 func (t *MutableTree) ensureFastIndex() error {
 	if !t.ndb.opts.FastIndex {
 		return nil
@@ -236,14 +239,16 @@ func (t *MutableTree) ensureFastIndex() error {
 	if err != nil {
 		return err
 	}
-	if ok && stamp >= t.version {
-		if stamp > t.version {
-			t.ndb.logger.Warn("bptree: fast index stamp ahead of loaded version; skipping rebuild",
-				"stamp", stamp, "version", t.version)
-		}
-		return nil // complete through the loaded version
+	if !ok || stamp < t.version {
+		return t.rebuildFastIndex()
 	}
-	return t.rebuildFastIndex()
+	if stamp > t.version {
+		return fmt.Errorf("bptree: fast index stamp (%d) is ahead of the loaded version (%d): "+
+			"the DB was rewound externally, or this load races a newer commit; "+
+			"refusing to trust or rebuild the index — delete the fast-index stamp "+
+			"(PrefixMeta%q) to force a rebuild at the next load, or resync", stamp, t.version, "fastidx")
+	}
+	return nil // stamp == version: complete through the loaded version
 }
 
 // rebuildFastIndex clears any stale 'F' entries, then re-derives the index from

--- a/tm2/pkg/bptree/fast_index_test.go
+++ b/tm2/pkg/bptree/fast_index_test.go
@@ -585,3 +585,85 @@ func TestFastIndex_Has(t *testing.T) {
 		t.Fatal("imm.Has(absent) = true; want false")
 	}
 }
+
+// TestGetImmutable_StampGate: an immutable snapshot must not trust the fast
+// index when the on-disk stamp is BEHIND the snapshot's version (e.g. versions
+// committed with the feature off, or a rebuild not yet durable). getImmutable
+// gates imm.fast on stamp >= version. A doctored sentinel entry makes the
+// served-vs-walked path observable; the reader loads via LoadVersion (never
+// Load, which would rebuild and heal the stamp, erasing the scenario).
+func TestGetImmutable_StampGate(t *testing.T) {
+	db := memdb.NewMemDB()
+	key := []byte("key")
+
+	on := NewMutableTreeWithDB(db, 256, NewNopLogger(), FastIndexOption(true))
+	mustSet(t, on, key, []byte("a1"))
+	v1 := mustSave(t, on) // stamp := v1, 'F'[key] = a1@v1
+
+	off := NewMutableTreeWithDB(db, 256, NewNopLogger()) // feature off: no stamp/index maintenance
+	if _, err := off.Load(); err != nil {
+		t.Fatal(err)
+	}
+	mustSet(t, off, key, []byte("a2"))
+	v2 := mustSave(t, off) // tree at v2 has key=a2; stamp still v1
+
+	// Plant a distinct sentinel at v1 so a fast hit is distinguishable from a walk.
+	doctorFastEntry(t, off, db, key, v1, []byte("sentinel"))
+
+	reader := NewMutableTreeWithDB(db, 256, NewNopLogger(), FastIndexOption(true))
+	if _, err := reader.LoadVersion(v2); err != nil { // LoadVersion, not Load: no rebuild
+		t.Fatal(err)
+	}
+
+	// Snapshot at v2: stamp(v1) < v2 → gate OFF → authoritative walk → a2.
+	// Without the gate, fastGet would trust sentinel@v1 (v1 <= v2) and return it.
+	immV2, err := reader.GetImmutable(v2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer immV2.Close()
+	if got, _ := immV2.Get(key); string(got) != "a2" {
+		t.Fatalf("v2 snapshot Get = %q; want a2 (stamp gate must disable the too-old index)", got)
+	}
+
+	// Snapshot at v1: stamp(v1) >= v1 → gate ON → fast path serves the sentinel.
+	// Anti-vacuity: proves the gate does not blanket-disable the index.
+	immV1, err := reader.GetImmutable(v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer immV1.Close()
+	if got, _ := immV1.Get(key); string(got) != "sentinel" {
+		t.Fatalf("v1 snapshot Get = %q; want sentinel (stamp covers v1 → fast path open)", got)
+	}
+}
+
+// TestFastIndex_OlderStampStillRebuildsLatestRoot ensures writer startup still
+// repairs an index whose stamp is behind the authoritative latest root.
+// Adopted from #6013.
+func TestFastIndex_OlderStampStillRebuildsLatestRoot(t *testing.T) {
+	db := memdb.NewMemDB()
+	tr := NewMutableTreeWithDB(db, 256, NewNopLogger(), FastIndexOption(true))
+	mustSet(t, tr, []byte("key"), []byte("v1"))
+	v1 := mustSave(t, tr)
+	mustSet(t, tr, []byte("key"), []byte("v2"))
+	v2 := mustSave(t, tr)
+
+	if err := tr.ndb.setFastIndexVersion(v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.ndb.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.ensureFastIndex(); err != nil {
+		t.Fatal(err)
+	}
+	stamp, ok, err := tr.ndb.getFastIndexVersion()
+	if err != nil || !ok || stamp != v2 {
+		t.Fatalf("stamp = (%d, %t, %v); want (%d, true, nil)", stamp, ok, err, v2)
+	}
+	got, err := tr.Get([]byte("key"))
+	if err != nil || string(got) != "v2" {
+		t.Fatalf("Get = %q, %v; want v2", got, err)
+	}
+}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -483,17 +483,12 @@ func (t *MutableTree) saveNode(node Node, version int64) error {
 	return t.ndb.SaveNode(node)
 }
 
-// Load loads the latest version from the DB.
+// Load loads the latest version from the DB and performs fast-index
+// maintenance. For the LIVE store only (single-threaded startup); read-only
+// consumers use LoadReadonly.
 func (t *MutableTree) Load() (int64, error) {
-	if err := t.ndb.discoverVersions(); err != nil {
-		return 0, err
-	}
-	latest := t.ndb.getLatestVersion()
-	if latest == 0 {
-		return 0, nil
-	}
-	v, err := t.LoadVersion(latest)
-	if err != nil {
+	v, err := t.LoadReadonly()
+	if err != nil || v == 0 {
 		return v, err
 	}
 	// Build the fast index from the loaded latest root if it is absent/stale
@@ -506,6 +501,24 @@ func (t *MutableTree) Load() (int64, error) {
 		return v, err
 	}
 	return v, nil
+}
+
+// LoadReadonly loads the latest version WITHOUT fast-index maintenance
+// (Load's ensureFastIndex can rebuild the index, i.e. WRITE). For read-only
+// consumers — the store layer's immutable/query views, which may sit on a
+// snapshot or read-only DB and may run concurrently with the live writer —
+// loading must never mutate shared persistent state. Fast-index READS remain
+// available (newImmutable wires imm.fast from the tree options; staleness is
+// handled by fastGet's version guard).
+func (t *MutableTree) LoadReadonly() (int64, error) {
+	if err := t.ndb.discoverVersions(); err != nil {
+		return 0, err
+	}
+	latest := t.ndb.getLatestVersion()
+	if latest == 0 {
+		return 0, nil
+	}
+	return t.LoadVersion(latest)
 }
 
 // LoadVersion loads a specific version from the DB.

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -512,8 +512,10 @@ func (t *MutableTree) Load() (int64, error) {
 // consumers — the store layer's immutable/query views, which may sit on a
 // snapshot or read-only DB and may run concurrently with the live writer —
 // loading must never mutate shared persistent state. Fast-index READS remain
-// available (newImmutable wires imm.fast from the tree options; staleness is
-// handled by fastGet's version guard).
+// available for snapshots taken via getImmutable, which gates them on the
+// stamp covering the snapshot version and on fastGet's per-entry version guard;
+// a bare working-tree read after LoadReadonly is outside the trust contract
+// (see fast_index.go).
 func (t *MutableTree) LoadReadonly() (int64, error) {
 	if err := t.ndb.discoverVersions(); err != nil {
 		return 0, err
@@ -686,6 +688,19 @@ func (t *MutableTree) getImmutable(version int64, register bool) (*ImmutableTree
 		return nil, err
 	}
 	imm := t.newImmutable(root, version, true)
+	// Gate the fast-index read path on stamp coverage: only trust the index if
+	// it is complete THROUGH this snapshot's version. A stamp behind `version`
+	// (e.g. versions committed with the feature off, or a rebuild not yet
+	// durable) can hold entries that are stale for keys updated in
+	// (stamp, version]; those entries pass fastGet's per-entry guard
+	// (vkVersion ≤ version) yet differ from the tree. The load paths avoid
+	// maintenance (LoadReadonly) so they can't refresh the stamp; this read-only
+	// re-verification is what keeps them safe. One point read per snapshot view;
+	// a read/checksum error degrades to the authoritative walk (fast off).
+	if imm.fast {
+		stamp, ok, err := t.ndb.getFastIndexVersion()
+		imm.fast = err == nil && ok && stamp >= version
+	}
 	imm.registered = reg
 	return imm, nil
 }

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -496,10 +496,11 @@ func (t *MutableTree) Load() (int64, error) {
 	}
 	// Build the fast index from the loaded latest root if it is absent/stale
 	// (e.g. enabling the feature on an existing DB, or post-import). No-op when
-	// disabled or already current. A rebuild error is returned (surfacing an
-	// index-write failure, or a value-read failure since the rebuild re-reads
-	// every live value, at startup); the loaded tree itself is unaffected and a
-	// retry Load re-attempts the rebuild.
+	// disabled or already current. Errors are returned with the loaded tree
+	// itself unaffected: a rebuild failure (index-write or value-read) is
+	// transient — a retry Load re-attempts it — while a stamp-ahead error
+	// (externally rewound DB) deterministically recurs until the operator
+	// deletes the stamp or resyncs (see ensureFastIndex).
 	if err := t.ensureFastIndex(); err != nil {
 		return v, err
 	}

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -32,8 +32,11 @@ import (
 // VersionExists, and AvailableVersions are likewise safe to call concurrently
 // with the writer.
 //
-// The gno ABCI path satisfies this contract by serializing all store access
-// through the connection mutex.
+// The gno ABCI path satisfies this contract by serializing all MUTATOR and
+// working-tree access through the shared consensus/mempool connection mutex.
+// The query connection runs on its OWN mutex, concurrently — query paths must
+// only use the committed-snapshot surfaces above (the store layer routes them
+// through read-only snapshot views; see rootmulti's query snapshot).
 type MutableTree struct {
 	root      Node  // nil for empty tree
 	lastSaved Node  // committed root: rollback target, and the clean-session witness gating fast-index reads (see fastReadable)
@@ -632,8 +635,11 @@ func (t *MutableTree) GetImmutable(version int64) (*ImmutableTree, error) {
 // registering as a version reader. For long-lived snapshots that have no Close
 // hook (e.g. the store's immutable LoadVersion view) — registering them would
 // pin the version against pruning forever. Such a snapshot is not protected
-// against a concurrent prune of its version (acceptable: prune and queries are
-// serialized by the ABCI mutex today).
+// against a concurrent prune of its version by REGISTRATION; the store layer's
+// query views are protected by the frozen DB snapshot they read through
+// (rootmulti's query snapshot). On backends without snapshot support the
+// fallback reads the live DB, so a held view racing a prune of its version
+// fails loudly on the missing records.
 func (t *MutableTree) GetImmutableUnregistered(version int64) (*ImmutableTree, error) {
 	return t.getImmutable(version, false)
 }

--- a/tm2/pkg/bptree/mutable_tree.go
+++ b/tm2/pkg/bptree/mutable_tree.go
@@ -521,7 +521,7 @@ func (t *MutableTree) LoadReadonly() (int64, error) {
 	if latest == 0 {
 		return 0, nil
 	}
-	return t.LoadVersion(latest)
+	return t.loadVersionDiscovered(latest)
 }
 
 // LoadVersion loads a specific version from the DB.
@@ -543,6 +543,16 @@ func (t *MutableTree) LoadVersion(version int64) (int64, error) {
 	if err := t.ndb.discoverVersions(); err != nil {
 		return 0, err
 	}
+	return t.loadVersionDiscovered(version)
+}
+
+// loadVersionDiscovered is LoadVersion's body after version discovery: it
+// loads version using the already-refreshed first/latest counters. Split out
+// so LoadReadonly — which has just discovered versions to FIND the latest —
+// doesn't pay a second full PrefixRoot scan. The scan is O(retained versions)
+// (~700k at gno.land's default syncable retention) and sits on the per-query
+// store-construction path, so the duplication was the dominant per-query cost.
+func (t *MutableTree) loadVersionDiscovered(version int64) (int64, error) {
 	latestVersion := t.ndb.getLatestVersion()
 
 	nkBytes, _, err := t.ndb.GetRoot(version)

--- a/tm2/pkg/db/collecting.go
+++ b/tm2/pkg/db/collecting.go
@@ -4,9 +4,11 @@ import "sync"
 
 // BatchCollector accumulates Set/Delete operations in memory without touching
 // disk. It backs CollectingDB and lets rootmulti fuse multiple sub-store write
-// sites (dbadapter flush, IAVL SaveVersion, rootmulti metadata) into one
-// atomic disk write: each writer appends via a batchHandle, and the caller
-// drains the accumulated ops into a real Batch at the end of the commit.
+// sites (dbadapter flush, IAVL/bptree SaveVersion, rootmulti metadata) into
+// one atomic disk write: direct DB writes enter the collector immediately,
+// batch writes enter when their batch is Written (see batchHandle), and the
+// caller drains the accumulated ops into a real Batch at the end of the
+// commit.
 //
 // pending indexes the last op per key so CollectingDB can serve read-your-
 // writes without touching the underlying DB — required when a caller writes
@@ -84,12 +86,27 @@ func (c *BatchCollector) Len() int {
 	return len(c.ops)
 }
 
-// NewBatch returns a Batch that appends into this collector. Callers use it
-// to write into the same op-log as CollectingDB-wrapped sub-stores; it lets
-// rootmulti feed its own metadata (commitInfo, latestVersion) into the same
-// atomic drain as IAVL and dbadapter writes.
+// NewBatch returns a Batch that flushes into this collector on Write. Callers
+// use it to write into the same op-log as CollectingDB-wrapped sub-stores; it
+// lets rootmulti feed its own metadata (commitInfo, latestVersion) into the
+// same atomic drain as IAVL and dbadapter writes.
 func (c *BatchCollector) NewBatch() Batch {
 	return &batchHandle{collector: c}
+}
+
+// appendOps moves a batch's staged ops into the collector, preserving order.
+// Ownership of ops (and their key/val backing) transfers to the collector;
+// callers must not reuse them.
+func (c *BatchCollector) appendOps(ops []collectOp) {
+	if len(ops) == 0 {
+		return
+	}
+	c.mu.Lock()
+	for _, op := range ops {
+		c.ops = append(c.ops, op)
+		c.pending[string(op.key)] = len(c.ops) - 1
+	}
+	c.mu.Unlock()
 }
 
 func (c *BatchCollector) set(key, value []byte) {
@@ -110,29 +127,18 @@ func (c *BatchCollector) delete(key []byte) {
 	c.mu.Unlock()
 }
 
-func (c *BatchCollector) byteSize() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	n := 0
-	for _, op := range c.ops {
-		n += len(op.key) + len(op.val)
-	}
-	return n
-}
-
 // CollectingDB wraps a real DB and routes every write through a shared
-// BatchCollector while reads pass through untouched. It is installed under
-// rootmulti's sub-stores so that IAVL, dbadapter, and rootmulti's own metadata
-// writes accumulate in one place during CommitAll and get flushed as a single
-// atomic batch.
+// BatchCollector while iterators pass through untouched. It is installed under
+// rootmulti's sub-stores so that IAVL/bptree, dbadapter, and rootmulti's own
+// metadata writes accumulate in one place during CommitAll and get flushed as
+// a single atomic batch.
 //
-// Reads always hit the underlying real DB — the collector never serves reads.
-// This is safe because:
-//   - IAVL's SaveVersion never re-reads a node it just wrote in the same call
-//     (newly-created nodes live in ndb.nodeCache, which GetNode checks before
-//     falling through to db.Get).
-//   - dbadapter's cache flush uses NewBatch()/batch.Set/batch.Write and never
-//     reads back its own uncommitted writes.
+// Point reads (Get/Has) consult the collector first for read-your-writes over
+// ops already in it — direct Sets/Deletes land there immediately, batch ops
+// once their batch is Written. Iterators read the underlying DB ONLY (see
+// Iterator below); consumers that iterate over keys they stage must not
+// depend on pending ops being visible (bptree's clearFastIndex resumes by
+// key for exactly this reason).
 type CollectingDB struct {
 	real      DB
 	collector *BatchCollector
@@ -196,25 +202,63 @@ func (c *CollectingDB) SetSync(key, value []byte) error { c.collector.set(key, v
 func (c *CollectingDB) Delete(key []byte) error         { c.collector.delete(key); return nil }
 func (c *CollectingDB) DeleteSync(key []byte) error     { c.collector.delete(key); return nil }
 
-// NewBatch and NewBatchWithSize return a Batch whose Set/Delete route into the
-// same collector as direct writes. Write/WriteSync/Close are no-ops so IAVL's
-// BatchWithFlusher can auto-flush freely without losing ops or forcing early
-// disk writes — the collector is drained externally when the commit closes.
+// NewBatch and NewBatchWithSize return a Batch that buffers Set/Delete locally
+// and moves them into the collector on Write/WriteSync (no disk I/O — the
+// collector is drained externally when the commit closes). Close without Write
+// DISCARDS the buffered ops, honoring the standard dbm.Batch contract: callers
+// like bptree's DiscardBatch rely on Close dropping staged-but-uncommitted
+// writes (session rollback, error paths). IAVL's BatchWithFlusher auto-flush
+// (Write, Close, NewBatch cycles) works unchanged.
 func (c *CollectingDB) NewBatch() Batch            { return &batchHandle{collector: c.collector} }
 func (c *CollectingDB) NewBatchWithSize(int) Batch { return &batchHandle{collector: c.collector} }
 
-// batchHandle is a Batch that forwards Set/Delete into a shared BatchCollector.
-// Write/WriteSync/Close return nil without persisting anything — the collector
-// is drained externally at the end of the commit window.
+// batchHandle is a Batch buffering ops locally until Write/WriteSync moves
+// them into the shared BatchCollector (order preserved). Close discards the
+// buffer. Unlike real backends (whose contract allows only Close after
+// Write), the handle is reusable after Write or Close — leniency, not a
+// contract to depend on. Like every dbm.Batch, it is NOT safe for concurrent
+// use (the local buffer is unsynchronized).
 type batchHandle struct {
 	collector *BatchCollector
+	ops       []collectOp
+	size      int // running sum of buffered key+val bytes (O(1) GetByteSize)
 }
 
 var _ Batch = (*batchHandle)(nil)
 
-func (b *batchHandle) Set(key, value []byte) error { b.collector.set(key, value); return nil }
-func (b *batchHandle) Delete(key []byte) error     { b.collector.delete(key); return nil }
-func (b *batchHandle) Write() error                { return nil }
-func (b *batchHandle) WriteSync() error            { return nil }
-func (b *batchHandle) Close() error                { return nil }
-func (b *batchHandle) GetByteSize() (int, error)   { return b.collector.byteSize(), nil }
+func (b *batchHandle) Set(key, value []byte) error {
+	// Copy inputs — callers (BatchWithFlusher, cache flush) reuse buffers.
+	k, v := cp(key), cp(value)
+	b.ops = append(b.ops, collectOp{key: k, val: v})
+	b.size += len(k) + len(v)
+	return nil
+}
+
+func (b *batchHandle) Delete(key []byte) error {
+	k := cp(key)
+	b.ops = append(b.ops, collectOp{del: true, key: k})
+	b.size += len(k)
+	return nil
+}
+
+func (b *batchHandle) Write() error {
+	b.collector.appendOps(b.ops)
+	b.ops = nil
+	b.size = 0
+	return nil
+}
+
+func (b *batchHandle) WriteSync() error { return b.Write() }
+
+func (b *batchHandle) Close() error {
+	b.ops = nil
+	b.size = 0
+	return nil
+}
+
+// GetByteSize returns the size of THIS batch's buffered ops (not the whole
+// collector), so size-threshold flush loops (bptree prune, BatchWithFlusher)
+// measure their own staging. O(1): BatchWithFlusher calls it on every op.
+func (b *batchHandle) GetByteSize() (int, error) {
+	return b.size, nil
+}

--- a/tm2/pkg/db/collecting_test.go
+++ b/tm2/pkg/db/collecting_test.go
@@ -1,0 +1,105 @@
+package db_test
+
+import (
+	"bytes"
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// TestCollectingDB_BatchSemantics pins the batchHandle contract the store
+// stack relies on: ops are buffered locally, become collector-visible (and
+// read-your-writes-visible) only on Write, are DISCARDED by Close without
+// Write (bptree's DiscardBatch depends on this for session rollback), the
+// handle is reusable, and GetByteSize measures this batch only.
+func TestCollectingDB_BatchSemantics(t *testing.T) {
+	c := dbm.NewBatchCollector()
+	cdb := dbm.NewCollectingDB(memdb.NewMemDB(), c)
+
+	// Direct writes are visible immediately (read-your-writes).
+	if err := cdb.Set([]byte("direct"), []byte("d1")); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := cdb.Get([]byte("direct")); err != nil || !bytes.Equal(v, []byte("d1")) {
+		t.Fatalf("direct set not visible: %q %v", v, err)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("collector len = %d, want 1", c.Len())
+	}
+
+	// Batch ops are buffered: invisible to reads and the collector pre-Write.
+	b := cdb.NewBatch()
+	if err := b.Set([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Delete([]byte("direct")); err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("staged batch ops leaked into collector: len = %d", c.Len())
+	}
+	if v, _ := cdb.Get([]byte("k1")); v != nil {
+		t.Fatalf("unwritten batch op visible: %q", v)
+	}
+	if sz, err := b.GetByteSize(); err != nil || sz != len("k1")+len("v1")+len("direct") {
+		t.Fatalf("GetByteSize = %d, %v", sz, err)
+	}
+
+	// Write flushes in order; reads see the result (delete masks direct set).
+	if err := b.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 3 {
+		t.Fatalf("collector len = %d, want 3", c.Len())
+	}
+	if v, _ := cdb.Get([]byte("k1")); !bytes.Equal(v, []byte("v1")) {
+		t.Fatalf("written batch op not visible: %q", v)
+	}
+	if v, _ := cdb.Get([]byte("direct")); v != nil {
+		t.Fatalf("pending delete not masking: %q", v)
+	}
+
+	// The handle is empty and reusable after Write.
+	if sz, _ := b.GetByteSize(); sz != 0 {
+		t.Fatalf("buffer not cleared by Write: size %d", sz)
+	}
+	if err := b.Set([]byte("k2"), []byte("v2")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close without Write DISCARDS the buffer.
+	if err := b.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Write(); err != nil { // reusable post-Close; nothing to flush
+		t.Fatal(err)
+	}
+	if c.Len() != 3 {
+		t.Fatalf("Close leaked staged ops: len = %d", c.Len())
+	}
+	if v, _ := cdb.Get([]byte("k2")); v != nil {
+		t.Fatalf("discarded op visible: %q", v)
+	}
+
+	// Drain applies everything in order to a destination and clears the
+	// collector: the delete staged after the direct set must win.
+	dst := memdb.NewMemDB()
+	dstBatch := dst.NewBatch()
+	defer dstBatch.Close()
+	if err := c.Drain(dstBatch); err != nil {
+		t.Fatal(err)
+	}
+	if err := dstBatch.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 0 {
+		t.Fatalf("collector not cleared by Drain: %d", c.Len())
+	}
+	if v, _ := dst.Get([]byte("direct")); v != nil {
+		t.Fatalf("drain order broken: deleted key present: %q", v)
+	}
+	if v, _ := dst.Get([]byte("k1")); !bytes.Equal(v, []byte("v1")) {
+		t.Fatalf("drained value wrong: %q", v)
+	}
+}

--- a/tm2/pkg/db/immutable.go
+++ b/tm2/pkg/db/immutable.go
@@ -59,14 +59,17 @@ func (idb *ImmutableDB) NewSnapshot() (Snapshot, error) {
 	return idb.db.NewSnapshot()
 }
 
-// Implements DB.
+// Implements DB. Returns a read-only no-op batch (Set/Delete are discarded,
+// Write/WriteSync panic) rather than nil: consumers construct batches eagerly
+// (bptree's nodeDB, IAVL's BatchWithFlusher) and Close them on read-only
+// paths, which must not nil-deref.
 func (idb *ImmutableDB) NewBatch() Batch {
-	return nil // XXX
+	return &readonlyNoopBatch{}
 }
 
-// Implements DB.
+// Implements DB. See NewBatch.
 func (idb *ImmutableDB) NewBatchWithSize(_ int) Batch {
-	return nil // XXX
+	return &readonlyNoopBatch{}
 }
 
 // Implements DB.

--- a/tm2/pkg/db/immutable_test.go
+++ b/tm2/pkg/db/immutable_test.go
@@ -1,0 +1,44 @@
+package db_test
+
+import (
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+// TestImmutableDB_BatchIsUsable pins that ImmutableDB hands out a usable
+// read-only no-op batch rather than nil: consumers construct batches eagerly
+// (bptree's nodeDB, IAVL's BatchWithFlusher) and Set/Close them on read-only
+// load paths, which must not nil-deref. ImmutableDB is the query-path
+// fallback on backends without snapshot support, so a nil batch would panic
+// every query there. Writes must still fail loud.
+func TestImmutableDB_BatchIsUsable(t *testing.T) {
+	idb := dbm.NewImmutableDB(memdb.NewMemDB())
+
+	for _, b := range []dbm.Batch{idb.NewBatch(), idb.NewBatchWithSize(16)} {
+		if b == nil {
+			t.Fatal("ImmutableDB returned a nil batch")
+		}
+		if err := b.Set([]byte("k"), []byte("v")); err != nil {
+			t.Fatalf("staging on a read-only batch must be a silent no-op: %v", err)
+		}
+		if err := b.Delete([]byte("k")); err != nil {
+			t.Fatalf("staging on a read-only batch must be a silent no-op: %v", err)
+		}
+		if sz, err := b.GetByteSize(); err != nil || sz != 0 {
+			t.Fatalf("GetByteSize = %d, %v", sz, err)
+		}
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("Write on a read-only batch must panic")
+				}
+			}()
+			_ = b.Write()
+		}()
+		if err := b.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}
+}

--- a/tm2/pkg/db/snapshot_db.go
+++ b/tm2/pkg/db/snapshot_db.go
@@ -30,21 +30,24 @@ func (s *SnapshotDB) DeleteSync([]byte) error      { panic("SnapshotDB is read-o
 // BatchWithFlusher eagerly in its constructor even for immutable loads, but
 // never commits it when skipFastStorageUpgrade=true. The no-op batch panics
 // on Write/WriteSync to catch any unexpected write attempts.
-func (s *SnapshotDB) NewBatch() Batch            { return &snapshotNoopBatch{} }
-func (s *SnapshotDB) NewBatchWithSize(int) Batch { return &snapshotNoopBatch{} }
+func (s *SnapshotDB) NewBatch() Batch            { return &readonlyNoopBatch{} }
+func (s *SnapshotDB) NewBatchWithSize(int) Batch { return &readonlyNoopBatch{} }
 
-// snapshotNoopBatch silently discards Set/Delete but panics on Write/WriteSync.
-type snapshotNoopBatch struct{}
+// readonlyNoopBatch is the batch of read-only DB views (SnapshotDB,
+// ImmutableDB): it silently discards Set/Delete but panics on Write/WriteSync,
+// so staging over a read-only view is harmless while an actual write attempt
+// fails loud.
+type readonlyNoopBatch struct{}
 
-var _ Batch = (*snapshotNoopBatch)(nil)
+var _ Batch = (*readonlyNoopBatch)(nil)
 
-func (b *snapshotNoopBatch) Set(_, _ []byte) error     { return nil }
-func (b *snapshotNoopBatch) Delete(_ []byte) error     { return nil }
-func (b *snapshotNoopBatch) Close() error              { return nil }
-func (b *snapshotNoopBatch) GetByteSize() (int, error) { return 0, nil }
-func (b *snapshotNoopBatch) Write() error {
-	panic("snapshotNoopBatch: unexpected Write on read-only DB")
+func (b *readonlyNoopBatch) Set(_, _ []byte) error     { return nil }
+func (b *readonlyNoopBatch) Delete(_ []byte) error     { return nil }
+func (b *readonlyNoopBatch) Close() error              { return nil }
+func (b *readonlyNoopBatch) GetByteSize() (int, error) { return 0, nil }
+func (b *readonlyNoopBatch) Write() error {
+	panic("readonlyNoopBatch: unexpected Write on read-only DB")
 }
-func (b *snapshotNoopBatch) WriteSync() error {
-	panic("snapshotNoopBatch: unexpected WriteSync on read-only DB")
+func (b *readonlyNoopBatch) WriteSync() error {
+	panic("readonlyNoopBatch: unexpected WriteSync on read-only DB")
 }

--- a/tm2/pkg/db/types.go
+++ b/tm2/pkg/db/types.go
@@ -85,7 +85,8 @@ type Batch interface {
 	// methods will error.
 	WriteSync() error
 
-	// Close closes the batch. It is idempotent, but calls to other methods afterwards will error.
+	// Close closes the batch, DISCARDING any ops staged since the last Write.
+	// It is idempotent, but calls to other methods afterwards will error.
 	Close() error
 
 	// GetByteSize that returns the current size of the batch in bytes. Depending on the implementation,

--- a/tm2/pkg/sdk/baseapp.go
+++ b/tm2/pkg/sdk/baseapp.go
@@ -484,13 +484,6 @@ func handleQueryApp(app *BaseApp, path []string, req abci.RequestQuery) (res abc
 
 func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) (res abci.ResponseQuery) {
 	// "/store" prefix for store queries
-	queryable, ok := app.cms.(store.Queryable)
-	if !ok {
-		msg := "multistore doesn't support queries"
-		res.Error = ABCIError(std.ErrUnknownRequest(msg))
-		return
-	}
-
 	req.Path = "/" + strings.Join(path[1:], "/")
 
 	// when a client did not provide a query height, manually inject the latest
@@ -500,6 +493,31 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) (res a
 
 	if req.Height <= 1 && req.Prove {
 		res.Error = ABCIError(std.ErrInternal("cannot query with proof when height <= 1; please provide a valid height"))
+		return
+	}
+
+	// Prefer the snapshot-isolated path: store queries run on the query ABCI
+	// connection, CONCURRENTLY with consensus commits, so they must not read
+	// live mutable store state when a snapshot view is available. On error
+	// (no committed state yet, pruned height, backend without a view at that
+	// height) fall through to the legacy live-query path, preserving its
+	// response surface for those corners — safe there because either nothing
+	// has been committed or the live path answers with its own
+	// version-existence handling, as today.
+	if iq, ok := app.cms.(store.ImmutableQueryer); ok {
+		resp, err := iq.QueryImmutable(req)
+		if err == nil {
+			resp.Height = req.Height
+			return resp
+		}
+		app.logger.Debug("store query snapshot path unavailable; using live path",
+			"height", req.Height, "err", err)
+	}
+
+	queryable, ok := app.cms.(store.Queryable)
+	if !ok {
+		msg := "multistore doesn't support queries"
+		res.Error = ABCIError(std.ErrUnknownRequest(msg))
 		return
 	}
 

--- a/tm2/pkg/store/bptree/store.go
+++ b/tm2/pkg/store/bptree/store.go
@@ -161,23 +161,39 @@ func (st *Store) LastCommitID() types.CommitID {
 func (st *Store) GetStoreOptions() types.StoreOptions     { return st.opts }
 func (st *Store) SetStoreOptions(opts types.StoreOptions) { st.opts = opts }
 
-func (st *Store) LoadLatestVersion() error {
-	// Load discovers versions and loads the latest
-	latestV, err := st.mtree.Load()
+// loadImmutableView loads the tree read-only and installs an immutable view
+// at ver (0 = the latest version). LoadReadonly skips fast-index maintenance —
+// a load on this path must never write (the DB may be a snapshot, and a
+// concurrent commit could otherwise be misread as a stale index; see
+// bptree.MutableTree.LoadReadonly). The view is loaded UNREGISTERED: it is
+// long-lived and never Closed, so registering it would pin its version
+// against pruning forever.
+func (st *Store) loadImmutableView(ver int64) error {
+	latestV, err := st.mtree.LoadReadonly()
 	if err != nil {
 		return err
 	}
-	if st.opts.Immutable {
-		// Long-lived immutable store view, never Closed → load UNREGISTERED so
-		// it doesn't pin this version against pruning forever.
-		iTree, err := st.mtree.GetImmutableUnregistered(latestV)
-		if err != nil {
-			return err
-		}
-		st.tree = &immutableTreeAdapter{iTree}
-	} else {
-		st.tree = &mutableTreeAdapter{st.mtree}
+	if ver == 0 {
+		ver = latestV
 	}
+	iTree, err := st.mtree.GetImmutableUnregistered(ver)
+	if err != nil {
+		return err
+	}
+	st.tree = &immutableTreeAdapter{iTree}
+	return nil
+}
+
+func (st *Store) LoadLatestVersion() error {
+	if st.opts.Immutable {
+		return st.loadImmutableView(0)
+	}
+	// Load discovers versions, loads the latest, and performs fast-index
+	// maintenance (live store, single-threaded startup).
+	if _, err := st.mtree.Load(); err != nil {
+		return err
+	}
+	st.tree = &mutableTreeAdapter{st.mtree}
 	return nil
 }
 
@@ -186,17 +202,7 @@ func (st *Store) LoadVersion(ver int64) error {
 		return nil // version 0 is always "empty"
 	}
 	if st.opts.Immutable {
-		if _, err := st.mtree.Load(); err != nil {
-			return err
-		}
-		// Long-lived immutable store view, never Closed → load UNREGISTERED so
-		// it doesn't pin this version against pruning forever.
-		iTree, err := st.mtree.GetImmutableUnregistered(ver)
-		if err != nil {
-			return err
-		}
-		st.tree = &immutableTreeAdapter{iTree}
-		return nil
+		return st.loadImmutableView(ver)
 	}
 	// Load() discovers versions and loads the latest.
 	// Then LoadVersion loads the specific requested version.

--- a/tm2/pkg/store/exports.go
+++ b/tm2/pkg/store/exports.go
@@ -19,6 +19,7 @@ type (
 	StoreKey               = types.StoreKey
 	StoreOptions           = types.StoreOptions
 	Queryable              = types.Queryable
+	ImmutableQueryer       = types.ImmutableQueryer
 	Gas                    = types.Gas
 	GasMeter               = types.GasMeter
 	GasConfig              = types.GasConfig

--- a/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
@@ -81,7 +81,11 @@ func TestFastIndex_RebuildOverCollectingDB(t *testing.T) {
 	var res loadResult
 	select {
 	case res = <-done:
-	case <-time.After(30 * time.Second):
+	case <-time.After(60 * time.Second):
+		// 60s, not 30s: the legitimate fixed-path work (build 70k entries +
+		// rebuild + drain) takes ~20s here and a loaded CI runner is slower;
+		// the watchdog only needs to sit well below the pre-fix behavior
+		// (unbounded re-scan), not tight. The package -timeout is the backstop.
 		t.Fatalf("REGRESSED: rebuild did not terminate (clearFastIndex loop); %d ops staged", collector.Len())
 	}
 	if res.err != nil {

--- a/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
@@ -1,0 +1,146 @@
+package rootmulti_test
+
+// Regression test for the clearFastIndex/CollectingDB incompatibility: a
+// fast-index rebuild whose clear phase must delete >= 65536 existing 'F'
+// entries used to loop forever when the tree's DB is CollectingDB-wrapped
+// (the production wiring), because the chunked ndb.Commit() only moves
+// deletes into the collector (not the DB) and CollectingDB.Iterator reads the
+// underlying DB — so a restart-from-start scan re-saw the same keys forever.
+// clearFastIndex now resumes each chunk after the last staged key, making
+// progress independent of whether the deletes have been applied.
+//
+// Production trigger: run with the fast index ON (>= 65536 entries
+// persisted), commit at least one version with it OFF (stamp goes stale),
+// then restart with it ON — Load() rebuilds at startup.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+)
+
+func TestFastIndex_RebuildOverCollectingDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a 70k-entry index")
+	}
+	db := memdb.NewMemDB()
+	const entries = 70_000 // > fastRebuildFlush (65536)
+
+	key := func(i int) []byte {
+		return []byte{'k', byte(i >> 16), byte(i >> 8), byte(i)}
+	}
+
+	// Step 1: fast-ON tree over the raw db — persist `entries` F entries and
+	// the stamp at version 1.
+	on := bp.NewMutableTreeWithDB(db, 1024, bp.NewNopLogger(), bp.FastIndexOption(true))
+	for i := 0; i < entries; i++ {
+		if _, err := on.Set(key(i), []byte("v1")); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+	}
+	if _, _, err := on.SaveVersion(); err != nil {
+		t.Fatalf("save v1: %v", err)
+	}
+
+	// Step 2: fast-OFF tree over the same db commits version 2 — no index
+	// maintenance, no stamp update. Disk now: stamp=1, latest=2, and the
+	// version-2 write leaves a stale 'F' entry for its key.
+	off := bp.NewMutableTreeWithDB(db, 1024, bp.NewNopLogger())
+	if _, err := off.Load(); err != nil {
+		t.Fatalf("off load: %v", err)
+	}
+	if _, err := off.Set(key(3), []byte("v2")); err != nil {
+		t.Fatalf("off set: %v", err)
+	}
+	if _, _, err := off.SaveVersion(); err != nil {
+		t.Fatalf("save v2: %v", err)
+	}
+
+	// Step 3: fast-ON tree over the PRODUCTION wiring (CollectingDB). Load()
+	// sees stamp(1) < latest(2) and rebuilds; the clear phase must remove the
+	// 70k stale entries first — and must terminate.
+	collector := dbm.NewBatchCollector()
+	cdb := dbm.NewCollectingDB(db, collector)
+	prod := bp.NewMutableTreeWithDB(cdb, 1024, bp.NewNopLogger(), bp.FastIndexOption(true))
+
+	type loadResult struct {
+		latest int64
+		err    error
+	}
+	done := make(chan loadResult, 1)
+	go func() {
+		latest, err := prod.Load()
+		done <- loadResult{latest, err}
+	}()
+
+	var res loadResult
+	select {
+	case res = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("REGRESSED: rebuild did not terminate (clearFastIndex loop); %d ops staged", collector.Len())
+	}
+	if res.err != nil {
+		t.Fatalf("rebuild load: %v", res.err)
+	}
+	if res.latest != 2 {
+		t.Fatalf("loaded latest = %d, want 2", res.latest)
+	}
+	// Single-pass clear (~entries deletes) + rebuild (~entries sets) + stamp:
+	// far below the re-scan blowup (the old loop staged the first 65536 keys
+	// over and over).
+	if n := collector.Len(); n > 3*entries {
+		t.Fatalf("REGRESSED: %d ops staged for %d entries (chunked clear re-scanned)", n, entries)
+	}
+
+	// The rebuild is durable only after the collector drains (in production:
+	// the next block's rootmulti Commit). Drain and verify the result.
+	realBatch := db.NewBatch()
+	defer realBatch.Close()
+	if err := collector.Drain(realBatch); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := realBatch.Write(); err != nil {
+		t.Fatalf("apply drain: %v", err)
+	}
+
+	stampRaw, err := db.Get(append([]byte{bp.PrefixMeta}, "fastidx"...))
+	if err != nil || stampRaw == nil {
+		t.Fatalf("stamp missing after drain (err=%v)", err)
+	}
+	payload, cerr := reproVerifyChecksum(stampRaw)
+	if cerr != nil || len(payload) != 8 {
+		t.Fatalf("bad stamp record: %v", cerr)
+	}
+	if stamp := int64(binary.BigEndian.Uint64(payload)); stamp != 2 {
+		t.Fatalf("stamp = %d, want 2", stamp)
+	}
+
+	// Spot-check rebuilt entries against the authoritative tree.
+	check := bp.NewMutableTreeWithDB(db, 1024, bp.NewNopLogger())
+	if _, err := check.Load(); err != nil {
+		t.Fatalf("check load: %v", err)
+	}
+	for _, i := range []int{0, 3, 65535, 65536, entries - 1} {
+		k := key(i)
+		want, err := check.Get(k)
+		if err != nil {
+			t.Fatalf("walk get %x: %v", k, err)
+		}
+		raw, err := db.Get(append([]byte{bp.PrefixFast}, k...))
+		if err != nil || raw == nil {
+			t.Fatalf("F entry missing for %x (err=%v)", k, err)
+		}
+		payload, cerr := reproVerifyChecksum(raw)
+		if cerr != nil || len(payload) < 8 {
+			t.Fatalf("corrupt F entry %x: %v", k, cerr)
+		}
+		if !bytes.Equal(payload[8:], want) {
+			t.Fatalf("rebuilt F entry stale for %x: fast=%q tree=%q", k, payload[8:], want)
+		}
+	}
+}

--- a/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_clear_hang_repro_test.go
@@ -38,7 +38,7 @@ func TestFastIndex_RebuildOverCollectingDB(t *testing.T) {
 	// Step 1: fast-ON tree over the raw db — persist `entries` F entries and
 	// the stamp at version 1.
 	on := bp.NewMutableTreeWithDB(db, 1024, bp.NewNopLogger(), bp.FastIndexOption(true))
-	for i := 0; i < entries; i++ {
+	for i := range entries {
 		if _, err := on.Set(key(i), []byte("v1")); err != nil {
 			t.Fatalf("set: %v", err)
 		}

--- a/tm2/pkg/store/rootmulti/fastindex_concurrent_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_concurrent_repro_test.go
@@ -53,7 +53,7 @@ func TestFastIndex_ConcurrentQueryCommit(t *testing.T) {
 
 	// Query hammer goroutines: the surfaces the RPC/query connection exercises
 	// concurrently with consensus in production.
-	for g := 0; g < 4; g++ {
+	for g := range 4 {
 		wg.Add(1)
 		go func(g int) {
 			defer wg.Done()
@@ -73,7 +73,7 @@ func TestFastIndex_ConcurrentQueryCommit(t *testing.T) {
 						continue // height pruned/not yet visible — fine
 					}
 					st := cacheMS.GetStore(mainKey)
-					for i := 0; i < 8; i++ {
+					for range 8 {
 						st.Get(nil, kname(qrng.Intn(keyspace)))
 					}
 					release()
@@ -94,7 +94,7 @@ func TestFastIndex_ConcurrentQueryCommit(t *testing.T) {
 						continue
 					}
 					st := cacheMS.GetStore(mainKey)
-					for i := 0; i < 8; i++ {
+					for range 8 {
 						st.Get(nil, kname(qrng.Intn(keyspace)))
 					}
 					release()
@@ -108,7 +108,7 @@ func TestFastIndex_ConcurrentQueryCommit(t *testing.T) {
 		cms := ms.MultiCacheWrap()
 		st := cms.GetStore(mainKey)
 		n := 1 + rng.Intn(60)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			k := kname(rng.Intn(keyspace))
 			if rng.Intn(6) == 0 {
 				st.Delete(nil, k)

--- a/tm2/pkg/store/rootmulti/fastindex_concurrent_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_concurrent_repro_test.go
@@ -1,0 +1,136 @@
+package rootmulti_test
+
+// Concurrency regression test for https://github.com/gnolang/gno/issues/6011:
+// the query ABCI connection has an INDEPENDENT mutex (tm2/pkg/bft/proxy), so
+// query-path reads run concurrently with consensus commits. This hammers the
+// production query surfaces — custom-query snapshot loads (handleQueryCustom /
+// Simulate shape) and snapshot-backed .store queries (QueryImmutable) — while
+// blocks commit, then audits the persisted fast index for staleness. Any
+// panic in a query goroutine fails the test (no recover): post-fix these
+// surfaces read frozen snapshots and must be crash-free.
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+func TestFastIndex_ConcurrentQueryCommit(t *testing.T) {
+	db, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, t.TempDir())
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	defer db.Close()
+
+	mainKey := types.NewStoreKey("main")
+	ms := rootmulti.NewMultiStore(db)
+	// Production-like retention (topaz runs syncable; pruning never fired in
+	// the incident window).
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.NewPruningOptions(0, 1)})
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	if err := ms.LoadLatestVersion(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer ms.Close() // release the query snapshot before db.Close
+
+	rng := rand.New(rand.NewSource(1))
+	oracle := map[string]string{}
+	kname := func(i int) []byte { return fmt.Appendf(nil, "key%04d", i) }
+	const keyspace = 2048
+
+	var stop atomic.Bool
+	var height atomic.Int64
+	var wg sync.WaitGroup
+
+	// Query hammer goroutines: the surfaces the RPC/query connection exercises
+	// concurrently with consensus in production.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			qrng := rand.New(rand.NewSource(int64(100 + g)))
+			for !stop.Load() {
+				h := height.Load()
+				if h < 2 {
+					continue
+				}
+				switch qrng.Intn(3) {
+				case 0:
+					// handleQueryCustom shape: snapshot multistore at a
+					// recent height.
+					qh := h - qrng.Int63n(2)
+					cacheMS, release, err := ms.MultiImmutableCacheWrapWithVersion(qh)
+					if err != nil {
+						continue // height pruned/not yet visible — fine
+					}
+					st := cacheMS.GetStore(mainKey)
+					for i := 0; i < 8; i++ {
+						st.Get(nil, kname(qrng.Intn(keyspace)))
+					}
+					release()
+				case 1:
+					// handleQueryStore shape: snapshot-backed .store query.
+					req := abci.RequestQuery{
+						Path:   "/main/key",
+						Data:   kname(qrng.Intn(keyspace)),
+						Height: h - qrng.Int63n(2),
+					}
+					if _, err := ms.QueryImmutable(req); err != nil {
+						continue // no snapshot view for that height — fine
+					}
+				case 2:
+					// Simulate shape: snapshot multistore at the latest height.
+					cacheMS, release, err := ms.MultiImmutableCacheWrapWithVersion(h)
+					if err != nil {
+						continue
+					}
+					st := cacheMS.GetStore(mainKey)
+					for i := 0; i < 8; i++ {
+						st.Get(nil, kname(qrng.Intn(keyspace)))
+					}
+					release()
+				}
+			}
+		}(g)
+	}
+
+	const blocks = 400
+	for blk := 1; blk <= blocks; blk++ {
+		cms := ms.MultiCacheWrap()
+		st := cms.GetStore(mainKey)
+		n := 1 + rng.Intn(60)
+		for i := 0; i < n; i++ {
+			k := kname(rng.Intn(keyspace))
+			if rng.Intn(6) == 0 {
+				st.Delete(nil, k)
+				delete(oracle, string(k))
+			} else {
+				v := fmt.Sprintf("v%d.%d", blk, i)
+				st.Set(nil, k, []byte(v))
+				oracle[string(k)] = v
+			}
+		}
+		cms.MultiWrite()
+		ms.Commit()
+		height.Store(int64(blk))
+
+		if blk%20 == 0 || blk == blocks {
+			checkFastIndexParity(t, db, oracle, blk, keyspace)
+			if t.Failed() {
+				break
+			}
+		}
+	}
+	stop.Store(true)
+	wg.Wait()
+	checkFastIndexParity(t, db, oracle, blocks, keyspace)
+}

--- a/tm2/pkg/store/rootmulti/fastindex_helpers_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_helpers_test.go
@@ -12,7 +12,10 @@ var reproCRC = crc32.MakeTable(crc32.Castagnoli)
 
 // reproVerifyChecksum splits a bptree record into payload and crc32c,
 // verifying it — an independent reimplementation of bptree's unexported
-// verifyChecksum so the audits don't trust the code under test.
+// verifyChecksum so the audits don't trust the code under test. Sibling of
+// queryRaceVerifyChecksum in gno.land/pkg/gnoland's full-app regression
+// (test-package helpers are not importable); update both together if the
+// framing changes.
 func reproVerifyChecksum(data []byte) ([]byte, error) {
 	if len(data) < 4 {
 		return nil, fmt.Errorf("record too short (%d bytes)", len(data))

--- a/tm2/pkg/store/rootmulti/fastindex_helpers_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_helpers_test.go
@@ -1,0 +1,26 @@
+package rootmulti_test
+
+// Shared helpers for the fastindex regression tests (gno#6011).
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+)
+
+var reproCRC = crc32.MakeTable(crc32.Castagnoli)
+
+// reproVerifyChecksum splits a bptree record into payload and crc32c,
+// verifying it — an independent reimplementation of bptree's unexported
+// verifyChecksum so the audits don't trust the code under test.
+func reproVerifyChecksum(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("record too short (%d bytes)", len(data))
+	}
+	payload := data[:len(data)-4]
+	want := binary.BigEndian.Uint32(data[len(data)-4:])
+	if got := crc32.Checksum(payload, reproCRC); got != want {
+		return nil, fmt.Errorf("crc mismatch")
+	}
+	return payload, nil
+}

--- a/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
@@ -68,10 +68,8 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 	var height atomic.Int64
 	height.Store(int64(blk))
 	var wg sync.WaitGroup
-	for g := 0; g < 8; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 8 {
+		wg.Go(func() {
 			for !stop.Load() {
 				h := height.Load()
 				if h < 2 {
@@ -85,12 +83,12 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 				cacheMS.GetStore(mainKey) // construction already did the damage, if any
 				release()
 			}
-		}()
+		})
 	}
 
 	// Update blocks: each block touches a disjoint 10-key slice exactly once.
 	const updateBlocks = 1900
-	for u := 0; u < updateBlocks; u++ {
+	for u := range updateBlocks {
 		blk++
 		from := (u * 10) % total
 		commit(from, from+10, blk)
@@ -106,7 +104,7 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 		t.Fatalf("plain load: %v", err)
 	}
 	stale := 0
-	for i := 0; i < total; i++ {
+	for i := range total {
 		k := kname(i)
 		want := oracle[string(k)]
 		got, err := plain.Get(k)

--- a/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
@@ -66,6 +66,7 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 
 	var stop atomic.Bool
 	var height atomic.Int64
+	var queryLoads atomic.Int64 // successful query-view loads, for the race floor
 	height.Store(int64(blk))
 	var wg sync.WaitGroup
 	for range 8 {
@@ -82,6 +83,7 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 				}
 				cacheMS.GetStore(mainKey) // construction already did the damage, if any
 				release()
+				queryLoads.Add(1)
 			}
 		})
 	}
@@ -96,6 +98,14 @@ func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
 	}
 	stop.Store(true)
 	wg.Wait()
+
+	// Race floor: if the query goroutines never actually interleaved with the
+	// committing writer (a fully-serialized scheduler), a zero-stale result
+	// below would be vacuous. Require that they did substantial concurrent
+	// work, so a genuine regression can't hide behind a quiet runner.
+	if n := queryLoads.Load(); n < int64(updateBlocks) {
+		t.Fatalf("query goroutines barely ran (%d loads over %d blocks); race not exercised", n, updateBlocks)
+	}
 
 	// Audit persisted fast index against the tree, from fresh handles.
 	pdb := dbm.NewPrefixDB(db, []byte("s/_/"))

--- a/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_natural_race_test.go
@@ -1,0 +1,140 @@
+package rootmulti_test
+
+// Natural (hook-free) reproduction of #6011: hammer the query path
+// (MultiImmutableCacheWrapWithVersion, as handleQueryCustom does on the
+// query connection's independent mutex) while blocks commit. Each block
+// updates a DISJOINT slice of pre-populated keys exactly once, so a stale
+// rebuild racing block N leaves permanently stale entries for block N's keys
+// that the final audit detects.
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+func TestFastIndex_NaturalQueryCommitRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-dependent race hunt")
+	}
+	db, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, t.TempDir())
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	defer db.Close()
+
+	mainKey := types.NewStoreKey("main")
+	ms := rootmulti.NewMultiStore(db)
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.NewPruningOptions(0, 1)})
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	if err := ms.LoadLatestVersion(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer ms.Close() // release the query snapshot before db.Close
+
+	kname := func(i int) []byte { return fmt.Appendf(nil, "acct%05d", i) }
+	oracle := map[string]string{}
+
+	commit := func(from, to int, blk int) {
+		cms := ms.MultiCacheWrap()
+		st := cms.GetStore(mainKey)
+		for i := from; i < to; i++ {
+			v := fmt.Sprintf("v%d/%d", blk, i)
+			st.Set(nil, kname(i), []byte(v))
+			oracle[string(kname(i))] = v
+		}
+		cms.MultiWrite()
+		ms.Commit()
+	}
+
+	// Pre-populate 20000 keys across 10 blocks.
+	const total = 20000
+	blk := 0
+	for i := 0; i < total; i += 2000 {
+		blk++
+		commit(i, i+2000, blk)
+	}
+
+	var stop atomic.Bool
+	var height atomic.Int64
+	height.Store(int64(blk))
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				h := height.Load()
+				if h < 2 {
+					continue
+				}
+				// handleQueryCustom's exact call, racing the commit drain.
+				cacheMS, release, err := ms.MultiImmutableCacheWrapWithVersion(h - 1)
+				if err != nil {
+					continue
+				}
+				cacheMS.GetStore(mainKey) // construction already did the damage, if any
+				release()
+			}
+		}()
+	}
+
+	// Update blocks: each block touches a disjoint 10-key slice exactly once.
+	const updateBlocks = 1900
+	for u := 0; u < updateBlocks; u++ {
+		blk++
+		from := (u * 10) % total
+		commit(from, from+10, blk)
+		height.Store(int64(blk))
+	}
+	stop.Store(true)
+	wg.Wait()
+
+	// Audit persisted fast index against the tree, from fresh handles.
+	pdb := dbm.NewPrefixDB(db, []byte("s/_/"))
+	plain := bp.NewMutableTreeWithDB(pdb, 256, bp.NewNopLogger())
+	if _, err := plain.Load(); err != nil {
+		t.Fatalf("plain load: %v", err)
+	}
+	stale := 0
+	for i := 0; i < total; i++ {
+		k := kname(i)
+		want := oracle[string(k)]
+		got, err := plain.Get(k)
+		if err != nil {
+			t.Fatalf("walk get %q: %v", k, err)
+		}
+		if string(got) != want {
+			t.Fatalf("tree diverged at %q: %q != %q", k, got, want)
+		}
+		raw, err := pdb.Get(append([]byte{bp.PrefixFast}, k...))
+		if err != nil {
+			t.Fatalf("F get %q: %v", k, err)
+		}
+		if raw == nil {
+			continue // missing entry is advisory-benign
+		}
+		payload, cerr := reproVerifyChecksum(raw)
+		if cerr != nil || len(payload) < 8 {
+			t.Fatalf("corrupt F entry %q: %v", k, cerr)
+		}
+		if !bytes.Equal(payload[8:], got) {
+			stale++
+			if stale <= 5 {
+				t.Logf("STALE F entry key=%q fast=%q tree=%q", k, payload[8:], got)
+			}
+		}
+	}
+	if stale > 0 {
+		t.Fatalf("NATURAL RACE REPRODUCED #6011: %d stale fast-index entries persisted", stale)
+	}
+}

--- a/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
@@ -1,0 +1,228 @@
+package rootmulti_test
+
+// Repro harness for https://github.com/gnolang/gno/issues/6011: drives the
+// bptree store through the REAL production write pipeline — rootmulti
+// multiStore -> CollectingDB (shared BatchCollector, no-op sub-batches) ->
+// PrefixDB("s/_/") -> bptree — across blocks, restarts, crash-restarts,
+// fast-index upgrades, and pruning, and after every commit audits the
+// persisted fast index against an oracle and the authoritative tree.
+//
+// The existing store tests drive Store directly over a plain memdb, which
+// bypasses the collector pipeline entirely; #6011 demonstrates persisted
+// stale fast-index state on a production DB, so the pipeline is a suspect.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+func TestFastIndex_RootmultiPipelineFuzz(t *testing.T) {
+	for seed := int64(1); seed <= 30; seed++ {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			runPipelineFuzz(t, seed, false, false)
+		})
+		t.Run(fmt.Sprintf("seed=%d/prune", seed), func(t *testing.T) {
+			runPipelineFuzz(t, seed, true, false)
+		})
+		t.Run(fmt.Sprintf("seed=%d/upgrade", seed), func(t *testing.T) {
+			runPipelineFuzz(t, seed, false, true)
+		})
+	}
+}
+
+func runPipelineFuzz(t *testing.T, seed int64, prune, upgrade bool) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	db := memdb.NewMemDB()
+	mainKey := types.NewStoreKey("main")
+	baseKey := types.NewStoreKey("base")
+
+	// newMS mirrors gnoland: main = bptree (fast index per `fast`), base =
+	// dbadapter, both mounted over the same cfg.DB (=> prefix "s/_/"), and the
+	// rootmulti metadata in the same DB.
+	newMS := func(fast bool) types.CommitMultiStore {
+		ms := rootmulti.NewMultiStore(db)
+		if prune {
+			ms.SetStoreOptions(types.StoreOptions{
+				PruningOptions: types.NewPruningOptions(2, 0),
+			})
+		}
+		ctor := storebptree.StoreConstructor
+		if fast {
+			ctor = storebptree.FastStoreConstructor
+		}
+		ms.MountStoreWithDB(mainKey, ctor, db)
+		ms.MountStoreWithDB(baseKey, dbadapter.StoreConstructor, db)
+		if err := ms.LoadLatestVersion(); err != nil {
+			t.Fatalf("LoadLatestVersion: %v", err)
+		}
+		// Loading must seed the query snapshot (snapshot-capable backend), so
+		// a restarted node has query isolation before its first commit.
+		if ms.QuerySnapshot() == nil {
+			t.Fatal("LoadLatestVersion did not seed the query snapshot")
+		}
+		return ms
+	}
+
+	// Upgrade mode: first blocks run with the fast index OFF, then a restart
+	// switches the mount to FastStoreConstructor (Load rebuilds the index
+	// through the CollectingDB) — the PR #5937 deployment path.
+	fastOn := !upgrade
+	ms := newMS(fastOn)
+
+	oracle := map[string]string{} // expected committed state of the main store
+	kname := func(i int) []byte { return fmt.Appendf(nil, "key%04d", i) }
+	// Large enough to force leaf splits and multi-level inner nodes (B=32):
+	// 4096 keys => height 3, exercising COW split/merge on every block.
+	const keyspace = 4096
+
+	stageBlock := func(cms types.MultiStore, commitOracle bool, blk int) {
+		st := cms.GetStore(mainKey)
+		bst := cms.GetStore(baseKey)
+		bst.Set(nil, []byte("_lastHeader"), fmt.Appendf(nil, "hdr%d", blk))
+		n := 1 + rng.Intn(120)
+		for i := 0; i < n; i++ {
+			k := kname(rng.Intn(keyspace))
+			if rng.Intn(5) == 0 {
+				st.Delete(nil, k)
+				if commitOracle {
+					delete(oracle, string(k))
+				}
+			} else {
+				v := fmt.Sprintf("v%d.%d.%d", blk, i, rng.Intn(1000))
+				st.Set(nil, k, []byte(v))
+				if commitOracle {
+					oracle[string(k)] = v
+				}
+			}
+		}
+	}
+
+	const blocks = 60
+	for blk := 1; blk <= blocks; blk++ {
+		if upgrade && blk == blocks/2 {
+			fastOn = true
+			ms = newMS(true) // upgrade restart: triggers index rebuild at Load
+		}
+		switch rng.Intn(8) {
+		case 0: // clean restart
+			ms = newMS(fastOn)
+		case 1: // crash restart: block staged through MultiWrite, never committed
+			cms := ms.MultiCacheWrap()
+			stageBlock(cms, false, blk)
+			cms.MultiWrite()
+			ms = newMS(fastOn) // collector (and tree state) dropped; db unchanged
+		}
+		cms := ms.MultiCacheWrap()
+		stageBlock(cms, true, blk)
+		cms.MultiWrite()
+		ms.Commit()
+		if fastOn {
+			checkFastIndexParity(t, db, oracle, blk, keyspace)
+		}
+	}
+}
+
+// checkFastIndexParity audits the RAW persisted state (what a restarted node
+// would see) after a commit:
+//  1. the fast-index stamp must be current (else the next Load would rebuild,
+//     masking any staleness),
+//  2. Get with the fast index on and off must agree with the oracle for every
+//     key in the keyspace,
+//  3. every persisted 'F' entry must match the authoritative tree: no
+//     stale-present entries (key removed but entry remains), no stale values,
+//     no entries newer than the committed version.
+func checkFastIndexParity(t *testing.T, db dbm.DB, oracle map[string]string, blk, keyspace int) {
+	t.Helper()
+	pdb := dbm.NewPrefixDB(db, []byte("s/_/"))
+
+	plain := bp.NewMutableTreeWithDB(pdb, 256, bp.NewNopLogger())
+	if _, err := plain.Load(); err != nil {
+		t.Fatalf("blk %d: plain load: %v", blk, err)
+	}
+	latest := plain.Version()
+
+	// Stamp must exist and equal latest BEFORE constructing the fast tree —
+	// a stale stamp would make fast.Load() rebuild the index and hide the bug.
+	stampRaw, err := db.Get(append(append([]byte("s/_/"), bp.PrefixMeta), "fastidx"...))
+	if err != nil || stampRaw == nil {
+		t.Fatalf("blk %d: fast index stamp missing (err=%v)", blk, err)
+	}
+	payload, cerr := reproVerifyChecksum(stampRaw)
+	if cerr != nil || len(payload) != 8 {
+		t.Fatalf("blk %d: bad stamp record: %v", blk, cerr)
+	}
+	if stamp := int64(binary.BigEndian.Uint64(payload)); stamp != latest {
+		t.Fatalf("blk %d: stamp %d != latest %d (Load would rebuild)", blk, stamp, latest)
+	}
+
+	fast := bp.NewMutableTreeWithDB(pdb, 256, bp.NewNopLogger(), bp.FastIndexOption(true))
+	if _, err := fast.Load(); err != nil {
+		t.Fatalf("blk %d: fast load: %v", blk, err)
+	}
+
+	// Whole keyspace (plus a margin of never-written keys): oracle vs plain
+	// walk vs fast-index read.
+	for i := 0; i < keyspace+8; i++ {
+		k := fmt.Appendf(nil, "key%04d", i)
+		want, present := oracle[string(k)]
+		pv, err := plain.Get(k)
+		if err != nil {
+			t.Fatalf("blk %d: plain get %q: %v", blk, k, err)
+		}
+		fv, err := fast.Get(k)
+		if err != nil {
+			t.Fatalf("blk %d: fast get %q: %v", blk, k, err)
+		}
+		if present != (pv != nil) || (present && string(pv) != want) {
+			t.Fatalf("blk %d: TREE DIVERGES FROM ORACLE key=%q tree=%q oracle=%q,%v",
+				blk, k, pv, want, present)
+		}
+		if !bytes.Equal(pv, fv) {
+			t.Fatalf("blk %d: FAST INDEX DIVERGES key=%q walk=%q fast=%q (issue #6011 shape)",
+				blk, k, pv, fv)
+		}
+	}
+
+	// Every persisted 'F' entry vs the authoritative tree.
+	itr, err := pdb.Iterator([]byte{bp.PrefixFast}, []byte{bp.PrefixFast + 1})
+	if err != nil {
+		t.Fatalf("blk %d: F iterator: %v", blk, err)
+	}
+	defer itr.Close()
+	for ; itr.Valid(); itr.Next() {
+		key := append([]byte(nil), itr.Key()[1:]...)
+		payload, cerr := reproVerifyChecksum(itr.Value())
+		if cerr != nil || len(payload) < 8 {
+			t.Fatalf("blk %d: corrupt F entry %q: %v", blk, key, cerr)
+		}
+		ver := int64(binary.BigEndian.Uint64(payload[:8]))
+		val := payload[8:]
+		want, present := oracle[string(key)]
+		if !present {
+			t.Fatalf("blk %d: STALE-PRESENT F entry key=%q ver=%d val=%q (key removed from tree)",
+				blk, key, ver, val)
+		}
+		if string(val) != want {
+			t.Fatalf("blk %d: STALE F VALUE key=%q ver=%d fast=%q tree=%q (issue #6011 shape)",
+				blk, key, ver, val, want)
+		}
+		if ver > latest {
+			t.Fatalf("blk %d: F entry from the future key=%q ver=%d latest=%d", blk, key, ver, latest)
+		}
+	}
+	if err := itr.Error(); err != nil {
+		t.Fatalf("blk %d: F iteration: %v", blk, err)
+	}
+}

--- a/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
@@ -28,6 +28,9 @@ import (
 )
 
 func TestFastIndex_RootmultiPipelineFuzz(t *testing.T) {
+	if testing.Short() {
+		t.Skip("30-seed x 3-mode pipeline fuzz (~20s); CI runs it (no -short)")
+	}
 	for seed := int64(1); seed <= 30; seed++ {
 		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
 			runPipelineFuzz(t, seed, false, false)
@@ -92,7 +95,7 @@ func runPipelineFuzz(t *testing.T, seed int64, prune, upgrade bool) {
 		bst := cms.GetStore(baseKey)
 		bst.Set(nil, []byte("_lastHeader"), fmt.Appendf(nil, "hdr%d", blk))
 		n := 1 + rng.Intn(120)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			k := kname(rng.Intn(keyspace))
 			if rng.Intn(5) == 0 {
 				st.Delete(nil, k)

--- a/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_pipeline_repro_test.go
@@ -1,15 +1,20 @@
 package rootmulti_test
 
-// Repro harness for https://github.com/gnolang/gno/issues/6011: drives the
+// Single-threaded pipeline guard for the gno#6011 fix set. It drives the
 // bptree store through the REAL production write pipeline — rootmulti
-// multiStore -> CollectingDB (shared BatchCollector, no-op sub-batches) ->
-// PrefixDB("s/_/") -> bptree — across blocks, restarts, crash-restarts,
-// fast-index upgrades, and pruning, and after every commit audits the
-// persisted fast index against an oracle and the authoritative tree.
+// multiStore -> CollectingDB (shared BatchCollector, buffered sub-batches) ->
+// PrefixDB("s/_/") -> bptree — across blocks, clean/crash restarts,
+// fast-index upgrades (off->on rebuild), and pruning, asserting after every
+// commit that the persisted fast index matches an oracle and the
+// authoritative tree, and that each load re-seeds the query snapshot.
 //
-// The existing store tests drive Store directly over a plain memdb, which
-// bypasses the collector pipeline entirely; #6011 demonstrates persisted
-// stale fast-index state on a production DB, so the pipeline is a suspect.
+// This does NOT reproduce #6011 itself — that is a concurrency race between
+// the query connection and consensus commits, covered by the natural-race
+// and concurrent tests. It guards the pieces the fix depends on that are
+// observable single-threaded: buffered-collector batch semantics, LoadVersion
+// query-snapshot seeding, and index parity across write/restart/upgrade/prune
+// schedules. The existing store tests drive Store directly over a plain
+// memdb, bypassing the collector pipeline entirely.
 
 import (
 	"bytes"

--- a/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
@@ -106,11 +106,15 @@ func TestFastIndex_NoStaleRebuildOnRacingQueryLoad(t *testing.T) {
 	commit(map[string][]byte{string(acct): oldVal, "filler-b": []byte("x2")})
 	commit(map[string][]byte{"filler-c": []byte("x3")})
 
-	// --- Layer 1: the immutable-store load path must never read (or write)
-	// the fast index. The store is built by hand the way the PRE-fix
-	// constructStore built it — over the LIVE db — which is exactly the
-	// configuration that used to write the poison; post-fix its load must be
-	// maintenance-free regardless of routing.
+	// --- Layer 1: an immutable-store load is READ-ONLY and version-correct
+	// even when a commit races it. The store is built by hand over the LIVE db
+	// (the PRE-fix configuration that used to write the poison). The load reads
+	// the fast-index stamp exactly once — the getImmutable snapshot gate, an
+	// advisory read, not maintenance — and the hook lands block N (acct→midVal)
+	// during that read. A view pinned at version 2 must return the version-2
+	// value: the gate keeps the index on (stamp ≥ 2), and fastGet's per-entry
+	// guard rejects the racing newer entry and walks to the version-2 root.
+	// Write-freedom is asserted by the end-of-test raw-DB audit below.
 	hdb := &hookDB{DB: db}
 	hdb.onStampGet = func() {
 		commit(map[string][]byte{string(acct): midVal, "filler-d": []byte("x4")})
@@ -122,12 +126,12 @@ func TestFastIndex_NoStaleRebuildOnRacingQueryLoad(t *testing.T) {
 	if err := queryStore.LoadVersion(2); err != nil {
 		t.Fatalf("query-path LoadVersion: %v", err)
 	}
-	if hdb.hasFired() {
-		t.Fatal("immutable store load read the fast-index stamp: the read-only load performed index maintenance")
+	if !hdb.hasFired() {
+		t.Fatal("immutable load did not read the fast-index stamp (getImmutable gate probe unfired)")
 	}
-	// The racing commit never happened (hook unfired) — apply block N now so
-	// the account's authoritative value moves past the fast-index entry.
-	commit(map[string][]byte{string(acct): midVal, "filler-d": []byte("x4")})
+	if got := queryStore.Get(nil, acct); !bytes.Equal(got, oldVal) {
+		t.Fatalf("version-2 view returned %q; want %q (gate on, per-entry guard rejects the racing entry)", got, oldVal)
+	}
 
 	// --- Layer 2: a FULL Load() (maintenance-capable) whose stamp read
 	// straddles the next commit observes stamp > version and must FAIL LOUD —

--- a/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
@@ -21,10 +21,12 @@ package rootmulti_test
 //     fast-index maintenance: the stamp is never read, nothing can write.
 //  2. Even a FULL Load() straddling the commit (stamp ahead of the loaded
 //     version) must NOT rebuild: ensureFastIndex treats stamp > version as
-//     "stale reader" and leaves the index alone.
+//     "out-of-contract racing reader or external rewind" and fails loud,
+//     leaving the index untouched.
 
 import (
 	"bytes"
+	"strings"
 	"sync"
 	"testing"
 
@@ -128,16 +130,19 @@ func TestFastIndex_NoStaleRebuildOnRacingQueryLoad(t *testing.T) {
 	commit(map[string][]byte{string(acct): midVal, "filler-d": []byte("x4")})
 
 	// --- Layer 2: a FULL Load() (maintenance-capable) whose stamp read
-	// straddles the next commit must skip the rebuild (stamp > version), not
-	// rewrite the index from its older root.
+	// straddles the next commit observes stamp > version and must FAIL LOUD —
+	// neither rewriting the index from its older root (the gno#6011 poisoning)
+	// nor silently proceeding.
 	hdb2 := &hookDB{DB: db}
 	hdb2.onStampGet = func() {
 		commit(map[string][]byte{string(acct): newVal, "filler-e": []byte("x5")})
 	}
 	racingTree := bp.NewMutableTreeWithDB(
 		dbm.NewPrefixDB(hdb2, []byte("s/_/")), 256, bp.NewNopLogger(), bp.FastIndexOption(true))
-	if _, err := racingTree.Load(); err != nil {
-		t.Fatalf("racing full load: %v", err)
+	if _, err := racingTree.Load(); err == nil {
+		t.Fatal("racing full Load succeeded; want a stamp-ahead error")
+	} else if !strings.Contains(err.Error(), "ahead of the loaded version") {
+		t.Fatalf("racing full Load failed with the wrong error: %v", err)
 	}
 	if !hdb2.hasFired() {
 		t.Fatal("test setup: full Load did not read the stamp (hook unfired)")

--- a/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
@@ -18,7 +18,9 @@ package rootmulti_test
 // made deterministic):
 //
 //  1. Immutable store loads use MutableTree.LoadReadonly, which performs NO
-//     fast-index maintenance: the stamp is never read, nothing can write.
+//     fast-index maintenance (never writes). The one stamp read they do make
+//     is getImmutable's advisory snapshot gate, and the view stays
+//     version-correct even when a commit races that read.
 //  2. Even a FULL Load() straddling the commit (stamp ahead of the loaded
 //     version) must NOT rebuild: ensureFastIndex treats stamp > version as
 //     "out-of-contract racing reader or external rewind" and fails loud,

--- a/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
+++ b/tm2/pkg/store/rootmulti/fastindex_stale_rebuild_repro_test.go
@@ -1,0 +1,176 @@
+package rootmulti_test
+
+// Regression tests for https://github.com/gnolang/gno/issues/6011.
+//
+// The original bug chain: gnoland mounts its stores with a dedicated db, so
+// constructStore routed the "immutable" query multistore's store reads (and,
+// via a real writable batch, WRITES) to the LIVE cfg.DB instead of the query
+// snapshot; the query ABCI connection runs concurrently with consensus; and
+// bptree's Store.LoadVersion (Immutable branch) ran ensureFastIndex, whose
+// version-scan (iterator, pre-commit view) and stamp-read (Get, post-commit)
+// could straddle a concurrent commit for block N — misreading the index as
+// stale and silently rebuilding ALL fast-index entries from root@N-1: old
+// values persisted under a stamp that later commits re-validate, served on
+// the consensus read path -> AppHash divergence.
+//
+// Fix layers exercised here, using a hook DB that commits block N at the
+// exact moment the fast-index stamp is first read (the racing interleaving,
+// made deterministic):
+//
+//  1. Immutable store loads use MutableTree.LoadReadonly, which performs NO
+//     fast-index maintenance: the stamp is never read, nothing can write.
+//  2. Even a FULL Load() straddling the commit (stamp ahead of the loaded
+//     version) must NOT rebuild: ensureFastIndex treats stamp > version as
+//     "stale reader" and leaves the index alone.
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	bp "github.com/gnolang/gno/tm2/pkg/bptree"
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+// hookDB delegates to db and runs onStampGet once, the first time the
+// fast-index stamp key is read. It stands in for the consensus drain landing
+// between a query-load's discoverVersions scan and its stamp read. The
+// "fastidx" suffix couples to bptree's unexported metaFastVersionKey; drift
+// is guarded by layer 2's mandatory hasFired assertion below.
+type hookDB struct {
+	dbm.DB
+	mu         sync.Mutex
+	onStampGet func()
+	fired      bool
+}
+
+func (h *hookDB) Get(key []byte) ([]byte, error) {
+	if bytes.HasSuffix(key, []byte("fastidx")) {
+		h.mu.Lock()
+		if !h.fired && h.onStampGet != nil {
+			h.fired = true
+			h.mu.Unlock()
+			h.onStampGet()
+		} else {
+			h.mu.Unlock()
+		}
+	}
+	return h.DB.Get(key)
+}
+
+func (h *hookDB) hasFired() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.fired
+}
+
+func TestFastIndex_NoStaleRebuildOnRacingQueryLoad(t *testing.T) {
+	db, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, t.TempDir())
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	defer db.Close()
+
+	mainKey := types.NewStoreKey("main")
+	ms := rootmulti.NewMultiStore(db)
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.NewPruningOptions(0, 1)})
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	if err := ms.LoadLatestVersion(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer ms.Close() // release the query snapshot before db.Close
+
+	acct := []byte("/a/account-under-test")
+	oldVal := []byte("balance=999999996959000000,seq=226") // written at an early block
+	midVal := []byte("balance=999999996943000000,seq=227") // written at block N (races load 1)
+	newVal := []byte("balance=999999996940000000,seq=228") // written at block N+1 (races load 2)
+
+	commit := func(kvs map[string][]byte) {
+		cms := ms.MultiCacheWrap()
+		st := cms.GetStore(mainKey)
+		for k, v := range kvs {
+			st.Set(nil, []byte(k), v)
+		}
+		cms.MultiWrite()
+		ms.Commit()
+	}
+
+	// Blocks 1..3: establish history; the account's last write lands at block 2.
+	commit(map[string][]byte{"filler-a": []byte("x1")})
+	commit(map[string][]byte{string(acct): oldVal, "filler-b": []byte("x2")})
+	commit(map[string][]byte{"filler-c": []byte("x3")})
+
+	// --- Layer 1: the immutable-store load path must never read (or write)
+	// the fast index. The store is built by hand the way the PRE-fix
+	// constructStore built it — over the LIVE db — which is exactly the
+	// configuration that used to write the poison; post-fix its load must be
+	// maintenance-free regardless of routing.
+	hdb := &hookDB{DB: db}
+	hdb.onStampGet = func() {
+		commit(map[string][]byte{string(acct): midVal, "filler-d": []byte("x4")})
+	}
+	queryStore := storebptree.FastStoreConstructor(
+		dbm.NewPrefixDB(hdb, []byte("s/_/")),
+		types.StoreOptions{Immutable: true},
+	).(*storebptree.Store)
+	if err := queryStore.LoadVersion(2); err != nil {
+		t.Fatalf("query-path LoadVersion: %v", err)
+	}
+	if hdb.hasFired() {
+		t.Fatal("immutable store load read the fast-index stamp: the read-only load performed index maintenance")
+	}
+	// The racing commit never happened (hook unfired) — apply block N now so
+	// the account's authoritative value moves past the fast-index entry.
+	commit(map[string][]byte{string(acct): midVal, "filler-d": []byte("x4")})
+
+	// --- Layer 2: a FULL Load() (maintenance-capable) whose stamp read
+	// straddles the next commit must skip the rebuild (stamp > version), not
+	// rewrite the index from its older root.
+	hdb2 := &hookDB{DB: db}
+	hdb2.onStampGet = func() {
+		commit(map[string][]byte{string(acct): newVal, "filler-e": []byte("x5")})
+	}
+	racingTree := bp.NewMutableTreeWithDB(
+		dbm.NewPrefixDB(hdb2, []byte("s/_/")), 256, bp.NewNopLogger(), bp.FastIndexOption(true))
+	if _, err := racingTree.Load(); err != nil {
+		t.Fatalf("racing full load: %v", err)
+	}
+	if !hdb2.hasFired() {
+		t.Fatal("test setup: full Load did not read the stamp (hook unfired)")
+	}
+
+	// More blocks; the stamp catches back up to latest.
+	commit(map[string][]byte{"filler-f": []byte("x6")})
+	commit(map[string][]byte{"filler-g": []byte("x7")})
+
+	// Audit persisted state from fresh handles, as a restarted node would.
+	pdb := dbm.NewPrefixDB(db, []byte("s/_/"))
+	plain := bp.NewMutableTreeWithDB(pdb, 256, bp.NewNopLogger())
+	if _, err := plain.Load(); err != nil {
+		t.Fatalf("plain load: %v", err)
+	}
+	fast := bp.NewMutableTreeWithDB(pdb, 256, bp.NewNopLogger(), bp.FastIndexOption(true))
+	if _, err := fast.Load(); err != nil {
+		t.Fatalf("fast load: %v", err)
+	}
+
+	walkV, err := plain.Get(acct)
+	if err != nil {
+		t.Fatalf("walk get: %v", err)
+	}
+	fastV, err := fast.Get(acct)
+	if err != nil {
+		t.Fatalf("fast get: %v", err)
+	}
+	if !bytes.Equal(walkV, newVal) {
+		t.Fatalf("tree corrupted: walk=%q want=%q", walkV, newVal)
+	}
+	if !bytes.Equal(fastV, walkV) {
+		t.Fatalf("issue #6011 regressed: fast-index Get returned stale value %q, tree has %q (stale=%v)",
+			fastV, walkV, bytes.Equal(fastV, midVal) || bytes.Equal(fastV, oldVal))
+	}
+}

--- a/tm2/pkg/store/rootmulti/query_snapshot_isolation_test.go
+++ b/tm2/pkg/store/rootmulti/query_snapshot_isolation_test.go
@@ -1,0 +1,79 @@
+package rootmulti_test
+
+// Pins the constructStore snapshot routing (gno#6011 fix layer: immutable
+// query multistores read ms.db — the frozen post-commit snapshot — instead of
+// the live dedicated-db mount): a query view held across commits must keep
+// serving its version even after the LIVE DB prunes it. With live-DB routing
+// the held view's lazy node loads hit pruned records and fail; with snapshot
+// routing they read the frozen state. Deterministic (single-threaded).
+
+import (
+	"fmt"
+	"testing"
+
+	dbm "github.com/gnolang/gno/tm2/pkg/db"
+	_ "github.com/gnolang/gno/tm2/pkg/db/pebbledb"
+	storebptree "github.com/gnolang/gno/tm2/pkg/store/bptree"
+	"github.com/gnolang/gno/tm2/pkg/store/rootmulti"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+func TestQueryView_SnapshotIsolationUnderPruning(t *testing.T) {
+	db, err := dbm.NewDB("gnolang", dbm.PebbleDBBackend, t.TempDir())
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	defer db.Close()
+
+	mainKey := types.NewStoreKey("main")
+	ms := rootmulti.NewMultiStore(db)
+	// Aggressive retention: Store.Commit prunes everything below the previous
+	// version on every commit.
+	ms.SetStoreOptions(types.StoreOptions{PruningOptions: types.NewPruningOptions(1, 0)})
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	if err := ms.LoadLatestVersion(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer ms.Close()
+
+	kname := func(i int) []byte { return fmt.Appendf(nil, "key%04d", i) }
+	const keyspace = 2000
+	commit := func(blk int, from, to int) {
+		cms := ms.MultiCacheWrap()
+		st := cms.GetStore(mainKey)
+		for i := from; i < to; i++ {
+			st.Set(nil, kname(i), fmt.Appendf(nil, "v%d/%d", blk, i))
+		}
+		cms.MultiWrite()
+		ms.Commit()
+	}
+
+	// Blocks 1..5 populate the keyspace; the view is taken at height 5.
+	for blk := 1; blk <= 5; blk++ {
+		commit(blk, (blk-1)*keyspace/5, blk*keyspace/5)
+	}
+	view, release, err := ms.MultiImmutableCacheWrapWithVersion(5)
+	if err != nil {
+		t.Fatalf("view at 5: %v", err)
+	}
+	defer release()
+
+	// Blocks 6..10 overwrite everything; pruning removes the version-5 records
+	// (nodes and orphaned values) from the LIVE DB while the view is held. The
+	// view is deliberately unregistered (long-lived query views must not pin
+	// versions against pruning), so only snapshot isolation protects it.
+	for blk := 6; blk <= 10; blk++ {
+		commit(blk, (blk-6)*keyspace/5, (blk-5)*keyspace/5)
+	}
+
+	st := view.GetStore(mainKey)
+	for i := 0; i < keyspace; i++ {
+		wantBlk := i*5/keyspace + 1 // the block (1..5) that last wrote key i
+		want := fmt.Sprintf("v%d/%d", wantBlk, i)
+		got := st.Get(nil, kname(i)) // panics on pruned nodes under live routing
+		if string(got) != want {
+			t.Fatalf("held view diverged at %q: got %q want %q (snapshot isolation broken)",
+				kname(i), got, want)
+		}
+	}
+}

--- a/tm2/pkg/store/rootmulti/query_snapshot_isolation_test.go
+++ b/tm2/pkg/store/rootmulti/query_snapshot_isolation_test.go
@@ -67,7 +67,7 @@ func TestQueryView_SnapshotIsolationUnderPruning(t *testing.T) {
 	}
 
 	st := view.GetStore(mainKey)
-	for i := 0; i < keyspace; i++ {
+	for i := range keyspace {
 		wantBlk := i*5/keyspace + 1 // the block (1..5) that last wrote key i
 		want := fmt.Sprintf("v%d/%d", wantBlk, i)
 		got := st.Get(nil, kname(i)) // panics on pruned nodes under live routing

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -263,10 +263,17 @@ func (ms *multiStore) Commit() types.CommitID {
 	commitInfo := commitStores(version, ms.stores)
 
 	// Feed metadata into the same collector as IAVL/dbadapter writes so a
-	// single drain covers all four write sites.
+	// single drain covers all four write sites. The Write() must precede
+	// Drain: batch ops enter the collector only on Write, and metadata that
+	// missed this drain would persist a block late (store data at N with
+	// commitInfo at N-1 after a crash).
 	metaBatch := ms.collector.NewBatch()
+	defer metaBatch.Close()
 	setCommitInfo(metaBatch, version, commitInfo)
 	setLatestVersion(metaBatch, version)
+	if err := metaBatch.Write(); err != nil {
+		panic("rootmulti: Commit() metadata write failed: " + err.Error())
+	}
 
 	// Drain the collector into a real batch and flush atomically.
 	realBatch := ms.db.NewBatch()

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -65,7 +65,8 @@ type multiStore struct {
 	initialVersion int64
 
 	// querySnapshot holds the last fully-committed DB snapshot.
-	// It is swapped atomically by Commit() and read by query paths.
+	// It is swapped atomically by Commit() and LoadVersion() (via
+	// refreshQuerySnapshot) and read by query paths.
 	querySnapshot atomic.Pointer[refSnapshot]
 
 	// collector accumulates every sub-store write (dbadapter cache flush, IAVL
@@ -91,9 +92,10 @@ type multiStore struct {
 	//   rs.snap.Get(...)         ← use-after-free / panic
 	//
 	// snapshotMu prevents this: MultiImmutableCacheWrapWithVersion holds it
-	// as an RLock around Load+acquire, and Commit() holds it as a write-lock
-	// around Swap+release. Because the write-lock excludes all RLocks, no
-	// release() can reach zero while a Load+acquire is in progress.
+	// as an RLock around Load+acquire, and refreshQuerySnapshot (Commit /
+	// LoadVersion) holds it as a write-lock around Swap+release. Because the
+	// write-lock excludes all RLocks, no release() can reach zero while a
+	// Load+acquire is in progress.
 	snapshotMu sync.RWMutex
 }
 
@@ -183,6 +185,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 		}
 		ms.stores = newStores
 		ms.lastCommitID = types.CommitID{}
+		ms.refreshQuerySnapshot()
 		return nil
 	}
 
@@ -224,6 +227,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 
 	ms.lastCommitID = cInfo.CommitID()
 	ms.stores = newStores
+	ms.refreshQuerySnapshot()
 
 	return nil
 }
@@ -276,6 +280,29 @@ func (ms *multiStore) Commit() types.CommitID {
 
 	// Take a fresh snapshot of the now-consistent DB state.
 	// Queries will read from this until the next Commit.
+	ms.refreshQuerySnapshot()
+
+	// Prepare for next version.
+	commitID := types.CommitID{
+		Version: version,
+		Hash:    commitInfo.Hash(),
+	}
+	ms.lastCommitID = commitID
+	return commitID
+}
+
+// refreshQuerySnapshot replaces querySnapshot with a fresh snapshot of the
+// current DB state, releasing the previous one. Called by Commit after the
+// atomic WriteSync, and by LoadVersion so a restarted node has snapshot
+// isolation for queries BEFORE its first commit (otherwise queries would fall
+// back to reading the live DB until the first block lands). No-op on immutable
+// multiStores (their ms.db is already a frozen view) and on backends without
+// snapshot support (queries there fall back to an ImmutableDB over the live
+// DB: unisolated reads, but write-proof).
+func (ms *multiStore) refreshQuerySnapshot() {
+	if ms.storeOpts.Immutable {
+		return
+	}
 	if snap, err := ms.db.NewSnapshot(); err == nil {
 		rs := newRefSnapshot(snap)
 		ms.snapshotMu.Lock()
@@ -285,14 +312,6 @@ func (ms *multiStore) Commit() types.CommitID {
 		}
 		ms.snapshotMu.Unlock()
 	}
-
-	// Prepare for next version.
-	commitID := types.CommitID{
-		Version: version,
-		Hash:    commitInfo.Hash(),
-	}
-	ms.lastCommitID = commitID
-	return commitID
 }
 
 // QuerySnapshot returns the current read-only DB snapshot representing the last
@@ -514,6 +533,22 @@ func (ms *multiStore) constructStore(params storeParams) (store types.CommitStor
 	} else {
 		raw = ms.db
 		prefix = []byte("s/k:" + params.key.Name() + "/")
+	}
+
+	// Immutable multiStores (query views built by MultiImmutableCacheWrapWithVersion)
+	// must read the frozen post-commit view in ms.db (SnapshotDB, or ImmutableDB
+	// on backends without snapshots) — NEVER params.db, which is the LIVE handle
+	// captured at mount time. Routing queries to the live DB let them race the
+	// consensus commit, and (via bptree's fast-index maintenance on load) WRITE
+	// to it — the gno#6011 index poisoning. CONSTRAINT: a dedicated params.db
+	// must be the same physical DB as the multistore's (true for every in-repo
+	// mount, which passes the app DB for both). A genuinely separate store DB
+	// would not be covered by the snapshot: merkleized stores (bptree/iavl)
+	// fail loudly at LoadVersion's commit-id check, but a dbadapter mount
+	// (constant zero CommitID) would silently serve an empty view — do not
+	// mount separate physical DBs.
+	if ms.storeOpts.Immutable {
+		raw = ms.db
 	}
 
 	// On the live multiStore, route sub-store writes through a CollectingDB so

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -137,6 +137,14 @@ func (ms *multiStore) MountStoreWithDB(key types.StoreKey, cons types.CommitStor
 	if key == nil {
 		panic("MountIAVLStore() key cannot be nil")
 	}
+	// A non-nil db must be the multistore's own DB. Sub-store writes drain
+	// through ms.collector into ms.db regardless of params.db (a separate DB
+	// would silently receive no writes), and immutable query views are routed
+	// to ms.db's snapshot in constructStore (a separate DB would misroute
+	// reads). Enforce the invariant the rest of the layer relies on.
+	if db != nil && db != ms.db {
+		panic("rootmulti: mounted DB must be nil or the root DB")
+	}
 	if _, ok := ms.storesParams[key]; ok {
 		panic(fmt.Sprintf("Store duplicate store key %v", key))
 	}
@@ -596,12 +604,9 @@ func (ms *multiStore) constructStore(params storeParams) (store types.CommitStor
 	// captured at mount time. Routing queries to the live DB let them race the
 	// consensus commit, and (via bptree's fast-index maintenance on load) WRITE
 	// to it — the gno#6011 index poisoning. CONSTRAINT: a dedicated params.db
-	// must be the same physical DB as the multistore's (true for every in-repo
-	// mount, which passes the app DB for both). A genuinely separate store DB
-	// would not be covered by the snapshot: merkleized stores (bptree/iavl)
-	// fail loudly at LoadVersion's commit-id check, but a dbadapter mount
-	// (constant zero CommitID) would silently serve an empty view — do not
-	// mount separate physical DBs.
+	// must be the same physical DB as the multistore's — enforced at mount time
+	// (MountStoreWithDB panics otherwise), so this reroute is always addressing
+	// the same DB the writes drained into.
 	if ms.storeOpts.Immutable {
 		raw = ms.db
 	}

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -91,7 +91,7 @@ type multiStore struct {
 	//   rs.acquire()             (snapshot already closed!)
 	//   rs.snap.Get(...)         ← use-after-free / panic
 	//
-	// snapshotMu prevents this: MultiImmutableCacheWrapWithVersion holds it
+	// snapshotMu prevents this: immutableAtVersion (the query paths) holds it
 	// as an RLock around Load+acquire, and refreshQuerySnapshot (Commit /
 	// LoadVersion) holds it as a write-lock around Swap+release. Because the
 	// write-lock excludes all RLocks, no release() can reach zero while a
@@ -102,6 +102,7 @@ type multiStore struct {
 var (
 	_ types.CommitMultiStore = (*multiStore)(nil)
 	_ types.Queryable        = (*multiStore)(nil)
+	_ types.ImmutableQueryer = (*multiStore)(nil)
 )
 
 func NewMultiStore(db dbm.DB) *multiStore {
@@ -383,8 +384,12 @@ func (ms *multiStore) MultiWrite() {
 	panic("unexpected .MultiWrite() on rootmulti.Store. Commit()?")
 }
 
-// Implements CommitMultiStore.
-func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.MultiStore, func(), error) {
+// immutableAtVersion builds a read-only multiStore over the frozen post-commit
+// query snapshot (or an ImmutableDB over the live DB on backends without
+// snapshot support), loaded at version. The returned release func MUST be
+// called when done — it drops the snapshot reference that blocks Commit from
+// closing the snapshot mid-read.
+func (ms *multiStore) immutableAtVersion(version int64) (*multiStore, func(), error) {
 	var db dbm.DB
 	var release func()
 
@@ -398,7 +403,8 @@ func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.M
 		db = dbm.NewSnapshotDB(rs.snap)
 	} else {
 		// Backend doesn't support snapshots (e.g. non-PebbleDB in tests).
-		// Fall back to ImmutableDB over the live DB — same behaviour as before.
+		// Fall back to ImmutableDB over the live DB — unisolated reads, but
+		// write-proof (read-only no-op batches).
 		release = func() {}
 		db = dbm.NewImmutableDB(ms.db)
 	}
@@ -416,12 +422,41 @@ func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.M
 		release() // don't leak the snapshot ref on error
 		return nil, nil, err
 	}
+	return ims, release, nil
+}
 
+// Implements CommitMultiStore.
+func (ms *multiStore) MultiImmutableCacheWrapWithVersion(version int64) (types.MultiStore, func(), error) {
+	ims, release, err := ms.immutableAtVersion(version)
+	if err != nil {
+		return nil, nil, err
+	}
 	stores := make(map[types.StoreKey]types.Store, len(ims.stores))
 	for storeKey, store := range ims.stores {
 		stores[storeKey] = immut.New(store)
 	}
 	return cachemulti.New(stores, ims.keysByName), release, nil
+}
+
+// QueryImmutable serves an ABCI store query from the frozen post-commit
+// snapshot at req.Height — the same isolation MultiImmutableCacheWrapWithVersion
+// gives custom queries — so .store queries on the concurrent query connection
+// never read live mutable store state. A non-nil error means no snapshot view
+// could be built for that height (height <= 0 pre-first-commit, pruned
+// heights); the caller is expected to fall back to the legacy live-query path,
+// preserving the existing response surface for those corners.
+func (ms *multiStore) QueryImmutable(req abci.RequestQuery) (abci.ResponseQuery, error) {
+	if req.Height <= 0 {
+		// No committed state to snapshot (and LoadVersion(0) would silently
+		// serve empty stores rather than the legacy height-resolution).
+		return abci.ResponseQuery{}, fmt.Errorf("no committed state at height %d", req.Height)
+	}
+	ims, release, err := ms.immutableAtVersion(req.Height)
+	if err != nil {
+		return abci.ResponseQuery{}, err
+	}
+	defer release()
+	return ims.Query(req), nil
 }
 
 // Implements MultiStore.

--- a/tm2/pkg/store/rootmulti/store.go
+++ b/tm2/pkg/store/rootmulti/store.go
@@ -50,8 +50,12 @@ func (rs *refSnapshot) release() {
 // cacheMultiStore which is for cache-wrapping other MultiStores. It implements
 // the CommitMultiStore interface.
 type multiStore struct {
-	db           dbm.DB
-	lastCommitID types.CommitID
+	db dbm.DB
+	// lastCommitID is written by Commit/LoadVersion (consensus and startup)
+	// and read by LastCommitID, which query handlers call per request on the
+	// CONCURRENT query connection (BaseApp.LastBlockHeight) — hence atomic.
+	// The stored CommitID is immutable once published.
+	lastCommitID atomic.Pointer[types.CommitID]
 	storeOpts    types.StoreOptions
 	storesParams map[types.StoreKey]storeParams
 	stores       map[types.StoreKey]types.CommitStore
@@ -185,7 +189,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 			newStores[key] = store
 		}
 		ms.stores = newStores
-		ms.lastCommitID = types.CommitID{}
+		ms.setLastCommitID(types.CommitID{})
 		ms.refreshQuerySnapshot()
 		return nil
 	}
@@ -226,7 +230,7 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 		newStores[key] = store
 	}
 
-	ms.lastCommitID = cInfo.CommitID()
+	ms.setLastCommitID(cInfo.CommitID())
 	ms.stores = newStores
 	ms.refreshQuerySnapshot()
 
@@ -238,7 +242,16 @@ func (ms *multiStore) LoadVersion(ver int64) error {
 
 // Implements Committer/CommitStore.
 func (ms *multiStore) LastCommitID() types.CommitID {
-	return ms.lastCommitID
+	if cid := ms.lastCommitID.Load(); cid != nil {
+		return *cid
+	}
+	return types.CommitID{}
+}
+
+// setLastCommitID publishes the commit id read by the concurrent query
+// connection. cid's Hash must not be mutated after publication.
+func (ms *multiStore) setLastCommitID(cid types.CommitID) {
+	ms.lastCommitID.Store(&cid)
 }
 
 // Implements Committer/CommitStore.
@@ -256,10 +269,10 @@ func (ms *multiStore) Commit() types.CommitID {
 	// must land at the chain's InitialHeight so multistore version equals
 	// real chain height. Subsequent commits auto-increment.
 	var version int64
-	if ms.lastCommitID.Version == 0 && ms.initialVersion > 0 {
+	if last := ms.LastCommitID(); last.Version == 0 && ms.initialVersion > 0 {
 		version = ms.initialVersion
 	} else {
-		version = ms.lastCommitID.Version + 1
+		version = last.Version + 1
 	}
 	commitInfo := commitStores(version, ms.stores)
 
@@ -295,7 +308,7 @@ func (ms *multiStore) Commit() types.CommitID {
 		Version: version,
 		Hash:    commitInfo.Hash(),
 	}
-	ms.lastCommitID = commitID
+	ms.setLastCommitID(commitID)
 	return commitID
 }
 

--- a/tm2/pkg/store/rootmulti/store_test.go
+++ b/tm2/pkg/store/rootmulti/store_test.go
@@ -468,7 +468,7 @@ func TestCommitAtomicBatchWithCacheFlush(t *testing.T) {
 	// batch actually carried IAVL nodes AND rootmulti metadata to persistence.
 	reload := newMultiStoreWithMounts(db)
 	require.NoError(t, reload.LoadLatestVersion())
-	require.Equal(t, cid.Version, reload.lastCommitID.Version)
+	require.Equal(t, cid.Version, reload.LastCommitID().Version)
 	require.Equal(t, []byte("v1"),
 		reload.getStoreByName("store1").Get(nil, []byte("k1")))
 	require.Equal(t, []byte("v2"),

--- a/tm2/pkg/store/rootmulti/store_test.go
+++ b/tm2/pkg/store/rootmulti/store_test.go
@@ -43,6 +43,25 @@ func TestStoreMount(t *testing.T) {
 	require.Panics(t, func() { store.MountStoreWithDB(dup1, iavl.StoreConstructor, db) })
 }
 
+// TestStoreMountRejectsSeparateDB ensures dedicated mounts cannot bypass the
+// root DB's atomic commit and query-snapshot boundary: a non-nil mount DB must
+// be the multistore's own DB (writes drain into ms.db; immutable query views
+// are routed to ms.db's snapshot).
+func TestStoreMountRejectsSeparateDB(t *testing.T) {
+	t.Parallel()
+
+	rootDB := memdb.NewMemDB()
+	store := NewMultiStore(rootDB)
+
+	require.Panics(t, func() {
+		store.MountStoreWithDB(
+			types.NewStoreKey("separate"),
+			iavl.StoreConstructor,
+			memdb.NewMemDB(),
+		)
+	})
+}
+
 func TestCacheMultiStoreWithVersion(t *testing.T) {
 	t.Parallel()
 

--- a/tm2/pkg/store/types/store.go
+++ b/tm2/pkg/store/types/store.go
@@ -58,6 +58,15 @@ type Queryable interface {
 	Query(abci.RequestQuery) abci.ResponseQuery
 }
 
+// ImmutableQueryer is the optional capability of serving a store query from a
+// frozen post-commit snapshot, so queries running concurrently with commits
+// (the query ABCI connection has its own mutex) never read live mutable store
+// state. A non-nil error means no snapshot view exists for req.Height (e.g.
+// pre-first-commit, pruned height); callers fall back to Queryable.
+type ImmutableQueryer interface {
+	QueryImmutable(req abci.RequestQuery) (abci.ResponseQuery, error)
+}
+
 // Useful for debugging.
 type Printer interface {
 	Print()

--- a/tm2/pkg/store/types/store.go
+++ b/tm2/pkg/store/types/store.go
@@ -148,6 +148,9 @@ type CommitMultiStore interface {
 
 	// Mount a store of type using the given db.
 	// If db == nil, the new store will use the CommitMultiStore db.
+	// A non-nil db MUST be the same physical DB as the CommitMultiStore's:
+	// query snapshots cover only that DB, so a separate one would be invisible
+	// to snapshot-isolated reads (see rootmulti constructStore).
 	MountStoreWithDB(key StoreKey, cons CommitStoreConstructor, db dbm.DB)
 
 	// Panics on a nil key.

--- a/tm2/pkg/store/types/store.go
+++ b/tm2/pkg/store/types/store.go
@@ -157,9 +157,10 @@ type CommitMultiStore interface {
 
 	// Mount a store of type using the given db.
 	// If db == nil, the new store will use the CommitMultiStore db.
-	// A non-nil db MUST be the same physical DB as the CommitMultiStore's:
-	// query snapshots cover only that DB, so a separate one would be invisible
-	// to snapshot-isolated reads (see rootmulti constructStore).
+	// A non-nil db MUST be the same physical DB as the CommitMultiStore's —
+	// ENFORCED (MountStoreWithDB panics otherwise): query snapshots cover only
+	// that DB, so a separate one would be invisible to snapshot-isolated reads
+	// (see rootmulti constructStore).
 	MountStoreWithDB(key StoreKey, cons CommitStoreConstructor, db dbm.DB)
 
 	// Panics on a nil key.


### PR DESCRIPTION
Fixes #6011.

## What happened

A topaz-1 node rejected the proposal for block 227783 with an AppHash mismatch: its persisted bptree fast-index entry for one account held the block-224859 value (sequence 226) while the authoritative tree carried the block-227773 update (sequence 227), under a stamp claiming currency at 227782. The stale entry was served by `MutableTree.Get`'s clean-working-tree fast path (#5937) during block execution.

## Root cause (reproduced deterministically and under natural concurrency)

Four interacting gaps — full analysis in `tm2/adr/prxxxx_fastindex_snapshot_isolation.md`:

1. **Snapshot bypass**: `rootmulti.constructStore` routed dedicated-db mounts (gno.land mounts both stores with `cfg.DB`) to the **live** DB even for the "immutable" query multistore — the query snapshot only covered rootmulti metadata.
2. **Concurrent queries**: the query ABCI connection has its own mutex (#5431), so query loads race the consensus commit drain.
3. **Write-capable query loads**: immutable multistores skip the CollectingDB wrap, so the throwaway query store held a real writable batch, and its `Load()` ran `ensureFastIndex()` — a maintenance path that can write.
4. **Load TOCTOU**: `Load()` reads "latest" via an iterator (pre-commit view) and the stamp via a later `Get`; a commit landing in between made the query conclude the index was stale and silently rebuild **the entire live fast index from the previous block's root** — old values under a stamp later commits re-validate. Keys updated in the raced block and never touched again stayed poisoned; the incident account was one.

## The fix (layered — any of the first three stops the incident)

1. `bptree.MutableTree.LoadReadonly`: immutable store loads perform **no index maintenance** (fast *reads* keep working).
2. `ensureFastIndex` stale-reader guard: a stamp **ahead** of the loaded version fails loud (rebuilding from an older root is exactly the poisoning; a warn would be invisible — production constructors use a nop logger); stamp behind/missing still rebuilds.
3. `rootmulti.constructStore`: immutable multistores read `ms.db` — the frozen post-commit snapshot — plus companions: `ImmutableDB` returns a usable read-only no-op batch (was `nil`), and `LoadVersion` seeds the query snapshot so restarted nodes are isolated before their first commit.
4. `.store` queries served from the snapshot via `rootmulti.QueryImmutable` (`types.ImmutableQueryer`, compile-time pinned), with the legacy live path as fallback for pre-commit/pruned heights.

## Adjacent bugs found and fixed during the investigation

- `CollectingDB` batches forwarded ops at `Set` time with no-op `Write`/`Close` — bptree's `DiscardBatch` discarded nothing under production wiring. Batches now buffer locally; `Close` discards; `rootmulti.Commit` writes its metadata batch **before** the drain (load-bearing).
- `clearFastIndex` looped forever clearing ≥65,536 entries under CollectingDB (iterator blind to pending deletes); chunks now resume after the last staged key. `Import → dropFastIndex` inherits the fix.
- `BaseApp.LastBlockHeight` read `ms.lastCommitID` unsynchronized on the query connection — now an atomic pointer.
- Per-query store construction ran the O(retained-versions) `discoverVersions` scan **twice** (~200 ms/query measured at default syncable retention, 705,600 roots); deduplicated — halves every query path's construction cost vs master. O(1) immutable loads noted as follow-up.

## Tests (each fix has a revert-verified failing guard)

All were run against unfixed master: the natural-concurrency repro persists 120–1,690 stale entries per run; the deterministic hook repro fails at the maintenance assertion; the clear-loop test times out at 66M staged ops; the held-query-view test panics on pruned nodes; the batch/nil-batch unit tests fail on the old semantics. The new **full-app regression** (`gno.land/pkg/gnoland/app_query_race_test.go`) drives the real app through the real ABCI proxy topology (consensus connection commits signed sends while goroutines hammer the read-only query connection) with a deterministic stamp-read hook: on master the hook fires (and, with that trip-wire bypassed for demonstration, the audit reports 3 persisted stale entries — two `/a/` account keys, the incident's exact shape); on this branch the hook never fires and the parity audit is clean, including under `-race`. Everything runs in `make test` and CI (no `-short` there).

## Reviewer notes

- Commit-by-commit review recommended: 14 commits, one concern each, individually green, in dependency order.
- Layer 2's disposition intentionally changes mid-stack: introduced as warn-and-skip, upgraded to fail-loud once review established the query path can no longer reach it and a nop-logger warning gives operators zero signal.
- Historical footnote for `contribs/gnogenesis` and one gnoland test: anything loading a rootmulti over pebble must now release it (`Close`) before closing the DB (the seeded query snapshot).

## Rollout note

The fix prevents new poisoning but cannot detect **existing** poison (its stamp claims currency). Nodes that ran the buggy build with the fast index enabled should either delete the fast-index stamp (`s/_/M` ‖ `fastidx` in the app DB) to force a rebuild at next start, or resync. Any external rollback tooling must delete the stamp; a rewound DB now refuses to boot with a clear error instead of booting into silent divergence.

## Follow-ups (not in this PR)

- O(1) immutable store loads (skip version discovery when the requested version is known).
- Pre-existing `tm2/pkg/db` `TestDBIterator` failure under `-race` on master and this branch alike (pebble 1.1.5 internals) — separate issue.
- Read isolation for non-snapshot backends (goleveldb/bolt/lmdb/mdbx keep unisolated-but-write-proof query reads; pebble, the default, gets full isolation).

## Files

**Core fixes** — `tm2/pkg/bptree/{fast_index,mutable_tree}.go`, `tm2/pkg/db/{collecting,immutable,snapshot_db,types}.go`, `tm2/pkg/store/bptree/store.go`, `tm2/pkg/store/rootmulti/store.go`, `tm2/pkg/store/{types/store,exports}.go`, `tm2/pkg/sdk/baseapp.go`.
**Companions** — `contribs/gnogenesis/internal/fork/source_txs_data_dir.go`, `gno.land/pkg/gnoland/app_test.go` (multistore lifecycle), `tm2/pkg/store/rootmulti/store_test.go` (field → accessor).
**Tests (new)** — `gno.land/pkg/gnoland/app_query_race_test.go`; `tm2/pkg/db/{collecting,immutable}_test.go`; `tm2/pkg/store/rootmulti/fastindex_{stale_rebuild,natural_race,concurrent,clear_hang,pipeline}_repro_test.go`, `fastindex_helpers_test.go`, `query_snapshot_isolation_test.go`.
**Docs** — `tm2/adr/prxxxx_fastindex_snapshot_isolation.md` (rename to `pr<number>_…` once this PR has a number).

---

Developed with AI assistance (Claude); analysis, fixes, and tests were driven through repeated adversarial review rounds, and all suites (including `gno.land` integration and `-race` runs) pass.
