### PR TITLE
chore(ci): don't run heavy workflows on documentation-only pull requests

### DIFF
--- a/.github/workflows/ci-dir-contribs.yml
+++ b/.github/workflows/ci-dir-contribs.yml
@@ -13,6 +13,11 @@ on:
       - gnovm/**
       - tm2/**
       - .github/workflows/ci-dir-contribs.yml
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - gnovm/stdlibs/**/*.md
 
   workflow_dispatch:
 

--- a/.github/workflows/ci-dir-examples.yml
+++ b/.github/workflows/ci-dir-examples.yml
@@ -11,6 +11,13 @@ on:
       - misc/deployments/**
       - contribs/gnogenesis/**
       - .github/workflows/ci-dir-examples.yml
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns)
+      # and is therefore linted/tested here.
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - examples/**/*.md
+      - gnovm/stdlibs/**/*.md
   workflow_dispatch:
     inputs:
       debug:

--- a/.github/workflows/ci-dir-gnoland.yml
+++ b/.github/workflows/ci-dir-gnoland.yml
@@ -12,6 +12,12 @@ on:
       - examples/**
       - go.mod
       - .github/workflows/ci-dir-gnoland.yml
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - examples/**/*.md
+      - gnovm/stdlibs/**/*.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-dir-gnovm.yml
+++ b/.github/workflows/ci-dir-gnovm.yml
@@ -13,6 +13,12 @@ on:
       # since this can affect test results
       - go.mod
       - .github/workflows/ci-dir-gnovm.yml
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - examples/**/*.md
+      - gnovm/stdlibs/**/*.md
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-dir-misc.yml
+++ b/.github/workflows/ci-dir-misc.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - misc/**
       - .github/workflows/ci-dir-misc.yml
+      # This only runs `go test` on the Go programs under misc/, so every
+      # *.md under it is prose (misc/deployments/, misc/val-scenarios/, ...).
+      - '!**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-dir-tm2.yml
+++ b/.github/workflows/ci-dir-tm2.yml
@@ -11,6 +11,8 @@ on:
       # since this can affect test results
       - go.mod
       - .github/workflows/ci-dir-tm2.yml
+      # tm2 holds no gno source, so every *.md under it is prose.
+      - '!**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,10 +1,27 @@
 name: ci / e2e
 
 on:
+  # No path filter on push: master always gets the full suite.
   push:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+    paths:
+      - .github/workflows/ci-e2e.yml
+      - misc/e2e/**
+      - Dockerfile
+      - gno.land/**
+      - gnovm/**
+      - tm2/**
+      - examples/**
+      - go.mod
+      - go.sum
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - examples/**/*.md
+      - gnovm/stdlibs/**/*.md
 
 permissions:
   contents: read

--- a/.github/workflows/ci-multiarch-determinism.yml
+++ b/.github/workflows/ci-multiarch-determinism.yml
@@ -36,6 +36,11 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/ci-multiarch-determinism.yml"
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - "!**/*.md"
+      - "gnovm/stdlibs/**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-tmkms-integration.yml
+++ b/.github/workflows/ci-tmkms-integration.yml
@@ -16,6 +16,8 @@ on:
       - tm2/pkg/p2p/conn/secret_connection.go
       - go.mod
       - .github/workflows/ci-tmkms-integration.yml
+      # tm2 holds no gno source, so every *.md under it is prose.
+      - '!**/*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-val-scenarios.yml
+++ b/.github/workflows/ci-val-scenarios.yml
@@ -27,6 +27,12 @@ on:
       - tm2/**
       - go.mod
       - go.sum
+      # *.md is prose, except in the gno source trees where it is valid
+      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
+      # Order matters: a later positive pattern wins over an earlier negation.
+      - '!**/*.md'
+      - examples/**/*.md
+      - gnovm/stdlibs/**/*.md
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,12 +3,24 @@
 name: deploy / pages
 
 on:
+  # No path filter on push: this is what actually publishes gh-pages.
   push:
     branches:
       - master
+  # On pull requests the `deploy` job and the artifact upload are skipped
+  # (see the `if:` conditions below), so `build` only proves the generators
+  # still work. Restrict it to what they read.
   pull_request:
     branches:
       - master
+    paths:
+      - .github/workflows/deploy-pages.yml
+      - misc/gendocs/**
+      - misc/stdlib_diff/**
+      - gnovm/stdlibs/**
+      - '**/*.go'
+      - go.mod
+      - go.sum
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
A `README.md`-only pull request currently starts the validator scenario matrix, the e2e chain, the Go test matrices, and the gh-pages generators. This narrows the `pull_request` path filters so it doesn't. **No `push` trigger is touched — `master` keeps exactly the coverage it has today.**

## What was happening

`ci / e2e` and `deploy / pages` had **no path filter at all**, so they ran on every pull request. The dir-scoped workflows do filter, but on whole trees (`gno.land/**`, `gnovm/**`, `tm2/**`, `misc/**`), and those trees hold 250+ prose Markdown files — so a docs edit inside them fired the full suite.

Two recent pull requests, #6038 and #6039, are the worked example. #6038 changes only `README.md`, three files under `docs/`, and `misc/docs/sidebar.json`; it still ran `ci / e2e` (two Docker image builds plus a live chain) and `deploy / pages` (godoc + `stdlib_diff` generation, whose output is then discarded on pull requests — the upload and deploy steps are already gated on `github.event_name != 'pull_request'`).

The worst case is `ci / val-scenarios`: one list job, one three-image Docker build, and a 15-way scenario matrix, ~8 minutes wall-clock and ~17 runners — reachable today by editing a single README under `gno.land/`, `gnovm/`, or `tm2/`.

## The one subtlety: Markdown is not always prose

`*.md` is a **valid mempackage file extension** (`gnovm/pkg/gnolang/mempackage.go`, `goodFileXtns`), so Markdown under `examples/` and `gnovm/stdlibs/` is on-chain package content, gets rendered by gnoweb, and is checked by `gno lint`. It must keep triggering CI.

So the negation is always paired with a re-include of the gno source trees the workflow already watches:

```yaml
      # *.md is prose, except in the gno source trees where it is valid
      # mempackage content (see gnovm/pkg/gnolang/mempackage.go goodFileXtns).
      # Order matters: a later positive pattern wins over an earlier negation.
      - '!**/*.md'
      - examples/**/*.md
      - gnovm/stdlibs/**/*.md
```

`paths` and `paths-ignore` can't be combined on one event, so negated patterns inside `paths` are the mechanism. Order matters and is relied on here: a later positive pattern re-includes what an earlier `!` excluded.

## Per workflow

| Workflow | Change |
|---|---|
| `ci / e2e` | **new** `pull_request.paths` (`misc/e2e/**`, `Dockerfile`, `gno.land/**`, `gnovm/**`, `tm2/**`, `examples/**`, `go.mod`, `go.sum`, self) |
| `deploy / pages` | **new** `pull_request.paths` — what the two generators actually read: `**/*.go`, `go.mod`, `go.sum`, `misc/gendocs/**`, `misc/stdlib_diff/**`, `gnovm/stdlibs/**` |
| `ci / val-scenarios` | Markdown negation + `examples/`, `gnovm/stdlibs/` re-includes |
| `ci / gnoland`, `ci / gnovm`, `ci / examples` | same |
| `ci / contribs`, `ci / multiarch-determinism` | negation + `gnovm/stdlibs/` (they don't watch `examples/`) |
| `ci / tm2`, `ci / tmkms-integration` | bare negation — tm2 holds no gno source |
| `ci / misc` | bare negation — this only `go test`s the Go programs under `misc/`, so Markdown under `misc/deployments/`, `misc/val-scenarios/`, … is prose |

`ci / codegen-verify` is deliberately **unchanged**: its `docs/**` entry is real, it runs `make generate -B` and `make lint` in `docs/`. `ci / genesis-verify` and `deploy / docs` are already narrow.

## Verification

`actionlint` passes (exit 0, the same pinned version `meta / actions-lint` uses).

I also simulated GitHub's filter semantics against real changesets, diffing which workflows fire before vs. after:

| Changeset | Before | After |
|---|---|---|
| #6038 (docs-only) | codegen-verify, **e2e**, misc, **pages** | codegen-verify, misc |
| #6039 (docs + a `r/gnops/valopers` realm file) | + **contribs**, **pages** | val-scenarios still runs — correct, scenario 18 imports that realm |
| `tm2/pkg/p2p/README.md` | contribs, e2e, gnoland, gnovm, multiarch, tm2, **val-scenarios**, pages | *(none)* |
| `gno.land/cmd/gnoland/README.md` | contribs, e2e, gnoland, **val-scenarios**, pages | *(none)* |
| `misc/deployments/gnoland1/README.md` | e2e, examples, misc, pages | *(none)* |
| `examples/gno.land/p/nt/avl/v0/README.md` | e2e, examples, gnoland, gnovm, val-scenarios | **unchanged** (mempackage content) |
| `gnovm/stdlibs/errors/README.md` | *(all)* | **unchanged** (mempackage content) |
| any `*.go` / `*.gno`, `Dockerfile` | — | unchanged, except `.gno`-only edits no longer build gh-pages |

A Markdown-only pull request can end up with zero workflow runs. That is safe here: `required_status_checks` on `master` is `{contexts: [], checks: []}`, so nothing hangs waiting for a skipped check. The `meta / *` workflows (title lint, labeler, assign) are unfiltered and still run.

## Deliberately not in this pull request

- **`push` filters are untouched.** `ci / val-scenarios` and `ci / multiarch-determinism` already had `push.paths` before this change; I left them exactly as they were rather than widen or narrow master's coverage in a pull request about pull-request latency. Happy to drop those two `push.paths` blocks in a follow-up if you'd rather every merge to `master` ran the full suite unconditionally.
- **Narrowing `ci / misc`'s `misc/**`.** Its matrix is a fixed list of five programs, but `misc/genproto`, `misc/genstd`, and `misc/goscan` have no `go.mod` and ride the root module, so scoping the filter to those five directories would change dependency semantics, not just runtime. Separate discussion.

## Contributors checklist

- [x] Added new tests, or not needed, or not feasible — CI configuration; validated with `actionlint` plus the before/after filter simulation above
- [x] Provided an example (screenshot, gif, text output) — see the verification table
- [x] Updated the official documentation or not needed — not needed; the reasoning is inline as comments in each filter
- [x] No breaking changes were made, or otherwise explained — no job logic changed; `master` coverage is identical
- [x] Updated the changelog file, or not needed — not needed, CI only
