### PR TITLE
fix(deployments/mainnet): seed the sole GovDAO T1 member with 9 invitation points

### DIFF
--- a/misc/deployments/mainnet.gno.land/gen-genesis.sh
+++ b/misc/deployments/mainnet.gno.land/gen-genesis.sh
@@ -1214,6 +1214,31 @@ if [ "$t1_seed_calls" -ne "$t1_count" ]; then
   die "$BOOTSTRAP_GNO makes $t1_seed_calls T1 SetMember calls for $t1_count distinct addresses — the repeated call fails with ErrMemberAlreadyExists and the bootstrap MsgRun panics at InitChain"
 fi
 
+# ---- The sole member's invitation points must cover the six post-genesis adds ----
+#
+# Every NewT1MemberRequest burns one point of the PROPOSER's balance when the
+# proposal executes, and there is no realm path that grants points after the
+# fact — not a proposal, not a promotion. So the number typed into NewMember()
+# at genesis is the permanent ceiling on how many members the launch member can
+# ever seat, and running out is terminal for the intended founding set: the
+# remaining seats could only be filled by spending the points of members he had
+# just invited, which no later proposal can rebalance.
+#
+# T1_EXPECTED_INVITATION_POINTS = the six remaining gnolang/multisigs [govdao]
+# members + the three the seven-member bootstrap gave every founder. Asserted
+# rather than defaulted, because the T1 tier's own default is 3 (it governs what
+# an INVITEE is seeded with, not an inviter) — so the wrong value here reads as
+# the right one, and only surfaces as a stuck governance set after launch.
+T1_EXPECTED_INVITATION_POINTS=9
+t1_points=$(grep -v '^[[:space:]]*//' "$BOOTSTRAP_GNO" |
+  grep -oE 'memberstore\.T1, address\("g1[0-9a-z]{38}"\), memberstore\.NewMember\([0-9]+\)' |
+  grep -oE 'NewMember\([0-9]+\)$' | grep -oE '[0-9]+') || t1_points=""
+if [ "$t1_points" != "$T1_EXPECTED_INVITATION_POINTS" ]; then
+  die "$(printf '%s\n%s' \
+    "expected the sole T1 member in $BOOTSTRAP_GNO to be seeded with $T1_EXPECTED_INVITATION_POINTS invitation points, found '${t1_points:-none}'." \
+    "With fewer, the six remaining [govdao] members cannot all be seated by proposal — and nothing on chain can top the balance up afterwards.")"
+fi
+
 t1_unfunded=""
 while IFS= read -r t1_addr; do
   t1_rc=0
@@ -1248,7 +1273,7 @@ if [ -n "$t1_unfunded" ]; then
     "$t1_unfunded" \
     "mainnet has no faucet: fund them in the gnolang/independence-day allocation, or drop them from the bootstrap.")"
 fi
-print_substep "2.7" "GovDAO T1 members: $t1_count seeded, each holds a genesis balance"
+print_substep "2.7" "GovDAO T1 members: $t1_count seeded with $t1_points invitation points, each holds a genesis balance"
 
 # ---- Every founding validator address must be able to pay for a tx ----
 # The same argument as 2.7, for the other set of addresses that must act on a

--- a/misc/deployments/mainnet.gno.land/transactions/base/bootstrap/govdao_prop1_mainnet.gno
+++ b/misc/deployments/mainnet.gno.land/transactions/base/bootstrap/govdao_prop1_mainnet.gno
@@ -24,7 +24,9 @@
 // members post-genesis through regular GovDAO proposals. The other six
 // gnolang/multisigs [govdao] keys were confirmed with their owners and
 // are recorded in the gen-genesis.sh history (commit 97987fa06) for when
-// those proposals are made.
+// those proposals are made. He is seeded with NINE invitation points
+// rather than the T1 default of three, because each of those six adds
+// burns one of HIS — see the comment on the SetMember call.
 //
 // Steps:
 //  1. Add the sole GovDAO T1 member.
@@ -42,7 +44,28 @@ func main(cur realm) {
 	ms := memberstore.Get(0, cur)
 
 	// ---- 1. Add the sole GovDAO T1 member ----
-	must(ms.SetMember(memberstore.T1, address("g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m"), memberstore.NewMember(3))) // aeddi
+	//
+	// NINE invitation points, not the T1 tier default of three.
+	//
+	// Each NewT1MemberRequest burns one point of the PROPOSER's balance at
+	// execution time (r/gov/dao/impl/v0/prop_requests.gno), and the T1 tier
+	// default only governs what the INVITEE is seeded with — every member
+	// added this way starts at three regardless of what the inviter holds.
+	// So seating the six remaining [govdao] members costs aeddi six points,
+	// and three is what the seven-member bootstrap gave every founder.
+	// 6 + 3 = 9 reproduces that end state exactly: seven T1 members holding
+	// three points each, which is what this chain would have launched with
+	// had all seven been seeded at genesis.
+	//
+	// Three would not merely be tight, it would be short: aeddi would run
+	// out after the third proposal (the fourth NewT1MemberRequest panics at
+	// creation with "proposer does not have enough invitation points"), and
+	// the remaining three members could only be seated by spending the
+	// points of members he had just invited — leaving the founding set with
+	// an arbitrary, lopsided point distribution that no proposal can
+	// rebalance, since nothing in the memberstore grants points after the
+	// fact.
+	must(ms.SetMember(memberstore.T1, address("g1aeddlftlfk27ret5rf750d7w5dume3kcsm8r8m"), memberstore.NewMember(9))) // aeddi
 
 	// ---- 2. Lock down memberstore access ----
 	// gno.land/r/gov/dao/impl/v0 is the production member-mutation realm;


### PR DESCRIPTION
Stacked on #6154 (`chain/mainnet`). Merge there, not into master.

## The problem

Since 5e357244c, mainnet launches with **one** GovDAO T1 member — aeddi — who adds the other six `[govdao]` members post-genesis by proposal. He is seeded with `memberstore.NewMember(3)`.

Three is not enough, and the shortfall is permanent.

`NewAddMemberRequest` burns one invitation point of the **proposer's** balance when the proposal executes:

```go
if member.InvitationPoints <= 0 {
    panic("proposer does not have enough invitation points for inviting new people to the board")
}

cb := func(cur realm) error {
    member.RemoveInvitationPoint()
    err := memberstore.Get(0, cur).SetMember(tier, addr, memberByTier(tier))
    return err
}
```

The `Tier.InvitationPoints = 3` default on T1 is a different number: it governs what the **invitee** is seeded with (`memberByTier(tier)`), not what the inviter spends. So every member added this way starts at 3 regardless of what aeddi holds, and aeddi's own balance only ever goes down.

With 3, he seats three members and the fourth `NewAddMemberRequest` panics at creation. The remaining three could only be seated by spending the points of members he had just invited — and nothing in the memberstore grants points after the fact, not a proposal and not a promotion, so the founding set would be stuck with an arbitrary, unrebalanceable distribution.

## The fix

`NewMember(9)` = the six remaining `[govdao]` members + the three that the seven-member bootstrap gave every founder. The end state is exactly what this chain would have launched with had all seven been seeded at genesis: seven T1 members holding three points each.

Guarded at build time in step 2.7, for the same reason the member-count guard exists — and specifically because the T1 tier default of 3 makes the wrong value read as the right one. Verified by tripping it: reverted to 3, the `SetMember` line commented out, and the call reshaped across lines each fail the build.

## Testing

A probe test against the real `r/gov/dao/v3/{impl,memberstore}` realms, reproducing the bootstrap exactly (sole T1 member, `AllowedDAOs` locked to impl, six adds by proposal, every current member voting YES, executed between adds):

```
seed3: before add #1 aeddi has 3 IP, T1 size 1
seed3: before add #2 aeddi has 2 IP, T1 size 2
seed3: before add #3 aeddi has 1 IP, T1 size 3
seed3: after 3 adds aeddi has 0 IP, T1 size 4
seed3: each invitee got 3 / 3 / 3 IP
seed3: 4th invite refused -> aeddi cannot seat all six by himself

seed9: before add #1 aeddi has 9 IP, T1 size 1, voters 1
seed9: before add #2 aeddi has 8 IP, T1 size 2, voters 2
...
seed9: before add #6 aeddi has 4 IP, T1 size 6, voters 6
seed9: DONE T1 size 7, aeddi 3 IP, others all 3 IP
```

The probe is not included in this PR (it needs a mutable memberstore and shares VM state across tests); it is reproducible from the description above.

## Not fixed here — three things the sole-member switch also implies

1. **`run_submitters` now contains only aeddi.** It is derived from the seeded T1 set (`RUN_SUBMITTERS_INCLUDE_GOVDAO_T1`), which is one address now. Proposal creation is MsgRun-only, so the six members added post-genesis can vote (`MustVoteOnProposalSimple` is MsgCall-able) and execute, but cannot author a proposal until a GovDAO vote runs `r/sys/params.ProposeSetRunSubmitters`. Recoverable, but cheaper to put the six confirmed addresses in `RUN_SUBMITTERS_EXTRA` at genesis.

2. **The adds must be executed one at a time.** Voting power is computed dynamically at execute time, so once the second member exists aeddi's lone YES is 50% and the next proposal will not execute until the new member votes. Verified: aborts with `proposal didn't reach supermajority yet: 66.66`.

3. **The proposals must not be batched ahead of the points.** The invitation-point check is at proposal *creation*, the decrement at *execution*. Pre-creating more proposals than there are points gets them all created and voted through, then the surplus aborts the execution tx with `not enough invitation points`.

Also worth noting: the T1 funding guard now covers aeddi only. All seven addresses from 97987fa06 are still funded at the current pin (`independence-day@0927710`, 1,000–7.5M GNOT, each with a §132 schedule), so nothing is broken today — it is just no longer asserted.