### PR TITLE
chore: update jae's address in the govDAO T1 extend script

### DIFF
--- a/misc/govdao-scripts/extend-govdao-t1.sh
+++ b/misc/govdao-scripts/extend-govdao-t1.sh
@@ -32,7 +32,7 @@ func must(err error) {
 
 func main(cur realm) {
 	ms := memberstore.Get(0, cur)
-	must(ms.SetMember(memberstore.T1, address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj"), &memberstore.Member{InvitationPoints: 3})) // Jae
+	must(ms.SetMember(memberstore.T1, address("g1ecsuj0q572jr0dhu29q9njtnmw03hyu7tyyvv6"), &memberstore.Member{InvitationPoints: 3})) // Jae
 	must(ms.SetMember(memberstore.T1, address("g1m0rgan0rla00ygmdmp55f5m0unvsvknluyg2a4"), &memberstore.Member{InvitationPoints: 3})) // Morgan
 	must(ms.SetMember(memberstore.T1, address("g1mx4pum9976th863jgry4sdjzfwu03qan5w2v9j"), &memberstore.Member{InvitationPoints: 3})) // Ray
 	must(ms.SetMember(memberstore.T1, address("g12vx7dn3dqq89mz550zwunvg4qw6epq73d9csay"), &memberstore.Member{InvitationPoints: 3})) // Dongwon


### PR DESCRIPTION
## Summary

`gnolang/multisigs` [#37](https://github.com/gnolang/multisigs/pull/37) rotated jaekwon's pubkey. This updates the one place in this repo that hardcodes jae's **personal** address.

|  | address |
|---|---|
| old | `g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj` |
| new | `g1ecsuj0q572jr0dhu29q9njtnmw03hyu7tyyvv6` |

Same change `gnolang/independence-day` [#62](https://github.com/gnolang/independence-day/pull/62) made to its `govdaoFounders` list. The new address is the one derived from jae's current entry in `gnolang/multisigs@main` `accounts.csv`.

## The one file

`misc/govdao-scripts/extend-govdao-t1.sh` builds a `MsgRun` payload that grants **govDAO T1 membership with 3 invitation points** to six people. Jae's row carried the stale address; the other five (Morgan, Ray, Dongwon, Maxwell, Milos) already match `independence-day`'s founder list and are unchanged.

Worth noting *which* address it was: `g1us8428…` is **`test2`**, the shared development account this repo funds in `gno.land/genesis/genesis_balances.txt` and drives from `misc/e2e/run_tests.sh`. It was a placeholder that was never swapped for the real key. A shared dev account should not be handed tier-1 governance, so this is worth fixing before the script is next used, independent of the rotation.

## What is deliberately NOT changed

Two files still carry `g1us8428…` labelled `# Jae`:

- `misc/deployments/test4.gno.land/genesis_balances.txt`
- `misc/deployments/test5.gno.land/genesis_balances.txt`

Those are records of chains that already ran, and rewriting them would make the archive stop describing what actually happened — same policy as #6131.

The remaining ~85 files containing `g1us8428…` use it as the `test2` fixture (boards2 filetests, docs, txtars). Those are not jae and are untouched.

## Scope

This is only about jae's personal address. The **govDAO T1 multisig** address — which also moved as a result of the same pubkey rotation, since a multisig address is derived from its sorted member pubkeys — was already handled in #6131 (`g1skl80cuz…`). Nothing further is needed there.

## Testing

No Go or Gno code is touched — the change is inside a heredoc in a shell script. `bash -n` passes.
