### PR TITLE
fix(amino): deep-copy slices instead of sharing backing array

### DIFF
--- a/tm2/pkg/amino/deep_copy.go
+++ b/tm2/pkg/amino/deep_copy.go
@@ -84,6 +84,10 @@ func _deepCopy(src, dst reflect.Value) {
 		}
 
 	case reflect.Slice:
+		if src.IsNil() {
+			dst.Set(src)
+			return
+		}
 		switch src.Type().Elem().Kind() {
 		case reflect.Int64, reflect.Int32, reflect.Int16,
 			reflect.Int8, reflect.Int, reflect.Uint64,

--- a/tm2/pkg/amino/deep_copy.go
+++ b/tm2/pkg/amino/deep_copy.go
@@ -94,7 +94,7 @@ func _deepCopy(src, dst reflect.Value) {
 			cpy := reflect.MakeSlice(
 				src.Type(), src.Len(), src.Len())
 			reflect.Copy(cpy, src)
-			dst.Set(src)
+			dst.Set(cpy)
 			return
 		default:
 			cpy := reflect.MakeSlice(
@@ -104,7 +104,7 @@ func _deepCopy(src, dst reflect.Value) {
 				ecpy := cpy.Index(i)
 				deepCopy(esrc, ecpy)
 			}
-			dst.Set(src)
+			dst.Set(cpy)
 			return
 		}
 

--- a/tm2/pkg/amino/deep_copy_test.go
+++ b/tm2/pkg/amino/deep_copy_test.go
@@ -167,4 +167,12 @@ func TestDeepCopySlice(t *testing.T) {
 	cpyStruct := amino.DeepCopy(srcStruct).([]dcItem)
 	srcStruct[0].N = 999
 	assert.Equal(t, 1, cpyStruct[0].N)
+
+	var nilInts []int
+	assert.Nil(t, amino.DeepCopy(nilInts))
+
+	nilBz := []byte(nil)
+	ptr := &nilBz
+	cpyPtr := amino.DeepCopy(ptr).(*[]byte)
+	assert.Nil(t, *cpyPtr)
 }

--- a/tm2/pkg/amino/deep_copy_test.go
+++ b/tm2/pkg/amino/deep_copy_test.go
@@ -151,3 +151,20 @@ func TestDeepCopyInterface2(t *testing.T) {
 	dci2 := amino.DeepCopy(dci1).(DCInterface1)
 	assert.Equal(t, "foo", dci2.Foo)
 }
+
+func TestDeepCopySlice(t *testing.T) {
+	t.Parallel()
+
+	src := []int{1, 2, 3}
+	cpy := amino.DeepCopy(src).([]int)
+	src[0] = 999
+	assert.Equal(t, 1, cpy[0])
+
+	type dcItem struct {
+		N int
+	}
+	srcStruct := []dcItem{{N: 1}, {N: 2}}
+	cpyStruct := amino.DeepCopy(srcStruct).([]dcItem)
+	srcStruct[0].N = 999
+	assert.Equal(t, 1, cpyStruct[0].N)
+}


### PR DESCRIPTION
## Summary

Fix `amino.DeepCopy` not deep-copying slices.

`_deepCopy` in `tm2/pkg/amino/deep_copy.go` allocates a new slice `cpy` and copies elements into it, but then sets `dst` to `src` instead of `cpy` in both the primitive-element branch and the struct/pointer-element branch. As a result the "copy" shares the original backing array — a shallow copy — discarding the work done on `cpy` and breaking the "independent copy" contract relied upon by `Header.Copy()`, `Context.BlockHeader()`, `Context.ConsensusParams()` and `GetRoundStateDeepCopy()`.

## Changes

- **Bug fix** — `tm2/pkg/amino/deep_copy.go`: change `dst.Set(src)` to `dst.Set(cpy)` in the two `reflect.Slice` branches of `_deepCopy`.
- **Test** — `tm2/pkg/amino/deep_copy_test.go`: add `TestDeepCopySlice` covering both the primitive-element branch (`[]int`) and the struct-element branch (`[]struct`), asserting that mutating the original does not affect the copy.

## Verification

```bash
cd tm2/pkg/amino
go test ./... -run TestDeepCopy
```
