### PR TITLE
test(p2p): cover the timer branch of waitForDialTime

### DIFF
--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -1023,6 +1023,52 @@ func TestMultiplexSwitch_DialLoop_BackedOff(t *testing.T) {
 			t.Fatal("the wait outlived the context")
 		}
 	})
+
+	t.Run("an item is dialed once its wait elapses", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancelFn := context.WithCancel(context.Background())
+		defer cancelFn()
+
+		var (
+			dialed = make(chan types.NetAddress, 1)
+			addr   = generateNetAddr(t, 1)[0]
+
+			mockTransport = &mockTransport{
+				dialFn: func(
+					_ context.Context,
+					a types.NetAddress,
+					_ PeerBehavior,
+				) (PeerConn, error) {
+					dialed <- a
+
+					return nil, errors.New("unable to dial")
+				},
+			}
+
+			sw = NewMultiplexSwitch(mockTransport)
+		)
+
+		sw.peers = &mockSet{
+			hasFn: func(types.ID) bool { return false },
+		}
+
+		// Nothing else is queued and the context stays live, so the loop can
+		// only come back on the timer
+		sw.dialQueue.Push(dial.Item{
+			Time:    time.Now().Add(100 * time.Millisecond),
+			Address: addr,
+		})
+
+		go sw.runDialLoop(ctx)
+
+		select {
+		case got := <-dialed:
+			assert.Equal(t, *addr, got)
+		case <-time.After(5 * time.Second):
+			t.Fatal("the item was not dialed once it became due")
+		}
+	})
 }
 
 // TestMultiplexSwitch_DialLoop_DoesNotSpin guards against the dial loop busy

--- a/tm2/pkg/p2p/switch_test.go
+++ b/tm2/pkg/p2p/switch_test.go
@@ -1027,8 +1027,7 @@ func TestMultiplexSwitch_DialLoop_BackedOff(t *testing.T) {
 	t.Run("an item is dialed once its wait elapses", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancelFn := context.WithCancel(context.Background())
-		defer cancelFn()
+		ctx := t.Context()
 
 		var (
 			dialed = make(chan types.NetAddress, 1)


### PR DESCRIPTION
## Description

Follow-up to #6054, from [AviaOne's review](https://github.com/gnolang/gno/pull/6054#issuecomment-5287170937). The test is theirs; I folded it in as a subtest and verified it.

`runDialLoop` parks on `waitForDialTime`, which wakes on three things:

```go
select {
case <-ctx.Done():      // covered: "the wait ends on context cancellation"
case <-timer.C:         // not covered
case <-sw.dialNotify:   // covered: "a due item is dialed while an earlier one backs off"
}
```

The timer branch had no coverage, and the gap was invisible — removing `case <-timer.C:` left the entire package green:

```
$ # with `case <-timer.C:` deleted from waitForDialTime
$ go test ./tm2/pkg/p2p/
ok      github.com/gnolang/gno/tm2/pkg/p2p    0.238s
```

That branch is not cosmetic. Without it, a backed off item is never dialed once it becomes due: the loop parks until something else is queued or the node shuts down, so persistent peer backoff silently stops retrying. It is the behaviour #6054 exists to provide.

## The test

Added as a third subtest of `TestMultiplexSwitch_DialLoop_BackedOff`, so the three subtests now map one to one onto the three `select` branches.

A single item is queued, due shortly, with nothing else in the queue and a live context — so the timer is the only thing that can bring the loop back.

## Verification

Mutation checked in both directions:

| | new subtest | other two subtests | `DoesNotSpin` | package |
|---|---|---|---|---|
| `case <-timer.C:` removed | **FAIL** | pass | pass | **FAIL** |
| unmodified `master` | pass | pass | pass | pass |

So the subtest is the one carrying the guarantee, and nothing else in the suite notices that branch going missing. Passing run repeated with `-count=3`; `gofmt`, `go vet` and `./tm2/pkg/p2p/...` all clean.

Test-only, so no ADR per `AGENTS.md`.

---

_Drafted with AI assistance (Claude Code). I have reviewed the change and the verification and stand behind them._
