### PR TITLE
docs(interrealm-v2): scope the IsCurrent() guard to a realm value the caller supplies

### DIFF
--- a/docs/resources/gno-interrealm-v2.md
+++ b/docs/resources/gno-interrealm-v2.md
@@ -387,9 +387,9 @@ per crossing frame, refuses to persist it, and validates each use.
 `rlm.IsCurrent()` before using `rlm.Address()`, `rlm.PkgPath()` or
 `rlm.Previous()`. Without it, a stale realm value still resolves to an
 identity that is no longer the live caller, class **2
-(designation-forgery)** in `gno-security.md`. A crossing function's own
-`cur` needs no such check: the runtime makes it current on entry, so a
-guard on `cur` cannot fire.
+(designation-forgery)** in [`gno-security.md`](./gno-security.md). A
+crossing function's own `cur` needs no such check: the runtime makes it
+current on entry, so a guard on `cur` cannot fire.
 
 ### 5.3 Realm values are ephemeral
 
@@ -677,9 +677,11 @@ holder** — equivalent to returning a setter closure.
 
 For every exported function or method in your `/r/` realm:
 
-- Does it take a realm value from the caller, `(_ int, rlm realm, ...)`?
-  If yes, does it check `rlm.IsCurrent()` before using `rlm.Previous()`,
-  `rlm.Address()`, or `rlm.PkgPath()`? Its own `cur` needs no check.
+- Does it take a realm value as an ordinary parameter, the way the
+  non-crossing `Send(_ int, rlm realm, ...)` takes the caller's identity
+  in its `rlm`? If yes, does it check `rlm.IsCurrent()` before using
+  `rlm.Previous()`, `rlm.Address()`, or `rlm.PkgPath()`? A crossing
+  function's own `cur` needs no check.
 - Does it return a pointer that aliases internal mutable state? If
   yes, expect attackers to invoke any method on the returned pointer
   type that borrow rule #2 borrows back to you.

--- a/docs/resources/gno-interrealm-v2.md
+++ b/docs/resources/gno-interrealm-v2.md
@@ -382,17 +382,14 @@ per crossing frame, refuses to persist it, and validates each use.
   classification by address and pkgpath.
 - `String() string` — debug representation.
 
-`IsCurrent()` is the authentication primitive for a realm value the
-caller supplies, `Send(_ int, rlm realm, ...)` in `p/nt/treasury/v0`
-for one: check `rlm.IsCurrent()` before using `rlm.Address()`,
-`rlm.PkgPath()` or `rlm.Previous()`. Without that check, a stale realm
-value's `Address()` and `PkgPath()` still resolve, to an identity that
-is no longer the live caller. This is class **2 (designation-forgery)**
-in `gno-security.md`. A guard on `cur` inside a crossing function
-cannot fire against anything another realm does: `cross(rlm)` mints
-`cur` fresh, and a non-crossing call from the same realm re-anchors
-the callee's frame on the value passed, so even a stale `cur` reads
-current there.
+`IsCurrent()` guards a realm value the caller supplies, such as the
+`rlm` of `Send(_ int, rlm realm, ...)` in `p/nt/treasury/v0`: check
+`rlm.IsCurrent()` before using `rlm.Address()`, `rlm.PkgPath()` or
+`rlm.Previous()`. Without it, a stale realm value still resolves to an
+identity that is no longer the live caller, class **2
+(designation-forgery)** in `gno-security.md`. A crossing function's own
+`cur` needs no such check: the runtime makes it current on entry, so a
+guard on `cur` cannot fire.
 
 ### 5.3 Realm values are ephemeral
 
@@ -682,8 +679,7 @@ For every exported function or method in your `/r/` realm:
 
 - Does it take a realm value from the caller, `(_ int, rlm realm, ...)`?
   If yes, does it check `rlm.IsCurrent()` before using `rlm.Previous()`,
-  `rlm.Address()`, or `rlm.PkgPath()`? A crossing function's own `cur`
-  needs no such check, per §5.2.
+  `rlm.Address()`, or `rlm.PkgPath()`? Its own `cur` needs no check.
 - Does it return a pointer that aliases internal mutable state? If
   yes, expect attackers to invoke any method on the returned pointer
   type that borrow rule #2 borrows back to you.

--- a/docs/resources/gno-interrealm-v2.md
+++ b/docs/resources/gno-interrealm-v2.md
@@ -382,13 +382,17 @@ per crossing frame, refuses to persist it, and validates each use.
   classification by address and pkgpath.
 - `String() string` — debug representation.
 
-`IsCurrent()` is the authentication primitive. Any public entry
-point that uses `cur` to derive caller identity (e.g.
-`cur.Previous().Address()`) **must** check `cur.IsCurrent()` first.
-Without that check, a stale or attacker-supplied realm value's
-`Address()` and `PkgPath()` still resolve numerically — they just
-no longer refer to the live caller. This is class **2
-(designation-forgery)** in `gno-security.md`.
+`IsCurrent()` is the authentication primitive for a realm value the
+caller supplies, `Send(_ int, rlm realm, ...)` in `p/nt/treasury/v0`
+for one: check `rlm.IsCurrent()` before using `rlm.Address()`,
+`rlm.PkgPath()` or `rlm.Previous()`. Without that check, a stale realm
+value's `Address()` and `PkgPath()` still resolve, to an identity that
+is no longer the live caller. This is class **2 (designation-forgery)**
+in `gno-security.md`. A guard on `cur` inside a crossing function
+cannot fire against anything another realm does: `cross(rlm)` mints
+`cur` fresh, and a non-crossing call from the same realm re-anchors
+the callee's frame on the value passed, so even a stale `cur` reads
+current there.
 
 ### 5.3 Realm values are ephemeral
 
@@ -676,8 +680,10 @@ holder** — equivalent to returning a setter closure.
 
 For every exported function or method in your `/r/` realm:
 
-- Does it take `cur realm`? If yes, does it check `cur.IsCurrent()`
-  before using `cur.Previous()`, `cur.Address()`, or `cur.PkgPath()`?
+- Does it take a realm value from the caller, `(_ int, rlm realm, ...)`?
+  If yes, does it check `rlm.IsCurrent()` before using `rlm.Previous()`,
+  `rlm.Address()`, or `rlm.PkgPath()`? A crossing function's own `cur`
+  needs no such check, per §5.2.
 - Does it return a pointer that aliases internal mutable state? If
   yes, expect attackers to invoke any method on the returned pointer
   type that borrow rule #2 borrows back to you.


### PR DESCRIPTION
A crossing function's `cur` is current at entry whatever another realm did: `cross(rlm)` mints it fresh in [`installCrossingCur`](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/gnovm/pkg/gnolang/op_call.go#L92-L109), and a same-realm non-crossing call re-anchors the callee's frame on the value passed, in [`doOpCall`](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/gnovm/pkg/gnolang/op_call.go#L377-L395), so even a stale `cur` reads current there. The page told every public entry point to check `cur.IsCurrent()` before `cur.Previous()` and its checklist asked the same, and the design record, [`interrealm_v2.md`](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/gnovm/adr/interrealm_v2.md?plain=1#L336-L339), says the opposite. The 39 guards written from it under `examples/` refuse nothing, and nothing is exploitable.

The check bites on a realm value handed over as a plain parameter, [`Send(_ int, rlm realm, ...)`](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/examples/gno.land/p/nt/treasury/v0/banker_coins.gno#L34-L37) in `p/nt/treasury/v0` for one, where `cur.Previous()` or a captured `cur` is refused.

The page's method list had the same error in its definition of `IsCurrent()`: it promised false for a stale realm value. `IsCurrent()` compares the receiver against the topmost live crossing frame's `cur` by [pointer identity](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/gnovm/pkg/gnolang/uverse.go#L595-L615) and reads nothing about age, so the stale value a cur-call re-anchored the frame on reads true. A sub-token is the other reading that entry ruled out and the runtime allows, by matching through its parent.

The repository's own `AGENTS.md` mandates the same check, and it is what an agent reads before it reaches any page, so it rides along. Its reason for preferring `cur.Previous()` over `chain/runtime/unsafe.PreviousRealm()` rested on frame verification `cur.IsCurrent()` does not provide; the preference holds on the [stack walk](https://github.com/gnolang/gno/blob/e144be662b31f9fc8bd02befda5b79de3fb28202/gnovm/stdlibs/chain/runtime/unsafe/unsafe.gno#L21-L25) that `PreviousRealm()` does and `cur.Previous()` does not.

This leaves `gno-ai-contract-review.md`, `gno-security-guide.md` and `community-packages.md` carrying the retired instruction.
