### PR TITLE
chore: update maxwell's address in the govDAO T1 extend script

### DIFF
--- a/misc/govdao-scripts/extend-govdao-t1.sh
+++ b/misc/govdao-scripts/extend-govdao-t1.sh
@@ -36,7 +36,7 @@ func main(cur realm) {
 	must(ms.SetMember(memberstore.T1, address("g1m0rgan0rla00ygmdmp55f5m0unvsvknluyg2a4"), &memberstore.Member{InvitationPoints: 3})) // Morgan
 	must(ms.SetMember(memberstore.T1, address("g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m"), &memberstore.Member{InvitationPoints: 3})) // Aeddi
 	must(ms.SetMember(memberstore.T1, address("g1gzhj234kpajz963z5vf42j4ylddscnkez2wvly"), &memberstore.Member{InvitationPoints: 3})) // Dongwon
-	must(ms.SetMember(memberstore.T1, address("g127l4gkhk0emwsx5tmxe96sp86c05h8vg5tufzq"), &memberstore.Member{InvitationPoints: 3})) // Maxwell
+	must(ms.SetMember(memberstore.T1, address("g1xnv893735y5ef0we0e8w3empa55lnvkfcmn3qs"), &memberstore.Member{InvitationPoints: 3})) // Maxwell
 	must(ms.SetMember(memberstore.T1, address("g1e6gxg5tvc55mwsn7t7dymmlasratv7mkv0rap2"), &memberstore.Member{InvitationPoints: 3})) // Milos
 }
 GOEOF


### PR DESCRIPTION
Updates Maxwell's T1 member address in
`misc/govdao-scripts/extend-govdao-t1.sh`.

- `g127l4gkhk0emwsx5tmxe96sp86c05h8vg5tufzq` →
  `g1xnv893735y5ef0we0e8w3empa55lnvkfcmn3qs`