### PR TITLE
fix(vm): record the approval digest at submit

### DIFF
--- a/gno.land/adr/pr6088_msgrun_allowlist_and_inert_charging.md
+++ b/gno.land/adr/pr6088_msgrun_allowlist_and_inert_charging.md
@@ -218,7 +218,7 @@ undeployed, and under `inert` that is precisely the state a chain boots in. It
 does **not** stop the submitter's own bait-and-switch: the same creator may
 still replace GOOD with EVIL after an approver has read GOOD, because that same
 replacement is the legitimate retry after a failed enable. Only a content hash
-in `MsgEnablePackage` closes that, and it remains open below.
+in `MsgEnablePackage` closes that, which item 12 records.
 
 **What was reverted**, and why it is recorded rather than deleted: the first
 attempt refused *any* submission over a parked path, and sat above the policy
@@ -1274,9 +1274,9 @@ Closing the `add_package` row for real transactions still means running under
    the slow ones, making the enable it signs the vehicle for exactly the
    unmetered compile it exists to prevent.
 
-   The other half is still open: the submitter may replace parked bytes between
-   verification and enable, because `MsgEnablePackage` names a path rather than a
-   content hash. See item 12. Blocks that fail to fetch are also no longer
+   The other half, the submitter replacing parked bytes between verification
+   and enable, is closed by the content hash `MsgEnablePackage` carries: see
+   item 12. Blocks that fail to fetch are also no longer
    skipped — the height is retried rather than advanced past.
 
 9. **The txtar genesis merge is a hand-maintained field list, now guarded.**
@@ -1323,19 +1323,97 @@ Closing the `add_package` row for real transactions still means running under
     replacement is also the legitimate retry after a failed enable. Approval
     named a path, not bytes.
 
-    `PkgHash` is now required on a live enable and checked against the parked
-    blob. `PackageContentHash` excludes `gnomod.toml`, which is what lets both
-    sides agree: `stampGnomod` rewrites that file at submit and touches nothing
-    else, so an approver hashing the source it saw in the transaction gets the
-    same value the keeper computes from the stored blob. Every reviewed byte is
-    still covered, and the gnomod rules are re-applied from the stored file at
-    enable regardless.
+    **Context.** `PkgHash` is required on a live enable and has to name the
+    bytes the approver reviewed. Approvers compute it from the bytes the
+    submitter sent: gpao from the `MsgAddPackage` it decodes out of the block,
+    `gnokey maketx enablepkg -pkgdir` from a local copy read exactly as
+    `addpkg` reads it. The chain stores different bytes, because the inert
+    branch of `AddPackage` rewrites `gnomod.toml` at submit through
+    `stampGnomod`, which pins `module` to the package path and writes the
+    `[addpkg]` section. So the chain cannot recompute an approver's digest
+    from what it stores. The same file carries five fields the submitter
+    authors (`gno`, `ignore`, `draft`, `private`, `replace`), and the digest
+    has to cover them: `private` is legal to substitute, and a same-creator
+    re-park of identical `.gno` source with `private = true`, activated on an
+    approval of the public package, puts live a realm no other realm may
+    import and whose slot the creator may silently replace.
+
+    **Decision.** `PackageContentHash` covers every file byte for byte as
+    submitted, `gnomod.toml` included, because the bytes a submitter sends are
+    the bytes an approver reviews. The inert branch of `AddPackage` computes
+    it before `stampGnomod` rewrites `gnomod.toml`, and records it as
+    `pkg_hash` in the `[addpkg]` section beside the creator, the height and
+    the deposit ceiling. `stampGnomod` replaces the whole section, so a
+    `pkg_hash` the submitter wrote never survives. A same-creator re-park runs
+    the same branch and overwrites the bytes and the digest together. The
+    ordinary path records no digest, and the field is omitted when empty, so
+    its stored `gnomod.toml` is unchanged.
+
+    `EnablePackage` parses the stored `gnomod.toml` first, so a file it cannot
+    read is refused as unreadable rather than as a swap. It then refuses an
+    approval with no `PkgHash`, refuses a parked package with no recorded
+    digest, and compares `PkgHash` with the recorded digest. gpao and `gnokey`
+    need no change, since both already hash the submitted bytes.
 
     Skipped on replay, like the policy and approver gates: history predating
     the field carries no hash, and replay is not racing a submitter. The wire
-    encoding of existing messages is unchanged — the field is appended and
+    encoding of existing messages is unchanged: the field is appended and
     omitted when empty.
-    (`TestEnableRefusesSourceChangedAfterApproval`, `TestEnableRequiresAHash`.)
+
+    **Alternatives considered.**
+
+    - *Leave `gnomod.toml` out of the digest.* Both sides agree, since the
+      stamp touches no other file, but the five authored fields fall outside
+      what an approver signs and the `private` substitution goes through.
+      Re-applying the gnomod rules at enable does not close it: the rules
+      catch an illegal value, not a legal one substituted.
+    - *Hash `gnomod.toml` in a canonical form*: parse it, pin `module`, zero
+      `[addpkg]` and re-encode, on both sides. The two sides agree across the
+      stamp, but the digest then depends on the `gnomod.File` schema, its
+      field order and the TOML encoder's output, so adding a field, reordering
+      one or changing the encoder moves every digest, and two builds can
+      disagree. It re-implements `stampGnomod` in a second place that has to
+      track it. The chain side parses the stored file, which the stamp can
+      make unparseable, and that failure then reads as a swap. And the digest
+      names the parsed file rather than the bytes, so bodies that differ only
+      in comments, unknown keys or whitespace share one.
+    - *Approvers re-apply the stamp* and hash the result. Every approver would
+      have to reproduce the creator, the submit height and the effective
+      deposit ceiling, which depends on the chain default at submit time, and
+      follow every change to `stampGnomod`. A chain-side rule would leak into
+      every client.
+
+    **Consequences.**
+
+    - A package parked by a binary that records no digest cannot be enabled.
+      `EnablePackage` refuses it and says its creator has to submit it again,
+      which records one. Recording the digest also changes the stored bytes on
+      the inert path, so adopting it is a coordinated upgrade. The inert flow
+      is dormant until a chain opts in, so this reaches only chains that run
+      `inert` across the upgrade.
+    - The digest lives in `[addpkg]`, keeper bookkeeping beside the creator.
+      The live package keeps the line after enable, because the parked blob is
+      what runs, and `vm/qfile` serves it.
+    - The digest line is 80 bytes. With a two-digit height and the default
+      deposit ceiling, the stamp adds 192 bytes to the stored `gnomod.toml`
+      where it added 112, so the largest submitted `gnomod.toml` already in
+      encoder form that still parses once stamped drops from 3984 bytes to
+      3904. Each further digit of height, and each byte a declared ceiling has
+      over the default's 14, lowers that by one.
+    - `AddPackage` parses the stamped `gnomod.toml` back and refuses the
+      submission if it does not parse, whatever the cause: the size above, or
+      a value the encoder writes back in a form the lexer refuses. A parked
+      file that does not parse could be neither enabled, replaced nor
+      rejected, since all three parse it first. `EnablePackage` still refuses
+      one as unreadable, for a blob parked before this check.
+
+    (`TestAddPackageRecordsTheSubmittedDigest`,
+    `TestAddPackageRefusesAGnomodTheStampMakesUnreadable`,
+    `TestEnableRefusesBytesTheApproverDidNotReview`,
+    `TestEnableRefusesAPackageParkedWithoutADigest`,
+    `TestEnableRefusesAnUnreadableParkedPackageAsUnreadable`,
+    `TestEnableRefusesSourceChangedAfterApproval`, `TestEnableRequiresAHash`,
+    `TestEnablePkgHashMatchesWhatTheChainWillCheck`.)
 
 13. **Fixed: a parked package can be removed.** `DelInertPackage` ran only
     after a successful enable and `DisablePackage` is unimplemented, so a

--- a/gno.land/pkg/gnoland/inert_lifecycle_test.go
+++ b/gno.land/pkg/gnoland/inert_lifecycle_test.go
@@ -201,9 +201,8 @@ func Origin(cur realm) string { return origin }
 	// 3. Enable, signed by the approver.
 	//
 	// The hash is computed from the source that was submitted, which is how a
-	// real approver gets it -- they saw the transaction. It matches the parked
-	// blob because PackageContentHash excludes gnomod.toml, the only file the
-	// keeper stamps at submit.
+	// real approver gets it -- they saw the transaction. It matches because
+	// AddPackage records the digest of those bytes before it stamps gnomod.toml.
 	enableResp := deliver(t, []std.Msg{vm.MsgEnablePackage{
 		Approver: approverAddr, PkgPath: path, PkgHash: vm.PackageContentHash(submitted),
 	}}, approver)

--- a/gno.land/pkg/keyscli/enablepkg.go
+++ b/gno.land/pkg/keyscli/enablepkg.go
@@ -107,9 +107,8 @@ func execMakeEnablePkg(cfg *MakeEnablePkgCfg, args []string, io commands.IO) err
 
 	pkgHash := cfg.PkgHash
 	if cfg.PkgDir != "" {
-		// MPUserAll, matching addpkg: a parked package is stored exactly as it
-		// was submitted, test files included, so anything less would hash a
-		// different file set than the chain holds.
+		// MPUserAll, as addpkg reads it: the chain records the digest of the
+		// package as submitted, test files included.
 		memPkg, err := gno.ReadMemPackage(cfg.PkgDir, cfg.PkgPath, gno.MPUserAll)
 		if err != nil {
 			return errors.Wrap(err, "reading package")

--- a/gno.land/pkg/keyscli/enablepkg_test.go
+++ b/gno.land/pkg/keyscli/enablepkg_test.go
@@ -1,12 +1,17 @@
 package keyscli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/commands"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/crypto/keys/client"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,50 +19,72 @@ import (
 
 // TestEnablePkgHashMatchesWhatTheChainWillCheck is the property the -pkgdir
 // flag exists for: the hash an approver computes from a local copy has to be
-// the one EnablePackage computes from the parked blob, or every hand-sent
+// the digest AddPackage records for the submission, or every hand-sent
 // approval is refused.
 //
-// The two differ in one file. AddPackage rewrites gnomod.toml at submit with
-// the creator, height and declared deposit, so the stored copy is not the
-// submitted one -- which is why PackageContentHash excludes it. This test
-// stages that difference rather than assuming it does not matter.
+// AddPackage records the digest of the package exactly as addpkg sends it, so
+// both commands run here against one directory and the approval is compared
+// with the submission they print. A test file rides along because the two
+// commands have to agree on the file set, not only on the bytes.
 func TestEnablePkgHashMatchesWhatTheChainWillCheck(t *testing.T) {
-	const pkgPath = "gno.land/r/test/enablecli"
+	const (
+		pkgPath = "gno.land/r/test/enablecli"
+		keyName = "approver"
+		// Any valid mnemonic: nothing here is signed.
+		mnemonic = "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+	)
 
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "gnomod.toml"),
-		[]byte(gno.GenGnoModLatest(pkgPath)), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "enablecli.gno"),
-		[]byte("package enablecli\n\nfunc Who(cur realm) string { return \"live\" }\n"), 0o644))
+	write := func(name, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	write("gnomod.toml", gno.GenGnoModLatest(pkgPath))
+	write("enablecli.gno", "package enablecli\n\nfunc Who(cur realm) string { return \"live\" }\n")
+	write("enablecli_test.gno", "package enablecli\n\nimport \"testing\"\n\nfunc TestWho(t *testing.T) {}\n")
 
-	local, err := gno.ReadMemPackage(dir, pkgPath, gno.MPUserAll)
+	home := t.TempDir()
+	kb, err := keys.NewKeyBaseFromDir(home)
 	require.NoError(t, err)
-
-	// The same package as the chain stores it: gnomod.toml stamped, everything
-	// else byte-identical.
-	stored := &std.MemPackage{Name: local.Name, Path: local.Path}
-	for _, f := range local.Files {
-		body := f.Body
-		if f.Name == "gnomod.toml" {
-			body += "\n[addpkg]\ncreator = \"g1abc\"\nheight = 42\n"
-		}
-		stored.Files = append(stored.Files, &std.MemFile{Name: f.Name, Body: body})
+	_, err = kb.CreateAccount(keyName, mnemonic, "", "", 0, 0)
+	require.NoError(t, err)
+	txCfg := &client.MakeTxCfg{
+		RootCfg:   &client.BaseCfg{BaseOptions: client.BaseOptions{Home: home}},
+		GasWanted: 1,
+		GasFee:    "1ugnot",
 	}
 
-	assert.Equal(t, vm.PackageContentHash(stored), vm.PackageContentHash(local),
-		"a stamped gnomod.toml must not change the hash, or -pkgdir can never match")
-
-	// And a real source change must, or the flag would approve anything.
-	changed := &std.MemPackage{Name: local.Name, Path: local.Path}
-	for _, f := range local.Files {
-		body := f.Body
-		if f.Name == "enablecli.gno" {
-			body = "package enablecli\n\nfunc Who(cur realm) string { return \"evil\" }\n"
-		}
-		changed.Files = append(changed.Files, &std.MemFile{Name: f.Name, Body: body})
+	// printed runs a command without -broadcast and returns the one message of
+	// the transaction it prints.
+	printed := func(t *testing.T, run func(commands.IO) error) std.Msg {
+		t.Helper()
+		var out bytes.Buffer
+		cio := commands.NewTestIO()
+		cio.SetOut(commands.WriteNopCloser(&out))
+		require.NoError(t, run(cio))
+		var tx std.Tx
+		require.NoError(t, amino.UnmarshalJSON(out.Bytes(), &tx))
+		require.Len(t, tx.Msgs, 1)
+		return tx.Msgs[0]
 	}
-	assert.NotEqual(t, vm.PackageContentHash(local), vm.PackageContentHash(changed),
-		"a source change must change the hash")
+	approve := func(t *testing.T) vm.MsgEnablePackage {
+		t.Helper()
+		return printed(t, func(cio commands.IO) error {
+			return execMakeEnablePkg(&MakeEnablePkgCfg{RootCfg: txCfg, PkgPath: pkgPath, PkgDir: dir}, []string{keyName}, cio)
+		}).(vm.MsgEnablePackage)
+	}
+
+	add := printed(t, func(cio commands.IO) error {
+		return execMakeAddPkg(&MakeAddPkgCfg{RootCfg: txCfg, PkgPath: pkgPath, PkgDir: dir}, []string{keyName}, cio)
+	}).(vm.MsgAddPackage)
+	require.NotNil(t, add.Package.GetFile("enablecli_test.gno"), "premise: addpkg submits test files")
+
+	approval := approve(t)
+	assert.Equal(t, vm.PackageContentHash(add.Package), approval.PkgHash,
+		"-pkgdir names a digest other than the one AddPackage records for what addpkg submits")
+
+	// And a real source change must move it, or the flag would approve anything.
+	write("enablecli.gno", "package enablecli\n\nfunc Who(cur realm) string { return \"evil\" }\n")
+	assert.NotEqual(t, approval.PkgHash, approve(t).PkgHash, "a source change must change the hash")
 }
 
 // TestEnablePkgRequiresASource pins that the command refuses to build an

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -604,20 +604,18 @@ func chargePreprocessGas(ctx sdk.Context, params Params, mpkg *std.MemPackage, d
 // paths ever stamped differently, the same source would initialize under a
 // different identity depending on which policy was in force when it was
 // submitted — with nothing to catch it. One writer makes that unrepresentable.
-// maxDeposit is the creator's declared storage-deposit ceiling, and is written
-// only where the charge outlives the declaring message — the inert path, where
-// EnablePackage reads it back. The ordinary path passes "".
+// MaxDeposit and PkgHash are set only where the enable outlives the submitting
+// message: the inert path, where EnablePackage reads them back. The ordinary
+// path leaves both empty.
 //
-// Every AddPkg field is assigned unconditionally, including the empty cases.
-// The section is keeper bookkeeping, but it lives in a file the submitter
-// authors, so anything not overwritten here is attacker-supplied: a hand-written
-// `[addpkg] max_deposit` would otherwise survive and be read at enable as though
-// the message had declared it.
-func stampGnomod(gm *gnomod.File, mpkg *std.MemPackage, pkgPath string, creator crypto.Address, height int64, maxDeposit string) {
+// The whole section is replaced, including the empty fields. The section is
+// keeper bookkeeping, but it lives in a file the submitter authors, so anything
+// not overwritten here is attacker-supplied: a hand-written `[addpkg]
+// max_deposit` would otherwise survive and be read at enable as though the
+// message had declared it.
+func stampGnomod(gm *gnomod.File, mpkg *std.MemPackage, pkgPath string, addpkg gnomod.AddPkg) {
 	gm.Module = pkgPath // XXX: if gm.Module != msg.Package.Path { panic() }?
-	gm.AddPkg.Creator = creator.String()
-	gm.AddPkg.Height = int(height)
-	gm.AddPkg.MaxDeposit = maxDeposit
+	gm.AddPkg = addpkg
 	mpkg.SetFile("gnomod.toml", gm.WriteString())
 }
 
@@ -912,7 +910,21 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 			}
 			declared = maxDeposit.String()
 		}
-		stampGnomod(gm, memPkg, pkgPath, creator, ctx.BlockHeight(), declared)
+		// Before the stamp rewrites gnomod.toml: approvers hash the bytes as
+		// submitted, and EnablePackage compares their approval with this.
+		digest := PackageContentHash(memPkg)
+		stampGnomod(gm, memPkg, pkgPath, gnomod.AddPkg{
+			Creator:    creator.String(),
+			Height:     int(ctx.BlockHeight()),
+			MaxDeposit: declared,
+			PkgHash:    digest,
+		})
+		// A parked file that does not parse can be neither enabled, replaced
+		// nor rejected, and the re-encode can produce one.
+		if _, err := gnomod.ParseMemPackage(memPkg); err != nil {
+			return ErrInvalidPackage(fmt.Sprintf(
+				"gnomod.toml cannot be read back once stamped: %v", err))
+		}
 		if err := vm.checkNamespacePermission(ctx, params, creator, pkgPath); err != nil {
 			return err
 		}
@@ -1025,9 +1037,9 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 		return err
 	}
 
-	// No ceiling stamped: on this path the deposit is charged in this same
-	// message, so nothing needs to outlive it.
-	stampGnomod(gm, memPkg, pkgPath, creator, ctx.BlockHeight(), "")
+	// No ceiling or digest stamped: on this path the deposit is charged and the
+	// package runs in this same message, so nothing needs to outlive it.
+	stampGnomod(gm, memPkg, pkgPath, gnomod.AddPkg{Creator: creator.String(), Height: int(ctx.BlockHeight())})
 
 	// Pay deposit from creator.
 	pkgAddr := gno.DerivePkgCryptoAddr(pkgPath)

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -205,8 +205,8 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	}
 	// AddPackage wrote the creator into gnomod.toml before storing (see the
 	// inert branch), so it round-trips; genesis.go reads it back the same way.
-	// gm was parsed above, before the liveness probe that needs it. Parsed here
-	// rather than lower down because the namespace check below needs it.
+	// Parsed here rather than lower down because the namespace check below
+	// needs it.
 	creator, err := crypto.AddressFromBech32(gm.AddPkg.Creator)
 	if err != nil {
 		return ErrInvalidPackage(fmt.Sprintf(

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -100,6 +100,12 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 		}
 		return ErrInvalidPkgPath("no inert package at path: " + msg.PkgPath)
 	}
+	// First, so a stored file that cannot be read is refused as that rather
+	// than as a source swap: the recorded digest is read out of it.
+	gm, err := gnomod.ParseMemPackage(memPkg)
+	if err != nil {
+		return ErrInvalidPackage(err.Error())
+	}
 	// The approver names the source it reviewed, and this is where that is
 	// checked. Approval otherwise names a path, and a path's contents can
 	// change: the same creator may replace parked bytes at any time, and that
@@ -107,6 +113,9 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	// creator who parked GOOD and had it reviewed can park EVIL before the
 	// enable lands, and nothing above would notice -- the creator-bound guard
 	// at submit stops a stranger doing it, not the submitter themselves.
+	//
+	// Compared with the digest AddPackage recorded over the bytes as submitted,
+	// which is what approvers hash; the stored gnomod.toml was stamped since.
 	//
 	// Skipped on replay, like the two gates above: history predating the field
 	// carries no hash, and refusing it would fail every replayed enable. The
@@ -117,11 +126,17 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 			return ErrInvalidPackage(
 				"missing pkg_hash: an approval has to name the source it approves")
 		}
-		if got := PackageContentHash(memPkg); got != msg.PkgHash {
+		if gm.AddPkg.PkgHash == "" {
+			return ErrInvalidPackage(fmt.Sprintf(
+				"no digest is recorded for the package parked at %s, so no approval "+
+					"can be checked against it: its creator has to submit it again",
+				msg.PkgPath))
+		}
+		if gm.AddPkg.PkgHash != msg.PkgHash {
 			return ErrInvalidPackage(fmt.Sprintf(
 				"the parked source at %s is not what was approved "+
-					"(approved %s, parked %s); it changed after review",
-				msg.PkgPath, msg.PkgHash, got))
+					"(approved %s, submitted %s)",
+				msg.PkgPath, msg.PkgHash, gm.AddPkg.PkgHash))
 		}
 	}
 	// Refuse to activate over a package that is already live, applying exactly
@@ -159,10 +174,6 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	// under a different key prefix and is invisible to GetMemPackage, while a
 	// live one always has a production blob (hasProdGnoFile guarantees it at
 	// deploy). `private` comes from the same gnomod.toml the deploy stored.
-	gm, err := gnomod.ParseMemPackage(memPkg)
-	if err != nil {
-		return ErrInvalidPackage(err.Error())
-	}
 	liveBlob := gnostore.GetMemPackage(msg.PkgPath)
 	priorPrivate := false
 	if liveBlob != nil {

--- a/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland/ugnot"
 	"github.com/gnolang/gno/gnovm/pkg/gnolang"
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
 	bft "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/sdk"
@@ -19,19 +20,23 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-// approvalFor builds an approval naming the source currently parked at path.
+// approvalFor builds an approval naming the digest AddPackage recorded for the
+// submission parked at path.
 //
 // EnablePackage refuses an approval that does not name the bytes it is
-// activating, so every test that expects an enable to succeed has to compute
-// the hash the same way a real approver would.
+// activating, so every test that expects an enable to succeed has to name that
+// digest. A real approver digests the submission instead, as the tests of the
+// digest itself do.
 func approvalFor(t *testing.T, env testEnv, ctx sdk.Context, approver crypto.Address, path string) MsgEnablePackage {
 	t.Helper()
 	parked := env.vmk.getGnoTransactionStore(ctx).GetInertPackage(path)
 	require.NotNil(t, parked, "nothing parked at %s to approve", path)
+	gm, err := gnomod.ParseMemPackage(parked)
+	require.NoError(t, err, "the package parked at %s has no readable gnomod.toml", path)
 	return MsgEnablePackage{
 		Approver: approver,
 		PkgPath:  path,
-		PkgHash:  PackageContentHash(parked),
+		PkgHash:  gm.AddPkg.PkgHash,
 	}
 }
 
@@ -1577,7 +1582,7 @@ func TestEnableRefusesSourceChangedAfterApproval(t *testing.T) {
 
 	err := env.vmk.EnablePackage(ctx, approval)
 	require.Error(t, err, "the approval named the source it read, which is no longer parked")
-	assert.Contains(t, fmt.Sprintf("%+v", err), "changed after review")
+	assert.Contains(t, fmt.Sprintf("%+v", err), "is not what was approved")
 	assert.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetPackage(pkgPath, false),
 		"and nothing may go live")
 
@@ -1600,6 +1605,113 @@ func TestEnableRequiresAHash(t *testing.T) {
 	err := env.vmk.EnablePackage(ctx, MsgEnablePackage{Approver: approver, PkgPath: pkgPath})
 	require.Error(t, err)
 	assert.Contains(t, fmt.Sprintf("%+v", err), "missing pkg_hash")
+}
+
+// TestEnableRefusesAPackageParkedWithoutADigest covers a package parked by a
+// binary that recorded no digest. Nothing names the bytes its submitter sent,
+// so no approval can be checked against it, and resubmitting records one.
+func TestEnableRefusesAPackageParkedWithoutADigest(t *testing.T) {
+	const pkgPath = "gno.land/r/test/nodigest"
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("submitter"))
+	env, ctx := inertEnv(t, approver, creator)
+	submitted := NewMsgAddPackage(creator, pkgPath, replayFiles("nodigest")).Package
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(creator, pkgPath, replayFiles("nodigest"))))
+
+	// The blob as a binary without the digest would have parked it.
+	store := env.vmk.getGnoTransactionStore(ctx)
+	parked := store.GetInertPackage(pkgPath)
+	gm, err := gnomod.ParseMemPackage(parked)
+	require.NoError(t, err)
+	gm.AddPkg.PkgHash = ""
+	parked.SetFile("gnomod.toml", gm.WriteString())
+	store.AddInertPackage(parked)
+
+	err = env.vmk.EnablePackage(ctx, MsgEnablePackage{
+		Approver: approver, PkgPath: pkgPath, PkgHash: PackageContentHash(submitted),
+	})
+	require.Error(t, err)
+	assert.Contains(t, fmt.Sprintf("%+v", err), "has to submit it again",
+		"the refusal has to tell the submitter what clears it")
+	assert.Nil(t, store.GetMemPackage(pkgPath), "and nothing may go live")
+}
+
+// gnomodAtSizeLimit renders a gnomod.toml exactly at gnomod's maxFileSize: it
+// parses as written, and any byte the stamp adds pushes it past the limit.
+func gnomodAtSizeLimit(pkgPath string) string {
+	const gnomodLimit = 4 << 10
+	head, tail := "module = \""+pkgPath+"\"\ngno = \"0.9", "\"\n"
+	return head + strings.Repeat("9", gnomodLimit-len(head)-len(tail)) + tail
+}
+
+// TestAddPackageRefusesAGnomodTheStampMakesUnreadable pins that a submission is
+// refused when its gnomod.toml stops parsing once stamped. Parked, such a file
+// can be neither enabled, replaced nor rejected: all three parse it first.
+func TestAddPackageRefusesAGnomodTheStampMakesUnreadable(t *testing.T) {
+	const pkgPath = "gno.land/r/test/unstampable"
+
+	cases := map[string]string{
+		// The [addpkg] section alone pushes it past the size limit.
+		"at the size limit": gnomodAtSizeLimit(pkgPath),
+		// The TOML escape decodes to U+001F, which the encoder writes back raw
+		// and the lexer refuses.
+		"a control character the encoder writes raw": "module = \"" + pkgPath + "\"\ngno = \"0.9\\u001F\"\n",
+	}
+	for name, mod := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := gnomod.ParseBytes("gnomod.toml", []byte(mod))
+			require.NoError(t, err, "premise: the gnomod.toml parses as submitted")
+
+			approver := crypto.AddressFromPreimage([]byte("oracle"))
+			creator := crypto.AddressFromPreimage([]byte("submitter"))
+			env, ctx := inertEnv(t, approver, creator)
+			err = env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, []*std.MemFile{
+				{Name: "gnomod.toml", Body: mod},
+				{Name: "unstampable.gno", Body: "package unstampable\n\nfunc Who(cur realm) string { return \"reviewed\" }"},
+			}))
+			require.Error(t, err)
+			assert.Contains(t, fmt.Sprintf("%+v", err), "cannot be read back once stamped",
+				"the refusal has to tell the submitter it is the stamped file that fails")
+			assert.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath),
+				"and nothing may be parked")
+		})
+	}
+}
+
+// TestEnableRefusesAnUnreadableParkedPackageAsUnreadable pins that a parked
+// gnomod.toml the chain cannot parse is reported as unreadable. Told the source
+// "is not what was approved", an approver hunts for a swap that never happened.
+//
+// AddPackage refuses to park such a file, so the blob is written directly, as a
+// binary without that refusal would have parked it.
+func TestEnableRefusesAnUnreadableParkedPackageAsUnreadable(t *testing.T) {
+	const pkgPath = "gno.land/r/test/unreadable"
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("submitter"))
+	env, ctx := inertEnv(t, approver, creator)
+	submitted := NewMsgAddPackage(creator, pkgPath, replayFiles("unreadable")).Package
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(creator, pkgPath, replayFiles("unreadable"))))
+
+	store := env.vmk.getGnoTransactionStore(ctx)
+	parked := store.GetInertPackage(pkgPath)
+	parked.SetFile("gnomod.toml", gnomodAtSizeLimit(pkgPath)+"\n")
+	store.AddInertPackage(parked)
+	_, err := gnomod.ParseMemPackage(store.GetInertPackage(pkgPath))
+	require.Error(t, err, "premise: the parked gnomod.toml does not parse")
+
+	err = env.vmk.EnablePackage(ctx, MsgEnablePackage{
+		Approver: approver, PkgPath: pkgPath, PkgHash: PackageContentHash(submitted),
+	})
+	require.Error(t, err)
+	assert.Contains(t, fmt.Sprintf("%+v", err), "exceeds limit",
+		"the refusal has to name why the parked file cannot be read")
+	assert.NotContains(t, fmt.Sprintf("%+v", err), "is not what was approved",
+		"an unreadable file is not evidence of a swap")
+	assert.Nil(t, store.GetMemPackage(pkgPath), "and nothing may go live")
 }
 
 // TestRejectPackageClearsTheQueue covers MsgRejectPackage.

--- a/gno.land/pkg/sdk/vm/pkghash.go
+++ b/gno.land/pkg/sdk/vm/pkghash.go
@@ -10,9 +10,6 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-// gnomodFileName is excluded from the content hash. See PackageContentHash.
-const gnomodFileName = "gnomod.toml"
-
 // PackageContentHash identifies the source an approver signed off on.
 //
 // Approval names a path, and a path's contents can change: the same creator may
@@ -20,25 +17,16 @@ const gnomodFileName = "gnomod.toml"
 // retry after a failed enable. Without naming the bytes, an approver who read
 // GOOD can be made to activate EVIL.
 //
-// gnomod.toml is excluded deliberately. AddPackage stamps the creator, height
-// and declared deposit into it at submit, so the stored file differs from the
-// one the submitter sent and from the one an approver saw in the transaction --
-// the two could never agree on a hash that included it. stampGnomod writes that
-// file and touches nothing else, which is what makes excluding it sufficient:
-// every byte an approver reviews is still covered, and the gnomod rules are
-// re-applied from the stored file at enable anyway.
+// The digest names every file exactly as the submitter sent it, gnomod.toml
+// included, because those are the bytes an approver reviews. AddPackage records
+// it before stamping gnomod.toml, so a parked blob does not hash to it: compare
+// against the recorded value, never a digest recomputed from storage.
 //
 // Each field is length-prefixed so that adjacent names and bodies cannot be
 // re-cut to collide -- without it, a file "ab" holding "c" and a file "a"
 // holding "bc" would hash alike.
 func PackageContentHash(mpkg *std.MemPackage) string {
-	files := make([]*std.MemFile, 0, len(mpkg.Files))
-	for _, f := range mpkg.Files {
-		if f.Name == gnomodFileName {
-			continue
-		}
-		files = append(files, f)
-	}
+	files := slices.Clone(mpkg.Files)
 	slices.SortFunc(files, func(a, b *std.MemFile) int {
 		return strings.Compare(a.Name, b.Name)
 	})

--- a/gno.land/pkg/sdk/vm/pkghash_gnomod_test.go
+++ b/gno.land/pkg/sdk/vm/pkghash_gnomod_test.go
@@ -1,0 +1,225 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	tmerrors "github.com/gnolang/gno/tm2/pkg/errors"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// An approval names a digest, and the digest has to name every byte that
+// decides what the chain does with the submission. gnomod.toml carries two
+// halves: the fields AddPackage stamps at submit (module, addpkg.creator,
+// addpkg.height, addpkg.max_deposit) and the five the submitter authors (gno,
+// ignore, draft, private, replace). PackageContentHash excludes the whole
+// file, so the authored half sits outside what an approver signs.
+//
+// One of the five reaches enable on a live chain. `private` is read back by
+// checkGnomodConstraints, which governs whether a public submission may go live
+// over a live private realm; the value is then carried onto the PackageValue,
+// where it decides whether any other realm may import the package. The rest
+// are stopped earlier: replaces and post-genesis drafts are refused at submit,
+// a gno version other than the current one panics the version gate before the
+// package runs, and a submission with no gnomod.toml has no module path to
+// park under. Their cases below pin the digest against a relaxation of those
+// checks rather than against a hole open today, and say so.
+//
+// These tests assert the property, not today's behaviour: they are red on
+// master. Canonicalizing the stamped fields before hashing, or hashing a
+// projection of the authored fields, would turn them green as they stand.
+// Refusing a re-park that moves an authored field closes the same hole at
+// submit instead, and would want the first test re-pointed at the second
+// AddPackage. Choosing between them is a design decision, so no fix is made
+// here.
+
+// storedGnomod renders a gnomod.toml in the shape the chain stores one: the
+// stamped section first, held byte-identical across every case below, then
+// whatever the submitter authored. Holding the stamp fixed is what makes a
+// moved digest attributable to the authored half alone.
+func storedGnomod(pkgPath, gnoVersion, authored string) string {
+	mod := "module = \"" + pkgPath + "\"\ngno = \"" + gnoVersion + "\"\n"
+	if authored != "" {
+		mod += authored + "\n"
+	}
+	return mod + "[addpkg]\ncreator = \"" +
+		crypto.AddressFromPreimage([]byte("stamped-creator")).String() +
+		"\"\nheight = 42\nmax_deposit = \"1000000ugnot\"\n"
+}
+
+// TestEnableRefusesBytesTheApproverDidNotReview drives the whole two-phase
+// deploy: a creator parks a public package, an approver digests what the chain
+// serves at that path, the creator re-parks the same .gno source with
+// `private = true`, and the approval of the public submission is presented.
+//
+// Activating it turns the reviewed public API into a realm no other package
+// may import and whose slot the creator may silently overwrite from then on --
+// none of which the approver saw or signed.
+func TestEnableRefusesBytesTheApproverDidNotReview(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/privacyflip"
+		srcName = "privacyflip.gno"
+		source  = "package privacyflip\n\nfunc Who(cur realm) string { return \"reviewed\" }"
+	)
+	files := func(private bool) []*std.MemFile {
+		authored := ""
+		if private {
+			authored = "private = true"
+		}
+		return []*std.MemFile{
+			{Name: "gnomod.toml", Body: storedGnomod(pkgPath, "0.9", authored)},
+			{Name: srcName, Body: source},
+		}
+	}
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("privacyflip-creator"))
+	env, ctx := inertEnv(t, approver, creator)
+	store := env.vmk.getGnoTransactionStore(ctx)
+
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files(false))))
+
+	// The approval an approver would actually send: the digest is taken from
+	// the bytes the chain serves for this path, not from a package built here.
+	approval := approvalFor(t, env, ctx, approver, pkgPath)
+	reviewed := store.GetInertPackage(pkgPath)
+	require.NotNil(t, reviewed, "premise: the public submission is parked")
+	require.NotContains(t, reviewed.GetFile("gnomod.toml").Body, "private",
+		"premise: what the approver reviews is a public package")
+
+	// Same creator, same path, identical source, private = true. Replacement by
+	// the original submitter is the retry path after a failed enable, so nothing
+	// ahead of the digest stands in the way.
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files(true))))
+	swapped := store.GetInertPackage(pkgPath)
+	require.NotNil(t, swapped)
+	require.Contains(t, swapped.GetFile("gnomod.toml").Body, "private = true",
+		"premise: the bytes now parked are private")
+	require.Equal(t, reviewed.GetFile(srcName).Body, swapped.GetFile(srcName).Body,
+		"premise: the re-park moved gnomod.toml and nothing else")
+
+	err := env.vmk.EnablePackage(ctx, approval)
+	require.Error(t, err,
+		"an approval of the public submission activated the private one: the "+
+			"approver's signature named source it never saw")
+	// The class, not the message: a fix is free to reword the detail.
+	assert.Equal(t, InvalidPackageError{}, tmerrors.Cause(err),
+		"the refusal has to be about the submission's contents, so the approver "+
+			"is told their approval no longer names what is parked")
+	assert.Nil(t, store.GetMemPackage(pkgPath),
+		"a refused enable must leave the path empty, not half-deployed")
+}
+
+// TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields walks the fields a
+// submitter writes into gnomod.toml and pins that each one moves the digest.
+//
+// Every case differs from the base in exactly one authored field and in
+// nothing else -- same source file, same stamped section -- so a digest that
+// does not move is an approver signing for a package the chain reads as a
+// different module from the one they reviewed.
+//
+// The digest is blind to all four. Only the first two reach a live chain; the
+// other two are stopped by a submit-time check that the digest knows nothing
+// about, so they pin the digest against that check being relaxed rather than
+// against a hole open today. `reaches` records which is which, because the two
+// carry very different weight and a reader deserves to be told.
+func TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pkgPath = "gno.land/r/test/authored"
+		source  = "package authored\n\nfunc Who(cur realm) string { return \"reviewed\" }"
+	)
+	pkgWith := func(mod string) *std.MemPackage {
+		return &std.MemPackage{Name: "authored", Path: pkgPath, Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: mod},
+			{Name: "authored.gno", Body: source},
+		}}
+	}
+
+	reviewed := pkgWith(storedGnomod(pkgPath, "0.9", ""))
+	reviewedMod, err := gnomod.ParseMemPackage(reviewed)
+	require.NoError(t, err, "premise: the reviewed gnomod.toml is one the chain accepts")
+
+	cases := map[string]struct {
+		mod string
+		// reaches is what the field does on a live chain today: what an
+		// unmoved digest actually buys a submitter.
+		reaches string
+	}{
+		"private": {
+			mod:     storedGnomod(pkgPath, "0.9", "private = true"),
+			reaches: "a realm no other package may import goes live over an approval of a public one",
+		},
+		"gno": {
+			mod: storedGnomod(pkgPath, "0.8", ""),
+			reaches: "nothing; ParseCheckGnoMod panics on any version but the current one before " +
+				"the package runs, so this pins the digest against that gate being relaxed",
+		},
+		"draft": {
+			mod: storedGnomod(pkgPath, "0.9", "draft = true"),
+			reaches: "nothing; checkGnomodConstraints refuses a post-genesis draft at submit, " +
+				"so this pins the digest against that rule being relaxed",
+		},
+		"replace": {
+			mod: storedGnomod(pkgPath, "0.9",
+				"[[replace]]\nold = \"gno.land/p/demo/avl\"\nnew = \"gno.land/p/demo/avl/v2\""),
+			reaches: "nothing; checkGnomodConstraints refuses any replace at submit, " +
+				"so this pins the digest against that rule being relaxed",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			submitted := pkgWith(tc.mod)
+			submittedMod, err := gnomod.ParseMemPackage(submitted)
+			require.NoError(t, err, "premise: this gnomod.toml is one the chain accepts")
+			require.NotEqual(t, *reviewedMod, *submittedMod,
+				"premise: the chain reads the two submissions as different modules")
+
+			assert.NotEqual(t, PackageContentHash(reviewed), PackageContentHash(submitted),
+				"%s is the submitter's to write, yet an approver who reviewed one value "+
+					"signs a digest that names the other just as well.\n"+
+					"What that buys on a live chain today: %s",
+				name, tc.reaches)
+		})
+	}
+}
+
+// TestApprovalDigestSeparatesASubmissionMissingItsGnomod pins the degenerate
+// end of the same property: a submission with no gnomod.toml at all must not
+// share a digest with one that has it.
+//
+// Nothing reaches a live chain through this one. A package with no module
+// declaration has no path to park under, which the premise below is the proof
+// of. It pins the digest at the far end of the range the exclusion covers: the
+// whole file is outside the hash, so an approver's signature covers a package
+// whose module path, privacy, gno version and replaces were all dropped, and
+// only a check elsewhere stops that mattering.
+func TestApprovalDigestSeparatesASubmissionMissingItsGnomod(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pkgPath = "gno.land/r/test/nomodfile"
+		source  = "package nomodfile\n\nfunc Who(cur realm) string { return \"reviewed\" }"
+	)
+	src := &std.MemFile{Name: "nomodfile.gno", Body: source}
+	mod := &std.MemFile{Name: "gnomod.toml", Body: storedGnomod(pkgPath, "0.9", "")}
+
+	reviewed := &std.MemPackage{Name: "nomodfile", Path: pkgPath, Files: []*std.MemFile{mod, src}}
+	stripped := &std.MemPackage{Name: "nomodfile", Path: pkgPath, Files: []*std.MemFile{src}}
+
+	_, err := gnomod.ParseMemPackage(reviewed)
+	require.NoError(t, err, "premise: the reviewed submission declares a module")
+	_, err = gnomod.ParseMemPackage(stripped)
+	require.Error(t, err, "premise: the stripped submission declares nothing at all")
+
+	assert.NotEqual(t, PackageContentHash(reviewed), PackageContentHash(stripped),
+		"deleting gnomod.toml outright leaves the digest untouched, so the file the "+
+			"approver reviewed contributes nothing to what their approval names")
+}

--- a/gno.land/pkg/sdk/vm/pkghash_gnomod_test.go
+++ b/gno.land/pkg/sdk/vm/pkghash_gnomod_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,11 +14,10 @@ import (
 )
 
 // An approval names a digest, and the digest has to name every byte that
-// decides what the chain does with the submission. gnomod.toml carries two
-// halves: the fields AddPackage stamps at submit (module, addpkg.creator,
-// addpkg.height, addpkg.max_deposit) and the five the submitter authors (gno,
-// ignore, draft, private, replace). PackageContentHash excludes the whole
-// file, so the authored half sits outside what an approver signs.
+// decides what the chain does with the submission. gnomod.toml carries the five
+// fields the submitter authors (gno, ignore, draft, private, replace) beside the
+// [addpkg] section AddPackage stamps at submit, so the digest covers the file as
+// submitted and AddPackage records it before the stamp.
 //
 // One of the five reaches enable on a live chain. `private` is read back by
 // checkGnomodConstraints, which governs whether a public submission may go live
@@ -28,20 +28,11 @@ import (
 // package runs, and a submission with no gnomod.toml has no module path to
 // park under. Their cases below pin the digest against a relaxation of those
 // checks rather than against a hole open today, and say so.
-//
-// These tests assert the property, not today's behaviour: they are red on
-// master. Canonicalizing the stamped fields before hashing, or hashing a
-// projection of the authored fields, would turn them green as they stand.
-// Refusing a re-park that moves an authored field closes the same hole at
-// submit instead, and would want the first test re-pointed at the second
-// AddPackage. Choosing between them is a design decision, so no fix is made
-// here.
 
-// storedGnomod renders a gnomod.toml in the shape the chain stores one: the
-// stamped section first, held byte-identical across every case below, then
-// whatever the submitter authored. Holding the stamp fixed is what makes a
-// moved digest attributable to the authored half alone.
-func storedGnomod(pkgPath, gnoVersion, authored string) string {
+// authoredGnomod renders a gnomod.toml whose bytes differ across the cases below
+// only in what the submitter authored. The hand-written [addpkg] section is one
+// a submitter is free to send and the stamp overwrites.
+func authoredGnomod(pkgPath, gnoVersion, authored string) string {
 	mod := "module = \"" + pkgPath + "\"\ngno = \"" + gnoVersion + "\"\n"
 	if authored != "" {
 		mod += authored + "\n"
@@ -52,13 +43,14 @@ func storedGnomod(pkgPath, gnoVersion, authored string) string {
 }
 
 // TestEnableRefusesBytesTheApproverDidNotReview drives the whole two-phase
-// deploy: a creator parks a public package, an approver digests what the chain
-// serves at that path, the creator re-parks the same .gno source with
-// `private = true`, and the approval of the public submission is presented.
+// deploy: a creator parks a public package, the creator re-parks the same .gno
+// source with `private = true`, and approvals digested from each submission are
+// presented.
 //
-// Activating it turns the reviewed public API into a realm no other package
-// may import and whose slot the creator may silently overwrite from then on --
-// none of which the approver saw or signed.
+// Activating the private one on an approval of the public one turns the
+// reviewed public API into a realm no other package may import and whose slot
+// the creator may silently overwrite from then on, none of which the approver
+// saw or signed.
 func TestEnableRefusesBytesTheApproverDidNotReview(t *testing.T) {
 	const (
 		pkgPath = "gno.land/r/test/privacyflip"
@@ -71,7 +63,7 @@ func TestEnableRefusesBytesTheApproverDidNotReview(t *testing.T) {
 			authored = "private = true"
 		}
 		return []*std.MemFile{
-			{Name: "gnomod.toml", Body: storedGnomod(pkgPath, "0.9", authored)},
+			{Name: "gnomod.toml", Body: authoredGnomod(pkgPath, "0.9", authored)},
 			{Name: srcName, Body: source},
 		}
 	}
@@ -81,11 +73,17 @@ func TestEnableRefusesBytesTheApproverDidNotReview(t *testing.T) {
 	env, ctx := inertEnv(t, approver, creator)
 	store := env.vmk.getGnoTransactionStore(ctx)
 
-	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files(false))))
+	// The approval an approver actually sends: digested from the submission, as
+	// gpao digests the MsgAddPackage in the block and gnokey -pkgdir a local copy.
+	approvalOf := func(private bool) MsgEnablePackage {
+		return MsgEnablePackage{
+			Approver: approver,
+			PkgPath:  pkgPath,
+			PkgHash:  PackageContentHash(NewMsgAddPackage(creator, pkgPath, files(private)).Package),
+		}
+	}
 
-	// The approval an approver would actually send: the digest is taken from
-	// the bytes the chain serves for this path, not from a package built here.
-	approval := approvalFor(t, env, ctx, approver, pkgPath)
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files(false))))
 	reviewed := store.GetInertPackage(pkgPath)
 	require.NotNil(t, reviewed, "premise: the public submission is parked")
 	require.NotContains(t, reviewed.GetFile("gnomod.toml").Body, "private",
@@ -102,31 +100,35 @@ func TestEnableRefusesBytesTheApproverDidNotReview(t *testing.T) {
 	require.Equal(t, reviewed.GetFile(srcName).Body, swapped.GetFile(srcName).Body,
 		"premise: the re-park moved gnomod.toml and nothing else")
 
-	err := env.vmk.EnablePackage(ctx, approval)
+	err := env.vmk.EnablePackage(ctx, approvalOf(false))
 	require.Error(t, err,
 		"an approval of the public submission activated the private one: the "+
 			"approver's signature named source it never saw")
-	// The class, not the message: a fix is free to reword the detail.
 	assert.Equal(t, InvalidPackageError{}, tmerrors.Cause(err),
-		"the refusal has to be about the submission's contents, so the approver "+
-			"is told their approval no longer names what is parked")
+		"the refusal has to be about the submission's contents")
+	assert.Contains(t, fmt.Sprintf("%+v", err), "is not what was approved",
+		"the approver has to be told their approval no longer names what is parked")
 	assert.Nil(t, store.GetMemPackage(pkgPath),
 		"a refused enable must leave the path empty, not half-deployed")
+
+	// The replacement overwrote the recorded digest along with the bytes, so an
+	// approval of what is parked now still lands.
+	require.NoError(t, env.vmk.EnablePackage(ctx, approvalOf(true)),
+		"an approval digested from the bytes now parked has to activate them")
+	assert.NotNil(t, store.GetMemPackage(pkgPath))
 }
 
 // TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields walks the fields a
 // submitter writes into gnomod.toml and pins that each one moves the digest.
 //
 // Every case differs from the base in exactly one authored field and in
-// nothing else -- same source file, same stamped section -- so a digest that
-// does not move is an approver signing for a package the chain reads as a
-// different module from the one they reviewed.
+// nothing else, so a digest that does not move is an approver signing for a
+// package the chain reads as a different module from the one they reviewed.
 //
-// The digest is blind to all four. Only the first two reach a live chain; the
-// other two are stopped by a submit-time check that the digest knows nothing
-// about, so they pin the digest against that check being relaxed rather than
-// against a hole open today. `reaches` records which is which, because the two
-// carry very different weight and a reader deserves to be told.
+// Only `private` reaches a live chain; the others are stopped by a submit-time
+// check that the digest knows nothing about, so they pin the digest against
+// that check being relaxed rather than against a hole open today. `reaches`
+// records which is which, because the two carry very different weight.
 func TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields(t *testing.T) {
 	t.Parallel()
 
@@ -141,7 +143,7 @@ func TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields(t *testing.T) {
 		}}
 	}
 
-	reviewed := pkgWith(storedGnomod(pkgPath, "0.9", ""))
+	reviewed := pkgWith(authoredGnomod(pkgPath, "0.9", ""))
 	reviewedMod, err := gnomod.ParseMemPackage(reviewed)
 	require.NoError(t, err, "premise: the reviewed gnomod.toml is one the chain accepts")
 
@@ -152,21 +154,21 @@ func TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields(t *testing.T) {
 		reaches string
 	}{
 		"private": {
-			mod:     storedGnomod(pkgPath, "0.9", "private = true"),
+			mod:     authoredGnomod(pkgPath, "0.9", "private = true"),
 			reaches: "a realm no other package may import goes live over an approval of a public one",
 		},
 		"gno": {
-			mod: storedGnomod(pkgPath, "0.8", ""),
+			mod: authoredGnomod(pkgPath, "0.8", ""),
 			reaches: "nothing; ParseCheckGnoMod panics on any version but the current one before " +
 				"the package runs, so this pins the digest against that gate being relaxed",
 		},
 		"draft": {
-			mod: storedGnomod(pkgPath, "0.9", "draft = true"),
+			mod: authoredGnomod(pkgPath, "0.9", "draft = true"),
 			reaches: "nothing; checkGnomodConstraints refuses a post-genesis draft at submit, " +
 				"so this pins the digest against that rule being relaxed",
 		},
 		"replace": {
-			mod: storedGnomod(pkgPath, "0.9",
+			mod: authoredGnomod(pkgPath, "0.9",
 				"[[replace]]\nold = \"gno.land/p/demo/avl\"\nnew = \"gno.land/p/demo/avl/v2\""),
 			reaches: "nothing; checkGnomodConstraints refuses any replace at submit, " +
 				"so this pins the digest against that rule being relaxed",
@@ -197,10 +199,7 @@ func TestApprovalDigestSeparatesSubmitterAuthoredGnomodFields(t *testing.T) {
 //
 // Nothing reaches a live chain through this one. A package with no module
 // declaration has no path to park under, which the premise below is the proof
-// of. It pins the digest at the far end of the range the exclusion covers: the
-// whole file is outside the hash, so an approver's signature covers a package
-// whose module path, privacy, gno version and replaces were all dropped, and
-// only a check elsewhere stops that mattering.
+// of, so this pins the digest against that check being relaxed.
 func TestApprovalDigestSeparatesASubmissionMissingItsGnomod(t *testing.T) {
 	t.Parallel()
 
@@ -209,7 +208,7 @@ func TestApprovalDigestSeparatesASubmissionMissingItsGnomod(t *testing.T) {
 		source  = "package nomodfile\n\nfunc Who(cur realm) string { return \"reviewed\" }"
 	)
 	src := &std.MemFile{Name: "nomodfile.gno", Body: source}
-	mod := &std.MemFile{Name: "gnomod.toml", Body: storedGnomod(pkgPath, "0.9", "")}
+	mod := &std.MemFile{Name: "gnomod.toml", Body: authoredGnomod(pkgPath, "0.9", "")}
 
 	reviewed := &std.MemPackage{Name: "nomodfile", Path: pkgPath, Files: []*std.MemFile{mod, src}}
 	stripped := &std.MemPackage{Name: "nomodfile", Path: pkgPath, Files: []*std.MemFile{src}}

--- a/gno.land/pkg/sdk/vm/pkghash_test.go
+++ b/gno.land/pkg/sdk/vm/pkghash_test.go
@@ -1,0 +1,81 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// TestAddPackageRecordsTheSubmittedDigest pins that the digest an approver
+// computes from a submission is the one AddPackage records for it. Approvers
+// hash the submitted bytes (gpao the MsgAddPackage it decodes out of the block,
+// gnokey -pkgdir a local copy) while the parked gnomod.toml is stamped, so the
+// record has to be taken from the bytes as received.
+//
+// The submission hand-writes the section the stamp overwrites, digest included,
+// as a submitter is free to: a recorded digest it chose would approve itself.
+func TestAddPackageRecordsTheSubmittedDigest(t *testing.T) {
+	const pkgPath = "gno.land/r/test/stamped"
+	// Fresh per call: stampGnomod rewrites msg.Package in place, so the copy
+	// hashed as "submitted" has to be a second instance of the same bytes.
+	files := func() []*std.MemFile {
+		return []*std.MemFile{
+			{Name: "gnomod.toml", Body: "module = \"" + pkgPath + "\"\n" +
+				"gno = \"0.9\"\n\n" +
+				"[addpkg]\n" +
+				"creator = \"g1forged\"\n" +
+				"pkg_hash = \"forged\"\n"},
+			{Name: "stamped.gno", Body: "package stamped\n\nfunc Who(cur realm) string { return \"reviewed\" }"},
+		}
+	}
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("stamped-creator"))
+	env, ctx := inertEnv(t, approver, creator)
+
+	submitted := NewMsgAddPackage(creator, pkgPath, files()).Package
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files())))
+
+	parked := env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath)
+	require.NotNil(t, parked)
+	gm, err := gnomod.ParseMemPackage(parked)
+	require.NoError(t, err)
+	require.Equal(t, creator.String(), gm.AddPkg.Creator, "premise: the stamp overwrote [addpkg]")
+	require.NotEqual(t, PackageContentHash(submitted), PackageContentHash(parked),
+		"premise: the stamp changed the stored bytes")
+
+	assert.Equal(t, PackageContentHash(submitted), gm.AddPkg.PkgHash,
+		"AddPackage recorded a digest other than the submission's, so no approval computed from it can land")
+	require.NoError(t, env.vmk.EnablePackage(ctx, MsgEnablePackage{
+		Approver: approver, PkgPath: pkgPath, PkgHash: PackageContentHash(submitted),
+	}), "an approval computed from the submitted bytes has to activate what was parked")
+}
+
+// TestPackageContentHashNamesTheBytes pins that the digest names the bytes a
+// submitter sent, not what a parser reads out of them: an approver reviews the
+// file as written, comments included.
+func TestPackageContentHashNamesTheBytes(t *testing.T) {
+	const pkgPath = "gno.land/r/test/rawbytes"
+	pkgWith := func(mod string) *std.MemPackage {
+		return &std.MemPackage{Name: "rawbytes", Path: pkgPath, Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: mod},
+			{Name: "rawbytes.gno", Body: "package rawbytes\n\nfunc Who(cur realm) string { return \"reviewed\" }"},
+		}}
+	}
+	plain := pkgWith("module = \"" + pkgPath + "\"\ngno = \"0.9\"\n")
+	commented := pkgWith("# the approver reads this line too\nmodule = \"" + pkgPath + "\"\ngno = \"0.9\"\n")
+
+	plainMod, err := gnomod.ParseMemPackage(plain)
+	require.NoError(t, err)
+	commentedMod, err := gnomod.ParseMemPackage(commented)
+	require.NoError(t, err)
+	require.Equal(t, plainMod, commentedMod, "premise: the parser reads both bodies as one module")
+
+	assert.NotEqual(t, PackageContentHash(plain), PackageContentHash(commented),
+		"two gnomod.toml bodies that read differently share a digest")
+}

--- a/gnovm/pkg/gnomod/file.go
+++ b/gnovm/pkg/gnomod/file.go
@@ -61,6 +61,10 @@ type AddPkg struct {
 	// Empty on the ordinary path: there the ceiling is used in the same
 	// transaction that declared it, so nothing needs to outlive it.
 	MaxDeposit string `toml:"max_deposit,omitempty" json:"max_deposit,omitempty"`
+	// PkgHash is the vm keeper's PackageContentHash of the package as it was
+	// submitted, before this section was written. Set only under the "inert"
+	// policy, where MsgEnablePackage has to name it.
+	PkgHash string `toml:"pkg_hash,omitempty" json:"pkg_hash,omitempty"`
 	// XXX: GnoVersion // gno version at add time?
 	// XXX: Consider things like IsUsingBanker or other security-awareness flags
 }

--- a/misc/gnoe2e/README.md
+++ b/misc/gnoe2e/README.md
@@ -116,7 +116,7 @@ back, and last an enable by hand with no oracle running.
 - `exhausted_purse.txtar`: `-max-spend` counts the fees the chain charges, refuses the approval that would cross the
   bound, and a run restarted with a larger bound reaches it without paying again for what is already live.
 - `substituted_source.txtar`: an approval computed over a reviewed submission must not activate different bytes at
-  the same path. Red: it states the boundary a fix has to meet.
+  the same path, even when the re-park changes only `gnomod.toml`.
 
 ## Limits
 

--- a/misc/gnoe2e/README.md
+++ b/misc/gnoe2e/README.md
@@ -115,6 +115,8 @@ back, and last an enable by hand with no oracle running.
   transaction reaches the chain, the run budget is untouched, and a fourth package still goes live.
 - `exhausted_purse.txtar`: `-max-spend` counts the fees the chain charges, refuses the approval that would cross the
   bound, and a run restarted with a larger bound reaches it without paying again for what is already live.
+- `substituted_source.txtar`: an approval computed over a reviewed submission must not activate different bytes at
+  the same path. Red: it states the boundary a fix has to meet.
 
 ## Limits
 

--- a/misc/gnoe2e/testdata/oracle/substituted_source.txtar
+++ b/misc/gnoe2e/testdata/oracle/substituted_source.txtar
@@ -1,0 +1,87 @@
+# **Red on master, and red on this branch: it states what should happen, and
+# picking the fix is a design decision this change does not make.**
+#
+# An approval computed over one submission must not activate different bytes at
+# the same path.
+#
+# The digest is the only thing binding an approval to source. It is computed
+# over the package's files with gnomod.toml left out, because AddPackage stamps
+# the creator, height and declared deposit into that file at submit, so the
+# stored bytes differ from what the submitter sent and no hash over the whole
+# file could agree. The exclusion is called sufficient on the grounds that every
+# byte an approver reviews is still covered.
+#
+# That leaves five fields the submitter authors in the same file, and one of them
+# is legal to substitute. Re-parking the same .gno source with private = true
+# moves no byte the digest can see, so an approval naming the reviewed digest
+# activates a realm no other package may import and the creator may silently
+# replace from then on. The approver saw none of that.
+#
+# A failure here is an approver's signature naming source it never read.
+
+# ---- The creator parks the package an approver will review
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/reviewed -pkgpath gno.land/r/probe/vault $USER_NAME
+
+# Parked and unreadable, which is where the inert policy this cluster declares
+# is read back.
+gnokey query vm/qinertpaths -data ''
+stdout 'gno.land/r/probe/vault'
+! gnokey query vm/qfile -data gno.land/r/probe/vault
+stdout 'is not available'
+
+# ---- The creator swaps the one file the digest cannot see
+# The substituted copy is assembled from the reviewed directory's own vault.gno
+# rather than from a second archive section, so the two .gno files cannot differ
+# by so much as the trailing newline a txtar section's position gives it. Only
+# gnomod.toml differs, by the one authored field no rule forbids.
+mkdir $WORK/swapped
+cp $WORK/reviewed/vault.gno $WORK/swapped/vault.gno
+cp $WORK/private/gnomod.toml $WORK/swapped/gnomod.toml
+
+# The same path and the same creator. AddPackage refuses a re-park by a
+# different creator, and permits this one: replacing your own submission is the
+# retry path after a failed enable.
+gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/swapped -pkgpath gno.land/r/probe/vault $USER_NAME
+
+gnokey query vm/qinertpaths -data ''
+stdout 'gno.land/r/probe/vault'
+
+# ---- The approval names the source the approver read
+# -pkgdir hashes the reviewed directory, exactly as the keeper hashes what is
+# parked, and both leave gnomod.toml out. So this names a digest that still
+# matches bytes the approver never saw.
+#
+# The refusal's wording belongs to whichever fix is chosen, so what is pinned
+# here is that the failure is about this package rather than about a key, a gas
+# figure or a missing path.
+! gnokey maketx enablepkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/reviewed -pkgpath gno.land/r/probe/vault $USER_NAME
+stderr 'gno.land/r/probe/vault'
+
+# ---- Nothing went live on that approval
+# The state, pinned independently of the wording above: the substituted bytes
+# are still parked, so no realm is serving source an approver did not read.
+! gnokey query vm/qfile -data gno.land/r/probe/vault
+stdout 'is not available'
+
+gnokey query vm/qinertpaths -data ''
+stdout 'gno.land/r/probe/vault'
+
+-- cluster --
+validators: 1
+code-submission-policy: inert
+pkg-approver: user
+-- reviewed/gnomod.toml --
+module = "gno.land/r/probe/vault"
+gno = "0.9"
+
+-- reviewed/vault.gno --
+package vault
+
+func Render(path string) string {
+	return "vault"
+}
+
+-- private/gnomod.toml --
+module = "gno.land/r/probe/vault"
+gno = "0.9"
+private = true

--- a/misc/gnoe2e/testdata/oracle/substituted_source.txtar
+++ b/misc/gnoe2e/testdata/oracle/substituted_source.txtar
@@ -12,6 +12,8 @@
 # creator may silently replace from then on. The approver saw none of that.
 #
 # A failure here is an approver's signature naming source it never read.
+#
+# **Red on master, green with the fix.**
 
 # ---- The creator parks the package an approver will review
 gnokey maketx addpkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/reviewed -pkgpath gno.land/r/probe/vault $USER_NAME

--- a/misc/gnoe2e/testdata/oracle/substituted_source.txtar
+++ b/misc/gnoe2e/testdata/oracle/substituted_source.txtar
@@ -1,21 +1,15 @@
-# **Red on master, and red on this branch: it states what should happen, and
-# picking the fix is a design decision this change does not make.**
-#
 # An approval computed over one submission must not activate different bytes at
 # the same path.
 #
-# The digest is the only thing binding an approval to source. It is computed
-# over the package's files with gnomod.toml left out, because AddPackage stamps
-# the creator, height and declared deposit into that file at submit, so the
-# stored bytes differ from what the submitter sent and no hash over the whole
-# file could agree. The exclusion is called sufficient on the grounds that every
-# byte an approver reviews is still covered.
+# The digest is the only thing binding an approval to source. It covers every
+# file as submitted, gnomod.toml included, and AddPackage records it at submit
+# before stamping the creator, height and declared deposit into that file. An
+# approver who hashes the directory they reviewed names that recorded digest.
 #
-# That leaves five fields the submitter authors in the same file, and one of them
-# is legal to substitute. Re-parking the same .gno source with private = true
-# moves no byte the digest can see, so an approval naming the reviewed digest
-# activates a realm no other package may import and the creator may silently
-# replace from then on. The approver saw none of that.
+# gnomod.toml carries five fields the submitter authors, and one of them is
+# legal to substitute. Re-parking the same .gno source with private = true would,
+# if the digest missed it, activate a realm no other package may import and the
+# creator may silently replace from then on. The approver saw none of that.
 #
 # A failure here is an approver's signature naming source it never read.
 
@@ -29,7 +23,7 @@ stdout 'gno.land/r/probe/vault'
 ! gnokey query vm/qfile -data gno.land/r/probe/vault
 stdout 'is not available'
 
-# ---- The creator swaps the one file the digest cannot see
+# ---- The creator swaps gnomod.toml and nothing else
 # The substituted copy is assembled from the reviewed directory's own vault.gno
 # rather than from a second archive section, so the two .gno files cannot differ
 # by so much as the trailing newline a txtar section's position gives it. Only
@@ -47,15 +41,11 @@ gnokey query vm/qinertpaths -data ''
 stdout 'gno.land/r/probe/vault'
 
 # ---- The approval names the source the approver read
-# -pkgdir hashes the reviewed directory, exactly as the keeper hashes what is
-# parked, and both leave gnomod.toml out. So this names a digest that still
-# matches bytes the approver never saw.
-#
-# The refusal's wording belongs to whichever fix is chosen, so what is pinned
-# here is that the failure is about this package rather than about a key, a gas
-# figure or a missing path.
+# -pkgdir hashes the reviewed directory exactly as AddPackage hashed the
+# submission it recorded. The re-park recorded the swapped digest in its place,
+# so this approval names bytes that are no longer parked.
 ! gnokey maketx enablepkg -broadcast=true -gas-wanted 20000000 -gas-fee 1000000ugnot -chainid $CHAIN_ID -pkgdir $WORK/reviewed -pkgpath gno.land/r/probe/vault $USER_NAME
-stderr 'gno.land/r/probe/vault'
+stderr 'gno.land/r/probe/vault is not what was approved'
 
 # ---- Nothing went live on that approval
 # The state, pinned independently of the wording above: the substituted bytes


### PR DESCRIPTION
An approver reviews a public package and their approval activates a private realm.

The creator parks a public package, the approver digests it and sends `MsgEnablePackage` naming that digest, and the creator re-parks the same `.gno` source with `private = true`. The digest skips `gnomod.toml`, so it does not move, the enable is accepted, and what goes live is unimportable by every other realm and silently replaceable by its creator from then on.

### Why the digest skipped the file

Approvers hash the bytes the submitter sent: gpao the `MsgAddPackage` it decodes out of the block, `gnokey maketx enablepkg -pkgdir` the directory read the way `addpkg` reads it. The chain hashes what it stores, and the inert branch of `AddPackage` rewrites `gnomod.toml` at submit through [`stampGnomod`](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/keeper.go#L616), so the two sides could only agree by leaving the file out. The same file carries five fields the submitter authors, and `private` is legal to substitute.

### The fix

[`AddPackage` records the digest of the files as received](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/keeper.go#L913-L921), before the stamp, as `pkg_hash` in the `[addpkg]` section, and [`EnablePackage` compares an approval with that record](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/keeper_inert.go#L129-L140) instead of hashing what it stores. [`PackageContentHash`](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/pkghash.go#L28) covers every file byte for byte, `gnomod.toml` included. gpao and `gnokey` need no change: both already hash the submitted bytes.

- **The stamp replaces the whole `[addpkg]` section**, so a `pkg_hash` written into the submitter's own `gnomod.toml` never survives.
- **A same-creator re-park overwrites the bytes and the record together**, so an approval of the replaced bytes is refused and an approval of the new ones lands.
- **`EnablePackage` parses the stored `gnomod.toml` before comparing**, so a file it cannot read is refused as unreadable rather than as a swapped source.
- **[`AddPackage` refuses a `gnomod.toml` the stamp makes unreadable](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/keeper.go#L922-L927).** Parked, such a file could be neither enabled, replaced nor rejected, since all three parse it first.

### Alternatives

| Option | Why not |
|---|---|
| Leave `gnomod.toml` out of the digest | the `private` substitution goes through; re-applying the gnomod rules at enable catches an illegal value, not a legal one substituted |
| Hash `gnomod.toml` in a canonical form: parse, pin `module`, zero `[addpkg]`, re-encode | the digest then depends on the `gnomod.File` schema and the TOML encoder, so two builds can disagree; it re-implements `stampGnomod`; and bodies differing only in comments share a digest |
| Approvers re-apply the stamp and hash the result | every client would have to reproduce the creator, the submit height and the deposit ceiling in force at submit time, and track every change to `stampGnomod` |

The decision and its consequences are recorded in [item 12 of the inert ADR](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/adr/pr6088_msgrun_allowlist_and_inert_charging.md#L1319).

### What changes for a chain running inert

- **A package parked before the upgrade cannot be enabled.** No digest was recorded for it, and the refusal tells its creator to submit it again. Adopting this is a coordinated upgrade.
- **A submitted `gnomod.toml` has 80 fewer bytes of headroom.** The stamp adds 192 bytes where it added 112, so the largest one accepted in encoder form drops from 3984 bytes to 3904; above that, the submission is refused.
- **The `pkg_hash` line stays in the live package's `gnomod.toml`** after enable, beside the creator and the height.

### Tests

- **[`pkghash_gnomod_test.go`](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/sdk/vm/pkghash_gnomod_test.go)** (new) runs the `private` substitution through the keeper, and separates by digest every `gnomod.toml` field a submitter authors and a submission without the file.
- **`pkghash_test.go`** ties the digest to the submitted bytes and checks that `AddPackage` records it.
- **`keeper_inert_guards_test.go`** covers the three new refusals: a package parked without a digest, a `gnomod.toml` the stamp makes unreadable, and a parked file that does not parse.
- **[`enablepkg_test.go`](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/gno.land/pkg/keyscli/enablepkg_test.go)** runs `gnokey maketx addpkg` and `enablepkg -pkgdir` against one directory, test file included, and compares the two printed messages.
- **[`substituted_source.txtar`](https://github.com/gnolang/gno/blob/ac271f2bfdee2b8d0df9820368c3f56dbeafd25a/misc/gnoe2e/testdata/oracle/substituted_source.txtar)** re-parks a reviewed package with only `gnomod.toml` changed, on a real cluster, and checks the approval is refused and nothing goes live. It is red on master and listed in the gnoe2e README.

`inert_lifecycle_test.go` and `keyscli/enablepkg.go` change a comment each.

### Left alone

- **The ordinary deploy path** records no digest and does not parse its stamped file back; nothing parks there.
- **Binding an approval to the submission itself**, the block and transaction that parked it, would remove the class altogether, but it breaks the retry path, which re-parks bytes under the same approval.

Other gpao and inert defects, and the design questions behind them: #6113, Q5.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
