### PR TITLE
fix(docs): don't link-check chain RPC endpoints

### DIFF
--- a/misc/docs/tools/linter/main_test.go
+++ b/misc/docs/tools/linter/main_test.go
@@ -76,6 +76,53 @@ nulla ac [blandit tempus](https://gitlab.org).
 	}
 }
 
+func TestExtractLinksSkipsRPCEndpoints(t *testing.T) {
+	t.Parallel()
+
+	// Chain RPC endpoints are JSON-RPC APIs, not documentation pages. A GET
+	// against them says nothing about the link being correct, but does tie
+	// docs CI to a live chain's uptime and TLS certificate.
+	mockFileContent := `# Networks
+- betanet: https://rpc.gno.land:443
+- staging: https://rpc.staging.gno.land:443
+- pearl: https://rpc.pearl.testnets.gno.land:443
+- a real doc link: https://docs.gno.land
+`
+
+	require.Equal(t,
+		[]string{"https://docs.gno.land"},
+		extractUrls([]byte(mockFileContent)),
+	)
+}
+
+func TestShouldCheckURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"plain docs link", "https://docs.gno.land", true},
+		{"unrelated host", "https://example.org/rpc", true},
+		// "rpc." only counts as a host prefix, not anywhere in the URL.
+		{"rpc in path only", "https://example.org/rpc.gno.land", true},
+		{"betanet rpc", "https://rpc.gno.land:443", false},
+		{"testnet rpc", "https://rpc.pearl.testnets.gno.land:443", false},
+		{"localhost", "http://localhost:26657", false},
+		{"staging deployment", "https://staging.gno.land", false},
+		{"youtube", "https://youtube.com/watch?v=abc", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, shouldCheckURL(tt.url))
+		})
+	}
+}
+
 func TestExtractJSX(t *testing.T) {
 	t.Parallel()
 

--- a/misc/docs/tools/linter/urls.go
+++ b/misc/docs/tools/linter/urls.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -38,28 +39,64 @@ func extractUrls(fileContent []byte) []string {
 
 		// Look for http & https only
 		if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-			// Ignore localhost
-			if !strings.Contains(url, "localhost") &&
-				!strings.Contains(url, "127.0.0.1") &&
-				// placeholder for examples
-				!strings.Contains(url, "example.land") &&
-				// deployment-specific hosts whose uptime is not a CI concern
-				!strings.Contains(url, "staging.gno.land") &&
-				// archive.org subdomains rate-limit and intermittently 502
-				// from CI runners; the canonical Aaron Swartz Manifesto URL
-				// lives there and its reachability is not a CI concern.
-				!strings.Contains(url, "archive.org") &&
-				// YouTube blocks/rate-limits requests from data-center
-				// (CI) IPs, returning 404/429 even for live videos; its
-				// reachability is not a CI concern.
-				!strings.Contains(url, "youtube.com") &&
-				!strings.Contains(url, "youtu.be") {
+			if shouldCheckURL(url) {
 				urls = append(urls, url)
 			}
 		}
 	}
 
 	return urls
+}
+
+// skippedURLSubstrings are URLs we deliberately do not reach out to, because a
+// failure would say nothing about whether the documentation link is correct.
+var skippedURLSubstrings = []string{
+	// Not routable from CI.
+	"localhost",
+	"127.0.0.1",
+	// Placeholder for examples.
+	"example.land",
+	// archive.org subdomains rate-limit and intermittently 502 from CI
+	// runners; the canonical Aaron Swartz Manifesto URL lives there and its
+	// reachability is not a CI concern.
+	"archive.org",
+	// YouTube blocks/rate-limits requests from data-center (CI) IPs,
+	// returning 404/429 even for live videos; its reachability is not a CI
+	// concern.
+	"youtube.com",
+	"youtu.be",
+	// Deployment-specific hosts whose uptime is not a CI concern.
+	"staging.gno.land",
+}
+
+// shouldCheckURL reports whether url is worth reaching out to from CI.
+func shouldCheckURL(rawURL string) bool {
+	for _, s := range skippedURLSubstrings {
+		if strings.Contains(rawURL, s) {
+			return false
+		}
+	}
+
+	return !isRPCEndpoint(rawURL)
+}
+
+// isRPCEndpoint reports whether url points at a chain RPC endpoint (an `rpc.*`
+// host, e.g. https://rpc.gno.land:443).
+//
+// These are JSON-RPC APIs, not documentation pages: a plain GET tells us
+// nothing about whether the documented endpoint is the right one, while it does
+// make docs CI fail whenever a live chain is down, rotating, or — as happened
+// with rpc.gno.land — serving an expired TLS certificate. Their availability is
+// an infrastructure concern, not a documentation one.
+func isRPCEndpoint(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		// Not parseable as a URL; leave the decision to the caller's other
+		// checks rather than silently skipping it.
+		return false
+	}
+
+	return strings.HasPrefix(u.Hostname(), "rpc.")
 }
 
 func lintURLs(ctx context.Context, filepathToURLs map[string][]string, treatAsError bool) (string, error) {


### PR DESCRIPTION
## Problem

`ci / codegen-verify` (the `docs` matrix leg) is red on `master`, and has been since 2026-08-27. [Failing run](https://github.com/gnolang/gno/actions/runs/33150009390):

```
found items that need linting
Remote links that need checking:
>>> https://rpc.gno.land:443 (found in file: docs/resources/gas-fees.md)
>>> https://rpc.gno.land:443 (found in file: docs/users/interact-with-gnokey.md)
... (11 occurrences)
exit status 1
make: *** [Makefile:2: lint] Error 1
```

The links are not actually broken. `rpc.gno.land` is serving a certificate issued for `rpc.betanet.testnets.gno.land` that **expired on 2026-08-27 14:05 UTC**:

```
$ echo | openssl s_client -connect rpc.gno.land:443 -servername rpc.gno.land \
    | openssl x509 -noout -subject -dates
subject=CN=rpc.betanet.testnets.gno.land
notBefore=May 29 14:05:45 2026 GMT
notAfter=Aug 27 14:05:44 2026 GMT
```

The docs linter GETs every remote URL it finds, so the TLS verification failure surfaces as eleven "broken" links and fails the job.

## Fix

The linter shouldn't be link-checking chain RPC endpoints at all. They are JSON-RPC APIs, not documentation pages — the response to a plain GET says nothing about whether the documented endpoint is correct, while it does make docs CI depend on a live chain's uptime and TLS certificate.

This skips `rpc.*` hosts, which is the same reasoning already applied to `staging.gno.land` in that file ("deployment-specific hosts whose uptime is not a CI concern"). It also covers `rpc.pearl.testnets.gno.land`, which would hit the identical problem at its next certificate rotation.

While here, the exclusion condition — now eight entries with interleaved comments — moves out of the `if` into `shouldCheckURL`, and the RPC check runs against the parsed hostname so a path segment like `https://example.org/rpc.gno.land` is still checked.

`docs/README.md` and the other docs are untouched; the URLs stay exactly as they are.

## Verification

```
$ cd docs && make lint
Lint complete, no issues found.

$ cd misc/docs/tools/linter && go test ./...
ok
```

`make generate` in `docs/` leaves the tree clean, so the other half of the `codegen-verify` job is unaffected.

New tests cover the skip list and the hostname-vs-path distinction.

## Still needed (infra, not this PR)

**The `rpc.gno.land` certificate needs renewing.** This PR only stops docs CI from failing on it; betanet's RPC endpoint is currently unusable for anything that verifies TLS.

---

Written with AI assistance (Claude Code); reviewed before submitting.
