### PR TITLE
fix(gno.land): post-merge fixes for inert packages

### DIFF
--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -1555,12 +1555,18 @@ func sessionAlwaysDenied(msg std.Msg) bool {
 		switch msg.Type() {
 		case "add_package":
 			return true
-		case "enable_package", "disable_package":
+		case "enable_package", "disable_package", "reject_package":
 			// Approver authority, and it cannot be scoped down. A session's
 			// AllowPaths are matched via GetPkgPath(), which only MsgCall
 			// implements -- so no path-scoped entry can ever match these, and
 			// the only way to grant them would be the "*" wildcard, handing a
 			// session its master's full approver power. Deny outright.
+			//
+			// reject_package is here even though its gate is approver OR
+			// creator: a creator withdrawing their own submission is
+			// legitimate, but there is no way to grant a session that half
+			// alone, and the wildcard that would grant it also hands over the
+			// approver half -- which can empty the whole approval queue.
 			return true
 		}
 	}

--- a/gno.land/pkg/gnoland/session_test.go
+++ b/gno.land/pkg/gnoland/session_test.go
@@ -589,6 +589,7 @@ func TestSessionAlwaysDeniedMatrix(t *testing.T) {
 		// Approver authority, unscopeable — the cases under test.
 		{"vm/enable_package", vm.MsgEnablePackage{Approver: addr, PkgPath: pkgPath}, true},
 		{"vm/disable_package", vm.MsgDisablePackage{Approver: addr, PkgPath: pkgPath}, true},
+		{"vm/reject_package", vm.MsgRejectPackage{Sender: addr, PkgPath: pkgPath}, true},
 		// The whole auth route: a session must not manage sessions, or it could
 		// mint itself a fresh one with wider AllowPaths and outlive its own
 		// revocation.

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1478,7 +1478,20 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 
 var reUserNamespace = regexp.MustCompile(`^[~_a-zA-Z0-9/-]+$`)
 
-func (vm *VMKeeper) QueryPaths(ctx sdk.Context, target string, limit int) ([]string, error) {
+func (vm *VMKeeper) QueryPaths(ctx sdk.Context, target string, limit int) (paths []string, err error) {
+	// Same reasoning as QueryInertPaths, which this is the sibling of: the
+	// iteration below is lazy and metered, maxGasQuery is a real ceiling, and
+	// exhausting it panics with OutOfGasError. handleQueryCustom does not
+	// recover, so without this the panic leaves the ABCI Query instead of being
+	// reported as an error.
+	//
+	// Reaching it takes roughly maxGasQuery/IterNextCostFlat steps, which is
+	// millions of packages under one prefix -- far enough away that there is no
+	// test for it here, and near enough that the answer should not be a node
+	// panic. Governance can also move IterNextCostFlat, which changes the
+	// distance without changing this code.
+	defer doRecoverQueryNoMachine(&err)
+
 	if limit < 0 {
 		return nil, errors.New("cannot have negative limit value")
 	}

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -25,6 +25,21 @@ import (
 // branch stays in keeper.go: it is a branch inside the submit path, not a
 // stage of its own.
 
+// approverGateSatisfied reports whether addr may exercise pkg-approver
+// authority for an inert-lifecycle message.
+//
+// Genesis replay passes unconditionally. A fork reproduces a record rather than
+// granting it again, so it must not refuse its own history because
+// pkg_approvers moved since -- the same reason EnablePackage exempts replay
+// from the policy gate beside this one.
+//
+// One function rather than the test repeated per message: every inert
+// lifecycle message shares this gate, and a copy that forgets the exemption
+// does not fail in tests, it fails the next time somebody forks the chain.
+func approverGateSatisfied(ctx sdk.Context, params Params, addr crypto.Address) bool {
+	return auth.IsGenesisReplay(ctx) || isApprover(params.PkgApprovers, addr)
+}
+
 // EnablePackage activates an inert package: runs the typechecker and
 // initializes the package so it becomes importable and callable on-chain.
 // Only addresses listed in Params.PkgApprovers may call this.
@@ -58,7 +73,7 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 			"code_submission_policy is %q, not %q: packages cannot be enabled",
 			params.CodeSubmissionPolicy, CodeSubmissionPolicyInert))
 	}
-	if !replay && !isApprover(params.PkgApprovers, msg.Approver) {
+	if !approverGateSatisfied(ctx, params, msg.Approver) {
 		return std.ErrUnauthorized(fmt.Sprintf(
 			"address %s is not a pkg approver", msg.Approver))
 	}
@@ -386,7 +401,7 @@ func (vm *VMKeeper) RejectPackage(ctx sdk.Context, msg MsgRejectPackage) error {
 	}
 
 	params := vm.GetParams(ctx)
-	if !isApprover(params.PkgApprovers, msg.Sender) && gm.AddPkg.Creator != msg.Sender.String() {
+	if !approverGateSatisfied(ctx, params, msg.Sender) && gm.AddPkg.Creator != msg.Sender.String() {
 		return std.ErrUnauthorized(fmt.Sprintf(
 			"address %s is neither a pkg approver nor the creator of %s",
 			msg.Sender, msg.PkgPath))
@@ -398,7 +413,7 @@ func (vm *VMKeeper) RejectPackage(ctx sdk.Context, msg MsgRejectPackage) error {
 
 func (vm *VMKeeper) DisablePackage(ctx sdk.Context, msg MsgDisablePackage) error {
 	params := vm.GetParams(ctx)
-	if !isApprover(params.PkgApprovers, msg.Approver) {
+	if !approverGateSatisfied(ctx, params, msg.Approver) {
 		return std.ErrUnauthorized(fmt.Sprintf(
 			"address %s is not a pkg approver", msg.Approver))
 	}

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -434,7 +434,15 @@ func (vm *VMKeeper) DisablePackage(ctx sdk.Context, msg MsgDisablePackage) error
 //
 // Deliberately a plain prefix match, without QueryPaths' @user handling. This
 // answers an operational question about a queue, not a browsing one.
-func (vm *VMKeeper) QueryInertPaths(ctx sdk.Context, prefix string, limit int) ([]string, error) {
+func (vm *VMKeeper) QueryInertPaths(ctx sdk.Context, prefix string, limit int) (paths []string, err error) {
+	// Named returns so the recover has somewhere to write. The iteration below
+	// is lazy and metered, and maxGasQuery is a real ceiling, so exhausting it
+	// panics with OutOfGasError -- and handleQueryCustom does not recover, so
+	// without this the panic leaves the ABCI Query rather than being reported
+	// as an error. Under "inert" anyone may park a package, so the size of the
+	// key space being walked is not the operator's to bound.
+	defer doRecoverQueryNoMachine(&err)
+
 	if limit < 0 {
 		return nil, errors.New("cannot have negative limit value")
 	}

--- a/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
@@ -1677,3 +1677,59 @@ func TestRejectPackageClearsTheQueue(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// TestVMKeeperGenesisReplayRejectByRotatedApprover pins the approver gate's
+// replay exemption for MsgRejectPackage.
+//
+// A reject recorded by an approver the fork has since rotated out has to
+// replay: the fork reproduces the record rather than granting it again.
+// Refusing it leaves a package parked that the chain's own history removed,
+// and under StrictReplay stops the fork booting at all.
+func TestVMKeeperGenesisReplayRejectByRotatedApprover(t *testing.T) {
+	const pkgPath = "gno.land/r/test/replayreject"
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("historical"))
+	stranger := crypto.AddressFromPreimage([]byte("rotated-out-approver"))
+	env, ctx := inertEnv(t, approver, creator, stranger)
+
+	replayCtx := ctx.WithValue(auth.GenesisReplayKey{}, true)
+
+	require.NoError(t, env.vmk.AddPackage(replayCtx,
+		NewMsgAddPackage(creator, pkgPath, replayFiles("replayreject"))))
+	gs := env.vmk.getGnoTransactionStore(ctx)
+	require.NotNil(t, gs.GetInertPackage(pkgPath), "the replayed add must park")
+
+	require.NoError(t, env.vmk.RejectPackage(replayCtx,
+		MsgRejectPackage{Sender: stranger, PkgPath: pkgPath}),
+		"a fork that rotated pkg_approvers must not refuse the rejects in its own history")
+	assert.Nil(t, gs.GetInertPackage(pkgPath),
+		"the replayed reject must clear the parked blob")
+}
+
+// TestVMKeeperGenesisReplayDisablePassesTheApproverGate pins the same exemption
+// for MsgDisablePackage.
+//
+// The body is still unimplemented, so what this asserts is which refusal comes
+// back: the not-implemented one, meaning the gate was passed. It guards the
+// implementation that replaces that TODO -- an unconditional approver check
+// there would make a fork refuse its own history, and nothing else would catch
+// it.
+func TestVMKeeperGenesisReplayDisablePassesTheApproverGate(t *testing.T) {
+	const pkgPath = "gno.land/r/test/replaydisable"
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	stranger := crypto.AddressFromPreimage([]byte("rotated-out-approver"))
+	env, ctx := inertEnv(t, approver, stranger)
+
+	replayCtx := ctx.WithValue(auth.GenesisReplayKey{}, true)
+
+	err := env.vmk.DisablePackage(replayCtx,
+		MsgDisablePackage{Approver: stranger, PkgPath: pkgPath})
+	// The detail text lives in the error's trace, not Error(), so the ABCI
+	// error type is what separates "gate passed, body missing" (UnknownRequest)
+	// from "gate refused" (Unauthorized).
+	require.Error(t, err)
+	assert.IsType(t, std.UnknownRequestError{}, sdk.ABCIError(err),
+		"replay must pass the approver gate and reach the unimplemented body")
+}


### PR DESCRIPTION
3 fixes/commits :

- `MsgRejectPackage`: don't check inert approvers for genesis txs e09e68c069a7efb1150c2e0ccb32bbff104e0ae7
- Deny new `MsgRejectPackage` to session keys (just like `MsgAddPackage`, `MsgEnablePackage` and `MsgDisablePackage`) ce7f217a783477dfafb4239b1e2b3b9081639fe0
- Add missing out-of-gas panic recover from new `QueryInertPaths`