### PR TITLE
fix(gnoweb): use help remote for CSP connect-src

### DIFF
--- a/gno.land/cmd/gnoweb/main.go
+++ b/gno.land/cmd/gnoweb/main.go
@@ -280,7 +280,7 @@ func setupWeb(cfg *webCfg, _ []string, io commands.IO) (func() error, error) {
 	logger.Info("Running", "listener", bindaddr.String())
 
 	// Setup security headers
-	secureHandler := SecureHeadersMiddleware(app, !cfg.noStrict, appcfg.NodeRemote)
+	secureHandler := newSecureHeadersMiddleware(app, !cfg.noStrict, appcfg)
 
 	// Setup server
 	server := &http.Server{
@@ -383,6 +383,10 @@ func SecureHeadersMiddleware(next http.Handler, strict bool, remote string) http
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func newSecureHeadersMiddleware(next http.Handler, strict bool, cfg *gnoweb.AppConfig) http.Handler {
+	return SecureHeadersMiddleware(next, strict, cfg.RemoteHelp)
 }
 
 // normalizeRemoteURL ensures the remote URL has a valid HTTP(S) protocol.

--- a/gno.land/cmd/gnoweb/main_test.go
+++ b/gno.land/cmd/gnoweb/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoweb"
 	"github.com/gnolang/gno/tm2/pkg/commands"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,6 +122,28 @@ func TestSecureHeadersMiddlewareStrict(t *testing.T) {
 	if !strings.Contains(body, "OK") {
 		t.Errorf("Unexpected response body: %s", body)
 	}
+}
+
+func TestSecureHeadersMiddlewareUsesRemoteHelp(t *testing.T) {
+	t.Parallel()
+
+	appcfg := gnoweb.NewDefaultAppConfig()
+	appcfg.NodeRemote = "http://internal-rpc:26657"
+	appcfg.RemoteHelp = "https://public-rpc.example.test"
+
+	handler := newSecureHeadersMiddleware(http.HandlerFunc(dummyHandler), true, appcfg)
+
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+	res := rec.Result()
+
+	csp := res.Header.Get("Content-Security-Policy")
+	require.Contains(t, csp, "connect-src 'self' https://public-rpc.example.test/abci_query")
+	require.NotContains(t, csp, "http://internal-rpc:26657/abci_query")
+	require.Contains(t, csp, "form-action 'self'")
+	require.Equal(t, "max-age=31536000", res.Header.Get("Strict-Transport-Security"))
 }
 
 func TestSecureHeadersMiddlewareNonStrict(t *testing.T) {


### PR DESCRIPTION
## Summary

- build gnoweb's `connect-src` CSP from the configured help remote
- keep the browser security policy aligned with the endpoint rendered to the action/help UI
- add regression coverage for configurations where `-remote` and `-help-remote` use different hosts

The action UI fetches `/abci_query` from `RemoteHelp`, while the CSP was built from `NodeRemote`. When those endpoints differ, the browser can block the action result request even though the configured help endpoint is valid.

Addresses #6121 §1.1.

## Test plan

- `go test ./gno.land/cmd/gnoweb -run TestSecureHeadersMiddlewareUsesRemoteHelp -count=1 -v`
- `go test ./gno.land/cmd/gnoweb -count=1`
- `go test ./gno.land/pkg/gnoweb/... -count=1`
- `make fmt`
- `make lint`
- `git diff --check`

## AI assistance

AI-assisted implementation and review using Codex. The final diff and test results were reviewed by the contributor.
