### PR TITLE
test(gpao): set the child budgets the configs leave unset

### DIFF
--- a/contribs/gpao/issettled_test.go
+++ b/contribs/gpao/issettled_test.go
@@ -126,13 +126,14 @@ func TestRedeployParkedOverLivePrivateRealmIsEnabled(t *testing.T) {
 	tio.SetOut(commands.WriteNopCloser(io.Discard))
 	tio.SetErr(commands.WriteNopCloser(io.Discard))
 	o, err := newOracle(config{
-		remote:       remote,
-		chainID:      cfg.Genesis.ChainID,
-		mnemonic:     integration.DefaultAccount_Seed,
-		gnoRoot:      gnoroot,
-		gasFee:       defaultGasFee,
-		gasWanted:    defaultGasWanted,
-		verifyBudget: time.Minute,
+		remote:        remote,
+		chainID:       cfg.Genesis.ChainID,
+		mnemonic:      integration.DefaultAccount_Seed,
+		gnoRoot:       gnoroot,
+		gasFee:        defaultGasFee,
+		gasWanted:     defaultGasWanted,
+		verifyBudget:  time.Minute,
+		prepareBudget: defaultPrepareBudget,
 	}, tio)
 	require.NoError(t, err)
 	o.blockMaxGas = o.queryBlockMaxGas(t.Context())

--- a/contribs/gpao/processblock_test.go
+++ b/contribs/gpao/processblock_test.go
@@ -211,26 +211,33 @@ func TestWouldExceedSpend(t *testing.T) {
 	}
 }
 
+// baseConfig is what the constructor tests start from and override one field
+// of. It carries more than newOracle reads, since the same config goes on to
+// sign, and it sets both child budgets: a zero one is unset rather than a
+// zero-length deadline, and it would expire the spawned child at once.
+func baseConfig() config {
+	return config{
+		remote:        "http://127.0.0.1:26657",
+		chainID:       "test",
+		mnemonic:      testMnemonic,
+		gnoRoot:       gnoenv.RootDir(),
+		gasFee:        "1000000ugnot",
+		gasWanted:     defaultGasWanted,
+		prepareBudget: defaultPrepareBudget,
+		verifyBudget:  defaultVerifyBudget,
+	}
+}
+
 // TestNewOracleRejectsUnusableSpendBound pins the startup checks. A bound that
 // cannot pay for a single approval would leave the daemon running and silently
 // approving nothing, which is worse than refusing to start.
 func TestNewOracleRejectsUnusableSpendBound(t *testing.T) {
-	base := func() config {
-		return config{
-			remote:    "http://127.0.0.1:26657",
-			chainID:   "test",
-			mnemonic:  testMnemonic,
-			gnoRoot:   gnoenv.RootDir(),
-			gasFee:    "1000000ugnot",
-			gasWanted: defaultGasWanted,
-		}
-	}
 	tio := commands.NewTestIO()
 	tio.SetOut(commands.WriteNopCloser(io.Discard))
 	tio.SetErr(commands.WriteNopCloser(io.Discard))
 
 	t.Run("below one approval", func(t *testing.T) {
-		cfg := base()
+		cfg := baseConfig()
 		cfg.maxSpend = "999999ugnot"
 		_, err := newOracle(cfg, tio)
 		require.Error(t, err)
@@ -238,7 +245,7 @@ func TestNewOracleRejectsUnusableSpendBound(t *testing.T) {
 	})
 
 	t.Run("wrong denom", func(t *testing.T) {
-		cfg := base()
+		cfg := baseConfig()
 		cfg.maxSpend = "100foocoin"
 		_, err := newOracle(cfg, tio)
 		require.Error(t, err)
@@ -246,7 +253,7 @@ func TestNewOracleRejectsUnusableSpendBound(t *testing.T) {
 	})
 
 	t.Run("a usable bound is accepted", func(t *testing.T) {
-		cfg := base()
+		cfg := baseConfig()
 		cfg.maxSpend = defaultMaxSpend
 		o, err := newOracle(cfg, tio)
 		require.NoError(t, err)


### PR DESCRIPTION
An oracle built in code, rather than from flags, can come up with a verification child that expires the moment it spawns. Every candidate then returns as the verifier being unavailable, which reads as an infrastructure fault rather than the setting nobody wrote.

Both child budgets [clock the spawned process](https://github.com/gfanton/gno/blob/fix/gpao-default-child-budget/contribs/gpao/verifyone.go#L187) and go straight to `time.AfterFunc`, where zero fires at once. `config.validate` [refuses a non-positive budget](https://github.com/gfanton/gno/blob/fix/gpao-default-child-budget/contribs/gpao/main.go#L183), and a config built in code never passes through it, so each budget is whatever its literal omits.

`TestRedeployParkedOverLivePrivateRealmIsEnabled` [sets the verify budget alone](https://github.com/gfanton/gno/blob/fix/gpao-default-child-budget/contribs/gpao/issettled_test.go#L135) and is the instance now on master, recording every candidate as pending with

```
Reason: the oracle could not run verification: verifier unavailable: the verifier did not have its sources within the -prepare-budget of 0s
```

Both configs that reach `newOracle` from a test carry both budgets. [`baseConfig`](https://github.com/gfanton/gno/blob/fix/gpao-default-child-budget/contribs/gpao/processblock_test.go#L218) comes out of the spend-bound test that built it inline, so the pair has one place to live rather than a literal each.

### Left alone

`newOracle` accepts a config whose budgets are unset. Carrying them is each config's own job.

🤖 Written with AI assistance (Claude); reviewed and submitted by a human.
