### PR TITLE
fix(grc20): preserve allowance on failed self transfer

### DIFF
--- a/examples/gno.land/p/demo/tokens/grc20/token.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token.gno
@@ -251,6 +251,10 @@ func (led *PrivateLedger) TransferFrom(owner, spender, to address, amount int64)
 		return ErrInvalidAddress
 	}
 
+	if owner == to {
+		return ErrCannotTransferToSelf
+	}
+
 	if led.balanceOf(owner) < amount {
 		return ErrInsufficientBalance
 	}

--- a/examples/gno.land/p/demo/tokens/grc20/token_test.gno
+++ b/examples/gno.land/p/demo/tokens/grc20/token_test.gno
@@ -202,6 +202,15 @@ func TestTransferFromAtomicity(cur realm, t *testing.T) {
 	uassert.Equal(t, remainingAllowance, initialAllowance,
 		"allowance should not be reduced when transfer fails")
 
+	// Self-transfers fail in Transfer after SpendAllowance. TransferFrom must
+	// reject them before it can mutate the allowance.
+	err = admin.TransferFrom(owner, spender, owner, transferAmount)
+	uassert.True(t, errors.Is(err, ErrCannotTransferToSelf), "self-transfer should fail")
+	uassert.Equal(t, initialBalance, token.BalanceOf(owner),
+		"owner balance should not change when self-transfer fails")
+	uassert.Equal(t, initialAllowance, token.Allowance(owner, spender),
+		"allowance should not be reduced when self-transfer fails")
+
 	// transfer all tokens
 	admin.Transfer(owner, recipient, 100)
 	remainingBalance := token.BalanceOf(owner)


### PR DESCRIPTION
## Summary

Fix `PrivateLedger.TransferFrom` so a rejected self-transfer cannot consume allowance.

`TransferFrom` previously decremented allowance before delegating to `Transfer`. `Transfer` rejects `owner == to`, so a caller that handles the returned error without panicking could observe a failed transfer with its allowance already reduced.

This matters in Gno because returning an `error` does not revert prior state changes. Only a panic aborts and rolls back the transaction.

## Reproduction

Initial state:

```text
balance(owner) = 100
allowance(owner, spender) = 50
```

Call:

```gno
err := ledger.TransferFrom(owner, spender, owner, 30)
```

Before this fix:

```text
err                        = ErrCannotTransferToSelf
balance(owner)             = 100
allowance(owner, spender)  = 20
```

The operation reports failure, but `SpendAllowance` has already committed its state change when the caller ignores `err`.

## Fix

Reject `owner == to` before the balance and allowance steps:

```gno
if owner == to {
    return ErrCannotTransferToSelf
}
```

After this change, every error `Transfer` may return is excluded before `SpendAllowance` mutates state.

## Tests

Extended `TestTransferFromAtomicity` to assert that a failed self-transfer:

- returns `ErrCannotTransferToSelf`;
- leaves the owner balance unchanged;
- leaves the spender allowance unchanged.

Verified with:

```sh
cd examples

GNOROOT="$(cd .. && pwd)" \
go run ../gnovm/cmd/gno test \
  ./gno.land/p/demo/tokens/grc20
```