### PR TITLE
chore(examples): replace the @devx address with the GovDAO T1 multisig

### DIFF
--- a/examples/gno.land/p/gnoland/boards/v0/flag_storage_test.gno
+++ b/examples/gno.land/p/gnoland/boards/v0/flag_storage_test.gno
@@ -158,7 +158,7 @@ func TestFlagStorageSize(t *testing.T) {
 			setup: func() boards.FlagStorage {
 				s := boards.NewFlagStorage()
 				s.Add(boards.Flag{User: "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"})
-				s.Add(boards.Flag{User: "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"})
+				s.Add(boards.Flag{User: "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"})
 				return s
 			},
 			size: 2,
@@ -175,13 +175,15 @@ func TestFlagStorageSize(t *testing.T) {
 }
 
 func TestFlagStorageIterate(t *testing.T) {
+	// Listed in sorted (bech32-string) user order, which is the order
+	// Iterate yields them in.
 	flags := []boards.Flag{
 		{
-			User:   "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq",
+			User:   "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
 			Reason: "a",
 		},
 		{
-			User:   "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5",
+			User:   "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx",
 			Reason: "b",
 		},
 	}

--- a/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_6_filetest.gno
+++ b/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_6_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	caller = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+	caller = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx")
 	msg    = "Boom!"
 )
 

--- a/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_7_filetest.gno
+++ b/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_7_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	caller = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+	caller = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx")
 	msg    = "Boom!"
 )
 

--- a/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_8_filetest.gno
+++ b/examples/gno.land/p/jeronimoalbi/expect/v0/filetests/z_func_8_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	caller = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+	caller = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx")
 	msg    = "Boom!"
 )
 

--- a/examples/gno.land/p/nt/addrset/v0/addrset_test.gno
+++ b/examples/gno.land/p/nt/addrset/v0/addrset_test.gno
@@ -12,7 +12,7 @@ import (
 const (
 	addr1 = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")
 	addr2 = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5")
-	addr3 = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+	addr3 = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx")
 )
 
 func TestSetBasics(t *testing.T) {
@@ -43,14 +43,14 @@ func TestSetIteration(t *testing.T) {
 	set.Add(addr2)
 	set.Add(addr3)
 
-	// Sorted (bech32-string) order: addr3 < addr1 < addr2.
+	// Sorted (bech32-string) order: addr1 < addr2 < addr3.
 	var got []address
 	set.IterateByOffset(0, set.Size(), func(a address) bool {
 		got = append(got, a)
 		return false
 	})
 	urequire.Equal(t, 3, len(got))
-	uassert.True(t, got[0] == addr3 && got[1] == addr1 && got[2] == addr2, "expect sorted order")
+	uassert.True(t, got[0] == addr1 && got[1] == addr2 && got[2] == addr3, "expect sorted order")
 
 	// Offset and count window.
 	got = nil
@@ -59,7 +59,7 @@ func TestSetIteration(t *testing.T) {
 		return false
 	})
 	urequire.Equal(t, 1, len(got))
-	uassert.True(t, got[0] == addr1, "expect the middle element")
+	uassert.True(t, got[0] == addr2, "expect the middle element")
 
 	// Early stop.
 	count := 0
@@ -76,7 +76,7 @@ func TestSetIteration(t *testing.T) {
 		return false
 	})
 	urequire.Equal(t, 3, len(got))
-	uassert.True(t, got[0] == addr2 && got[2] == addr3, "expect reverse order")
+	uassert.True(t, got[0] == addr3 && got[2] == addr1, "expect reverse order")
 }
 
 func TestSetIterationLimits(t *testing.T) {
@@ -98,14 +98,14 @@ func TestSetIterationLimits(t *testing.T) {
 	uassert.Equal(t, 2, visits)
 
 	// The reverse offset counts from the END: offset 1, count 1 is the
-	// second-to-last address in sorted order (addr1: addr3 < addr1 < addr2).
+	// second-to-last address in sorted order (addr2: addr1 < addr2 < addr3).
 	var got []address
 	set.ReverseIterateByOffset(1, 1, func(a address) bool {
 		got = append(got, a)
 		return false
 	})
 	urequire.Equal(t, 1, len(got))
-	uassert.True(t, got[0] == addr1, "expect reverse offset anchored at the end")
+	uassert.True(t, got[0] == addr2, "expect reverse offset anchored at the end")
 }
 
 // TestSetAcrossLeafSplits exercises the wrapper over a multi-leaf tree

--- a/examples/gno.land/p/nt/commondao/v0/commondao_test.gno
+++ b/examples/gno.land/p/nt/commondao/v0/commondao_test.gno
@@ -15,7 +15,7 @@ const (
 	memberA address = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
 	memberB address = "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"
 	memberC address = "g1w4ek2u3jta047h6lta047h6lta047h6l9huexc"
-	memberD address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	memberD address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 	memberE address = "g1yx35a8f4lhhhrarljrgr37u55gkqdrl0949ycf"
 	memberF address = "g1cyh9qm4y43w38gfk77qxczrhqj2asdr8l7uk54"
 	memberG address = "g1x95kxqpwvqjf98qpkvsay7tppkh6zs9fr7wwda"

--- a/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_0_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_0_filetest.gno
@@ -7,7 +7,7 @@ import (
 	"gno.land/p/nt/commondao/v0"
 )
 
-const member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq" // @devx
+const member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx" // govdao t1 multisig
 
 var (
 	dao        *commondao.CommonDAO

--- a/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_1_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_1_filetest.gno
@@ -8,7 +8,7 @@ import (
 	"gno.land/p/nt/commondao/v0"
 )
 
-const member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq" // @devx
+const member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx" // govdao t1 multisig
 
 var (
 	dao      *commondao.CommonDAO

--- a/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_2_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_2_filetest.gno
@@ -7,7 +7,7 @@ import (
 	"gno.land/p/nt/commondao/v0"
 )
 
-const member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq" // @devx
+const member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx" // govdao t1 multisig
 
 var (
 	dao      *commondao.CommonDAO

--- a/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_3_filetest.gno
+++ b/examples/gno.land/p/nt/commondao/v0/filetests/z_commondao_execute_3_filetest.gno
@@ -7,7 +7,7 @@ import (
 	"gno.land/p/nt/commondao/v0"
 )
 
-const member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq" // @devx
+const member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx" // govdao t1 multisig
 
 var (
 	dao                  *commondao.CommonDAO

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_10_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_10_a_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_10_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_10_b_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_10_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_10_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 
@@ -57,4 +57,4 @@ func main() {
 // Purpose
 //
 // **Council Members:**
-// - g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq
+// - g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_10_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_10_d_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_10_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_10_e_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_a_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_c_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_e_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_f_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_g_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_11_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_11_h_filetest.gno
@@ -19,7 +19,7 @@ import (
 // pins the spend threshold behaviourally: flipping it to SimpleMajority
 // would let this same vote pass and spend the funds.
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	mF    = address("g1cyh9qm4y43w38gfk77qxczrhqj2asdr8l7uk54")

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_a_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_d_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_e_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_f_filetest.gno
@@ -18,7 +18,7 @@ import (
 // clawback executes and empties the target; a mutated Super threshold would
 // dismiss it, leaving the funds.
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	mF    = address("g1cyh9qm4y43w38gfk77qxczrhqj2asdr8l7uk54")

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_g_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_h_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_i_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_i_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_j_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_j_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_12_k_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_12_k_filetest.gno
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx, genesis council only
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig, genesis council only
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1, owns the tree below
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_a_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_d_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_e_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_f_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_13_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_13_g_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_a_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_b_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_c_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_d_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_e_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_f_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_g_filetest.gno
@@ -15,7 +15,7 @@ import (
 // supermajority (3*3 < 2*5), so under the correct Simple threshold the
 // target is frozen; a mutated Super threshold would dismiss it.
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	mF    = address("g1cyh9qm4y43w38gfk77qxczrhqj2asdr8l7uk54")

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_h_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_14_i_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_14_i_filetest.gno
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx, genesis council only
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig, genesis council only
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1, owns the tree below
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_15_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_15_a_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner  = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner  = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user   = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	nonMbr = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_e_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_f_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_16_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_16_g_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_17_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_17_a_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner  = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner  = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user   = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	rescue = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_17_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_17_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_17_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_17_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_18_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_18_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_18_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_18_b_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_18_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_18_c_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_a_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_b_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_c_filetest.gno
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_d_filetest.gno
@@ -16,7 +16,7 @@ import (
 // the proposal stays active and cannot be executed before its deadline. A
 // mutant deciding it by simple majority would pass it early here.
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	memD  = address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner    = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner    = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user     = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	stranger = address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // @test2
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_19_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_19_f_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_1_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_1_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_1_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_1_b_filetest.gno
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_a_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_c_filetest.gno
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_d_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_f_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_g_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_h_filetest.gno
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_i_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_i_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_20_j_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_20_j_filetest.gno
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx, genesis council only
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig, genesis council only
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1, owns the DAO below
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_21_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_21_a_filetest.gno
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx (genesis council)
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig (genesis council)
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1 (operator)
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_22_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_22_a_filetest.gno
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_22_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_22_b_filetest.gno
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_22_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_22_c_filetest.gno
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_22_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_22_d_filetest.gno
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_22_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_22_e_filetest.gno
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_23_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_23_a_filetest.gno
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_23_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_23_b_filetest.gno
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_23_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_23_c_filetest.gno
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	owner     = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner     = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user      = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	silent    = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // in the electorate, never votes
 	latecomer = address("g1us8428u2a5satrlxzagqqa5m6vmuze025anjlj") // joined the council AFTER the proposal

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_23_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_23_d_filetest.gno
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx, genesis council
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig, genesis council
 )
 
 func init(cur realm) {

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_23_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_23_e_filetest.gno
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_2_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_2_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_4_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_4_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	name  = "B"
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_5_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_5_a_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_5_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_5_c_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_5_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_5_d_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_5_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_5_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_a_filetest.gno
@@ -10,7 +10,7 @@ import (
 	"gno.land/r/nt/commondao/v0"
 )
 
-const owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+const owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 
 var (
 	daoID uint64

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_b_filetest.gno
@@ -8,7 +8,7 @@ import (
 	"gno.land/r/nt/commondao/v0"
 )
 
-const owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+const owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(owner))

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_c_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_f_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_g_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_6_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_6_h_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_7_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_7_a_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	name  = "Foo"
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_7_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_7_b_filetest.gno
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	owner  = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner  = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user   = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	origin = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	policy = "gno.land/r/demo/policy"

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_7_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_7_f_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_7_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_7_g_filetest.gno
@@ -16,7 +16,7 @@ import (
 // correct Simple threshold the sub-DAO is created; a mutated Super threshold
 // would dismiss it. Mirror of z_11_h (spend = Super).
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 	mF    = address("g1cyh9qm4y43w38gfk77qxczrhqj2asdr8l7uk54")

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_b_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_c_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/z_9_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/z_9_f_filetest.gno
@@ -17,7 +17,7 @@ import (
 // snapshot electorate stays 3, so at the deadline the proposal is DISMISSED.
 // A mutant tallying the live council at Execute would instead pass it.
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	moul  = address("g1manfred47kzduec920z88wfr64ylksmdcedlf5") // @moul
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_a_filetest.gno
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	owner         = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner         = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user          = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
-	newMembers    = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq\ng147ah9520z0r6jh9mjr6c75rv6l8aypzvcd3f7d"
+	newMembers    = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx\ng147ah9520z0r6jh9mjr6c75rv6l8aypzvcd3f7d"
 	removeMembers = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
 )
 
@@ -49,7 +49,7 @@ func main(cur realm) {
 // true
 //
 // **Council Members to Add:**
-// - g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq
+// - g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx
 // - g147ah9520z0r6jh9mjr6c75rv6l8aypzvcd3f7d
 //
 //

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_g_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_h_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_i_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_0_i_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner      = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner      = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user       = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	title      = "General Proposal"
 	body       = "Foo Bar"

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_1_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_a_filetest.gno
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	owner   = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner   = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user    = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	name    = "Foo SubDAO"
-	members = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq\ng1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+	members = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx\ng1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
 )
 
 var daoID uint64
@@ -58,5 +58,5 @@ func main(cur realm) {
 // Purpose
 //
 // **Council Members:**
-// - g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq
+// - g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx
 // - g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_d_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_d_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_f_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 	name  = "Foo"
 )

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_g_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_g_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_h_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_2_h_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_a_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_a_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 
@@ -50,4 +50,4 @@ func main(cur realm) {
 // [Foo](/r/nt/commondao/v0:2)
 //
 // **Sweep destination:**
-// g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq
+// g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_b_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_b_filetest.gno
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_c_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_c_filetest.gno
@@ -7,7 +7,7 @@ import (
 )
 
 func main(cur realm) {
-	commondao.CreateDissolutionProposal(cross(cur), 404, "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq")
+	commondao.CreateDissolutionProposal(cross(cur), 404, "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx")
 }
 
 // Error:

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_e_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_e_filetest.gno
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_f_filetest.gno
+++ b/examples/gno.land/r/nt/commondao/v0/filetests/zp_3_f_filetest.gno
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	owner = address("g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq") // @devx
+	owner = address("g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx") // govdao t1 multisig
 	user  = address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5") // @test1
 )
 

--- a/examples/gno.land/r/nt/commondao/v0/genesis.gno
+++ b/examples/gno.land/r/nt/commondao/v0/genesis.gno
@@ -12,7 +12,7 @@ func init() {
 		"Common DAO",
 		"Govern and maintain the commondao reference realm.",
 		"This DAO is responsible for managing `commondao` realm functionalities.",
-		"g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq", // @devx
+		"g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx", // govdao t1 multisig
 		"g1manfred47kzduec920z88wfr64ylksmdcedlf5", // @moul
 	)
 	setListed(dao.ID(), true)

--- a/examples/gno.land/r/nt/commondao/v0/genesis_test.gno
+++ b/examples/gno.land/r/nt/commondao/v0/genesis_test.gno
@@ -1,0 +1,29 @@
+package commondao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+// TestGenesisCouncilOrder pins the council of the DAO genesis.gno creates.
+// renderCouncil walks the addrset, so the realm's own page lists the two
+// founding members in bech32 order, not in the order genesis.gno passes
+// them. No filetest renders DAO 1, so nothing else in the suite notices
+// when either address moves.
+func TestGenesisCouncilOrder(t *testing.T) {
+	dao := mustGetDAO(1)
+	council := dao.Council()
+	urequire.Equal(t, 2, council.Size())
+
+	var got []string
+	council.IterateByOffset(0, council.Size(), func(addr address) bool {
+		got = append(got, addr.String())
+		return false
+	})
+
+	urequire.Equal(t, 2, len(got))
+	uassert.Equal(t, "g1manfred47kzduec920z88wfr64ylksmdcedlf5", got[0])
+	uassert.Equal(t, "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx", got[1])
+}

--- a/examples/gno.land/r/nt/commondao/v0/proposal_council_test.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_council_test.gno
@@ -14,7 +14,7 @@ var (
 )
 
 func TestCouncilUpdatePropDefinitionNew(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	dao := commondao.New(commondao.WithCouncilMember(member))
 
@@ -35,7 +35,7 @@ func TestCouncilUpdatePropDefinitionNew(cur realm, t *testing.T) {
 
 func TestCouncilUpdatePropDefinitionValidate(t *testing.T) {
 	var (
-		memberA address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+		memberA address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 		memberB address = "g1manfred47kzduec920z88wfr64ylksmdcedlf5"
 	)
 
@@ -53,7 +53,7 @@ func TestCouncilUpdatePropDefinitionValidate(t *testing.T) {
 
 func TestCouncilUpdatePropDefinitionExecute(cur realm, t *testing.T) {
 	var (
-		memberA address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+		memberA address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 		memberB address = "g1manfred47kzduec920z88wfr64ylksmdcedlf5"
 	)
 
@@ -84,7 +84,7 @@ func TestCouncilUpdatePropDefinitionExecute(cur realm, t *testing.T) {
 }
 
 func TestAncestorCouncilUpdatePropDefinition(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	root := commondao.New(commondao.WithID(201), commondao.WithName("Root"))
 	mid := commondao.New(commondao.WithID(202), commondao.WithName("Mid"), commondao.WithParent(root))

--- a/examples/gno.land/r/nt/commondao/v0/proposal_subdao_test.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_subdao_test.gno
@@ -37,7 +37,7 @@ func newTestDAO(t *testing.T, name string, members ...address) *commondao.Common
 }
 
 func TestSubDAOPropDefinitionNew(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	dao := newTestDAO(t, "Root", member)
 
@@ -61,7 +61,7 @@ func TestSubDAOPropDefinitionNew(cur realm, t *testing.T) {
 }
 
 func TestSubDAOPropDefinitionExecute(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	dao := newTestDAO(t, "Root2", member)
 
@@ -84,7 +84,7 @@ func TestSubDAOPropDefinitionExecute(cur realm, t *testing.T) {
 }
 
 func TestDissolvePropDefinitionExecute(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	dao := newTestDAO(t, "Root3", member)
 

--- a/examples/gno.land/r/nt/commondao/v0/proposal_treasury_test.gno
+++ b/examples/gno.land/r/nt/commondao/v0/proposal_treasury_test.gno
@@ -24,7 +24,7 @@ func newTestTree() (root, mid, leaf *commondao.CommonDAO) {
 }
 
 func TestTreasurySpendPropDefinition(cur realm, t *testing.T) {
-	var member address = "g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq"
+	var member address = "g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx"
 
 	dao := commondao.New(
 		commondao.WithID(100),

--- a/gno.land/pkg/integration/testdata/commondao_ancestor.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_ancestor.txtar
@@ -11,7 +11,7 @@ adduser test2
 adduser test3
 
 # Genesis council collapses to test1 (the inviter / root creator).
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test1_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_council.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_council.txtar
@@ -9,7 +9,7 @@ adduser test2
 adduser test3
 
 # Genesis council = {test1, test2}.
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test2_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_dao_member.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_dao_member.txtar
@@ -22,7 +22,7 @@ loadpkg gno.land/r/nt/commondao/v0
 
 # Collapse the genesis council to test1 (the two hardcoded members become a
 # one-address set, so a single YES is a supermajority there).
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test1_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_election.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_election.txtar
@@ -15,7 +15,7 @@ adduser test3
 
 # Make the genesis council a real two-member set {test1, test2} (the two
 # hardcoded genesis members map to two distinct accounts).
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test2_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_governance.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_governance.txtar
@@ -7,7 +7,7 @@ loadpkg gno.land/r/nt/commondao/v0
 adduser test2
 
 # Genesis council collapses to test1, so test1 is the realm's inviter.
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test1_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_new_caller_shapes.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_new_caller_shapes.txtar
@@ -19,7 +19,7 @@ adduser test3
 adduser test4
 
 # Collapse the genesis council to test1 so it can Invite.
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test1_user_addr
 
 gnoland start

--- a/gno.land/pkg/integration/testdata/commondao_treasury.txtar
+++ b/gno.land/pkg/integration/testdata/commondao_treasury.txtar
@@ -11,7 +11,7 @@ loadpkg gno.land/r/nt/commondao/v0
 
 # Make test1 the sole genesis council member (the two hardcoded members
 # collapse into a one-address set, so a single YES is a supermajority).
-patchpkg g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq $test1_user_addr
+patchpkg g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx $test1_user_addr
 patchpkg g1manfred47kzduec920z88wfr64ylksmdcedlf5 $test1_user_addr
 
 gnoland start


### PR DESCRIPTION
Replaces the hardcoded `@devx` address `g16jpf0puufcpcjkph5nxueec8etpcldz7zwgydq`
with the GovDAO T1 multisig `g1skl80cuz8zq3lul9pgz5pc35l2pfzgxgfpsqkx` everywhere
it appears in `examples/`.

### Why

`r/nt/commondao/v0/genesis.gno` seeds the realm's own DAO with two founding
members. One of them was a team key (`// @devx`); the realm's governance should
sit with the GovDAO T1 multisig instead — the same address already used as the
admin across `r/gnoland/faucet`, `r/demo/foo721`, `r/demo/foo1155`,
`r/demo/releases_example`, and as `NAMES_ADMIN` in the pearl/sapphire/topaz
genesis scripts.

The address was also reused as a generic caller/admin fixture across the
commondao test suite, so this sweeps it there too and keeps the codebase down to
one address for "the entity that governs these realms".

### What changed

| | |
|---|---|
| Occurrences replaced | 151 across 139 files |
| `r/nt/commondao/v0` (realm + filetests) | 129 |
| `p/nt/commondao/v0` | 5 |
| `p/jeronimoalbi/expect` filetests | 3 |
| `p/nt/addrset/v0`, `p/gnoland/boards` | 1 each |
| `gno.land/pkg/integration/testdata/commondao_*.txtar` | 7 |

Beyond the mechanical swap, three deliberate edits:

- **`genesis.gno`** — the `// @devx` annotation becomes `// govdao t1 multisig`,
  matching the convention used elsewhere in `examples/`. All 128 `// @devx`
  comments were updated the same way; every one of them sat on a line carrying
  the old address.
- **`p/nt/addrset/v0/addrset_test.gno`** — `TestSetIteration` /
  `TestSetIterationLimits` assert AVL iteration order against a fixed three-address
  fixture. `g1skl80cuz…` sorts *after* `g1jg8mtut…` and `g1manfred…`, where
  `g16jpf0…` sorted before both, so the expected order moves from
  `addr3 < addr1 < addr2` to `addr1 < addr2 < addr3`.
- **`p/gnoland/boards/flag_storage_test.gno`** — same reason: the `flags` fixture
  is declared in sorted user order, so the two entries are swapped (with a comment
  recording that the ordering is load-bearing).

The 7 `patchpkg` lines in `gno.land/pkg/integration/testdata/` had to move with the
address, otherwise they'd silently become no-ops and the commondao txtar tests
would run against an unpatched realm.

### Left alone deliberately

- `misc/deployments/test13.gno.land/transactions/patched/boards2-cascade/*` —
  archived transactions from a chain that already ran.
- `contribs/gnofaucet/github/testdata/events.1.json` — a recorded GitHub API
  response fixture.

### Verification

```
gno test ./...                                          # full examples suite, no failures
gno test -v ./gno.land/r/nt/commondao/v0                # 147 filetests, all pass
go test ./gno.land/pkg/integration -run TestTestdata/commondao   # 7/7 pass
```

The commondao filetests print members in insertion order rather than sorted order,
so no golden output needed regenerating there.
