### PR TITLE
feat(grc20): let a registry own token identity and event emission

### DIFF
--- a/examples/gno.land/p/demo/tokens/grc20/emitter.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/emitter.gno
@@ -1,0 +1,87 @@
+package grc20
+
+// This file defines the opt-in hand-off that lets a registry realm own a
+// token's identity and its event stream.
+//
+// # The problem
+//
+// Two Token objects created in one realm can share a Token.ID(), because the
+// trailing id is caller-supplied and nothing outside the realm can tell the
+// objects apart. Both then emit Mint/Burn/Transfer/Approval events carrying an
+// identical "token" attribute and an identical pkg_path
+// (gno.land/p/demo/tokens/grc20, since grc20 is what calls chain.Emit). A
+// consumer reconstructing balances from events cannot attribute an event to the
+// object that produced it.
+//
+// # Why it cannot be fixed inside grc20
+//
+// Distinguishing the objects requires an identifier no realm can reissue, which
+// requires state that survives across transactions. A /p/ package holds no
+// persistent state, so grc20 cannot own a counter. Any counter grc20 is *handed*
+// is equally useless: state passed in as a struct or a pointer-to-struct can be
+// copied by the caller — `snapshot := *gen` — and replayed to mint a second
+// token carrying the first one's identifier. Handing out the counter is handing
+// out the ability to defeat it.
+//
+// # The hand-off
+//
+// So the state must stay inside a realm that the creating realm cannot reach
+// into. A Token may therefore be created against an Emitter — a registry realm
+// — which does two things grc20 cannot do for itself:
+//
+//   - It issues the token's identifier from a counter held in its own package
+//     state. Because that state is never returned to the caller, it cannot be
+//     copied or replayed. IssueToken is a crossing method, so the registry reads
+//     the creating realm from the live frame (cur.Previous()) instead of trusting
+//     an argument.
+//
+//   - It emits the token's events from its own package. The VM stamps pkg_path
+//     from the package that calls chain.Emit, so every event carries the
+//     registry's path as an unforgeable label. A counterfeit Emitter cannot
+//     borrow it: events emitted through a fake carry the fake's own path, so
+//     consumers filter on pkg_path and are done.
+//
+// Together these close the gap. The registry never issues one identifier twice,
+// so two Tokens cannot collide; and any Token that opted out is visible as such,
+// because its events carry grc20's path rather than a registry's.
+//
+// # Note on capability
+//
+// Emit is a real capability: whoever holds a TokenEmitter can emit events
+// bearing the registry's pkg_path for that token id. Token keeps its emitter in
+// an unexported field and exposes no accessor, deliberately. Returning it
+// through a narrowed interface would not help — a caller can assert the value
+// back to a wider interface and recover Emit, the same way an unexported-marker
+// "seal" is bypassed by embedding (see IsCanonicalTeller). For the same reason a
+// registry should verify provenance from its own records of what it issued, not
+// by asking the token to describe its emitter.
+//
+// NewToken remains supported and unchanged. Tokens created through it have no
+// emitter, emit under grc20's own pkg_path, and carry the ambiguity described
+// above — which is what makes the guarantee legible to consumers rather than
+// silent.
+
+// Emitter is a registry realm that can issue token identities and record token
+// events. Implementations live in /r/; grc20 imports none of them.
+//
+// IssueToken must be a crossing method so the implementation can authenticate
+// the creating realm from cur.Previous() rather than from an argument. It must
+// return a distinct identifier on every call, derived from state the caller
+// cannot obtain — package-level state, never a returned struct.
+type Emitter interface {
+	IssueToken(cur realm, symbol string) TokenEmitter
+}
+
+// TokenEmitter is the per-token handle an Emitter returns. It is bound to one
+// token identifier for its whole life, so copying it grants nothing its holder
+// did not already have.
+//
+// Emit must call chain.Emit from the implementation's own package, so the VM
+// stamps that package's path onto the event.
+type TokenEmitter interface {
+	// TokenID returns the identifier the Emitter assigned to this token.
+	TokenID() string
+
+	// Emit records one token event.
+	Emit(kind string, attrs ...string)
+}

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/emitter_foreign_namespace_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/emitter_foreign_namespace_filetest.gno
@@ -1,0 +1,31 @@
+// PKGPATH: gno.land/r/demo/grc20fakeemitter
+
+// A counterfeit Emitter is free to return whatever identifier it likes, so
+// NewTokenWithEmitter checks the issued id against the live crossing frame
+// before adopting it. That keeps Token.ID()'s namespace guarantee identical to
+// NewToken's no matter which Emitter is supplied: a realm cannot obtain a token
+// that appears to belong to somebody else.
+package grc20fakeemitter
+
+import (
+	"gno.land/p/demo/tokens/grc20"
+)
+
+type fakeEmitter struct{}
+
+func (f *fakeEmitter) IssueToken(cur realm, symbol string) grc20.TokenEmitter {
+	// Claim a victim realm's namespace.
+	return &fakeTokenEmitter{id: "gno.land/r/demo/grc20victim.VIC.1"}
+}
+
+type fakeTokenEmitter struct{ id string }
+
+func (f *fakeTokenEmitter) TokenID() string                   { return f.id }
+func (f *fakeTokenEmitter) Emit(kind string, attrs ...string) {}
+
+func main(cur realm) {
+	grc20.NewTokenWithEmitter("Fake", "VIC", 6, &fakeEmitter{}, cur)
+}
+
+// Error:
+// emitter issued an id outside the calling realm's namespace

--- a/examples/gno.land/p/demo/tokens/grc20/token.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token.gno
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/overflow"
 	"strconv"
+	"strings"
 
 	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/ufmt/v0"
@@ -57,6 +58,77 @@ func NewToken(name, symbol string, decimals int, id seqid.ID, rlm realm) (*Token
 	}
 	ledger.token = token
 	return token, ledger
+}
+
+// NewTokenWithEmitter creates a Token whose identifier is issued by reg, and
+// whose events reg records on the token's behalf. See emitter.gno for why this
+// is the only arrangement that makes a token's event stream attributable.
+//
+// rlm must be the caller's own captured cur (asserted via rlm.IsCurrent()).
+// reg.IssueToken is invoked here rather than by the caller, so the caller never
+// holds a TokenEmitter and cannot reuse one across two tokens.
+//
+// Token.ID() is whatever reg issued, after this function has checked that it
+// falls inside the calling realm's namespace. That check is what preserves the
+// namespace guarantee NewToken gives, no matter what reg is: a counterfeit
+// Emitter cannot mint an identifier under another realm's path.
+//
+// Discoverability is then up to reg. A registry that keeps a record of the
+// identifiers it issued can verify a token's provenance from its own state at
+// registration time, which is strictly better than asking the token to describe
+// its own emitter.
+func NewTokenWithEmitter(name, symbol string, decimals int, reg Emitter, rlm realm) (*Token, *PrivateLedger) {
+	if !rlm.IsCurrent() {
+		panic(ErrSpoofedRealm)
+	}
+	pkgPath := rlm.PkgPath()
+	if pkgPath == "" {
+		panic(ErrNotRealm)
+	}
+	if !validName(name) {
+		panic(ErrInvalidName)
+	}
+	if !validSymbol(symbol) {
+		panic(ErrInvalidSymbol)
+	}
+	if decimals < 0 || decimals > MaxDecimals {
+		panic(ErrInvalidDecimals)
+	}
+	if reg == nil {
+		panic(ErrNilEmitter)
+	}
+
+	emitter := reg.IssueToken(cross(rlm), symbol)
+	if emitter == nil {
+		panic(ErrNilTokenEmitter)
+	}
+	id := emitter.TokenID()
+	if !strings.HasPrefix(id, pkgPath+".") {
+		panic(ErrForeignTokenID)
+	}
+
+	ledger := &PrivateLedger{}
+	token := &Token{
+		id:       id,
+		name:     name,
+		symbol:   symbol,
+		decimals: decimals,
+		emitter:  emitter,
+		ledger:   ledger,
+	}
+	ledger.token = token
+	return token, ledger
+}
+
+// emit routes an event through the token's registry when it has one, so the VM
+// stamps the registry's pkg_path on it, and falls back to emitting under grc20's
+// own path otherwise.
+func (tok *Token) emit(kind string, attrs ...string) {
+	if tok.emitter != nil {
+		tok.emitter.Emit(kind, attrs...)
+		return
+	}
+	chain.Emit(kind, attrs...)
 }
 
 // validName reports whether name is a valid display name: non-empty,
@@ -206,7 +278,7 @@ func (led *PrivateLedger) Transfer(from, to address, amount int64) error {
 		led.balances.Set(string(from), newFromBalance)
 	}
 
-	chain.Emit(
+	led.token.emit(
 		TransferEvent,
 		"token", led.token.ID(),
 		"from", from.String(),
@@ -256,7 +328,7 @@ func (led *PrivateLedger) Approve(owner, spender address, amount int64) error {
 
 	led.allowances.Set(allowanceKey(owner, spender), amount)
 
-	chain.Emit(
+	led.token.emit(
 		ApprovalEvent,
 		"token", led.token.ID(),
 		"owner", string(owner),
@@ -287,7 +359,7 @@ func (led *PrivateLedger) Mint(addr address, amount int64) error {
 
 	led.balances.Set(string(addr), newBalance)
 
-	chain.Emit(
+	led.token.emit(
 		TransferEvent,
 		"token", led.token.ID(),
 		"from", "",
@@ -321,7 +393,7 @@ func (led *PrivateLedger) Burn(addr address, amount int64) error {
 		led.balances.Set(string(addr), newBalance)
 	}
 
-	chain.Emit(
+	led.token.emit(
 		TransferEvent,
 		"token", led.token.ID(),
 		"from", string(addr),

--- a/examples/gno.land/p/demo/tokens/grc20/types.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/types.gno
@@ -89,6 +89,10 @@ type Token struct {
 	symbol string
 	// Number of decimal places used for the token's precision.
 	decimals int
+	// Registry that issued id and records this token's events, or nil when the
+	// token was created through NewToken. Deliberately unexported with no
+	// accessor: Emit is a capability — see emitter.gno.
+	emitter TokenEmitter
 	// Pointer to the PrivateLedger that manages balances and allowances.
 	ledger *PrivateLedger
 }
@@ -125,6 +129,9 @@ var (
 	ErrInvalidName           = errors.New("invalid token name (empty, too long, or contains control chars)")
 	ErrInvalidSymbol         = errors.New("invalid token symbol (empty, too long, or contains chars outside [A-Za-z0-9_-])")
 	ErrInvalidDecimals       = errors.New("invalid decimals (must be 0..18)")
+	ErrNilEmitter            = errors.New("emitter must not be nil")
+	ErrNilTokenEmitter       = errors.New("emitter returned a nil TokenEmitter")
+	ErrForeignTokenID        = errors.New("emitter issued an id outside the calling realm's namespace")
 )
 
 // Construction limits. Symbol is restricted to the same charset as

--- a/examples/gno.land/r/demo/defi/grc20reg/emitter.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/emitter.gno
@@ -1,0 +1,113 @@
+package grc20reg
+
+import (
+	"chain"
+	"strconv"
+
+	"gno.land/p/demo/tokens/grc20"
+	"gno.land/p/nt/avl/v0"
+)
+
+// This file makes grc20reg a grc20.Emitter: it issues token identifiers and
+// records the events of the tokens that opted into it.
+//
+// A token realm opts in at construction:
+//
+//	Token, ledger := grc20.NewTokenWithEmitter("Foo", "FOO", 4, grc20reg.Emitter(), cur)
+//	key := grc20reg.Register(cross(cur), Token, "")
+//
+// What that buys, and why it holds:
+//
+//   - Distinct identifiers. sequences below lives in this realm's package state
+//     and is never returned to a caller, so it cannot be copied and replayed.
+//     Two tokens from one realm therefore cannot share an identifier, which is
+//     what made their event streams inseparable before.
+//
+//   - An unforgeable label on every event. tokenEmitter.Emit calls chain.Emit
+//     from this package, so the VM stamps pkg_path = gno.land/r/demo/defi/grc20reg.
+//     A counterfeit grc20.Emitter cannot borrow that: its events carry its own
+//     path. Consumers filter on pkg_path and need trust nothing in-band.
+//
+//   - Provenance checkable from this realm's own records. issued below maps every
+//     identifier this realm handed out to the realm it was handed to, so Register
+//     verifies provenance without asking the token to describe its emitter — and
+//     so without ever type-asserting or handing back a value that carries the
+//     Emit capability.
+//
+// Tokens built with grc20.NewToken still work and still register. They emit
+// under grc20's own pkg_path and keep the ambiguity, which is the point: opting
+// out is visible rather than silent.
+
+type emitter struct{}
+
+type tokenEmitter struct{ id string }
+
+var (
+	// realm path -> int64, the per-realm issuance counter. Package state, never
+	// handed out: this is the difference between a counter that cannot be
+	// replayed and one that can.
+	sequences = avl.NewTree()
+
+	// token identifier -> issuing realm path. Register reads this instead of
+	// trusting anything the token reports about itself.
+	issued = avl.NewTree()
+
+	canonicalEmitter = &emitter{}
+)
+
+var (
+	_ grc20.Emitter      = (*emitter)(nil)
+	_ grc20.TokenEmitter = (*tokenEmitter)(nil)
+)
+
+// Emitter returns this realm as a grc20.Emitter, for grc20.NewTokenWithEmitter.
+//
+// Unlike handing out a counter, handing out this value grants nothing: it holds
+// no state, and every method that mutates state runs here.
+func Emitter() grc20.Emitter {
+	return canonicalEmitter
+}
+
+// IssueToken assigns a fresh identifier to a token being created by the calling
+// realm. It is a crossing method, so the creating realm is read from the live
+// frame rather than taken as an argument — an argument could name any realm.
+func (e *emitter) IssueToken(cur realm, symbol string) grc20.TokenEmitter {
+	rlmPath := cur.Previous().PkgPath()
+	if rlmPath == "" {
+		panic("grc20reg: token issuer must be a realm")
+	}
+
+	n := int64(0)
+	if v := sequences.Get(rlmPath); v != nil {
+		n = v.(int64)
+	}
+	n++
+	sequences.Set(rlmPath, n)
+
+	id := rlmPath + "." + symbol + "." + strconv.FormatInt(n, 10)
+	issued.Set(id, rlmPath)
+
+	return &tokenEmitter{id: id}
+}
+
+// TokenID returns the identifier this handle is permanently bound to.
+func (t *tokenEmitter) TokenID() string { return t.id }
+
+// Emit records one token event. Called from this package, so the VM stamps this
+// realm's path onto the event.
+//
+// The handle is bound to a single identifier for life, so a copy of it conveys
+// no authority its holder did not already have.
+func (t *tokenEmitter) Emit(kind string, attrs ...string) {
+	chain.Emit(kind, attrs...)
+}
+
+// IssuedTo returns the realm this registry issued id to, and whether it issued
+// id at all.
+func IssuedTo(id string) (string, bool) {
+	v := issued.Get(id)
+	if v == nil {
+		return "", false
+	}
+	return v.(string), true
+}

--- a/examples/gno.land/r/demo/defi/grc20reg/emitter_test.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/emitter_test.gno
@@ -1,0 +1,71 @@
+package grc20reg
+
+import (
+	"strings"
+	"testing"
+
+	"gno.land/p/demo/tokens/grc20"
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+// Two tokens created by one realm with the same symbol get distinct identifiers,
+// so their event streams can be told apart. This is the case that motivated the
+// whole exercise: with grc20.NewToken and a reused seqid they would collide.
+func TestEmitterNeverReissuesAnIdentifier(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/emitdup"))
+
+	first, _ := grc20.NewTokenWithEmitter("Same", "DUP", 6, Emitter(), cur)
+	second, _ := grc20.NewTokenWithEmitter("Same", "DUP", 6, Emitter(), cur)
+
+	t.Log("first :", first.ID())
+	t.Log("second:", second.ID())
+	uassert.NotEqual(t, first.ID(), second.ID())
+}
+
+// Identifiers stay inside the creating realm's namespace, so one realm cannot
+// obtain an identifier that appears to belong to another.
+func TestIdentifierIsNamespacedToTheCreatingRealm(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/emitns"))
+	tok, _ := grc20.NewTokenWithEmitter("Ns", "NS", 6, Emitter(), cur)
+
+	uassert.True(t, strings.HasPrefix(tok.ID(), "gno.land/r/demo/emitns.NS."))
+
+	to, ok := IssuedTo(tok.ID())
+	urequire.True(t, ok, "registry should have a record of the id it issued")
+	uassert.Equal(t, "gno.land/r/demo/emitns", to)
+}
+
+// The attack that defeats a handed-out counter: copy the value the registry
+// returns and replay it. Here the counter lives in the registry's package state,
+// so a copy of the returned handle carries none of it.
+func TestCopyingTheEmitterCannotReplayAnIdentifier(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/emitcopy"))
+
+	snapshot := *canonicalEmitter // the move that breaks a struct-based generator
+
+	viaRegistry, _ := grc20.NewTokenWithEmitter("A", "CP", 6, Emitter(), cur)
+	viaCopy, _ := grc20.NewTokenWithEmitter("B", "CP", 6, &snapshot, cur)
+
+	t.Log("via registry:", viaRegistry.ID())
+	t.Log("via copy    :", viaCopy.ID())
+	uassert.NotEqual(t, viaRegistry.ID(), viaCopy.ID())
+}
+
+// Register reports whether this registry issued the identifier, read from its own
+// record rather than from anything the token claims about itself.
+func TestRegisterReportsWhetherTheRegistryIssuedTheIdentifier(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/emitowned"))
+	owned, _ := grc20.NewTokenWithEmitter("Owned", "OWN", 6, Emitter(), cur)
+	Register(cross(cur), owned, "")
+	to, ok := IssuedTo(owned.ID())
+	uassert.True(t, ok)
+	uassert.Equal(t, "gno.land/r/demo/emitowned", to)
+
+	// A legacy token: created without an emitter, still registers, no record.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/emitlegacy"))
+	legacy, _ := grc20.NewToken("Legacy", "LEG", 6, 0, cur)
+	Register(cross(cur), legacy, "")
+	_, ok = IssuedTo(legacy.ID())
+	uassert.False(t, ok, "a token grc20 identified itself must not appear as registry-issued")
+}

--- a/examples/gno.land/r/demo/defi/grc20reg/filetests/emitter_pkgpath_filetest.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/filetests/emitter_pkgpath_filetest.gno
@@ -1,0 +1,78 @@
+// PKGPATH: gno.land/r/demo/grc20emitpath
+
+// The observable payoff of registry-owned emission: pkg_path.
+//
+// The VM stamps pkg_path from the package that calls chain.Emit, so a token that
+// opted into the registry has every event labelled with the registry's path,
+// and that label cannot be forged — a counterfeit emitter's events carry the
+// counterfeit's own path. A token created with plain NewToken emits under
+// grc20's path, so the two are trivially distinguishable in the event stream.
+package grc20emitpath
+
+import (
+	"gno.land/p/demo/tokens/grc20"
+	"gno.land/r/demo/defi/grc20reg"
+)
+
+func main(cur realm) {
+	owned, ownedLedger := grc20.NewTokenWithEmitter("Owned", "OWN", 6, grc20reg.Emitter(), cur)
+	legacy, legacyLedger := grc20.NewToken("Legacy", "LEG", 6, 0, cur)
+
+	println("owned  id:", owned.ID())
+	println("legacy id:", legacy.ID())
+
+	ownedLedger.Mint(cur.Address(), 1)
+	legacyLedger.Mint(cur.Address(), 1)
+}
+
+// Output:
+// owned  id: gno.land/r/demo/grc20emitpath.OWN.1
+// legacy id: gno.land/r/demo/grc20emitpath.LEG.0000000
+
+// Events:
+// [
+//   {
+//     "type": "Transfer",
+//     "attrs": [
+//       {
+//         "key": "token",
+//         "value": "gno.land/r/demo/grc20emitpath.OWN.1"
+//       },
+//       {
+//         "key": "from",
+//         "value": ""
+//       },
+//       {
+//         "key": "to",
+//         "value": "g1y4j5mkkjel0n43knx9jt82hq4ndwe47nnwcc70"
+//       },
+//       {
+//         "key": "value",
+//         "value": "1"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/demo/defi/grc20reg"
+//   },
+//   {
+//     "type": "Transfer",
+//     "attrs": [
+//       {
+//         "key": "token",
+//         "value": "gno.land/r/demo/grc20emitpath.LEG.0000000"
+//       },
+//       {
+//         "key": "from",
+//         "value": ""
+//       },
+//       {
+//         "key": "to",
+//         "value": "g1y4j5mkkjel0n43knx9jt82hq4ndwe47nnwcc70"
+//       },
+//       {
+//         "key": "value",
+//         "value": "1"
+//       }
+//     ],
+//     "pkg_path": "gno.land/p/demo/tokens/grc20"
+//   }
+// ]

--- a/examples/gno.land/r/demo/defi/grc20reg/grc20reg.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/grc20reg.gno
@@ -47,12 +47,26 @@ func Register(cur realm, token *grc20.Token, slug string) string {
 		panic("grc20reg: token already registered")
 	}
 	registry.Set(key, token)
+
+	// Report whether this registry issued the token's identifier, checked
+	// against its own record of what it handed out (see emitter.gno) rather than
+	// against anything the token says about itself. When it did, the token's
+	// events carry this realm's pkg_path and are attributable; when it did not,
+	// they carry grc20's and two ledgers behind one identifier remain possible.
+	// Either way a consumer learns which it is at registration time.
+	emitterPath := ""
+	if to, ok := IssuedTo(token.ID()); ok && to == rlmPath {
+		emitterPath = cur.PkgPath()
+	}
+
 	chain.Emit(
 		registerEvent,
 		"token_path", key,
+		"token_id", token.ID(),
 		"pkgpath", rlmPath,
 		"slug", slug,
 		"symbol", token.GetSymbol(),
+		"emitter", emitterPath,
 	)
 	return key
 }

--- a/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
@@ -34,7 +34,7 @@ gnokey query vm/qstorage --data gno.land/r/test/storage
 stdout 'storage: 503690, deposit: 50369000'
 
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999816'
+stdout '"coins": "9999814'
 
 gnokey query params/vm:p:storage_price
 stdout '100ugnot'
@@ -69,7 +69,7 @@ stdout 'storage: 3374, deposit: 337400'
 
 ## Verify user received a refund (balance should have increased despite gas fees)
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999853'
+stdout '"coins": "9999852'
 
 -- loader/load_govdao.gno --
 package loader


### PR DESCRIPTION
## Summary

Lets a registry realm own a token's identity and its event stream, as an opt-in at construction. `grc20` declares the interfaces and imports nothing; `grc20reg` implements them.

**Read #6042 first.** That PR is the small, additive answer to #6026 and the one I'd merge now. This one is the thorough answer: it *prevents* the ambiguity rather than making it detectable, at the cost of relocating `pkg_path` on every event of every token that opts in. I'm opening it because if we decide detection isn't enough, this is the shape the fix has to take — and it's cleaner than any in-band identifier scheme can be, for reasons set out below.

#6028 proposes a third approach. I've requested changes there: its trusted-issuer check is defeated by copying the generator handle (`a, b := *g, *g`), which reproduces the exact ambiguity it aims to close. That failure is what motivates the design here — the state has to be somewhere the creating realm cannot reach.

Related: #6026, #6028, #6042

## The problem

Two `Token` objects created in one realm can share a `Token.ID()`, because the trailing id is caller-supplied. Both emit `Mint`/`Burn`/`Transfer`/`Approval` with an identical `token` attribute *and* an identical `pkg_path` (`gno.land/p/demo/tokens/grc20`, since grc20 is what calls `chain.Emit`). A consumer reconstructing balances cannot attribute an event to the object that produced it.

## Why it cannot be fixed inside grc20

Telling the objects apart needs an identifier no realm can reissue, which needs state that survives across transactions. A `/p/` package holds no persistent state, so grc20 cannot own a counter.

Any counter grc20 is *handed* is equally useless. State passed in as a struct — or as a pointer to one — can be copied by the caller:

```go
snapshot := *gen
```

and replayed to mint a second token carrying the first one's identifier. Unexported fields do not prevent this; copying a struct from another package is legal regardless. **Handing out the counter is handing out the ability to defeat it.**

So the state has to stay inside a realm the creating realm cannot reach into.

## The design

```go
type Emitter interface {
    IssueToken(cur realm, symbol string) TokenEmitter
}

type TokenEmitter interface {
    TokenID() string
    Emit(kind string, attrs ...string)
}
```

```go
Token, ledger := grc20.NewTokenWithEmitter("Foo", "FOO", 4, grc20reg.Emitter(), cur)
key := grc20reg.Register(cross(cur), Token, "")
```

Three properties, each resting on something the VM enforces rather than on application logic:

**Identifiers cannot be replayed.** The counter lives in grc20reg's *package* state and is never returned to a caller. `NewTokenWithEmitter` calls `IssueToken` itself, so the caller never holds a `TokenEmitter` and cannot reuse one across two tokens.

**The creating realm cannot be spoofed.** `IssueToken` is a crossing method, so grc20reg reads the realm from `cur.Previous()` — the live frame — rather than trusting an argument. A `/p/` package crossing into a caller-supplied realm works; this PR relies on it.

**Every event carries an unforgeable label.** The VM stamps `pkg_path` from the package that calls `chain.Emit` (`currentPkgPath` peeks the calling frame's `LastPackage`), so events routed through grc20reg carry its path. A counterfeit `Emitter` cannot borrow it — its events carry its own path. Consumers filter on `pkg_path` and need trust nothing in-band.

Notably this means the emitter does **not** need to be a crossing call, so no `realm` has to be threaded through the ledger write methods. A realm value is needed only at construction.

### On capability

`Emit` is a real capability: whoever holds a `TokenEmitter` can emit events bearing the registry's `pkg_path` for that token id. So `Token` keeps its emitter in an unexported field with **no accessor**. Returning it through a narrowed interface would not help — a caller can assert the value back to a wider interface and recover `Emit`, the same way an unexported-marker "seal" is bypassed by embedding (cf. `IsCanonicalTeller`).

For the same reason `Register` verifies provenance from grc20reg's *own record* of what it issued (`IssuedTo`), not by asking the token to describe its emitter. No type assertion, no self-reported string.

`NewTokenWithEmitter` additionally checks the issued id falls inside the calling realm's namespace, so `Token.ID()` keeps exactly the guarantee `NewToken` gives no matter which `Emitter` is supplied.

## Backward compatibility

`NewToken` is unchanged and still supported. Tokens created with it have no emitter, emit under grc20's own `pkg_path`, and keep the ambiguity above.

That is deliberate: opting out is **visible** rather than silent. `Register` now reports an `emitter` attribute so a consumer learns at registration time which kind of token it is looking at.

## Verified

Same realm, same transaction, one token of each kind:

```
"type": "Transfer"  "gno.land/r/demo/grc20emitpath.OWN.1"        pkg_path: gno.land/r/demo/defi/grc20reg
"type": "Transfer"  "gno.land/r/demo/grc20emitpath.LEG.0000000"  pkg_path: gno.land/p/demo/tokens/grc20
```

Tests cover: distinct identifiers for same-symbol tokens from one realm; namespace binding; that copying the emitter cannot replay an identifier; that a counterfeit emitter cannot claim another realm's namespace; and that `Register` reports issuance from the registry's own records.

- `gno test ./...` over `examples/`: 222 packages ok, 0 failures.
- `TestTestdata/grc20_registry_emit` passes unchanged.
- `TestTestdata/storage_deposit_price_change` needed two genesis-sensitive balance assertions retuned (`9999816`→`9999814`, `9999853`→`9999852`). These shift because the added code grows the genesis deployment; they are not a behaviour change.

## What this does not do

It does not migrate any existing token, and it does not change any current registry key. Moving a live token onto a registry emitter relocates `pkg_path` on its events, which every indexer of that token would need to handle — so that is a separate, deliberate decision per token, not something this PR performs.

## Why not a smaller fix

Worth stating what was ruled out, since the obvious cheaper options all fail:

- **A counter inside grc20.** A `/p/` package holds no persistent state, so there is nothing to count with.
- **A counter handed to grc20** (#6028's shape). Copyable, therefore replayable. Unexported fields don't help: copying a struct from another package is legal regardless of visibility.
- **A registry that issues ids but doesn't emit.** The realm can pass the same issued id to two constructions, and grc20 has no state to detect the reuse. Identity has to be issued and consumed in the same place.
- **A VM-level object id or tx index.** Would be the cleanest source of uniqueness, but nothing suitable is exposed today — `chain/runtime` offers `ChainHeight()` and no object identity — so this would need a VM change.

That leaves registry-owned emission. The reason it works is not clever application logic: it's that `pkg_path` is stamped by the VM from the package that calls `chain.Emit`, so the label cannot be forged by anything running in a realm.
