### PR TITLE
fix(gpao): a resolver fault is unavailability, not a bad package

### DIFF
--- a/contribs/gpao/README.md
+++ b/contribs/gpao/README.md
@@ -123,6 +123,14 @@ budget be *enforced* — a goroutine cannot be killed, but a process can. It als
 means a package that crashes the typechecker takes down only its own child, and
 that the approver key is never loaded in the process handling untrusted code.
 
+The budget starts once the child has everything the compile needs: the standard
+library and examples from disk, and every chain package the candidate imports,
+fetched from the node. Fetching is the oracle's cost, not the package's, so a
+slow node cannot turn a fast package into an overrun. That phase has a ceiling
+of its own, one minute, and each request to the node is given the budget as its
+timeout; either expiring leaves the package pending as unavailable rather than
+counting against it.
+
 The child's type-check options mirror `MsgEnablePackage`'s exactly (production
 files only, no test-file evaluation), because the whole point is to predict what
 the validator will do — any divergence is a way to approve something the chain

--- a/contribs/gpao/README.md
+++ b/contribs/gpao/README.md
@@ -71,6 +71,7 @@ set (for unattended/service deployments), otherwise prompts once interactively.
 | `--poll-interval` | `1s` | How often to poll for new blocks |
 | `--start-height` | `0` | Height to start watching from (0 = current tip) |
 | `--verify-budget` | `10s` | Withhold approval from a package that takes longer than this to verify |
+| `--prepare-budget` | `1m` | How long the verifier may take to fetch a package's imports from the node before verification starts |
 | `--status-listen` | *(off)* | Address to serve the read-only status API on, e.g. `127.0.0.1:8546` |
 
 ### About `--status-listen`
@@ -126,10 +127,9 @@ that the approver key is never loaded in the process handling untrusted code.
 The budget starts once the child has everything the compile needs: the standard
 library and examples from disk, and every chain package the candidate imports,
 fetched from the node. Fetching is the oracle's cost, not the package's, so a
-slow node cannot turn a fast package into an overrun. That phase has a ceiling
-of its own, one minute, and each request to the node is given the budget as its
-timeout; either expiring leaves the package pending as unavailable rather than
-counting against it.
+slow node cannot turn a fast package into an overrun. That phase has a budget
+of its own, `--prepare-budget`, a minute by default; its expiry leaves the
+package pending as unavailable rather than counting against it.
 
 The child's type-check options mirror `MsgEnablePackage`'s exactly (production
 files only, no test-file evaluation), because the whole point is to predict what

--- a/contribs/gpao/config_test.go
+++ b/contribs/gpao/config_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigRejectsANonPositivePrepareBudget: the prepare budget bounds the
+// child until it reports ready, and zero would kill every child at spawn while
+// reporting the node as unavailable.
+func TestConfigRejectsANonPositivePrepareBudget(t *testing.T) {
+	valid := config{
+		chainID:       "test",
+		key:           "approver",
+		gnoRoot:       "/gno",
+		verifyBudget:  10 * time.Second,
+		prepareBudget: time.Minute,
+		gasWanted:     1,
+	}
+	require.NoError(t, valid.validate())
+
+	for _, budget := range []time.Duration{0, -time.Second} {
+		cfg := valid
+		cfg.prepareBudget = budget
+		err := cfg.validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "prepare-budget must be positive")
+	}
+}

--- a/contribs/gpao/getter.go
+++ b/contribs/gpao/getter.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path"
 	"strings"
 
@@ -48,6 +50,13 @@ func (h hybridGetter) GetMemPackage(pkgPath string) *std.MemPackage {
 	return h.disk.GetMemPackage(pkgPath)
 }
 
+// errResolverUnavailable reports that an import could not be resolved because
+// the node could not be ASKED -- as opposed to the node answering that nothing
+// is stored at the path. The distinction is the whole triage: the second is
+// evidence about the package, the first is evidence about the operator's
+// network, and only evidence about the package may become a verdict.
+var errResolverUnavailable = errors.New("import resolver unavailable")
+
 // qfileFunc runs a vm/qfile query for a package path or a package file path.
 type qfileFunc func(filepath string) ([]byte, error)
 
@@ -58,13 +67,17 @@ type qfileFunc func(filepath string) ([]byte, error)
 type rpcGetter struct {
 	qfile qfileFunc
 	cache map[string]*std.MemPackage
+
+	// transportErr is the first transport fault seen this verification; the
+	// child makes exactly one.
+	transportErr error
 }
 
 func newRPCGetter(client rpcclient.Client) *rpcGetter {
 	qfile := func(filepath string) ([]byte, error) {
 		qres, err := client.ABCIQuery(context.Background(), "vm/qfile", []byte(filepath))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", errResolverUnavailable, err)
 		}
 		if qres.Response.Error != nil {
 			return nil, qres.Response.Error
@@ -90,9 +103,11 @@ func (g *rpcGetter) GetMemPackage(pkgPath string) *std.MemPackage {
 
 // fetch queries vm/qfile for the package's file list, then each file's body,
 // and assembles a MemPackage. Returns nil if the package is not on-chain or any
-// query fails (the typechecker then reports the import as unresolved).
+// query fails (the typechecker then reports the import as unresolved); a
+// transport failure is additionally recorded in transportErr, because it is not
+// evidence about the import.
 func (g *rpcGetter) fetch(pkgPath string) *std.MemPackage {
-	list, err := g.qfile(pkgPath)
+	list, err := g.query(pkgPath)
 	if err != nil {
 		return nil
 	}
@@ -102,7 +117,7 @@ func (g *rpcGetter) fetch(pkgPath string) *std.MemPackage {
 		if name == "" {
 			continue
 		}
-		body, err := g.qfile(path.Join(pkgPath, name))
+		body, err := g.query(path.Join(pkgPath, name))
 		if err != nil {
 			return nil
 		}
@@ -118,6 +133,16 @@ func (g *rpcGetter) fetch(pkgPath string) *std.MemPackage {
 		Files: files,
 		Type:  gno.MPUserProd,
 	}
+}
+
+// query wraps qfile and remembers a transport fault, which is evidence
+// about the operator's network rather than about the import.
+func (g *rpcGetter) query(filepath string) ([]byte, error) {
+	body, err := g.qfile(filepath)
+	if err != nil && errors.Is(err, errResolverUnavailable) && g.transportErr == nil {
+		g.transportErr = err
+	}
+	return body, err
 }
 
 // packageName derives the package name from the first .gno file whose package

--- a/contribs/gpao/getter.go
+++ b/contribs/gpao/getter.go
@@ -7,7 +7,9 @@ import (
 	"path"
 	"strings"
 
+	vm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
@@ -77,14 +79,40 @@ func newRPCGetter(client rpcclient.Client) *rpcGetter {
 	qfile := func(filepath string) ([]byte, error) {
 		qres, err := client.ABCIQuery(context.Background(), "vm/qfile", []byte(filepath))
 		if err != nil {
+			// The node could not be reached at all.
 			return nil, fmt.Errorf("%w: %w", errResolverUnavailable, err)
 		}
-		if qres.Response.Error != nil {
-			return nil, qres.Response.Error
+		if qerr := qres.Response.Error; qerr != nil {
+			if absence(qerr) {
+				return nil, qerr
+			}
+			// The node was reached and answered about itself, not the path.
+			return nil, fmt.Errorf("%w: %w", errResolverUnavailable, qerr)
 		}
 		return qres.Response.Data, nil
 	}
 	return &rpcGetter{qfile: qfile, cache: make(map[string]*std.MemPackage)}
+}
+
+// absence reports whether an answered query said "nothing is stored at this
+// path", as opposed to saying something about the node.
+//
+// vm/qfile reports a genuine miss as exactly two types (VMKeeper.QueryFile).
+// Anything else the node answers with -- an internal error from a node that is
+// pruned, restarting or replaying and cannot load state at the height; an
+// unknown request from a build without the route -- is the node describing
+// itself, and is no more evidence about the import than an unreachable node is.
+//
+// Keyed on the type, not the text: the ABCI layer unwraps to the cause before
+// the answer leaves the node, so what arrives carries only the static "file is
+// not available" / "invalid package" and no path.
+func absence(err abci.Error) bool {
+	switch err.(type) {
+	case vm.InvalidFileError, *vm.InvalidFileError,
+		vm.InvalidPackageError, *vm.InvalidPackageError:
+		return true
+	}
+	return false
 }
 
 func (g *rpcGetter) GetMemPackage(pkgPath string) *std.MemPackage {

--- a/contribs/gpao/getter_test.go
+++ b/contribs/gpao/getter_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"path"
 	"testing"
 
@@ -87,4 +88,34 @@ func TestRPCGetterCaching(t *testing.T) {
 	callsAfterHit := calls
 	g.GetMemPackage(pkgPath)
 	assert.Equal(t, callsAfterHit, calls, "cached package must not be re-queried")
+}
+
+// TestRPCGetterSeparatesTransportFaultsFromAbsence pins the two kinds of
+// failure fetch used to collapse. "The chain answered: nothing at this path"
+// is evidence about the import; "the chain could not be asked" is evidence
+// about the operator's network -- and only the first may become a verdict.
+func TestRPCGetterSeparatesTransportFaultsFromAbsence(t *testing.T) {
+	t.Run("a fault the closure marked is remembered as no answer", func(t *testing.T) {
+		g := &rpcGetter{
+			cache: map[string]*std.MemPackage{},
+			qfile: func(string) ([]byte, error) {
+				return nil, fmt.Errorf("%w: connection refused", errResolverUnavailable)
+			},
+		}
+		require.Nil(t, g.GetMemPackage("gno.land/p/x"))
+		require.ErrorIs(t, g.transportErr, errResolverUnavailable,
+			"the getter must remember that its answer was no answer at all")
+	})
+
+	t.Run("a chain that answered 'not found' is a miss, not a fault", func(t *testing.T) {
+		g := &rpcGetter{
+			cache: map[string]*std.MemPackage{},
+			qfile: func(string) ([]byte, error) {
+				return nil, errors.New("package is not available") // the node ran the query
+			},
+		}
+		require.Nil(t, g.GetMemPackage("gno.land/p/x"))
+		require.NoError(t, g.transportErr,
+			"an import the chain genuinely lacks IS evidence about the package")
+	})
 }

--- a/contribs/gpao/main.go
+++ b/contribs/gpao/main.go
@@ -49,6 +49,14 @@ const (
 	// sources the compile needs are local, so a slow node is not the
 	// package's problem.
 	defaultVerifyBudget = 10 * time.Second
+	// defaultPrepareBudget bounds the verifier from spawn until it reports
+	// that every source the compile needs is local: process start, the disk
+	// imports, and the import closure fetched from the node. That phase is the
+	// oracle's own cost and is not the verify budget, but it cannot be left
+	// unbounded either. A minute is the RPC client's own default request
+	// timeout; a node that has not delivered the sources in that long is not
+	// answering. Expiry is unavailability, not a verdict.
+	defaultPrepareBudget = time.Minute
 )
 
 // newRootCmd builds the full command tree.
@@ -114,7 +122,9 @@ type config struct {
 	pollInterval time.Duration
 	// verifyBudget: see defaultVerifyBudget.
 	verifyBudget time.Duration
-	startHeight  int64
+	// prepareBudget: see defaultPrepareBudget.
+	prepareBudget time.Duration
+	startHeight   int64
 	// maxSpend bounds the total gas fees this run will pay for approvals. See
 	// defaultMaxSpend.
 	maxSpend string
@@ -146,6 +156,8 @@ func (c *config) RegisterFlags(fs *flag.FlagSet) {
 		"gas fee for approval transactions")
 	fs.DurationVar(&c.verifyBudget, "verify-budget", defaultVerifyBudget,
 		"withhold approval from a package whose verification exceeds this duration (it is left pending, not rejected)")
+	fs.DurationVar(&c.prepareBudget, "prepare-budget", defaultPrepareBudget,
+		"how long the verifier may take to fetch a package's imports from the node before verification starts; expiry leaves the package pending as unavailable, not as slow")
 	fs.Int64Var(&c.gasWanted, "gas-wanted", defaultGasWanted,
 		"fallback gas wanted for approval transactions, used only when the node will not simulate one (each approval is normally estimated, plus 20%, capped at the block limit)")
 	fs.DurationVar(&c.pollInterval, "poll-interval", defaultPollInterval,
@@ -166,6 +178,9 @@ func (c *config) validate() error {
 	}
 	if c.verifyBudget <= 0 {
 		return fmt.Errorf("verify-budget must be positive, got %s", c.verifyBudget)
+	}
+	if c.prepareBudget <= 0 {
+		return fmt.Errorf("prepare-budget must be positive, got %s", c.prepareBudget)
 	}
 	if c.gasWanted <= 0 {
 		return fmt.Errorf("--gas-wanted must be > 0")

--- a/contribs/gpao/main.go
+++ b/contribs/gpao/main.go
@@ -45,7 +45,9 @@ const (
 	// daemon does not refuse slow packages it only repeats a correctness
 	// check the chain already does. Generous on purpose -- a real package
 	// takes milliseconds, and borderline ones should pass rather than be
-	// rejected for losing a race with CPU contention.
+	// rejected for losing a race with CPU contention. It starts once the
+	// sources the compile needs are local, so a slow node is not the
+	// package's problem.
 	defaultVerifyBudget = 10 * time.Second
 )
 

--- a/contribs/gpao/oracle.go
+++ b/contribs/gpao/oracle.go
@@ -653,11 +653,13 @@ func candidateKey(mpkg *std.MemPackage) string {
 // simply have lost a race with whatever else the box was doing.
 var errVerifyBudget = errors.New("verify budget exceeded")
 
-// errVerifyUnavailable reports that the verifier itself could not run -- a fork
-// failure, a signal death, a missing binary. Distinguished from both a rejection
-// and an overrun: it says nothing about the package, and unlike an overrun it
-// does not count against the per-path allowance, because the operator's box
-// misbehaving is not the submitter's doing.
+// errVerifyUnavailable reports that verification could not produce evidence --
+// a fork failure, a signal death, a missing binary, or the child running fine
+// while the network under its import resolver failed. Distinguished from both
+// a rejection and an overrun: it says
+// nothing about the package, and unlike an overrun it does not count against
+// the per-path allowance, because the operator's box misbehaving is not the
+// submitter's doing.
 var errVerifyUnavailable = errors.New("verifier unavailable")
 
 // defaultBlockMaxGas is the fallback ceiling on a gas-wanted, used until the

--- a/contribs/gpao/oracle_test.go
+++ b/contribs/gpao/oracle_test.go
@@ -95,6 +95,10 @@ func newTestOracle(t *testing.T) *oracle {
 		gnoRoot:   gnoenv.RootDir(),
 		gasFee:    defaultGasFee,
 		gasWanted: defaultGasWanted,
+		// The prepare budget bounds every spawned child until it reports
+		// ready; the verify budget is set per test, since it is what most of
+		// them are about.
+		prepareBudget: defaultPrepareBudget,
 	}
 	// Real writers, not NewTestIO's nil ones: the parent tees a child's stderr
 	// through io.Err(), and a nil there is a crash the tests should surface

--- a/contribs/gpao/oracle_test.go
+++ b/contribs/gpao/oracle_test.go
@@ -344,6 +344,52 @@ func TestVerifierWithoutRemoteDoesNotPanic(t *testing.T) {
 		"a missing remote must degrade to an unresolved import, not a crash")
 }
 
+// TestUnreachableRemoteIsNotAVerdict draws the triage boundary at the
+// evidence, not the process.
+//
+// The child runs fine; the network under it fails; the typechecker reports the
+// unfetchable import as unresolved; the child exits 1 -- and the parent read
+// any non-negative exit as a verdict about the PACKAGE. handleCandidate then
+// recorded statusRejected and marked the content seen, so resubmitting
+// identical bytes was a silent no-op forever. The submitter was told their
+// code is bad because the operator's network hiccuped.
+//
+// No chain anywhere: an unreachable remote is the whole reproduction.
+func TestUnreachableRemoteIsNotAVerdict(t *testing.T) {
+	o := newTestOracle(t)
+	o.cfg.remote = "http://127.0.0.1:1" // nothing listens; connection refused, fast
+	o.cfg.verifyBudget = time.Minute
+
+	mpkg := packageImportingChainOnly()
+	err := o.verify(context.Background(), mpkg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errVerifyUnavailable,
+		"the child ran and the network under it failed; that says nothing about the package")
+	assert.ErrorContains(t, err, "import resolver unavailable")
+
+	// And the consequence the submitter feels: the content is NOT settled, so
+	// a resubmission (or a restart) gets a fresh look once the fault clears.
+	o.handleCandidate(context.Background(), mpkg)
+	assert.NotContains(t, o.seen, candidateKey(mpkg),
+		"a fault that was never about the bytes must not retire them")
+	assert.Equal(t, statusPending, o.status.get(mpkg.Path).Status)
+}
+
+// packageImportingChainOnly imports a chain path that exists nowhere on disk,
+// so with a remote configured the RPC getter is the only possible resolver.
+func packageImportingChainOnly() *std.MemPackage {
+	const path = "gno.land/r/test/needschain"
+	return &std.MemPackage{
+		Name: "needschain",
+		Path: path,
+		Type: gno.MPUserAll,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gno.GenGnoModLatest(path)},
+			{Name: "needschain.gno", Body: "package needschain\n\nimport \"gno.land/p/nobody/nothing\"\n\nfunc F(cur realm) { _ = nothing.X }\n"},
+		},
+	}
+}
+
 // TestVerifierAcceptsPackageWithTestFiles pins the package type the child uses.
 //
 // Real packages contain _test.gno files. AddPackage stamps the stored package

--- a/contribs/gpao/oracle_test.go
+++ b/contribs/gpao/oracle_test.go
@@ -32,7 +32,8 @@ const testMnemonic = "source bonus chronic canvas draft south burst lottery vaca
 // test binary's own arguments are all -test.* flags, so the only way to see
 // "verify-one" there is to have been spawned as one.
 // spinEnv puts a spawned child into an endless loop that appends a byte to the
-// named file every 20ms, instead of verifying. Only TestOracleVerifyBudgetKills
+// named file every 20ms, instead of verifying, after reporting ready the way a
+// real child does once its sources are local. Only TestOracleVerifyBudgetKills
 // sets it; production never does. It is the only way to observe whether the
 // budget actually STOPPED the work, as opposed to returning while it continued.
 const spinEnv = "GPAO_TEST_SPIN_HEARTBEAT"
@@ -63,6 +64,9 @@ func spinForever(path string) {
 	if err != nil {
 		os.Exit(2)
 	}
+	// Report ready first: the spin stands in for a compile that never ends,
+	// and the budget only starts once the child says it is compiling.
+	fmt.Println(childReadyMarker)
 	for {
 		if _, err := f.WriteString("x"); err != nil {
 			os.Exit(2)

--- a/contribs/gpao/preparephase_test.go
+++ b/contribs/gpao/preparephase_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/gno.land/pkg/integration"
+	vm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchingSourcesDoesNotSpendTheBudget: the budget measures the compile,
+// which is the cost the validator pays at enable. Fetching the import closure
+// from the node is the oracle's own cost, and a slow node must not turn a
+// package that compiles in milliseconds into an overrun.
+func TestFetchingSourcesDoesNotSpendTheBudget(t *testing.T) {
+	const dep = "gno.land/p/nt/ufmt/v0"
+	remote := nodeServing(t, dep)
+
+	// Every RPC round trip pays this. The closure is one file listing plus
+	// one query per file, so fetching it costs several times the budget below.
+	const perRequest = 800 * time.Millisecond
+	slow := httptest.NewServer(delaying(t, remote, perRequest))
+	t.Cleanup(slow.Close)
+
+	o := newTestOracle(t)
+	o.cfg.remote = slow.URL
+	o.cfg.verifyBudget = 2 * time.Second
+
+	start := time.Now()
+	err := o.verify(context.Background(), packageImporting(dep))
+	elapsed := time.Since(start)
+
+	require.Greater(t, elapsed, o.cfg.verifyBudget,
+		"premise: fetching the closure must take longer than the budget, or this test proves nothing")
+	require.NoError(t, err,
+		"the package compiles in milliseconds; the time went to fetching its dependency from a slow node, which is not what the budget measures")
+}
+
+// nodeServing starts a node with the named examples package live on it, and
+// returns its RPC address.
+func nodeServing(t *testing.T, pkgPath string) string {
+	t.Helper()
+	gnoroot := gnoenv.RootDir()
+	cfg := integration.TestingMinimalNodeConfig(gnoroot)
+	cfg.SkipGenesisSigVerification = true
+
+	signer, err := gnoclient.SignerFromBip39(
+		integration.DefaultAccount_Seed, cfg.Genesis.ChainID, "", 0, 0)
+	require.NoError(t, err)
+	info, err := signer.Info()
+	require.NoError(t, err)
+	who := info.GetAddress()
+
+	ggs := cfg.Genesis.AppState.(gnoland.GnoGenesisState)
+	ggs.Balances = []gnoland.Balance{{
+		Address: who,
+		Amount:  std.NewCoins(std.NewCoin("ugnot", 100_000_000_000)),
+	}}
+	cfg.Genesis.AppState = ggs
+
+	node, remote := integration.TestingInMemoryNode(t, log.NewNoopLogger(), cfg)
+	t.Cleanup(func() { node.Stop() })
+
+	rpc, err := rpcclient.NewHTTPClient(remote)
+	require.NoError(t, err)
+	client := gnoclient.Client{Signer: signer, RPCClient: rpc}
+
+	mpkg, err := gno.ReadMemPackage(filepath.Join(gnoroot, "examples", pkgPath), pkgPath, gno.MPUserAll)
+	require.NoError(t, err)
+	signed, err := client.SignTx(std.Tx{
+		Msgs: []std.Msg{vm.MsgAddPackage{Creator: who, Package: mpkg}},
+		Fee:  std.NewFee(50_000_000, std.MustParseCoin("1000000ugnot")),
+	}, 0, 0)
+	require.NoError(t, err)
+	res, err := client.BroadcastTxCommit(signed)
+	require.NoError(t, err)
+	require.True(t, res.CheckTx.IsOK(), "deploy %s: %v", pkgPath, res.CheckTx.Error)
+	require.True(t, res.DeliverTx.IsOK(), "deploy %s: %v", pkgPath, res.DeliverTx.Error)
+	return remote
+}
+
+// delaying proxies every request to remote after sleeping d: a node that
+// answers, slowly.
+func delaying(t *testing.T, remote string, d time.Duration) http.Handler {
+	t.Helper()
+	// The node advertises tcp://; the proxy speaks HTTP to it.
+	target, err := url.Parse(strings.Replace(remote, "tcp://", "http://", 1))
+	require.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(d):
+			proxy.ServeHTTP(w, r)
+		case <-r.Context().Done():
+		}
+	})
+}
+
+// packageImporting is a realm whose only chain import is dep.
+func packageImporting(dep string) *std.MemPackage {
+	const path = "gno.land/r/test/needsdep"
+	return &std.MemPackage{
+		Name: "needsdep",
+		Path: path,
+		Type: gno.MPUserAll,
+		Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gno.GenGnoModLatest(path)},
+			{Name: "needsdep.gno", Body: "package needsdep\n\nimport \"" + dep + "\"\n\nfunc F(cur realm) string { return ufmt.Sprintf(\"%d\", 1) }\n"},
+		},
+	}
+}

--- a/contribs/gpao/queryfault_test.go
+++ b/contribs/gpao/queryfault_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/integration"
+	vm "github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/gnovm/pkg/gnoenv"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
+	ctypes "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/log"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// answeringClient is an RPC client whose every ABCI query is answered, with the
+// given response, by a node that was reached.
+type answeringClient struct {
+	rpcclient.Client
+	resp abci.ResponseQuery
+}
+
+func (c answeringClient) ABCIQuery(context.Context, string, []byte) (*ctypes.ResultABCIQuery, error) {
+	return &ctypes.ResultABCIQuery{Response: c.resp}, nil
+}
+
+// TestNodeAnswersAboutItselfAreNotAMiss pins the line between "nothing is
+// stored at this path" and "the node could not answer". Both arrive as a
+// query error from a node that was reached; only the first is evidence about
+// the import.
+func TestNodeAnswersAboutItselfAreNotAMiss(t *testing.T) {
+	cases := map[string]struct {
+		answer          abci.Error
+		wantUnavailable bool
+	}{
+		"file is not available":            {vm.InvalidFileError{}, false},
+		"file is not available, pointer":   {&vm.InvalidFileError{}, false},
+		"package is not available":         {vm.InvalidPackageError{}, false},
+		"internal error, state unloadable": {std.InternalError{}, true},
+		"unknown request, route missing":   {std.UnknownRequestError{}, true},
+		"string error":                     {abci.StringError("failed to load state at height 12"), true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := newRPCGetter(answeringClient{resp: abci.ResponseQuery{
+				ResponseBase: abci.ResponseBase{Error: tc.answer},
+			}})
+
+			body, err := g.query("gno.land/p/nobody/nothing")
+			require.Nil(t, body)
+			require.Error(t, err)
+			assert.Equal(t, tc.wantUnavailable, errors.Is(err, errResolverUnavailable),
+				"a node saying something about itself is not evidence about the import; a node saying nothing is stored is")
+			if tc.wantUnavailable {
+				assert.ErrorIs(t, g.transportErr, errResolverUnavailable,
+					"the fault must be remembered so a failed typecheck is outranked by it")
+			} else {
+				assert.NoError(t, g.transportErr,
+					"a genuine miss records no fault, so the typecheck's verdict stands")
+			}
+		})
+	}
+}
+
+// TestGenuineMissFromARealNode pins the wire form of a miss, so the type
+// switch above matches what a node actually sends rather than what the keeper
+// constructs.
+func TestGenuineMissFromARealNode(t *testing.T) {
+	cfg := integration.TestingMinimalNodeConfig(gnoenv.RootDir())
+	cfg.SkipGenesisSigVerification = true
+	node, remote := integration.TestingInMemoryNode(t, log.NewNoopLogger(), cfg)
+	defer node.Stop()
+
+	rpc, err := rpcclient.NewHTTPClient(remote)
+	require.NoError(t, err)
+	g := newRPCGetter(rpc)
+
+	const path = "gno.land/p/nobody/nothing"
+	body, err := g.query(path)
+	require.Nil(t, body)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errResolverUnavailable,
+		"a healthy node answering that nothing is stored at %q is a verdict, not a fault: %T", path, err)
+	assert.NoError(t, g.transportErr)
+	assert.Nil(t, g.GetMemPackage(path))
+}
+
+// TestStalledRemoteIsNotABudgetOverrun: a node that accepts the connection and
+// never answers must be reported as unavailable, not as a package that ran out
+// of verification time.
+func TestStalledRemoteIsNotABudgetOverrun(t *testing.T) {
+	stall := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-stall:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(stall) })
+
+	o := newTestOracle(t)
+	o.cfg.remote = srv.URL
+	o.cfg.verifyBudget = 3 * time.Second
+
+	err := o.verify(context.Background(), packageImportingChainOnly())
+	require.ErrorIs(t, err, errVerifyUnavailable,
+		"the network under the resolver stalled; that says nothing about the package")
+	assert.NotErrorIs(t, err, errVerifyBudget,
+		"a stall must not count against the package's budget allowance, which gives up after %d", maxOverBudgetAttempts)
+}

--- a/contribs/gpao/queryfault_test.go
+++ b/contribs/gpao/queryfault_test.go
@@ -108,7 +108,10 @@ func TestStalledRemoteIsNotABudgetOverrun(t *testing.T) {
 
 	o := newTestOracle(t)
 	o.cfg.remote = srv.URL
-	o.cfg.verifyBudget = 3 * time.Second
+	// The stall is ended by the prepare budget alone: the child has no
+	// per-request timeout of its own.
+	o.cfg.prepareBudget = 3 * time.Second
+	o.cfg.verifyBudget = 10 * time.Second
 
 	err := o.verify(context.Background(), packageImportingChainOnly())
 	require.ErrorIs(t, err, errVerifyUnavailable,

--- a/contribs/gpao/readywatch_test.go
+++ b/contribs/gpao/readywatch_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadyWatchStartsTheBudgetOnTheMarker: the budget must start when the
+// child reports ready, wherever on stdout that report lands. A child that
+// writes something else first is still compiling once it has said so, and
+// leaving it under the prepare budget would time the compile against the
+// wrong bound.
+func TestReadyWatchStartsTheBudgetOnTheMarker(t *testing.T) {
+	cases := map[string]struct {
+		writes    []string
+		wantReady int
+	}{
+		"marker alone":                   {[]string{childReadyMarker + "\n"}, 1},
+		"marker split across writes":     {[]string{childReadyMarker[:5], childReadyMarker[5:] + "\n"}, 1},
+		"a stray line before the marker": {[]string{"warning: something\n", childReadyMarker + "\n"}, 1},
+		"an overlong line before it":     {[]string{strings.Repeat("x", 2*maxReadyLine) + "\n", childReadyMarker + "\n"}, 1},
+		"marker then more output":        {[]string{childReadyMarker + "\n", childReadyMarker + "\n", "more\n"}, 1},
+		"never ready":                    {[]string{"nothing\n", "here\n"}, 0},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ready := 0
+			w := &readyWatch{onReady: func() { ready++ }}
+			for _, s := range tc.writes {
+				n, err := w.Write([]byte(s))
+				require.NoError(t, err)
+				require.Equal(t, len(s), n, "a short write would make exec report the child as failed")
+			}
+			assert.Equal(t, tc.wantReady, ready, "the budget must start exactly once, on the marker")
+		})
+	}
+}

--- a/contribs/gpao/verifier.go
+++ b/contribs/gpao/verifier.go
@@ -45,10 +45,10 @@ type verifier struct {
 // Deliberately no signer and no keystore: a verifier handles untrusted input
 // and cannot approve anything, so the approver key never enters the process
 // that compiles a stranger's code.
-func newVerifier(gnoRoot, remote string, errw io.Writer) (*verifier, error) {
+func newVerifier(gnoRoot, remote string, errw io.Writer, rpcOpts ...rpcclient.Option) (*verifier, error) {
 	var rpc *rpcGetter
 	if remote != "" {
-		c, err := rpcclient.NewHTTPClient(remote)
+		c, err := rpcclient.NewHTTPClient(remote, rpcOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("build RPC client: %w", err)
 		}
@@ -179,13 +179,54 @@ func (v *verifier) preprocess(mpkg *std.MemPackage) error {
 	return nil
 }
 
+// prepare does the work verification needs that is not the package's cost:
+// the disk imports, and the chain-domain import closure fetched into the RPC
+// cache so that neither stage below asks the network again. The validator pays
+// for the typecheck and the preprocess; it never pays for the oracle's node
+// being slow. So this runs before the budget starts, and the budget then
+// measures only what the validator will.
+//
+// A transport fault is returned as such: no verdict was possible. An import
+// that nothing serves is not an error here; the typecheck judges that.
+func (v *verifier) prepare(mpkg *std.MemPackage) error {
+	_ = test.LoadImports(v.prodgs, mpkg, false)
+	if v.rpc == nil {
+		return nil
+	}
+	v.walkChainImports(mpkg, v.rpc.GetMemPackage)
+	if v.rpc.transportErr != nil {
+		return v.rpc.transportErr
+	}
+	return nil
+}
+
 // seedChainImports loads mpkg's chain-domain imports into st, transitively,
 // fetching over RPC whatever the disk store lacks. It returns the first import
 // path it could not resolve, or "" if everything resolved.
-//
-// Transitive because a fetched dependency has imports of its own, and the
-// preprocessor needs the whole graph present, not just the first level.
 func (v *verifier) seedChainImports(st gno.Store, mpkg *std.MemPackage) string {
+	return v.walkChainImports(mpkg, func(path string) *std.MemPackage {
+		if dep := v.prodgs.GetMemPackage(path); dep != nil {
+			return dep
+		}
+		if v.rpc == nil {
+			return nil
+		}
+		dep := v.rpc.GetMemPackage(path)
+		if dep != nil {
+			st.AddMemPackage(dep, gno.MPUserProd)
+		}
+		return dep
+	})
+}
+
+// walkChainImports visits mpkg's chain-domain imports transitively, resolving
+// each through resolve, and returns the first path resolve could not supply, or
+// "" if everything resolved.
+//
+// Transitive because a fetched dependency has imports of its own, and both the
+// typechecker and the preprocessor need the whole graph present, not just the
+// first level.
+func (v *verifier) walkChainImports(mpkg *std.MemPackage, resolve func(path string) *std.MemPackage) string {
 	seen := map[string]bool{mpkg.Path: true}
 	queue := []*std.MemPackage{mpkg}
 
@@ -207,15 +248,9 @@ func (v *verifier) seedChainImports(st gno.Store, mpkg *std.MemPackage) string {
 			}
 			seen[path] = true
 
-			dep := v.prodgs.GetMemPackage(path)
+			dep := resolve(path)
 			if dep == nil {
-				if v.rpc == nil {
-					return path
-				}
-				if dep = v.rpc.GetMemPackage(path); dep == nil {
-					return path
-				}
-				st.AddMemPackage(dep, gno.MPUserProd)
+				return path
 			}
 			queue = append(queue, dep)
 		}

--- a/contribs/gpao/verifier.go
+++ b/contribs/gpao/verifier.go
@@ -45,10 +45,10 @@ type verifier struct {
 // Deliberately no signer and no keystore: a verifier handles untrusted input
 // and cannot approve anything, so the approver key never enters the process
 // that compiles a stranger's code.
-func newVerifier(gnoRoot, remote string, errw io.Writer, rpcOpts ...rpcclient.Option) (*verifier, error) {
+func newVerifier(gnoRoot, remote string, errw io.Writer) (*verifier, error) {
 	var rpc *rpcGetter
 	if remote != "" {
-		c, err := rpcclient.NewHTTPClient(remote, rpcOpts...)
+		c, err := rpcclient.NewHTTPClient(remote)
 		if err != nil {
 			return nil, fmt.Errorf("build RPC client: %w", err)
 		}

--- a/contribs/gpao/verifier.go
+++ b/contribs/gpao/verifier.go
@@ -80,6 +80,11 @@ func (v *verifier) verifyPackage(mpkg *std.MemPackage) (err error) {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("verification panicked: %v", r)
 		}
+		// A failure reached while the resolver under it was failing is not a
+		// verdict: the unresolved import may exist and be unfetchable.
+		if err != nil && v.rpc != nil && v.rpc.transportErr != nil {
+			err = fmt.Errorf("%w (verification said: %w)", v.rpc.transportErr, err)
+		}
 	}()
 
 	// Best-effort preload of imports resolvable from disk (stdlibs, examples).

--- a/contribs/gpao/verifyone.go
+++ b/contribs/gpao/verifyone.go
@@ -15,7 +15,6 @@ import (
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/tm2/pkg/amino"
-	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
@@ -44,16 +43,13 @@ const verifyOneCmdName = "verify-one"
 // No signer, no keystore — a child cannot approve anything, so the approver key
 // never enters the process that compiles untrusted code.
 type verifyOneConfig struct {
-	gnoRoot    string
-	remote     string
-	rpcTimeout time.Duration
+	gnoRoot string
+	remote  string
 }
 
 func (c *verifyOneConfig) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.gnoRoot, "gno-root", "", "gno repository root")
 	fs.StringVar(&c.remote, "remote", "", "RPC address, for resolving on-chain-only imports")
-	fs.DurationVar(&c.rpcTimeout, "rpc-timeout", 0,
-		"per-request timeout on the RPC address; zero keeps the client's default")
 }
 
 func newVerifyOneCmd(io commands.IO) *commands.Command {
@@ -107,11 +103,7 @@ func execVerifyOne(_ context.Context, cfg *verifyOneConfig, cio commands.IO) err
 	// (ProdOnly), not the package type's.
 	mpkg.Type = gno.MPUserAll
 
-	var rpcOpts []rpcclient.Option
-	if cfg.rpcTimeout > 0 {
-		rpcOpts = append(rpcOpts, rpcclient.WithRequestTimeout(cfg.rpcTimeout))
-	}
-	v, err := newVerifier(cfg.gnoRoot, cfg.remote, cio.Err(), rpcOpts...)
+	v, err := newVerifier(cfg.gnoRoot, cfg.remote, cio.Err())
 	if err != nil {
 		return err
 	}
@@ -152,14 +144,6 @@ const exitResolverUnavailable = 3
 // arrives, so what the budget measures is the compile and nothing else.
 const childReadyMarker = "gpao: ready"
 
-// prepareCeiling bounds the child from spawn until it reports ready: process
-// start, the disk imports, and fetching the import closure from the node. That
-// phase is the oracle's own cost and is not the budget, but it cannot be left
-// unbounded either. A minute is the RPC client's own default request timeout;
-// a node that has not delivered the sources in that long is not answering.
-// Expiry is unavailability, not a verdict.
-const prepareCeiling = time.Minute
-
 // verify runs one verification in a child process, killed if it outlasts the
 // budget.
 //
@@ -172,10 +156,11 @@ const prepareCeiling = time.Minute
 //
 // The child runs in two phases and the parent times them apart. Until the
 // child reports ready it is fetching what the compile needs, from disk and
-// from the node; that is bounded by prepareCeiling and its expiry is
+// from the node; that is bounded by the prepare budget and its expiry is
 // unavailability. From ready onward it is compiling, which is what the
-// validator will pay for; that is bounded by the budget and its expiry is an
-// overrun. Timing the two together made a slow node read as a slow package.
+// validator will pay for; that is bounded by the verify budget and its expiry
+// is an overrun. Timing the two together made a slow node read as a slow
+// package.
 //
 // Exit status is the verdict: a clean exit passes, and a non-zero exit from a
 // child that ran to completion is a rejection carrying the child's stderr as
@@ -199,17 +184,12 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 	// rather than merely returning from the wait and leaving it running.
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	clock := newChildClock(cancel, o.cfg.verifyBudget)
+	clock := newChildClock(cancel, o.cfg.prepareBudget, o.cfg.verifyBudget)
 	defer clock.stop()
 
 	args := []string{verifyOneCmdName, "-gno-root", o.cfg.gnoRoot}
 	if o.cfg.remote != "" {
-		// One request to the node gets as long as the compile does. The RPC
-		// client's own default is a minute, so without this a node that
-		// accepts the connection and never answers would hold the child until
-		// prepareCeiling rather than being reported promptly.
-		args = append(args, "-remote", o.cfg.remote,
-			"-rpc-timeout", o.cfg.verifyBudget.String())
+		args = append(args, "-remote", o.cfg.remote)
 	}
 	cmd := exec.CommandContext(runCtx, self, args...)
 	cmd.Stdin = bytes.NewReader(payload)
@@ -293,27 +273,27 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 }
 
 // childClock times the child's two phases apart. From spawn until the child
-// reports ready it runs against prepareCeiling; from ready it runs against the
-// budget. Whichever expires cancels the child's context, which kills it, and
-// is remembered so the kill can be classified afterwards.
+// reports ready it runs against the prepare budget; from ready it runs against
+// the verify budget. Whichever expires cancels the child's context, which kills
+// it, and is remembered so the kill can be classified afterwards.
 type childClock struct {
 	mu      sync.Mutex
 	kill    context.CancelFunc
-	budget  time.Duration
+	verify  time.Duration
 	timer   *time.Timer
 	expired error
 }
 
-func newChildClock(kill context.CancelFunc, budget time.Duration) *childClock {
-	c := &childClock{kill: kill, budget: budget}
-	c.timer = time.AfterFunc(prepareCeiling, func() {
-		c.expire(fmt.Errorf("%w: the verifier did not have its sources within %s",
-			errVerifyUnavailable, prepareCeiling))
+func newChildClock(kill context.CancelFunc, prepare, verify time.Duration) *childClock {
+	c := &childClock{kill: kill, verify: verify}
+	c.timer = time.AfterFunc(prepare, func() {
+		c.expire(fmt.Errorf("%w: the verifier did not have its sources within the "+
+			"-prepare-budget of %s", errVerifyUnavailable, prepare))
 	})
 	return c
 }
 
-// ready switches from the prepare ceiling to the budget.
+// ready switches from the prepare budget to the verify budget.
 func (c *childClock) ready() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -321,8 +301,8 @@ func (c *childClock) ready() {
 		return
 	}
 	c.timer.Stop()
-	c.timer = time.AfterFunc(c.budget, func() {
-		c.expire(fmt.Errorf("%w: exceeded %s and was killed", errVerifyBudget, c.budget))
+	c.timer = time.AfterFunc(c.verify, func() {
+		c.expire(fmt.Errorf("%w: exceeded %s and was killed", errVerifyBudget, c.verify))
 	})
 }
 
@@ -343,33 +323,44 @@ func (c *childClock) stop() error {
 	return c.expired
 }
 
-// readyWatch is the child's stdout: it looks for the ready marker on the first
-// line and calls onReady once when it sees it. Nothing else is expected on
-// stdout, so anything after the first line, or a first line that is not the
-// marker, is dropped.
+// readyWatch is the child's stdout: it calls onReady once, on the first line
+// that is the ready marker, wherever that line lands. Nothing else is expected
+// on stdout, and whatever else arrives is dropped rather than read into.
 type readyWatch struct {
 	onReady func()
-	first   bytes.Buffer
-	decided bool
+	line    bytes.Buffer
+	ready   bool
 }
 
-// maxReadyLine bounds what is buffered while waiting for the first newline.
+// maxReadyLine bounds what is buffered of a line still waiting for its newline;
+// a longer one cannot be the marker and is dropped as it streams.
 const maxReadyLine = 256
 
 func (w *readyWatch) Write(p []byte) (int, error) {
-	if w.decided {
-		return len(p), nil
-	}
-	w.first.Write(p)
-	if i := bytes.IndexByte(w.first.Bytes(), '\n'); i >= 0 {
-		w.decided = true
-		if strings.TrimSpace(w.first.String()[:i]) == childReadyMarker {
+	// Report the full length whatever is consumed: a short write would make
+	// exec's copier report an error, which would be misread as the child
+	// failing.
+	n := len(p)
+	for !w.ready && len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			if w.line.Len()+len(p) <= maxReadyLine {
+				w.line.Write(p)
+			} else {
+				w.line.Reset()
+				w.line.WriteByte(0) // poison: this line is already too long
+			}
+			break
+		}
+		w.line.Write(p[:i])
+		if strings.TrimSpace(w.line.String()) == childReadyMarker {
+			w.ready = true
 			w.onReady()
 		}
-	} else if w.first.Len() > maxReadyLine {
-		w.decided = true
+		w.line.Reset()
+		p = p[i+1:]
 	}
-	return len(p), nil
+	return n, nil
 }
 
 // maxChildStderr bounds what we retain and mirror from a child.

--- a/contribs/gpao/verifyone.go
+++ b/contribs/gpao/verifyone.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 	"github.com/gnolang/gno/tm2/pkg/amino"
+	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
@@ -42,13 +44,16 @@ const verifyOneCmdName = "verify-one"
 // No signer, no keystore — a child cannot approve anything, so the approver key
 // never enters the process that compiles untrusted code.
 type verifyOneConfig struct {
-	gnoRoot string
-	remote  string
+	gnoRoot    string
+	remote     string
+	rpcTimeout time.Duration
 }
 
 func (c *verifyOneConfig) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.gnoRoot, "gno-root", "", "gno repository root")
 	fs.StringVar(&c.remote, "remote", "", "RPC address, for resolving on-chain-only imports")
+	fs.DurationVar(&c.rpcTimeout, "rpc-timeout", 0,
+		"per-request timeout on the RPC address; zero keeps the client's default")
 }
 
 func newVerifyOneCmd(io commands.IO) *commands.Command {
@@ -102,10 +107,23 @@ func execVerifyOne(_ context.Context, cfg *verifyOneConfig, cio commands.IO) err
 	// (ProdOnly), not the package type's.
 	mpkg.Type = gno.MPUserAll
 
-	v, err := newVerifier(cfg.gnoRoot, cfg.remote, cio.Err())
+	var rpcOpts []rpcclient.Option
+	if cfg.rpcTimeout > 0 {
+		rpcOpts = append(rpcOpts, rpcclient.WithRequestTimeout(cfg.rpcTimeout))
+	}
+	v, err := newVerifier(cfg.gnoRoot, cfg.remote, cio.Err(), rpcOpts...)
 	if err != nil {
 		return err
 	}
+	if err := v.prepare(&mpkg); err != nil {
+		// The network under the resolver failed before any verdict was
+		// possible; same channel as below.
+		fmt.Fprintln(cio.Err(), err)
+		os.Exit(exitResolverUnavailable)
+	}
+	// Everything the compile needs is local now. The parent starts the budget
+	// on this line.
+	fmt.Fprintln(cio.Out(), childReadyMarker)
 	if err := v.verifyPackage(&mpkg); err != nil {
 		if errors.Is(err, errResolverUnavailable) {
 			// Not a verdict; say so with the exit status, which is the only
@@ -129,6 +147,19 @@ func execVerifyOne(_ context.Context, cfg *verifyOneConfig, cio commands.IO) err
 // status alone.
 const exitResolverUnavailable = 3
 
+// childReadyMarker is the one line the child writes to stdout, once every
+// source the compile needs is local. The parent starts the budget when it
+// arrives, so what the budget measures is the compile and nothing else.
+const childReadyMarker = "gpao: ready"
+
+// prepareCeiling bounds the child from spawn until it reports ready: process
+// start, the disk imports, and fetching the import closure from the node. That
+// phase is the oracle's own cost and is not the budget, but it cannot be left
+// unbounded either. A minute is the RPC client's own default request timeout;
+// a node that has not delivered the sources in that long is not answering.
+// Expiry is unavailability, not a verdict.
+const prepareCeiling = time.Minute
+
 // verify runs one verification in a child process, killed if it outlasts the
 // budget.
 //
@@ -138,6 +169,13 @@ const exitResolverUnavailable = 3
 // contributes nothing the chain does not already do for itself. "This finishes
 // quickly" is the claim only an off-chain actor can make, and it is what gates
 // approval here.
+//
+// The child runs in two phases and the parent times them apart. Until the
+// child reports ready it is fetching what the compile needs, from disk and
+// from the node; that is bounded by prepareCeiling and its expiry is
+// unavailability. From ready onward it is compiling, which is what the
+// validator will pay for; that is bounded by the budget and its expiry is an
+// overrun. Timing the two together made a slow node read as a slow package.
 //
 // Exit status is the verdict: a clean exit passes, and a non-zero exit from a
 // child that ran to completion is a rejection carrying the child's stderr as
@@ -157,14 +195,21 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 		return fmt.Errorf("encode mempackage: %w", err)
 	}
 
-	// The timeout is on the CHILD's context, so expiry kills the process rather
-	// than merely returning from the wait and leaving it running.
-	runCtx, cancel := context.WithTimeout(ctx, o.cfg.verifyBudget)
+	// Both deadlines cancel the CHILD's context, so expiry kills the process
+	// rather than merely returning from the wait and leaving it running.
+	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	clock := newChildClock(cancel, o.cfg.verifyBudget)
+	defer clock.stop()
 
 	args := []string{verifyOneCmdName, "-gno-root", o.cfg.gnoRoot}
 	if o.cfg.remote != "" {
-		args = append(args, "-remote", o.cfg.remote)
+		// One request to the node gets as long as the compile does. The RPC
+		// client's own default is a minute, so without this a node that
+		// accepts the connection and never answers would hold the child until
+		// prepareCeiling rather than being reported promptly.
+		args = append(args, "-remote", o.cfg.remote,
+			"-rpc-timeout", o.cfg.verifyBudget.String())
 	}
 	cmd := exec.CommandContext(runCtx, self, args...)
 	cmd.Stdin = bytes.NewReader(payload)
@@ -184,8 +229,9 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 		// anywhere near here.
 		cmd.Stderr = io.MultiWriter(stderr, w)
 	}
-	// Stdout left nil on purpose: exec wires nil to os.DevNull, whereas any
-	// non-*os.File writer costs a pipe and a copying goroutine per candidate.
+	// Stdout carries exactly one line, the ready marker, and starting the
+	// budget on it is worth the pipe and the copying goroutine it costs.
+	cmd.Stdout = &readyWatch{onReady: clock.ready}
 
 	// Explicit env, so the invariant this file claims is actually true: the
 	// process that compiles untrusted code does not hold the approver's key
@@ -204,22 +250,11 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 
 	runErr := cmd.Run()
 
-	// A clean exit is unambiguous, so it is checked first. Checking the deadline
-	// ahead of it would report a pass that landed just as the timer fired as an
-	// overrun, and count it against the per-path budget allowance.
+	// A clean exit is unambiguous, so it is checked first. Checking the
+	// deadlines ahead of it would report a pass that landed just as a timer
+	// fired as an overrun, and count it against the per-path budget allowance.
 	if runErr == nil {
 		return nil
-	}
-
-	// Then the deadline: a killed child also exits non-zero, and reading that as
-	// a rejection would permanently settle a package that was only slow.
-	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		return fmt.Errorf("%w: exceeded %s and was killed",
-			errVerifyBudget, o.cfg.verifyBudget)
-	}
-	if ctx.Err() != nil {
-		// Parent shutdown, not a verdict about this package.
-		return fmt.Errorf("%w: shutting down", errVerifyBudget)
 	}
 
 	// Only a child that RAN and chose to exit non-zero has judged the package.
@@ -241,8 +276,100 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 		}
 		return errors.New(msg)
 	}
+
+	// A killed child: one of the two deadlines, or the parent shutting down.
+	// Which deadline decides what it means, and reading either as a rejection
+	// would permanently settle a package that was only slow, or only unlucky
+	// in its node.
+	if expired := clock.stop(); expired != nil {
+		return expired
+	}
+	if ctx.Err() != nil {
+		// Parent shutdown, not a verdict about this package.
+		return fmt.Errorf("%w: shutting down", errVerifyBudget)
+	}
 	return fmt.Errorf("%w: the verifier could not complete, this is not a "+
 		"verdict about the package: %v", errVerifyUnavailable, runErr)
+}
+
+// childClock times the child's two phases apart. From spawn until the child
+// reports ready it runs against prepareCeiling; from ready it runs against the
+// budget. Whichever expires cancels the child's context, which kills it, and
+// is remembered so the kill can be classified afterwards.
+type childClock struct {
+	mu      sync.Mutex
+	kill    context.CancelFunc
+	budget  time.Duration
+	timer   *time.Timer
+	expired error
+}
+
+func newChildClock(kill context.CancelFunc, budget time.Duration) *childClock {
+	c := &childClock{kill: kill, budget: budget}
+	c.timer = time.AfterFunc(prepareCeiling, func() {
+		c.expire(fmt.Errorf("%w: the verifier did not have its sources within %s",
+			errVerifyUnavailable, prepareCeiling))
+	})
+	return c
+}
+
+// ready switches from the prepare ceiling to the budget.
+func (c *childClock) ready() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.expired != nil {
+		return
+	}
+	c.timer.Stop()
+	c.timer = time.AfterFunc(c.budget, func() {
+		c.expire(fmt.Errorf("%w: exceeded %s and was killed", errVerifyBudget, c.budget))
+	})
+}
+
+func (c *childClock) expire(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.expired == nil {
+		c.expired = err
+		c.kill()
+	}
+}
+
+// stop disarms the running timer and reports which deadline expired, if any.
+func (c *childClock) stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.timer.Stop()
+	return c.expired
+}
+
+// readyWatch is the child's stdout: it looks for the ready marker on the first
+// line and calls onReady once when it sees it. Nothing else is expected on
+// stdout, so anything after the first line, or a first line that is not the
+// marker, is dropped.
+type readyWatch struct {
+	onReady func()
+	first   bytes.Buffer
+	decided bool
+}
+
+// maxReadyLine bounds what is buffered while waiting for the first newline.
+const maxReadyLine = 256
+
+func (w *readyWatch) Write(p []byte) (int, error) {
+	if w.decided {
+		return len(p), nil
+	}
+	w.first.Write(p)
+	if i := bytes.IndexByte(w.first.Bytes(), '\n'); i >= 0 {
+		w.decided = true
+		if strings.TrimSpace(w.first.String()[:i]) == childReadyMarker {
+			w.onReady()
+		}
+	} else if w.first.Len() > maxReadyLine {
+		w.decided = true
+	}
+	return len(p), nil
 }
 
 // maxChildStderr bounds what we retain and mirror from a child.

--- a/contribs/gpao/verifyone.go
+++ b/contribs/gpao/verifyone.go
@@ -106,8 +106,28 @@ func execVerifyOne(_ context.Context, cfg *verifyOneConfig, cio commands.IO) err
 	if err != nil {
 		return err
 	}
-	return v.verifyPackage(&mpkg)
+	if err := v.verifyPackage(&mpkg); err != nil {
+		if errors.Is(err, errResolverUnavailable) {
+			// Not a verdict; say so with the exit status, which is the only
+			// channel the parent classifies on. The reason still goes to
+			// stderr, which the parent tees and reports.
+			fmt.Fprintln(cio.Err(), err)
+			os.Exit(exitResolverUnavailable)
+		}
+		return err
+	}
+	return nil
 }
+
+// exitResolverUnavailable is the child's exit status when verification could
+// not obtain evidence -- the network under the import resolver failed -- as
+// opposed to exiting 1 with a verdict. 2 belongs to the Go runtime (panic).
+//
+// Exited directly rather than through commands.ExitCodeError: the test
+// harness drives the command through ParseAndRun, which returns that error
+// instead of translating it into a status, and the parent classifies on the
+// status alone.
+const exitResolverUnavailable = 3
 
 // verify runs one verification in a child process, killed if it outlasts the
 // budget.
@@ -119,11 +139,14 @@ func execVerifyOne(_ context.Context, cfg *verifyOneConfig, cio commands.IO) err
 // quickly" is the claim only an off-chain actor can make, and it is what gates
 // approval here.
 //
-// Exit status is the verdict: clean exit passes, non-zero exit is a rejection
-// carrying the child's stderr as the reason, and a deadline is errVerifyBudget,
-// which upstream treats as "no verdict yet" rather than as a rejection. That
-// distinction matters — a rejected package is settled, a slow one may just have
-// lost a race with whatever else the machine was doing.
+// Exit status is the verdict: a clean exit passes, and a non-zero exit from a
+// child that ran to completion is a rejection carrying the child's stderr as
+// the reason. Two exits are not verdicts at all: exitResolverUnavailable, which
+// says verification could not obtain evidence and becomes errVerifyUnavailable,
+// and a deadline, which becomes errVerifyBudget. Upstream treats both as "no
+// verdict yet" rather than as a rejection, and that distinction matters — a
+// rejected package is settled, a slow one may just have lost a race with
+// whatever else the machine was doing.
 func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 	self, err := os.Executable()
 	if err != nil {
@@ -212,6 +235,9 @@ func (o *oracle) verify(ctx context.Context, mpkg *std.MemPackage) error {
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = runErr.Error()
+		}
+		if ee.ExitCode() == exitResolverUnavailable {
+			return fmt.Errorf("%w: %s", errVerifyUnavailable, msg)
 		}
 		return errors.New(msg)
 	}


### PR DESCRIPTION
One network hiccup while resolving imports tells a submitter their code is bad, permanently.

[`rpcGetter.fetch` returns nil on any qfile error](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/contribs/gpao/getter.go#L91-L98), as its own doc comment says, and the typechecker then reports the unfetchable import as unresolved. The child exits 1, the parent reads any non-negative exit as a verdict about the package, and `handleCandidate` records `rejected` keyed on the content hash, so resubmitting identical bytes is a silent no-op.

A timeout, a node mid-restart, and an import that genuinely does not exist were indistinguishable. All three landed in the one status whose comment says the submitter can act on it.

### The boundary belongs at the evidence

The existing triage principle scoped "not a verdict" to the child process failing to run: fork failure, OOM, signal death. It never contemplated the child running fine while the network under it fails.

The RPC closure is the one place the two failures are distinguishable. A transport error from `ABCIQuery` is marked with a sentinel there; the node answering "nothing stored at this path" stays a plain miss. From there the getter records the fault, a failed typecheck is outranked by it, the child exits a dedicated status (3, since 1 is a verdict and 2 belongs to the Go runtime), and the parent maps that status to `errVerifyUnavailable`. The package stays pending, unseen, and retryable, exactly like the existing infrastructure failures.

Two more faults sit on the same boundary and are classified the same way:

| The node | Before | Now |
|---|---|---|
| is reached and answers about itself: an internal error because it cannot load state at the height, an unknown request from a build without the route | a miss, so a rejection | unavailable |
| is slow, or accepts the connection and never answers | the fetch ran inside the verification budget, so the package was killed at the budget and counted against its over-budget allowance, which gives up after three | outside the budget: a slow node costs the oracle time, a stalled one is unavailability |

`vm/qfile` reports a genuine miss as [exactly two error types](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/gno.land/pkg/sdk/vm/keeper.go#L1805-L1812), and the ABCI layer [unwraps to the cause](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/tm2/pkg/bft/abci/types/util.go#L193-L204) before the answer leaves the node, so [the classification is on the type](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/contribs/gpao/getter.go#L85-L116) and the text, which carries no path, is never read. A real-node test pins the wire form of a miss so the switch matches what a node sends rather than what the keeper constructs.

The budget now measures the compile and nothing else, because that is what the validator pays for. [The child fetches the import closure into its cache first](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/contribs/gpao/verifier.go#L182-L202), then [reports ready on stdout](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/contribs/gpao/verifyone.go#L110-L118), and [the parent starts the budget on that report](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/contribs/gpao/verifyone.go#L275-L324). A proxy that delays every RPC round trip by 800ms in front of a real node, with a 2s budget, takes about 4s to deliver `ufmt` and the package verifies; before, it was killed at 2s as an overrun.

Until the child reports ready it runs against [`-prepare-budget`](https://github.com/gnolang/gno/blob/d0c7da283a37fddc0eb85f43c7ae6639568aae3e/contribs/gpao/main.go#L159), a minute by default, and its expiry is unavailability rather than an overrun. The disk imports run before ready too; they measure about 250ms for a realm importing two libraries, so they were never the problem, but they are not the validator's cost either.

The fetch stays in the child rather than moving to the parent. The parent's verifier loop is single-threaded, so a stall there would hold every candidate, and the child is where the kill lives.

### Four behaviours unchanged on purpose

- **No remote configured.** There is no transport, so an unresolved import stays a rejection. Development mode, where the operator's disk is the authority.
- **A healthy node answering that an import does not exist.** Still a verdict. The case where that import is parked on-chain awaiting approval is its own question, posed in #6114.
- **The preprocess stage's deliberate skip.** The outranking covers failures, including a preprocess panic, but not this. When `seedChainImports` cannot resolve an import it logs and approves on the typecheck alone, returning success, so a transport fault arriving after a passing typecheck still approves with preprocess unmeasured. That path is fail-open where this one is fail-closed, it predates this change, and narrowing it is a separate question.
- **A child that dies by panic.** Exit 2 is the Go runtime's, and it still lands in the rejection branch, so a panic escaping `verifyPackage`'s recover is still a permanent verdict. Pre-existing, and tracked on #6113.

Other gpao defects and the design questions behind them: #6113.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
