### PR TITLE
fix(gpao): derive a dependency's name from its production files

### DIFF
--- a/contribs/gpao/getter.go
+++ b/contribs/gpao/getter.go
@@ -120,16 +120,41 @@ func (g *rpcGetter) fetch(pkgPath string) *std.MemPackage {
 	}
 }
 
-// packageName derives the package name from the first .gno file whose package
-// clause parses. Returns "" if none do; the typechecker will then error out.
+// packageName derives the package name the way the chain derives it in
+// ReadMemPackageFromList: the first production .gno file whose package clause
+// parses names the package, with a _test suffix trimmed. Filetests carry
+// arbitrary clauses, so they name a package only when it holds nothing else --
+// their own clause where they agree on one, and the literal "filetests" where
+// they do not.
+//
+// The order matters here because the file list comes from vm/qfile sorted, and
+// ReadMemPackage flattens a package's filetests/ directory into it, so a
+// filetest carrying a package clause of its own routinely sorts ahead of the
+// production files. The fallback matters because the name is what
+// typeCheckMemPackage writes .gnobuiltins.gno under, and an empty one makes
+// that file unparseable.
 func packageName(files []*std.MemFile) string {
+	var filetestName string
+	filetestsDiffer := false
 	for _, f := range files {
 		if !strings.HasSuffix(f.Name, ".gno") {
 			continue
 		}
-		if name, err := gno.PackageNameFromFileBody(f.Name, f.Body); err == nil {
-			return string(name)
+		name, err := gno.PackageNameFromFileBody(f.Name, f.Body)
+		if err != nil {
+			continue
+		}
+		if !strings.HasSuffix(f.Name, "_filetest.gno") {
+			return strings.TrimSuffix(string(name), "_test")
+		}
+		if filetestName == "" {
+			filetestName = string(name)
+		} else if filetestName != string(name) {
+			filetestsDiffer = true
 		}
 	}
-	return ""
+	if filetestsDiffer {
+		return "filetests"
+	}
+	return filetestName
 }

--- a/contribs/gpao/getter_test.go
+++ b/contribs/gpao/getter_test.go
@@ -38,12 +38,81 @@ func TestPackageName(t *testing.T) {
 			files: []*std.MemFile{{Name: "gnomod.toml", Body: "module = \"x\""}},
 			want:  "",
 		},
+		{
+			// vm/qfile serves a package's files sorted, and ReadMemPackage
+			// flattens filetests/ into the same list, so a filetest routinely
+			// sorts ahead of the production files. Its package clause is
+			// arbitrary and unrelated to the package's own.
+			name: "ignores a filetest sorting ahead of the production files",
+			files: []*std.MemFile{
+				{Name: "caller_teller_sub_realm_filetest.gno", Body: "package grc20subrealm\n"},
+				{Name: "token.gno", Body: "package grc20\n\nfunc F() {}"},
+			},
+			want: "grc20",
+		},
+		{
+			name: "strips the _test suffix an external test file carries",
+			files: []*std.MemFile{
+				{Name: "grc20_test.gno", Body: "package grc20_test\n"},
+				{Name: "token.gno", Body: "package grc20\n"},
+			},
+			want: "grc20",
+		},
+		{
+			name: "filetests agreeing on a clause name the package",
+			files: []*std.MemFile{
+				{Name: "a_filetest.gno", Body: "package anything\n"},
+				{Name: "b_filetest.gno", Body: "package anything\n"},
+			},
+			want: "anything",
+		},
+		{
+			name: "filetests disagreeing fall back to the chain's default",
+			files: []*std.MemFile{
+				{Name: "a_filetest.gno", Body: "package anything\n"},
+				{Name: "b_filetest.gno", Body: "package something\n"},
+			},
+			want: "filetests",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, packageName(tt.files))
 		})
 	}
+}
+
+// TestRPCGetterNamesReconstructedPackage pins the name a dependency rebuilt from
+// vm/qfile carries. The listing is what a node serves for a package holding
+// filetests: production files, stored _test.gno, and flattened _filetest.gno,
+// sorted, so the filetest comes first and its package clause is not the
+// package's own.
+func TestRPCGetterNamesReconstructedPackage(t *testing.T) {
+	const pkgPath = "gno.land/p/demo/tokens/grc20"
+	files := map[string]string{
+		pkgPath: "caller_teller_sub_realm_filetest.gno\ngnomod.toml\ntoken.gno\ntoken_test.gno",
+		path.Join(pkgPath, "caller_teller_sub_realm_filetest.gno"): "package grc20subrealm\n",
+		path.Join(pkgPath, "gnomod.toml"):                          "module = \"" + pkgPath + "\"\n",
+		path.Join(pkgPath, "token.gno"):                            "package grc20\n\nfunc F() {}\n",
+		path.Join(pkgPath, "token_test.gno"):                       "package grc20_test\n",
+	}
+
+	g := &rpcGetter{
+		cache: make(map[string]*std.MemPackage),
+		qfile: func(fp string) ([]byte, error) {
+			body, ok := files[fp]
+			if !ok {
+				return nil, errors.New("file is not available")
+			}
+			return []byte(body), nil
+		},
+	}
+
+	mpkg := g.GetMemPackage(pkgPath)
+	require.NotNil(t, mpkg)
+	assert.Equal(t, "grc20", mpkg.Name,
+		"the typechecker emits .gnobuiltins.gno under this name, so a filetest's "+
+			"clause here rejects the importing package for a name its author never wrote")
 }
 
 // TestRPCGetterCaching verifies the getter caches successful fetches (immutable


### PR DESCRIPTION
Importing `gno.land/p/demo/tokens/grc20` is a terminal rejection, and the reason names a package the submitter never wrote.

Three packages in `examples/` are unimportable this way: `p/demo/tokens/grc20` (named `grc20subrealm`), `p/demo/tokens/grc721` (named `grc721dupsignal`), and `p/nt/treasury/v0` (named `canonicaltest`). Counted across all 325 package directories with the derivation the chain itself uses.

### A filetest sorts first and names the package

[`vm/qfile` serves a package's files sorted](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gnovm/pkg/gnolang/store.go#L1199), and [`ReadMemPackage` flattens `filetests/` into that list](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gnovm/pkg/gnolang/mempackage.go#L821-L833), so a filetest routinely arrives ahead of the production files. [`packageName` took the first `.gno` file that parsed](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/contribs/gpao/getter.go#L123-L134), and filetests carry package clauses of their own.

```
caller_teller_sub_realm_filetest.gno   # package grc20subrealm   <- taken
gnomod.toml
token.gno                              # package grc20
token_test.gno                         # package grc20_test
```

The wrong name reaches the typechecker, which emits `.gnobuiltins.gno` under it:

```
.gnobuiltins.gno:1:1: package grc20subrealm; expected package grc20
token.gno:3:14: undefined: address
token.gno:5:14: undefined: realm
```

`handleCandidate` then records `rejected` and marks the content hash seen, so resubmitting identical bytes changes nothing.

### The chain already has the rule

[`ReadMemPackageFromList`](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gnovm/pkg/gnolang/mempackage.go#L910) derives a package's own name by skipping filetests, whose clauses ["may have arbitrary package names"](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gnovm/pkg/gnolang/mempackage.go#L964), and trimming a `_test` suffix. For a package holding only filetests it [takes the filetests' clause where they agree and the literal `"filetests"` where they do not](https://github.com/gnolang/gno/blob/2ed70a202e6f92364be56c5c17ddd706e0c9d922/gnovm/pkg/gnolang/mempackage.go#L1008-L1014). `packageName` now does the same.

An empty name was never a safe fallback: it leaves `.gnobuiltins.gno` unparseable, and the verifier reports a panic rather than a diagnostic.

### Left alone

- Which files the typechecker considers is unchanged. The getter labels the reconstructed package `MPUserProd`, which excludes tests and filetests at typecheck.
- Which imports are fetched from the chain and which from disk is unchanged. That is Q5 on #6113.

Other gpao defects and the design questions behind them: #6113.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
