### PR TITLE
feat(gnovm): Deterministic realm scoped token IDs for GRC20

### DIFF
--- a/docs/resources/effective-gno.md
+++ b/docs/resources/effective-gno.md
@@ -906,7 +906,7 @@ var (
 )
 
 func init(cur realm) {
-	Token, privateLedger = grc20.NewToken("Foo Token", "FOO", 4, 0, cur)
+	Token, privateLedger = grc20.NewToken("Foo Token", "FOO", 4, cur)
 	userTeller = privateLedger.CallerTeller()
 }
 

--- a/docs/users/interact-with-gnokey.md
+++ b/docs/users/interact-with-gnokey.md
@@ -1284,7 +1284,7 @@ var (
 )
 
 func init(cur realm) {
-        Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0, "token", cur)
+        Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0, cur)
 }
 
 const (

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/caller_teller_sub_realm_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/caller_teller_sub_realm_filetest.gno
@@ -20,7 +20,7 @@ var (
 )
 
 func init(cur realm) {
-	token, ledger = grc20.NewToken("SubRealm", "SUBR", 4, 0, cur)
+	token, ledger = grc20.NewToken("SubRealm", "SUBR", 4, cur)
 	teller = ledger.CallerTeller()
 }
 
@@ -46,7 +46,7 @@ func main(cur realm) {
 	// The mirror image: a token CREATED from a sub frame must still be usable
 	// from its host realm. origRealm drops the subpath at construction, so the
 	// token belongs to the host rather than being stranded in the sub.
-	subTok, subLedger := grc20.NewToken("FromSub", "FSUB", 4, 1, cur.Sub("vault"))
+	subTok, subLedger := grc20.NewToken("FromSub", "FSUB", 4, cur.Sub("vault"))
 	subTeller := subLedger.CallerTeller()
 	subLedger.Mint(payer, 500)
 	if err := subTeller.Transfer(0, cur, bob, 50); err != nil {

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
@@ -2,7 +2,7 @@
 
 // This filetest shows how an indexer attributes a grc20 event to its issuer.
 //
-// Two fields matter, and neither is sufficient alone:
+// Three fields matter:
 //
 //   - pkg_path is stamped by the VM from the package whose code calls
 //     chain.Emit. Every genuine grc20 event therefore carries
@@ -10,9 +10,13 @@
 //     but never the token.
 //   - the "token" attribute carries Token.ID(). The VM creates this opaque ID
 //     from the issuing realm's package identifier and a persistent counter.
+//   - the NewToken "realm" attribute carries Token.GetOriginRealm(), captured
+//     only after IsCurrent verifies the issuing realm.
 //
-// Together they prove that grc20 emitted the event and that the VM assigned
-// its token ID to the issuing realm. Callers cannot forge that package identity.
+// Together they prove that grc20 emitted NewToken, that the VM assigned its ID,
+// and that its realm attribute is authentic. An indexer can bind token ID to
+// realm there, then attribute later grc20 events through that mapping. Callers
+// cannot forge the grc20 package identity or supply a non-current origin realm.
 //
 // The realm below is an impostor trying to pass its own transfers off as
 // another realm's token, by both routes available to it, and failing at both.
@@ -57,6 +61,10 @@ func main(cur realm) {
 //       {
 //         "key": "token",
 //         "value": "gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5"
+//       },
+//       {
+//         "key": "realm",
+//         "value": "gno.land/r/demo/grc20provenance"
 //       },
 //       {
 //         "key": "name",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
@@ -8,15 +8,12 @@
 //     chain.Emit. Every genuine grc20 event therefore carries
 //     gno.land/p/demo/tokens/grc20 — a constant, so it identifies the library
 //     but never the token.
-//   - the "token" attribute carries Token.ID(). The VM creates this opaque ID
-//     from the issuing realm's package identifier and a persistent counter.
-//   - the NewToken "realm" attribute carries Token.GetOriginRealm(), captured
-//     only after IsCurrent verifies the issuing realm.
+//   - the "token" attribute carries Token.ID(). The VM builds it from the
+//     current realm path and its persistent time after IsCurrent verifies it.
 //
-// Together they prove that grc20 emitted NewToken, that the VM assigned its ID,
-// and that its realm attribute is authentic. An indexer can bind token ID to
-// realm there, then attribute later grc20 events through that mapping. Callers
-// cannot forge the grc20 package identity or supply a non-current origin realm.
+// Together they make every genuine grc20 event independently attributable to
+// its origin realm. Callers cannot forge the grc20 package identity or supply a
+// non-current origin realm.
 //
 // The realm below is an impostor trying to pass its own transfers off as
 // another realm's token, by both routes available to it, and failing at both.
@@ -28,7 +25,7 @@ import (
 	"gno.land/p/demo/tokens/grc20"
 )
 
-const canonical = "gno:realm-id:unforgeable-package-id:1"
+const canonical = "gno.land/r/demo/defi/foo20:1"
 
 func main(cur realm) {
 	println("canonical id:", canonical)
@@ -49,8 +46,8 @@ func main(cur realm) {
 }
 
 // Output:
-// canonical id: gno:realm-id:unforgeable-package-id:1
-// impostor id:  gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5
+// canonical id: gno.land/r/demo/defi/foo20:1
+// impostor id:  gno.land/r/demo/grc20provenance:5
 // impostor claims canonical id: false
 
 // Events:
@@ -60,11 +57,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5"
-//       },
-//       {
-//         "key": "realm",
-//         "value": "gno.land/r/demo/grc20provenance"
+//         "value": "gno.land/r/demo/grc20provenance:5"
 //       },
 //       {
 //         "key": "name",
@@ -86,7 +79,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5"
+//         "value": "gno.land/r/demo/grc20provenance:5"
 //       },
 //       {
 //         "key": "from",
@@ -108,7 +101,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:unforgeable-package-id:1"
+//         "value": "gno.land/r/demo/defi/foo20:1"
 //       },
 //       {
 //         "key": "from",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/event_provenance_filetest.gno
@@ -1,8 +1,6 @@
 // PKGPATH: gno.land/r/demo/grc20provenance
 
-// This filetest is the reference for how an indexer attributes a grc20 event to
-// the realm that issued the token. It is the cross-realm counterpart to
-// newtoken_event_filetest.gno, which covers the within-realm duplicate signal.
+// This filetest shows how an indexer attributes a grc20 event to its issuer.
 //
 // Two fields matter, and neither is sufficient alone:
 //
@@ -10,14 +8,11 @@
 //     chain.Emit. Every genuine grc20 event therefore carries
 //     gno.land/p/demo/tokens/grc20 — a constant, so it identifies the library
 //     but never the token.
-//   - the "token" attribute carries Token.ID(), whose leading component is
-//     rlm.PkgPath() captured under IsCurrent() in NewToken. A realm cannot
-//     produce a Token whose id claims a different realm.
+//   - the "token" attribute carries Token.ID(). The VM creates this opaque ID
+//     from the issuing realm's package identifier and a persistent counter.
 //
-// Chained, they are sufficient: pkg_path proves the event came from grc20's
-// code, and grc20's code only ever writes an IsCurrent-verified realm prefix
-// into "token". So for any event bearing grc20's pkg_path, the realm prefix in
-// "token" is unforgeable.
+// Together they prove that grc20 emitted the event and that the VM assigned
+// its token ID to the issuing realm. Callers cannot forge that package identity.
 //
 // The realm below is an impostor trying to pass its own transfers off as
 // another realm's token, by both routes available to it, and failing at both.
@@ -29,31 +24,17 @@ import (
 	"gno.land/p/demo/tokens/grc20"
 )
 
-// Stand-in for a token issued and registered by some other realm. Written as a
-// literal rather than imported: a filetest under a /p/ package that imports an
-// /r/ realm which itself imports that /p/ package forms a genesis dependency
-// cycle (grc20 -> realm -> grc20), which breaks package loading chain-wide.
-const canonical = "gno.land/r/demo/canonicaltoken.FOO.0000000"
+const canonical = "gno:realm-id:unforgeable-package-id:1"
 
 func main(cur realm) {
 	println("canonical id:", canonical)
 
-	// Route 1: ask grc20 for a token using the canonical token's own
-	// name/symbol/decimals/id. NewToken derives the id prefix from the live
-	// crossing frame, so the id names *this* realm. No argument changes that.
-	impostor, impostorLedger := grc20.NewToken("Foo", "FOO", 4, 0, cur)
+	impostor, impostorLedger := grc20.NewToken("Foo", "FOO", 4, cur)
 	println("impostor id: ", impostor.ID())
 	println("impostor claims canonical id:", impostor.ID() == canonical)
 
-	// A genuine grc20 event from the impostor. It carries grc20's pkg_path —
-	// identical to the canonical token's events — but the "token" prefix is
-	// this realm, so an indexer attributes it here.
 	impostorLedger.Mint(cur.Address(), 999_999)
 
-	// Route 2: skip grc20 and hand-emit an event carrying the canonical id.
-	// The attributes are fully attacker-chosen, but pkg_path is not: the VM
-	// stamps this realm. An indexer that accepts Transfer only from grc20's
-	// pkg_path drops this event.
 	chain.Emit(
 		"Transfer",
 		"token", canonical,
@@ -64,8 +45,8 @@ func main(cur realm) {
 }
 
 // Output:
-// canonical id: gno.land/r/demo/canonicaltoken.FOO.0000000
-// impostor id:  gno.land/r/demo/grc20provenance.FOO.0000000
+// canonical id: gno:realm-id:unforgeable-package-id:1
+// impostor id:  gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5
 // impostor claims canonical id: false
 
 // Events:
@@ -75,7 +56,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20provenance.FOO.0000000"
+//         "value": "gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5"
 //       },
 //       {
 //         "key": "name",
@@ -97,7 +78,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20provenance.FOO.0000000"
+//         "value": "gno:realm-id:08f54204e7bb748ba312daa76fd11641ce50906d:5"
 //       },
 //       {
 //         "key": "from",
@@ -119,7 +100,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/canonicaltoken.FOO.0000000"
+//         "value": "gno:realm-id:unforgeable-package-id:1"
 //       },
 //       {
 //         "key": "from",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
@@ -31,6 +31,10 @@ func main(cur realm) {
 //         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:5"
 //       },
 //       {
+//         "key": "realm",
+//         "value": "gno.land/r/demo/grc20dupsignal"
+//       },
+//       {
 //         "key": "name",
 //         "value": "Same"
 //       },
@@ -51,6 +55,10 @@ func main(cur realm) {
 //       {
 //         "key": "token",
 //         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:6"
+//       },
+//       {
+//         "key": "realm",
+//         "value": "gno.land/r/demo/grc20dupsignal"
 //       },
 //       {
 //         "key": "name",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
@@ -28,11 +28,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:5"
-//       },
-//       {
-//         "key": "realm",
-//         "value": "gno.land/r/demo/grc20dupsignal"
+//         "value": "gno.land/r/demo/grc20dupsignal:5"
 //       },
 //       {
 //         "key": "name",
@@ -54,11 +50,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:6"
-//       },
-//       {
-//         "key": "realm",
-//         "value": "gno.land/r/demo/grc20dupsignal"
+//         "value": "gno.land/r/demo/grc20dupsignal:6"
 //       },
 //       {
 //         "key": "name",
@@ -80,7 +72,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:5"
+//         "value": "gno.land/r/demo/grc20dupsignal:5"
 //       },
 //       {
 //         "key": "from",
@@ -102,7 +94,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:6"
+//         "value": "gno.land/r/demo/grc20dupsignal:6"
 //       },
 //       {
 //         "key": "from",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/newtoken_event_filetest.gno
@@ -1,15 +1,7 @@
 // PKGPATH: gno.land/r/demo/grc20dupsignal
 
-// This filetest is the reference for the detection rule the NewToken event
-// enables. The realm below reuses seqid 0 twice, so both tokens end up with the
-// same Token.ID() and their Transfer events are indistinguishable — the
-// long-standing event-provenance ambiguity.
-//
-// What changes is that the ambiguity is now *announced*. Two NewToken events
-// carry the same "token" value, which is a complete signal: NewToken is the only
-// way a Token can exist (Token's fields are unexported), so an indexer watching
-// this event sees every token that will ever emit. On the second duplicate
-// announcement it should flag the realm and stop trusting its token events.
+// Two tokens with identical metadata receive distinct VM assigned IDs.
+// Their NewToken and Transfer events remain attributable to one token.
 package grc20dupsignal
 
 import (
@@ -17,19 +9,17 @@ import (
 )
 
 func main(cur realm) {
-	first, firstLedger := grc20.NewToken("Same", "DUP", 6, 0, cur)
-	second, secondLedger := grc20.NewToken("Same", "DUP", 6, 0, cur)
+	first, firstLedger := grc20.NewToken("Same", "DUP", 6, cur)
+	second, secondLedger := grc20.NewToken("Same", "DUP", 6, cur)
 
 	println("same id:", first.ID() == second.ID())
 
-	// Two independent ledgers, one identifier: these Transfers cannot be
-	// attributed to either object from the event stream alone.
 	firstLedger.Mint(cur.Address(), 1)
 	secondLedger.Mint(cur.Address(), 999999)
 }
 
 // Output:
-// same id: true
+// same id: false
 
 // Events:
 // [
@@ -38,7 +28,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20dupsignal.DUP.0000000"
+//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:5"
 //       },
 //       {
 //         "key": "name",
@@ -60,7 +50,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20dupsignal.DUP.0000000"
+//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:6"
 //       },
 //       {
 //         "key": "name",
@@ -82,7 +72,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20dupsignal.DUP.0000000"
+//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:5"
 //       },
 //       {
 //         "key": "from",
@@ -104,7 +94,7 @@ func main(cur realm) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20dupsignal.DUP.0000000"
+//         "value": "gno:realm-id:083acbcef4b740a693cac246bf49a6128be52c82:6"
 //       },
 //       {
 //         "key": "from",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
@@ -35,11 +35,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
-//       },
-//       {
-//         "key": "realm",
-//         "value": "gno.land/r/demo/grc20identity"
+//         "value": "gno.land/r/demo/grc20identity:6"
 //       },
 //       {
 //         "key": "name",
@@ -61,11 +57,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
-//       },
-//       {
-//         "key": "realm",
-//         "value": "gno.land/r/demo/grc20identity"
+//         "value": "gno.land/r/demo/grc20identity:7"
 //       },
 //       {
 //         "key": "name",
@@ -87,7 +79,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
+//         "value": "gno.land/r/demo/grc20identity:6"
 //       },
 //       {
 //         "key": "from",
@@ -109,7 +101,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
+//         "value": "gno.land/r/demo/grc20identity:6"
 //       },
 //       {
 //         "key": "owner",
@@ -131,7 +123,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
+//         "value": "gno.land/r/demo/grc20identity:7"
 //       },
 //       {
 //         "key": "from",
@@ -153,7 +145,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
+//         "value": "gno.land/r/demo/grc20identity:7"
 //       },
 //       {
 //         "key": "owner",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
@@ -6,20 +6,14 @@ import (
 	"chain"
 
 	"gno.land/p/demo/tokens/grc20"
-	"gno.land/p/nt/seqid/v0"
 )
-
-var nextTokenID seqid.ID
 
 func main(cur realm) {
 	first, firstLedger := newToken(cur)
 	second, secondLedger := newToken(cur)
 
-	if first.ID() != "gno.land/r/demo/grc20identity.DUP.0000001" {
-		panic("unexpected first token ID: " + first.ID())
-	}
-	if second.ID() != "gno.land/r/demo/grc20identity.DUP.0000002" {
-		panic("unexpected second token ID: " + second.ID())
+	if first.ID() == second.ID() {
+		panic("duplicate token IDs")
 	}
 
 	holder := chain.PackageAddress("holder")
@@ -31,7 +25,7 @@ func main(cur realm) {
 }
 
 func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
-	return grc20.NewToken("Same", "DUP", 6, nextTokenID.Next(), cur)
+	return grc20.NewToken("Same", "DUP", 6, cur)
 }
 
 // Events:
@@ -41,7 +35,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000001"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
 //       },
 //       {
 //         "key": "name",
@@ -63,7 +57,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000002"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
 //       },
 //       {
 //         "key": "name",
@@ -85,7 +79,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000001"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
 //       },
 //       {
 //         "key": "from",
@@ -107,7 +101,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000001"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
 //       },
 //       {
 //         "key": "owner",
@@ -129,7 +123,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000002"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
 //       },
 //       {
 //         "key": "from",
@@ -151,7 +145,7 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //     "attrs": [
 //       {
 //         "key": "token",
-//         "value": "gno.land/r/demo/grc20identity.DUP.0000002"
+//         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
 //       },
 //       {
 //         "key": "owner",

--- a/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/filetests/token_identity_filetest.gno
@@ -38,6 +38,10 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:6"
 //       },
 //       {
+//         "key": "realm",
+//         "value": "gno.land/r/demo/grc20identity"
+//       },
+//       {
 //         "key": "name",
 //         "value": "Same"
 //       },
@@ -58,6 +62,10 @@ func newToken(cur realm) (*grc20.Token, *grc20.PrivateLedger) {
 //       {
 //         "key": "token",
 //         "value": "gno:realm-id:054f7b1709e31b44b2e39810b7be83378b0c25b7:7"
+//       },
+//       {
+//         "key": "realm",
+//         "value": "gno.land/r/demo/grc20identity"
 //       },
 //       {
 //         "key": "name",

--- a/examples/gno.land/p/demo/tokens/grc20/tellers_test.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/tellers_test.gno
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCallerTellerImpl(cur realm, t *testing.T) {
-	tok, ledger := newTestToken("Dummy", "DUMMY", 4, 0, cur)
+	tok, ledger := newTokenFixture("Dummy", "DUMMY", 4)
 	teller := ledger.CallerTeller()
 	urequire.False(t, tok == nil)
 	var _ Teller = teller
@@ -29,7 +29,7 @@ type evilWrap struct {
 }
 
 func TestIsCanonicalTeller(cur realm, t *testing.T) {
-	_, ledger := newTestToken("Dummy", "DUMMY", 4, 0, cur)
+	_, ledger := newTokenFixture("Dummy", "DUMMY", 4)
 	legit := ledger.CallerTeller()
 
 	uassert.True(t, IsCanonicalTeller(legit),
@@ -47,7 +47,7 @@ func TestTeller(cur realm, t *testing.T) {
 		carl  = testutils.TestAddress("carl")
 	)
 
-	token, ledger := newTestToken("Dummy", "DUMMY", 6, 0, cur)
+	token, ledger := newTokenFixture("Dummy", "DUMMY", 6)
 
 	checkBalances := func(aliceEB, bobEB, carlEB int64) {
 		t.Helper()
@@ -109,7 +109,7 @@ func TestCallerTeller(cur realm, t *testing.T) {
 	bob := testutils.TestAddress("bob")
 	carl := testutils.TestAddress("carl")
 
-	token, ledger := newTestToken("Dummy", "DUMMY", 6, 0, cur)
+	token, ledger := newTokenFixture("Dummy", "DUMMY", 6)
 	teller := ledger.CallerTeller()
 
 	checkBalances := func(aliceEB, bobEB, carlEB int64) {

--- a/examples/gno.land/p/demo/tokens/grc20/token.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token.gno
@@ -11,16 +11,14 @@ import (
 )
 
 // NewToken creates a Token bound to the calling realm.
-// rlm must be the caller's current realm. The VM assigns Token.ID() and
-// guarantees that every token created by the realm receives a unique value.
-// The ID is opaque and safe to use directly as an event attribute or key.
-// Its package identifier is assigned by the VM and cannot be forged by a caller.
+// rlm must be the caller's current realm. Token.ID() is assigned by the VM as
+// "<origin-realm>:<realm-time>", so every event remains attributable without
+// first observing its NewToken event.
 //
 // If the Token should be discoverable, follow up with
 // grc20reg.Register(cross(cur), Token, slug).
 //
-// Every successful call emits a NewToken event carrying the resulting ID and
-// origin realm.
+// Every successful call emits a NewToken event carrying the resulting ID.
 func NewToken(name, symbol string, decimals int, rlm realm) (*Token, *PrivateLedger) {
 	if !rlm.IsCurrent() {
 		panic(ErrSpoofedRealm)
@@ -57,7 +55,6 @@ func NewToken(name, symbol string, decimals int, rlm realm) (*Token, *PrivateLed
 	chain.Emit(
 		NewTokenEvent,
 		"token", token.id,
-		"realm", token.origRealm,
 		"name", name,
 		"symbol", symbol,
 		"decimals", strconv.Itoa(decimals),
@@ -115,7 +112,7 @@ func (tok Token) TotalSupply() int64 { return tok.ledger.totalSupply }
 // KnownAccounts returns the number of known accounts in the bank.
 func (tok Token) KnownAccounts() int { return tok.ledger.balances.Size() }
 
-// ID returns the VM assigned identifier of the token.
+// ID returns the VM-assigned "<origin-realm>:<realm-time>" identifier.
 func (tok *Token) ID() string {
 	return tok.id
 }

--- a/examples/gno.land/p/demo/tokens/grc20/token.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token.gno
@@ -2,43 +2,25 @@ package grc20
 
 import (
 	"chain"
+	"chain/runtime"
 	"math"
 	"math/overflow"
 	"strconv"
 
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/ufmt/v0"
 )
 
-// NewToken creates a Token whose origRealm is bound to the calling realm.
-// rlm must be the caller's own captured cur (asserted via rlm.IsCurrent()),
-// and rlm.PkgPath() — the calling realm itself — becomes the Token's
-// origRealm. Token.ID() returns origRealm + "." + symbol + "." + id.
-//
-// Because IsCurrent runtime-validates that rlm came from the live
-// crossing frame, origRealm is unforgeable: an external realm cannot
-// fabricate a Token claiming to belong to a different package.
-//
-// Realms that create multiple tokens should allocate id from one persistent
-// seqid.ID, shared by every creation path, to avoid conflicting identifiers:
-//
-//	var nextTokenID seqid.ID
-//	Token, ledger := grc20.NewToken("Foo", "FOO", 4, nextTokenID.Next(), cur)
-//
-// A realm that creates only a single token can pass 0 directly, since no
-// other token of that realm can collide with it.
+// NewToken creates a Token bound to the calling realm.
+// rlm must be the caller's current realm. The VM assigns Token.ID() and
+// guarantees that every token created by the realm receives a unique value.
+// The ID is opaque and safe to use directly as an event attribute or key.
+// Its package identifier is assigned by the VM and cannot be forged by a caller.
 //
 // If the Token should be discoverable, follow up with
-// grc20reg.Register(cross(cur), Token, slug). The registry key is Token.ID().
+// grc20reg.Register(cross(cur), Token, slug).
 //
-// Every successful call emits a NewToken event carrying the resulting
-// Token.ID(). Because Token's fields are unexported, NewToken is the only way a
-// Token can come into existence, so this event makes token creation fully
-// observable: an indexer that sees the same Token.ID() announced twice knows the
-// realm built two independent ledgers behind one identifier, and that every
-// later Mint/Burn/Transfer/Approval carrying that id is ambiguous. Such a realm
-// is emitting untrustworthy events and should be flagged or ignored wholesale.
-func NewToken(name, symbol string, decimals int, id seqid.ID, rlm realm) (*Token, *PrivateLedger) {
+// Every successful call emits a NewToken event carrying the resulting ID.
+func NewToken(name, symbol string, decimals int, rlm realm) (*Token, *PrivateLedger) {
 	if !rlm.IsCurrent() {
 		panic(ErrSpoofedRealm)
 	}
@@ -62,7 +44,7 @@ func NewToken(name, symbol string, decimals int, id seqid.ID, rlm realm) (*Token
 	origRealm, _, _ := chain.SplitPkgSubPath(pkgPath)
 	ledger := &PrivateLedger{}
 	token := &Token{
-		id:        pkgPath + "." + symbol + "." + id.String(),
+		id:        runtime.NewRealmID(),
 		name:      name,
 		symbol:    symbol,
 		decimals:  decimals,
@@ -131,11 +113,13 @@ func (tok Token) TotalSupply() int64 { return tok.ledger.totalSupply }
 // KnownAccounts returns the number of known accounts in the bank.
 func (tok Token) KnownAccounts() int { return tok.ledger.balances.Size() }
 
-// ID returns the Identifier of the token.
-// It is composed of the original realm, the symbol, and the provided id.
+// ID returns the VM assigned identifier of the token.
 func (tok *Token) ID() string {
 	return tok.id
 }
+
+// GetOriginRealm returns the realm that created the token.
+func (tok *Token) GetOriginRealm() string { return tok.origRealm }
 
 // HasAddr checks if the specified address is a known account in the bank.
 func (tok Token) HasAddr(addr address) bool {

--- a/examples/gno.land/p/demo/tokens/grc20/token.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token.gno
@@ -19,7 +19,8 @@ import (
 // If the Token should be discoverable, follow up with
 // grc20reg.Register(cross(cur), Token, slug).
 //
-// Every successful call emits a NewToken event carrying the resulting ID.
+// Every successful call emits a NewToken event carrying the resulting ID and
+// origin realm.
 func NewToken(name, symbol string, decimals int, rlm realm) (*Token, *PrivateLedger) {
 	if !rlm.IsCurrent() {
 		panic(ErrSpoofedRealm)
@@ -56,6 +57,7 @@ func NewToken(name, symbol string, decimals int, rlm realm) (*Token, *PrivateLed
 	chain.Emit(
 		NewTokenEvent,
 		"token", token.id,
+		"realm", token.origRealm,
 		"name", name,
 		"symbol", symbol,
 		"decimals", strconv.Itoa(decimals),

--- a/examples/gno.land/p/demo/tokens/grc20/token_test.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token_test.gno
@@ -6,36 +6,36 @@ import (
 	"strings"
 	"testing"
 
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/testutils/v0"
 	"gno.land/p/nt/uassert/v0"
 	"gno.land/p/nt/ufmt/v0"
 	"gno.land/p/nt/urequire/v0"
 )
 
-// newTestToken constructs a Token. The IIFE same-realm cross
-// promotes the test's EOA-origin cur into a fresh /p/grc20
-// CodeRealm cur so NewToken's IsCurrent + non-empty rlm.PkgPath()
-// checks pass.
-func newTestToken(name, symbol string, decimals int, id seqid.ID, rlm realm) (tok *Token, adm *PrivateLedger) {
-	func(cur realm) {
-		tok, adm = NewToken(name, symbol, decimals, id, cur)
-	}(cross(rlm))
-	return
+func newTokenFixture(name, symbol string, decimals int) (*Token, *PrivateLedger) {
+	ledger := &PrivateLedger{}
+	token := &Token{
+		id:        "test",
+		name:      name,
+		symbol:    symbol,
+		decimals:  decimals,
+		ledger:    ledger,
+		origRealm: "gno.land/p/demo/tokens/grc20",
+	}
+	ledger.token = token
+	return token, ledger
 }
 
 func TestTestImpl(cur realm, t *testing.T) {
-	bank, _ := newTestToken("Dummy", "DUMMY", 4, 0, cur)
+	bank, _ := newTokenFixture("Dummy", "DUMMY", 4)
 	urequire.False(t, bank == nil, "dummy should not be nil")
 }
 
-func TestNewTokenAllowsDuplicateSymbolInSameRealm(cur realm, t *testing.T) {
+func TestSeparateLedgersForDuplicateSymbol(cur realm, t *testing.T) {
 	holder := testutils.TestAddress("holder")
 
-	first, firstLedger := newTestToken("Same", "DUP", 6, 1, cur)
-	second, secondLedger := newTestToken("Same", "DUP", 6, 2, cur)
-
-	urequire.True(t, first.ID() != second.ID(), "duplicate symbols should not force duplicate IDs")
+	first, firstLedger := newTokenFixture("Same", "DUP", 6)
+	second, secondLedger := newTokenFixture("Same", "DUP", 6)
 
 	urequire.NoError(t, firstLedger.Mint(holder, 11))
 	urequire.NoError(t, secondLedger.Mint(holder, 22))
@@ -43,55 +43,39 @@ func TestNewTokenAllowsDuplicateSymbolInSameRealm(cur realm, t *testing.T) {
 	urequire.Equal(t, int64(22), second.BalanceOf(holder))
 }
 
-func TestNewTokenValidation(cur realm, t *testing.T) {
-	// Wrap NewToken to satisfy IsCurrent and pkgPath requirements,
-	// then validate name, symbol, and decimals.
-	mustPanic := func(name, sym string, dec int, want error, label string) {
-		t.Helper()
-		// newTestToken wraps NewToken in cross(...), so the panic from
-		// NewToken's validators crosses a realm boundary — use revive()
-		// (defer-recover doesn't see cross-realm panics).
-		r := revive(func() {
-			newTestToken(name, sym, dec, 0, cur)
-		})
-		if r == nil {
-			t.Errorf("%s: expected panic, got none", label)
-			return
-		}
-		if r != want {
-			t.Errorf("%s: expected %v, got %v", label, want, r)
-		}
+func TestValidName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"", false},
+		{strings.Repeat("a", MaxNameLen+1), false},
+		{"bad\x01name", false},
+		{"bad\nname", false},
+		{strings.Repeat("a", MaxNameLen), true},
+		{"Доллар", true},
 	}
+	for _, test := range tests {
+		uassert.Equal(t, test.want, validName(test.name))
+	}
+}
 
-	// Empty name / symbol.
-	mustPanic("", "OK", 4, ErrInvalidName, "empty name")
-	mustPanic("Name", "", 4, ErrInvalidSymbol, "empty symbol")
-
-	// Length caps.
-	mustPanic(strings.Repeat("a", MaxNameLen+1), "OK", 4, ErrInvalidName, "name too long")
-	mustPanic("Name", strings.Repeat("A", MaxSymbolLen+1), 4, ErrInvalidSymbol, "symbol too long")
-
-	// Name control characters.
-	mustPanic("bad\x01name", "OK", 4, ErrInvalidName, "name with control char")
-	mustPanic("bad\nname", "OK", 4, ErrInvalidName, "name with newline")
-
-	// Symbol charset — disallowed delimiters and whitespace.
-	mustPanic("Name", "BA.D", 4, ErrInvalidSymbol, "symbol with dot")
-	mustPanic("Name", "BA/D", 4, ErrInvalidSymbol, "symbol with slash")
-	mustPanic("Name", "BA D", 4, ErrInvalidSymbol, "symbol with space")
-	mustPanic("Name", "BA\"D", 4, ErrInvalidSymbol, "symbol with quote")
-
-	// Decimals out of range.
-	mustPanic("Name", "OK", -1, ErrInvalidDecimals, "negative decimals")
-	mustPanic("Name", "OK", MaxDecimals+1, ErrInvalidDecimals, "decimals over cap")
-
-	// Boundary positives — should NOT panic.
-	tok, _ := newTestToken(strings.Repeat("a", MaxNameLen), strings.Repeat("A", MaxSymbolLen), MaxDecimals, 0, cur)
-	urequire.True(t, tok != nil, "boundary name+symbol+decimals should succeed")
-
-	// UTF-8 name with non-ASCII is allowed.
-	tok2, _ := newTestToken("Доллар", "RUB", 2, 0, cur)
-	urequire.True(t, tok2 != nil, "UTF-8 name should be allowed")
+func TestValidSymbol(t *testing.T) {
+	tests := []struct {
+		symbol string
+		want   bool
+	}{
+		{"", false},
+		{strings.Repeat("A", MaxSymbolLen+1), false},
+		{"BA.D", false},
+		{"BA/D", false},
+		{"BA D", false},
+		{"BA\"D", false},
+		{strings.Repeat("A", MaxSymbolLen), true},
+	}
+	for _, test := range tests {
+		uassert.Equal(t, test.want, validSymbol(test.symbol))
+	}
 }
 
 func TestToken(cur realm, t *testing.T) {
@@ -101,7 +85,7 @@ func TestToken(cur realm, t *testing.T) {
 		carl  = testutils.TestAddress("carl")
 	)
 
-	bank, adm := newTestToken("Dummy", "DUMMY", 6, 0, cur)
+	bank, adm := newTokenFixture("Dummy", "DUMMY", 6)
 
 	checkBalances := func(aliceEB, bobEB, carlEB int64) {
 		t.Helper()
@@ -161,7 +145,7 @@ func TestToken(cur realm, t *testing.T) {
 func TestMintOverflow(cur realm, t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	bob := testutils.TestAddress("bob")
-	tok, adm := newTestToken("Dummy", "DUMMY", 6, 0, cur)
+	tok, adm := newTokenFixture("Dummy", "DUMMY", 6)
 
 	safeValue := int64(1 << 62)
 	urequire.NoError(t, adm.Mint(alice, safeValue))
@@ -180,7 +164,7 @@ func TestTransferFromAtomicity(cur realm, t *testing.T) {
 		recipient        = testutils.TestAddress("to")
 	)
 
-	token, admin := newTestToken("Test", "TEST", 6, 0, cur)
+	token, admin := newTokenFixture("Test", "TEST", 6)
 
 	// owner has 100 tokens, spender has 50 allowance
 	initialBalance := int64(100)
@@ -215,7 +199,7 @@ func TestTransferFromAtomicity(cur realm, t *testing.T) {
 func TestMintUntilOverflow(cur realm, t *testing.T) {
 	alice := testutils.TestAddress("alice")
 	bob := testutils.TestAddress("bob")
-	tok, adm := newTestToken("Dummy", "DUMMY", 6, 0, cur)
+	tok, adm := newTokenFixture("Dummy", "DUMMY", 6)
 
 	tests := []struct {
 		name           string

--- a/examples/gno.land/p/demo/tokens/grc20/types.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/types.gno
@@ -132,11 +132,9 @@ var (
 )
 
 // Construction limits. Symbol is restricted to the same charset as
-// grc20reg.validateSlug because it is included in Token.ID(), which is
-// emitted in events and frequently used as a registry slug; banning `.` `/`
-// and whitespace here prevents downstream parsers from being fooled by
-// ambiguous IDs. Name is for display only and allows any valid UTF-8 except
-// control characters.
+// grc20reg.validateSlug because it is emitted in events and frequently used
+// as a registry slug. Name is for display only and allows any valid UTF-8
+// except control characters.
 const (
 	MaxNameLen   = 64
 	MaxSymbolLen = 11

--- a/examples/gno.land/p/demo/tokens/grc20/types.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/types.gno
@@ -81,7 +81,7 @@ type Teller interface {
 // name, symbol, and decimals, as well as methods for interacting with the
 // ledger, including checking balances and allowances.
 type Token struct {
-	// Identifier precomputed in NewToken to make ID() a cheap field read.
+	// VM-assigned identifier precomputed in NewToken to make ID() a cheap field read.
 	id string
 	// Name of the token (e.g., "Dummy Token").
 	name string

--- a/examples/gno.land/p/nt/treasury/v0/filetests/banker_grc20_filetest.gno
+++ b/examples/gno.land/p/nt/treasury/v0/filetests/banker_grc20_filetest.gno
@@ -7,18 +7,15 @@ import (
 	"strings"
 
 	"gno.land/p/demo/tokens/grc20"
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/treasury/v0"
 )
 
 const amount = int64(1000)
 
-var nextTokenID seqid.ID
-
 func createToken(_ int, rlm realm, name string, toMint address) *grc20.Token {
 	// Create the token.
 	symbol := strings.ToUpper(name)
-	token, ledger := grc20.NewToken(name, symbol, 0, nextTokenID.Next(), rlm)
+	token, ledger := grc20.NewToken(name, symbol, 0, rlm)
 
 	// Mint the requested amount.
 	ledger.Mint(toMint, amount)

--- a/examples/gno.land/p/nt/treasury/v0/filetests/treasury_filetest.gno
+++ b/examples/gno.land/p/nt/treasury/v0/filetests/treasury_filetest.gno
@@ -41,7 +41,7 @@ func main(cur realm) {
 
 	// Define a token and the associated lister.
 	const amount = int64(1000)
-	token, ledger := grc20.NewToken("TestToken", "TEST", 0, 0, cur)
+	token, ledger := grc20.NewToken("TestToken", "TEST", 0, cur)
 	ledger.Mint(ownerAddr, amount)
 
 	grc20Lister := func() map[string]*grc20.Token {

--- a/examples/gno.land/r/demo/defi/foo20/foo20.gno
+++ b/examples/gno.land/r/demo/defi/foo20/foo20.gno
@@ -19,8 +19,7 @@ var (
 )
 
 func init(cur realm) {
-	// foo20 only ever creates this one token, so id 0 can't collide.
-	Token, privateLedger = grc20.NewToken("Foo", "FOO", 4, 0, cur)
+	Token, privateLedger = grc20.NewToken("Foo", "FOO", 4, cur)
 	userTeller = privateLedger.CallerTeller()
 	privateLedger.Mint(Ownable.Owner(), 1_000_000*10_000) // @privateLedgeristrator (1M)
 	grc20reg.Register(cross(cur), Token, "")

--- a/examples/gno.land/r/demo/defi/grc20factory/grc20factory.gno
+++ b/examples/gno.land/r/demo/defi/grc20factory/grc20factory.gno
@@ -8,15 +8,13 @@ import (
 	"gno.land/p/nt/avl/v0/rotree"
 	"gno.land/p/nt/mux/v0"
 	"gno.land/p/nt/ownable/v0"
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/demo/defi/grc20reg"
 )
 
 var (
-	instances   avl.Tree // symbol -> *instance
-	nextTokenID seqid.ID
-	pager       = p.NewPager(rotree.Wrap(&instances, nil), 20, false)
+	instances avl.Tree // symbol -> *instance
+	pager     = p.NewPager(rotree.Wrap(&instances, nil), 20, false)
 )
 
 type instance struct {
@@ -37,7 +35,7 @@ func NewWithAdmin(cur realm, name, symbol string, decimals int, initialMint, fau
 		panic("token already exists")
 	}
 
-	token, ledger := grc20.NewToken(name, symbol, decimals, nextTokenID.Next(), cur)
+	token, ledger := grc20.NewToken(name, symbol, decimals, cur)
 	if initialMint > 0 {
 		ledger.Mint(admin, initialMint)
 	}

--- a/examples/gno.land/r/demo/defi/grc20factory/grc20factory_test.gno
+++ b/examples/gno.land/r/demo/defi/grc20factory/grc20factory_test.gno
@@ -37,8 +37,7 @@ func TestReadOnlyPublicMethods(cur realm, t *testing.T) {
 	testing.SetOriginCaller(admin)
 	NewWithAdmin(cross(cur), "Foo", "FOO", 3, 1_111_111_000, 5_555, admin)
 	NewWithAdmin(cross(cur), "Bar", "BAR", 3, 2_222_000, 6_666, admin)
-	uassert.Equal(t, Bank("FOO").ID(), "gno.land/r/demo/defi/grc20factory.FOO.0000001")
-	uassert.Equal(t, Bank("BAR").ID(), "gno.land/r/demo/defi/grc20factory.BAR.0000002")
+	uassert.NotEqual(t, Bank("FOO").ID(), Bank("BAR").ID())
 	checkBalances("step1", 1_111_111_000, 1_111_111_000, 0, 0, 0)
 
 	// admin mints to bob.

--- a/examples/gno.land/r/demo/defi/grc20reg/grc20reg.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/grc20reg.gno
@@ -2,7 +2,6 @@ package grc20reg
 
 import (
 	"chain"
-	"strings"
 
 	"gno.land/p/demo/tokens/grc20"
 	"gno.land/p/moul/md"
@@ -14,19 +13,19 @@ import (
 
 var registry = avl.NewTree() // rlmPath.symbol -> *Token
 
-// Construction lives in grc20.NewToken — it takes rlm realm last
+// Construction lives in grc20.NewToken. It takes rlm realm last
 // and binds origRealm from rlm.PkgPath() under an IsCurrent assertion.
 // The registry key is the canonical fqname rlmPath.symbol (one token per
-// realm+symbol), independent of Token.ID()'s trailing sequence id, so
+// realm+symbol), independent of Token.ID(), so
 // callers can look a token up from the (realm, symbol) pair they already
 // know:
 //
-//	Token, ledger := grc20.NewToken(name, symbol, decimals, id, cur)
+//	Token, ledger := grc20.NewToken(name, symbol, decimals, cur)
 //	key := grc20reg.Register(cross(cur), Token, "")
 
 // Register records token under its rlmPath.symbol key and returns that key.
-// Token.ID() carries a trailing sequence id (rlmPath.symbol.<id>) that keeps
-// token identities/events unique, but the registry deliberately keys by
+// Token.ID() is a VM assigned opaque identifier that keeps token identities
+// and events unique, but the registry deliberately keys by
 // rlmPath.symbol so lookups don't need to know the id, and so a realm cannot
 // register two tokens under the same symbol (overwrite/alias guard).
 func Register(cur realm, token *grc20.Token, slug string) string {
@@ -38,9 +37,7 @@ func Register(cur realm, token *grc20.Token, slug string) string {
 	}
 	rlmPath := cur.Previous().PkgPath()
 	key := fqname.Construct(rlmPath, token.GetSymbol())
-	// Token.ID() == key + "." + <id>; verify the token originates from the
-	// registering realm and symbol.
-	if !strings.HasPrefix(token.ID(), key+".") {
+	if token.GetOriginRealm() != rlmPath {
 		panic("grc20reg: token must be registered from its own realm")
 	}
 	if registry.Has(key) {

--- a/examples/gno.land/r/demo/defi/grc20reg/grc20reg_test.gno
+++ b/examples/gno.land/r/demo/defi/grc20reg/grc20reg_test.gno
@@ -13,7 +13,7 @@ import (
 
 func TestRegistry(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/foo"))
-	token, ledger := grc20.NewToken("TestToken", "TST", 4, 0, cur)
+	token, ledger := grc20.NewToken("TestToken", "TST", 4, cur)
 	ledger.Mint(cur.Address(), 1234567)
 	// register
 	key := Register(cross(cur), token, "mySlug")
@@ -42,9 +42,9 @@ func TestRegistry(cur realm, t *testing.T) {
 	urequire.Equal(t, expected, got)
 
 	// The registry keys by rlmPath.symbol, so a second token with the same
-	// symbol in the same realm is rejected even though its Token.ID() differs
-	// (distinct trailing sequence id). See TestRegisterRejectsOverwrite.
-	second, _ := grc20.NewToken("Second", "TST", 4, 1, cur)
+	// symbol in the same realm is rejected even though its Token.ID() differs.
+	// See TestRegisterRejectsOverwrite.
+	second, _ := grc20.NewToken("Second", "TST", 4, cur)
 	urequire.NotEqual(t, token.ID(), second.ID()) // ids are decoupled from symbol
 	urequire.AbortsContains(t, cur, "token already registered", func() {
 		Register(cross(cur), second, "")
@@ -71,7 +71,7 @@ func TestRegistryLookupGrantsNoSpendAuthority(cur realm, t *testing.T) {
 	consumer := chain.PackageAddress(consumerPath)
 
 	testing.SetRealm(testing.NewCodeRealm(tokenPath))
-	token, ledger := grc20.NewToken("TestToken", "TST", 4, 0, cur)
+	token, ledger := grc20.NewToken("TestToken", "TST", 4, cur)
 	urequire.NoError(t, ledger.Mint(alice, 1_000))
 	tokenKey := Register(cross(cur), token, "")
 	uassert.Equal(t, "TestToken", MustGet(tokenKey).GetName())
@@ -116,7 +116,7 @@ func TestRegistryConsumerCannotRedirectItsActor(cur realm, t *testing.T) {
 	consumer := chain.PackageAddress(consumerPath)
 
 	testing.SetRealm(testing.NewCodeRealm(tokenPath))
-	token, ledger := grc20.NewToken("ActorBinding", "ACTB", 4, 0, cur)
+	token, ledger := grc20.NewToken("ActorBinding", "ACTB", 4, cur)
 	urequire.NoError(t, ledger.Mint(alice, 1_000))
 	urequire.NoError(t, ledger.Mint(consumer, 500))
 	tokenKey := Register(cross(cur), token, "")
@@ -133,14 +133,14 @@ func TestRegistryConsumerCannotRedirectItsActor(cur realm, t *testing.T) {
 
 func TestRegisterRejectsOverwrite(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/grc20reg_overwrite"))
-	token, ledger := grc20.NewToken("Bar", "BAR", 4, 0, cur)
+	token, ledger := grc20.NewToken("Bar", "BAR", 4, cur)
 	ledger.Mint(cur.Address(), 11)
 	key := Register(cross(cur), token, "")
 
 	urequire.Equal(t, "BAR", Get(key).GetSymbol())
 	urequire.Equal(t, int64(11), Get(key).BalanceOf(cur.Address()))
 
-	replacement, _ := grc20.NewToken("Replacement", "BAR", 6, 0, cur)
+	replacement, _ := grc20.NewToken("Replacement", "BAR", 6, cur)
 	urequire.AbortsContains(t, cur, "token already registered", func() {
 		Register(cross(cur), replacement, "")
 	})
@@ -148,7 +148,7 @@ func TestRegisterRejectsOverwrite(cur realm, t *testing.T) {
 
 func TestRegisterRejectsAliasedTokenPaths(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/grc20reg_alias"))
-	token, _ := grc20.NewToken("Aliased Token", "ALIAS", 4, 0, cur)
+	token, _ := grc20.NewToken("Aliased Token", "ALIAS", 4, cur)
 	Register(cross(cur), token, "first")
 
 	urequire.AbortsContains(t, cur, "token already registered", func() {
@@ -158,7 +158,7 @@ func TestRegisterRejectsAliasedTokenPaths(cur realm, t *testing.T) {
 
 func TestRegisterRejectsTokenFromDifferentRealm(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/grc20reg_id_source"))
-	token, _ := grc20.NewToken("Mismatch Token", "MISMATCH", 4, 0, cur)
+	token, _ := grc20.NewToken("Mismatch Token", "MISMATCH", 4, cur)
 
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/demo/grc20reg_id_target"))
 	urequire.AbortsContains(t, cur, "token must be registered from its own realm", func() {
@@ -241,7 +241,7 @@ func TestWrappersBindActorToCallingRealm(cur realm, t *testing.T) {
 	registry := chain.PackageAddress("gno.land/r/demo/defi/grc20reg")
 
 	testing.SetRealm(testing.NewCodeRealm(tokenPath))
-	token, ledger := grc20.NewToken("WrapperActor", "WRPA", 4, 0, cur)
+	token, ledger := grc20.NewToken("WrapperActor", "WRPA", 4, cur)
 	urequire.NoError(t, ledger.Mint(consumer, 1_000))
 	urequire.NoError(t, ledger.Mint(registry, 1_000))
 	tokenKey := Register(cross(cur), token, "")
@@ -268,7 +268,7 @@ func TestWrapperActorIgnoresSigningUser(cur realm, t *testing.T) {
 	consumer := chain.PackageAddress(consumerPath)
 
 	testing.SetRealm(testing.NewCodeRealm(tokenPath))
-	token, ledger := grc20.NewToken("WrapperOrigin", "WRPO", 4, 0, cur)
+	token, ledger := grc20.NewToken("WrapperOrigin", "WRPO", 4, cur)
 	urequire.NoError(t, ledger.Mint(alice, 1_000))
 	urequire.NoError(t, ledger.Mint(consumer, 500))
 	tokenKey := Register(cross(cur), token, "")
@@ -295,7 +295,7 @@ func TestTransferFromSpendsAllowanceGrantedToCallingRealm(cur realm, t *testing.
 	consumer := chain.PackageAddress(consumerPath)
 
 	testing.SetRealm(testing.NewCodeRealm(tokenPath))
-	token, ledger := grc20.NewToken("WrapperAllowance", "WRPL", 4, 0, cur)
+	token, ledger := grc20.NewToken("WrapperAllowance", "WRPL", 4, cur)
 	urequire.NoError(t, ledger.Mint(alice, 1_000))
 	tokenKey := Register(cross(cur), token, "")
 

--- a/examples/gno.land/r/demo/tests/grc20xfer/gnomod.toml
+++ b/examples/gno.land/r/demo/tests/grc20xfer/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/tests/grc20xfer"
+gno = "0.9"

--- a/examples/gno.land/r/demo/tests/grc20xfer/grc20xfer.gno
+++ b/examples/gno.land/r/demo/tests/grc20xfer/grc20xfer.gno
@@ -1,0 +1,20 @@
+package grc20xfer
+
+import "gno.land/r/demo/defi/foo20"
+
+// TokenID returns the identifier of the FOO token used by this realm.
+func TokenID() string {
+	return foo20.Token.ID()
+}
+
+// Faucet requests unrestricted FOO for this realm.
+func Faucet(cur realm) {
+	foo20.Faucet(cross(cur))
+}
+
+// Transfer sends FOO held by this realm.
+func Transfer(cur realm, to address, amount int64) {
+	if err := foo20.Token.RealmTeller(0, cur).Transfer(0, cur, to, amount); err != nil {
+		panic(err)
+	}
+}

--- a/examples/gno.land/r/gnoland/wugnot/wugnot.gno
+++ b/examples/gno.land/r/gnoland/wugnot/wugnot.gno
@@ -23,8 +23,7 @@ const (
 )
 
 func init(cur realm) {
-	// wugnot only ever creates this one token, so id 0 can't collide.
-	Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0, 0, cur)
+	Token, adm = grc20.NewToken("wrapped GNOT", "wugnot", 0, cur)
 	grc20reg.Register(cross(cur), Token, "")
 }
 

--- a/examples/gno.land/r/gov/dao/v3/treasury/test/treasury_test.gno
+++ b/examples/gno.land/r/gov/dao/v3/treasury/test/treasury_test.gno
@@ -10,7 +10,6 @@ import (
 
 	"gno.land/p/demo/tokens/grc20"
 	"gno.land/p/nt/fqname/v0"
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/testutils/v0"
 	trs_pkg "gno.land/p/nt/treasury/v0"
 	"gno.land/p/nt/uassert/v0"
@@ -26,7 +25,6 @@ import (
 // These tests pass `func()` callbacks (no crossing inside the callback),
 // so rlm is ignored — a nil realm here is safe.
 var cur realm
-var nextTokenID seqid.ID
 var (
 	user1Addr       = testutils.TestAddress("g1user1")
 	user2Addr       = testutils.TestAddress("g1user2")
@@ -86,7 +84,7 @@ func registerGRC20Tokens(_ int, rlm realm, t *testing.T, tokenNames []string, to
 	for _, name := range tokenNames {
 		// Create the token.
 		symbol := strings.ToUpper(name)
-		token, ledger := grc20.NewToken(name, symbol, 0, nextTokenID.Next(), rlm)
+		token, ledger := grc20.NewToken(name, symbol, 0, rlm)
 
 		// Register the token.
 		grc20reg.Register(cross(rlm), token, symbol)

--- a/examples/gno.land/r/tests/vm/test20/test20.gno
+++ b/examples/gno.land/r/tests/vm/test20/test20.gno
@@ -19,7 +19,6 @@ var (
 )
 
 func init(cur realm) {
-	// test20 only ever creates this one token, so id 0 can't collide.
-	Token, PrivateLedger = grc20.NewToken("Test20", "TST", 4, 0, cur)
+	Token, PrivateLedger = grc20.NewToken("Test20", "TST", 4, cur)
 	grc20reg.Register(cross(cur), Token, "")
 }

--- a/examples/quarantined/gno.land/r/demo/defi/bar20/bar20.gno
+++ b/examples/quarantined/gno.land/r/demo/defi/bar20/bar20.gno
@@ -30,8 +30,7 @@ var (
 )
 
 func init(cur realm) {
-	// bar20 only ever creates this one token, so id 0 can't collide.
-	Token, adm = grc20.NewToken("Bar", "BAR", 4, 0, cur)
+	Token, adm = grc20.NewToken("Bar", "BAR", 4, cur)
 	userTeller = adm.CallerTeller()
 	grc20reg.Register(cross(cur), Token, "")
 }

--- a/examples/quarantined/gno.land/r/jjoptimist/eventix/eventix_test.gno
+++ b/examples/quarantined/gno.land/r/jjoptimist/eventix/eventix_test.gno
@@ -97,7 +97,7 @@ func TestBuyTicketWithGRC20(cur realm, t *testing.T) {
 	var token *grc20.Token
 	var ledger *grc20.PrivateLedger
 	func(cur realm) {
-		token, ledger = grc20.NewToken("Test Token", "TEST", 6, 0, cur)
+		token, ledger = grc20.NewToken("Test Token", "TEST", 6, cur)
 	}(cross(cur))
 
 	testing.SetRealm(testing.NewUserRealm(alice))

--- a/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/render.gno
+++ b/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/render.gno
@@ -59,16 +59,13 @@ import (
 	"gno.land/p/demo/tokens/grc20"
 	"gno.land/p/demo/tokens/grc721"
 	"gno.land/p/demo/tokens/grc1155"
-	"gno.land/p/nt/seqid/v0"
 )
-
-var nextTokenID seqid.ID
 
 // grc20.NewToken and grc721.NewToken must be constructed from a realm
 // context (init or a crossing function) because they assert cur.IsCurrent().
 func init(cur realm) {
 	// GRC20 token
-	myToken, myLedger := grc20.NewToken("My Token", "MTK", 6, nextTokenID.Next(), cur)
+	myToken, myLedger := grc20.NewToken("My Token", "MTK", 6, cur)
 	myTokenPath := tokenhub.RegisterToken(myToken, "my_token")
 
 	// GRC721 NFT

--- a/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/tokenhub.gno
+++ b/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/tokenhub.gno
@@ -31,7 +31,7 @@ func init(cur realm) {
 // RegisterToken registers a token in grc20reg.
 // Returns the registry key (rlmPath.symbol) that can be used to retrieve the
 // token; this is grc20reg's canonical key, not the token's full ID (which
-// carries a trailing sequence id).
+// has a VM assigned identifier).
 func RegisterToken(cur realm, token *grc20.Token, slug string) string {
 	return grc20reg.Register(cross(cur), token, slug)
 }

--- a/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/tokenhub_test.gno
+++ b/examples/quarantined/gno.land/r/matijamarjanovic/tokenhub/tokenhub_test.gno
@@ -9,14 +9,11 @@ import (
 	"gno.land/p/demo/tokens/grc20"
 	"gno.land/p/demo/tokens/grc721"
 	"gno.land/p/nt/avl/v0"
-	"gno.land/p/nt/seqid/v0"
 	"gno.land/p/nt/uassert/v0"
 	"gno.land/p/nt/urequire/v0"
 )
 
 const testRealmPkgPath = "gno.land/r/matijamarjanovic/testrealm"
-
-var nextGRC20ID seqid.ID
 
 // Same-realm cross so NewToken's IsCurrent + non-empty PkgPath checks pass.
 func newTestNFT(name, symbol string, rlm realm) (tok *grc721.Token, led *grc721.PrivateLedger) {
@@ -29,10 +26,10 @@ func newTestNFT(name, symbol string, rlm realm) (tok *grc721.Token, led *grc721.
 func TestTokenRegistration(cur realm, t *testing.T) {
 	resetState(t)
 
-	token, _ := grc20.NewToken("Test Token", "TEST", 6, nextGRC20ID.Next(), cur)
+	token, _ := grc20.NewToken("Test Token", "TEST", 6, cur)
 	key := RegisterToken(cross(cur), token, "test_token")
 
-	uassert.True(t, strings.HasPrefix(token.ID(), key+"."), "registry key should be the token's rlmPath.symbol prefix")
+	uassert.Equal(t, token.GetOriginRealm(), "gno.land/r/matijamarjanovic/tokenhub")
 
 	retrievedToken := GetToken(key)
 
@@ -79,7 +76,7 @@ func TestGRC1155Registration(cur realm, t *testing.T) {
 func TestBalanceRetrieval(cur realm, t *testing.T) {
 	resetState(t)
 
-	token, ledger := grc20.NewToken("Balance Token", "BAL", 6, nextGRC20ID.Next(), cur)
+	token, ledger := grc20.NewToken("Balance Token", "BAL", 6, cur)
 	key := RegisterToken(cross(cur), token, "balance_token")
 	holder := unsafe.CurrentRealm().Address()
 	ledger.Mint(holder, 1000)
@@ -132,7 +129,7 @@ func TestErrorCases(cur realm, t *testing.T) {
 func TestTokenListingFunctions(cur realm, t *testing.T) {
 	resetState(t)
 
-	grc20Token, _ := grc20.NewToken("Listing Token", "LST", 6, nextGRC20ID.Next(), cur)
+	grc20Token, _ := grc20.NewToken("Listing Token", "LST", 6, cur)
 	grc20Key := RegisterToken(cross(cur), grc20Token, "listing_token")
 
 	grc20List := GetAllTokens()
@@ -168,7 +165,7 @@ func TestTokenListingFunctions(cur realm, t *testing.T) {
 func TestMustGetFunctions(cur realm, t *testing.T) {
 	resetState(t)
 
-	token, _ := grc20.NewToken("Must Token", "MUST", 6, nextGRC20ID.Next(), cur)
+	token, _ := grc20.NewToken("Must Token", "MUST", 6, cur)
 	key := RegisterToken(cross(cur), token, "must_token")
 
 	retrievedToken := MustGetToken(key)

--- a/gno.land/adr/prxxxx_grc20_realm_ids.md
+++ b/gno.land/adr/prxxxx_grc20_realm_ids.md
@@ -1,0 +1,35 @@
+# VM assigned GRC20 token IDs
+
+## Context
+
+GRC20 callers supplied a local sequence ID. Two tokens created with the same
+realm, symbol, and sequence ID produced identical event identifiers even when
+their ledgers were independent. Package initialization also could not call
+`runtime.NewRealmID` because only `MsgCall` enabled issuance.
+
+## Decision
+
+`grc20.NewToken` obtains its canonical ID directly from
+`runtime.NewRealmID`. The returned string remains opaque and is stored without
+prefixing or parsing. The token keeps its origin realm separately for registry
+authorization and display metadata.
+
+Realm ID issuance is enabled while `AddPackage` and `EnablePackage` execute
+package initialization. The shared Gno test context enables the same behavior
+so realm filetests exercise production token construction.
+
+## Alternatives considered
+
+Keeping caller managed sequence IDs would preserve the old API but would not
+prevent collisions. Combining the realm path and symbol with the VM ID would
+duplicate metadata and create another delimiter format for consumers to parse.
+Parsing the VM ID to recover provenance would turn an opaque value into a
+public encoding contract.
+
+## Consequences
+
+Every successful token construction consumes the issuing realm's persistent
+counter. Token IDs are unique within the realm and carry an unforgeable VM
+assigned package identifier. Existing callers must remove the sequence ID
+argument. Consumers that parsed the old dotted ID must treat the new ID as an
+opaque key and use token metadata for the origin realm and symbol.

--- a/gno.land/adr/prxxxx_grc20_realm_ids.md
+++ b/gno.land/adr/prxxxx_grc20_realm_ids.md
@@ -5,14 +5,19 @@
 GRC20 callers supplied a local sequence ID. Two tokens created with the same
 realm, symbol, and sequence ID produced identical event identifiers even when
 their ledgers were independent. Package initialization also could not call
-`runtime.NewRealmID` because only `MsgCall` enabled issuance.
+`runtime.NewRealmID` because only `MsgCall` enabled issuance. A fully opaque
+token ID would also force indexers to observe `NewToken` before they could map
+later `Transfer` or `Approval` events to an origin realm.
 
 ## Decision
 
-`grc20.NewToken` obtains its canonical ID directly from
-`runtime.NewRealmID`. The returned string remains opaque and is stored without
-prefixing or parsing. The token keeps its origin realm separately for registry
-authorization and display metadata.
+`runtime.NewRealmID` returns `<realm-path>:<realm-time>` for the current
+persistent realm. Valid package paths cannot contain `:`, so consumers may
+split on that delimiter and recover both the verified origin realm and numeric
+realm time. `grc20.NewToken` stores this value directly as its canonical ID.
+The token also keeps its origin realm separately for registry authorization
+and display metadata. `NewToken` does not emit a redundant `realm` attribute
+because every event already carries the canonical token ID.
 
 Realm ID issuance is enabled while `AddPackage` and `EnablePackage` execute
 package initialization. The shared Gno test context enables the same behavior
@@ -21,15 +26,19 @@ so realm filetests exercise production token construction.
 ## Alternatives considered
 
 Keeping caller managed sequence IDs would preserve the old API but would not
-prevent collisions. Combining the realm path and symbol with the VM ID would
-duplicate metadata and create another delimiter format for consumers to parse.
-Parsing the VM ID to recover provenance would turn an opaque value into a
-public encoding contract.
+prevent collisions. Adding a `realm` attribute to every token event would keep
+the ID opaque, but duplicate the same metadata and expand every event. Keeping
+that attribute only on `NewToken` would require indexers to retain the complete
+creation history. Prefixing GRC20 IDs with the origin realm while retaining an
+opaque VM ID would repeat the realm identity in two encodings and add extra
+delimiters without improving uniqueness.
 
 ## Consequences
 
 Every successful token construction consumes the issuing realm's persistent
-counter. Token IDs are unique within the realm and carry an unforgeable VM
-assigned package identifier. Existing callers must remove the sequence ID
-argument. Consumers that parsed the old dotted ID must treat the new ID as an
-opaque key and use token metadata for the origin realm and symbol.
+time. Token IDs are unique within the realm and make every token event
+independently attributable to its verified origin realm. The numeric suffix is
+not contiguous across ID calls because object finalization advances the same
+realm time. The `<realm-path>:<realm-time>` representation becomes a public
+format for `runtime.NewRealmID`. Existing callers must remove the sequence ID
+argument; symbol remains token metadata rather than part of the ID.

--- a/gno.land/pkg/integration/testdata/grc20_callerteller_home.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_callerteller_home.txtar
@@ -108,7 +108,7 @@ var (
 )
 
 func init(cur realm) {
-	Token, adm = grc20.NewToken("Leaky", "LEAK", 4, 0, cur)
+	Token, adm = grc20.NewToken("Leaky", "LEAK", 4, cur)
 	Teller = adm.CallerTeller()
 }
 

--- a/gno.land/pkg/integration/testdata/grc20_id_persists_cross_realm.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_id_persists_cross_realm.txtar
@@ -14,30 +14,30 @@ cp $GNOROOT/examples/gno.land/r/demo/tests/grc20xfer/grc20xfer.gno $WORK/grc20xf
 cp $GNOROOT/examples/gno.land/r/demo/tests/grc20xfer/gnomod.toml $WORK/grc20xfer/gnomod.toml
 
 gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/demo/defi/foo20 -gas-fee 2000000ugnot -gas-wanted 20_000_000 -chainid=tendermint_test test1
-stdout '"type":"NewToken","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24"},{"key":"realm","value":"gno.land/r/demo/defi/foo20"}'
+stdout '"type":"NewToken","attrs":\[{"key":"token","value":"gno.land/r/demo/defi/foo20:24"}'
 
 gnokey maketx addpkg -pkgdir $WORK/grc20xfer -pkgpath gno.land/r/demo/tests/grc20xfer -gas-fee 2000000ugnot -gas-wanted 20_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey query vm/qeval --data 'gno.land/r/demo/tests/grc20xfer.TokenID()'
-stdout '"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24" string'
+stdout '"gno.land/r/demo/defi/foo20:24" string'
 
 gnokey maketx call -pkgpath gno.land/r/demo/tests/grc20xfer -func Faucet -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout OK!
 
 gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func NewID -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
-stdout 'gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:[0-9]+'
+stdout 'gno.land/r/demo/defi/foo20:[0-9]+'
 
 gnokey maketx call -pkgpath gno.land/r/demo/tests/grc20xfer -func Transfer -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '250000' -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
 stdout OK!
-stdout '"type":"Transfer","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24"},{"key":"from","value":"g1xe3hgeurhdejuzpvfy9ntalhea5wxq2ln4psft"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"250000"}'
+stdout '"type":"Transfer","attrs":\[{"key":"token","value":"gno.land/r/demo/defi/foo20:24"},{"key":"from","value":"g1xe3hgeurhdejuzpvfy9ntalhea5wxq2ln4psft"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"250000"}'
 ! stdout '"type":"NewToken"'
 
 gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func NewID -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
-stdout 'gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:[0-9]+'
+stdout 'gno.land/r/demo/defi/foo20:[0-9]+'
 
 gnokey query vm/qeval --data 'gno.land/r/demo/tests/grc20xfer.TokenID()'
-stdout '"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24" string'
+stdout '"gno.land/r/demo/defi/foo20:24" string'
 
 -- idprobe.gno --
 package foo20

--- a/gno.land/pkg/integration/testdata/grc20_id_persists_cross_realm.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_id_persists_cross_realm.txtar
@@ -1,0 +1,49 @@
+# A GRC20 token keeps its VM assigned identifier across later realm transfers.
+
+loadpkg gno.land/r/demo/defi/grc20reg
+loadpkg gno.land/p/nt/ownable/v0
+
+gnoland start
+
+mkdir $WORK/foo20
+mkdir $WORK/grc20xfer
+cp $GNOROOT/examples/gno.land/r/demo/defi/foo20/foo20.gno $WORK/foo20/foo20.gno
+cp $GNOROOT/examples/gno.land/r/demo/defi/foo20/gnomod.toml $WORK/foo20/gnomod.toml
+cp $WORK/idprobe.gno $WORK/foo20/idprobe.gno
+cp $GNOROOT/examples/gno.land/r/demo/tests/grc20xfer/grc20xfer.gno $WORK/grc20xfer/grc20xfer.gno
+cp $GNOROOT/examples/gno.land/r/demo/tests/grc20xfer/gnomod.toml $WORK/grc20xfer/gnomod.toml
+
+gnokey maketx addpkg -pkgdir $WORK/foo20 -pkgpath gno.land/r/demo/defi/foo20 -gas-fee 2000000ugnot -gas-wanted 20_000_000 -chainid=tendermint_test test1
+stdout '"type":"NewToken","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24"},{"key":"realm","value":"gno.land/r/demo/defi/foo20"}'
+
+gnokey maketx addpkg -pkgdir $WORK/grc20xfer -pkgpath gno.land/r/demo/tests/grc20xfer -gas-fee 2000000ugnot -gas-wanted 20_000_000 -chainid=tendermint_test test1
+stdout OK!
+
+gnokey query vm/qeval --data 'gno.land/r/demo/tests/grc20xfer.TokenID()'
+stdout '"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24" string'
+
+gnokey maketx call -pkgpath gno.land/r/demo/tests/grc20xfer -func Faucet -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+stdout OK!
+
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func NewID -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+stdout 'gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:[0-9]+'
+
+gnokey maketx call -pkgpath gno.land/r/demo/tests/grc20xfer -func Transfer -args 'g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp' -args '250000' -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+stdout OK!
+stdout '"type":"Transfer","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24"},{"key":"from","value":"g1xe3hgeurhdejuzpvfy9ntalhea5wxq2ln4psft"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"250000"}'
+! stdout '"type":"NewToken"'
+
+gnokey maketx call -pkgpath gno.land/r/demo/defi/foo20 -func NewID -gas-fee 1000000ugnot -gas-wanted 10_000_000 -chainid=tendermint_test test1
+stdout 'gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:[0-9]+'
+
+gnokey query vm/qeval --data 'gno.land/r/demo/tests/grc20xfer.TokenID()'
+stdout '"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:24" string'
+
+-- idprobe.gno --
+package foo20
+
+import "chain/runtime"
+
+func NewID(cur realm) string {
+	return runtime.NewRealmID()
+}

--- a/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
@@ -23,7 +23,7 @@ stdout OK!
 stdout 'GAS WANTED: [0-9]+'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
-stdout 'EVENTS:     \[{"type":"Transfer","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:22"},{"key":"from","value":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"1000000"}\],"pkg_path":"gno.land/p/demo/tokens/grc20"},{\"bytes_delta\":959,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":95900},\"pkg_path\":\"gno.land/r/demo/defi/foo20\"}\]'
+stdout 'EVENTS:     \[{"type":"Transfer","attrs":\[{"key":"token","value":"gno.land/r/demo/defi/foo20:22"},{"key":"from","value":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"1000000"}\],"pkg_path":"gno.land/p/demo/tokens/grc20"},{\"bytes_delta\":959,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":95900},\"pkg_path\":\"gno.land/r/demo/defi/foo20\"}\]'
 stdout 'TX HASH:    '
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_emit.txtar
@@ -23,7 +23,7 @@ stdout OK!
 stdout 'GAS WANTED: [0-9]+'
 stdout 'GAS USED:   [0-9]+'
 stdout 'HEIGHT:     [0-9]+'
-stdout 'EVENTS:     \[{"type":"Transfer","attrs":\[{"key":"token","value":"gno.land/r/demo/defi/foo20.FOO.0000000"},{"key":"from","value":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"1000000"}\],"pkg_path":"gno.land/p/demo/tokens/grc20"},{\"bytes_delta\":959,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":95900},\"pkg_path\":\"gno.land/r/demo/defi/foo20\"}\]'
+stdout 'EVENTS:     \[{"type":"Transfer","attrs":\[{"key":"token","value":"gno:realm-id:09228f741a31eb49ece0316589810182dd642d85:22"},{"key":"from","value":"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"},{"key":"to","value":"g1c8cf99clyyjr2kh9awxnfyt36cvmr703tsmazp"},{"key":"value","value":"1000000"}\],"pkg_path":"gno.land/p/demo/tokens/grc20"},{\"bytes_delta\":959,\"fee_delta\":{\"denom\":\"ugnot\",\"amount\":95900},\"pkg_path\":\"gno.land/r/demo/defi/foo20\"}\]'
 stdout 'TX HASH:    '
 
 -- gnomod.toml --

--- a/gno.land/pkg/integration/testdata/grc20_registry_wrappers.txtar
+++ b/gno.land/pkg/integration/testdata/grc20_registry_wrappers.txtar
@@ -82,7 +82,7 @@ var (
 )
 
 func init(cur realm) {
-	Token, ledger = grc20.NewToken("WToken", "WTK", 4, 0, cur)
+	Token, ledger = grc20.NewToken("WToken", "WTK", 4, cur)
 	Key = grc20reg.Register(cross(cur), Token, "")
 }
 

--- a/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
@@ -38,7 +38,7 @@ stdout 'storage: 503690, deposit: 50369000'
 # be re-derived. The assertion that actually tests this file's subject is the
 # storage/deposit pair above.
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999813596400ugnot"'
+stdout '"coins": "9999813676200ugnot"'
 
 gnokey query params/vm:p:storage_price
 stdout '100ugnot'
@@ -73,7 +73,7 @@ stdout 'storage: 3374, deposit: 337400'
 
 ## Verify user received a refund (balance should have increased despite gas fees)
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999851239900ugnot"'
+stdout '"coins": "9999851319700ugnot"'
 
 -- loader/load_govdao.gno --
 package loader

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -207,7 +207,7 @@ import (
 // Bumped again by adding the NewRealmID native to chain/runtime. The native's
 // source bytes land in the genesis stdlib MemPackage and move the root; the
 // scenario never calls NewRealmID, so behavior is unchanged.
-const expectedCrossrealm38Hash = "952fe400be4644917df2c76c299a6b7bd0f5848081fa6749f26b5783bbbda97b"
+const expectedCrossrealm38Hash = "10f6347ec659e5d83a35aac273153fbd29e2526f4247c8f6e22c67c131beeb7a"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -203,7 +203,11 @@ import (
 // claimed an invalid result panics; neither checks the sign, and 5ugnot.Sub
 // (10ugnot) returns -5ugnot. Comments only — no code changed, the scenario
 // calls neither method, and the zrealm_crossrealm38.gno filetest still passes.
-const expectedCrossrealm38Hash = "1d05023c96f166ae4cb352baf98adee2facc3fa92abd9f777814d275cc175398"
+//
+// Bumped again by adding the NewRealmID native to chain/runtime. The native's
+// source bytes land in the genesis stdlib MemPackage and move the root; the
+// scenario never calls NewRealmID, so behavior is unchanged.
+const expectedCrossrealm38Hash = "952fe400be4644917df2c76c299a6b7bd0f5848081fa6749f26b5783bbbda97b"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1069,6 +1069,9 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 		Params:              NewSDKParams(vm.prmk, ctx),
 		EventLogger:         ctx.EventLogger(),
 		SessionAccount:      getSessionAccount(ctx, creator),
+		// Successful package initialization commits realm state. The package
+		// object gets ID 1 before init, so token realms can issue later IDs.
+		RealmIDEnabled:      true,
 	}
 	// Parse and run the files, construct *PV.
 	m2 := gno.NewMachineWithOptions(
@@ -1178,6 +1181,8 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 		ChainDomain:        chainDomain,
 		Height:             ctx.BlockHeight(),
 		Timestamp:          ctx.BlockTime().Unix(),
+		// Successful calls commit realm state, so they may issue realm IDs.
+		// Queries and temporary executions leave this disabled.
 		RealmIDEnabled:     true,
 		OriginCaller:       caller.Bech32(),
 		OriginSend:         send,

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1071,7 +1071,7 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 		SessionAccount:      getSessionAccount(ctx, creator),
 		// Successful package initialization commits realm state. The package
 		// object gets ID 1 before init, so token realms can issue later IDs.
-		RealmIDEnabled:      true,
+		RealmIDEnabled: true,
 	}
 	// Parse and run the files, construct *PV.
 	m2 := gno.NewMachineWithOptions(
@@ -1177,10 +1177,10 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 	// Seed per-message accumulator before NewSDKParams captures ctx.
 	ctx = ContextWithParamsAccum(ctx)
 	msgCtx := stdlibs.ExecContext{
-		ChainID:            ctx.ChainID(),
-		ChainDomain:        chainDomain,
-		Height:             ctx.BlockHeight(),
-		Timestamp:          ctx.BlockTime().Unix(),
+		ChainID:     ctx.ChainID(),
+		ChainDomain: chainDomain,
+		Height:      ctx.BlockHeight(),
+		Timestamp:   ctx.BlockTime().Unix(),
 		// Successful calls commit realm state, so they may issue realm IDs.
 		// Queries and temporary executions leave this disabled.
 		RealmIDEnabled:     true,
@@ -1451,9 +1451,12 @@ func (vm *VMKeeper) Run(ctx sdk.Context, msg MsgRun) (res string, err error) {
 		// ephemeral /e/<addr>/run realm, so IsUserCall() is false. Leaving
 		// the recipient empty is fail-closed: nothing can spend against an
 		// envelope that never moved.
-		Banker:         NewSDKBanker(vm, ctx),
-		Params:         NewSDKParams(vm.prmk, ctx),
-		EventLogger:    ctx.EventLogger(),
+		Banker:      NewSDKBanker(vm, ctx),
+		Params:      NewSDKParams(vm.prmk, ctx),
+		EventLogger: ctx.EventLogger(),
+		// A run script is ephemeral, but the persistent realms it cross-calls
+		// commit their state, so they may issue realm IDs just as under Call.
+		RealmIDEnabled: true,
 		SessionAccount: getSessionAccount(ctx, caller),
 	}
 

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -1178,6 +1178,7 @@ func (vm *VMKeeper) Call(ctx sdk.Context, msg MsgCall) (res string, err error) {
 		ChainDomain:        chainDomain,
 		Height:             ctx.BlockHeight(),
 		Timestamp:          ctx.BlockTime().Unix(),
+		RealmIDEnabled:     true,
 		OriginCaller:       caller.Bech32(),
 		OriginSend:         send,
 		OriginSendSpent:    new(std.Coins),

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -283,6 +283,9 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 		// is normally not a signer of this tx, so this is normally nil — the
 		// correct answer, since no session of theirs authorised the enable.
 		SessionAccount: getSessionAccount(ctx, creator),
+		// Successful inert initialization commits realm state. The package
+		// object gets ID 1 before init, so token realms can issue later IDs.
+		RealmIDEnabled: true,
 	}
 	m2 := gno.NewMachineWithOptions(gno.MachineOptions{
 		PkgPath:            "",

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -1015,6 +1015,85 @@ func main(cur realm) {
 	require.ErrorContains(t, err, "realm ID issuance is disabled")
 }
 
+func TestVMKeeperNewRealmIDProvenance(t *testing.T) {
+	env := setupTestEnv()
+	addr := crypto.AddressFromPreimage([]byte("realm-id-provenance"))
+	const (
+		helperPath = "gno.land/p/test/idhelper"
+		callerPath = "gno.land/r/test/acaller"
+		issuerPath = "gno.land/r/test/bissuer"
+	)
+
+	ctx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bankk.SetCoins(ctx, addr, initialBalance)
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, helperPath, []*std.MemFile{
+		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(helperPath)},
+		{Name: "idhelper.gno", Body: `package idhelper
+
+import "chain/runtime"
+
+func New() string {
+	return runtime.NewRealmID()
+}`},
+	})))
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, issuerPath, []*std.MemFile{
+		{Name: "bissuer.gno", Body: `package bissuer
+
+import "chain/runtime"
+
+func New(cur realm) string {
+	return runtime.NewRealmID()
+}`},
+		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(issuerPath)},
+	})))
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, callerPath, []*std.MemFile{
+		{Name: "acaller.gno", Body: `package acaller
+
+import (
+	"gno.land/p/test/idhelper"
+	"gno.land/r/test/bissuer"
+)
+
+func NewFromIssuer(cur realm) string {
+	return bissuer.New(cross(cur))
+}
+
+func NewFromHelper(cur realm) string {
+	return idhelper.New()
+}`},
+		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(callerPath)},
+	})))
+	env.vmk.CommitGnoTransactionStore(ctx)
+
+	tests := []struct {
+		fn        string
+		realmPath string
+	}{
+		{fn: "NewFromIssuer", realmPath: issuerPath},
+		{fn: "NewFromHelper", realmPath: callerPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fn, func(t *testing.T) {
+			pkgID, err := gnolang.PkgIDFromPkgPath(tt.realmPath).MarshalAmino()
+			require.NoError(t, err)
+			for range 2 {
+				callCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+				before := env.vmk.getGnoTransactionStore(callCtx).GetPackageRealm(tt.realmPath).Time
+				res, err := env.vmk.Call(callCtx, NewMsgCall(addr, nil, callerPath, tt.fn, nil))
+				require.NoError(t, err)
+				require.Equal(t, fmt.Sprintf("(\"gno:realm-id:%s:%d\" string)\n\n", pkgID, before+1), res)
+				env.vmk.CommitGnoTransactionStore(callCtx)
+
+				freshCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+				persisted := env.vmk.getGnoTransactionStore(freshCtx).GetPackageRealm(tt.realmPath).Time
+				require.Equal(t, before+1, persisted)
+			}
+		})
+	}
+}
+
 // Call Run without imports, without variables.
 func TestVMKeeperRunSimple(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -971,6 +971,50 @@ func GetAdmin(cur realm) string { // XXX: remove crossing call ?
 	assert.Equal(t, addrString, res)
 }
 
+func TestVMKeeperNewRealmIDGate(t *testing.T) {
+	env := setupTestEnv()
+	addr := crypto.AddressFromPreimage([]byte("realm-id-gate"))
+	pkgPath := "gno.land/r/test/realmidgate"
+
+	ctx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	acc := env.acck.NewAccountWithAddress(ctx, addr)
+	env.acck.SetAccount(ctx, acc)
+	env.bankk.SetCoins(ctx, addr, initialBalance)
+	realmFiles := []*std.MemFile{
+		{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
+		{Name: "realmidgate.gno", Body: `package realmidgate
+
+import "chain/runtime"
+
+func New(cur realm) string {
+	return runtime.NewRealmID()
+}`},
+	}
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, pkgPath, realmFiles)))
+	env.vmk.CommitGnoTransactionStore(ctx)
+
+	callCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	res, err := env.vmk.Call(callCtx, NewMsgCall(addr, nil, pkgPath, "New", nil))
+	require.NoError(t, err)
+	require.Contains(t, res, `("gno:realm-id:`)
+
+	_, err = env.vmk.QueryEval(env.ctx, pkgPath, "New()")
+	require.ErrorContains(t, err, "realm ID issuance is disabled")
+
+	runCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	runFiles := []*std.MemFile{
+		{Name: "main.gno", Body: `package main
+
+import "gno.land/r/test/realmidgate"
+
+func main(cur realm) {
+	realmidgate.New(cross(cur))
+}`},
+	}
+	_, err = env.vmk.Run(runCtx, NewMsgRun(addr, nil, runFiles))
+	require.ErrorContains(t, err, "realm ID issuance is disabled")
+}
+
 // Call Run without imports, without variables.
 func TestVMKeeperRunSimple(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -1001,6 +1001,8 @@ func New(cur realm) string {
 	_, err = env.vmk.QueryEval(env.ctx, pkgPath, "New()")
 	require.ErrorContains(t, err, "realm ID issuance is disabled")
 
+	// A run script is ephemeral, but the persistent realm it cross-calls
+	// commits the issued ID, so Run may issue IDs just as Call does.
 	runCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
 	runFiles := []*std.MemFile{
 		{Name: "main.gno", Body: `package main
@@ -1008,11 +1010,12 @@ func New(cur realm) string {
 import "gno.land/r/test/realmidgate"
 
 func main(cur realm) {
-	realmidgate.New(cross(cur))
+	println(realmidgate.New(cross(cur)))
 }`},
 	}
-	_, err = env.vmk.Run(runCtx, NewMsgRun(addr, nil, runFiles))
-	require.ErrorContains(t, err, "realm ID issuance is disabled")
+	runRes, err := env.vmk.Run(runCtx, NewMsgRun(addr, nil, runFiles))
+	require.NoError(t, err)
+	require.Contains(t, runRes, "gno:realm-id:")
 }
 
 func TestVMKeeperNewRealmIDInInit(t *testing.T) {
@@ -1035,6 +1038,7 @@ func New(cur realm) string {
 }`
 
 	run := func(t *testing.T, env testEnv, ctx sdk.Context, addr crypto.Address, pkgPath string) {
+		t.Helper()
 		env.vmk.CommitGnoTransactionStore(ctx)
 
 		call := func(fn string) string {

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -1015,6 +1015,81 @@ func main(cur realm) {
 	require.ErrorContains(t, err, "realm ID issuance is disabled")
 }
 
+func TestVMKeeperNewRealmIDInInit(t *testing.T) {
+	const source = `package realmidinit
+
+import "chain/runtime"
+
+var initID string
+
+func init(cur realm) {
+	initID = runtime.NewRealmID()
+}
+
+func InitID(cur realm) string {
+	return initID
+}
+
+func New(cur realm) string {
+	return runtime.NewRealmID()
+}`
+
+	run := func(t *testing.T, env testEnv, ctx sdk.Context, addr crypto.Address, pkgPath string) {
+		env.vmk.CommitGnoTransactionStore(ctx)
+
+		call := func(fn string) string {
+			t.Helper()
+			callCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
+			res, err := env.vmk.Call(callCtx, NewMsgCall(addr, nil, pkgPath, fn, nil))
+			require.NoError(t, err)
+			env.vmk.CommitGnoTransactionStore(callCtx)
+			return res
+		}
+
+		initID := call("InitID")
+		first := call("New")
+		second := call("New")
+		pkgID, err := gnolang.PkgIDFromPkgPath(pkgPath).MarshalAmino()
+		require.NoError(t, err)
+		prefix := fmt.Sprintf(`("gno:realm-id:%s:`, pkgID)
+		require.Contains(t, initID, prefix)
+		require.Contains(t, first, prefix)
+		require.Contains(t, second, prefix)
+		require.NotEqual(t, initID, first)
+		require.NotEqual(t, first, second)
+	}
+
+	t.Run("AddPackage", func(t *testing.T) {
+		env := setupTestEnv()
+		ctx := env.vmk.MakeGnoTransactionStore(env.ctx)
+		addr := crypto.AddressFromPreimage([]byte("realm-id-init-add"))
+		pkgPath := "gno.land/r/test/realmidinit"
+		acc := env.acck.NewAccountWithAddress(ctx, addr)
+		env.acck.SetAccount(ctx, acc)
+		require.NoError(t, env.bankk.SetCoins(ctx, addr, initialBalance))
+		files := []*std.MemFile{
+			{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
+			{Name: "realmidinit.gno", Body: source},
+		}
+		require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, pkgPath, files)))
+		run(t, env, ctx, addr, pkgPath)
+	})
+
+	t.Run("EnablePackage", func(t *testing.T) {
+		approver := crypto.AddressFromPreimage([]byte("realm-id-init-approver"))
+		addr := crypto.AddressFromPreimage([]byte("realm-id-init-enable"))
+		env, ctx := inertEnv(t, approver, addr)
+		pkgPath := "gno.land/r/test/realmidinit"
+		files := []*std.MemFile{
+			{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
+			{Name: "realmidinit.gno", Body: source},
+		}
+		require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(addr, pkgPath, files)))
+		require.NoError(t, env.vmk.EnablePackage(ctx, approvalFor(t, env, ctx, approver, pkgPath)))
+		run(t, env, ctx, addr, pkgPath)
+	})
+}
+
 func TestVMKeeperNewRealmIDProvenance(t *testing.T) {
 	env := setupTestEnv()
 	addr := crypto.AddressFromPreimage([]byte("realm-id-provenance"))

--- a/gno.land/pkg/sdk/vm/keeper_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_test.go
@@ -996,7 +996,7 @@ func New(cur realm) string {
 	callCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
 	res, err := env.vmk.Call(callCtx, NewMsgCall(addr, nil, pkgPath, "New", nil))
 	require.NoError(t, err)
-	require.Contains(t, res, `("gno:realm-id:`)
+	require.Contains(t, res, `("gno.land/r/test/realmidgate:`)
 
 	_, err = env.vmk.QueryEval(env.ctx, pkgPath, "New()")
 	require.ErrorContains(t, err, "realm ID issuance is disabled")
@@ -1015,7 +1015,7 @@ func main(cur realm) {
 	}
 	runRes, err := env.vmk.Run(runCtx, NewMsgRun(addr, nil, runFiles))
 	require.NoError(t, err)
-	require.Contains(t, runRes, "gno:realm-id:")
+	require.Contains(t, runRes, "gno.land/r/test/realmidgate:")
 }
 
 func TestVMKeeperNewRealmIDInInit(t *testing.T) {
@@ -1053,9 +1053,7 @@ func New(cur realm) string {
 		initID := call("InitID")
 		first := call("New")
 		second := call("New")
-		pkgID, err := gnolang.PkgIDFromPkgPath(pkgPath).MarshalAmino()
-		require.NoError(t, err)
-		prefix := fmt.Sprintf(`("gno:realm-id:%s:`, pkgID)
+		prefix := fmt.Sprintf(`("%s:`, pkgPath)
 		require.Contains(t, initID, prefix)
 		require.Contains(t, first, prefix)
 		require.Contains(t, second, prefix)
@@ -1155,14 +1153,12 @@ func NewFromHelper(cur realm) string {
 	}
 	for _, tt := range tests {
 		t.Run(tt.fn, func(t *testing.T) {
-			pkgID, err := gnolang.PkgIDFromPkgPath(tt.realmPath).MarshalAmino()
-			require.NoError(t, err)
 			for range 2 {
 				callCtx := env.vmk.MakeGnoTransactionStore(env.ctx)
 				before := env.vmk.getGnoTransactionStore(callCtx).GetPackageRealm(tt.realmPath).Time
 				res, err := env.vmk.Call(callCtx, NewMsgCall(addr, nil, callerPath, tt.fn, nil))
 				require.NoError(t, err)
-				require.Equal(t, fmt.Sprintf("(\"gno:realm-id:%s:%d\" string)\n\n", pkgID, before+1), res)
+				require.Equal(t, fmt.Sprintf("(\"%s:%d\" string)\n\n", tt.realmPath, before+1), res)
 				env.vmk.CommitGnoTransactionStore(callCtx)
 
 				freshCtx := env.vmk.MakeGnoTransactionStore(env.ctx)

--- a/gnovm/pkg/gnolang/objectid_reservation_test.go
+++ b/gnovm/pkg/gnolang/objectid_reservation_test.go
@@ -1,0 +1,244 @@
+package gnolang
+
+import (
+	"io"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	storetypes "github.com/gnolang/gno/tm2/pkg/store/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectID_AllocationStampsPkgIDNotNewTime(t *testing.T) {
+	rlm := NewRealm("gno.land/r/demo/objid_reservation")
+
+	alloc := NewAllocator(math.MaxInt64)
+	alloc.currentRealmID = rlm.ID
+	alloc.currentRealmPath = rlm.Path
+
+	sv := alloc.NewStruct(nil, nil)
+
+	oid := sv.GetObjectID()
+	require.Equal(t, rlm.ID, oid.PkgID, "allocation must stamp the executing realm PkgID")
+	require.Equal(t, uint64(0), oid.NewTime, "allocation must leave NewTime unassigned")
+	require.False(t, oid.IsFinalized(), "freshly allocated object must not be finalized")
+	require.False(t, sv.GetIsReal(), "freshly allocated object must not be real")
+}
+
+func TestObjectID_NewTimeAssignedOnlyAtFinalize(t *testing.T) {
+	rlm := NewRealm("gno.land/r/demo/objid_reservation")
+	alloc := NewAllocator(math.MaxInt64)
+	alloc.currentRealmID = rlm.ID
+	alloc.currentRealmPath = rlm.Path
+
+	a := alloc.NewStruct(nil, nil)
+	b := alloc.NewStruct(nil, nil)
+
+	require.Equal(t, uint64(0), a.GetObjectID().NewTime)
+	require.Equal(t, uint64(0), b.GetObjectID().NewTime)
+	require.Equal(t, a.GetObjectID(), b.GetObjectID(),
+		"two unfinalized objects share an indistinguishable ObjectID: the collision window #6026 describes")
+
+	rlm.assignNewObjectID(nil, a)
+	rlm.assignNewObjectID(nil, b)
+
+	require.True(t, a.GetObjectID().IsFinalized())
+	require.True(t, b.GetObjectID().IsFinalized())
+	require.NotEqual(t, a.GetObjectID(), b.GetObjectID(),
+		"finalize must give each object a distinct ObjectID")
+	require.Equal(t, uint64(1), a.GetObjectID().NewTime)
+	require.Equal(t, uint64(2), b.GetObjectID().NewTime)
+}
+
+func TestObjectID_RealmTimeIsMonotonicUniqueCounter(t *testing.T) {
+	db := memdb.NewMemDB()
+	baseStore := dbadapter.StoreConstructor(db, storetypes.StoreOptions{})
+	iavlStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
+	st := NewStore(NewAllocator(math.MaxInt64), baseStore, iavlStore)
+	pkgPath := "gno.land/r/demo/objid_reservation"
+
+	baseTx := baseStore.CacheWrap()
+	iavlTx := iavlStore.CacheWrap()
+	tx := st.BeginTransaction(baseTx, iavlTx, nil, nil)
+	m := NewMachineWithOptions(MachineOptions{PkgPath: pkgPath, Store: tx, Output: io.Discard})
+	m.RunMemPackage(&std.MemPackage{
+		Type: MPUserProd,
+		Name: "objid_reservation",
+		Path: pkgPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: GenGnoModLatest(pkgPath)},
+			{Name: "main.gno", Body: `package objid_reservation
+
+type item struct {
+	n int
+}
+
+var items []*item
+
+func main() {
+	items = append(items, &item{n: len(items)}, &item{n: len(items) + 1})
+}
+`},
+		},
+	}, true)
+	tx.Write()
+	baseTx.Write()
+	iavlTx.Write()
+
+	previousTime := st.BeginTransaction(nil, nil, nil, nil).GetPackageRealm(pkgPath).Time
+	seen := map[ObjectID]bool{}
+	for i := 0; i < 3; i++ {
+		baseTx = baseStore.CacheWrap()
+		iavlTx = iavlStore.CacheWrap()
+		tx = st.BeginTransaction(baseTx, iavlTx, nil, nil)
+		reloaded := tx.GetPackageRealm(pkgPath)
+		require.Equal(t, previousTime, reloaded.Time, "Realm.Time must survive the transaction store round-trip")
+
+		pv := tx.GetPackage(pkgPath, false)
+		m = NewMachineWithOptions(MachineOptions{PkgPath: pkgPath, Store: tx, Output: io.Discard})
+		m.SetActivePackage(pv)
+		m.RunMain()
+		tx.Write()
+		baseTx.Write()
+		iavlTx.Write()
+
+		fresh := NewStore(NewAllocator(math.MaxInt64), baseStore, iavlStore)
+		persisted := fresh.GetPackageRealm(pkgPath)
+		require.Greater(t, persisted.Time, previousTime, "a transaction that finalizes objects must advance Realm.Time")
+
+		ids := persistedStructObjectIDs(t, baseStore, persisted.ID)
+		newIDs := make([]ObjectID, 0, 2)
+		for _, oid := range ids {
+			if seen[oid] {
+				continue
+			}
+			require.Greater(t, oid.NewTime, previousTime, "new objects must use a counter after the prior transaction")
+			seen[oid] = true
+			newIDs = append(newIDs, oid)
+		}
+		require.Len(t, newIDs, 2, "each main call must persist two distinct item objects")
+		require.Less(t, newIDs[0].NewTime, newIDs[1].NewTime, "finalized ObjectIDs must be strictly monotonic")
+		previousTime = persisted.Time
+	}
+	require.Len(t, seen, 6)
+}
+
+func TestObjectID_ForeignObjectUsesOwningRealmCounter(t *testing.T) {
+	baseStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
+	st := NewStore(NewAllocator(math.MaxInt64), baseStore, baseStore)
+	finalizingRealm := NewRealm("gno.land/r/demo/finalizer")
+	ownerRealm := NewRealm("gno.land/r/demo/owner")
+	ownerRealm.Time = 7
+	ownerNode := NewPackageNode("owner", ownerRealm.Path, &FileSet{})
+	st.SetCachePackage(ownerNode.NewPackage(NewAllocator(math.MaxInt64)))
+	st.SetPackageRealm(ownerRealm)
+
+	alloc := NewAllocator(math.MaxInt64)
+	alloc.currentRealmID = ownerRealm.ID
+	alloc.currentRealmPath = ownerRealm.Path
+	object := alloc.NewStruct(nil, nil)
+
+	oid := finalizingRealm.assignNewObjectID(st, object)
+	require.Equal(t, ObjectID{PkgID: ownerRealm.ID, NewTime: 8}, oid)
+	require.Zero(t, finalizingRealm.Time, "the finalizing realm must not issue a foreign object's NewTime")
+	require.Equal(t, uint64(8), ownerRealm.Time)
+
+	finalizingRealm.FinalizeRealmTransaction(st)
+	fresh := NewStore(NewAllocator(math.MaxInt64), baseStore, baseStore)
+	require.Equal(t, uint64(8), fresh.GetPackageRealm(ownerRealm.Path).Time,
+		"the owning realm's advanced counter must persist")
+}
+
+func TestObjectID_AdoptedObjectsUsePersistingRealmProvenance(t *testing.T) {
+	rlm := NewRealm("gno.land/r/demo/adopter")
+	baseStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
+	st := NewStore(NewAllocator(math.MaxInt64), baseStore, baseStore)
+
+	ephemeralPath := "gno.land/e/g1user123/run"
+	ephemeralNode := NewPackageNode("run", ephemeralPath, &FileSet{})
+	st.SetCachePackage(ephemeralNode.NewPackage(NewAllocator(math.MaxInt64)))
+	stdlibNode := NewPackageNode("bytes", "bytes", &FileSet{})
+	st.SetCachePackage(stdlibNode.NewPackage(NewAllocator(math.MaxInt64)))
+
+	for _, sourcePath := range []string{"bytes", ephemeralPath} {
+		alloc := NewAllocator(math.MaxInt64)
+		alloc.currentRealmID = PkgIDFromPkgPath(sourcePath)
+		alloc.currentRealmPath = sourcePath
+		object := alloc.NewStruct(nil, nil)
+
+		oid := rlm.assignNewObjectID(st, object)
+		require.Equal(t, rlm.ID, oid.PkgID, "%s object must be adopted by the persisting realm", sourcePath)
+		require.Equal(t, rlm.Time, oid.NewTime, "%s object must use the persisting realm counter", sourcePath)
+	}
+	require.Equal(t, uint64(2), rlm.Time)
+}
+
+func persistedStructObjectIDs(t *testing.T, baseStore storetypes.Store, pkgID PkgID) []ObjectID {
+	t.Helper()
+	iter := baseStore.Iterator(nil, nil, nil)
+	defer iter.Close()
+
+	ids := make([]ObjectID, 0)
+	for ; iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if len(key) < 6 || key[:4] != "oid:" || key[len(key)-6:] == "#realm" {
+			continue
+		}
+		var oid ObjectID
+		require.NoError(t, oid.UnmarshalAmino(key[4:]))
+		if oid.PkgID == pkgID {
+			if _, ok := loadObjectFromDB(baseStore, oid).(*StructValue); ok {
+				ids = append(ids, oid)
+			}
+		}
+	}
+	require.NoError(t, iter.Error())
+	sort.Slice(ids, func(i, j int) bool { return ids[i].NewTime < ids[j].NewTime })
+	return ids
+}
+
+func TestObjectID_RealmTimeReservationNeverCollides(t *testing.T) {
+	rlm := NewRealm("gno.land/r/demo/objid_reservation")
+	alloc := NewAllocator(math.MaxInt64)
+	alloc.currentRealmID = rlm.ID
+	alloc.currentRealmPath = rlm.Path
+
+	used := map[uint64]bool{}
+
+	reserveID := func() uint64 {
+		if rlm.Time == math.MaxUint64 {
+			t.Fatal("realm time overflow")
+		}
+		rlm.Time++
+		return rlm.Time
+	}
+
+	finalizeOne := func() uint64 {
+		sv := alloc.NewStruct(nil, nil)
+		rlm.assignNewObjectID(nil, sv)
+		return sv.GetObjectID().NewTime
+	}
+
+	record := func(v uint64) {
+		require.False(t, used[v], "value %d handed out twice across reservations and finalizations", v)
+		used[v] = true
+	}
+
+	record(finalizeOne())
+	record(reserveID())
+	record(reserveID())
+	record(finalizeOne())
+	record(reserveID())
+	record(finalizeOne())
+
+	require.Len(t, used, 6)
+
+	next := finalizeOne()
+	for v := range used {
+		require.NotEqual(t, v, next, "a later object must not reuse a reserved value")
+	}
+}

--- a/gnovm/pkg/gnolang/objectid_reservation_test.go
+++ b/gnovm/pkg/gnolang/objectid_reservation_test.go
@@ -245,8 +245,6 @@ func TestObjectID_SharedRealmTimeModelNeverCollides(t *testing.T) {
 }
 
 func TestObjectID_RealmTimeOverflowGuard(t *testing.T) {
-	t.Skip("assignNewObjectID has no overflow guard; enable when the production guard is added")
-
 	rlm := NewRealm("gno.land/r/demo/objid_reservation")
 	rlm.Time = math.MaxUint64
 	alloc := NewAllocator(math.MaxInt64)
@@ -254,5 +252,8 @@ func TestObjectID_RealmTimeOverflowGuard(t *testing.T) {
 	alloc.currentRealmPath = rlm.Path
 	object := alloc.NewStruct(nil, nil)
 
+	// Exhausted realm time must fail without wrapping or finalizing the object ID.
 	require.Panics(t, func() { rlm.assignNewObjectID(nil, object) })
+	require.Equal(t, uint64(math.MaxUint64), rlm.Time)
+	require.False(t, object.GetObjectID().IsFinalized())
 }

--- a/gnovm/pkg/gnolang/objectid_reservation_test.go
+++ b/gnovm/pkg/gnolang/objectid_reservation_test.go
@@ -91,7 +91,8 @@ func main() {
 
 	previousTime := st.BeginTransaction(nil, nil, nil, nil).GetPackageRealm(pkgPath).Time
 	seen := map[ObjectID]bool{}
-	for i := 0; i < 3; i++ {
+	const rounds = 3
+	for range rounds {
 		baseTx = baseStore.CacheWrap()
 		iavlTx = iavlStore.CacheWrap()
 		tx = st.BeginTransaction(baseTx, iavlTx, nil, nil)

--- a/gnovm/pkg/gnolang/objectid_reservation_test.go
+++ b/gnovm/pkg/gnolang/objectid_reservation_test.go
@@ -201,7 +201,7 @@ func persistedStructObjectIDs(t *testing.T, baseStore storetypes.Store, pkgID Pk
 	return ids
 }
 
-func TestObjectID_RealmTimeReservationNeverCollides(t *testing.T) {
+func TestObjectID_SharedRealmTimeModelNeverCollides(t *testing.T) {
 	rlm := NewRealm("gno.land/r/demo/objid_reservation")
 	alloc := NewAllocator(math.MaxInt64)
 	alloc.currentRealmID = rlm.ID
@@ -241,4 +241,17 @@ func TestObjectID_RealmTimeReservationNeverCollides(t *testing.T) {
 	for v := range used {
 		require.NotEqual(t, v, next, "a later object must not reuse a reserved value")
 	}
+}
+
+func TestObjectID_RealmTimeOverflowGuard(t *testing.T) {
+	t.Skip("assignNewObjectID has no overflow guard; enable when the production guard is added")
+
+	rlm := NewRealm("gno.land/r/demo/objid_reservation")
+	rlm.Time = math.MaxUint64
+	alloc := NewAllocator(math.MaxInt64)
+	alloc.currentRealmID = rlm.ID
+	alloc.currentRealmPath = rlm.Path
+	object := alloc.NewStruct(nil, nil)
+
+	require.Panics(t, func() { rlm.assignNewObjectID(nil, object) })
 }

--- a/gnovm/pkg/gnolang/realm.go
+++ b/gnovm/pkg/gnolang/realm.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 
@@ -2025,6 +2026,9 @@ func (rlm *Realm) assignNewObjectID(store Store, oo Object) ObjectID {
 	targetRlm := rlm
 	if oid.PkgID != rlm.ID {
 		targetRlm = rlm.touchForeignRealm(store, oid.PkgID)
+	}
+	if targetRlm.Time == math.MaxUint64 {
+		panic("realm time overflow")
 	}
 	targetRlm.Time++
 	oo.SetNewTime(targetRlm.Time)

--- a/gnovm/pkg/test/test.go
+++ b/gnovm/pkg/test/test.go
@@ -73,6 +73,7 @@ func Context(caller crypto.Bech32Address, pkgPath string, send std.Coins) *runti
 		Banker:                  banker,
 		Params:                  newTestParams(),
 		EventLogger:             sdk.NewEventLogger(),
+		RealmIDEnabled:          true,
 	}
 	return &runtime.TestExecContext{
 		ExecContext: ctx,

--- a/gnovm/stdlibs/chain/runtime/native.gno
+++ b/gnovm/stdlibs/chain/runtime/native.gno
@@ -10,6 +10,9 @@ func ChainID() string     // injected
 func ChainDomain() string // injected
 func ChainHeight() int64  // injected
 
+// NewRealmID returns a deterministic ID scoped to the current persistent realm.
+func NewRealmID() string // injected
+
 // GetSessionInfo returns session metadata if the current transaction was
 // signed by a session key. Returns isSession=false for master-key transactions.
 //

--- a/gnovm/stdlibs/chain/runtime/native.gno
+++ b/gnovm/stdlibs/chain/runtime/native.gno
@@ -10,7 +10,7 @@ func ChainID() string     // injected
 func ChainDomain() string // injected
 func ChainHeight() int64  // injected
 
-// NewRealmID returns a deterministic ID scoped to the current persistent realm.
+// NewRealmID returns "<realm-path>:<realm-time>" for the current persistent realm.
 func NewRealmID() string // injected
 
 // GetSessionInfo returns session metadata if the current transaction was

--- a/gnovm/stdlibs/chain/runtime/native.go
+++ b/gnovm/stdlibs/chain/runtime/native.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"math"
+	"strconv"
+
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/stdlibs/internal/execctx"
 	"github.com/gnolang/gno/tm2/pkg/std"
@@ -37,6 +40,24 @@ func ChainDomain(m *gno.Machine) string {
 
 func ChainHeight(m *gno.Machine) int64 {
 	return execctx.GetContext(m).Height
+}
+
+func NewRealmID(m *gno.Machine) string {
+	if !execctx.GetContext(m).RealmIDEnabled {
+		m.PanicString("realm ID issuance is disabled")
+	}
+	if m.Realm == nil || !gno.IsRealmPath(m.Realm.Path) {
+		m.PanicString("realm ID issuance requires a persistent realm")
+	}
+	if m.Realm.Time == math.MaxUint64 {
+		m.PanicString("realm ID counter overflow")
+	}
+	m.Realm.Time++
+	// Persist the counter here because realm finalization may have nothing else to
+	// save. Without this write, a later transaction could issue the same ID.
+	m.Store.SetPackageRealm(m.Realm)
+	pkgID, _ := m.Realm.ID.MarshalAmino()
+	return "gno:realm-id:" + pkgID + ":" + strconv.FormatUint(m.Realm.Time, 10)
 }
 
 // pathRestricted is satisfied by GnoSessionAccount without importing gno.land.

--- a/gnovm/stdlibs/chain/runtime/native.go
+++ b/gnovm/stdlibs/chain/runtime/native.go
@@ -56,8 +56,7 @@ func NewRealmID(m *gno.Machine) string {
 	// Persist the counter here because realm finalization may have nothing else to
 	// save. Without this write, a later transaction could issue the same ID.
 	m.Store.SetPackageRealm(m.Realm)
-	pkgID, _ := m.Realm.ID.MarshalAmino()
-	return "gno:realm-id:" + pkgID + ":" + strconv.FormatUint(m.Realm.Time, 10)
+	return m.Realm.Path + ":" + strconv.FormatUint(m.Realm.Time, 10)
 }
 
 // pathRestricted is satisfied by GnoSessionAccount without importing gno.land.

--- a/gnovm/stdlibs/chain/runtime/native_test.go
+++ b/gnovm/stdlibs/chain/runtime/native_test.go
@@ -2,15 +2,96 @@ package runtime
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/gnovm/stdlibs/chain/runtime/unsafe"
 	"github.com/gnolang/gno/gnovm/stdlibs/internal/execctx"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	storetypes "github.com/gnolang/gno/tm2/pkg/store/types"
 )
+
+func TestNewRealmID(t *testing.T) {
+	baseStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
+	iavlStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
+	store := gno.NewStore(gno.NewAllocator(math.MaxInt64), baseStore, iavlStore)
+	pkgPath := "gno.land/r/demo/realm_id"
+	store.SetPackageRealm(gno.NewRealm(pkgPath))
+
+	baseTx := baseStore.CacheWrap()
+	iavlTx := iavlStore.CacheWrap()
+	tx := store.BeginTransaction(baseTx, iavlTx, nil, nil)
+	m := gno.NewMachineWithOptions(gno.MachineOptions{
+		Store:   tx,
+		Context: execctx.ExecContext{RealmIDEnabled: true},
+	})
+	m.Realm = tx.GetPackageRealm(pkgPath)
+
+	first := NewRealmID(m)
+	second := NewRealmID(m)
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:1", first)
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:2", second)
+	require.NotEqual(t, first, second)
+	var oid gno.ObjectID
+	require.Error(t, oid.UnmarshalAmino(first))
+
+	tx.Write()
+	baseTx.Write()
+	iavlTx.Write()
+
+	fresh := gno.NewStore(gno.NewAllocator(math.MaxInt64), baseStore, iavlStore)
+	require.Equal(t, uint64(2), fresh.GetPackageRealm(pkgPath).Time)
+
+	baseTx = baseStore.CacheWrap()
+	iavlTx = iavlStore.CacheWrap()
+	tx = fresh.BeginTransaction(baseTx, iavlTx, nil, nil)
+	m = gno.NewMachineWithOptions(gno.MachineOptions{
+		Store:   tx,
+		Context: execctx.ExecContext{RealmIDEnabled: true},
+	})
+	m.Realm = tx.GetPackageRealm(pkgPath)
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:3", NewRealmID(m))
+}
+
+func TestNewRealmIDPanicsInQueryContext(t *testing.T) {
+	pkgPath := "gno.land/r/demo/realm_id"
+	m := &gno.Machine{
+		Realm:   gno.NewRealm(pkgPath),
+		Context: execctx.ExecContext{},
+	}
+	require.Panics(t, func() { NewRealmID(m) })
+}
+
+func TestNewRealmIDRejectsInvalidRealm(t *testing.T) {
+	tests := []struct {
+		name     string
+		realm    *gno.Realm
+		wantTime uint64
+	}{
+		{name: "nil realm"},
+		{name: "package", realm: gno.NewRealm("gno.land/p/demo/realm_id")},
+		{name: "ephemeral", realm: gno.NewRealm("gno.land/e/g1user/run")},
+		{name: "overflow", realm: &gno.Realm{Path: "gno.land/r/demo/realm_id", Time: math.MaxUint64}, wantTime: math.MaxUint64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &gno.Machine{
+				Realm:   tt.realm,
+				Context: execctx.ExecContext{RealmIDEnabled: true},
+			}
+			require.Panics(t, func() { NewRealmID(m) })
+			if tt.realm != nil {
+				require.Equal(t, tt.wantTime, tt.realm.Time)
+			}
+		})
+	}
+}
 
 func TestPreviousRealmIsOrigin(t *testing.T) {
 	var (

--- a/gnovm/stdlibs/chain/runtime/native_test.go
+++ b/gnovm/stdlibs/chain/runtime/native_test.go
@@ -37,8 +37,8 @@ func TestNewRealmID(t *testing.T) {
 
 	first := NewRealmID(m)
 	second := NewRealmID(m)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:2", first)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:3", second)
+	require.Equal(t, "gno.land/r/demo/realm_id:2", first)
+	require.Equal(t, "gno.land/r/demo/realm_id:3", second)
 	require.NotEqual(t, first, second)
 	require.Equal(t, uint64(3), m.Realm.Time)
 	var oid gno.ObjectID
@@ -73,7 +73,7 @@ func TestNewRealmID(t *testing.T) {
 		Context: execctx.ExecContext{RealmIDEnabled: true},
 	})
 	m.Realm = tx.GetPackageRealm(pkgPath)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:5", NewRealmID(m))
+	require.Equal(t, "gno.land/r/demo/realm_id:5", NewRealmID(m))
 }
 
 func TestNewRealmIDPanicsInQueryContext(t *testing.T) {

--- a/gnovm/stdlibs/chain/runtime/native_test.go
+++ b/gnovm/stdlibs/chain/runtime/native_test.go
@@ -22,7 +22,9 @@ func TestNewRealmID(t *testing.T) {
 	iavlStore := dbadapter.StoreConstructor(memdb.NewMemDB(), storetypes.StoreOptions{})
 	store := gno.NewStore(gno.NewAllocator(math.MaxInt64), baseStore, iavlStore)
 	pkgPath := "gno.land/r/demo/realm_id"
-	store.SetPackageRealm(gno.NewRealm(pkgPath))
+	rlm := gno.NewRealm(pkgPath)
+	rlm.Time = 1 // An existing owner was finalized at time 1.
+	store.SetPackageRealm(rlm)
 
 	baseTx := baseStore.CacheWrap()
 	iavlTx := iavlStore.CacheWrap()
@@ -35,18 +37,33 @@ func TestNewRealmID(t *testing.T) {
 
 	first := NewRealmID(m)
 	second := NewRealmID(m)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:1", first)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:2", second)
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:2", first)
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:3", second)
 	require.NotEqual(t, first, second)
+	require.Equal(t, uint64(3), m.Realm.Time)
 	var oid gno.ObjectID
 	require.Error(t, oid.UnmarshalAmino(first))
+
+	// Object finalization consumes the next value from the same realm clock.
+	alloc := gno.NewAllocator(math.MaxInt64)
+	owner := alloc.NewStruct(nil, nil)
+	owner.SetPkgID(m.Realm.ID)
+	owner.SetNewTime(1)
+	object := alloc.NewStruct(nil, nil)
+	object.SetPkgID(m.Realm.ID)
+	object.SetOwner(owner)
+	object.IncRefCount()
+	m.Realm.MarkNewReal(object)
+	m.Realm.FinalizeRealmTransaction(tx)
+	require.Equal(t, uint64(4), m.Realm.Time)
+	require.Equal(t, uint64(4), object.GetObjectID().NewTime)
 
 	tx.Write()
 	baseTx.Write()
 	iavlTx.Write()
 
 	fresh := gno.NewStore(gno.NewAllocator(math.MaxInt64), baseStore, iavlStore)
-	require.Equal(t, uint64(2), fresh.GetPackageRealm(pkgPath).Time)
+	require.Equal(t, uint64(4), fresh.GetPackageRealm(pkgPath).Time)
 
 	baseTx = baseStore.CacheWrap()
 	iavlTx = iavlStore.CacheWrap()
@@ -56,7 +73,7 @@ func TestNewRealmID(t *testing.T) {
 		Context: execctx.ExecContext{RealmIDEnabled: true},
 	})
 	m.Realm = tx.GetPackageRealm(pkgPath)
-	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:3", NewRealmID(m))
+	require.Equal(t, "gno:realm-id:0510954b76375c303d02cacf694f6135b1adc474:5", NewRealmID(m))
 }
 
 func TestNewRealmIDPanicsInQueryContext(t *testing.T) {

--- a/gnovm/stdlibs/generated.go
+++ b/gnovm/stdlibs/generated.go
@@ -1276,6 +1276,26 @@ var nativeFuncs = [...]NativeFunc{
 	},
 	{
 		"chain/runtime",
+		"NewRealmID",
+		[]gno.FieldTypeExpr{},
+		[]gno.FieldTypeExpr{
+			{NameExpr: *gno.Nx("r0"), Type: gno.X("string")},
+		},
+		true,
+		func(m *gno.Machine) {
+			r0 := libs_chain_runtime.NewRealmID(
+				m,
+			)
+
+			m.PushValue(gno.Go2GnoValue(
+				m.Alloc,
+				m.Store,
+				reflect.ValueOf(&r0).Elem(),
+			))
+		},
+	},
+	{
+		"chain/runtime",
 		"getSessionInfo",
 		[]gno.FieldTypeExpr{},
 		[]gno.FieldTypeExpr{

--- a/gnovm/stdlibs/internal/execctx/context.go
+++ b/gnovm/stdlibs/internal/execctx/context.go
@@ -43,6 +43,7 @@ type ExecContext struct {
 	Height          int64
 	Timestamp       int64 // seconds
 	TimestampNano   int64 // nanoseconds, only used for testing.
+	RealmIDEnabled  bool
 	OriginCaller    crypto.Bech32Address
 	OriginSend      std.Coins
 	OriginSendSpent *std.Coins // mutable

--- a/gnovm/stdlibs/native_gas.go
+++ b/gnovm/stdlibs/native_gas.go
@@ -77,7 +77,7 @@ type nativeGasEntry struct {
 // today, so the table stays single-slope; the schema fields support
 // future natives that genuinely scale on both dimensions.
 //
-// 72 entries — exhaustive coverage of gnovm/stdlibs/generated.go.
+// 73 entries — exhaustive coverage of gnovm/stdlibs/generated.go.
 // The trailing 10 IBC-crypto entries (crypto/bn254, crypto/cometbls,
 // crypto/keccak256, crypto/merkle, crypto/modexp) are draft fits measured
 // on Intel Xeon Silver 4114; the chain/markdown rows and the rest are on
@@ -140,6 +140,7 @@ var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "chain/runtime", Fn: "ChainID", Base: 45, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                         // flat, median 44.8ns
 	{Pkg: "chain/runtime", Fn: "ChainDomain", Base: 45, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                     // flat, median 44.5ns
 	{Pkg: "chain/runtime", Fn: "ChainHeight", Base: 30, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                     // flat, median 30.2ns
+	{Pkg: "chain/runtime", Fn: "NewRealmID", Base: 1772, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                    // POC: conservative chain/params.SetString base; SetPackageRealm charges store work separately
 	{Pkg: "chain/runtime", Fn: "getSessionInfo", Base: 148, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                 // flat, median 148.4ns
 	{Pkg: "chain/runtime", Fn: "AssertOriginCall", Base: 5, SlopeIdx: -1, SlopeKind: SizeFlat},                                                                 // flat, median 5.0ns
 	// chain/runtime/unsafe natives — same implementations as their chain/runtime / chain/banker counterparts.


### PR DESCRIPTION
## Description

GRC20 previously built `Token.id` from `<pkg-path>.<symbol>.<caller-supplied-seqid>`. A realm could therefore create independent tokens with the same ID, making their events indistinguishable (issue #6026).

This PR moves ID issuance into the VM. `runtime.NewRealmID()` returns a deterministic, persistent ID in the form `<realm-path>:<realm-time>`, for example `gno.land/r/demo/defi/foo20:24`. The realm path makes every token-bearing event directly attributable without first observing `NewToken`.

## Changes

### VM realm IDs

- Add `chain/runtime.NewRealmID() string`.
- Validate that issuance is enabled and the active package is a persistent `/r/` realm.
- Increment and persist the realm's shared `Realm.Time`, rejecting overflow before mutation.
- Enable issuance in state-committing `AddPackage`, `EnablePackage`, `Call`, and `Run` execution; query/eval contexts remain disabled.
- Guard object finalization against the same `Realm.Time` overflow.

`Realm.Time` is shared with object finalization, so the numeric suffix is unique and persistent but not guaranteed to be contiguous across `NewRealmID` calls.

### GRC20 integration

- Remove the caller-supplied `seqid.ID` argument from `grc20.NewToken` and update all example, treasury, registry, factory, test, and quarantined callers.
- Store the VM-issued ID directly in `Token.id`.
- Remove the redundant `realm` attribute from `NewToken`; `NewToken`, `Transfer`, and `Approval` already expose the origin realm through their `token` value.
- Keep `origRealm` separately for authorization and display metadata.

### Tests and fixtures

- Add runtime and keeper coverage for persistence, provenance, disabled contexts, initialization, `Run`, invalid realms, and overflow.
- Add object-ID reservation coverage showing that `NewRealmID` and object finalization advance the same realm time without collisions.
- Add GRC20 filetests for token identity, duplicate construction, event provenance, and cross-realm persistence.
- Update integration txtars, app-hash expectations, generated stdlib bindings, and native gas registration.

### Documentation

- Update GRC20 usage documentation and examples for the new constructor and ID format.
- Add an ADR covering the decision, alternatives, and compatibility consequences.

## Why not expose `ObjectID` directly?

`ObjectID.NewTime` is assigned during realm finalization and is still zero while a new object is executing. Assigning it early would violate existing object lifecycle invariants. `NewRealmID` instead reserves the next value from the same persistent realm clock explicitly.

## Compatibility

This changes both the `grc20.NewToken` signature and the textual token ID format. Consumers should parse the ID at `:` into a realm path and numeric realm time; the token symbol remains metadata rather than part of the ID.

## Verification

- `go test ./gnovm/stdlibs/chain/runtime -count=1`
- `go test ./gno.land/pkg/sdk/vm -run TestVMKeeperNewRealmID -count=1`
- `go test ./gno.land/pkg/sdk/vm/ -run Gas -count=1`
- Targeted GRC20 package and integration tests
