### PR TITLE
feat(gpao): publish a gpao docker image

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -20,7 +20,7 @@ jobs:
   bake:
     strategy:
       matrix:
-        image: [gnoland,gnokey,gnoweb,gno,gnofaucet,gnodev,gnocontribs]
+        image: [gnoland,gnokey,gnoweb,gno,gnofaucet,gnodev,gnocontribs,gpao]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,19 @@ RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
             -ldflags "-X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
             -o /gnoroot/build/gnobro .
 
+# Gpao build
+FROM        setup-gnocore AS build-gpao
+ARG         TARGETPLATFORM
+WORKDIR     /gnoroot/contribs/gpao
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
+            go mod download -x
+RUN         --mount=type=cache,target=/go/pkg/mod,id=gomodcache \
+            --mount=type=cache,target=/root/.cache/go-build,id=gobuildcache-${TARGETPLATFORM} \
+            go build \
+            -ldflags "-w -s -X github.com/gnolang/gno/gnovm/pkg/gnoenv._GNOROOT=/gnoroot -X github.com/gnolang/gno/tm2/pkg/version.Version=$(cat /gnoroot/build_version)" \
+            -o /gnoroot/build/gpao .
+
 # Gnocontribs
 ## Gnogenesis
 FROM        setup-gnocore AS build-contribs
@@ -155,6 +168,16 @@ COPY        --from=build-gnocore /gnoroot/gno.land/genesis/genesis_balances.txt 
 # gnoweb port exposed by default
 EXPOSE     8888
 ENTRYPOINT  ["/usr/bin/gnodev"]
+
+# Gpao image
+## ghcr.io/gnolang/gno/gpao
+FROM        base AS gpao
+COPY        --from=build-gpao    /gnoroot/build/gpao                             /usr/bin/gpao
+COPY        --from=build-gnocore /gnoroot/examples                               /gnoroot/examples
+COPY        --from=build-gnocore /gnoroot/gnovm/stdlibs                          /gnoroot/gnovm/stdlibs
+COPY        --from=build-gnocore /gnoroot/gnovm/tests/stdlibs                    /gnoroot/gnovm/tests/stdlibs
+EXPOSE      8546
+ENTRYPOINT  ["/usr/bin/gpao"]
 
 # Gno
 FROM        base AS gno

--- a/contribs/gpao/README.md
+++ b/contribs/gpao/README.md
@@ -40,6 +40,26 @@ make install   # go install . — puts gpao on your $PATH
 make build     # go build -o build/gpao . — leaves it here instead
 ```
 
+### Docker
+
+`ghcr.io/gnolang/gno/gpao` ships the binary with the repo's stdlibs and
+examples at `/gnoroot` (the baked-in `--gno-root` default), built from the same
+`Dockerfile` targets as the other images. Mount a gnokey keystore and pass the
+key password through `GPAO_PASSWORD`:
+
+```sh
+docker run -d \
+  -v /path/to/gnokey-home:/keystore \
+  -e GPAO_PASSWORD=... \
+  -p 8546:8546 \
+  ghcr.io/gnolang/gno/gpao \
+  --remote http://node:26657 \
+  --chain-id dev \
+  --home /keystore \
+  --key approver \
+  --status-listen 0.0.0.0:8546
+```
+
 ## Usage
 
 The approver key lives in a local [gnokey](../../gno.land/cmd/gnokey) keystore.

--- a/misc/deployments/bake/docker-bake.hcl
+++ b/misc/deployments/bake/docker-bake.hcl
@@ -28,7 +28,8 @@ group "default" {
 group "contribs" {
   targets = [
     "gnodev",
-    "gnocontribs"
+    "gnocontribs",
+    "gpao"
   ]
 }
 
@@ -120,6 +121,14 @@ target "gnocontribs" {
   target = "gnocontribs"
   labels = {
     "org.opencontainers.image.title" = "${PROJECT_NAME}/gnocontribs"
+  }
+}
+
+target "gpao" {
+  inherits = ["common"]
+  target = "gpao"
+  labels = {
+    "org.opencontainers.image.title" = "${PROJECT_NAME}/gpao"
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a `gpao` image to the docker release pipeline, published as
`ghcr.io/gnolang/gno/gpao` alongside the other images:

- **`Dockerfile`** — a `build-gpao` stage (own-module build like the other
  contribs).
- **`docker-bake.hcl`** — a `gpao` target in the `contribs` group.
- **`release-docker.yml`** — `gpao` in the bake matrix, so it ships on
  `chain/*` pushes/tags and `workflow_dispatch` like every other image.
- **gpao README** — a Docker section with a ready-to-run `docker run`
  (keystore mount + `GPAO_PASSWORD`).

## Testing

- `docker buildx bake --print gpao` resolves the target (amd64+arm64,
  provenance+sbom attests inherited from `common`).
- Full local `docker build --target gpao`: image runs (`--help`), `/gnoroot`
  carries `examples` + `gnovm/stdlibs` + `gnovm/tests/stdlibs`, 50.9 MB.
- An earlier hand-built equivalent of this image layout (binary + gnoroot
  tree) is what runs the approval oracle on our inert-policy labnet, watching
  and enabling packages end-to-end.