### PR TITLE
fix(tests): bound test memory by memory, not by core count

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,6 +21,11 @@ GOFMT_FLAGS ?= -w
 GOIMPORTS_FLAGS ?= $(GOFMT_FLAGS)
 # test suite flags.
 GOTEST_FLAGS ?= -v -p 1 -timeout=30m
+# `gno test` worker count. Each worker holds a full GnoVM store, so leaving this
+# at the default (GOMAXPROCS) makes peak memory track the host's core count:
+# ~8 GiB over sixteen workers against ~4 GiB over four, for the same wall time —
+# this suite is bound by memory, not CPU.
+GNOTEST_JOBS ?= 4
 
 ########################################
 # Dev tools
@@ -34,7 +39,7 @@ build:
 
 .PHONY: test
 test:
-	go run ../gnovm/cmd/gno test -v ./... 2>&1 | tee /dev/stderr | grep -E '^(FAIL|--- FAIL)|\(type: \*[a-zA-Z._]*[Ee]rror' > /tmp/gno-test-failures; \
+	go run ../gnovm/cmd/gno test -v -p $(GNOTEST_JOBS) ./... 2>&1 | tee /dev/stderr | grep -E '^(FAIL|--- FAIL)|\(type: \*[a-zA-Z._]*[Ee]rror' > /tmp/gno-test-failures; \
 	if [ -s /tmp/gno-test-failures ]; then \
 		echo ""; \
 		echo "========================================"; \
@@ -46,7 +51,7 @@ test:
 
 .PHONY: test.fast
 test.fast:
-	go run ../gnovm/cmd/gno test -failfast -v  ./... 
+	go run ../gnovm/cmd/gno test -failfast -v -p $(GNOTEST_JOBS) ./...
 
 .PHONY: lint
 lint:

--- a/gno.land/pkg/integration/node_budget_test.go
+++ b/gno.land/pkg/integration/node_budget_test.go
@@ -1,0 +1,180 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/tm2/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memOf returns a readMem stub reporting a fixed amount of available memory.
+func memOf(available uint64) func() (testutils.MemInfo, bool) {
+	return func() (testutils.MemInfo, bool) {
+		return testutils.MemInfo{Total: 32 << 30, Available: available}, true
+	}
+}
+
+// elapse back-dates the resize clock so the next resize is allowed, rather than
+// sleeping out the settle window.
+func elapse(b *nodeBudget) {
+	b.lastCheck = time.Now().Add(-nodeStartSettle)
+}
+
+func TestNodeBudgetMinIgnoresMemory(t *testing.T) {
+	t.Parallel()
+
+	// No memory free at all: the minimum must still be admitted, or a loaded
+	// machine would never finish the suite.
+	b := &nodeBudget{min: 2, max: 8, limit: 2, reserve: 8 << 30, readMem: memOf(0)}
+	for i := range 2 {
+		require.True(t, b.tryAcquire(), "minimum node %d refused", i+1)
+	}
+	elapse(b)
+	assert.False(t, b.tryAcquire(), "ramped past the minimum with no memory free")
+	assert.Equal(t, 2, b.running)
+	assert.Equal(t, 2, b.limit, "limit must not fall below min")
+}
+
+func TestNodeBudgetRampsWithHeadroom(t *testing.T) {
+	t.Parallel()
+
+	b := &nodeBudget{
+		min: 2, max: 5, limit: 2,
+		lastCheck: time.Now(), // start inside the settle window
+		reserve:   8 << 30,
+		readMem:   memOf(8<<30 + nodeMemCost), // room for exactly one more node
+	}
+	for range 2 {
+		require.True(t, b.tryAcquire())
+	}
+	for want := 3; want <= 5; want++ {
+		assert.False(t, b.tryAcquire(), "grew inside the settle window")
+		elapse(b)
+		require.True(t, b.tryAcquire(), "refused node %d with headroom to spare", want)
+		assert.Equal(t, want, b.running)
+	}
+
+	// max is a hard ceiling however much memory is free.
+	elapse(b)
+	assert.False(t, b.tryAcquire(), "admitted past max")
+	assert.Equal(t, 5, b.limit)
+}
+
+func TestNodeBudgetHoldsBetweenThresholds(t *testing.T) {
+	t.Parallel()
+
+	// Above the reserve, but without room for a whole further node: the limit
+	// should sit still rather than oscillate.
+	b := &nodeBudget{
+		min: 1, max: 8, limit: 3,
+		reserve: 8 << 30,
+		readMem: memOf(8<<30 + nodeMemCost - 1),
+	}
+	for range 3 {
+		require.True(t, b.tryAcquire())
+	}
+	elapse(b)
+	assert.False(t, b.tryAcquire(), "ate into the reserve")
+	assert.Equal(t, 3, b.limit, "limit moved while inside the hysteresis band")
+}
+
+func TestNodeBudgetShrinksUnderPressure(t *testing.T) {
+	t.Parallel()
+
+	// Ramped up, then the machine loses memory to something else.
+	avail := uint64(8<<30 + nodeMemCost)
+	b := &nodeBudget{
+		min: 2, max: 8, limit: 6,
+		reserve: 8 << 30,
+		readMem: func() (testutils.MemInfo, bool) {
+			return testutils.MemInfo{Total: 32 << 30, Available: avail}, true
+		},
+	}
+	avail = 1 << 30 // now below the reserve
+	for want := 5; want >= 2; want-- {
+		elapse(b)
+		b.tryAcquire()
+		assert.Equal(t, want, b.limit)
+	}
+	// Never below min, however tight things get.
+	elapse(b)
+	b.tryAcquire()
+	assert.Equal(t, 2, b.limit, "shrank past min")
+}
+
+func TestNodeBudgetStaticWhenMemoryUnknown(t *testing.T) {
+	t.Parallel()
+
+	// reserve == 0 marks a platform whose free memory we cannot read: the
+	// allowance is then whatever min says, and never moves.
+	b := &nodeBudget{min: 4, max: 16, limit: 4, readMem: func() (testutils.MemInfo, bool) {
+		return testutils.MemInfo{}, false
+	}}
+	for range 4 {
+		require.True(t, b.tryAcquire())
+	}
+	elapse(b)
+	assert.False(t, b.tryAcquire(), "ramped without a memory reading")
+	assert.Equal(t, 4, b.limit)
+}
+
+func TestNodeBudgetReleaseFreesRoom(t *testing.T) {
+	t.Parallel()
+
+	b := &nodeBudget{min: 1, max: 1, limit: 1, readMem: memOf(0)}
+	require.True(t, b.tryAcquire())
+	require.False(t, b.tryAcquire())
+	b.release()
+	assert.Equal(t, 0, b.running)
+	assert.True(t, b.tryAcquire(), "slot not reusable after release")
+}
+
+func TestNewNodeBudgetHonoursOverride(t *testing.T) {
+	t.Setenv(testutils.MaxParallelEnv, "3")
+
+	b := newNodeBudget()
+	assert.Equal(t, 3, b.min)
+	assert.Equal(t, 3, b.max)
+	assert.Equal(t, 3, b.limit)
+	assert.Zero(t, b.reserve, "override should pin the budget, not ramp")
+}
+
+func TestNewNodeBudgetDefaults(t *testing.T) {
+	// Not parallel: reads the ambient environment.
+	if _, ok := testutils.ReadMemInfo(); !ok {
+		t.Skip("no memory reading on this platform")
+	}
+	b := newNodeBudget()
+	assert.Equal(t, nodeMinParallel, b.min)
+	assert.GreaterOrEqual(t, b.max, b.min)
+	assert.NotZero(t, b.reserve, "should ramp where memory can be read")
+	// Starts at the static cap, so no platform is slower than before ramping.
+	assert.Equal(t, max(testutils.MaxParallel(), nodeMinParallel), b.limit)
+	assert.GreaterOrEqual(t, b.limit, b.min)
+	assert.LessOrEqual(t, b.limit, b.max)
+}
+
+func TestNodeBudgetPacesReadings(t *testing.T) {
+	t.Parallel()
+
+	// Sitting inside the hysteresis band must not re-read on every poll: a
+	// blocked script polls five times a second, and reading costs a subprocess
+	// on darwin.
+	var reads int
+	b := &nodeBudget{
+		min: 1, max: 8, limit: 1,
+		reserve: 8 << 30,
+		readMem: func() (testutils.MemInfo, bool) {
+			reads++
+			// In the band: above the reserve, no room for a whole node.
+			return testutils.MemInfo{Total: 32 << 30, Available: 8<<30 + nodeMemCost - 1}, true
+		},
+	}
+	for range 20 {
+		b.tryAcquire()
+	}
+	assert.Equal(t, 1, reads, "re-read inside the settle window")
+	assert.Equal(t, 1, b.limit, "limit moved while inside the band")
+}

--- a/gno.land/pkg/integration/testscript_gnoland.go
+++ b/gno.land/pkg/integration/testscript_gnoland.go
@@ -6,7 +6,9 @@ import (
 	"flag"
 	"fmt"
 	"hash/crc32"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,6 +34,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/crypto/secp256k1"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
 	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +53,172 @@ const (
 	envKeyExecCommand
 	envKeyBase
 	envKeyStdinBuffer
+	envKeyNodeSlot
 )
+
+// nodeSlot records whether a script already holds a node budget token.
+// Only the script's own goroutine touches it.
+type nodeSlot struct{ held bool }
+
+// Constants governing how many nodes run at once; see [nodeBudget]. The memory
+// figures come from running the testdata suite at fixed node counts on a
+// 16-core host: peak RSS goes 3.9 GiB at two nodes, 7.2 at six, 12.0 at
+// sixteen, while wall time goes 145s, 54s, 43s.
+const (
+	// nodeMinParallel is the floor the allowance never shrinks below, so that a
+	// machine under memory pressure still makes progress. One node stretches
+	// the suite to ~240s against ~54s at six, and a machine that cannot hold
+	// two nodes cannot build this repo either.
+	nodeMinParallel = 2
+
+	// nodeMemCost is the peak RSS one more concurrent node adds: ~580 MiB
+	// measured over the range above, rounded up.
+	nodeMemCost = 640 << 20
+
+	// nodeMemReserveDiv makes the suite leave a quarter of the memory it may
+	// use — the machine's, or its cgroup's — to everything else. A fraction
+	// rather than a constant so the same rule holds for an 8 GiB laptop and a
+	// 128 GiB builder. It needs to be this generous because the ramp stops only
+	// once a further node would not fit, and the nodes already admitted are
+	// still growing into theirs: the reserve is what absorbs that overshoot.
+	nodeMemReserveDiv = 4
+
+	// nodeStartSettle paces changes of allowance, so that the memory claimed by
+	// the node the last change let in is reflected in the reading behind the
+	// next one — rather than a burst of scripts all deciding against the same
+	// stale figure. Node startup measures p50 320ms, p90 1.2s.
+	nodeStartSettle = time.Second
+
+	// nodeBudgetPoll is how often a blocked script re-checks. The conditions
+	// are time- and memory-based, so there is nothing to signal on.
+	nodeBudgetPoll = 200 * time.Millisecond
+)
+
+// traceNodeBudget logs every change of allowance to stderr. The budget tunes
+// itself, so this is the way to see what it decided and why on a given machine.
+var traceNodeBudget = os.Getenv("GNO_TEST_TRACE_BUDGET") != ""
+
+// nodeBudget decides how many nodes may run at once. testscript runs every
+// txtar as a parallel subtest, so left alone the node count is whatever
+// `go test -parallel` allows — GOMAXPROCS by default. Each node keeps its own
+// store, stdlib byte cache and genesis write batch alive, which makes peak
+// memory a function of the host's core count: ~6 GiB over four nodes, ~12 GiB
+// over sixteen, enough to take a workstation down while CI's four-core runners
+// never notice.
+//
+// Rather than pin a single number, start at the count CI validates and move
+// from there: up towards max while the machine reports room to spare, down
+// towards [nodeMinParallel] when it stops doing so. That spends the memory
+// actually going free, on the machine at hand, without anyone having to tune a
+// flag — and gives it back when something else needs it.
+type nodeBudget struct {
+	mu      sync.Mutex
+	running int
+
+	// limit is the current allowance, between min and max. It is a value that
+	// ratchets rather than a decision re-made per node: scripts finish
+	// constantly, so a rule phrased against the live count would keep falling
+	// back to the floor and never accumulate a ramp.
+	limit     int
+	lastCheck time.Time
+
+	min, max int
+
+	// reserve is the memory left to the rest of the system. Zero means this
+	// platform cannot report free memory, in which case min == max and the
+	// budget never ramps.
+	reserve uint64
+
+	// readMem is [testutils.ReadMemInfo], swapped out by tests.
+	readMem func() (testutils.MemInfo, bool)
+}
+
+func newNodeBudget() *nodeBudget {
+	// An explicit override pins the count, as does a platform whose free
+	// memory we cannot read.
+	if n, ok := testutils.MaxParallelOverride(); ok {
+		return &nodeBudget{min: n, max: n, limit: n, readMem: testutils.ReadMemInfo}
+	}
+	mi, ok := testutils.ReadMemInfo()
+	if !ok {
+		n := testutils.MaxParallel()
+		return &nodeBudget{min: n, max: n, limit: n, readMem: testutils.ReadMemInfo}
+	}
+	return &nodeBudget{
+		min: nodeMinParallel,
+		max: max(runtime.GOMAXPROCS(0), nodeMinParallel),
+		// Start where the static cap would have: the count CI validates, and
+		// therefore the one worth assuming before any reading has been taken.
+		// Starting at the floor instead would leave any platform with a
+		// pessimistic reading — darwin, counting only wholly free pages —
+		// permanently slower than the fixed cap it replaced.
+		limit:   max(testutils.MaxParallel(), nodeMinParallel),
+		reserve: mi.Total / nodeMemReserveDiv,
+		readMem: testutils.ReadMemInfo,
+	}
+}
+
+// acquire blocks until there is room for one more node.
+func (b *nodeBudget) acquire() {
+	for !b.tryAcquire() {
+		time.Sleep(nodeBudgetPoll)
+	}
+}
+
+func (b *nodeBudget) tryAcquire() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.resize()
+	if b.running >= b.limit {
+		return false
+	}
+	b.running++
+	return true
+}
+
+// resize moves the allowance one step towards what the machine can currently
+// take. Called with b.mu held.
+//
+// Growing and shrinking use different thresholds so the limit settles instead
+// of oscillating: room for a whole further node to grow, dipping into the
+// reserve to shrink, and nothing in between. Shrinking matters because the
+// memory being measured is shared — a second suite, or a browser, starting
+// midway through should cost this one its ramp rather than the machine.
+func (b *nodeBudget) resize() {
+	if b.reserve == 0 || time.Since(b.lastCheck) < nodeStartSettle {
+		return
+	}
+	mi, ok := b.readMem()
+	if !ok {
+		return
+	}
+	// Pace the reading itself and not merely changes to the limit: blocked
+	// scripts poll five times a second, and on darwin every reading costs a
+	// vm_stat subprocess. Sitting inside the hysteresis band must be cheap.
+	b.lastCheck = time.Now()
+	switch {
+	case mi.Available < b.reserve && b.limit > b.min:
+		b.limit--
+	case mi.Available >= b.reserve+nodeMemCost && b.limit < b.max && b.running >= b.limit:
+		// Only when the current allowance is actually saturated. Raising it
+		// while slots sit free buys nothing and overshoots, the nodes already
+		// admitted still being on their way up to full size.
+		b.limit++
+	default:
+		return
+	}
+	if traceNodeBudget {
+		fmt.Fprintf(os.Stderr, "nodeBudget: limit=%d running=%d max=%d avail=%.2fGiB reserve=%.2fGiB\n",
+			b.limit, b.running, b.max, float64(mi.Available)/(1<<30), float64(b.reserve)/(1<<30))
+	}
+}
+
+func (b *nodeBudget) release() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.running--
+}
 
 type commandkind int
 
@@ -74,13 +242,33 @@ type NodesManager struct {
 	mu    sync.RWMutex
 
 	sequentialMu sync.RWMutex
+
+	// budget bounds how many nodes exist at once. Nodes are the expensive part
+	// of a script, so cap those rather than overriding the user's -parallel.
+	budget *nodeBudget
 }
 
 // NewNodesManager creates a new instance of NodesManager.
 func NewNodesManager() *NodesManager {
 	return &NodesManager{
-		nodes: make(map[string]*tNodeProcess),
+		nodes:  make(map[string]*tNodeProcess),
+		budget: newNodeBudget(),
 	}
+}
+
+// acquireSlot reserves the right to run one node, blocking until the suite is
+// below its node budget. The token is held for the rest of the script rather
+// than released on `gnoland stop`, so that a script which stops and starts
+// again never waits on a second token — every holder waiting for one more
+// would deadlock once the budget is full.
+func (nm *NodesManager) acquireSlot(ts *testscript.TestScript) {
+	slot := ts.Value(envKeyNodeSlot).(*nodeSlot)
+	if slot.held {
+		return
+	}
+	nm.budget.acquire()
+	slot.held = true
+	ts.Defer(nm.budget.release)
 }
 
 func (nm *NodesManager) IsNodeRunning(sid string) bool {
@@ -182,6 +370,7 @@ func SetupGnolandTestscript(t *testing.T, p *testscript.Params) error {
 		env.Values[envKeyGenesis] = &genesis
 		env.Values[envKeyPkgsLoader] = NewPkgsLoader()
 		env.Values[envKeyStdinBuffer] = new(strings.Builder)
+		env.Values[envKeyNodeSlot] = new(nodeSlot)
 
 		env.Setenv("GNOROOT", gnoRootDir)
 		env.Setenv("GNOHOME", gnoHomeDir)
@@ -272,6 +461,11 @@ func gnolandCmd(t *testing.T, nodesManager *NodesManager, gnoRootDir string) fun
 			if err := fs.Parse(cmdargs); err != nil {
 				ts.Fatalf("unable to parse `gnoland start` flags: %s", err)
 			}
+
+			// Before the genesis txs are built, which are themselves held in
+			// memory until the node has them. Always taken before
+			// sequentialMu, never the other way around.
+			nodesManager.acquireSlot(ts)
 
 			pkgs := ts.Value(envKeyPkgsLoader).(*PkgsLoader)
 			defaultFee := std.NewFee(50000, std.MustParseCoin(ugnot.ValueString(1000000)))

--- a/gnovm/pkg/gnolang/files_test.go
+++ b/gnovm/pkg/gnolang/files_test.go
@@ -8,12 +8,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/pkg/test"
+	"github.com/gnolang/gno/tm2/pkg/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +57,13 @@ func TestFiles(t *testing.T) {
 	// pool. Reusing stores lets tests share previously loaded packages.
 	// When syncing golden files, run sequentially to keep walk-order writes
 	// and error propagation deterministic.
-	poolSize := runtime.GOMAXPROCS(0)
+	//
+	// The pool is sized by memory rather than by GOMAXPROCS: a store retains
+	// the preprocessed AST and values of every package its tests touch, which
+	// grows towards the full set, so one store per core costs ~7 GiB on a
+	// 16-core host against ~1.8 GiB on one core — for no wall-clock gain, the
+	// suite having stopped being CPU-bound well before that.
+	poolSize := testutils.MaxParallel()
 	if *withSync {
 		poolSize = 1
 	}
@@ -65,6 +71,9 @@ func TestFiles(t *testing.T) {
 	for range poolSize {
 		optsPool <- newOpts()
 	}
+	// Tests below that opt out of the pool still draw against its budget, so
+	// their fresh stores can't push the total past twice the pool size.
+	freshStore := make(chan struct{}, poolSize)
 
 	dir := "../../tests/files"
 	fsys := os.DirFS(dir)
@@ -125,6 +134,8 @@ func TestFiles(t *testing.T) {
 				// loaded — scheduling-dependent, so their goldens flake under
 				// the pool (and always diverge in filtered runs). A fresh
 				// store makes the counted allocations deterministic.
+				freshStore <- struct{}{}
+				defer func() { <-freshStore }()
 				opts = newOpts()
 			} else {
 				opts = <-optsPool

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gtank/merlin v0.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/libp2p/go-buffer-pool v0.1.0
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pelletier/go-toml v1.9.5
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=

--- a/tm2/pkg/testutils/parallel.go
+++ b/tm2/pkg/testutils/parallel.go
@@ -1,0 +1,57 @@
+package testutils
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+)
+
+// MaxParallelEnv pins the worker counts derived in this file. Setting it opts
+// out of scaling to fit the machine, which is occasionally useful when
+// profiling or bisecting a memory problem.
+const MaxParallelEnv = "GNO_TEST_MAX_PARALLEL"
+
+// defaultMaxParallel is the worker count used when the machine's memory can't
+// be read. It matches the CPU count of the GitHub-hosted runners the suites are
+// tuned on, which is why CI stays within its memory budget while a workstation
+// with four times the cores does not.
+const defaultMaxParallel = 4
+
+// MaxParallelOverride reports the [MaxParallelEnv] setting, if it holds a
+// positive integer.
+func MaxParallelOverride() (int, bool) {
+	n, err := strconv.Atoi(os.Getenv(MaxParallelEnv))
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// MaxParallel reports how many memory-heavy workers a test suite may run
+// concurrently, for suites that must fix the count up front — a pool of GnoVM
+// stores, say, as opposed to workers started one at a time, which can instead
+// ramp against [MemInfo].
+//
+// Such workers cost hundreds of megabytes of live heap each, so sizing their
+// concurrency off GOMAXPROCS — the default for `go test` parallelism — makes
+// peak memory scale with the core count. That is the wrong axis: these suites
+// are bound by memory, not CPU, and stop getting faster well before they stop
+// getting bigger.
+func MaxParallel() int {
+	if n, ok := MaxParallelOverride(); ok {
+		return n
+	}
+	return min(runtime.GOMAXPROCS(0), defaultMaxParallel)
+}
+
+// MemInfo is a snapshot of the machine's memory, in bytes.
+type MemInfo struct {
+	// Total is the machine's physical memory.
+	Total uint64
+
+	// Available is the kernel's estimate of what can still be allocated
+	// without pushing the system into swap. Unlike free memory it accounts for
+	// reclaimable caches, and it falls as this process's heap grows — which is
+	// what makes it usable as a feedback signal for admitting more workers.
+	Available uint64
+}

--- a/tm2/pkg/testutils/parallel_linux.go
+++ b/tm2/pkg/testutils/parallel_linux.go
@@ -1,0 +1,131 @@
+package testutils
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// cgroupMount is where cgroup v2 is mounted on every distribution that ships it.
+const cgroupMount = "/sys/fs/cgroup"
+
+// ReadMemInfo reports the memory this process may use, from /proc/meminfo
+// narrowed by the memory limit of its cgroup. It returns false if neither
+// figure could be read.
+func ReadMemInfo() (MemInfo, bool) {
+	// A few kB of virtual file; read it whole rather than scanning it.
+	bz, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return MemInfo{}, false
+	}
+
+	var mi MemInfo
+	for line := range strings.Lines(string(bz)) {
+		key, rest, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		var dst *uint64
+		switch key {
+		case "MemTotal":
+			dst = &mi.Total
+		case "MemAvailable":
+			dst = &mi.Available
+		default:
+			continue
+		}
+		// The value is in kB: "MemTotal:       32950272 kB".
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		if kb, err := strconv.ParseUint(fields[0], 10, 64); err == nil {
+			*dst = kb * 1024
+		}
+	}
+
+	if limit, used, ok := cgroupMemory(); ok {
+		mi = clampToCgroup(mi, limit, used)
+	}
+	return mi, mi.Total > 0 && mi.Available > 0
+}
+
+// clampToCgroup narrows a host reading to what a cgroup memory limit allows.
+//
+// /proc/meminfo is not namespaced, so inside a container it describes the host:
+// a caller sizing itself against it would be OOM-killed by the cgroup rather
+// than throttled by its own accounting. Total is narrowed as well as Available,
+// since callers scale their headroom off the memory they believe they have.
+func clampToCgroup(mi MemInfo, limit, used uint64) MemInfo {
+	mi.Total = min(mi.Total, limit)
+	var free uint64
+	if limit > used {
+		free = limit - used
+	}
+	mi.Available = min(mi.Available, free)
+	return mi
+}
+
+// cgroupMemory reports this process's cgroup v2 memory limit and current usage.
+// It returns false when there is no v2 limit in force — cgroup v1, or the
+// common case of "max". A memory.high throttle, if one is set below the limit,
+// is not considered.
+func cgroupMemory() (limit, used uint64, ok bool) {
+	dir, ok := cgroupDir()
+	if !ok {
+		return 0, 0, false
+	}
+	if limit, ok = readCgroupUint(filepath.Join(dir, "memory.max")); !ok {
+		return 0, 0, false
+	}
+	if used, ok = readCgroupUint(filepath.Join(dir, "memory.current")); !ok {
+		return 0, 0, false
+	}
+	return limit, used, true
+}
+
+// cgroupDir locates the directory holding this process's cgroup v2 files.
+func cgroupDir() (string, bool) {
+	bz, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", false
+	}
+	for line := range strings.Lines(string(bz)) {
+		// v2 has a single unified entry, "0::<path>"; v1 lines name a
+		// controller instead and are skipped.
+		rel, ok := strings.CutPrefix(strings.TrimSpace(line), "0::")
+		if !ok {
+			continue
+		}
+		// The path is relative to the cgroup root this process can see, which
+		// under a cgroup namespace is already the mount. Where it is not — a
+		// container sharing the host's namespace — the path names a directory
+		// that does not exist here, and the mount root is the right answer.
+		if dir := filepath.Join(cgroupMount, rel); fileExists(filepath.Join(dir, "memory.max")) {
+			return dir, true
+		}
+		return cgroupMount, fileExists(filepath.Join(cgroupMount, "memory.max"))
+	}
+	return "", false
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// readCgroupUint reads a single-value cgroup file. The literal "max" means no
+// limit is in force, which is reported as absent rather than as a huge number.
+func readCgroupUint(path string) (uint64, bool) {
+	bz, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(bz))
+	if s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 10, 64)
+	return v, err == nil
+}

--- a/tm2/pkg/testutils/parallel_linux_test.go
+++ b/tm2/pkg/testutils/parallel_linux_test.go
@@ -1,0 +1,87 @@
+package testutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClampToCgroup(t *testing.T) {
+	t.Parallel()
+
+	const host = 32 << 30
+	for _, tt := range []struct {
+		name              string
+		mi                MemInfo
+		limit, used       uint64
+		wantTotal, wantAv uint64
+	}{
+		{
+			// The case this exists for: a container far smaller than its host.
+			name: "limit below host",
+			mi:   MemInfo{Total: host, Available: 20 << 30},
+			// A quarter of 4 GiB is a very different reserve from a quarter of
+			// 32, so Total has to be narrowed too, not just Available.
+			limit: 4 << 30, used: 1 << 30,
+			wantTotal: 4 << 30, wantAv: 3 << 30,
+		},
+		{
+			name: "host tighter than the limit",
+			mi:   MemInfo{Total: host, Available: 2 << 30},
+			// The host is already short of memory; the cgroup's generous
+			// headroom does not conjure any.
+			limit: 16 << 30, used: 1 << 30,
+			wantTotal: 16 << 30, wantAv: 2 << 30,
+		},
+		{
+			name:  "usage at the limit",
+			mi:    MemInfo{Total: host, Available: 20 << 30},
+			limit: 4 << 30, used: 4 << 30,
+			wantTotal: 4 << 30, wantAv: 0,
+		},
+		{
+			// memory.current can exceed memory.max transiently, before reclaim
+			// catches up. Must not underflow into a huge Available.
+			name:  "usage past the limit",
+			mi:    MemInfo{Total: host, Available: 20 << 30},
+			limit: 4 << 30, used: 5 << 30,
+			wantTotal: 4 << 30, wantAv: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := clampToCgroup(tt.mi, tt.limit, tt.used)
+			assert.Equal(t, tt.wantTotal, got.Total, "Total")
+			assert.Equal(t, tt.wantAv, got.Available, "Available")
+			assert.LessOrEqual(t, got.Available, got.Total)
+		})
+	}
+}
+
+func TestReadCgroupUint(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	v, ok := readCgroupUint(write("bytes", "4294967296\n"))
+	assert.True(t, ok)
+	assert.Equal(t, uint64(4<<30), v)
+
+	// "max" means no limit in force, and must not read as a number.
+	_, ok = readCgroupUint(write("unlimited", "max\n"))
+	assert.False(t, ok)
+
+	_, ok = readCgroupUint(write("garbage", "not a number"))
+	assert.False(t, ok)
+
+	_, ok = readCgroupUint(dir + "/does-not-exist")
+	assert.False(t, ok)
+}

--- a/tm2/pkg/testutils/parallel_other.go
+++ b/tm2/pkg/testutils/parallel_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package testutils
+
+import "github.com/pbnjay/memory"
+
+// ReadMemInfo reports the machine's memory via github.com/pbnjay/memory, which
+// covers darwin, windows and the BSDs. Linux has its own implementation, using
+// MemAvailable rather than the free-memory figure the library reports there.
+//
+// How good Available is varies by platform. Windows reports genuinely available
+// physical memory, so it behaves like the Linux reading. darwin counts only
+// wholly free pages — not the inactive and purgeable ones it would reclaim on
+// demand — and so under-reports on any machine putting the rest to use as
+// cache; callers get a conservative ramp there rather than a wrong one. On
+// platforms the library does not cover it reports zero and this returns false,
+// leaving callers on their static fallback.
+func ReadMemInfo() (MemInfo, bool) {
+	mi := MemInfo{
+		Total:     memory.TotalMemory(),
+		Available: memory.FreeMemory(),
+	}
+	return mi, mi.Total > 0 && mi.Available > 0
+}

--- a/tm2/pkg/testutils/parallel_test.go
+++ b/tm2/pkg/testutils/parallel_test.go
@@ -1,0 +1,61 @@
+package testutils
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxParallelOverride(t *testing.T) {
+	for _, tt := range []struct {
+		set  string
+		want int
+		ok   bool
+	}{
+		{set: "", want: 0, ok: false},
+		{set: "8", want: 8, ok: true},
+		{set: "1", want: 1, ok: true},
+		{set: "0", want: 0, ok: false},    // meaningless: would admit nothing
+		{set: "-2", want: 0, ok: false},   // ditto
+		{set: "many", want: 0, ok: false}, // typo shouldn't silently pin a count
+		{set: "4.5", want: 0, ok: false},
+	} {
+		t.Run("set="+tt.set, func(t *testing.T) {
+			t.Setenv(MaxParallelEnv, tt.set)
+			n, ok := MaxParallelOverride()
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, n)
+		})
+	}
+}
+
+func TestMaxParallel(t *testing.T) {
+	t.Run("override wins", func(t *testing.T) {
+		t.Setenv(MaxParallelEnv, "11")
+		assert.Equal(t, 11, MaxParallel())
+	})
+
+	t.Run("otherwise capped", func(t *testing.T) {
+		t.Setenv(MaxParallelEnv, "")
+		n := MaxParallel()
+		assert.GreaterOrEqual(t, n, 1)
+		assert.LessOrEqual(t, n, defaultMaxParallel)
+		assert.LessOrEqual(t, n, runtime.GOMAXPROCS(0), "never more workers than cores")
+	})
+}
+
+func TestReadMemInfo(t *testing.T) {
+	t.Parallel()
+
+	mi, ok := ReadMemInfo()
+	if !ok {
+		t.Skip("not implemented on this platform")
+	}
+	require.NotZero(t, mi.Total)
+	assert.LessOrEqual(t, mi.Available, mi.Total, "more available than exists")
+	// A machine running this test has some memory going spare, and the units
+	// had better be bytes: a kB/byte mix-up would show up as an absurd total.
+	assert.Greater(t, mi.Total, uint64(256<<20), "total looks like it is not in bytes")
+}


### PR DESCRIPTION
Running the test suite on a workstation can take the machine down. The heavyweight suites size their concurrency off `GOMAXPROCS`, but a worker costs hundreds of megabytes of live heap, so peak memory scales with the host's core count. CI never sees this: `ubuntu-latest` has four cores, which is the number these suites are implicitly tuned for. A sixteen-core machine quadruples every one of them.

## Why CPU count is the wrong axis

`gno.land/pkg/integration` testdata suite, measured at fixed node counts on a 16-core host:

| nodes | 2 | 4 | 6 | 8 | 12 | 16 |
|---|---|---|---|---|---|---|
| wall | 145s | 83s | 54s | 54s | 42s | 43s |
| peak RSS | 3.9G | 5.8G | 7.2G | 8.2G | 9.4G | 12.0G |

Memory keeps climbing long after wall time stops improving. `gno test` on examples is starker still: 8.0 GiB at sixteen workers against 4.2 GiB at four, for *identical* wall time.

At the peak, per node: the genesis write batch, the preprocessed AST kept by its store, a goleveldb memtable, and the store's own stdlib byte cache — none of it shared between nodes.

## What this does

Caps the expensive thing in each suite, rather than overriding anyone's `-parallel`:

**`gno.land/pkg/integration`** — nodes are what a script costs, so they are admitted against a budget. It starts at the count CI validates and ramps towards `GOMAXPROCS` while the machine reports memory to spare, shrinking back towards two when it stops doing so. Growth is paced, and only happens when the current allowance is saturated; growing and shrinking use different thresholds so the limit settles rather than oscillates.

The result is that it spends the memory actually going free, on the machine at hand, and gives it back when something else wants it — no flag to tune. On a 16-core/30 GiB host with ~15 GiB free: **43s at 10.1 GiB, against 43s at 12.0 GiB uncapped, and no swap touched.** On a loaded machine it simply ramps less far.

**`gnovm/pkg/gnolang` `TestFiles`** — the store pool is fixed at construction, so there is nothing to ramp; it takes the static cap. **7.3 GiB → 3.3 GiB, no slower.** Tests that opt out of the pool for their own store now draw against the same budget, so the total cannot quietly double.

**`examples`** — `gno test` holds a store per worker, so the Makefile targets pass `-p`. **8.0 GiB → 4.2 GiB, same wall time.** The CLI's own default is left alone; that is a shipped binary's documented behaviour and a separate decision.

## The reading

`MemAvailable` on Linux, narrowed by the cgroup's `memory.max` so a container is not sized against its host, and `pbnjay/memory` elsewhere. Where no reading is available — plan9, or cgroup v1 — the budget is static, and the suites behave as they did before this change but capped.

Worth knowing: the platforms do not agree on what "free" means. Windows reports genuinely available pages; darwin counts only wholly free ones, so it under-reports on any machine using the rest as cache. That is why the allowance *starts* at the static cap rather than at the floor — otherwise darwin would end up permanently slower than the fixed cap it replaces.

## Verification

- All 188 txtar scripts pass; the `TestFiles` failure set is byte-identical to what pristine master produces on this machine, including the gas and alloc goldens that are sensitive to store reuse.
- 15 unit tests cover the controller: floor, ramp, hysteresis band, shrink-under-pressure, read pacing, static fallback, override; plus cgroup clamping and env parsing.
- Builds on linux, darwin, windows, freebsd, openbsd, netbsd, plan9.
- Verified end-to-end with no cgroup safety net: the budget is the only thing between the suite and the machine, and the machine stayed healthy.

## Escape hatches

`GNO_TEST_MAX_PARALLEL` pins the worker count outright. `GNO_TEST_TRACE_BUDGET` logs every change of allowance with the reading behind it, which is the way to see what the budget decided on a given machine.
