### PR TITLE
fix(gnovm): handle panics during package initialization

### DIFF
--- a/gnovm/adr/pr6129_package_init_panic.md
+++ b/gnovm/adr/pr6129_package_init_panic.md
@@ -1,0 +1,41 @@
+# Package-initialization panic without a call frame
+
+## Context
+
+Runtime panics raised by package-level variable initializers can happen before
+the VM has pushed any function call frame. `pushPanic` converted the panic value
+into a VM `Exception`, called `PopUntilLastCallFrame`, and then assumed the
+returned frame was non-nil so it could link `fr.LastException`.
+
+During package initialization that assumption is false. A normal VM runtime
+panic, such as an out-of-range index or division by zero in a variable
+initializer, therefore became a Go-host nil pointer dereference instead of the
+intended Gno unhandled panic.
+
+## Decision
+
+When `pushPanic` finds no call frame to unwind, keep the constructed exception
+in `m.Exception` and immediately use the existing `makeUnhandledPanicError`
+terminal path.
+
+The normal call-frame path is unchanged: if a call frame exists, `pushPanic`
+continues to link the previous frame exception and pushes
+`OpPanic2`/`OpReturnCallDefers` so defers and `recover` run as before.
+
+## Alternatives Considered
+
+- Return when no call frame exists. Rejected because it leaves the machine with
+  an active exception but no panic-unwind ops; the remaining `OpHalt` could let
+  package initialization continue and swallow the original panic.
+- Broaden the exception subsystem. Rejected because `doOpPanic2` already
+  defines the no-call-frame terminal behavior, and #6051 only needs
+  `pushPanic` to use that same path when package initialization starts without
+  a frame.
+
+## Consequences
+
+- Package-level initializer panics now surface as Gno unhandled panics with the
+  original runtime error value.
+- Ordinary function panics, defer unwinding, and `recover` behavior remain on
+  the existing call-frame path.
+- No gas constants, package initialization order, or public API are changed.

--- a/gnovm/pkg/gnolang/machine.go
+++ b/gnovm/pkg/gnolang/machine.go
@@ -3124,8 +3124,9 @@ func (m *Machine) Panic(etv TypedValue) {
 	panic(ex)
 }
 
-// This function does not go-panic:
-// caller must return manually.
+// This function normally schedules VM panic unwinding rather than go-panicking.
+// If no call frame exists, there is nothing to unwind or recover through, so
+// it terminates through the existing unhandled-panic path.
 // It should ONLY be called from doOp* Op handlers,
 // and should return immediately from the origin Op.
 func (m *Machine) pushPanic(etv TypedValue) {
@@ -3138,11 +3139,18 @@ func (m *Machine) pushPanic(etv TypedValue) {
 	fr := m.PopUntilLastCallFrame()
 	// Link ex.Previous.
 	if m.Exception == nil {
-		// Recall the last m.Exception before frame.
-		m.Exception = ex.WithPrevious(fr.LastException)
+		if fr == nil {
+			m.Exception = ex
+		} else {
+			// Recall the last m.Exception before frame.
+			m.Exception = ex.WithPrevious(fr.LastException)
+		}
 	} else {
 		// Replace existing m.Exception with new.
 		m.Exception = ex.WithPrevious(m.Exception)
+	}
+	if fr == nil {
+		panic(m.makeUnhandledPanicError())
 	}
 
 	m.PushOp(OpPanic2)

--- a/gnovm/tests/files/var_init_panic_divzero.gno
+++ b/gnovm/tests/files/var_init_panic_divzero.gno
@@ -1,0 +1,11 @@
+package main
+
+var (
+	z int
+	A = 1 / z
+)
+
+func main() {}
+
+// Error:
+// runtime error: division by zero

--- a/gnovm/tests/files/var_init_panic_index.gno
+++ b/gnovm/tests/files/var_init_panic_index.gno
@@ -1,0 +1,11 @@
+package main
+
+var (
+	a = ""
+	A = a[0]
+)
+
+func main() {}
+
+// Error:
+// runtime error: index out of range [0] with length 0


### PR DESCRIPTION
## Summary

- prevent package-level initializer panics from dereferencing a missing call frame
- preserve the underlying Gno runtime panic instead of crashing the Go host
- add regression coverage for runtime panics before a function call frame exists

During package initialization there may be no enclosing call frame. `pushPanic`
assumed one was always available after frame unwinding, so a normal runtime panic
in a package variable initializer could become a Go-host nil pointer dereference.

Fixes #6051.

## Test plan

- `go test ./gnovm/pkg/gnolang/ -run 'TestFiles/^var_init_panic_(index|divzero)\.gno$' -count=1`
- `go test ./gnovm/pkg/gnolang/ -run 'TestFiles/^(panic.*|recover.*|defer.*|var_initorder.*|var_init_panic_(index|divzero))\.gno$' -count=1`
- `go test -race ./gnovm/pkg/gnolang/ -run 'TestFiles/^var_init_panic_(index|divzero)\.gno$' -count=1`
- `go test ./gnovm/cmd/gno -run Run -count=1`
- `go test ./gnovm/pkg/gnolang/... -count=1`
- `make fmt`
- `make lint`
- `git diff --check`

## AI assistance

AI-assisted implementation and review using Codex. The contributor reviewed the
final panic-state behavior, diff, and test results.
