### PR TITLE
fix(gnovm,gno.land): three ways coins were lost or over-authorized around the send-envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ make fmt                        # Format all code
 
 ### Verification Rules
 
+- After changing anything under `gnovm/stdlibs/`, `gnovm/tests/stdlibs/`, or the
+  VM's execution context, always run the Gno example suite before declaring done:
+  - `cd examples && go run ../gnovm/cmd/gno test ./...`
+  Go tests do not cover `.gno` filetests. A change can pass every `go test`
+  target below and still leave `examples/` red — stdlib behavior reaches
+  filetests through a different path.
 - After changing gas constants or allocation/GC logic, always run these before declaring done:
   - `go test ./gno.land/pkg/sdk/vm/ -run Gas`
   - `go test ./gno.land/pkg/integration/ -run TestTestdata`

--- a/contribs/gnodev/pkg/proxy/path_interceptor_test.go
+++ b/contribs/gnodev/pkg/proxy/path_interceptor_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gnolang/gno/contribs/gnodev/pkg/proxy"
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
-	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gno.land/pkg/integration"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
@@ -117,12 +116,15 @@ func Incr(cur realm) {
 	t.Run("simulate_tx_paths", func(t *testing.T) {
 		// Build transaction with multiple messages
 		var tx std.Tx
-		send := std.MustParseCoins(ugnot.ValueString(1_000_000))
+		// No coins attached: this test is about capturing package paths,
+		// and Incr has no notion of being paid. MsgCall now rejects coins
+		// that the called function never reads, because they would be
+		// stranded in its address.
 		tx.Fee = std.Fee{GasWanted: 5e6, GasFee: std.Coin{Amount: 1e6, Denom: "ugnot"}}
 		tx.Msgs = []std.Msg{
-			vm.NewMsgCall(creator, send, targetPath, "Incr", nil),
-			vm.NewMsgCall(creator, send, targetPath, "Incr", nil),
-			vm.NewMsgCall(creator, send, targetPath, "Incr", nil),
+			vm.NewMsgCall(creator, nil, targetPath, "Incr", nil),
+			vm.NewMsgCall(creator, nil, targetPath, "Incr", nil),
+			vm.NewMsgCall(creator, nil, targetPath, "Incr", nil),
 		}
 
 		bytes, err := tx.GetSignBytes(cfg.Genesis.ChainID, 0, seq)

--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -185,14 +185,13 @@ building AI and robotics systems seemingly in order to bring about armageddon.
 An [anonymous whistleblower leaked in 2023](./images/manifesto/project_lazarus_leak.jpg) that Meta is building
 an AI that can take over a deceased person's social media account and continue
 posting convincing posts including age progression. On 5 February 2025,
-Alphabet, which owns Google, [reneged on its pledge to not use AI for
-weapons](https://www.stopkillerrobots.org/news/alphabet-rollback-on-policy-to-not-use-ai-for-weapons/).
-Eric Schmidt former CEO of Google now runs an AI drone company and is a
-licensed arms dealer. Boston Dynamics develops the Atlas humanoid robot that
-can be even [more agile](https://www.youtube.com/watch?v=tjFHRVr7aNE) than
-humans, and the US military works with many robotics companies such as with
-Foundation Future Industries Inc. which develops the Phantom MK1 designed for
-military applications including carrying firearms.
+Alphabet, which owns Google, reneged on its pledge to not use AI for
+weapons.  Eric Schmidt former CEO of Google now runs an AI drone company and is
+a licensed arms dealer. Boston Dynamics develops the Atlas humanoid robot that
+can be even [more agile](https://www.youtube.com/watch?v=tjFHRVr7aNE) than humans, and the US military
+works with many robotics companies such as with Foundation Future Industries
+Inc. which develops the Phantom MK1 designed for military applications including
+carrying firearms.
 
 Here are some of the things to look forward to in the coming AI armageddon.
 

--- a/examples/quarantined/gno.land/r/archive/banktest/filetests/z_0_filetest.gno
+++ b/examples/quarantined/gno.land/r/archive/banktest/filetests/z_0_filetest.gno
@@ -26,6 +26,10 @@ func main(cur realm) {
 	// simulate a Deposit call. use Send + OriginSend to simulate -send.
 	banker_.SendCoins(mainaddr, banktestAddr, chain.Coins{{"ugnot", 100_000_000}})
 	testing.SetOriginSend(chain.Coins{{"ugnot", 100_000_000}})
+	// The -send envelope lands on banktest, so name banktest as the payee.
+	// Must come before the user-realm line below: after it, cur is a code
+	// realm and banker.NewBanker(BankerTypeOriginSend, cur) is refused.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/archive/banktest"))
 	testing.SetRealm(testing.NewUserRealm(mainaddr))
 	res := banktest.Deposit(cross(cur), "ugnot", 50_000_000) // bank1 can't send? should be r/demo/bank1 to r/demo/banktest, is bank1 -> bank1.
 	println("Deposit():", res)

--- a/examples/quarantined/gno.land/r/archive/banktest/filetests/z_1_filetest.gno
+++ b/examples/quarantined/gno.land/r/archive/banktest/filetests/z_1_filetest.gno
@@ -16,6 +16,10 @@ func main(cur realm) {
 	// simulate a Deposit call.
 	testing.IssueCoins(banktestAddr, chain.Coins{{"ugnot", 100000000}})
 	testing.SetOriginSend(chain.Coins{{"ugnot", 100000000}})
+	// The -send envelope lands on banktest, so name banktest as the payee.
+	// Must come before the user-realm line below: after it, cur is a code
+	// realm and banker.NewBanker(BankerTypeOriginSend, cur) is refused.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/archive/banktest"))
 	testing.SetRealm(testing.NewUserRealm(mainaddr))
 
 	res := banktest.Deposit(cross(cur), "ugnot", 101000000)

--- a/examples/quarantined/gno.land/r/archive/banktest/filetests/z_2_filetest.gno
+++ b/examples/quarantined/gno.land/r/archive/banktest/filetests/z_2_filetest.gno
@@ -24,6 +24,10 @@ func main(cur realm) {
 	// simulate a Deposit call.
 	testing.IssueCoins(banktestAddr, chain.Coins{{"ugnot", 100000000}})
 	testing.SetOriginSend(chain.Coins{{"ugnot", 100000000}})
+	// The -send envelope lands on banktest, so name banktest as the payee.
+	// Must come before the user-realm line below: after it, cur is a code
+	// realm and banker.NewBanker(BankerTypeOriginSend, cur) is refused.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/archive/banktest"))
 	testing.SetRealm(testing.NewUserRealm(mainaddr))
 	res := banktest.Deposit(cross(cur), "ugnot", 55000000)
 	println("Deposit():", res)

--- a/gno.land/adr/pr6062_payable_send_check.md
+++ b/gno.land/adr/pr6062_payable_send_check.md
@@ -1,0 +1,219 @@
+# Reject coins nobody looked at
+
+## Status
+
+Implemented. Verified against the full test suite.
+
+## The problem
+
+You can attach coins to a call. They are moved into the address of the
+realm you called, before that realm's code runs. We call them the
+envelope.
+
+Nothing required the realm to notice. If its code never looked at the
+envelope, the coins simply sat in its address. There was no error, no
+refund, and often no way to get them back. The caller believed they had
+paid for something. The realm had no idea it had been paid.
+
+There is no way to work this out ahead of time. Gno has interface calls
+and function values, so whether a given call will end up reading the
+envelope cannot be decided by reading the code. Any safe approximation
+would mark most of the ecosystem as accepting payment.
+
+## The decision
+
+Work it out while the call runs, and use the only definition that is
+actually true: **the code read the envelope**.
+
+Two places in the code that runs on chain make the envelope visible:
+
+1. `unsafe.OriginSend()`, which returns it directly.
+2. The spending limit check inside an OriginSend banker.
+
+Both now set a flag. After a `MsgCall` finishes, if coins were attached
+and the flag was never set, the whole message fails and the coins go back.
+
+The second place matters. A realm that simply forwards the payment on
+never calls `unsafe.OriginSend()` — it only ever touches the envelope
+through the banker. Marking in one place only would have rejected the most
+ordinary payment-handling realm there is.
+
+A third place reads it, but only in tests: `testing.GetContext()`
+hands the whole context, envelope included, to test code. It deliberately
+does not set the flag, and it does not need to — the payable check only
+runs on the real chain, and the test harness is not reachable from there.
+
+It is left alone for a practical reason. Every `testing.Set…` helper works
+by reading the context, changing one field, and writing it back. Blanking
+or refusing the envelope on the way out would make `SetHeight` silently
+erase a payment a test had just set up. The cost is a small fidelity gap:
+a test that reads the envelope this way is not exercising the payable
+path, and cannot tell.
+
+### Only the realm that was paid may vouch
+
+The first version of this marked the flag whenever anyone read the
+envelope, at any depth. That was wrong.
+
+Any realm can read the envelope, not just the one the coins went to. So a
+realm that never looked could still have its call accepted, because
+something it called happened to look. The coins stranded in the first
+realm while the second one believed it had been paid. We reproduced this.
+
+Now the flag is only set when the realm doing the reading is the realm the
+coins went to. The runtime already tracks which realm is executing, so
+this is a single comparison — no stack walking, and no change to gas
+costs.
+
+The banker path is deliberately different. It marks without checking who
+is running, because by that point it has already proved the coins being
+spent are the ones that were paid in. The owner of a banker may hand it to
+another realm to spend within the same message, so the realm running at
+that moment is not necessarily the one that was paid. Building a banker
+over your own envelope is itself proof you noticed the payment.
+
+## Scope
+
+`MsgCall` only.
+
+`MsgAddPackage` is exempt: coins attached there land in the new package's
+own address, and a realm can spend from its own address later, so they are
+not lost.
+
+That exemption was too broad, and it hid a second bug. A pure library
+package has no realm identity, so it can never obtain a banker and can
+never spend from its address. Deploying one with coins attached used to
+succeed, and those coins were gone permanently.
+
+**Fixed separately, in the commit that follows this one.** `MsgAddPackage`
+now rejects a non-empty payment when the path is not a realm. Realms still
+accept coins on deploy, because a realm can spend from its own address
+later. See `addpkg_unspendable_send.txtar`.
+
+`MsgRun` is exempt: the coins are moved from the caller to the caller, so
+nothing actually moves.
+
+## Alternatives considered
+
+**Mark a function as accepting payment, like `payable` in other
+languages.** Cannot be checked. See above.
+
+**Track whether the coins were spent instead of whether they were seen.**
+Wrong test. A realm that takes a deposit and holds it never spends the
+envelope. It only checks the amount and keeps it. That is a normal, honest
+realm and this would have rejected it.
+
+**Return the envelope as empty to realms that were not paid, instead of
+tracking who looked.** Dangerous. A realm asking "was I paid?" would
+silently read zero and take its "no payment" branch while the coins sat
+elsewhere. We tested a version of this and it quietly changed the meaning
+of five existing payment tests without any of them failing.
+
+**Leave it alone.** Coins keep getting stranded with no signal.
+
+## A known limitation, in both directions
+
+"Which realm is running" is answered by the realm the VM is currently
+operating in. That is normally the realm whose code is executing, but not
+always: when a realm calls a method on an object owned by a *different*
+realm, the VM switches to the owner for the duration. That is deliberate
+and correct for storage, but it means the answer can be the owning realm
+rather than the calling one.
+
+So there are two ways to get the wrong answer:
+
+- **A realm gets credit it did not earn.** A realm deeper in the chain
+  reads the envelope through a shared helper owned by the realm that was
+  paid. The read is attributed to the owner, and the payment is accepted
+  even though the owner never looked. The coins are still stranded, which
+  is the thing we were trying to catch.
+- **A realm is refused credit it did earn.** The realm that was paid reads
+  its own envelope through a shared helper owned by *another* realm. The
+  read is attributed to that other realm, the flag never gets set, and a
+  perfectly good payment is rejected.
+
+The second is worse, and it is worth being precise about why. This is a
+safety net against losing coins, not a security boundary. Missing a
+stranding means an accident goes uncaught — bad, but it is the situation
+we were already in. Rejecting a real payment breaks a working system, and
+does it with a message that blames the wrong thing.
+
+That asymmetry is an argument for erring loose rather than strict, which
+the earlier version of this check did — and which had its own problem, the
+callee-vouching hole described above. There is no cheap setting that
+avoids both. Worth revisiting deliberately rather than inheriting.
+
+The refusal case is reproducible in a few lines. A `/p/` library exports a
+shared object whose method reads the envelope; a realm that genuinely
+requires payment calls that method instead of reading directly. Same
+realm, same coins, same requirement — reading directly is accepted,
+reading through the shared object is rejected.
+
+**Do not read too much comfort into the fact that no `/p/` package in this
+tree does that.** We checked all 609 of them and none reads the envelope,
+which is why nothing breaks today. But `/p/` packages are user-deployable.
+Anyone can publish a shared payment helper tomorrow, and a shared helper
+that checks "was I paid" is a natural thing to write. The first person who
+does it breaks payments in their own realms, with an error message that
+points at the wrong thing.
+
+So the honest statement is: nothing in the tree triggers it, and nothing
+prevents it.
+
+An exact answer needs to know whether the paid realm is anywhere on the
+call stack, which a single comparison cannot tell. Doing it properly means
+tracking that as the VM pushes and pops frames — more than this change was
+scoped for, but the shape of the real fix.
+
+We accepted this rather than walking the call stack to get an exact
+answer, because the exact version costs a stack walk on every read and
+would change the gas table.
+
+Both directions were demonstrated with throwaway tests during review. They
+are not checked in: they assert the buggy behavior, so they would fail the
+day someone fixes it, and they need a `/p/` helper that reads the envelope
+— which is exactly what does not exist. Rebuilding one is a few minutes'
+work from the description above.
+
+**If anyone ever writes a `/p/` helper that reads the envelope, revisit
+this.** That is the trigger.
+
+## Consequences
+
+- Some calls that used to succeed now fail. This is the point, but it is a
+  change in what counts as a valid transaction.
+- Seventeen edits across nine test files. No realm source changed.
+  - Fourteen were one pattern: using an attached payment to *fund* a
+    realm's address rather than to pay it. Those realms can spend their
+    own balance, so nothing was ever stranded — they just never looked.
+    They now acknowledge the payment. Funding an address without calling
+    it is still possible with an ordinary transfer, which does not go
+    through this path at all.
+  - Two dropped an attached payment that was never meaningful. One was a
+    test fixture whose function has no notion of being paid. The other is
+    the `valopers` registration test — see below.
+  - One switched a call to send nothing, in a test that asserts nothing
+    about balances and had copied the payment from elsewhere.
+- The `valopers` realm reads the envelope only when a registration fee is
+  configured, and that fee currently defaults to zero. Attaching a payment
+  while the fee is off is now rejected. That is the correct outcome: those
+  coins would have been stranded. Its test was updated to stop attaching
+  one. If a test ever turns the fee on, the payment goes back.
+- The app hash does not change **for this commit**. Everything here is Go,
+  which is compiled into the node rather than stored on chain. (The banker
+  fix in the preceding commit does move it, because it edits Gno standard
+  library source, which is genesis state.)
+- Gas costs do not change. The new check is one string comparison.
+- This is a safety net against losing coins, not a permission check. A
+  realm can opt in by reading the envelope and ignoring the result. That
+  is fine — the goal is to catch accidents, not to police intent.
+
+## What we checked
+
+- `gno test ./examples/...` — 221 packages pass, none fail.
+- The full integration suite passes.
+- The VM, test-harness, and file-test suites pass.
+- A new test pins the exact hole: a realm that never looks cannot be
+  vouched for by one it calls.
+- Reading the envelope from a deeper realm still returns the real number.
+  This is about who may vouch, not about hiding anything.

--- a/gno.land/pkg/gnoclient/integration_test.go
+++ b/gno.land/pkg/gnoclient/integration_test.go
@@ -581,7 +581,6 @@ func TestAddPackageMultiple_Integration(t *testing.T) {
 	}
 
 	deposit := std.Coins{{Denom: ugnot.Denom, Amount: int64(10000000)}}
-	send := std.Coins{{Denom: ugnot.Denom, Amount: int64(1000000)}}
 	deploymentPath1 := "gno.land/p/demo/integration/test/echo"
 
 	body1 := `package echo
@@ -635,7 +634,6 @@ func Hello(str string) string {
 				},
 			},
 		},
-		Send:       send,
 		MaxDeposit: deposit,
 	}
 
@@ -674,16 +672,19 @@ func Hello(str string) string {
 	require.NoError(t, err)
 	assert.Equal(t, std.Coins{std.Coin{Denom: "ugnot", Amount: 177900}}, baseAcc.GetCoins())
 
-	// Verify the realm account balance received from the send
-	baseAcc, _, err = client.QueryAccount(gnolang.DerivePkgCryptoAddr(deploymentPath2))
-	require.NoError(t, err)
-	assert.Equal(t, std.Coins{std.Coin{Denom: "ugnot", Amount: 1000000}}, baseAcc.GetCoins())
+	// This used to attach coins to the deploy and assert they landed in the
+	// package's address. That is no longer allowed: a pure package has no
+	// realm identity, so it can never obtain a banker and could never spend
+	// from that address — the coins were unrecoverable. MsgAddPackage now
+	// rejects it, so no account is created for the package address at all.
 
 	// Verify remaining balance of deployer's account
 	baseAcc, _, err = client.QueryAccount(caller.GetAddress())
 	require.NoError(t, err)
 	// 999999654370 = 10000000000000 - (GasFee 2100000 + Storage Deposit 176800 + Storage Deposit 177900 + Send 1000000)
-	assert.Equal(t, std.Coins{std.Coin{Denom: "ugnot", Amount: 9999996545300}}, baseAcc.GetCoins())
+	// 1_000_000 higher than before: that is the payment the deployer used to
+	// attach to the pure-package deploy and lose permanently.
+	assert.Equal(t, std.Coins{std.Coin{Denom: "ugnot", Amount: 9999997545300}}, baseAcc.GetCoins())
 
 	// Test signing separately (using a different deployment path)
 	deploymentPath1B := "gno.land/p/demo/integration/test2/echo"

--- a/gno.land/pkg/integration/testdata/addpkg_unspendable_send.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_unspendable_send.txtar
@@ -1,0 +1,60 @@
+# Coins must not be attached to the deployment of a pure library package.
+#
+# When you deploy a package you can attach coins. They are moved into the
+# package's address. A realm can get them back later — it can ask for a
+# banker and spend from its own address.
+#
+# A pure library package cannot. It has no realm identity, so it can never
+# get a banker, and nothing else can move coins out of that address either.
+# The coins would be gone permanently, with no error at the time.
+#
+# So the deployment is refused instead.
+
+adduser alice
+
+gnoland start
+
+## A pure library package with coins attached is rejected.
+! gnokey maketx addpkg -pkgdir $WORK/lib -pkgpath gno.land/p/test/lib -send 700000ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test alice
+stderr 'can never spend it'
+
+## The same package with no coins attached deploys fine.
+gnokey maketx addpkg -pkgdir $WORK/lib -pkgpath gno.land/p/test/lib -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test alice
+stdout OK!
+
+## A realm with coins attached is still allowed: it can spend them later.
+gnokey maketx addpkg -pkgdir $WORK/rlm -pkgpath gno.land/r/test/rlm -send 700000ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test alice
+stdout OK!
+
+## And the realm really did receive them.
+gnokey maketx call -pkgpath gno.land/r/test/rlm -func Balance -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout 'balance=700000'
+
+-- lib/gnomod.toml --
+module = "gno.land/p/test/lib"
+gno = "0.9"
+
+-- lib/lib.gno --
+package lib
+
+func Hello() string { return "hi" }
+
+-- rlm/gnomod.toml --
+module = "gno.land/r/test/rlm"
+gno = "0.9"
+
+-- rlm/rlm.gno --
+package rlm
+
+import (
+	"strconv"
+
+	"chain/banker"
+	"chain/runtime/unsafe"
+)
+
+func Balance(cur realm) string {
+	me := unsafe.CurrentRealm().Address()
+	return "balance=" + strconv.FormatInt(
+		banker.NewReadonlyBanker().GetCoins(me).AmountOf("ugnot"), 10)
+}

--- a/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag.txtar
@@ -81,6 +81,9 @@ import (
 
 // Variant A: close BEFORE store. Sanity check; should succeed.
 func InlineCloseBeforeStore(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),
@@ -93,6 +96,9 @@ func InlineCloseBeforeStore(cur realm) {
 // the taint is value-based (struct now owned by callee), this should
 // panic with "cannot directly modify readonly tainted".
 func InlineCloseAfterStore(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),
@@ -106,6 +112,9 @@ func InlineCloseAfterStore(cur realm) {
 // specifically in how method dispatch handles the taint state at
 // invocation vs dispatch time.
 func ClosureCallAfterStore(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),

--- a/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_diag2.txtar
@@ -71,6 +71,10 @@ import (
 )
 
 func newAllowance(cur realm) *allowancesender.AllowanceSender {
+	// The -send envelope on these calls provisions this realm's address so
+	// the allowance has something to draw on. Acknowledge it: MsgCall
+	// rejects an envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	return allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),

--- a/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_outer_recover.txtar
@@ -99,6 +99,10 @@ import (
 // from `defer al.Close()`? And if so, does the tx commit with the
 // persisted allowance still in open (closed=false) state?
 func GrantWithOuterRecover(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
+
 	defer func() {
 		if r := recover(); r != nil {
 			println("OUTER_RECOVERED_FROM:", r)

--- a/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_persistence.txtar
@@ -122,6 +122,9 @@ import (
 // spend `amount` to the original caller, then closes via defer.
 // Supported within-call pattern.
 func GrantAndSpend(cur realm, limit int64, amount int64) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),
@@ -134,6 +137,9 @@ func GrantAndSpend(cur realm, limit int64, amount int64) {
 
 // GrantAndSpendNegative exercises the negative-amount path.
 func GrantAndSpendNegative(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),
@@ -148,6 +154,9 @@ func GrantAndSpendNegative(cur realm) {
 // the pointer. granter's defer Close() then fails because the struct
 // is no longer granter-owned. The whole tx reverts.
 func GrantAndStore(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),

--- a/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
+++ b/gno.land/pkg/integration/testdata/allowancesender_recover.txtar
@@ -110,6 +110,9 @@ import (
 
 // GrantAndStoreWithRecover wraps defer Close() in a recover.
 func GrantAndStoreWithRecover(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),
@@ -133,6 +136,9 @@ func GrantAndStoreWithRecover(cur realm) {
 // no recover wrapper. Used to isolate whether the closure-wrap is what
 // changes behavior.
 func GrantAndStoreDirect(cur realm) {
+	// Acknowledge the provisioning envelope; MsgCall rejects an
+	// envelope no executing code ever observes.
+	_ = unsafe.OriginSend()
 	src := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	al := allowancesender.New(src,
 		unsafe.CurrentRealm().Address(),

--- a/gno.land/pkg/integration/testdata/banker_originsend_lifetime.txtar
+++ b/gno.land/pkg/integration/testdata/banker_originsend_lifetime.txtar
@@ -1,0 +1,176 @@
+# Regression test: a BankerTypeOriginSend banker must not outlive the
+# message that created it.
+#
+# Its authority IS the send-envelope of one message. The
+# construction-time guard (rlm.Previous().IsUserCall()) only proves the
+# realm was the entry realm AT THAT MOMENT; a banker value stashed in
+# realm state and woken up in a later message spends the realm's own
+# treasury against an envelope it never received.
+#
+# The rule is enforced structurally: an OriginSend banker carries a live
+# realm handle, and the realm finalization walk refuses to persist realm
+# values. Both stash-it-yourself and hand-it-to-a-delegate therefore
+# abort the whole transaction at commit, before any coins move.
+#
+# Same-message construct-and-use — the only thing the type is actually
+# for, including cross-realm delegation within the message — is
+# unaffected.
+
+loadpkg gno.land/r/test/stash $WORK/stash
+loadpkg gno.land/r/test/plugin $WORK/plugin
+loadpkg gno.land/r/test/vault $WORK/vault
+
+adduser attacker
+
+gnoland start
+
+## Fund stash so there would be a treasury to drain.
+gnokey maketx call -pkgpath gno.land/r/test/stash -func Fund -send 1000000ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test attacker
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/test/stash -func Report -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test attacker
+stdout '1000000'
+
+## SHAPE 1 — self-stash. The entry realm builds a legitimate OriginSend
+## banker (envelope 1ugnot) and assigns it to a package-level var. The
+## tx must abort at commit.
+! gnokey maketx call -pkgpath gno.land/r/test/stash -func Save -send 1ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test attacker
+stderr 'cannot persist realm value'
+
+## Nothing was persisted, so nothing can be revived later.
+! gnokey maketx call -pkgpath gno.land/r/test/stash -func UseSaved -args 500000 -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test attacker
+stderr 'no saved banker'
+
+## SHAPE 2 — delegation to a hostile plugin that persists the grant.
+## vault legitimately delegates a bounded banker within the message;
+## plugin stores it. The tx must abort at commit.
+! gnokey maketx call -pkgpath gno.land/r/test/vault -func Delegate -send 1ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test attacker
+stderr 'cannot persist realm value'
+
+## stash's treasury is untouched throughout.
+gnokey maketx call -pkgpath gno.land/r/test/stash -func Report -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test attacker
+stdout '1000000'
+
+## POSITIVE 1 — same-message construct-and-use, within the envelope.
+## stash is the entry realm, receives 7ugnot, forwards 7ugnot.
+gnokey maketx call -pkgpath gno.land/r/test/stash -func Forward -args 7 -send 7ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test attacker
+stdout OK!
+
+## Envelope in, same amount out: treasury still 1000000.
+gnokey maketx call -pkgpath gno.land/r/test/stash -func Report -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test attacker
+stdout '1000000'
+
+## POSITIVE 2 — the envelope bound still applies within the message.
+! gnokey maketx call -pkgpath gno.land/r/test/stash -func Forward -args 500000 -send 7ugnot -gas-fee 1000000ugnot -gas-wanted 8000000 -chainid=tendermint_test attacker
+stderr 'limit'
+
+## POSITIVE 3 — same-message cross-realm delegation still works: vault
+## builds the banker and hands it to plugin, which spends it inside the
+## same message without storing it.
+gnokey maketx call -pkgpath gno.land/r/test/vault -func DelegateAndSpend -args 5 -send 5ugnot -gas-fee 1000000ugnot -gas-wanted 9000000 -chainid=tendermint_test attacker
+stdout OK!
+
+-- stash/gnomod.toml --
+module = "gno.land/r/test/stash"
+gno = "0.9"
+
+-- stash/stash.gno --
+package stash
+
+import (
+	"strconv"
+
+	"chain"
+	"chain/banker"
+	"chain/runtime/unsafe"
+)
+
+var saved banker.Banker
+
+// Save tries to persist an OriginSend banker built by the entry realm.
+// NewBanker itself succeeds; the tx dies at commit when the realm
+// finalization walk refuses the pinned realm value.
+func Save(cur realm) {
+	saved = banker.NewBanker(banker.BankerTypeOriginSend, cur)
+}
+
+// UseSaved is the revival attempt. It can never find a banker.
+func UseSaved(cur realm, amount int64) {
+	if saved == nil {
+		panic("no saved banker")
+	}
+	me := unsafe.CurrentRealm().Address()
+	saved.SendCoins(me, unsafe.OriginCaller(), chain.Coins{{"ugnot", amount}})
+}
+
+// Fund provisions stash's address with a treasury to drain. It must
+// acknowledge the envelope or MsgCall rejects it as unobserved.
+func Fund(cur realm) { _ = unsafe.OriginSend() }
+
+func Report(cur realm) string {
+	me := unsafe.CurrentRealm().Address()
+	b := banker.NewReadonlyBanker()
+	return "balance=" + strconv.FormatInt(b.GetCoins(me).AmountOf("ugnot"), 10)
+}
+
+// Forward is the legitimate shape: build and spend in one message.
+func Forward(cur realm, amount int64) {
+	b := banker.NewBanker(banker.BankerTypeOriginSend, cur)
+	me := unsafe.CurrentRealm().Address()
+	b.SendCoins(me, unsafe.OriginCaller(), chain.Coins{{"ugnot", amount}})
+}
+
+-- plugin/gnomod.toml --
+module = "gno.land/r/test/plugin"
+gno = "0.9"
+
+-- plugin/plugin.gno --
+package plugin
+
+import (
+	"chain"
+	"chain/banker"
+	"chain/runtime/unsafe"
+)
+
+var saved banker.Banker
+
+// Keep persists a delegated banker — the hostile-delegate shape.
+func Keep(cur realm, b banker.Banker) {
+	saved = b
+}
+
+// SpendNow uses a delegated banker within the granting message and
+// never stores it — the legitimate delegation shape.
+func SpendNow(cur realm, b banker.Banker, from address, amount int64) {
+	b.SendCoins(from, unsafe.OriginCaller(), chain.Coins{{"ugnot", amount}})
+}
+
+-- vault/gnomod.toml --
+module = "gno.land/r/test/vault"
+gno = "0.9"
+
+-- vault/vault.gno --
+package vault
+
+import (
+	"chain/banker"
+	"chain/runtime/unsafe"
+
+	"gno.land/r/test/plugin"
+)
+
+// Delegate hands a bounded OriginSend banker to a plugin that stashes
+// it. Aborts at commit.
+func Delegate(cur realm) {
+	b := banker.NewBanker(banker.BankerTypeOriginSend, cur)
+	plugin.Keep(cross(cur), b)
+}
+
+// DelegateAndSpend hands the same banker to a plugin that spends it
+// immediately. This must keep working.
+func DelegateAndSpend(cur realm, amount int64) {
+	b := banker.NewBanker(banker.BankerTypeOriginSend, cur)
+	me := unsafe.CurrentRealm().Address()
+	plugin.SpendNow(cross(cur), b, me, amount)
+}

--- a/gno.land/pkg/integration/testdata/banker_persistence.txtar
+++ b/gno.land/pkg/integration/testdata/banker_persistence.txtar
@@ -98,6 +98,10 @@ import (
 var saved banker.Banker
 
 func Save(cur realm) {
+	// The -send envelope provisions A's address so later txs have a
+	// balance to spend. Acknowledge it: MsgCall rejects an envelope no
+	// executing code ever observes.
+	_ = unsafe.OriginSend()
 	saved = banker.NewBanker(banker.BankerTypeRealmSend, cur)
 }
 
@@ -116,6 +120,8 @@ func UseSelfAmount(cur realm, amount int64) {
 // hands it to realm B. Any -send envelope on this call accrues to A's
 // address as additional funds B can later drain.
 func GiveBankerToB(cur realm) {
+	// Same as Save: the -send envelope funds A for B to later drain.
+	_ = unsafe.OriginSend()
 	b := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	bankerb.Receive(cross(cur), b)
 }

--- a/gno.land/pkg/integration/testdata/payable_callee_read.txtar
+++ b/gno.land/pkg/integration/testdata/payable_callee_read.txtar
@@ -1,0 +1,94 @@
+# A realm deeper in the call chain must not vouch for the realm that got paid.
+#
+# When you attach coins to a call, they land in the address of the realm you
+# called. That realm has to look at them, or the coins sit there and nobody
+# knows they arrived. The chain rejects the call if nobody looked.
+#
+# The catch: any realm can read the envelope, at any depth. So a realm that
+# never looked could still have its call accepted, just because something it
+# called happened to look. The coins would strand in the first realm, while
+# the second one believes it was paid.
+#
+# This test pins that shut. Only the realm the coins landed in counts as
+# having looked.
+
+loadpkg gno.land/r/test/inner $WORK/inner
+loadpkg gno.land/r/test/outer $WORK/outer
+
+adduser alice
+
+gnoland start
+
+## The realm that was paid never looks; the one it calls does.
+## Rejected, and the coins stay with alice.
+! gnokey maketx call -pkgpath gno.land/r/test/outer -func Ignores -send 400ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stderr 'never read the send-envelope'
+
+## Control: the realm that was paid looks. Accepted.
+gnokey maketx call -pkgpath gno.land/r/test/outer -func Looks -send 400ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout OK!
+stdout 'outer-saw=400'
+
+## Only the accepted call moved coins, so outer holds 400, not 800.
+gnokey maketx call -pkgpath gno.land/r/test/outer -func Balance -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout 'balance=400'
+
+## Reading at depth still returns the real number. This is not about hiding
+## it, only about who is allowed to vouch for it.
+gnokey maketx call -pkgpath gno.land/r/test/outer -func Looks -send 100ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout 'inner-saw=100'
+
+-- inner/gnomod.toml --
+module = "gno.land/r/test/inner"
+gno = "0.9"
+
+-- inner/inner.gno --
+package inner
+
+import (
+	"strconv"
+
+	"chain/runtime/unsafe"
+)
+
+// Peek reads the envelope while running one level down. The coins are not
+// in this realm's address.
+func Peek(cur realm) string {
+	return "inner-saw=" + strconv.FormatInt(
+		unsafe.OriginSend().AmountOf("ugnot"), 10)
+}
+
+-- outer/gnomod.toml --
+module = "gno.land/r/test/outer"
+gno = "0.9"
+
+-- outer/outer.gno --
+package outer
+
+import (
+	"strconv"
+
+	"chain/banker"
+	"chain/runtime/unsafe"
+
+	"gno.land/r/test/inner"
+)
+
+// Ignores is the realm the coins land in, and it never looks at them.
+// It only calls inner, which does look.
+func Ignores(cur realm) string {
+	return inner.Peek(cross(cur))
+}
+
+// Looks is the same shape, except this realm looks first.
+func Looks(cur realm) string {
+	mine := unsafe.OriginSend().AmountOf("ugnot")
+	return "outer-saw=" + strconv.FormatInt(mine, 10) +
+		" " + inner.Peek(cross(cur))
+}
+
+func Balance(cur realm) string {
+	me := unsafe.CurrentRealm().Address()
+	return "balance=" + strconv.FormatInt(
+		banker.NewReadonlyBanker().GetCoins(me).AmountOf("ugnot"), 10)
+}

--- a/gno.land/pkg/integration/testdata/payable_observed_send.txtar
+++ b/gno.land/pkg/integration/testdata/payable_observed_send.txtar
@@ -1,0 +1,85 @@
+# MsgCall rejects a send-envelope that no executing code ever observed.
+#
+# "The code read the envelope" is the operational definition of payable.
+# It cannot be decided statically (interface dispatch + function values),
+# so it is reconstructed at runtime: the two natives that read
+# ctx.OriginSend mark a per-message flag, and MsgCall fails the message if
+# a non-empty envelope was attached and the flag was never set.
+#
+# There are TWO observation points, not one: the direct accessor
+# (unsafe.OriginSend) and the BankerTypeOriginSend limit check. A realm
+# that forwards its envelope through an OriginSend banker never calls the
+# former, and must still count as payable.
+
+loadpkg gno.land/r/test/payable $WORK/payable
+
+adduser alice
+
+gnoland start
+
+## 1. Reads the envelope, keeps it (the "bond" shape) -> OK.
+gnokey maketx call -pkgpath gno.land/r/test/payable -func HoldBond -send 500ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout OK!
+stdout 'held=500'
+
+## 2. Forwards via an OriginSend banker, never calls unsafe.OriginSend()
+##    -> still payable, must NOT be rejected.
+gnokey maketx call -pkgpath gno.land/r/test/payable -func Forward -args 300 -send 300ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout OK!
+
+## 3. Never looks at the envelope -> coins would be stranded -> REJECTED.
+! gnokey maketx call -pkgpath gno.land/r/test/payable -func Ignores -send 400ugnot -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stderr 'never read the send-envelope'
+
+## 4. Same non-payable function with no envelope -> fine.
+gnokey maketx call -pkgpath gno.land/r/test/payable -func Ignores -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout OK!
+
+## 5. The rejection in (3) rolled back: the realm holds only what
+##    txs 1 and 2 delivered, and tx 2 forwarded its 300 straight out.
+##    500 (held) + 300 (in) - 300 (out) = 500.
+gnokey maketx call -pkgpath gno.land/r/test/payable -func Report -gas-fee 1000000ugnot -gas-wanted 5000000 -chainid=tendermint_test alice
+stdout 'balance=500'
+
+-- payable/gnomod.toml --
+module = "gno.land/r/test/payable"
+gno = "0.9"
+
+-- payable/payable.gno --
+package payable
+
+import (
+	"strconv"
+
+	"chain"
+	"chain/banker"
+	"chain/runtime/unsafe"
+)
+
+// HoldBond verifies the envelope and keeps it. It never spends, so
+// keying on OriginSendSpent would wrongly judge it non-payable.
+func HoldBond(cur realm) string {
+	amt := unsafe.OriginSend().AmountOf("ugnot")
+	if amt <= 0 {
+		panic("expected a bond")
+	}
+	return "held=" + strconv.FormatInt(amt, 10)
+}
+
+// Forward moves the envelope back out through an OriginSend banker.
+// Note it never calls unsafe.OriginSend() — the banker limit check is
+// the only thing that reads ctx.OriginSend on this path.
+func Forward(cur realm, amount int64) {
+	b := banker.NewBanker(banker.BankerTypeOriginSend, cur)
+	b.SendCoins(unsafe.CurrentRealm().Address(), unsafe.OriginCaller(),
+		chain.Coins{{"ugnot", amount}})
+}
+
+// Ignores has no notion of payment.
+func Ignores(cur realm) {}
+
+func Report(cur realm) string {
+	me := unsafe.CurrentRealm().Address()
+	return "balance=" + strconv.FormatInt(
+		banker.NewReadonlyBanker().GetCoins(me).AmountOf("ugnot"), 10)
+}

--- a/gno.land/pkg/integration/testdata/user_journey.txtar
+++ b/gno.land/pkg/integration/testdata/user_journey.txtar
@@ -191,8 +191,9 @@ stdout 'OK!'
 gnokey query vm/qrender --data "gno.land/r/$user2_user_addr/home:"
 stdout 'My awesome home package with admin: '${user2_user_addr}
 
-# user2's transfer ownership to user1
-gnokey maketx call -pkgpath gno.land/r/$user2_user_addr/home -func TransferOwnership -args "$user1_user_addr" -send 100000000ugnot -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test user2
+# user2's transfer ownership to user1. No -send: TransferOwnership has no
+# notion of payment, and MsgCall now rejects an envelope no code reads.
+gnokey maketx call -pkgpath gno.land/r/$user2_user_addr/home -func TransferOwnership -args "$user1_user_addr" -gas-fee 500001ugnot -gas-wanted 5_000_000 -chainid=tendermint_test user2
 stdout 'OK!'
 
 # Wait for https://github.com/gnolang/gno/pull/4278 to be merged

--- a/gno.land/pkg/integration/testdata/valopers.txtar
+++ b/gno.land/pkg/integration/testdata/valopers.txtar
@@ -36,7 +36,13 @@ stderr 'consensus pubkey type is not allowed for validators'
 # guard passes. chain.PubKeyAddress(pubKey) derives the signing address
 # g10ddhfxv47lhyhpj426u57ckxwl0qtrk6c9rs5v; v3's executor resolves operator
 # -> signing-key via valoperCache at proposal-execute time.
-gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 4000001ugnot -gas-wanted 55_000_000 -send 20000000ugnot -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -chainid=tendermint_test test1
+#
+# No -send: GetValoperRegisterFee() defaults to 0, so Register never reaches
+# its unsafe.OriginSend() read (valopers.gno:148) and MsgCall would reject
+# the envelope as unobserved. Any fee attached while the fee is 0 would be
+# stranded in the valopers address. Restore -send here if a test ever raises
+# the fee first.
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -gas-fee 4000001ugnot -gas-wanted 55_000_000 -args berty -args "My validator description" -args on-prem -args g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr -chainid=tendermint_test test1
 stdout OK!
 
 # see the valoper in the Render

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -119,7 +119,14 @@ import (
 // stdlib source change and is intended. Note this is the *only* reason this
 // branch moves the pin — the balance split alone does not, because that scenario
 // holds no non-gas denom.
-const expectedCrossrealm38Hash = "914602d9e206bf666cbfdf6e28f9147317e96e2d16b665bda67ffb33b7d0e1a8"
+//
+// Bumped again by the OriginSend banker lifetime fix. banker.gno gains the
+// realm-handle field that pins such a banker to its message, plus the
+// accompanying doc. Same reason as the comment-only bump noted above:
+// stdlib .gno source bytes are genesis state, so any edit to them moves the
+// root. This one does change behavior, and is intentionally
+// consensus-breaking.
+const expectedCrossrealm38Hash = "b43e5fd5ab1a255ee177aef54e35a584b657b823718cc822d11c6139a2b65a8a"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/errors.go
+++ b/gno.land/pkg/sdk/vm/errors.go
@@ -33,6 +33,11 @@ type (
 	// msg trace instead, which reaches the user via the unhashed
 	// Result.Log.
 	TypeCheckError struct{ abciError }
+	// UnspendableSendError is returned by MsgAddPackage when coins are
+	// attached to the deployment of a pure `p/` package. Such a package has
+	// no realm identity, so it can never obtain a banker and can never
+	// spend from its own address — the coins would be lost for good.
+	UnspendableSendError struct{ abciError }
 )
 
 func (e InvalidPkgPathError) Error() string   { return "invalid package path" }
@@ -45,6 +50,10 @@ func (e UnauthorizedUserError) Error() string { return "unauthorized user" }
 func (e InvalidPackageError) Error() string   { return "invalid package" }
 func (e ObjectNotFoundError) Error() string   { return "object not found" }
 func (e TypeCheckError) Error() string        { return "invalid gno package; type check failed" }
+
+func (e UnspendableSendError) Error() string {
+	return "coins cannot be sent to a pure package; nothing could ever spend them"
+}
 
 func ErrPkgAlreadyExists(msg string) error {
 	return errors.Wrap(PkgExistError{}, msg)
@@ -76,6 +85,10 @@ func ErrInvalidPackage(msg string) error {
 
 func ErrObjectNotFound(msg string) error {
 	return errors.Wrap(ObjectNotFoundError{}, msg)
+}
+
+func ErrUnspendableSend(msg string) error {
+	return errors.Wrap(UnspendableSendError{}, msg)
 }
 
 // ErrTypeCheck wraps err's full messages around the empty TypeCheckError

--- a/gno.land/pkg/sdk/vm/errors.go
+++ b/gno.land/pkg/sdk/vm/errors.go
@@ -33,6 +33,11 @@ type (
 	// msg trace instead, which reaches the user via the unhashed
 	// Result.Log.
 	TypeCheckError struct{ abciError }
+	// UnobservedSendError is returned by MsgCall when a non-empty
+	// send-envelope was attached but no executing code ever observed it.
+	// Such a call would otherwise strand the coins in the callee's
+	// address. See ExecContext.OriginSendObserved.
+	UnobservedSendError struct{ abciError }
 	// UnspendableSendError is returned by MsgAddPackage when coins are
 	// attached to the deployment of a pure `p/` package. Such a package has
 	// no realm identity, so it can never obtain a banker and can never
@@ -50,6 +55,9 @@ func (e UnauthorizedUserError) Error() string { return "unauthorized user" }
 func (e InvalidPackageError) Error() string   { return "invalid package" }
 func (e ObjectNotFoundError) Error() string   { return "object not found" }
 func (e TypeCheckError) Error() string        { return "invalid gno package; type check failed" }
+func (e UnobservedSendError) Error() string {
+	return "coins were sent but the called function never read them"
+}
 
 func (e UnspendableSendError) Error() string {
 	return "coins cannot be sent to a pure package; nothing could ever spend them"
@@ -85,6 +93,10 @@ func ErrInvalidPackage(msg string) error {
 
 func ErrObjectNotFound(msg string) error {
 	return errors.Wrap(ObjectNotFoundError{}, msg)
+}
+
+func ErrUnobservedSend(msg string) error {
+	return errors.Wrap(UnobservedSendError{}, msg)
 }
 
 func ErrUnspendableSend(msg string) error {

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -739,10 +739,14 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 		OriginCaller:    creator.Bech32(),
 		OriginSend:      send,
 		OriginSendSpent: new(std.Coins),
-		Banker:          NewSDKBanker(vm, ctx),
-		Params:          NewSDKParams(vm.prmk, ctx),
-		EventLogger:     ctx.EventLogger(),
-		SessionAccount:  getSessionAccount(ctx, creator),
+		// send was credited to pkgAddr just above; that is the only
+		// address a BankerTypeOriginSend banker may spend from in this
+		// message.
+		OriginSendRecipient: pkgAddr.Bech32(),
+		Banker:              NewSDKBanker(vm, ctx),
+		Params:              NewSDKParams(vm.prmk, ctx),
+		EventLogger:         ctx.EventLogger(),
+		SessionAccount:      getSessionAccount(ctx, creator),
 	}
 	// Parse and run the files, construct *PV.
 	m2 := gno.NewMachineWithOptions(
@@ -850,10 +854,14 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 		OriginCaller:    caller.Bech32(),
 		OriginSend:      send,
 		OriginSendSpent: new(std.Coins),
-		Banker:          NewSDKBanker(vm, ctx),
-		Params:          NewSDKParams(vm.prmk, ctx),
-		EventLogger:     ctx.EventLogger(),
-		SessionAccount:  getSessionAccount(ctx, caller),
+		// send is credited to pkgAddr (the entry realm) below; that is
+		// the only address a BankerTypeOriginSend banker may spend from
+		// in this message.
+		OriginSendRecipient: pkgAddr.Bech32(),
+		Banker:              NewSDKBanker(vm, ctx),
+		Params:              NewSDKParams(vm.prmk, ctx),
+		EventLogger:         ctx.EventLogger(),
+		SessionAccount:      getSessionAccount(ctx, caller),
 	}
 	preAlloc := gno.NewAllocator(maxAllocTx)
 	preAlloc.SetGasMeter(ctx.GasMeter())
@@ -1083,10 +1091,17 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 		OriginCaller:    caller.Bech32(),
 		OriginSend:      send,
 		OriginSendSpent: new(std.Coins),
-		Banker:          NewSDKBanker(vm, ctx),
-		Params:          NewSDKParams(vm.prmk, ctx),
-		EventLogger:     ctx.EventLogger(),
-		SessionAccount:  getSessionAccount(ctx, caller),
+		// No OriginSendRecipient here, deliberately. pkgAddr == caller for
+		// MsgRun, so the coins move from the caller to the caller and the
+		// envelope never lands anywhere. A run script cannot construct a
+		// BankerTypeOriginSend banker either — its cur.Previous() is the
+		// ephemeral /e/<addr>/run realm, so IsUserCall() is false. Leaving
+		// the recipient empty is fail-closed: nothing can spend against an
+		// envelope that never moved.
+		Banker:         NewSDKBanker(vm, ctx),
+		Params:         NewSDKParams(vm.prmk, ctx),
+		EventLogger:    ctx.EventLogger(),
+		SessionAccount: getSessionAccount(ctx, caller),
 	}
 
 	buf := new(bytes.Buffer)

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -847,21 +847,23 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 	// Seed per-message accumulator before NewSDKParams captures ctx.
 	ctx = ContextWithParamsAccum(ctx)
 	msgCtx := stdlibs.ExecContext{
-		ChainID:         ctx.ChainID(),
-		ChainDomain:     chainDomain,
-		Height:          ctx.BlockHeight(),
-		Timestamp:       ctx.BlockTime().Unix(),
-		OriginCaller:    caller.Bech32(),
-		OriginSend:      send,
-		OriginSendSpent: new(std.Coins),
+		ChainID:            ctx.ChainID(),
+		ChainDomain:        chainDomain,
+		Height:             ctx.BlockHeight(),
+		Timestamp:          ctx.BlockTime().Unix(),
+		OriginCaller:       caller.Bech32(),
+		OriginSend:         send,
+		OriginSendSpent:    new(std.Coins),
+		OriginSendObserved: new(bool),
 		// send is credited to pkgAddr (the entry realm) below; that is
 		// the only address a BankerTypeOriginSend banker may spend from
 		// in this message.
-		OriginSendRecipient: pkgAddr.Bech32(),
-		Banker:              NewSDKBanker(vm, ctx),
-		Params:              NewSDKParams(vm.prmk, ctx),
-		EventLogger:         ctx.EventLogger(),
-		SessionAccount:      getSessionAccount(ctx, caller),
+		OriginSendRecipient:     pkgAddr.Bech32(),
+		OriginSendRecipientPath: pkgPath,
+		Banker:                  NewSDKBanker(vm, ctx),
+		Params:                  NewSDKParams(vm.prmk, ctx),
+		EventLogger:             ctx.EventLogger(),
+		SessionAccount:          getSessionAccount(ctx, caller),
 	}
 	preAlloc := gno.NewAllocator(maxAllocTx)
 	preAlloc.SetGasMeter(ctx.GasMeter())
@@ -936,6 +938,23 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 		if i < len(rtvs)-1 {
 			res += "\n"
 		}
+	}
+
+	// Reject a send-envelope that nothing observed. The coins were credited
+	// to pkgAddr above; if no executing code ever read them, the callee has
+	// no notion of being paid and they would be stranded there. Returning an
+	// error discards the whole message including that credit (msg execution
+	// is cache-wrapped, tm2/pkg/sdk/baseapp.go:901).
+	//
+	// MsgCall only. MsgAddPackage is exempt because its envelope lands in
+	// the new package's own address, recoverable later by the realm itself
+	// — except for a pure `p/` package, whose address nothing can ever
+	// spend from. MsgRun is exempt because pkgAddr == caller makes its
+	// send a self-transfer no-op.
+	if !send.IsZero() && !*msgCtx.OriginSendObserved {
+		return "", ErrUnobservedSend(fmt.Sprintf(
+			"%s sent to %s.%s, which never read the send-envelope",
+			send.String(), pkgPath, fnc))
 	}
 
 	// Use parameters before executing the message, as they may change during execution.

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -630,6 +630,27 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 	if _, ok := gno.IsGnoRunPath(pkgPath); ok {
 		return ErrInvalidPkgPath("reserved package name: " + pkgPath)
 	}
+	// Refuse coins that could never be spent again.
+	//
+	// A realm can spend from its own address later, via a banker, so coins
+	// attached to a realm deploy are recoverable and are allowed. A pure
+	// `p/` package cannot: it has no realm identity, so it can never obtain
+	// a banker, and nothing else can move coins out of its address either.
+	// Crediting it would destroy the coins with no error and no way back.
+	//
+	// The principle is that we refuse a payment the receiver could not act
+	// on, rather than accepting it and losing it silently.
+	//
+	// Placed after the path checks above so a bad path reports the path
+	// problem rather than this one, and before the type check below so the
+	// caller is not charged for compiling a package we are going to reject.
+	// The checks above have already established the path is a realm or a
+	// pure package, so "not a realm" here means "pure package".
+	if !send.IsZero() && !gno.IsRealmPath(pkgPath) {
+		return ErrUnspendableSend(fmt.Sprintf(
+			"%s sent to %s, which is a pure package and can never spend it",
+			send.String(), pkgPath))
+	}
 	opts := gno.TypeCheckOptions{
 		Getter: gnostore,
 		Mode:   gno.TCLatestStrict,

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -783,6 +783,7 @@ func init() {
 func Echo(cur realm, msg string) string {
 	addr := unsafe.OriginCaller()
 	pkgAddr := unsafe.CurrentRealm().Address()
+	_ = unsafe.OriginSend() // acknowledge the envelope; MsgCall rejects unobserved sends
 	send := chain.Coins{{"ugnot", 1000000}}
 	banker_ := banker.NewBanker(banker.BankerTypeRealmSend, cur)
 	banker_.SendCoins(pkgAddr, addr, send) // send back
@@ -893,9 +894,10 @@ func Do(cur realm) string {
 	err := env.vmk.AddPackage(ctx, msg1)
 	assert.NoError(t, err)
 
-	// Run Echo function.
-	coins := std.MustParseCoins(ugnot.ValueString(8_000_000))
-	msg2 := NewMsgCall(addr, coins, pkgPath, "Do", []string{})
+	// Run Do function. No send-envelope: Do only writes params and has no
+	// notion of payment, and MsgCall rejects an envelope no code reads.
+	// This test asserts nothing about balances, so the send was incidental.
+	msg2 := NewMsgCall(addr, nil, pkgPath, "Do", []string{})
 
 	res, err := env.vmk.Call(ctx, msg2)
 	assert.NoError(t, err)
@@ -2008,13 +2010,18 @@ func TestSessionMsgCallSendCountsAgainstSpendLimit(t *testing.T) {
 	env.acck.SetAccount(ctx, masterAcc)
 	env.bankk.SetCoins(ctx, master, initialBalance)
 
-	// Deploy a simple realm that accepts coins (no-op on them).
+	// Deploy a simple realm that accepts coins and keeps them. It must
+	// read the envelope: this test's whole point is that a MsgCall send
+	// counts against the session spend limit, and MsgCall rejects an
+	// envelope no executing code observes.
 	const pkgPath = "gno.land/r/absorb"
 	files := []*std.MemFile{
 		{Name: "absorb.gno", Body: `
 package absorb
 
-func Absorb(cur realm) {}`},
+import "chain/runtime/unsafe"
+
+func Absorb(cur realm) { _ = unsafe.OriginSend() }`},
 		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
 	}
 	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(master, pkgPath, files)))

--- a/gno.land/pkg/sdk/vm/package.go
+++ b/gno.land/pkg/sdk/vm/package.go
@@ -29,6 +29,7 @@ var Package = amino.RegisterPackage(amino.NewPackage(
 	InvalidPackageError{}, "InvalidPackageError",
 	InvalidFileError{}, "InvalidFileError",
 	ObjectNotFoundError{}, "ObjectNotFoundError",
+	UnspendableSendError{}, "UnspendableSendError",
 	GenesisState{}, "GenesisState",
 	Params{}, "Params",
 ))

--- a/gno.land/pkg/sdk/vm/package.go
+++ b/gno.land/pkg/sdk/vm/package.go
@@ -29,6 +29,7 @@ var Package = amino.RegisterPackage(amino.NewPackage(
 	InvalidPackageError{}, "InvalidPackageError",
 	InvalidFileError{}, "InvalidFileError",
 	ObjectNotFoundError{}, "ObjectNotFoundError",
+	UnobservedSendError{}, "UnobservedSendError",
 	UnspendableSendError{}, "UnspendableSendError",
 	GenesisState{}, "GenesisState",
 	Params{}, "Params",

--- a/gno.land/pkg/sdk/vm/pb3_gen.go
+++ b/gno.land/pkg/sdk/vm/pb3_gen.go
@@ -31,6 +31,7 @@ func init() {
 	amino.RegisterGenproto2Type(reflect.TypeOf((*InvalidPackageError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*InvalidFileError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*ObjectNotFoundError)(nil)).Elem())
+	amino.RegisterGenproto2Type(reflect.TypeOf((*UnspendableSendError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*GenesisState)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*Params)(nil)).Elem())
 }
@@ -987,6 +988,38 @@ func (goo *ObjectNotFoundError) UnmarshalBinary2(cdc *amino.Codec, bz []byte, an
 		switch fnum {
 		default:
 			return fmt.Errorf("unknown field number %d for ObjectNotFoundError", fnum)
+		}
+	}
+	return nil
+}
+
+func (goo UnspendableSendError) MarshalBinary2(cdc *amino.Codec, buf []byte, offset int) (int, error) {
+	var err error
+	return offset, err
+}
+
+func (goo UnspendableSendError) SizeBinary2(cdc *amino.Codec) (int, error) {
+	var s int
+	return s, nil
+}
+
+func (goo *UnspendableSendError) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDepth int) error {
+	*goo = UnspendableSendError{}
+	var lastFieldNum uint32
+	for len(bz) > 0 {
+		fnum, typ3, n, err := amino.DecodeFieldNumberAndTyp3(bz)
+		_ = typ3
+		if err != nil {
+			return err
+		}
+		if fnum <= lastFieldNum {
+			return fmt.Errorf("encountered fieldNum: %v, but we have already seen fnum: %v", fnum, lastFieldNum)
+		}
+		lastFieldNum = fnum
+		bz = bz[n:]
+		switch fnum {
+		default:
+			return fmt.Errorf("unknown field number %d for UnspendableSendError", fnum)
 		}
 	}
 	return nil

--- a/gno.land/pkg/sdk/vm/pb3_gen.go
+++ b/gno.land/pkg/sdk/vm/pb3_gen.go
@@ -31,6 +31,7 @@ func init() {
 	amino.RegisterGenproto2Type(reflect.TypeOf((*InvalidPackageError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*InvalidFileError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*ObjectNotFoundError)(nil)).Elem())
+	amino.RegisterGenproto2Type(reflect.TypeOf((*UnobservedSendError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*UnspendableSendError)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*GenesisState)(nil)).Elem())
 	amino.RegisterGenproto2Type(reflect.TypeOf((*Params)(nil)).Elem())
@@ -988,6 +989,38 @@ func (goo *ObjectNotFoundError) UnmarshalBinary2(cdc *amino.Codec, bz []byte, an
 		switch fnum {
 		default:
 			return fmt.Errorf("unknown field number %d for ObjectNotFoundError", fnum)
+		}
+	}
+	return nil
+}
+
+func (goo UnobservedSendError) MarshalBinary2(cdc *amino.Codec, buf []byte, offset int) (int, error) {
+	var err error
+	return offset, err
+}
+
+func (goo UnobservedSendError) SizeBinary2(cdc *amino.Codec) (int, error) {
+	var s int
+	return s, nil
+}
+
+func (goo *UnobservedSendError) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDepth int) error {
+	*goo = UnobservedSendError{}
+	var lastFieldNum uint32
+	for len(bz) > 0 {
+		fnum, typ3, n, err := amino.DecodeFieldNumberAndTyp3(bz)
+		_ = typ3
+		if err != nil {
+			return err
+		}
+		if fnum <= lastFieldNum {
+			return fmt.Errorf("encountered fieldNum: %v, but we have already seen fnum: %v", fnum, lastFieldNum)
+		}
+		lastFieldNum = fnum
+		bz = bz[n:]
+		switch fnum {
+		default:
+			return fmt.Errorf("unknown field number %d for UnobservedSendError", fnum)
 		}
 	}
 	return nil

--- a/gno.land/pkg/sdk/vm/vm.proto
+++ b/gno.land/pkg/sdk/vm/vm.proto
@@ -61,6 +61,9 @@ message InvalidFileError {
 message ObjectNotFoundError {
 }
 
+message UnspendableSendError {
+}
+
 message GenesisState {
 	Params params = 1;
 	repeated string realm_params = 2;

--- a/gno.land/pkg/sdk/vm/vm.proto
+++ b/gno.land/pkg/sdk/vm/vm.proto
@@ -61,6 +61,9 @@ message InvalidFileError {
 message ObjectNotFoundError {
 }
 
+message UnobservedSendError {
+}
+
 message UnspendableSendError {
 }
 

--- a/gnovm/adr/pr6062_originsend_banker_lifetime.md
+++ b/gnovm/adr/pr6062_originsend_banker_lifetime.md
@@ -1,0 +1,141 @@
+# An OriginSend banker must not outlive its message
+
+## Status
+
+Implemented. Verified against the full test suite.
+
+## The problem
+
+When you send a transaction to a realm you can attach coins to it. Those
+coins land in that realm's address. We call them the envelope.
+
+A realm can ask for a "banker" to move coins. There are several kinds. The
+`BankerTypeOriginSend` kind is meant to be the safe, limited one: it can
+only spend the envelope that came with the current transaction. The other
+kinds can spend everything the realm owns.
+
+Two facts about the code did not fit together:
+
+1. A banker was a plain value. You could store it and it would still be
+   there in the next transaction. This was on purpose and was tested.
+2. The spending limit was not stored inside the banker. It was looked up
+   fresh every time, from whatever transaction happened to be running.
+
+So a stored OriginSend banker did not stay limited to the envelope it was
+made for. Every new transaction re-armed it against a new envelope. The
+coins came out of the realm's own balance, not out of any envelope.
+
+The check that a realm may create one of these bankers happens once, when
+it is created. Nothing re-checked it later.
+
+### Why this mattered
+
+On its own this gave a realm nothing new. A realm can always ask for the
+stronger `BankerTypeRealmSend` and spend its whole balance.
+
+The problem was giving one away. Bankers are meant to be passed to other
+realms — that is written in the docs. A realm handing out an OriginSend
+banker believes it is handing out a limited, one-transaction permission.
+It is not. The receiver can store it and reuse it in **any** later
+transaction that carries coins, spending from the giver's balance up to
+whatever that unrelated transaction happened to attach. The original code
+never checked who the coins were paid to — only that the amount fit the
+envelope of whatever message was running. Nothing in the type prevents
+this, and the giver cannot revoke it.
+
+We proved this end to end. Realm A hands a banker to realm B during a
+legitimate call carrying a 1 coin envelope, and B stores it. In a later
+message — carrying a 500,000 coin envelope that had nothing to do with A —
+B uses the stored banker to take 500,000 coins out of A's own treasury.
+The banker was armed for 1 coin and spent 500,000.
+
+### Where it came from
+
+This is a regression, not an original flaw.
+
+The first version of this code (April 2022) stored the envelope and the
+running total inside the banker itself. There was no lookup. The banker
+could not be stored, and the docs said so.
+
+A refactor in March 2024 removed a feature of the native-function
+machinery. As part of that, the banker was reduced to a small value and
+the limit check moved to the ambient lookup. Nothing in that change
+suggests the security effect was noticed.
+
+Later, storing bankers was documented as supported and given a test. But
+that test only ever exercised the *other* banker kind. The support was
+verified for one kind and then written up as applying to all of them.
+
+## The decision
+
+Make an OriginSend banker impossible to store.
+
+The virtual machine already refuses to save realm handles — they are meant
+to live only for one call. So we put a live realm handle inside the banker,
+but only for the OriginSend kind. Any attempt to write such a banker into
+realm storage now fails, and the whole transaction is rolled back before
+any coins move.
+
+The banker can still be passed to other realms *during* the same message,
+which is the case the type exists for.
+
+Other banker kinds get an empty field and are unaffected. They can still
+be stored, exactly as before.
+
+Underneath that we added a second, independent check: when an OriginSend
+banker spends, the address it spends from must be the address the current
+message's envelope was actually credited to.
+
+We also added a fail-closed check for any banker that somehow arrives
+without the handle set.
+
+## Alternatives considered
+
+**Only add the second check (spender must be the payee).** This was tried
+first and it does not work. It does not stop a stored banker, it only puts
+it to sleep. The banker wakes up at full value in any later message where
+its own realm happens to be the one being called. We built a working
+attack against it: a hostile add-on stored a banker from a vault, then
+drained the vault every time an innocent user deposited. Keeping this
+check as a second layer is still worthwhile, so we did.
+
+**Give each message an identity token and store it in the banker.** This
+works but it fails in the wrong direction. Any place that builds an
+execution context and forgets to set the token would let everything
+through. There are nine such places outside tests, five of them in the
+keeper alone. The handle approach cannot be forgotten, because there is
+nothing to set.
+
+**Stop storing bankers entirely.** This would break a documented and
+tested feature that other realms rely on for the other banker kinds.
+
+**Leave it and document the hazard.** The whole point of this banker kind
+is to be the safe one to hand out. A documented warning does not restore
+that.
+
+## Consequences
+
+- The app hash changes. The banker's Gno source is part of genesis state,
+  so editing it moves the hash. Expected and intentional.
+- The banker value gains a field. On a chain that already has stored
+  bankers this would need migration. Not an issue for a new chain.
+- Test setup had to change. When a test says "pretend a user is calling",
+  the harness was also saying "pretend that user received the envelope".
+  A user address can never equal a realm address, so this pointed the
+  payee at something no realm could match. Now only a *realm* override
+  moves the payee.
+- Three `banktest` filetests needed one line each, naming which realm the
+  coins were sent to. These are tests that call a realm from a wrapper, so
+  the payee is not obvious from context.
+- `IsUserCall()` guards in realms are still needed and should not be
+  removed. This change does not replace them.
+
+## What we checked
+
+- `gno test ./examples/...` — 221 packages pass, none fail.
+- The full integration suite passes.
+- The VM, test-harness, and file-test suites pass.
+- The attack test fails at the moment the banker is handed over, before
+  any coins move.
+- Storing the other banker kinds still works, and delegating an
+  OriginSend banker within one message still works.

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -56,21 +56,23 @@ func Context(caller crypto.Bech32Address, pkgPath string, send std.Coins) *runti
 		},
 	}
 	ctx := stdlibs.ExecContext{
-		ChainID:         "dev",
-		ChainDomain:     "gno.land", // TODO: make this configurable
-		Height:          DefaultHeight,
-		Timestamp:       DefaultTimestamp,
-		OriginCaller:    caller,
-		OriginSend:      send,
-		OriginSendSpent: new(std.Coins),
+		ChainID:            "dev",
+		ChainDomain:        "gno.land", // TODO: make this configurable
+		Height:             DefaultHeight,
+		Timestamp:          DefaultTimestamp,
+		OriginCaller:       caller,
+		OriginSend:         send,
+		OriginSendSpent:    new(std.Coins),
+		OriginSendObserved: new(bool),
 		// Mirrors the CoinTable above: pkgAddr is the only address
 		// credited with `send`, so it is the only one a
 		// BankerTypeOriginSend banker may spend from. On chain this is
 		// the entry realm's address (keeper.go).
-		OriginSendRecipient: pkgAddr,
-		Banker:              banker,
-		Params:              newTestParams(),
-		EventLogger:         sdk.NewEventLogger(),
+		OriginSendRecipient:     pkgAddr,
+		OriginSendRecipientPath: pkgPath,
+		Banker:                  banker,
+		Params:                  newTestParams(),
+		EventLogger:             sdk.NewEventLogger(),
 	}
 	return &runtime.TestExecContext{
 		ExecContext: ctx,

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -63,9 +63,14 @@ func Context(caller crypto.Bech32Address, pkgPath string, send std.Coins) *runti
 		OriginCaller:    caller,
 		OriginSend:      send,
 		OriginSendSpent: new(std.Coins),
-		Banker:          banker,
-		Params:          newTestParams(),
-		EventLogger:     sdk.NewEventLogger(),
+		// Mirrors the CoinTable above: pkgAddr is the only address
+		// credited with `send`, so it is the only one a
+		// BankerTypeOriginSend banker may spend from. On chain this is
+		// the entry realm's address (keeper.go).
+		OriginSendRecipient: pkgAddr,
+		Banker:              banker,
+		Params:              newTestParams(),
+		EventLogger:         sdk.NewEventLogger(),
 	}
 	return &runtime.TestExecContext{
 		ExecContext: ctx,

--- a/gnovm/stdlibs/chain/banker/banker.gno
+++ b/gnovm/stdlibs/chain/banker/banker.gno
@@ -32,6 +32,14 @@ import (
 // bypassed entirely by a retained banker, which reaches the bank keeper
 // without re-entering your code.
 //
+// BankerTypeOriginSend is the one exception, and is NOT persistable. Its
+// authority is the send-envelope of a single message, so it is pinned to
+// that message: it carries a live realm value, which the persistence walk
+// refuses to store, so any attempt to keep one in realm state aborts the
+// transaction before any coins move. For that type alone the paragraph
+// above does not apply — the grant expires when the message ends. See
+// [NewBanker]. Every other banker type behaves exactly as described.
+//
 // Banker panics on errors instead of returning errors.
 // This also helps simplify the interface and prevent
 // hidden bugs (e.g. ignoring errors)
@@ -56,7 +64,10 @@ type BankerType uint8
 const (
 	// Can only read state.
 	BankerTypeReadonly BankerType = iota
-	// Can only send from tx send.
+	// Can only send from tx send: at most the coins this message's
+	// send-envelope credited to the realm's own address. Valid only
+	// inside the message that created it (it cannot be persisted) and
+	// only while that realm is the envelope's recipient.
 	BankerTypeOriginSend
 	// Can send from all realm coins.
 	BankerTypeRealmSend
@@ -133,11 +144,30 @@ func NewBanker(bt BankerType, rlm realm) Banker {
 	if bt == BankerTypeOriginSend && !rlm.Previous().IsUserCall() {
 		panic("banker with type BankerTypeOriginSend can only be instantiated by the origin package")
 	}
-	return banker{
+	b := banker{
 		bt:      bt,
 		pkgAddr: rlm.Address(),
 		pkgPath: rlm.PkgPath(),
 	}
+	if bt == BankerTypeOriginSend {
+		// Pin the banker to the message that created it. An OriginSend
+		// banker's authority IS the send-envelope of one message, so it
+		// must not outlive that message; the construction-time check
+		// above is worthless against a value stashed in realm state and
+		// woken up later. Carrying a live (non-origin) realm handle makes
+		// the value structurally unpersistable — the realm finalization
+		// walk refuses realm values outright (refusePersistRealmHIV in
+		// gnovm/pkg/gnolang/uverse.go), so any attempt to store this
+		// banker in realm state aborts the whole transaction. It stays
+		// freely passable to other realms WITHIN the message, which is
+		// the delegation the type exists for.
+		//
+		// This is structural, not a token: there is no per-message value
+		// for a caller to forge and no context field for a construction
+		// site to forget to populate.
+		b.rlm = rlm
+	}
+	return b
 }
 
 // These are native bindings to the banker's functions.
@@ -152,6 +182,14 @@ type banker struct {
 	bt      BankerType
 	pkgAddr address
 	pkgPath string // realm pkgpath, for IssueCoin/RemoveCoin denom-prefix.
+	// rlm is set only for BankerTypeOriginSend, where it is the
+	// message-lifetime pin described in [NewBanker]: realm values are
+	// refused by the persistence walk, so a banker holding one cannot be
+	// written to realm state. Nil for every other banker type — those
+	// are genuine cross-transaction capabilities (see
+	// gno.land/pkg/integration/testdata/banker_persistence.txtar) and
+	// keep persisting exactly as before.
+	rlm realm
 }
 
 // IsCanonical reports whether b is the canonical bank-keeper-backed
@@ -199,6 +237,16 @@ func (b banker) SendCoins(from, to address, amt chain.Coins) {
 	if b.pkgAddr != from {
 		msg := `can only send coins from realm that created banker "` + b.pkgAddr + `", not "` + from + `"`
 		panic(msg)
+	}
+	if b.bt == BankerTypeOriginSend && b.rlm == nil {
+		// Unreachable for anything NewBanker built in this message: it
+		// always sets rlm for OriginSend. Reaching here means the value
+		// crossed a message boundary through some route the persistence
+		// refusal did not catch (e.g. a realm object written before this
+		// rule existed). Fail closed rather than fall through to the
+		// envelope check, which alone cannot tell a revived banker from
+		// a fresh one.
+		panic("BankerTypeOriginSend banker is not valid outside the message that created it")
 	}
 	denoms, amounts := expandNative(amt)
 	bankerSendCoins(uint8(b.bt), string(from), string(to), denoms, amounts)

--- a/gnovm/stdlibs/chain/banker/banker.go
+++ b/gnovm/stdlibs/chain/banker/banker.go
@@ -26,7 +26,16 @@ type BankerInterface interface {
 const (
 	// Can only read state.
 	btReadonly uint8 = iota //nolint
-	// Can only send from tx send.
+	// Can only send from tx send: at most the coins the current message's
+	// send-envelope credited to the realm's own address, and only if that
+	// realm is the envelope's recipient.
+	//
+	// The recipient half is checked here at use time, in X_bankerSendCoins,
+	// rather than only at construction in banker.gno. It is a second layer:
+	// the primary rule is that an OriginSend banker cannot outlive its
+	// message at all, which banker.gno enforces structurally by pinning it
+	// to a realm value the persistence walk refuses to store. This check
+	// does not depend on that reasoning holding.
 	btOriginSend
 	// Can send from all realm coins.
 	btRealmSend
@@ -52,6 +61,33 @@ func X_bankerSendCoins(m *gno.Machine, bt uint8, fromS, toS string, denoms []str
 
 	switch bt {
 	case btOriginSend:
+		// Second layer. The primary rule is that an OriginSend banker
+		// cannot outlive the message that created it — enforced
+		// structurally in banker.gno, which pins such a banker to a
+		// realm value that the persistence walk refuses to store.
+		//
+		// This gate is independent of that: the envelope of this message
+		// was credited to exactly one address (ctx.OriginSendRecipient),
+		// and `from` is already pinned to the banker's bound pkgAddr by
+		// banker.gno's SendCoins, so it asserts the spending realm is
+		// the realm that actually received the envelope. It holds even
+		// for a banker built and used entirely within one message, and
+		// it does not depend on any Gno-side lifetime reasoning.
+		//
+		// NOTE: this check alone is NOT sufficient. It only stops a
+		// revived banker whose realm is not the current entry realm; a
+		// banker delegated to another realm and stashed there revives at
+		// full envelope value in any later message where the grantor
+		// happens to be the entry realm. That is why the lifetime pin,
+		// not this gate, is the primary control.
+		if from != ctx.OriginSendRecipient {
+			m.PanicString(
+				fmt.Sprintf(
+					`cannot send from "%v": it did not receive the origin send of this message`,
+					from),
+			)
+			return
+		}
 		// indirection allows us to "commit" in a second phase
 		spent := (*ctx.OriginSendSpent).Add(amt)
 		if !ctx.OriginSend.IsAllGTE(spent) {

--- a/gnovm/stdlibs/chain/banker/banker.go
+++ b/gnovm/stdlibs/chain/banker/banker.go
@@ -88,6 +88,19 @@ func X_bankerSendCoins(m *gno.Machine, bt uint8, fromS, toS string, denoms []str
 			)
 			return
 		}
+		// Past the gate above, `from` is the address the envelope was
+		// credited to, so this banker belongs to the realm that was paid.
+		// Forwarding the envelope through a banker counts as noticing the
+		// payment just as much as reading it does — the limit check below
+		// consults ctx.OriginSend. Mark here rather than after the limit
+		// check: a realm that gets this far is payable even if the send is
+		// then rejected for being too large, and failing it twice over
+		// would be wrong.
+		//
+		// Unconditional by design: the owner may have handed this banker to
+		// another realm to spend within this message, so the realm running
+		// right now is not necessarily the one that was paid.
+		ctx.MarkOriginSendObserved()
 		// indirection allows us to "commit" in a second phase
 		spent := (*ctx.OriginSendSpent).Add(amt)
 		if !ctx.OriginSend.IsAllGTE(spent) {

--- a/gnovm/stdlibs/chain/runtime/unsafe/unsafe.go
+++ b/gnovm/stdlibs/chain/runtime/unsafe/unsafe.go
@@ -20,7 +20,24 @@ func X_originCaller(m *gno.Machine) string {
 // a tx-origin primitive (see Class-2 in docs/resources/gno-security.md),
 // so its native binding belongs with the other tx-origin natives.
 func X_originSend(m *gno.Machine) (denoms []string, amounts []int64) {
-	os := execctx.GetContext(m).OriginSend
+	ctx := execctx.GetContext(m)
+	// Reading the envelope is what makes a realm payable; MsgCall rejects
+	// a non-empty envelope no code ever looked at. Only the realm that was
+	// actually paid may mark — a callee reading the ambient envelope must
+	// not vouch for an entry realm that never looked.
+	// MarkOriginSendObservedBy does that comparison; m.Realm is the realm
+	// currently executing, which the VM already tracks, so this costs one
+	// string compare and no stack walk.
+	//
+	// Marking for an empty envelope is harmless and kept: the flag records
+	// observation, not amount, and the keeper only consults it when send is
+	// non-empty.
+	var realmPath string
+	if m.Realm != nil {
+		realmPath = m.Realm.Path
+	}
+	ctx.MarkOriginSendObservedBy(realmPath)
+	os := ctx.OriginSend
 	denoms = make([]string, len(os))
 	amounts = make([]int64, len(os))
 	for i, coin := range os {

--- a/gnovm/stdlibs/internal/execctx/context.go
+++ b/gnovm/stdlibs/internal/execctx/context.go
@@ -46,10 +46,25 @@ type ExecContext struct {
 	OriginCaller    crypto.Bech32Address
 	OriginSend      std.Coins
 	OriginSendSpent *std.Coins // mutable
-	Banker          BankerInterface
-	Params          ParamsInterface
-	EventLogger     *sdk.EventLogger
-	SessionAccount  std.DelegatedAccount // nil for master-key txs
+	// OriginSendRecipient is the single address that OriginSend was
+	// actually credited to for this message — the entry realm's address
+	// (for MsgRun, the caller's, since /e/<addr>/run derives to it).
+	// BankerTypeOriginSend spending is gated on it: a banker is a plain
+	// persistable value, so its construction-time authority check
+	// (rlm.Previous().IsUserCall(), see chain/banker/banker.gno) can be
+	// separated arbitrarily in time from its use. Without this field the
+	// use-time limit would re-arm against the ambient envelope of any
+	// later message, one the banker's realm never received.
+	//
+	// The zero value means "no envelope was delivered in this message",
+	// which is fail-closed: no BankerTypeOriginSend send can succeed.
+	// That is the correct value for envelope-less contexts (queries,
+	// internal realm callouts).
+	OriginSendRecipient crypto.Bech32Address
+	Banker              BankerInterface
+	Params              ParamsInterface
+	EventLogger         *sdk.EventLogger
+	SessionAccount      std.DelegatedAccount // nil for master-key txs
 }
 
 // GetContext returns the execution context.

--- a/gnovm/stdlibs/internal/execctx/context.go
+++ b/gnovm/stdlibs/internal/execctx/context.go
@@ -61,10 +61,90 @@ type ExecContext struct {
 	// That is the correct value for envelope-less contexts (queries,
 	// internal realm callouts).
 	OriginSendRecipient crypto.Bech32Address
-	Banker              BankerInterface
-	Params              ParamsInterface
-	EventLogger         *sdk.EventLogger
-	SessionAccount      std.DelegatedAccount // nil for master-key txs
+	// OriginSendRecipientPath is the same realm as OriginSendRecipient,
+	// written as a package path instead of an address. It exists so the
+	// payable check can tell "the realm that got paid looked at the
+	// envelope" apart from "some other realm looked at it" using the
+	// realm the VM is already tracking (Machine.Realm), with no stack
+	// walk and no change to the gas table.
+	//
+	// Empty in contexts that cannot carry a send, which is fail-closed:
+	// no realm has an empty path, so nothing matches and nothing is
+	// marked as observed.
+	OriginSendRecipientPath string
+	// OriginSendObserved records whether the realm that was paid ever made
+	// the send-envelope observable — set via MarkOriginSendObservedBy, or
+	// MarkOriginSendObserved on the banker path. MsgCall uses
+	// it to reject a non-empty envelope that the callee never looked at,
+	// which is what would otherwise silently strand coins in a realm that
+	// has no notion of being paid.
+	//
+	// "The code read the envelope" is the operational definition of
+	// payable. It cannot be decided statically: Gno has interface dispatch
+	// and function values, so whether a call path reaches a read is
+	// undecidable in general, and any conservative approximation marks
+	// most of the ecosystem payable.
+	//
+	// This is a safety net against stranded funds, NOT an access-control
+	// boundary: a realm opts in simply by reading the envelope and
+	// discarding the result. Nil in contexts that cannot carry a send.
+	//
+	// Must stay a pointer. The Mark* methods below have value receivers and
+	// GetContext returns a copy, so they can only write through this
+	// indirection. Change it to a plain bool and they become silent no-ops,
+	// which would fail every MsgCall that carries coins.
+	OriginSendObserved *bool // mutable
+	Banker             BankerInterface
+	Params             ParamsInterface
+	EventLogger        *sdk.EventLogger
+	SessionAccount     std.DelegatedAccount // nil for master-key txs
+}
+
+// MarkOriginSendObservedBy records that the realm at realmPath made the
+// message's send-envelope observable — but only if that realm is the one
+// the envelope was credited to.
+//
+// The check is the point. Any realm can read the ambient envelope at any
+// call depth, so without it a realm deeper in the chain could satisfy the
+// payable check on behalf of an entry realm that never looked. That is
+// exactly the stranding this is meant to catch: the coins sit in the entry
+// realm, which has no idea it was paid.
+//
+// Callers pass Machine.Realm.Path — the realm the VM is currently
+// executing in, which it already tracks, so this costs one string compare
+// and no stack walk.
+//
+// Nil-safe and empty-safe: contexts that cannot carry a send leave the
+// field unset, and no realm has an empty path, so nothing is marked.
+//
+// Use MarkOriginSendObserved instead when the caller has already proved
+// the envelope belongs to the realm some other way.
+func (e ExecContext) MarkOriginSendObservedBy(realmPath string) {
+	if e.OriginSendObserved == nil {
+		return
+	}
+	if realmPath == "" || realmPath != e.OriginSendRecipientPath {
+		return
+	}
+	*e.OriginSendObserved = true
+}
+
+// MarkOriginSendObserved marks the envelope observed without checking who
+// is running.
+//
+// Only call this once you have already proved the envelope belongs to the
+// caller some other way. The one such place is the BankerTypeOriginSend
+// send path, which first checks that the spending address is the address
+// the envelope was credited to. Once that holds, the realm that owns the
+// banker is by definition the realm that was paid, even if it handed the
+// banker to another realm to spend within this message — building a
+// banker over your own envelope is itself proof you noticed the payment.
+//
+// Nil-safe.
+func (e ExecContext) MarkOriginSendObserved() {
+	if e.OriginSendObserved != nil {
+		*e.OriginSendObserved = true
+	}
 }
 
 // GetContext returns the execution context.

--- a/gnovm/tests/stdlibs/testing/context_testing.go
+++ b/gnovm/tests/stdlibs/testing/context_testing.go
@@ -144,8 +144,15 @@ func X_setContext(
 	// testing.SetOriginSend passes an empty currRealmAddr (GetContext
 	// does not round-trip CurrentRealm), so it leaves the recipient
 	// alone either way.
+	//
+	// Move both spellings together. OriginSendRecipient (address) and
+	// OriginSendRecipientPath (package path) name the same realm and must
+	// never disagree: the banker gate reads the address, the payable check
+	// reads the path. Setting one without the other leaves the harness
+	// describing two different realms.
 	if currRealmAddr != "" && currRealmPkgPath != "" {
 		ctx.OriginSendRecipient = crypto.Bech32Address(currRealmAddr)
+		ctx.OriginSendRecipientPath = currRealmPkgPath
 	}
 
 	m.Context = ctx

--- a/gnovm/tests/stdlibs/testing/context_testing.go
+++ b/gnovm/tests/stdlibs/testing/context_testing.go
@@ -126,6 +126,27 @@ func X_setContext(
 	ctx.OriginSend = banker.CompactCoins(origSendDenoms, origSendAmounts)
 	coins := banker.CompactCoins(origSpendDenoms, origSpendAmounts)
 	ctx.OriginSendSpent = &coins
+	// Keep OriginSendRecipient consistent with the envelope being set.
+	//
+	// On chain the -send envelope always lands on the entry realm, so a
+	// test that re-points the current realm to a *code* realm is
+	// modelling a different entry realm and must move the recipient with
+	// it. Otherwise BankerTypeOriginSend sends fail against a stale
+	// recipient.
+	//
+	// A *user* realm override (testing.SetRealm(testing.NewUserRealm))
+	// means "an EOA is calling", not "this EOA received the envelope".
+	// A user address can never equal any realm's address, so moving the
+	// recipient there would point it at something no realm can match and
+	// break every payment test. Leave it on the package under test, which
+	// gnovm/pkg/test.Context already seeded.
+	//
+	// testing.SetOriginSend passes an empty currRealmAddr (GetContext
+	// does not round-trip CurrentRealm), so it leaves the recipient
+	// alone either way.
+	if currRealmAddr != "" && currRealmPkgPath != "" {
+		ctx.OriginSendRecipient = crypto.Bech32Address(currRealmAddr)
+	}
 
 	m.Context = ctx
 }


### PR DESCRIPTION

## One known problem, written down but not fixed

Working out "which realm is running" follows who *owns* an object, not whose
code it is. So if a realm reads its coins through a shared helper owned by a
different realm, we can get the answer wrong — in both directions. The worse
one rejects a payment that was perfectly good.

This needs a library package that reads the attached coins. None of the 609
in the tree does. **But anyone can publish one**, so this is "nothing sets it
off today", not "nothing can". The ADR says what to watch for and what a real
fix would look like.

## What else is in here

- **Two ADRs** explaining the first two fixes. Filenames still say `prxxxx_`
  and need the real number.
- **Four new tests**, one for each bug plus one covering the legitimate cases
  that must keep working.
- **A test-setup fix.** When a test said "pretend a user is calling", the
  setup also claimed that user had received the coins — which no realm can
  ever match. Now only pretending to be a *realm* does that.
- **Twelve existing tests updated.** Nearly all the same thing: they used
  attached coins to top up a realm's balance rather than to pay it, so they
  now acknowledge the payment. **No realm source code changed.**
- **`AGENTS.md`**: run the Gno example tests after changing the standard
  library. Leaving that out is exactly why commit 2 first went in with three
  broken tests — the Go tests don't reach them.

ai assisted