### PR TITLE
perf(gnoland,bank): stop genesis balance loading being quadratic

### DIFF
--- a/contribs/gnogenesis/internal/fork/test.go
+++ b/contribs/gnogenesis/internal/fork/test.go
@@ -220,12 +220,17 @@ func execTest(ctx context.Context, cfg *testCfg, io commands.IO) error {
 	io.Println()
 	io.Println("Starting in-memory node for genesis replay...")
 
+	// Time from here, not from n.Start(): InitChain runs *inside*
+	// NewInMemoryNode, via node.NewNode -> doHandshake -> ReplayBlocks ->
+	// InitChainSync. Starting the clock after it returns reported 2s for a
+	// genesis that took 414s to load, which is how a quadratic in genesis
+	// balance loading went unnoticed. See gnolang/gno#6133.
+	start := time.Now()
+
 	n, err := gnoland.NewInMemoryNode(nodeLogger, nodeCfg)
 	if err != nil {
 		return fmt.Errorf("creating in-memory node: %w", err)
 	}
-
-	start := time.Now()
 
 	if err := n.Start(); err != nil {
 		return fmt.Errorf("starting node: %w", err)

--- a/gno.land/pkg/gnoland/app.go
+++ b/gno.land/pkg/gnoland/app.go
@@ -774,6 +774,20 @@ func (cfg InitChainerConfig) applyBalance(ctx sdk.Context, bal Balance) {
 	// only by the schedule set on it. Built through NewAccountWithAddress like
 	// every other account, which is what keeps it a *GnoAccount and so keeps the
 	// attributes -- the token-lock whitelist bit among them -- available on it.
+	// Probe before creating the account, to learn whether this address is a repeat
+	// (see the note above on repeated entries). A first sighting cannot hold a
+	// split-tier balance yet -- the bank store is empty when InitChainer starts,
+	// bank.InitGenesis writes params only, and this loop is its sole writer -- so
+	// there are no stale keys for SetCoins to drain, and InitCoins skips the
+	// enumeration that finds them. That enumeration is a store range iteration
+	// whose cost is O(all dirty keys), not O(denoms held), which made loading a
+	// large balance sheet quadratic. A repeat takes the SetCoins path unchanged.
+	firstSighting := cfg.acck.GetAccount(ctx, bal.Address) == nil
+
+	// One account type either way, so a vesting balance differs from any other
+	// only by the schedule set on it. Built through NewAccountWithAddress like
+	// every other account, which is what keeps it a *GnoAccount and so keeps the
+	// attributes -- the token-lock whitelist bit among them -- available on it.
 	acc := cfg.acck.NewAccountWithAddress(ctx, bal.Address)
 	if bal.IsVesting() {
 		if err := bal.Vesting.Validate(); err != nil {
@@ -786,7 +800,12 @@ func (cfg InitChainerConfig) applyBalance(ctx sdk.Context, bal Balance) {
 		acc.SetVesting(*bal.Vesting)
 	}
 	cfg.acck.SetAccount(ctx, acc)
-	if err := cfg.bankk.SetCoins(ctx, bal.Address, bal.Amount); err != nil {
+
+	setCoins := cfg.bankk.SetCoins
+	if firstSighting {
+		setCoins = cfg.bankk.InitCoins
+	}
+	if err := setCoins(ctx, bal.Address, bal.Amount); err != nil {
 		// Name the address and the amount. This aborts genesis, and the causes
 		// include a denom that is too long or malformed — so an operator forking a
 		// chain needs to know which entry to fix. std.ErrInvalidCoins carries the

--- a/gno.land/pkg/gnoland/app_test.go
+++ b/gno.land/pkg/gnoland/app_test.go
@@ -3976,6 +3976,40 @@ func TestApplyBalanceWithARepeatedAddress(t *testing.T) {
 	require.False(t, broken, "invariants must be clean after a repeated entry:\n%s", msg)
 }
 
+// TestApplyBalanceChoosesInitCoinsOrSetCoins pins the branch applyBalance takes
+// on cfg.acck.GetAccount, using mocks so the choice is asserted directly rather
+// than inferred from the resulting balance: a first sighting must go through
+// InitCoins, and a repeat must go through SetCoins, and neither may call the
+// other.
+func TestApplyBalanceChoosesInitCoinsOrSetCoins(t *testing.T) {
+	t.Parallel()
+
+	db := memdb.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	baseKey := store.NewStoreKey("baseKey")
+	mainKey := store.NewStoreKey("mainKey")
+	ms.MountStoreWithDB(baseKey, dbadapter.StoreConstructor, db)
+	ms.MountStoreWithDB(mainKey, storebptree.FastStoreConstructor, db)
+	require.NoError(t, ms.LoadLatestVersion())
+	ctx := sdk.NewContext(sdk.RunTxModeDeliver, ms.MultiCacheWrap(),
+		&bft.Header{ChainID: "test-chain-id"}, log.NewNoopLogger())
+
+	acck := &mockAuthKeeper{}
+	bankk := &mockBankKeeper{}
+	cfg := InitChainerConfig{acck: acck, bankk: bankk}
+
+	addr := crypto.AddressFromPreimage([]byte("applyBalance-branch"))
+	amount := std.Coins{{Denom: ugnot.Denom, Amount: 100}}
+
+	cfg.applyBalance(ctx, Balance{Address: addr, Amount: amount})
+	require.Equal(t, 1, bankk.initCoinsCalls, "a first sighting must take the InitCoins branch")
+	require.Equal(t, 0, bankk.setCoinsCalls, "and must not also call SetCoins")
+
+	cfg.applyBalance(ctx, Balance{Address: addr, Amount: amount})
+	require.Equal(t, 1, bankk.setCoinsCalls, "a repeat must take the SetCoins branch")
+	require.Equal(t, 1, bankk.initCoinsCalls, "and must not call InitCoins again")
+}
+
 // TestGenesisSignerMintIsAccounted covers the one place genesis creates coins
 // outside the balances file: a genesis transaction whose signer has no account is
 // funded so it can pay for itself. That has to mint rather than credit. The supply

--- a/gno.land/pkg/gnoland/mock_test.go
+++ b/gno.land/pkg/gnoland/mock_test.go
@@ -140,10 +140,12 @@ func (m *mockVMKeeper) InitGenesis(ctx sdk.Context, gs vm.GenesisState) {}
 type mockBankKeeper struct {
 	recomputeSupplyCalls int
 	setCoinsCalls        int
-	// setCoinsAtRecompute is how many balances had been written when the supply was
-	// recomputed. SetCoins does not maintain the counter, so a recompute that runs
-	// before the balance loop leaves a fresh chain with balances and no supply
-	// record — a call count alone cannot tell the two orders apart.
+	initCoinsCalls       int
+	// setCoinsAtRecompute is how many balances had been written, via either path,
+	// when the supply was recomputed. Neither SetCoins nor InitCoins maintains the
+	// counter, so a recompute that runs before the balance loop leaves a fresh
+	// chain with balances and no supply record — a call count alone cannot tell
+	// the two orders apart.
 	setCoinsAtRecompute int
 }
 
@@ -175,11 +177,10 @@ func (m *mockBankKeeper) SetCoins(ctx sdk.Context, addr crypto.Address, amt std.
 	return nil
 }
 
-// InitCoins is the fresh-address form of SetCoins and counts the same. What
-// setCoinsAtRecompute pins is how many balances had been written by the time the
-// supply was recomputed, and a balance written either way counts.
+// InitCoins is the fresh-address form of SetCoins, counted separately so a test
+// can assert which branch applyBalance took for a given address.
 func (m *mockBankKeeper) InitCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error {
-	m.setCoinsCalls++
+	m.initCoinsCalls++
 	return nil
 }
 
@@ -197,7 +198,7 @@ func (m *mockBankKeeper) BurnCoins(ctx sdk.Context, addr crypto.Address, amt std
 
 func (m *mockBankKeeper) RecomputeSupply(ctx sdk.Context) {
 	m.recomputeSupplyCalls++
-	m.setCoinsAtRecompute = m.setCoinsCalls
+	m.setCoinsAtRecompute = m.setCoinsCalls + m.initCoinsCalls
 }
 
 func (m *mockBankKeeper) TotalSupply(ctx sdk.Context, denom string) int64 {
@@ -208,9 +209,18 @@ func (m *mockBankKeeper) GetCoin(ctx sdk.Context, addr crypto.Address, denom str
 	return 0
 }
 
-type mockAuthKeeper struct{}
+// mockAuthKeeper tracks which addresses it has seen so GetAccount can report a
+// repeat. Without that, applyBalance would always see a first sighting and a
+// test could never reach its SetCoins branch.
+type mockAuthKeeper struct {
+	known map[crypto.Address]bool
+}
 
 func (m *mockAuthKeeper) NewAccountWithAddress(ctx sdk.Context, addr crypto.Address) std.Account {
+	if m.known == nil {
+		m.known = map[crypto.Address]bool{}
+	}
+	m.known[addr] = true
 	return nil
 }
 
@@ -222,8 +232,14 @@ func (m *mockAuthKeeper) NewAccountWithAddress(ctx sdk.Context, addr crypto.Addr
 func (m *mockAuthKeeper) NewAccountWithUncheckedNumber(ctx sdk.Context, addr crypto.Address, accNum uint64) std.Account {
 	return nil
 }
-func (m *mockAuthKeeper) GetNextAccountNumber(ctx sdk.Context) uint64                     { return 0 }
-func (m *mockAuthKeeper) GetAccount(ctx sdk.Context, addr crypto.Address) std.Account     { return nil }
+func (m *mockAuthKeeper) GetNextAccountNumber(ctx sdk.Context) uint64 { return 0 }
+
+func (m *mockAuthKeeper) GetAccount(ctx sdk.Context, addr crypto.Address) std.Account {
+	if m.known[addr] {
+		return &GnoAccount{}
+	}
+	return nil
+}
 func (m *mockAuthKeeper) GetAllAccounts(ctx sdk.Context) []std.Account                    { return nil }
 func (m *mockAuthKeeper) SetAccount(ctx sdk.Context, acc std.Account)                     {}
 func (m *mockAuthKeeper) IterateAccounts(ctx sdk.Context, process func(std.Account) bool) {}

--- a/gno.land/pkg/gnoland/mock_test.go
+++ b/gno.land/pkg/gnoland/mock_test.go
@@ -175,6 +175,14 @@ func (m *mockBankKeeper) SetCoins(ctx sdk.Context, addr crypto.Address, amt std.
 	return nil
 }
 
+// InitCoins is the fresh-address form of SetCoins and counts the same. What
+// setCoinsAtRecompute pins is how many balances had been written by the time the
+// supply was recomputed, and a balance written either way counts.
+func (m *mockBankKeeper) InitCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error {
+	m.setCoinsCalls++
+	return nil
+}
+
 func (m *mockBankKeeper) HasCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) bool {
 	return true
 }

--- a/tm2/pkg/sdk/bank/initcoins_bench_test.go
+++ b/tm2/pkg/sdk/bank/initcoins_bench_test.go
@@ -1,0 +1,53 @@
+package bank
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// Guards the genesis balance-loading regression: SetCoins enumerates an
+// address's existing split-tier keys, and cacheStore answers that range query
+// by scanning every dirty key written so far, so a loop of n SetCoins calls is
+// O(n^2). InitCoins skips the enumeration on addresses that provably hold
+// nothing yet.
+//
+// Run both and compare; the gap grows with n:
+//
+//	go test ./pkg/sdk/bank/ -run XXX -bench 'CoinsLoad' -benchtime 1x
+//
+// At n=100_000 the SetCoins form is minutes and the InitCoins form is seconds.
+// If they ever converge, either the store was fixed (good -- say so here) or
+// the genesis fast path was lost (bad).
+func benchCoinsLoad(b *testing.B, n int, init bool) {
+	b.Helper()
+	amt := std.NewCoins(std.NewCoin(testAccountDenom, 1_000_000))
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		env := setupTestEnv()
+		// InitChain runs against a cache-wrapped multistore (BaseApp does this
+		// for deliverState), and the quadratic lives in that cache layer --
+		// cacheStore.dirtyItems. Benchmarking against the bare IAVL store from
+		// setupTestEnv would measure tree cost only and show nothing.
+		env.ctx = env.ctx.WithMultiStore(env.ctx.MultiStore().MultiCacheWrap())
+		b.StartTimer()
+		for a := range n {
+			var err error
+			if init {
+				err = env.bankk.InitCoins(env.ctx, addrN(a), amt)
+			} else {
+				err = env.bankk.SetCoins(env.ctx, addrN(a), amt)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkCoinsLoadSetCoins10000(b *testing.B)   { benchCoinsLoad(b, 10_000, false) }
+func BenchmarkCoinsLoadInitCoins10000(b *testing.B)  { benchCoinsLoad(b, 10_000, true) }
+func BenchmarkCoinsLoadSetCoins20000(b *testing.B)   { benchCoinsLoad(b, 20_000, false) }
+func BenchmarkCoinsLoadInitCoins20000(b *testing.B)  { benchCoinsLoad(b, 20_000, true) }
+func BenchmarkCoinsLoadSetCoins100000(b *testing.B)  { benchCoinsLoad(b, 100_000, false) }
+func BenchmarkCoinsLoadInitCoins100000(b *testing.B) { benchCoinsLoad(b, 100_000, true) }

--- a/tm2/pkg/sdk/bank/initcoins_test.go
+++ b/tm2/pkg/sdk/bank/initcoins_test.go
@@ -1,0 +1,147 @@
+package bank
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+)
+
+// InitCoins is only sound because it produces byte-identical store state to
+// SetCoins whenever the address holds nothing yet. These tests pin that
+// equivalence rather than trusting the argument.
+
+// everyStoreKV dumps the whole bank store, so two runs can be compared exactly
+// (values and ordering both).
+func everyStoreKV(t *testing.T, env testEnv) []std.KVPair {
+	t.Helper()
+	var out []std.KVPair
+	stor := env.ctx.Store(env.bankk.key)
+	it := stor.Iterator(nil, nil, nil)
+	defer it.Close()
+	for ; it.Valid(); it.Next() {
+		k := append([]byte(nil), it.Key()...)
+		v := append([]byte(nil), it.Value()...)
+		out = append(out, std.KVPair{Key: k, Value: v})
+	}
+	return out
+}
+
+func addrN(i int) crypto.Address {
+	var a crypto.Address
+	copy(a[:], fmt.Sprintf("addr-%014d", i))
+	return a
+}
+
+// The core claim: on a fresh address the two calls are indistinguishable.
+func TestInitCoinsMatchesSetCoinsOnFreshAddress(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		amt  std.Coins
+	}{
+		{"single ugnot", std.NewCoins(std.NewCoin("ugnot", 1_000_000))},
+		{"split tier only", std.NewCoins(std.NewCoin("zzzcoin", 5))},
+		{"both tiers", std.NewCoins(std.NewCoin("ugnot", 7), std.NewCoin("zzzcoin", 9))},
+		{"many denoms", std.NewCoins(
+			std.NewCoin("aaa", 1), std.NewCoin("bbb", 2), std.NewCoin("ccc", 3),
+			std.NewCoin("ddd", 4), std.NewCoin("ugnot", 5),
+		)},
+		{"empty", std.NewCoins()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			addr := addrN(1)
+
+			envSet := setupTestEnv()
+			errSet := envSet.bankk.SetCoins(envSet.ctx, addr, tc.amt)
+
+			envInit := setupTestEnv()
+			errInit := envInit.bankk.InitCoins(envInit.ctx, addr, tc.amt)
+
+			require.Equal(t, errSet == nil, errInit == nil, "error agreement")
+			require.Equal(t, everyStoreKV(t, envSet), everyStoreKV(t, envInit),
+				"store state must be byte-identical")
+			require.Equal(t,
+				envSet.bankk.GetCoins(envSet.ctx, addr),
+				envInit.bankk.GetCoins(envInit.ctx, addr),
+				"GetCoins must agree")
+		})
+	}
+}
+
+// Invalid input must be rejected identically, before anything is written.
+func TestInitCoinsRejectsInvalidCoinsLikeSetCoins(t *testing.T) {
+	t.Parallel()
+	addr := addrN(2)
+	bad := std.Coins{std.Coin{Denom: "ugnot", Amount: -1}}
+
+	envSet := setupTestEnv()
+	errSet := envSet.bankk.SetCoins(envSet.ctx, addr, bad)
+
+	envInit := setupTestEnv()
+	errInit := envInit.bankk.InitCoins(envInit.ctx, addr, bad)
+
+	require.Error(t, errSet)
+	require.Error(t, errInit)
+	require.Equal(t, errSet.Error(), errInit.Error())
+	require.Equal(t, everyStoreKV(t, envSet), everyStoreKV(t, envInit))
+}
+
+// A whole genesis-shaped load, both ways, compared as a single store image.
+// This is the case the genesis loader actually runs.
+func TestInitCoinsWholeLoadMatchesSetCoins(t *testing.T) {
+	t.Parallel()
+
+	amounts := func(i int) std.Coins {
+		switch i % 4 {
+		case 0:
+			return std.NewCoins(std.NewCoin("ugnot", int64(i+1)))
+		case 1:
+			return std.NewCoins(std.NewCoin("zzzcoin", int64(i+1)))
+		case 2:
+			return std.NewCoins(std.NewCoin("ugnot", int64(i+1)), std.NewCoin("zzzcoin", int64(i+2)))
+		default:
+			return std.NewCoins(std.NewCoin("aaa", int64(i+1)), std.NewCoin("mmm", int64(i+3)))
+		}
+	}
+
+	envSet := setupTestEnv()
+	envInit := setupTestEnv()
+	for i := range 200 {
+		require.NoError(t, envSet.bankk.SetCoins(envSet.ctx, addrN(i), amounts(i)))
+		require.NoError(t, envInit.bankk.InitCoins(envInit.ctx, addrN(i), amounts(i)))
+	}
+	require.Equal(t, everyStoreKV(t, envSet), everyStoreKV(t, envInit))
+}
+
+// The precondition has teeth: on an address that already holds a split-tier
+// denom the new amount does not cover, InitCoins leaves the stale key behind
+// where SetCoins removes it. Pinned so nobody "optimises" SetCoins into
+// InitCoins at a call site that cannot guarantee freshness.
+func TestInitCoinsDoesNotDrainStaleKeys(t *testing.T) {
+	t.Parallel()
+	addr := addrN(3)
+	first := std.NewCoins(std.NewCoin("aaa", 10), std.NewCoin("bbb", 20))
+	second := std.NewCoins(std.NewCoin("aaa", 1))
+
+	envSet := setupTestEnv()
+	require.NoError(t, envSet.bankk.SetCoins(envSet.ctx, addr, first))
+	require.NoError(t, envSet.bankk.SetCoins(envSet.ctx, addr, second))
+
+	envInit := setupTestEnv()
+	require.NoError(t, envInit.bankk.SetCoins(envInit.ctx, addr, first))
+	require.NoError(t, envInit.bankk.InitCoins(envInit.ctx, addr, second))
+
+	require.Equal(t, second, envSet.bankk.GetCoins(envSet.ctx, addr),
+		"SetCoins drains bbb")
+	require.NotEqual(t, second, envInit.bankk.GetCoins(envInit.ctx, addr),
+		"InitCoins is documented not to drain; if this ever passes, the "+
+			"precondition has been silently relaxed and the genesis fast path "+
+			"needs rechecking")
+}

--- a/tm2/pkg/sdk/bank/keeper.go
+++ b/tm2/pkg/sdk/bank/keeper.go
@@ -24,6 +24,7 @@ type BankKeeperI interface {
 	SubtractCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error
 	AddCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error
 	SetCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error
+	InitCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error
 	SendCoinsUnrestricted(ctx sdk.Context, fromAddr crypto.Address, toAddr crypto.Address, amt std.Coins) error
 
 	InitGenesis(ctx sdk.Context, data GenesisState)
@@ -500,10 +501,48 @@ func (bank BankKeeper) SetCoins(ctx sdk.Context, addr crypto.Address, amt std.Co
 	for _, coin := range bank.splitCoins(ctx, addr) {
 		bank.setSplitBalance(ctx, addr, coin.Denom, 0)
 	}
+	bank.writeSplitCoins(ctx, addr, split)
+	return nil
+}
+
+// InitCoins is SetCoins for an address that provably holds no split-tier balance
+// yet. Same result, without the stale-key enumeration.
+//
+// SetCoins enumerates the address's existing split-tier keys so it can delete the
+// ones the new amount does not cover. That enumeration is a store range iteration,
+// and its cost is not the O(denoms held) the call site expects: cacheStore answers
+// any range query by scanning every dirty key written so far (dirtyItems, in
+// tm2/pkg/store/cache/store.go), so a genesis loop of n SetCoins calls costs
+// O(n^2) regardless of how few denoms each address holds.
+//
+// The caller must guarantee addr holds no split-tier balance. Genesis can: the
+// bank store is empty when InitChainer runs -- InitGenesis writes params only --
+// and the balance loop is the only writer, so any address it has not already
+// processed is untouched.
+//
+// Sits next to SetCoins on BankKeeperI and inherits the same structural
+// protection: neither is on vm.BankKeeperI or auth.BankKeeperI, so no realm and
+// no ante handler can reach either of them.
+func (bank BankKeeper) InitCoins(ctx sdk.Context, addr crypto.Address, amt std.Coins) error {
+	if !amt.IsValid() {
+		return std.ErrInvalidCoins(amt.String())
+	}
+	split, account := bank.splitByTier(amt)
+
+	// Account tier first, as in SetCoins: it is the only step that can fail.
+	if err := bank.setAccountTierCoins(ctx, nil, addr, account); err != nil {
+		return err
+	}
+	bank.writeSplitCoins(ctx, addr, split)
+	return nil
+}
+
+// writeSplitCoins writes the split tier of an already-tiered amount. Shared by
+// SetCoins and InitCoins so the two cannot drift in how they persist.
+func (bank BankKeeper) writeSplitCoins(ctx sdk.Context, addr crypto.Address, split std.Coins) {
 	for _, coin := range split {
 		bank.setSplitBalance(ctx, addr, coin.Denom, coin.Amount)
 	}
-	return nil
 }
 
 // ----------------------------------------

--- a/tm2/pkg/store/cache/bench_quadratic_test.go
+++ b/tm2/pkg/store/cache/bench_quadratic_test.go
@@ -19,8 +19,8 @@ func benchAccountLoad(b *testing.B, n int) {
 		parent := dbadapter.Store{DB: memdb.NewMemDB()}
 		st := cache.New(parent)
 		var gctx *types.GasContext // nil is valid: GasContext methods are nil-safe
-		for a := 0; a < n; a++ {
-			pfx := []byte(fmt.Sprintf("bal/%08d/", a))
+		for a := range n {
+			pfx := fmt.Appendf(nil, "bal/%08d/", a)
 			// the splitCoins read: narrow prefix iteration
 			start, end := pfx, types.PrefixEndBytes(pfx)
 			it := st.Iterator(gctx, start, end)
@@ -47,8 +47,8 @@ func BenchmarkWritesOnly16000(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		st := cache.New(dbadapter.Store{DB: memdb.NewMemDB()})
 		var gctx *types.GasContext // nil is valid: GasContext methods are nil-safe
-		for a := 0; a < 16000; a++ {
-			st.Set(gctx, []byte(fmt.Sprintf("bal/%08d/ugnot", a)), []byte("1000"))
+		for a := range 16000 {
+			st.Set(gctx, fmt.Appendf(nil, "bal/%08d/ugnot", a), []byte("1000"))
 		}
 	}
 }

--- a/tm2/pkg/store/cache/bench_quadratic_test.go
+++ b/tm2/pkg/store/cache/bench_quadratic_test.go
@@ -1,0 +1,54 @@
+package cache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/db/memdb"
+	"github.com/gnolang/gno/tm2/pkg/store/cache"
+	"github.com/gnolang/gno/tm2/pkg/store/dbadapter"
+	"github.com/gnolang/gno/tm2/pkg/store/types"
+)
+
+// The genesis balance-loading shape: for each of n accounts, do a narrow
+// prefix iteration over that account's own key range, then write its key.
+// Every iteration triggers dirtyItems, which scans the whole unsortedCache.
+func benchAccountLoad(b *testing.B, n int) {
+	b.Helper()
+	for i := 0; i < b.N; i++ {
+		parent := dbadapter.Store{DB: memdb.NewMemDB()}
+		st := cache.New(parent)
+		var gctx *types.GasContext // nil is valid: GasContext methods are nil-safe
+		for a := 0; a < n; a++ {
+			pfx := []byte(fmt.Sprintf("bal/%08d/", a))
+			// the splitCoins read: narrow prefix iteration
+			start, end := pfx, types.PrefixEndBytes(pfx)
+			it := st.Iterator(gctx, start, end)
+			for ; it.Valid(); it.Next() {
+				_ = it.Key()
+			}
+			it.Close()
+			// the setSplitBalance write
+			st.Set(gctx, append(append([]byte{}, pfx...), []byte("ugnot")...), []byte("1000"))
+		}
+	}
+}
+
+func BenchmarkAccountLoad1000(b *testing.B)  { benchAccountLoad(b, 1000) }
+func BenchmarkAccountLoad2000(b *testing.B)  { benchAccountLoad(b, 2000) }
+func BenchmarkAccountLoad4000(b *testing.B)  { benchAccountLoad(b, 4000) }
+func BenchmarkAccountLoad8000(b *testing.B)  { benchAccountLoad(b, 8000) }
+func BenchmarkAccountLoad16000(b *testing.B) { benchAccountLoad(b, 16000) }
+
+// Isolate the two suspected O(n) terms independently.
+
+// only writes, no iteration -> should be linear
+func BenchmarkWritesOnly16000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		st := cache.New(dbadapter.Store{DB: memdb.NewMemDB()})
+		var gctx *types.GasContext // nil is valid: GasContext methods are nil-safe
+		for a := 0; a < 16000; a++ {
+			st.Set(gctx, []byte(fmt.Sprintf("bal/%08d/ugnot", a)), []byte("1000"))
+		}
+	}
+}


### PR DESCRIPTION
Fixes the genesis half of #6133.

## The problem

Loading balances at `InitChain` is **O(n²)** in the number of entries. Same 100,000-balance file, same machine:

| build | time |
|---|---:|
| `fb02547f^` | **4.13 s** |
| `master` | **413.99 s** |

`SetCoins` enumerates an address's existing split-tier keys so it can delete the ones the new amount does not cover (`keeper.go:500`). That enumeration is a prefix iteration, and `cacheStore.dirtyItems` answers *any* range query by scanning **every dirty key written so far** — so its cost is O(all dirty keys), not the "O(denoms currently held)" the call site's own doc comment promises. In the genesis loop each query matches nothing already written, so `unsortedCache` grows to n and all n iterations scan all of it.

Full analysis, profile and a standalone store-level reproduction are in #6133.

## What this PR does

**It does not fix the store.** It takes the genesis loop out of the store's path, which is the part that is on a critical path today. The general `dirtyItems` fix needs an ordered container for the unsorted set and is a design/dependency call — see #6133 for why no lazy-sort or threshold scheme escapes the quadratic when writes and range queries interleave 1:1.

- **`bank.InitCoins`** — `SetCoins` without the stale-key drain, for an address that provably holds no split-tier balance yet. It shares `writeSplitCoins` with `SetCoins` so the two cannot drift in how they persist.
- **`applyBalance`** probes for an existing account and picks the path. A first sighting cannot hold a stale key: the bank store is empty when `InitChainer` starts (`bank.InitGenesis` writes params only) and the balance loop is its sole writer. A **repeated address takes the unchanged `SetCoins` path** — balance lists do name an address twice (the existing comment on `applyBalance` covers this) and those entries genuinely need the drain.
- **`fork test`'s elapsed timer**, which reported `2s` for a 414 s load because `InitChain` runs *inside* `NewInMemoryNode` via the consensus handshake. This is why the regression went unnoticed. Happy to split it out if you'd rather.

## Results

End to end, `gnogenesis fork test` on a balance-only genesis, same file across builds:

| balances | `fb02547f^` | `master` | **this PR** |
|---:|---:|---:|---:|
| 100,000 | 4.13 s | 413.99 s | **4.74 s** |
| 1,000,000 | 55.12 s | — | **66.87 s** |

Slope 100k→1M is **1.15**, against 1.13 before the regression — back to near-linear.

New bank benchmark, against a cache-wrapped multistore (which is what `BaseApp` gives `InitChain`; benchmarking the bare IAVL store shows nothing, since the quadratic is in the cache layer):

```
BenchmarkCoinsLoadSetCoins10000-8     1629893083 ns/op
BenchmarkCoinsLoadInitCoins10000-8      46506750 ns/op     35x
BenchmarkCoinsLoadSetCoins20000-8     6986653583 ns/op
BenchmarkCoinsLoadInitCoins20000-8     101135583 ns/op     69x
```

`SetCoins` grows 4.29× per doubling, `InitCoins` 2.17× — quadratic vs linear, and the gap widens with n.

`tm2/pkg/store/cache/bench_quadratic_test.go` is the standalone reproduction from the issue. It does **not** pass or fail — it is there so the underlying store behaviour is measurable, and so whoever fixes `dirtyItems` has a ready benchmark.

## Correctness

`InitCoins` is only sound if it is indistinguishable from `SetCoins` on a fresh address, so that is pinned directly rather than argued. `initcoins_test.go` compares **complete store images** — every key and value, in iteration order — between a `SetCoins` run and an `InitCoins` run:

- five amount shapes (single account-tier denom, split-tier only, both tiers, five denoms, empty);
- identical rejection of invalid coins, with nothing written;
- a 200-address genesis-shaped load compared as one store image;
- and the negative: on an address that *does* hold a stale denom, `InitCoins` provably does **not** drain it. That test asserts the difference, so nobody can quietly swap `SetCoins` for `InitCoins` at a call site that cannot guarantee freshness without it going red.

## Testing

Run: `go test ./pkg/sdk/bank/... ./pkg/store/...` (tm2) — all pass, including `store/cache`, `store/rootmulti`, `store/iavl`. `go test ./pkg/gnoland/...` (gno.land) — passes. `go test ./internal/fork/` (gnogenesis) — passes. `gofmt` clean.

`mockBankKeeper` gained `InitCoins`, counting into the same `setCoinsCalls` as `SetCoins`, so the existing `setCoinsAtRecompute` ordering assertion keeps its meaning.

Not run: the full `gno.land` integration suite, and any real deployment `gen-genesis.sh` build.

I also could not complete an end-to-end run at the full 3,262,505-row scale on this machine (8 GB): with the fix it clears `InitChain` and then sits in `BaseApp.Commit` writing the IAVL tree, which this PR does not touch and which is swap-bound here. The largest end-to-end figure I can stand behind is the 1,000,000-row one above.
