### PR TITLE
chore: stop linguist from detecting gno file as Go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-*.gno linguist-language=Go
 *.pb.go linguist-generated merge=ours -diff
 go.sum linguist-generated text
 gnovm/stdlibs/generated.go linguist-generated


### PR DESCRIPTION
GitHub's Linguist now supports Gno, officially.

ref:
<img width="355" height="187" alt="스크린샷 2026-09-01 오전 11 59 09" src="https://github.com/user-attachments/assets/f692f78a-5cc2-4a40-a5a0-78682e786143" />
