### PR TITLE
chore(deployments/pearl): enable inert packages policy

### DIFF
--- a/gno.land/pkg/gnoland/inert_lifecycle_test.go
+++ b/gno.land/pkg/gnoland/inert_lifecycle_test.go
@@ -309,3 +309,145 @@ func Hello(cur realm) string { return "hi" }
 	assert.Equal(t, collectorAfterSubmit, ugnotBalance(t, app, collectorAddr),
 		"enable must not charge again; the charge is a submit-time cost")
 }
+
+// TestInertPolicyAtGenesisDeploysLive pins the exemption a chain launching
+// directly into the "inert" policy depends on: a FRESH chain whose genesis
+// params already carry code_submission_policy = "inert" must still deploy its
+// own genesis packages live, rather than parking them.
+//
+// The failure this rules out is unrecoverable, which is why it is worth a boot
+// of its own. A chain that parked its genesis content would come up with
+// nothing deployed -- no r/sys/params, no govdao -- so there would be no way to
+// propose a policy change, and no approver could act either, because the realms
+// an approver's transaction needs do not exist yet. The only repair is a new
+// genesis file and a relaunch.
+//
+// The behavior rests on two facts in two packages, neither of which mentions
+// the other: the keeper's parking branch is guarded on ctx.BlockHeight() > 0,
+// and baseapp's InitChain builds its header without a Height, so genesis runs
+// at 0. Either could move without the other looking wrong, so this asserts the
+// outcome rather than either fact.
+//
+// Two consequences of the same carve-out ride along, since they need this exact
+// boot to observe: the submission charge is not levied on genesis content (the
+// charge is taken inside the parking branch), and an armed run_submitters does
+// not refuse the genesis deployer. The latter is also covered from the MsgRun
+// side by TestChainUpgradeGenesisReplay's fresh-chain subtest; here it is a
+// premise, so that a pass cannot be explained by an unarmed gate.
+func TestInertPolicyAtGenesisDeploysLive(t *testing.T) {
+	t.Parallel()
+
+	var (
+		db      = memdb.NewMemDB()
+		key     = getDummyKey(t) // genesis deployer
+		chainID = "inert-at-genesis"
+
+		// Three capabilities the deployer must NOT hold, so that a live deploy
+		// cannot be explained by the deployer being privileged.
+		approverAddr  = crypto.MustAddressFromString("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
+		collectorAddr = crypto.MustAddressFromString("g1dmt3sa5ucvecxuhf3j6ne5r0e3z4x7h6c03xc0")
+		gateHolder    = crypto.MustAddressFromString("g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m")
+
+		path = "gno.land/r/demo/genesislive"
+		body = `package genesislive
+
+func Status(cur realm) string { return "live" }
+`
+	)
+
+	vmGen := vm.DefaultGenesisState()
+	vmGen.Params.CodeSubmissionPolicy = vm.CodeSubmissionPolicyInert
+	vmGen.Params.PkgApprovers = []crypto.Address{approverAddr}
+	vmGen.Params.InertSubmissionCharge = "1000000ugnot"
+	vmGen.Params.InertChargeCollector = collectorAddr
+	vmGen.Params.RunSubmitters = []crypto.Address{gateHolder}
+
+	deployer := key.PubKey().Address()
+	require.NotContains(t, vmGen.Params.PkgApprovers, deployer,
+		"premise: the genesis deployer must not be an approver")
+	require.NotContains(t, vmGen.Params.RunSubmitters, deployer,
+		"premise: the genesis deployer must be off the armed MsgRun allowlist")
+	require.NotEqual(t, collectorAddr, deployer,
+		"premise: the deployer must not be the charge collector")
+
+	app, err := NewAppWithOptions(TestAppOptions(db))
+	require.NoError(t, err)
+
+	addPkg := vm.MsgAddPackage{
+		Creator: deployer,
+		Package: &std.MemPackage{
+			Name: "genesislive",
+			Path: path,
+			Files: []*std.MemFile{
+				{Name: "genesislive.gno", Body: body},
+				{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(path)},
+			},
+		},
+	}
+
+	// TestAppOptions installs PanicOnFailingTxResultHandler, so a genesis tx
+	// that the policy refused would abort the boot rather than surface later as
+	// a confusing query result.
+	require.NotPanics(t, func() {
+		app.InitChain(abci.RequestInitChain{
+			ChainID:       chainID,
+			Time:          time.Now(),
+			InitialHeight: 1,
+			ConsensusParams: &abci.ConsensusParams{
+				Block:     defaultBlockParams(),
+				Validator: &abci.ValidatorParams{PubKeyTypeURLs: []string{}},
+			},
+			AppState: GnoGenesisState{
+				// No Metadata: this is a fresh chain's own genesis tx, not
+				// replayed history.
+				Txs: []TxWithMetadata{
+					{Tx: createAndSignTx(t, []std.Msg{addPkg}, chainID, key)},
+				},
+				Balances: []Balance{{
+					Address: deployer,
+					Amount:  std.NewCoins(std.NewCoin("ugnot", 100_000_000)),
+				}},
+				Auth: auth.DefaultGenesisState(),
+				Bank: bank.DefaultGenesisState(),
+				VM:   vmGen,
+			},
+		})
+	}, "the genesis addpkg must be delivered under the inert policy")
+	app.Commit()
+
+	// Nothing parked. Checked before the call, because an empty queue and a
+	// successful call are different claims: this one would still catch a
+	// package that was BOTH parked and somehow reachable.
+	inert := app.Query(abci.RequestQuery{Path: "vm/qinertpaths"})
+	require.True(t, inert.IsOK(), "inert-path query failed: %v", inert.ResponseBase.Error)
+	assert.Empty(t, string(inert.Data),
+		"genesis content must not be parked under the inert policy")
+
+	// And live: MsgCall reaches a crossing function, which needs the package
+	// typechecked, its init run, and its node in the active store -- exactly
+	// the three things parking skips.
+	signer := queryAccount(t, app, deployer)
+	app.BeginBlock(abci.RequestBeginBlock{Header: &bft.Header{
+		ChainID: chainID, Height: 1, Time: time.Now(),
+	}})
+	callTx := createAndSignTxWithAccSeq(t, []std.Msg{vm.MsgCall{
+		Caller: deployer, PkgPath: path, Func: "Status",
+	}}, chainID, key, signer.AccountNumber, signer.Sequence)
+	raw, err := amino.Marshal(callTx)
+	require.NoError(t, err)
+	callResp := app.DeliverTx(abci.RequestDeliverTx{Tx: raw})
+	require.True(t, callResp.IsOK(), "genesis package must be callable: %s", callResp.Log)
+	assert.Contains(t, string(callResp.Data), "live")
+
+	// The charge lives inside the parking branch, so a genesis deploy must not
+	// have funded the collector. Queried tolerantly: with nothing received the
+	// account may not exist at all, and "no account" is the stronger outcome.
+	collector := app.Query(abci.RequestQuery{Path: "auth/accounts/" + collectorAddr.String()})
+	require.True(t, collector.IsOK(), "collector query failed: %v", collector.ResponseBase.Error)
+	if len(collector.Data) > 0 {
+		var acc GnoAccount
+		require.NoError(t, amino.UnmarshalJSON(collector.Data, &acc))
+		assert.Zero(t, acc.Coins.AmountOf("ugnot"),
+			"genesis content must not be charged the inert submission charge")
+	}
+}

--- a/misc/deployments/pearl.gno.land/README.md
+++ b/misc/deployments/pearl.gno.land/README.md
@@ -2,7 +2,7 @@
 
 Builds the **pearl** genesis. pearl is a **fresh chain** — not a hardfork, no historical replay.
 
-> **Status: all launch values are final and `CHECKSUMS_DATA` is locked.** Ceremony keys, operators, genesis time, faucet accounts, peers, and the ten vested test accounts are in; any build producing different bytes fails loudly.
+> **Status: one launch value outstanding.** The ceremony keys, operators, genesis time, faucet accounts, peers, and the ten vested test accounts are final. Outstanding: the `PKG_APPROVERS` oracle address. pearl launches under the `inert` code-submission policy, and `gen-genesis.sh` refuses to build a genesis without an approver (step 1, before anything is compiled) rather than shipping a chain that parks deploys nobody can activate. `CHECKSUMS_DATA` is locked on the first clean build after that address is pasted in.
 
 ## What pearl contains
 
@@ -10,13 +10,36 @@ Builds the **pearl** genesis. pearl is a **fresh chain** — not a hardfork, no 
 - **Governance**: aeddi (`g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m`) is the sole GovDAO T1 member, seeded by the bootstrap MsgRun, which also locks `dao.UpdateImpl`'s `AllowedDAOs` to `r/gov/dao/v3/impl`. Additional members join via GovDAO proposals.
 - **Validators**: 3 founding validators (`gno-core-validator-1/-2/-3`, power 60 each) in `GenesisDoc.Validators` — at 3 × 60, one validator dark is exactly the one-third halt boundary, accepted for launch until partners join. InitChainer seeds `r/sys/params`' `valset:current` from it, so `r/sys/validators/v3` proposals manage the set post-genesis. Each founder has a valoper profile (registered at genesis via `gnogenesis fork valoper-seed`) keyed on an operator address, giving them the operator-keyed management plane (signing-key rotation, profile edits, opt-out).
 - **Namespace enforcement**: `r/sys/names.Enable` runs as a genesis MsgCall, so name-based deploy authorization is on from block 1. The call's caller field is patched to the admin address hardcoded in `r/sys/names/verifier.gno` (trusted under `--skip-genesis-sig-verification`; the private key is not needed).
-- **Balances**: 3 faucet accounts at 1e18 ugnot (≈1T GNOT) each — the web faucet's dispensing account, the faucet-agent's dispensing account, and an operator reserve — plus exact-burn funding for the genesis-tx fee payers — the deployer, the names admin, and every `gnomod.toml` `[addpkg] creator` address in the package set — which land at zero once the genesis txs execute. No airdrop, no inherited balances.
+- **Code submission**: pearl launches under the **`inert`** policy (`code_submission_policy`, from #6088). A post-genesis `MsgAddPackage` from anyone is *parked* — stored without a type-check, without `init()`, not importable — and becomes callable only once an address in `pkg_approvers` sends `MsgEnablePackage`; see [Approval oracle](#approval-oracle). Genesis content is exempt by construction, and the launch rests on it: the keeper's parking branch requires `BlockHeight() > 0` and `InitChain` runs at height 0, so all 85 packages deploy live. Pinned by `TestInertPolicyAtGenesisDeploysLive` (`gno.land/pkg/gnoland`) and confirmed on the built artifact — `vm/qinertpaths` empty, `vm/qpaths` listing all 85. A parked submission also returns `ok`, so the strict-replay report alone does not prove liveness; the queries do. Submitting costs a flat `inert_submission_charge` of 1 GNOT paid to the approver, so submissions fund the approvals they cause — not levied on genesis content, which is why it cannot perturb the fee-payer measurement.
+- **MsgRun allowlist**: `run_submitters` is **armed** — aeddi (`g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m`) and the relayer (`g1z437dpuh5s4p64vtq09dulg6jzxpr2hd4q8r5x`). This is what makes the review gate mean something: `inert` defers only `MsgAddPackage`'s type-check, while `MsgRun` type-checks and *executes* arbitrary source immediately under every policy value, in an ephemeral `gno.land/e/<caller>/run` realm. Two consequences to know before launch. Ordinary users cannot `gnokey maketx run` on pearl. And because GovDAO proposal creation is MsgRun-only (a `ProposalRequest` carries a func value, which `MsgCall` cannot marshal), **every future GovDAO member has to be added to this list too**, or they can join the DAO and still not be able to propose — nine of the twelve `misc/govdao-scripts/` commands are `maketx run`. Genesis txs are exempt (every InitChain tx bypasses the code-policy ante), so the bootstrap MsgRun is unaffected. Post-genesis the key is *not* settable through `r/sys/params`' generic factories: it is reserved for `ProposeSetRunSubmitters`, which can also delegate add-only management to one other realm.
+- **Balances**: 3 faucet accounts at 1e18 ugnot (≈1T GNOT) each — the web faucet's dispensing account, the faucet-agent's dispensing account, and an operator reserve — plus the `PKG_APPROVERS` oracle at 1e18 (it pays the gas for every `MsgEnablePackage`, so an unfunded approver stalls the policy on the first submission), plus exact-burn funding for the genesis-tx fee payers — the deployer, the names admin, and every `gnomod.toml` `[addpkg] creator` address in the package set — which land at zero once the genesis txs execute. No airdrop, no inherited balances.
 - **Vested accounts**: the `VESTED_ACCOUNTS` entries, created at genesis as vesting accounts via the balance-sheet vesting syntax (`addr=coins;vesting=coins,start,end[;type=delayed]`). Continuous schedules unlock linearly between start and end; delayed schedules are a cliff. The unvested remainder is spendable immediately.
 - **Transfers**: unrestricted — no bank lock, no unrestricted-accounts list.
 
-Not set at genesis (defaults apply; adjustable post-genesis via GovDAO proposals, see `misc/govdao-scripts/`): CLA, minimum fee.
+Not set at genesis (defaults apply; adjustable post-genesis via GovDAO proposals, see `misc/govdao-scripts/`): CLA, minimum fee, and `default_deposit` — `100000000ugnot` (100 GNOT, ≈1 MB of state at the 100ugnot/byte storage price) since #6088 lowered it from 600M; it is a per-package ceiling, not a charge.
 
 To run a full node and put yourself forward as a validator on pearl, see [`VALIDATOR.md`](./VALIDATOR.md).
+
+## Approval oracle
+
+Under `inert`, nothing submitted after genesis becomes callable until an approver enables it. That approver is [`contribs/gpao`](../../../contribs/gpao) — it watches blocks, re-runs the type-check and preprocess off-chain under a wall-clock budget, and broadcasts `MsgEnablePackage` for what passes.
+
+**pearl does not deploy new code without it running.** If the oracle is down, nothing breaks and nothing is lost — submissions accumulate parked, and activate whenever it comes back. But no new package goes live in the meantime, so treat it as launch infrastructure alongside the RPC and faucet, not as an optional extra.
+
+```bash
+gpao \
+  --remote https://rpc.pearl.testnets.gno.land \
+  --chain-id pearl-1 \
+  --key <approver-key> \
+  --status-listen 127.0.0.1:8546
+```
+
+Operational notes:
+
+- **The key** is the `PKG_APPROVERS` entry, funded at genesis. It can activate any parked package and disable any active one, which makes it the most consequential key on the chain after governance — and it sits unattended on a daemon, unlocked from `$GPAO_PASSWORD`. Keep it to this one job.
+- **Why the charge goes to the approver.** `MsgEnablePackage` runs the submitted package's `init()` on the *oracle's* transaction and gas meter, so the submitter chooses the work and the oracle pays for it. Unpriced, that is a cheap way to exhaust the oracle's `--max-spend` and stop approvals for everyone; `inert_submission_charge` prices it and routes it back to the payer.
+- **Serve `--status-listen`.** A refusal is the oracle's knowledge alone: the chain can say a package is parked, never why this one was not approved. Without the status endpoint a submitter pays the charge and hears nothing.
+- **The oracle is untrusted for correctness.** The chain re-runs `TypeCheckMemPackage` at enable and rejects ill-typed code regardless, and the namespace check already applied at submit. gpao only decides *which* parked packages are proposed for activation, and when.
 
 ## Quick start
 
@@ -51,15 +74,15 @@ pearl.gno.land/
 
 `gen-genesis.sh` is a single-phase script, 9 steps:
 
-1. Resolve script paths and tooling.
+1. Resolve script paths and tooling, and validate the code-submission launch parameters. This runs before anything is compiled, and refuses the combinations that cannot be repaired on a live chain: `inert` with no approver, an armed `run_submitters` missing the GovDAO T1 seed (cross-checked against the bootstrap tx, not against a comment), a charge above the on-chain cap, and a charge with no real collector.
 2. Verify required tools (preflight with `brew` + `apt` install hints).
 3. Build binaries from source (`gno`, `gnokey`, `gnoland`, `gnogenesis`).
-4. Resolve `FILTERED_PACKAGES` deps, stage them, and `addpkg` them to the genesis.
+4. Resolve `FILTERED_PACKAGES` deps, stage them, and `addpkg` them to the genesis. The code-submission vm params are written here, by the same helper that writes them into every other genesis this script generates — step 8 asserts the measurement genesis's vm params equal the shipping genesis's, since a measurement taken under different fee-governing params would be wrong.
 5. Add the bootstrap MsgRun from `transactions/base/bootstrap/`.
 6. Add the `names.Enable` MsgCall from `transactions/migration/names-enable/`.
 7. Build the valoper CSV from `INITIAL_VALSET` + `INITIAL_VALSET_OPERATORS` and add the `valopers.Register` txs (via `gnogenesis fork valoper-seed`).
 8. Measure fee-payer balances via a two-pass temp-node run (measure → verify zero). Readiness gates on committed state, and a fee payer reading zero in the measure pass aborts the build.
-9. Add the validators + balances (fee payers + faucet accounts + vested accounts), run `gnogenesis verify`, move `genesis.json` into place.
+9. Add the validators + balances (fee payers + faucet accounts + the approver + vested accounts), run `gnogenesis verify`, move `genesis.json` into place.
 
 The locked artifacts (package list, valoper seed, tx stream, `genesis.json`) are checked against the `CHECKSUMS_DATA` manifest embedded in the script: after the first clean build, paste the printed "not listed" lines into the heredoc to lock the build; any future run producing different bytes fails loudly.
 

--- a/misc/deployments/pearl.gno.land/gen-genesis.sh
+++ b/misc/deployments/pearl.gno.land/gen-genesis.sh
@@ -24,10 +24,17 @@
 #   5. The INITIAL_VALSET as GenesisDoc.Validators (InitChainer seeds
 #      valset:current from it, so v3/EndBlocker valset changes work).
 #   6. Balances: the faucet accounts at FAUCET_BALANCE each, the
+#      PKG_APPROVERS entries at APPROVER_BALANCE each, the
 #      VESTED_ACCOUNTS entries (created as vesting accounts at genesis),
 #      plus exact-burn funding for every genesis-tx fee payer (measured on
 #      a temp node; those accounts land at zero once the genesis txs
 #      execute).
+#   7. Code-submission vm params: CODE_SUBMISSION_POLICY (pearl launches
+#      under "inert" — post-genesis submissions park until an approver
+#      enables them), PKG_APPROVERS, an armed RUN_SUBMITTERS MsgRun
+#      allowlist, and the inert submission charge. Genesis content itself
+#      is exempt from parking and from the charge (both live behind a
+#      BlockHeight() > 0 guard in the keeper).
 #
 # Output:
 #   work/packages.gen.txt    resolved package list (audit artifact)
@@ -126,10 +133,11 @@ INITIAL_VALSET_OPERATORS=(
 # unrestrict step is needed anywhere.
 #
 # 1e18 leaves ~9.2x headroom under int64 max per account. Keep the total
-# genesis supply — (count × FAUCET_BALANCE) plus every VESTED_ACCOUNTS
-# total — under int64 max (~9.22e18): Coin.Add panics on int64 overflow,
-# so consolidating all genesis funds into one account must not be able to
-# exceed it.
+# genesis supply — (count × FAUCET_BALANCE) plus (count × APPROVER_BALANCE)
+# plus every VESTED_ACCOUNTS total — under int64 max (~9.22e18): Coin.Add
+# panics on int64 overflow, so consolidating all genesis funds into one
+# account must not be able to exceed it. Three faucets and one approver at
+# 1e18 is 4e18.
 FAUCET_BALANCE=1000000000000000000 # 1e18 ugnot per faucet (1 trillion GNOT)
 # Confirmed by PEARL-PR-HANDOFF.md: reuse sapphire's accounts and
 # amounts. The faucet account doubles as the infra's snapshot-validation
@@ -168,6 +176,102 @@ VESTED_ACCOUNTS=(
   "g10w8l2hg7690upa4dcy6suq8yvkju7q4za0sfey=1000000000ugnot;vesting=750000000ugnot,$((GENESIS_TIME + 86400)),$((GENESIS_TIME + 345600))"  # testing-acct-9: continuous, starts 1 day after genesis, ends at 4 days
   "g17s8dlta3fjgztppcr5z7tlmkeg4ecwsfeeatag=1000000000ugnot;vesting=750000000ugnot,$((GENESIS_TIME - 604800)),$((GENESIS_TIME + 604800))" # testing-acct-10: continuous, started 7 days before genesis, half unlocked at launch, ends at 7 days
 )
+
+# Code-submission policy (vm params — see gno.land/pkg/sdk/vm/params.go).
+#
+# pearl launches under "inert": a MsgAddPackage from a stranger is PARKED —
+# stored without typecheck, without init(), not importable — and becomes
+# callable only when an address in PKG_APPROVERS sends MsgEnablePackage.
+# contribs/gpao is the daemon that does that unattended.
+#
+# Genesis content is exempt by construction, and the whole launch rests on it:
+# the keeper's parking branch requires ctx.BlockHeight() > 0, and baseapp's
+# InitChain builds its header without a Height, so genesis runs at 0 and every
+# FILTERED_PACKAGES entry deploys live. Pinned by
+# TestInertPolicyAtGenesisDeploysLive (gno.land/pkg/gnoland) — including that
+# the submission charge is not levied on genesis content. The "never set this
+# policy in a fork's genesis params" caveat in keeper.go is about REPLAYED
+# history running under a policy that was never in force for it; pearl is a
+# fresh chain with no history, so it does not apply.
+CODE_SUBMISSION_POLICY=inert
+
+# Addresses permitted to send MsgEnablePackage / MsgDisablePackage.
+#
+# Load-bearing under "inert": with no approver, every submission parks forever
+# and the chain accepts deploys it can never activate. The preflight below
+# refuses to build in that state rather than shipping it.
+#
+# Keep this to the gpao oracle key and nothing else. An approver can activate
+# any parked package and disable any active one, so it is the second most
+# consequential key on the chain after governance — and it lives unattended on
+# an internet-facing daemon (gpao reads GPAO_PASSWORD to unlock it).
+PKG_APPROVERS=(
+  # PASTE THE ORACLE ADDRESS BEFORE THE LOCKING BUILD, e.g.
+  # g1... # gpao approval oracle
+)
+
+# Genesis balance for each PKG_APPROVERS entry. The approver signs one
+# MsgEnablePackage per approval and pays the gas itself (gpao defaults:
+# --gas-fee 1000000ugnot, --max-spend 100000000ugnot per run), so it must be
+# funded at genesis or the policy stalls on the first submission.
+#
+# Same 1e18 as the faucets, which keeps the supply comment above honest: four
+# accounts at 1e18 is 4e18, still well under int64 max (~9.22e18) even if every
+# genesis balance were consolidated into one account.
+APPROVER_BALANCE=1000000000000000000 # 1e18 ugnot (1 trillion GNOT)
+
+# MsgRun allowlist. NON-EMPTY MEANS THE GATE IS ARMED: only these addresses may
+# send MsgRun at all. (Empty would mean the gate is OFF — the pre-#6088
+# behaviour, where anyone may send it.)
+#
+# Armed deliberately. "inert" defers MsgAddPackage's typecheck but leaves MsgRun
+# typechecking and EXECUTING arbitrary source immediately under every policy
+# value, so an unarmed gate would leave the review gate bypassable by anyone
+# willing to run their code in an ephemeral gno.land/e/<caller>/run realm
+# instead of deploying it. Arming it is what makes "inert" mean something.
+#
+# The cost, stated plainly: ordinary testnet users cannot `gnokey maketx run` on
+# pearl. That is the trade accepted for a real review gate.
+#
+# GovDAO proposal creation is MsgRun-only (a ProposalRequest carries a func
+# value, which MsgCall cannot marshal), so the GovDAO T1 seed MUST be on this
+# list or governance is unreachable at launch with no in-band repair — amending
+# this list is itself a proposal. The preflight below cross-checks that against
+# the bootstrap tx rather than trusting this comment.
+#
+# Nine of the twelve misc/govdao-scripts/ commands are `gnokey maketx run`, and
+# pearl's govdao-exec.sh signs them as aeddi.
+#
+# Every future GovDAO member needs adding here too, or they can join the DAO and
+# still not be able to propose. Post-genesis this key is NOT settable through
+# r/sys/params' generic factories — it is reserved for ProposeSetRunSubmitters
+# (which can also delegate add-only management to another realm).
+RUN_SUBMITTERS=(
+  g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m # aeddi — sole GovDAO T1 member at launch
+  g1z437dpuh5s4p64vtq09dulg6jzxpr2hd4q8r5x # relayer
+)
+
+# Flat amount taken from the creator on every MsgAddPackage that PARKS, paid to
+# INERT_CHARGE_COLLECTOR. Empty would mean off.
+#
+# On at launch, because the party who chooses the work should pay for it: under
+# "inert" the submitter picks the package and the ORACLE pays to compile it, on
+# the enable tx's own gas meter. Unpriced, that is a cheap way to drain the
+# oracle's --max-spend and stop approvals for everyone. 1 GNOT matches gpao's
+# default --gas-fee, so roughly one submission funds one approval.
+#
+# Not charged on genesis content (the charge sits inside the parking branch),
+# so it cannot perturb the fee-payer measurement in step 8. Capped on chain at
+# 1000 GNOT (maxInertSubmissionCharge).
+INERT_SUBMISSION_CHARGE=1000000ugnot
+
+# Where the charge goes. Empty defaults to the first PKG_APPROVERS entry, so
+# submissions fund the approvals they cause — the arrangement the param was
+# written for.
+#
+# Never leave this at the chain default: that is a derived address with no
+# private key, so the charge would be burned rather than collected.
+INERT_CHARGE_COLLECTOR=
 
 # =============================================================================
 # Internal — everything below is glue, you shouldn't need to change it.
@@ -512,6 +616,139 @@ trap cleanup EXIT
 # don't speak AnnotatedTx (e.g. `gnogenesis txs add sheets`).
 # =============================================================================
 
+# ---- Code-submission (vm) params
+
+# join_commas <item>...
+# Joins its arguments with commas, the form `gnogenesis params set` takes for an
+# address-list param.
+join_commas() {
+  local IFS=,
+  echo "$*"
+}
+
+# validate_code_submission_params
+# Refuses, before anything is built, the parameter combinations that would ship
+# a broken chain. Every one of these is unrecoverable once the chain is live, so
+# they are hard failures rather than warnings.
+validate_code_submission_params() {
+  case "$CODE_SUBMISSION_POLICY" in
+  permissionless | permissioned | inert) ;;
+  *) die "CODE_SUBMISSION_POLICY must be permissionless, permissioned or inert (got '$CODE_SUBMISSION_POLICY')" ;;
+  esac
+
+  # An inert chain with no approver accepts submissions it can never activate,
+  # and only a proposal can add one — which needs a governance that has to be
+  # deployed and reachable first.
+  if [ "$CODE_SUBMISSION_POLICY" = inert ] && [ "${#PKG_APPROVERS[@]}" -eq 0 ]; then
+    die "CODE_SUBMISSION_POLICY=inert with an empty PKG_APPROVERS: every post-genesis submission would park with nobody able to enable it. Paste the gpao oracle address into PKG_APPROVERS."
+  fi
+
+  # Approvers outside "inert" are inert themselves (nothing ever parks), which
+  # is more likely a half-finished edit than an intent.
+  if [ "$CODE_SUBMISSION_POLICY" != inert ] && [ "${#PKG_APPROVERS[@]}" -gt 0 ]; then
+    die "PKG_APPROVERS is set but CODE_SUBMISSION_POLICY is '$CODE_SUBMISSION_POLICY': nothing would ever park, so the approvers would have nothing to enable"
+  fi
+
+  # A typo guard with a message that names the launch parameter. Real bech32
+  # validation happens in `gnogenesis params set`, which decodes every entry.
+  local addr
+  for addr in "${PKG_APPROVERS[@]}" "${RUN_SUBMITTERS[@]}"; do
+    case "$addr" in
+    g1*[!a-z0-9]*) die "address contains invalid characters: '$addr'" ;;
+    g1*) [ "${#addr}" -eq 40 ] || die "address is ${#addr} chars, expected 40: '$addr'" ;;
+    *) die "address does not start with 'g1': '$addr'" ;;
+    esac
+  done
+
+  # Governance is MsgRun-only, so arming the gate without the GovDAO T1 seed
+  # leaves a chain whose only governance member cannot propose anything —
+  # including the proposal that would fix the list. Read the seed out of the
+  # bootstrap tx instead of duplicating it here, so the two cannot drift.
+  if [ "${#RUN_SUBMITTERS[@]}" -gt 0 ]; then
+    local t1
+    t1=$(sed -n 's/^const govdaoT1Addr = address("\(g1[a-z0-9]*\)").*$/\1/p' \
+      "$PEARL_DIR/transactions/base/bootstrap/govdao_prop1_pearl.gno")
+    [ -n "$t1" ] || die "could not read govdaoT1Addr from the bootstrap tx — the RUN_SUBMITTERS cross-check cannot be skipped silently"
+    case ",$(join_commas "${RUN_SUBMITTERS[@]}")," in
+    *",$t1,"*) ;;
+    *) die "RUN_SUBMITTERS is armed but does not contain the GovDAO T1 seed $t1: proposal creation is MsgRun-only, so governance would be unreachable and the list could never be amended" ;;
+    esac
+  fi
+
+  # A charge with no real collector is a burn. The chain default for the
+  # collector is a derived address with no private key, and Params.Validate
+  # cannot tell that from a treasury, so the check has to live here.
+  if [ -n "$INERT_SUBMISSION_CHARGE" ]; then
+    case "$INERT_SUBMISSION_CHARGE" in
+    *[!0-9ugnot]* | "" | ugnot) die "INERT_SUBMISSION_CHARGE must look like '<amount>ugnot' (got '$INERT_SUBMISSION_CHARGE')" ;;
+    *ugnot) ;;
+    *) die "INERT_SUBMISSION_CHARGE must be denominated in ugnot (got '$INERT_SUBMISSION_CHARGE')" ;;
+    esac
+    # Read the cap out of the keeper rather than repeating the number, so the
+    # two cannot drift. Checked here at all — rather than left to `gnogenesis
+    # params set`, which validates it too — so the failure names the launch
+    # parameter, and lands before the binaries are built.
+    local cap amount=${INERT_SUBMISSION_CHARGE%ugnot}
+    cap=$(sed -n 's/.*maxInertSubmissionCharge = int64(\([0-9_]*\)).*/\1/p' \
+      "$REPO_ROOT/gno.land/pkg/sdk/vm/params.go" | tr -d _)
+    [ -n "$cap" ] || die "could not read maxInertSubmissionCharge from gno.land/pkg/sdk/vm/params.go — the INERT_SUBMISSION_CHARGE cap check cannot be skipped silently"
+    if [ "$amount" -gt "$cap" ]; then
+      die "INERT_SUBMISSION_CHARGE $INERT_SUBMISSION_CHARGE exceeds the on-chain cap of ${cap}ugnot"
+    fi
+  fi
+
+  # One place decides the collector: default it to the approver that will
+  # receive the charges, and refuse a charge that has nowhere to go. Left
+  # empty with a charge set, the chain default would take it — a derived
+  # address with no private key, so the charge would burn.
+  if [ -z "$INERT_CHARGE_COLLECTOR" ]; then
+    if [ "${#PKG_APPROVERS[@]}" -gt 0 ]; then
+      INERT_CHARGE_COLLECTOR="${PKG_APPROVERS[0]}"
+    elif [ -n "$INERT_SUBMISSION_CHARGE" ]; then
+      die "INERT_SUBMISSION_CHARGE is set but there is no collector: INERT_CHARGE_COLLECTOR is empty and there is no PKG_APPROVERS entry to default to. The charge would be burned to a keyless address."
+    fi
+  fi
+}
+
+# apply_vm_params <genesis-path>
+# Writes the code-submission params into a freshly generated genesis.
+#
+# Called for EVERY genesis this script generates, not just the shipping one.
+# The measurement genesis in step 8 is generated from scratch rather than copied
+# (so its genesis-time differs), and step 8 asserts its vm params equal the
+# shipping genesis's — a measurement taken under different fee-governing params
+# would be wrong. Applying this in one place is what keeps that assertion true.
+#
+# `gnogenesis params set` validates the whole Params struct before writing, so
+# an invalid value fails here rather than when a node boots on it.
+# _set_vm_param <genesis-path> <param-name> <value>
+_set_vm_param() {
+  run "$GNOGENESIS_BIN" params set "vm.$2" "$3" -genesis-path "$1" >/dev/null
+}
+
+apply_vm_params() {
+  local genesis="$1"
+
+  _set_vm_param "$genesis" code_submission_policy "$CODE_SUBMISSION_POLICY"
+
+  if [ "${#PKG_APPROVERS[@]}" -gt 0 ]; then
+    _set_vm_param "$genesis" pkg_approvers "$(join_commas "${PKG_APPROVERS[@]}")"
+  fi
+
+  if [ "${#RUN_SUBMITTERS[@]}" -gt 0 ]; then
+    _set_vm_param "$genesis" run_submitters "$(join_commas "${RUN_SUBMITTERS[@]}")"
+  fi
+
+  # Both or neither: an empty charge means off, and the collector is then
+  # unread, so writing one would only invite a stale value.
+  if [ -n "$INERT_SUBMISSION_CHARGE" ]; then
+    _set_vm_param "$genesis" inert_submission_charge "$INERT_SUBMISSION_CHARGE"
+    _set_vm_param "$genesis" inert_charge_collector "$INERT_CHARGE_COLLECTOR"
+  fi
+}
+
+# =============================================================================
+
 txn_dir_to_jsonl() {
   local dir="$1" outfile="$2"
   local meta="$dir/meta.json"
@@ -655,6 +892,12 @@ print_substep "1.1" "PEARL_DIR=$PEARL_DIR"
 print_substep "1.2" "REPO_ROOT=$REPO_ROOT"
 print_substep "1.3" "WORK_DIR=$WORK_DIR"
 
+# Before anything is built: a bad policy/approver/charge combination is cheaper
+# to catch now than after a full binary build, and unrecoverable if it ships.
+validate_code_submission_params
+print_substep "1.4" "Code submission: policy=$CODE_SUBMISSION_POLICY, approvers=${#PKG_APPROVERS[@]}, run_submitters=${#RUN_SUBMITTERS[@]} (gate $([ "${#RUN_SUBMITTERS[@]}" -gt 0 ] && echo ARMED || echo off))"
+print_substep "1.5" "Inert submission charge: ${INERT_SUBMISSION_CHARGE:-off}${INERT_SUBMISSION_CHARGE:+ -> $INERT_CHARGE_COLLECTOR}"
+
 # ---- Step 2: Verify required tools
 
 print_step_header 2 "$TOTAL_STEPS" "Verify required tools"
@@ -750,6 +993,7 @@ esac
 
 print_substep "4.5" "Generating empty genesis..."
 run "$GNOGENESIS_BIN" generate -chain-id "$CHAIN_ID" -genesis-time "$GENESIS_TIME" --output-path "$GENESIS_FILE" 2>&1 | sed 's/^/    /'
+apply_vm_params "$GENESIS_FILE"
 
 print_substep "4.6" "Adding $pkg_count packages to genesis..."
 echo "" | run "$GNOGENESIS_BIN" txs add packages "$WORK_DIR_EXAMPLES" -gno-home "$WORK_DIR_GNOKEY_HOME" -key-name "$DEPLOYER_KEY" --genesis-path "$GENESIS_FILE" --insecure-password-stdin 2>&1 | sed 's/^/    /'
@@ -934,6 +1178,12 @@ FUNDED_ADDRESSES_FILE="$BALANCES_TMP_DIR/funded-addrs.txt"
   for faucet in "${FAUCET_ADDRESSES[@]}"; do
     echo "$faucet"
   done
+  # Approvers are a funded list like the faucets: same last-write-wins hazard,
+  # and an approver that were also a fee payer would have its exact-burn entry
+  # replaced by the flat approver balance.
+  for approver in "${PKG_APPROVERS[@]}"; do
+    echo "$approver"
+  done
   for vested in "${VESTED_ACCOUNTS[@]}"; do
     # Balance.Parse trims whitespace, so a padded entry would parse fine
     # downstream while its extracted address silently misses the guard —
@@ -967,6 +1217,7 @@ if [ "${#VESTED_ACCOUNTS[@]}" -gt 0 ]; then
     echo "$vested"
   done >"$VESTED_PREFLIGHT_SHEET"
   run "$GNOGENESIS_BIN" generate -chain-id "$CHAIN_ID" -genesis-time "$GENESIS_TIME" -output-path "$VESTED_PREFLIGHT_GENESIS" >/dev/null 2>&1
+  apply_vm_params "$VESTED_PREFLIGHT_GENESIS"
   run "$GNOGENESIS_BIN" balances add -balance-sheet "$VESTED_PREFLIGHT_SHEET" -genesis-path "$VESTED_PREFLIGHT_GENESIS" >/dev/null
   # verify refuses an empty validator set; borrow the first founding
   # validator to make the throwaway genesis verifiable.
@@ -1003,6 +1254,7 @@ start_temp_node() {
   NODE_RPC_ADDR="127.0.0.1:$NODE_RPC_PORT"
 
   run "$GNOGENESIS_BIN" generate -chain-id "$CHAIN_ID" -genesis-time "$(date +%s)" -output-path "$BALANCES_TMP_GENESIS"
+  apply_vm_params "$BALANCES_TMP_GENESIS"
   run "$GNOGENESIS_BIN" txs add sheets "$GENESIS_TXS_JSONL" -genesis-path "$BALANCES_TMP_GENESIS"
   run "$GNOGENESIS_BIN" balances add -balance-sheet "$BALANCES_TMP_FILE" -genesis-path "$BALANCES_TMP_GENESIS"
 
@@ -1175,10 +1427,10 @@ for validator in "${INITIAL_VALSET[@]}"; do
   run "$GNOGENESIS_BIN" validator add -name "$name" -power "$power" -address "$address" -pub-key "$pub_key" --genesis-path "$GENESIS_FILE"
 done
 
-# Fee payers (exact-burn, land at zero) + the faucets + the vested
-# accounts, one sheet. One entry per address (last write wins), so an
-# address on two lists would lose one of its entries — the overlap guard
-# in step 8 rules that out. Vested entries already carry the full
+# Fee payers (exact-burn, land at zero) + the faucets + the approvers +
+# the vested accounts, one sheet. One entry per address (last write wins),
+# so an address on two lists would lose one of its entries — the overlap
+# guard in step 8 rules that out. Vested entries already carry the full
 # balance-sheet syntax (amount + vesting schedule) and are appended
 # verbatim.
 FULL_BALANCES_FILE="$WORK_DIR/balances.txt"
@@ -1186,11 +1438,17 @@ cp "$DEPLOYER_BALANCES" "$FULL_BALANCES_FILE"
 for addr in "${FAUCET_ADDRESSES[@]}"; do
   echo "${addr}=${FAUCET_BALANCE}ugnot" >>"$FULL_BALANCES_FILE"
 done
+# The approver pays gas for every MsgEnablePackage it sends, so under the
+# "inert" policy an unfunded approver stalls the policy on the first
+# submission.
+for addr in "${PKG_APPROVERS[@]}"; do
+  echo "${addr}=${APPROVER_BALANCE}ugnot" >>"$FULL_BALANCES_FILE"
+done
 for vested in "${VESTED_ACCOUNTS[@]}"; do
   echo "$vested" >>"$FULL_BALANCES_FILE"
 done
 balance_count=$(wc -l <"$FULL_BALANCES_FILE" | tr -d ' ')
-print_substep "9.2" "Adding $balance_count balances (fee payers + ${#FAUCET_ADDRESSES[@]} faucets + ${#VESTED_ACCOUNTS[@]} vested)..."
+print_substep "9.2" "Adding $balance_count balances (fee payers + ${#FAUCET_ADDRESSES[@]} faucets + ${#PKG_APPROVERS[@]} approvers + ${#VESTED_ACCOUNTS[@]} vested)..."
 run "$GNOGENESIS_BIN" balances add -balance-sheet "$FULL_BALANCES_FILE" --genesis-path "$GENESIS_FILE" >/dev/null
 
 print_substep "9.3" "Running gnogenesis verify..."


### PR DESCRIPTION
# Launch pearl under the `inert` code-submission policy, with the MsgRun gate armed

## Status

Proposed (PR #6091, `chain/pearl`). Depends on the vm params added by #6088
(`gno.land/adr/pr6088_msgrun_allowlist_and_inert_charging.md`), which the branch
already carries.

## Context

pearl is a fresh chain. Until now its builder set no code-submission params, so
it inherited the chain defaults: `code_submission_policy = "permissionless"`,
every allowlist empty, and the inert submission charge off. That means anyone
may deploy code that type-checks and runs `init()` inside the deploying
transaction, gated only by the namespace check that `r/sys/names.Enable` turns on
at genesis.

We want a review gate on pearl at launch instead: code arrives, and a human-run
oracle decides whether it becomes live. #6088 supplies exactly that as the
`inert` policy, plus the pieces around it — `pkg_approvers`, the
`inert_submission_charge`/`inert_charge_collector` pair, and the `run_submitters`
MsgRun allowlist.

Three facts shaped the decision, all verified against the code rather than
assumed:

1. **Genesis content is exempt from parking.** The keeper's parking branch is
   guarded on `ctx.BlockHeight() > 0`
   (`gno.land/pkg/sdk/vm/keeper.go`), and baseapp's `InitChain` builds its header
   without a `Height` (`tm2/pkg/sdk/baseapp.go`), so genesis runs at 0. The
   caveat in `keeper.go` about never setting this policy in a fork's genesis
   params is about *replayed history* running under a policy that was never in
   force for it; pearl has no history, so it does not apply.
2. **`inert` does not gate `MsgRun`.** `checkCodePolicy`'s matrix
   (`gno.land/pkg/gnoland/app.go`) leaves `vm/run` answering only to
   `run_submitters` under every policy value, because `MsgRun` type-checks and
   executes arbitrary source immediately regardless of policy. With that list
   empty, the review gate covers persisted packages only and anyone can still
   execute whatever they like in an ephemeral `gno.land/e/<caller>/run` realm.
3. **GovDAO proposal creation is MsgRun-only.** A `ProposalRequest` carries a
   func value, which `MsgCall` cannot marshal. Nine of the twelve
   `misc/govdao-scripts/` commands are `gnokey maketx run`, and pearl's
   `govdao-exec.sh` signs them as aeddi.

## Decision

Set four vm params in pearl's genesis, from new launch parameters in
`gen-genesis.sh`:

1. **`code_submission_policy = "inert"`.** Post-genesis submissions park until
   an approver enables them. All 85 genesis packages still deploy live, per
   fact 1.
2. **`pkg_approvers` = one dedicated gpao oracle key**, funded at genesis with
   `APPROVER_BALANCE` (1e18 ugnot, matching the faucets) because the approver
   pays the gas for every `MsgEnablePackage` it sends. The address is a launch
   value that is not yet known; the build refuses to run without it rather than
   defaulting to something.
3. **`run_submitters` armed** with aeddi (the GovDAO T1 seed) and the relayer.
   Arming it is what makes `inert` mean something, per fact 2.
4. **`inert_submission_charge = 1000000ugnot`, collected to the approver.** Under
   `inert` the submitter chooses the work and the oracle pays for it — the
   package's `init()` runs on the enable transaction's gas meter — so an
   unpriced submission is a cheap way to exhaust the oracle's `--max-spend` and
   stop approvals for everyone. 1 GNOT matches gpao's default `--gas-fee`, so
   roughly one submission funds one approval. The collector defaults to the first
   `pkg_approvers` entry; it must never be left at the chain default, which is a
   derived address with no private key, so the charge would burn.

Supporting changes:

- **One helper writes the params into every genesis the script generates.** Step
  8 asserts the measurement genesis's vm params equal the shipping genesis's,
  since a measurement taken under different fee-governing params would be wrong.
  Three `gnogenesis generate` calls therefore share one `apply_vm_params`.
- **A preflight in step 1, before anything is compiled**, refuses the
  combinations that cannot be repaired on a live chain: `inert` with no approver;
  approvers set under a policy where nothing parks; an armed `run_submitters`
  that omits the GovDAO T1 seed (read out of the bootstrap tx, so the two cannot
  drift); a charge above the on-chain cap; a charge with no real collector.
- **`TestInertPolicyAtGenesisDeploysLive`** (`gno.land/pkg/gnoland`) pins fact 1
  from the outside: a fresh chain booted with `inert` in its genesis params, an
  armed `run_submitters` the deployer is not on, and a genesis `MsgAddPackage`
  must end with nothing parked and the package callable.

## Alternatives considered

- **Leave `run_submitters` empty.** Simpler, and it keeps `maketx run` working
  for testnet users and keeps proposal creation open to any address. Rejected:
  it leaves the review gate bypassable by anyone willing to run their code
  instead of deploying it, which is most of what a reviewer would want to stop.
  The accepted cost is that ordinary users cannot `maketx run` on pearl, and
  that every future GovDAO member must be added to the list or they can join the
  DAO and still not be able to propose.
- **Reuse the operator reserve as the approver.** No new account and no
  balance-sheet change, and the operator already holds the key. Rejected: it
  would put a key used for manual hand-sends onto an unattended
  internet-facing daemon, and share its sequence number between the two uses.
- **Turn the policy on post-genesis by proposal instead.** Would let pearl launch
  on the familiar permissionless path and tighten later. Rejected: the window
  between launch and the proposal is exactly when an unreviewed deploy is most
  likely, and the proposal needs governance to be reachable first — which is a
  larger dependency than setting a genesis param.
- **Leave the charge off.** One less moving part, no burn risk, and the collector
  could stay at its keyless default. Rejected on the reasoning in decision 4:
  the oracle's spend limit is the thing an attacker aims at, and it is cheap to
  provoke while submitting is free.

## Consequences

- **pearl does not deploy new code unless the oracle runs.** If gpao is down,
  nothing breaks and nothing is lost — submissions accumulate parked and
  activate when it returns — but no new package goes live. It is launch
  infrastructure alongside the RPC and the faucet.
- **The approver key is the most consequential key on the chain after
  governance.** It can activate any parked package and disable any active one,
  and it lives unattended, unlocked from `$GPAO_PASSWORD`.
- **A parked submission returns `ok`.** The builder's strict-replay report
  (`total: 90, ok: 90, failed: 0`) therefore cannot distinguish live from parked;
  the evidence that genesis content is live is `vm/qinertpaths` being empty and
  `vm/qpaths` listing all 85 paths. Both were checked on the built artifact.
- **`run_submitters` is not amendable through the generic `r/sys/params`
  factories.** It is reserved for `ProposeSetRunSubmitters`, which can also
  delegate add-only management to one other realm. `misc/govdao-scripts/` has no
  command for it today.
- **The build now fails until the oracle address is pasted in.** That is the
  intended state: it is the one launch value still outstanding, and
  `CHECKSUMS_DATA` cannot be locked before it is set, since the address changes
  the genesis bytes.
- **Reverting to permissionless is a one-line change plus a rebuild**, as long as
  it happens before launch. After launch it is a GovDAO param change, and
  `pkg_approvers` should be cleared in the same proposal so an approver key does
  not keep authority nothing uses.
