### PR TITLE
fix(gpao): debit max-spend at the broadcast, not at the decision to send

### DIFF
--- a/contribs/gpao/README.md
+++ b/contribs/gpao/README.md
@@ -221,9 +221,10 @@ can disturb it stall approvals for the whole chain.
 
 ### About `--max-spend`
 
-Every approval costs the full gas fee, whether or not the message succeeds. The
-daemon decides on its own when to send one, so anything that makes approvals
-fail repeatedly will drain the approver key. The bound stops that.
+Every approval that reaches a block costs the full gas fee, whether or not the
+message succeeds. The daemon decides on its own when to send one, so anything
+that makes approvals fail repeatedly will drain the approver key. The bound
+stops that.
 
 Two things reduce how often it is reached. Before approving, the daemon checks
 whether the package is already deployed and skips it if so, which is the common

--- a/contribs/gpao/oracle.go
+++ b/contribs/gpao/oracle.go
@@ -528,9 +528,6 @@ func (o *oracle) handleCandidate(ctx context.Context, mpkg *std.MemPackage) {
 	}
 
 	o.logf("gpao: %q passed typecheck, broadcasting approval", path)
-	// Counted before the call, not after: the fee is deducted by the ante
-	// handler, so a failed approval costs exactly as much as a successful one.
-	o.spent += o.enableFee
 	if err := o.enable(path, vm.PackageContentHash(mpkg)); err != nil {
 		// Left unseen until the count runs out, for the reason at
 		// maxEnableAttempts: the package verified, so the failure is about the
@@ -749,6 +746,18 @@ func gasWantedFor(estimated, fallback, ceiling int64) int64 {
 	return ceiling
 }
 
+// broadcastWasFree says whether a failed broadcast cost nothing, and so whether
+// the debit taken before it has to be given back.
+//
+// Only a CheckTx rejection is free: the ante refused it before any block, so
+// nothing was deducted. A DeliverTx failure ran in a block and was charged. A
+// missing result covers both a pre-mempool refusal, which is free, and an
+// answer lost after the transaction was handed over, which may have committed
+// -- indistinguishable here, and over-counting is the safe half of that guess.
+func broadcastWasFree(res *ctypes.ResultBroadcastTxCommit) bool {
+	return res != nil && res.CheckTx.IsErr()
+}
+
 // enable builds, signs and broadcasts a MsgEnablePackage for pkgPath.
 //
 // Signed twice, deliberately. The fee is part of the sign bytes, so the
@@ -804,8 +813,18 @@ func (o *oracle) enable(pkgPath, pkgHash string) error {
 	if err != nil {
 		return fmt.Errorf("sign: %w", err)
 	}
+	// Counted at the send, not at the decision to send: what is handed to the
+	// node is counted, and the paths above that return without broadcasting are
+	// not. No transaction exists on those, so the ante charges nothing, and
+	// counting them would make the oracle report itself out of budget while
+	// holding every coin it started with.
+	o.spent += o.enableFee
 	// BroadcastTxCommit returns an error if CheckTx or DeliverTx failed.
-	if _, err := o.client.BroadcastTxCommit(signed); err != nil {
+	res, err := o.client.BroadcastTxCommit(signed)
+	if err != nil {
+		if broadcastWasFree(res) {
+			o.spent -= o.enableFee
+		}
 		return fmt.Errorf("broadcast: %w", err)
 	}
 	return nil

--- a/contribs/gpao/spenddebit_test.go
+++ b/contribs/gpao/spenddebit_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/integration"
+	vm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpentMovesOnlyWhenATransactionIsSent pins the accounting to the money.
+//
+// The ante handler deducts the fee for any transaction that reaches the chain,
+// and for nothing else. An enable whose simulate says verdictWillFail returns
+// before BroadcastTxCommit -- no transaction exists, nothing is charged -- so
+// counting it against -max-spend makes the oracle report itself out of budget
+// while holding every coin it started with, and refuse legitimate packages for
+// want of funds it still has.
+//
+// The failing arm uses a package whose init() panics: it passes verification
+// (the verifier preprocesses rather than executes) but EnablePackage runs
+// init(), so the simulate probe fails -- the cheapest reproduction of "verified
+// clean, enable would fail".
+func TestSpentMovesOnlyWhenATransactionIsSent(t *testing.T) {
+	gnoroot := gnoenv.RootDir()
+	cfg := integration.TestingMinimalNodeConfig(gnoroot)
+	cfg.SkipGenesisSigVerification = true
+
+	signer, err := gnoclient.SignerFromBip39(
+		integration.DefaultAccount_Seed, cfg.Genesis.ChainID, "", 0, 0)
+	require.NoError(t, err)
+	info, err := signer.Info()
+	require.NoError(t, err)
+	who := info.GetAddress()
+
+	ggs := cfg.Genesis.AppState.(gnoland.GnoGenesisState)
+	ggs.Balances = []gnoland.Balance{{
+		Address: who,
+		Amount:  std.NewCoins(std.NewCoin("ugnot", 100_000_000_000)),
+	}}
+	ggs.VM.Params.CodeSubmissionPolicy = "inert"
+	ggs.VM.Params.PkgApprovers = []crypto.Address{who}
+	cfg.Genesis.AppState = ggs
+
+	node, remote := integration.TestingInMemoryNode(t, log.NewNoopLogger(), cfg)
+	defer node.Stop()
+
+	rpc, err := rpcclient.NewHTTPClient(remote)
+	require.NoError(t, err)
+	client := gnoclient.Client{Signer: signer, RPCClient: rpc}
+
+	park := func(t *testing.T, mpkg *std.MemPackage) {
+		t.Helper()
+		tx := std.Tx{
+			Msgs: []std.Msg{vm.MsgAddPackage{Creator: who, Package: mpkg}},
+			Fee:  std.NewFee(20_000_000, std.MustParseCoin("1000000ugnot")),
+		}
+		signed, err := client.SignTx(tx, 0, 0)
+		require.NoError(t, err)
+		res, err := client.BroadcastTxCommit(signed)
+		require.NoError(t, err)
+		require.True(t, res.CheckTx.IsOK(), "park checkTx: %v", res.CheckTx.Error)
+		require.True(t, res.DeliverTx.IsOK(), "park deliverTx: %v", res.DeliverTx.Error)
+	}
+
+	const badPath = "gno.land/r/test/tollbad"
+	bad := &std.MemPackage{
+		Name: "tollbad",
+		Path: badPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gno.GenGnoModLatest(badPath)},
+			{Name: "tollbad.gno", Body: "package tollbad\n\nfunc init() { panic(\"never enables\") }\n\nfunc F(cur realm) {}\n"},
+		},
+	}
+	const goodPath = "gno.land/r/test/tollgood"
+	good := &std.MemPackage{
+		Name: "tollgood",
+		Path: goodPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gno.GenGnoModLatest(goodPath)},
+			{Name: "tollgood.gno", Body: "package tollgood\n\nfunc F(cur realm) string { return \"ok\" }\n"},
+		},
+	}
+	park(t, bad)
+	park(t, good)
+
+	ocfg := config{
+		remote:       remote,
+		chainID:      cfg.Genesis.ChainID,
+		mnemonic:     integration.DefaultAccount_Seed,
+		gnoRoot:      gnoroot,
+		gasFee:       defaultGasFee,
+		gasWanted:    defaultGasWanted,
+		verifyBudget: time.Minute,
+	}
+	o, err := newOracle(ocfg, testIO(t))
+	require.NoError(t, err)
+	o.blockMaxGas = o.queryBlockMaxGas(t.Context())
+
+	// Verified clean, refused at simulate, nothing broadcast: the counter must
+	// not move, because the money did not.
+	o.handleCandidate(t.Context(), bad)
+	badStatus := o.status.get(badPath)
+	require.Equal(t, statusPending, badStatus.Status)
+	require.Contains(t, badStatus.Reason, "simulate says the enable would fail",
+		"the arm has to reach the simulate refusal, not stop earlier at verification")
+	require.Zero(t, o.spent,
+		"no transaction was broadcast and the ante charged nothing; the counter disagrees with the money")
+
+	// Control arm: a broadcast approval costs exactly one fee, counted at the
+	// send.
+	o.handleCandidate(t.Context(), good)
+	assert.Equal(t, o.enableFee, o.spent,
+		"a broadcast approval must be counted, whether or not it succeeds -- the ante charges for it")
+	assert.Equal(t, statusApproved, o.status.get(goodPath).Status)
+}
+
+// TestSpentIsRefundedWhenCheckTxRejects covers the other half of the same rule:
+// the debit is taken before BroadcastTxCommit, so the one failure that costs
+// nothing has to give it back.
+//
+// CheckTx runs the ante handler and aborts on the first refusal, before the fee
+// is deducted, and the transaction never enters a block -- nothing was charged.
+// A DeliverTx failure did run in a block and was charged, so it stays counted,
+// and so does a transport error, which may have committed with the answer lost.
+// Only the CheckTx arm is refunded, and an unrefunded one walks the counter away
+// from the balance one rejection at a time.
+//
+// The rejection is provoked with a gas fee of 1ugnot against this chain's block
+// gas price of 1ugnot per 1000 gas. Simulate skips two of the ante handler's
+// checks -- the mempool fee and the signature -- but RequireSigForSimulate puts
+// the signature back for MsgEnablePackage (tm2/pkg/sdk/auth/ante.go), leaving
+// the fee as the only gate this transaction clears at simulate and fails at
+// CheckTx: the arm under test, without contriving anything else.
+func TestSpentIsRefundedWhenCheckTxRejects(t *testing.T) {
+	gnoroot := gnoenv.RootDir()
+	cfg := integration.TestingMinimalNodeConfig(gnoroot)
+	cfg.SkipGenesisSigVerification = true
+
+	signer, err := gnoclient.SignerFromBip39(
+		integration.DefaultAccount_Seed, cfg.Genesis.ChainID, "", 0, 0)
+	require.NoError(t, err)
+	info, err := signer.Info()
+	require.NoError(t, err)
+	who := info.GetAddress()
+
+	ggs := cfg.Genesis.AppState.(gnoland.GnoGenesisState)
+	ggs.Balances = []gnoland.Balance{{
+		Address: who,
+		Amount:  std.NewCoins(std.NewCoin("ugnot", 100_000_000_000)),
+	}}
+	ggs.VM.Params.CodeSubmissionPolicy = "inert"
+	ggs.VM.Params.PkgApprovers = []crypto.Address{who}
+	cfg.Genesis.AppState = ggs
+
+	node, remote := integration.TestingInMemoryNode(t, log.NewNoopLogger(), cfg)
+	defer node.Stop()
+
+	rpc, err := rpcclient.NewHTTPClient(remote)
+	require.NoError(t, err)
+	client := gnoclient.Client{Signer: signer, RPCClient: rpc}
+
+	const pkgPath = "gno.land/r/test/tollrefund"
+	mpkg := &std.MemPackage{
+		Name: "tollrefund",
+		Path: pkgPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gno.GenGnoModLatest(pkgPath)},
+			{Name: "tollrefund.gno", Body: "package tollrefund\n\nfunc F(cur realm) string { return \"ok\" }\n"},
+		},
+	}
+	addTx := std.Tx{
+		Msgs: []std.Msg{vm.MsgAddPackage{Creator: who, Package: mpkg}},
+		Fee:  std.NewFee(20_000_000, std.MustParseCoin("1000000ugnot")),
+	}
+	signedAdd, err := client.SignTx(addTx, 0, 0)
+	require.NoError(t, err)
+	addRes, err := client.BroadcastTxCommit(signedAdd)
+	require.NoError(t, err)
+	require.True(t, addRes.CheckTx.IsOK(), "park checkTx: %v", addRes.CheckTx.Error)
+	require.True(t, addRes.DeliverTx.IsOK(), "park deliverTx: %v", addRes.DeliverTx.Error)
+
+	ocfg := config{
+		remote:   remote,
+		chainID:  cfg.Genesis.ChainID,
+		mnemonic: integration.DefaultAccount_Seed,
+		gnoRoot:  gnoroot,
+		// Underpriced on purpose: one ugnot for a whole enable, on a chain that
+		// asks one per 1000 gas.
+		gasFee:       "1ugnot",
+		gasWanted:    defaultGasWanted,
+		verifyBudget: time.Minute,
+	}
+	o, err := newOracle(ocfg, testIO(t))
+	require.NoError(t, err)
+	o.blockMaxGas = o.queryBlockMaxGas(t.Context())
+
+	before, _, err := client.QueryBalance(who)
+	require.NoError(t, err)
+
+	o.handleCandidate(t.Context(), mpkg)
+
+	status := o.status.get(pkgPath)
+	require.Equal(t, statusPending, status.Status)
+	require.Contains(t, status.Reason, "broadcast:",
+		"the arm has to reach BroadcastTxCommit; an earlier return leaves the counter alone for another reason")
+
+	after, _, err := client.QueryBalance(who)
+	require.NoError(t, err)
+	require.Equal(t, before, after,
+		"the refusal has to be CheckTx's: a DeliverTx failure would have run in a block and been charged")
+	assert.Zero(t, o.spent,
+		"the ante deducted nothing, so the debit taken before the broadcast has to be given back")
+}
+
+// TestBroadcastWasFree covers the discriminator neither test above can reach:
+// which broadcast outcome gives the debit back.
+//
+// The node tests each exercise one arm, and both stay green if the rule is
+// widened to "always refund" -- neither one distinguishes the outcomes it does
+// not provoke. All four are named here, without a chain.
+func TestBroadcastWasFree(t *testing.T) {
+	refused := abci.StringError("insufficient fee")
+
+	for _, tc := range []struct {
+		name string
+		res  *ctypes.ResultBroadcastTxCommit
+		want bool
+	}{
+		{
+			// The dangerous one. gnoclient.BroadcastTxCommit returns no result
+			// for a lost answer and for every pre-mempool refusal alike, and a
+			// refusal that never reached a block cannot be told apart from one
+			// that may have committed, so the fee stays counted.
+			name: "nothing came back",
+			want: false,
+		},
+		{
+			name: "CheckTx refused it before any block",
+			res: &ctypes.ResultBroadcastTxCommit{
+				CheckTx: abci.ResponseCheckTx{ResponseBase: abci.ResponseBase{Error: refused}},
+			},
+			want: true,
+		},
+		{
+			name: "DeliverTx failed inside a block",
+			res: &ctypes.ResultBroadcastTxCommit{
+				DeliverTx: abci.ResponseDeliverTx{ResponseBase: abci.ResponseBase{Error: refused}},
+			},
+			want: false,
+		},
+		{
+			name: "it committed",
+			res:  &ctypes.ResultBroadcastTxCommit{Height: 42},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, broadcastWasFree(tc.res))
+		})
+	}
+}
+
+// testIO builds a quiet commands.IO with real (non-nil) writers, which the
+// child-teeing path in verify() requires.
+func testIO(t *testing.T) commands.IO {
+	t.Helper()
+	tio := commands.NewTestIO()
+	tio.SetOut(commands.WriteNopCloser(io.Discard))
+	tio.SetErr(commands.WriteNopCloser(io.Discard))
+	return tio
+}

--- a/contribs/gpao/spenddebit_test.go
+++ b/contribs/gpao/spenddebit_test.go
@@ -99,13 +99,14 @@ func TestSpentMovesOnlyWhenATransactionIsSent(t *testing.T) {
 	park(t, good)
 
 	ocfg := config{
-		remote:       remote,
-		chainID:      cfg.Genesis.ChainID,
-		mnemonic:     integration.DefaultAccount_Seed,
-		gnoRoot:      gnoroot,
-		gasFee:       defaultGasFee,
-		gasWanted:    defaultGasWanted,
-		verifyBudget: time.Minute,
+		remote:        remote,
+		chainID:       cfg.Genesis.ChainID,
+		mnemonic:      integration.DefaultAccount_Seed,
+		gnoRoot:       gnoroot,
+		gasFee:        defaultGasFee,
+		gasWanted:     defaultGasWanted,
+		verifyBudget:  time.Minute,
+		prepareBudget: defaultPrepareBudget,
 	}
 	o, err := newOracle(ocfg, testIO(t))
 	require.NoError(t, err)
@@ -201,9 +202,10 @@ func TestSpentIsRefundedWhenCheckTxRejects(t *testing.T) {
 		gnoRoot:  gnoroot,
 		// Underpriced on purpose: one ugnot for a whole enable, on a chain that
 		// asks one per 1000 gas.
-		gasFee:       "1ugnot",
-		gasWanted:    defaultGasWanted,
-		verifyBudget: time.Minute,
+		gasFee:        "1ugnot",
+		gasWanted:     defaultGasWanted,
+		verifyBudget:  time.Minute,
+		prepareBudget: defaultPrepareBudget,
 	}
 	o, err := newOracle(ocfg, testIO(t))
 	require.NoError(t, err)

--- a/contribs/gpao/spenddebit_test.go
+++ b/contribs/gpao/spenddebit_test.go
@@ -110,7 +110,9 @@ func TestSpentMovesOnlyWhenATransactionIsSent(t *testing.T) {
 	}
 	o, err := newOracle(ocfg, testIO(t))
 	require.NoError(t, err)
-	o.blockMaxGas = o.queryBlockMaxGas(t.Context())
+	maxGas, answered := o.queryBlockMaxGas(t.Context())
+	require.True(t, answered, "a zero ceiling clamps every gas figure to zero and the enable is refused")
+	o.blockMaxGas = maxGas
 
 	// Verified clean, refused at simulate, nothing broadcast: the counter must
 	// not move, because the money did not.
@@ -209,7 +211,9 @@ func TestSpentIsRefundedWhenCheckTxRejects(t *testing.T) {
 	}
 	o, err := newOracle(ocfg, testIO(t))
 	require.NoError(t, err)
-	o.blockMaxGas = o.queryBlockMaxGas(t.Context())
+	maxGas, answered := o.queryBlockMaxGas(t.Context())
+	require.True(t, answered, "a zero ceiling clamps every gas figure to zero and the enable is refused")
+	o.blockMaxGas = maxGas
 
 	before, _, err := client.QueryBalance(who)
 	require.NoError(t, err)

--- a/misc/gnoe2e/README.md
+++ b/misc/gnoe2e/README.md
@@ -111,6 +111,10 @@ back, and last an enable by hand with no oracle running.
   the result. Submission enters through one node and the oracle works through another.
 - `patient_oracle.txtar`: losing two validators of four halts consensus while the survivors keep serving RPC. The
   oracle waits on a frozen tip without spinning, exiting or losing its place.
+- `uncollected_toll.txtar`: three packages whose `init()` panics verify clean and fail the enable at simulate. No
+  transaction reaches the chain, the run budget is untouched, and a fourth package still goes live.
+- `exhausted_purse.txtar`: `-max-spend` counts the fees the chain charges, refuses the approval that would cross the
+  bound, and a run restarted with a larger bound reaches it without paying again for what is already live.
 
 ## Limits
 

--- a/misc/gnoe2e/testdata/oracle/exhausted_purse.txtar
+++ b/misc/gnoe2e/testdata/oracle/exhausted_purse.txtar
@@ -1,0 +1,102 @@
+# -max-spend bounds a run by the fees the chain actually charges, and a run
+# restarted with a larger bound picks up what the bound refused without paying
+# again for what is already live. The oracle signs every approval with one hot
+# key, and this bound is the only thing standing between a misbehaving run and
+# that key's whole balance.
+#
+# Every number below is read off the chain. The approver starts a run with
+# 1000000000ugnot, an approval costs the gas fee whole, since the ante deducts
+# tx.Fee.GasFee rather than metering it, and the default fee is 1000000ugnot.
+# Two approvals therefore leave exactly 998000000ugnot, and that figure is the
+# scenario: it is the difference between a bound that counts and a bound that
+# bills.
+
+# ---- Two approvals the chain really charges for
+gpao start -start-height 1 -max-spend 2000000ugnot
+
+# The opening balance is asserted rather than assumed, because every figure
+# after it is this one minus a known number of fees. If provisioning ever funds
+# the approver differently, this line says so instead of the later ones failing
+# with arithmetic that looks wrong.
+gnokey query bank/balances/$GPAO_ADDR
+stdout 'data: "1000000000ugnot"'
+
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/one -pkgpath gno.land/r/purse/one $USER_NAME
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/two -pkgpath gno.land/r/purse/two $USER_NAME
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/three -pkgpath gno.land/r/purse/three $USER_NAME
+
+# The wait goes on "two" and "one" is then a one-shot read. runVerifier drains
+# one candidate queue one package at a time, in the order the blocks committed,
+# so "two" being live proves "one" was decided before it.
+eventually gnokey query vm/qrender -data 'gno.land/r/purse/two:x'
+stdout 'two'
+gnokey query vm/qrender -data 'gno.land/r/purse/one:x'
+stdout 'one'
+
+# ---- The bound bites a package nothing is wrong with
+# It is refused because the bound is checked before the approval is attempted,
+# and two debits of the fee have already landed on it exactly.
+eventually http_get $GPAO_STATUS/status/gno.land/r/purse/three '"status":"blocked"'
+
+# The bound billed. Two approvals reached the chain, the ante charged each of
+# them a whole gas fee, and the approver is down by precisely that.
+gnokey query bank/balances/$GPAO_ADDR
+stdout 'data: "998000000ugnot"'
+
+gnokey query vm/qinertpaths -data ''
+stdout 'gno.land/r/purse/three'
+
+# ---- Raising the bound reaches what it refused
+# A blocked package is never recorded as seen, so a run started again over the
+# same heights reaches it a second time; nothing has to be resubmitted and no
+# height has to be worked out by hand.
+gpao stop
+gpao start -start-height 1 -max-spend 9000000ugnot
+
+eventually gnokey query vm/qrender -data 'gno.land/r/purse/three:x'
+stdout 'three'
+
+# Exactly one more fee. The rescan passed back over two live packages and
+# isActive skipped both without spending, which is what keeps restarting an
+# oracle from costing a fee per package it has already approved.
+gnokey query bank/balances/$GPAO_ADDR
+stdout 'data: "997000000ugnot"'
+
+http_get $GPAO_STATUS/status/gno.land/r/purse/one
+stdout '"reason":"already active on-chain"'
+
+-- cluster --
+validators: 1
+code-submission-policy: inert
+-- one/gnomod.toml --
+module = "gno.land/r/purse/one"
+gno = "0.9"
+
+-- one/one.gno --
+package one
+
+func Render(path string) string {
+	return "one"
+}
+
+-- two/gnomod.toml --
+module = "gno.land/r/purse/two"
+gno = "0.9"
+
+-- two/two.gno --
+package two
+
+func Render(path string) string {
+	return "two"
+}
+
+-- three/gnomod.toml --
+module = "gno.land/r/purse/three"
+gno = "0.9"
+
+-- three/three.gno --
+package three
+
+func Render(path string) string {
+	return "three"
+}

--- a/misc/gnoe2e/testdata/oracle/uncollected_toll.txtar
+++ b/misc/gnoe2e/testdata/oracle/uncollected_toll.txtar
@@ -1,0 +1,123 @@
+# The run budget counts an approval when the transaction is handed to the node.
+# A candidate the oracle refuses before that point leaves the budget untouched,
+# so well-formed packages submitted afterwards are still approved.
+#
+# What makes this reachable with an ordinary submission is that the two stages
+# disagree about init(). gpao's verifier preprocesses rather than executes, so a
+# package whose init() panics passes verification; EnablePackage runs init() at
+# activation, so the enable fails at simulate every time. handleCandidate
+# reaches a verdict on such a package without a transaction existing, which is
+# the shape of every refusal that costs nothing.
+#
+# The bound below is three times the default -gas-fee, so a run that counted
+# those three refusals would land exactly on it and refuse a fourth package
+# outright. The fourth going live is what says the count follows the money.
+
+gpao start -start-height 1 -max-spend 3000000ugnot
+
+# Compared against itself at the end rather than against a literal, because
+# what this proves is that nothing moved, and the figure it started from does
+# not matter to that.
+gnokey query bank/balances/$GPAO_ADDR
+cp stdout balance-before.txt
+
+# ---- Three packages that verify clean and die at simulate
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/boom1 -pkgpath gno.land/r/probe/boom1 $USER_NAME
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/boom2 -pkgpath gno.land/r/probe/boom2 $USER_NAME
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/boom3 -pkgpath gno.land/r/probe/boom3 $USER_NAME
+
+# gpao drains one candidate queue on one verifier goroutine, so boom3 reaching a
+# terminal verdict proves boom1 and boom2, queued strictly earlier, have already
+# been decided too.
+#
+# "pending" is terminal here: recordEnableFailure leaves the content unseen
+# until the enable-attempt count runs out, and nothing in this script resolves
+# it further. Neither verdict has a chain-state equivalent to poll, since
+# nothing happens on chain for either, so this uses the body-gated http_get
+# form rather than a chain read.
+eventually http_get $GPAO_STATUS/status/gno.land/r/probe/boom3 '"status":"pending"'
+
+# WHICH "pending", pinned directly. statusPending is also written when the
+# verifier is unavailable and when verification runs out of time, and neither of
+# those reaches a broadcast either; only the enable-failure branch records the
+# error enable() returned, which for a package whose init() panics is
+# simulate's. One-shot: the gated wait above already proved the record settled,
+# and http_get succeeds on any HTTP 200 regardless of body, so retrying this
+# would poll nothing.
+http_get $GPAO_STATUS/status/gno.land/r/probe/boom3
+stdout '"reason":"simulate says the enable would fail'
+
+# ---- Nothing reached the chain
+# The balance did not move, so no transaction for any of the three ever reached
+# BroadcastTxCommit and the ante handler never ran.
+gnokey query bank/balances/$GPAO_ADDR
+cp stdout balance-after.txt
+cmp balance-before.txt balance-after.txt
+
+# All three are still parked, which is also where the inert policy this cluster
+# declares is read back: on a chain that activated submissions directly there
+# would be nothing awaiting an approver.
+gnokey query vm/qinertpaths -data ''
+stdout 'gno.land/r/probe/boom1'
+stdout 'gno.land/r/probe/boom2'
+stdout 'gno.land/r/probe/boom3'
+
+# ---- The budget was never touched
+# Nothing is wrong with this package, and three refusals sit behind it. It goes
+# live, so the bound was still whole when it arrived: an approval that was never
+# broadcast was never counted.
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/fourth -pkgpath gno.land/r/probe/fourth $USER_NAME
+eventually gnokey query vm/qrender -data 'gno.land/r/probe/fourth:x'
+stdout 'fourth'
+
+# The board agrees, which separates "the chain has it" from "the oracle put it
+# there". A one-shot read: the render above cannot answer until the enable has
+# committed, and the board records the approval on the same return.
+eventually http_get $GPAO_STATUS/status/gno.land/r/probe/fourth '"status":"approved"'
+
+-- cluster --
+validators: 1
+code-submission-policy: inert
+-- boom1/gnomod.toml --
+module = "gno.land/r/probe/boom1"
+gno = "0.9"
+
+-- boom1/boom1.gno --
+package boom1
+
+func init() {
+	panic("boom1")
+}
+
+-- boom2/gnomod.toml --
+module = "gno.land/r/probe/boom2"
+gno = "0.9"
+
+-- boom2/boom2.gno --
+package boom2
+
+func init() {
+	panic("boom2")
+}
+
+-- boom3/gnomod.toml --
+module = "gno.land/r/probe/boom3"
+gno = "0.9"
+
+-- boom3/boom3.gno --
+package boom3
+
+func init() {
+	panic("boom3")
+}
+
+-- fourth/gnomod.toml --
+module = "gno.land/r/probe/fourth"
+gno = "0.9"
+
+-- fourth/fourth.gno --
+package fourth
+
+func Render(path string) string {
+	return "fourth"
+}


### PR DESCRIPTION
An oracle running with `-max-spend` can stop approving for lack of budget while holding every coin it started with.

Each candidate that verifies clean but fails the enable's simulate burns one fee's worth of allowance without a transaction existing. Enough of them exhaust the bound, and well-formed packages submitted afterwards are refused as `blocked`. Verification preprocesses rather than executes, so a package whose `init()` panics is exactly this shape: clean at verify, dead at simulate.

### The counter moved before the money could

`handleCandidate` ran [`o.spent += o.enableFee`](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/contribs/gpao/oracle.go#L533) before calling `enable()`, and `enable()` has four returns that broadcast nothing.

The sharpest is `verdictWillFail`, whose own comment declines to pay for a rejection the node already gave: no `BroadcastTxCommit`, no transaction, nothing for the ante to charge.

The comment above the debit claimed "a failed approval costs exactly as much as a successful one". That is true for a transaction that reaches the chain, and wrong for the one path where none does.

### What each outcome costs now

The debit sits immediately before `BroadcastTxCommit`.

| Outcome | Allowance | Why |
|---|---|---|
| Returns before the broadcast | nothing | no transaction exists |
| CheckTx rejects | debited, then refunded | never entered a block, so the ante charged nothing |
| DeliverTx fails | debited, kept | ran in a block and the ante charged for it |
| Returns with no result | debited, kept | a refusal that never reached a block cannot be told apart from one that may have committed |

The last row is wider than a transport error: mempool-full, tx-too-large and already-in-cache all return no result too, and are known to be free. Over-counting them is the safe half of a guess the client does not let the oracle make.

### Left alone

- `wouldExceedSpend` still runs before the enable, so the bound stops the oracle one approval early rather than one late.
- A DeliverTx failure still costs one fee.
- `spent` is not exposed anywhere new; the status board's `blocked` reason reads as before.

`README.md`'s `--max-spend` section said "Every approval costs the full gas fee, whether or not the message succeeds". It now says "every approval that reaches a block", which is what the code does.

Other gpao defects and the design questions behind them: #6113.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
