### PR TITLE
docs: add a "Running a node" routing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Explore Gno through our comprehensive documentation:
   understand the Gno language, and deploy your applications  
 - **[Reference](./docs#reference)** - Technical specifications, best 
   practices, and advanced topics
+- **[Running a node](./docs/builders/running-a-node.md)** - Start here if you were 
+  about to run one — most use cases don't need it
 
 Visit [gno.land](https://gno.land) to see live smart contracts in action.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Gno-specific features, connect to Gno apps with clients, and more.
 - [Tutorial: `minisocial` dApp](builders/tutorial-minisocial.md) - Build a complete social media application while learning the full local development workflow for Gno packages.
 - [RPC clients](builders/rpc-clients.md) - Discover how to connect external applications to Gno.land networks using both Go and JavaScript clients.
 - [Contributor guide](builders/contributor-guide.md) - Learn what makes a great Gno.land contributor and how to showcase your work in the ecosystem.
+- [Running a node](builders/running-a-node.md) - Start here if you were about to run a node: most use cases don't need one. Routes you to `gnodev`, public RPC, a full node, a validator, or a local chain.
 
 ## References
 

--- a/docs/builders/running-a-node.md
+++ b/docs/builders/running-a-node.md
@@ -1,0 +1,87 @@
+# Running a node
+
+Usually you don't need to. Running a node is an infrastructure job, and
+most of what people want one for is already covered by a tool — or a
+public endpoint — that needs no node at all.
+
+So before anything else, name what you're actually trying to do:
+
+| I want to…                                          | What you actually need           | Where to go                                                     |
+|-----------------------------------------------------|----------------------------------|-----------------------------------------------------------------|
+| Write, test, and debug contracts                    | `gnodev`, or a current testnet   | [Develop contracts](#develop-contracts)                         |
+| Read chain state, or build an app on top of a chain  | A public RPC endpoint, or an indexer | [Read a chain](#read-a-chain)                               |
+| My own synced, low-latency copy of a public network  | A full node                      | [Join a network as a full node](#join-a-network-as-a-full-node)  |
+| Sign blocks on a public network                     | A validator node                 | [Become a validator](#become-a-validator)                       |
+| Learn how a Gno chain works, or just for fun        | A throwaway local chain          | [Run a chain locally](#run-a-chain-locally)                     |
+
+## Develop contracts
+
+No node needed. [`gnodev`](../resources/gnodev.md) boots a local devnet
+with hot reload, pre-funded accounts, and a built-in web UI — a faster
+loop than any real chain. `gno test` runs your tests with no chain at
+all, and the [Playground](https://play.gno.land) runs Gno in your
+browser with nothing installed.
+
+When you want your code on a shared chain, deploy to a current testnet
+rather than operating your own — see
+[Networks](../resources/gnoland-networks.md).
+
+Start with [Getting started](./getting-started.md), or
+[Quick Start](./quickstart.md) if you already know Go.
+
+## Read a chain
+
+No node needed. Every network exposes a public RPC endpoint — see
+[Networks](../resources/gnoland-networks.md) — and
+[`tx-indexer`](https://github.com/gnolang/tx-indexer) serves indexed
+history over GraphQL for the queries an RPC node can't answer
+efficiently.
+
+- [RPC clients](./rpc-clients.md) — Go and JavaScript clients.
+- [Ways to interact with Gno.land](../resources/comparison-of-ways-to-interact-with-gnoland.md)
+  — pick the right client for your language and platform.
+
+Run your own node for this only if you need the state locally: heavy
+read traffic, custom indexing, or archival history.
+
+## Join a network as a full node
+
+A full node syncs a public network's blocks without taking part in
+consensus. Each network pins its own binary, genesis file, and peer
+list, so the instructions live with the network:
+[Networks → deployment files](../resources/gnoland-networks.md#deployment-files).
+
+:::warning
+Don't point a `master` build at a released network. Chains run pinned
+releases; a node built from `master` will not reach consensus with them.
+:::
+
+## Become a validator
+
+Start from the full-node setup above, then register as a validator
+candidate — getting into the set is a governance decision, not a config
+change: the network's DAO votes candidates in.
+
+- Per-network instructions live next to that network's
+  [deployment files](../resources/gnoland-networks.md#deployment-files),
+  as `README.md` or `VALIDATOR.md`.
+- [Signing with TMKMS](../validators/tmkms.md) — keep validator keys off
+  the node.
+- Sentry architectures and other operator guides: [gnops.io](https://gnops.io).
+
+New networks and their validator onboarding are announced on
+[Discord](https://discord.gg/YFtMjWwUN7).
+
+## Run a chain locally
+
+Here a node is the point: no network to join, no genesis to fetch — just
+`gnoland` running a single-validator chain you can break. See
+[`gno.land/cmd/gnoland`](https://github.com/gnolang/gno/tree/master/gno.land/cmd/gnoland).
+
+Install the binary with the `--full` flag of the
+[one-line installer](./install.md).
+
+## Still not sure?
+
+Ask on [Discord](https://discord.gg/YFtMjWwUN7). Say what you're trying
+to build; someone will tell you whether a node is part of the answer.

--- a/docs/resources/gnoland-networks.md
+++ b/docs/resources/gnoland-networks.md
@@ -2,11 +2,11 @@
 
 ## Network configurations
 
-| Network           | RPC Endpoint                             |  Chain ID    |
-|-------------------|------------------------------------------|--------------|
-| Betanet (current) | https://rpc.gno.land:443                 | `gnoland1`   |
-| Staging           | https://rpc.staging.gno.land:443         | `staging`    |
-| Topaz / Test14    | https://rpc.topaz.testnets.gno.land:443  | `topaz-1`    |
+| Network           | RPC Endpoint                             |  Chain ID    | Deployment files |
+|-------------------|------------------------------------------|--------------|------------------|
+| Betanet (current) | https://rpc.gno.land:443                 | `gnoland1`   | [`misc/deployments/gnoland1`](https://github.com/gnolang/gno/tree/chain/gnoland1/misc/deployments/gnoland1) |
+| Staging           | https://rpc.staging.gno.land:443         | `staging`    | [`misc/loop`](https://github.com/gnolang/gno/tree/master/misc/loop) |
+| Topaz / Test14    | https://rpc.topaz.testnets.gno.land:443  | `topaz-1`    | [`misc/deployments/topaz.gno.land`](https://github.com/gnolang/gno/tree/chain/topaz/misc/deployments/topaz.gno.land) |
 
 ### WebSocket endpoints
 
@@ -15,6 +15,35 @@ All networks follow the same pattern for websocket connections:
 ```shell
 wss://<rpc-endpoint:port>/websocket
 ```
+
+### Deployment files
+
+If you intend to [run a node](../builders/running-a-node.md) — a full node
+or a validator — the operational details you need are not in this page.
+They live with the network itself, under
+[`misc/deployments/`](https://github.com/gnolang/gno/tree/master/misc/deployments)
+in the monorepo: one directory per network, holding its `config.toml`,
+its genesis (or the script that regenerates it), and a `README.md` /
+`VALIDATOR.md` with the join instructions.
+
+Two conventions to know:
+
+- A network's directory sits on that network's **`chain/<name>` branch**,
+  not on `master` — that's the branch the chain's release is cut from. The
+  `master` copy is where the next network is prepared, plus the archives of
+  past ones.
+- Release artifacts — binaries, container images, `genesis.json` and its
+  checksum — are attached to the matching
+  [release tag](https://github.com/gnolang/gno/releases).
+
+Related infrastructure directories in the monorepo:
+
+| Directory | What it is |
+|-----------|------------|
+| [`misc/deployments`](https://github.com/gnolang/gno/tree/master/misc/deployments) | Per-network genesis, config, and node/validator instructions |
+| [`misc/loop`](https://github.com/gnolang/gno/tree/master/misc/loop) | Infrastructure running the Staging chain |
+| [`contribs/tx-archive`](https://github.com/gnolang/gno/tree/master/contribs/tx-archive) | Archiving and replaying transaction history between networks |
+| [`gnolang/tx-exports`](https://github.com/gnolang/tx-exports) | Archived transaction data of past testnets |
 
 ## Staging Environments
 

--- a/misc/docs/sidebar.json
+++ b/misc/docs/sidebar.json
@@ -25,7 +25,8 @@
           "builders/editor-setup",
           "builders/tutorial-minisocial",
           "builders/rpc-clients",
-          "builders/contributor-guide"
+          "builders/contributor-guide",
+          "builders/running-a-node"
         ]
       },
       {


### PR DESCRIPTION
## Why

A recurring pattern in Discord/Telegram: someone asks how to run a node, and it takes a few round-trips to find out they wanted `gnodev`, or a public RPC endpoint, or nothing at all. There is no page that challenges the premise first, so the default answer is a link to a validator guide — which is usually the wrong one.

## What

A short routing page, `docs/builders/running-a-node.md`, added as the last item of **Build on Gno.land**. It starts by asking *why*, then dispatches:

| I want to… | What you actually need |
|---|---|
| Write, test, and debug contracts | `gnodev`, or a current testnet |
| Read chain state, or build an app on top of a chain | A public RPC endpoint, or an indexer |
| My own synced, low-latency copy of a public network | A full node |
| Sign blocks on a public network | A validator node |
| Learn how a Gno chain works, or just for fun | A throwaway local chain |

Each section is a few lines and links out to existing docs — no new content that can drift: `gnodev`, Getting started / Quick Start, Networks, RPC clients, ways-to-interact, TMKMS, `gno.land/cmd/gnoland`, gnops.io, Discord. Two of the five answers say "no node needed" up front.

The intent is that this becomes the single link to hand someone who asks, so it stays deliberately short.

## Also

`docs/resources/gnoland-networks.md` gains a **Deployment files** column and a `Deployment files` section, because that page was the natural place to route node operators to and did not mention `misc/deployments/` at all. The section documents the convention (a network's directory lives on its `chain/<name>` branch; release artifacts hang off the matching tag) and indexes the infra directories: `misc/deployments`, `misc/loop`, `contribs/tx-archive`, `gnolang/tx-exports`.

Note the Betanet row points at `chain/gnoland1`, not `master`: the `master` copy of `misc/deployments/gnoland1` is behind the chain branch (missing the `govdao-scripts/`, among others), so linking `master` would send operators to a stale copy.

## Contributors checklist

- [x] Added new tests, or not needed, or not feasible — docs only
- [x] Provided an example (screenshot, gif, text output) — see the table above
- [x] Updated the official documentation or not needed — this *is* the documentation change
- [x] No breaking changes were made, or otherwise explained
- [x] Updated the changelog file, or not needed — docs only