### PR TITLE
fix(gpao): stop reporting a parked redeploy as already active

### DIFF
--- a/contribs/gpao/README.md
+++ b/contribs/gpao/README.md
@@ -218,10 +218,10 @@ daemon decides on its own when to send one, so anything that makes approvals
 fail repeatedly will drain the approver key. The bound stops that.
 
 Two things reduce how often it is reached. Before approving, the daemon checks
-whether the package is already deployed and skips it if so, which is the common
-case when catching up with `--start-height` over blocks that were already
-approved. And it ignores transactions that failed on chain, so a submission the
-chain rejected never leads to an approval.
+whether the package is already live with nothing waiting to be enabled, and
+skips it if so, which is the common case when catching up with `--start-height`
+over blocks that were already approved. And it ignores transactions that
+failed on chain, so a submission the chain rejected never leads to an approval.
 
 When the bound is reached the daemon says so and stops approving. It keeps
 watching blocks. Raise the bound or restart to continue.

--- a/contribs/gpao/issettled_test.go
+++ b/contribs/gpao/issettled_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/integration"
+	vm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// privateGnoMod is a gnomod.toml marking the package a PRIVATE realm.
+//
+// GenGnoModLatest ends its last line without a newline, so the marker supplies
+// its own separator; gnomod.ParseMemPackage in the keeper is what has to accept
+// the result.
+func privateGnoMod(path string) string {
+	return gno.GenGnoModLatest(path) + "\nprivate = true\n"
+}
+
+// TestRedeployParkedOverLivePrivateRealmIsEnabled pins the pre-flight to what
+// the chain can actually hold at a path.
+//
+// AddPackage refuses to park over a live PUBLIC package but allows it for a
+// PRIVATE one, so "live" and "has a submission pending" coexist. vm/qfile
+// reads the live store only; a pre-flight built on it reports the parked
+// redeploy as already active, records SUCCESS, and silently drops it. The
+// chain ships vm/qpkgmeta_json for exactly this: its Pending field is true for
+// a live private realm with a redeploy parked over it.
+func TestRedeployParkedOverLivePrivateRealmIsEnabled(t *testing.T) {
+	gnoroot := gnoenv.RootDir()
+	cfg := integration.TestingMinimalNodeConfig(gnoroot)
+	cfg.SkipGenesisSigVerification = true
+
+	signer, err := gnoclient.SignerFromBip39(
+		integration.DefaultAccount_Seed, cfg.Genesis.ChainID, "", 0, 0)
+	require.NoError(t, err)
+	info, err := signer.Info()
+	require.NoError(t, err)
+	who := info.GetAddress()
+
+	// The chain runs "inert" and trusts this one key to approve.
+	ggs := cfg.Genesis.AppState.(gnoland.GnoGenesisState)
+	ggs.Balances = []gnoland.Balance{{
+		Address: who,
+		Amount:  std.NewCoins(std.NewCoin("ugnot", 100_000_000_000)),
+	}}
+	ggs.VM.Params.CodeSubmissionPolicy = "inert"
+	ggs.VM.Params.PkgApprovers = []crypto.Address{who}
+	cfg.Genesis.AppState = ggs
+
+	node, remote := integration.TestingInMemoryNode(t, log.NewNoopLogger(), cfg)
+	defer node.Stop()
+
+	rpc, err := rpcclient.NewHTTPClient(remote)
+	require.NoError(t, err)
+	client := gnoclient.Client{Signer: signer, RPCClient: rpc}
+
+	parkPrivate := func(t *testing.T, mpkg *std.MemPackage) {
+		t.Helper()
+		signed, err := client.SignTx(std.Tx{
+			Msgs: []std.Msg{vm.MsgAddPackage{Creator: who, Package: mpkg}},
+			Fee:  std.NewFee(20_000_000, std.MustParseCoin("1000000ugnot")),
+		}, 0, 0)
+		require.NoError(t, err)
+		res, err := client.BroadcastTxCommit(signed)
+		require.NoError(t, err)
+		require.True(t, res.CheckTx.IsOK(), "park checkTx: %v", res.CheckTx.Error)
+		require.True(t, res.DeliverTx.IsOK(), "park deliverTx: %v", res.DeliverTx.Error)
+	}
+
+	enableAsApprover := func(t *testing.T, mpkg *std.MemPackage) {
+		t.Helper()
+		signed, err := client.SignTx(std.Tx{
+			Msgs: []std.Msg{vm.MsgEnablePackage{
+				Approver: who,
+				PkgPath:  mpkg.Path,
+				PkgHash:  vm.PackageContentHash(mpkg),
+			}},
+			Fee: std.NewFee(20_000_000, std.MustParseCoin("1000000ugnot")),
+		}, 0, 0)
+		require.NoError(t, err)
+		res, err := client.BroadcastTxCommit(signed)
+		require.NoError(t, err)
+		require.True(t, res.CheckTx.IsOK(), "enable checkTx: %v", res.CheckTx.Error)
+		require.True(t, res.DeliverTx.IsOK(), "enable deliverTx: %v", res.DeliverTx.Error)
+	}
+
+	const pkgPath = "gno.land/r/test/privrealm"
+	v1 := &std.MemPackage{
+		Name: "privrealm",
+		Path: pkgPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: privateGnoMod(pkgPath)},
+			{Name: "privrealm.gno", Body: "package privrealm\n\nfunc V(cur realm) string { return \"v1\" }\n"},
+		},
+	}
+	v2 := &std.MemPackage{
+		Name: "privrealm",
+		Path: pkgPath,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: privateGnoMod(pkgPath)},
+			{Name: "privrealm.gno", Body: "package privrealm\n\nfunc V(cur realm) string { return \"v2\" }\n"},
+		},
+	}
+
+	parkPrivate(t, v1)
+	enableAsApprover(t, v1)
+	parkPrivate(t, v2) // the chain permits this: private over private
+
+	// Real writers, not NewTestIO's nil ones: the parent tees a child's stderr
+	// through io.Err(), and a nil there is a crash the tests should surface
+	// rather than dodge.
+	tio := commands.NewTestIO()
+	tio.SetOut(commands.WriteNopCloser(io.Discard))
+	tio.SetErr(commands.WriteNopCloser(io.Discard))
+	o, err := newOracle(config{
+		remote:       remote,
+		chainID:      cfg.Genesis.ChainID,
+		mnemonic:     integration.DefaultAccount_Seed,
+		gnoRoot:      gnoroot,
+		gasFee:       defaultGasFee,
+		gasWanted:    defaultGasWanted,
+		verifyBudget: time.Minute,
+	}, tio)
+	require.NoError(t, err)
+	o.blockMaxGas = o.queryBlockMaxGas(t.Context())
+
+	o.handleCandidate(t.Context(), v2)
+
+	st := o.status.get(pkgPath)
+	require.NotEqual(t, "already active on-chain", st.Reason,
+		"the redeploy was parked, not live; reporting success without enabling silently drops it")
+	require.Equal(t, statusApproved, st.Status, "status board: %+v", st)
+
+	// The proof that an enable was actually sent: the chain now serves v2.
+	res, err := client.Query(gnoclient.QueryCfg{
+		Path: "vm/qfile",
+		Data: []byte(pkgPath + "/privrealm.gno"),
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Response.Error)
+	assert.Contains(t, string(res.Response.Data), "v2",
+		"the live blob must be the redeploy, not the original")
+}
+
+// TestPkgMetaSettled covers the three answers vm/qpkgmeta_json can give and
+// the two failure shapes, without a node.
+func TestPkgMetaSettled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"live with nothing pending: settled", `{"path":"p","status":"live"}`, true},
+		{"live with a redeploy parked: NOT settled", `{"path":"p","status":"live","pending":true}`, false},
+		{"inert: not settled", `{"path":"p","status":"inert","pending":true}`, false},
+		{"absent: not settled", `{"path":"p","status":"absent"}`, false},
+		{"garbage: not settled, so the oracle still tries", `{`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pkgMetaSettled([]byte(tc.data)))
+		})
+	}
+}

--- a/contribs/gpao/oracle.go
+++ b/contribs/gpao/oracle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -498,11 +499,11 @@ func (o *oracle) handleCandidate(ctx context.Context, mpkg *std.MemPackage) {
 		return
 	}
 
-	// Already live? Then there is nothing to enable, and sending the message
-	// anyway costs the full fee to be told so. This is the common case when
-	// catching up with -start-height over blocks that were already approved.
-	// Terminal, so recorded.
-	if o.isActive(ctx, path) {
+	// Live with nothing waiting to be enabled? Then there is nothing to enable,
+	// and sending the message anyway costs the full fee to be told so. This is
+	// the common case when catching up with -start-height over blocks that were
+	// already approved. Terminal, so recorded.
+	if o.isSettled(ctx, path) {
 		o.status.record(path, statusApproved, "already active on-chain", 0)
 		o.seen[key] = struct{}{}
 		o.logf("gpao: %q is already active, nothing to approve", path)
@@ -619,24 +620,46 @@ func (o *oracle) wouldExceedSpend() bool {
 
 const ugnotDenom = "ugnot"
 
-// isActive reports whether a package is already deployed at this path.
+// isSettled reports whether a package is live at this path with nothing left to
+// enable.
 //
-// vm/qfile reads the active store, so a successful answer means the path is
-// live. A parked package is invisible to it, which is what makes this a useful
-// pre-flight: it distinguishes "waiting to be enabled" from "already enabled".
+// vm/qpkgmeta_json reads BOTH key spaces, unlike vm/qfile, which answers for
+// the live blob only. The difference is a redeploy parked over a live PRIVATE
+// realm -- a state the chain permits -- which qfile cannot see: a pre-flight
+// built on it records SUCCESS for an enable that was never sent, and the
+// redeploy is silently dropped.
+//
+// A PUBLIC path can be live-and-pending too, by a longer route: parked under
+// "inert", the policy moves to permissionless, someone deploys at the path, the
+// policy moves back. That enable can never succeed -- EnablePackage refuses to
+// activate over a live public package. The classifier needs no special case for
+// it: reporting "not settled" sends the enable, and maxEnableAttempts bounds
+// what the dead end costs.
 //
 // On a query error this returns false, so a node that cannot answer does not
 // silently stop the oracle approving. The spend bound is what limits the damage
 // if the node is wrong.
-func (o *oracle) isActive(ctx context.Context, pkgPath string) bool {
+func (o *oracle) isSettled(ctx context.Context, pkgPath string) bool {
 	res, err := o.client.Query(gnoclient.QueryCfg{
-		Path: "vm/qfile",
+		Path: "vm/qpkgmeta_json",
 		Data: []byte(pkgPath),
 	})
-	if err != nil || res == nil {
+	if err != nil || res == nil || res.Response.Error != nil {
 		return false
 	}
-	return res.Response.Error == nil
+	return pkgMetaSettled(res.Response.Data)
+}
+
+// pkgMetaSettled reads a vm/qpkgmeta_json response and reports "live with no
+// submission pending" -- the one state where an enable has nothing to do.
+// Split out from the query so it can be tested without a node, like
+// blockMaxGasFrom.
+func pkgMetaSettled(data []byte) bool {
+	var meta vm.PackageMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return false
+	}
+	return meta.Status == vm.PackageStatusLive && !meta.Pending
 }
 
 // candidateKey identifies what was verified: the path plus a hash of the


### PR DESCRIPTION
The oracle silently drops a redeploy of a live private realm. The status board reports `approved` with reason "already active on-chain", and no `MsgEnablePackage` is ever sent. The submitter paid the submission charge and the chain holds their redeploy parked.

### The pre-flight cannot see the state it rules on

The chain permits exactly this state: [`AddPackage`](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gno.land/pkg/sdk/vm/keeper.go#L730) refuses to park over a live package only when the live one is public, so a private realm can be live and have a submission parked over it.

gpao's pre-flight probes `vm/qfile`, which reads the live key space only. The parked redeploy is invisible there, so `isActive` answers true and `handleCandidate` records success for an enable it never sent.

`vm/qpkgmeta_json` reads both key spaces, and its [`Pending` field's doc](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gno.land/pkg/sdk/vm/keeper_inert.go#L496-L503) names exactly this case: a live private realm with a redeploy parked over it.

### Only "live with nothing pending" counts as settled

The pre-flight now asks `vm/qpkgmeta_json`. Three answers are not settled:

- a query error
- a response error
- unparsable data

That preserves the old fail-open posture: a node that cannot answer must not stop the oracle approving, and `-max-spend` bounds the damage if it answers wrongly.

### What this costs

The pre-flight does not become content-aware. It stays path-scoped while the enable carries the candidate's content hash.

Replaying old blocks can now offer a stale candidate at a path whose parked bytes are newer. The old code skipped it free; the new code attempts the enable. The simulate pre-check catches the hash mismatch and nothing is broadcast, so no fee is paid unless the node cannot simulate and gpao falls back to broadcasting blind, in which case the ante charges for a transaction the chain then refuses. The attempt consumes an enable-retry slot, spend allowance until the max-spend debit moves to the broadcast (#6111), and records the path as `pending` with the chain's "it changed after review" reason on a realm nothing is wrong with.

The alternative was reporting success for work never done.

The test asserts the chain serves v2's body afterwards, so a pass cannot come from the status board alone.

Other gpao defects and the design questions behind them: #6113.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
