### PR TITLE
fix(gnovm,gno.land,tm2)!: native gas metering, package-hash binding and authority APIs

### DIFF
--- a/contribs/gpao/endtoend_test.go
+++ b/contribs/gpao/endtoend_test.go
@@ -101,8 +101,11 @@ func TestEstimateEnableAgainstARealChain(t *testing.T) {
 		return client.SimulateResult(probe)
 	}
 
+	pkgHash, err := vm.PackageContentHash(mpkg)
+	require.NoError(t, err)
+
 	t.Run("an enable that would succeed estimates", func(t *testing.T) {
-		res, simErr := simulateEnable(t, vm.PackageContentHash(mpkg))
+		res, simErr := simulateEnable(t, pkgHash)
 		require.Equal(t, verdictReady, classifySimulate(res, simErr),
 			"a probe signed at the chain's own Block.MaxGas must be accepted and run")
 		assert.Positive(t, res.GasUsed, "and report what the enable actually costs")

--- a/contribs/gpao/issettled_test.go
+++ b/contribs/gpao/issettled_test.go
@@ -82,11 +82,13 @@ func TestRedeployParkedOverLivePrivateRealmIsEnabled(t *testing.T) {
 
 	enableAsApprover := func(t *testing.T, mpkg *std.MemPackage) {
 		t.Helper()
+		pkgHash, err := vm.PackageContentHash(mpkg)
+		require.NoError(t, err)
 		signed, err := client.SignTx(std.Tx{
 			Msgs: []std.Msg{vm.MsgEnablePackage{
 				Approver: who,
 				PkgPath:  mpkg.Path,
-				PkgHash:  vm.PackageContentHash(mpkg),
+				PkgHash:  pkgHash,
 			}},
 			Fee: std.NewFee(20_000_000, std.MustParseCoin("1000000ugnot")),
 		}, 0, 0)
@@ -140,7 +142,7 @@ func TestRedeployParkedOverLivePrivateRealmIsEnabled(t *testing.T) {
 	require.True(t, answered, "a zero ceiling clamps every gas figure to zero and the enable is refused")
 	o.blockMaxGas = maxGas
 
-	o.handleCandidate(t.Context(), v2)
+	o.handleCandidate(t.Context(), candidate{mpkg: v2})
 
 	st := o.status.get(pkgPath)
 	require.NotEqual(t, "already active on-chain", st.Reason,

--- a/contribs/gpao/oracle.go
+++ b/contribs/gpao/oracle.go
@@ -37,7 +37,7 @@ type oracle struct {
 
 	// candidates carries submitted packages from the block reader to the
 	// verifier goroutine. See runVerifier for why they are separate.
-	candidates chan *std.MemPackage
+	candidates chan candidate
 
 	// seen dedupes packages already processed in this run. Touched ONLY by the
 	// verifier goroutine, never by the block reader, or the two race on a plain
@@ -178,7 +178,7 @@ func newOracle(cfg config, io commands.IO) (*oracle, error) {
 		io:           io,
 		client:       gnoclient.Client{Signer: signer, RPCClient: rpc},
 		approver:     info.GetAddress(),
-		candidates:   make(chan *std.MemPackage, candidateQueueSize),
+		candidates:   make(chan candidate, candidateQueueSize),
 		seen:         make(map[string]struct{}),
 		overBudget:   make(map[string]int),
 		failedEnable: make(map[string]int),
@@ -411,7 +411,7 @@ func (o *oracle) processBlock(ctx context.Context, height int64) error {
 			if !ok || add.Package == nil {
 				continue
 			}
-			if err := o.enqueue(ctx, add.Package); err != nil {
+			if err := o.enqueue(ctx, candidate{mpkg: add.Package, height: height}); err != nil {
 				return err
 			}
 		}
@@ -432,10 +432,23 @@ func (o *oracle) runVerifier(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case mpkg := <-o.candidates:
-			o.handleCandidate(ctx, mpkg)
+		case c := <-o.candidates:
+			o.handleCandidate(ctx, c)
 		}
 	}
+}
+
+// candidate is a submitted package together with the block it was submitted in.
+//
+// The height travels with the bytes because it is part of what gets approved,
+// not merely context for a log line: MsgEnablePackage pins it, so that a
+// re-submission of the same sources -- which keeps the content hash while
+// rewriting the [addpkg] section underneath it, including the storage-deposit
+// ceiling this oracle's own transaction pays against -- cannot ride an approval
+// issued for the submission that was actually verified.
+type candidate struct {
+	mpkg   *std.MemPackage
+	height int64
 }
 
 // enqueue hands a candidate to the verifier, blocking if it is behind.
@@ -445,9 +458,9 @@ func (o *oracle) runVerifier(ctx context.Context) {
 // retry -- it would stay inert with no record of why. Blocking is the honest
 // alternative, and saturation is announced rather than left to be inferred from
 // the oracle mysteriously lagging.
-func (o *oracle) enqueue(ctx context.Context, mpkg *std.MemPackage) error {
+func (o *oracle) enqueue(ctx context.Context, c candidate) error {
 	select {
-	case o.candidates <- mpkg:
+	case o.candidates <- c:
 		return nil
 	default:
 	}
@@ -455,7 +468,7 @@ func (o *oracle) enqueue(ctx context.Context, mpkg *std.MemPackage) error {
 		"gpao: verify queue full (%d), pausing block reads; the oracle is CPU-saturated",
 		cap(o.candidates))
 	select {
-	case o.candidates <- mpkg:
+	case o.candidates <- c:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -464,7 +477,8 @@ func (o *oracle) enqueue(ctx context.Context, mpkg *std.MemPackage) error {
 
 // handleCandidate typechecks a submitted package and, if it passes, broadcasts
 // a MsgEnablePackage to activate it on-chain.
-func (o *oracle) handleCandidate(ctx context.Context, mpkg *std.MemPackage) {
+func (o *oracle) handleCandidate(ctx context.Context, c candidate) {
+	mpkg := c.mpkg
 	path := mpkg.Path
 	// Keyed on the bytes, not just the path. A rejection is a verdict about the
 	// code, so a submitter who fixes the code and resubmits deserves a fresh
@@ -553,7 +567,19 @@ func (o *oracle) handleCandidate(ctx context.Context, mpkg *std.MemPackage) {
 	}
 
 	o.logf("gpao: %q passed typecheck, broadcasting approval", path)
-	if err := o.enable(path, vm.PackageContentHash(mpkg)); err != nil {
+	// Checked, not assigned: a package whose gnomod.toml cannot be parsed has
+	// no hash to approve, and an empty one would ride into MsgEnablePackage as
+	// "names no source" -- rejected on chain after the fee, three times, before
+	// being filed as a generic enable failure. It is a verdict about the
+	// package, so it is recorded as one.
+	pkgHash, err := vm.PackageContentHash(mpkg)
+	if err != nil {
+		o.seen[key] = struct{}{}
+		o.status.record(path, statusRejected, "cannot hash the submitted source: "+err.Error(), 0)
+		o.errf("gpao: not approving %q: %v", path, err)
+		return
+	}
+	if err := o.enable(path, pkgHash, c.height); err != nil {
 		// Left unseen until the count runs out, for the reason at
 		// maxEnableAttempts: the package verified, so the failure is about the
 		// chain's state rather than the code, and most such causes clear.
@@ -837,15 +863,23 @@ func broadcastWasFree(res *ctypes.ResultBroadcastTxCommit) bool {
 // at -gas-wanted would make the simulation run out of gas exactly on the
 // packages whose cost we most need to learn, and report that failure instead of
 // a measurement.
-func (o *oracle) enable(pkgPath, pkgHash string) error {
+func (o *oracle) enable(pkgPath, pkgHash string, pkgHeight int64) error {
 	gasFee, err := std.ParseCoin(o.cfg.gasFee)
 	if err != nil {
 		return fmt.Errorf("invalid gas fee %q: %w", o.cfg.gasFee, err)
 	}
-	// Name the source that was verified. The keeper hashes the parked blob the
-	// same way and refuses if they differ, so a creator who replaces the bytes
-	// after verification cannot ride this approval.
-	msg := vm.MsgEnablePackage{Approver: o.approver, PkgPath: pkgPath, PkgHash: pkgHash}
+	// Name the source that was verified, and the submission it came from. The
+	// keeper hashes the parked blob the same way and refuses if they differ, so
+	// a creator who replaces the bytes after verification cannot ride this
+	// approval; the height covers the case where the bytes are identical and
+	// only the [addpkg] section the keeper stamps has moved, which the hash
+	// cannot see. See MsgEnablePackage.PkgHeight.
+	msg := vm.MsgEnablePackage{
+		Approver:  o.approver,
+		PkgPath:   pkgPath,
+		PkgHash:   pkgHash,
+		PkgHeight: pkgHeight,
+	}
 
 	// accountNumber/sequenceNumber == 0 lets SignTx auto-query the chain.
 	probe, err := o.client.SignTx(std.Tx{

--- a/contribs/gpao/oracle_test.go
+++ b/contribs/gpao/oracle_test.go
@@ -238,20 +238,20 @@ func TestOracleHandleCandidateOverBudgetCap(t *testing.T) {
 	// Every attempt before the cap leaves the package pending, so a restart or
 	// a resubmission can still reach it.
 	for i := 1; i < maxOverBudgetAttempts; i++ {
-		o.handleCandidate(context.Background(), mpkg)
+		o.handleCandidate(context.Background(), candidate{mpkg: mpkg})
 		assert.NotContains(t, o.seen, path,
 			"attempt %d of %d must leave the package pending", i, maxOverBudgetAttempts)
 		assert.Equal(t, i, o.overBudget[path], "overrun count after attempt %d", i)
 	}
 
 	// At the cap the oracle stops paying for it.
-	o.handleCandidate(context.Background(), mpkg)
+	o.handleCandidate(context.Background(), candidate{mpkg: mpkg})
 	assert.Contains(t, o.seen, path,
 		"the package must be given up on once it has burned %d budgets", maxOverBudgetAttempts)
 
 	// And having given up, it is not verified again: the count stays put
 	// because handleCandidate now returns on the seen check.
-	o.handleCandidate(context.Background(), mpkg)
+	o.handleCandidate(context.Background(), candidate{mpkg: mpkg})
 	assert.Equal(t, maxOverBudgetAttempts, o.overBudget[path],
 		"a given-up package must not be re-verified")
 }
@@ -398,7 +398,7 @@ func TestUnreachableRemoteIsNotAVerdict(t *testing.T) {
 
 	// And the consequence the submitter feels: the content is NOT settled, so
 	// a resubmission (or a restart) gets a fresh look once the fault clears.
-	o.handleCandidate(context.Background(), mpkg)
+	o.handleCandidate(context.Background(), candidate{mpkg: mpkg})
 	assert.NotContains(t, o.seen, candidateKey(mpkg),
 		"a fault that was never about the bytes must not retire them")
 	assert.Equal(t, statusPending, o.status.get(mpkg.Path).Status)
@@ -497,13 +497,13 @@ func TestOracleReVerifiesChangedBytesAtTheSamePath(t *testing.T) {
 
 	// Burn the first candidate's whole allowance so it is given up on.
 	for range maxOverBudgetAttempts {
-		o.handleCandidate(context.Background(), first)
+		o.handleCandidate(context.Background(), candidate{mpkg: first})
 	}
 	require.Contains(t, o.seen, candidateKey(first))
 
 	// The corrected resubmission at the same path gets a fresh look: it is not
 	// short-circuited by the first one's verdict.
-	o.handleCandidate(context.Background(), second)
+	o.handleCandidate(context.Background(), candidate{mpkg: second})
 	assert.Equal(t, 1, o.overBudget[candidateKey(second)],
 		"the corrected package must be verified rather than skipped")
 	assert.NotContains(t, o.seen, candidateKey(second),

--- a/contribs/gpao/processblock_test.go
+++ b/contribs/gpao/processblock_test.go
@@ -79,7 +79,7 @@ func newStubOracle(rpc rpcclient.Client) *oracle {
 	return &oracle{
 		io:         commands.NewTestIO(),
 		client:     gnoclient.Client{RPCClient: rpc},
-		candidates: make(chan *std.MemPackage, 8),
+		candidates: make(chan candidate, 8),
 		seen:       map[string]struct{}{},
 		overBudget: map[string]int{},
 	}
@@ -105,7 +105,7 @@ func TestProcessBlockIgnoresFailedTransactions(t *testing.T) {
 
 	var queued []string
 	for len(o.candidates) > 0 {
-		queued = append(queued, (<-o.candidates).Path)
+		queued = append(queued, (<-o.candidates).mpkg.Path)
 	}
 	require.Equal(t, []string{"gno.land/r/test/good"}, queued,
 		"only the package from the transaction that SUCCEEDED may be queued")

--- a/contribs/gpao/spenddebit_test.go
+++ b/contribs/gpao/spenddebit_test.go
@@ -116,7 +116,7 @@ func TestSpentMovesOnlyWhenATransactionIsSent(t *testing.T) {
 
 	// Verified clean, refused at simulate, nothing broadcast: the counter must
 	// not move, because the money did not.
-	o.handleCandidate(t.Context(), bad)
+	o.handleCandidate(t.Context(), candidate{mpkg: bad})
 	badStatus := o.status.get(badPath)
 	require.Equal(t, statusPending, badStatus.Status)
 	require.Contains(t, badStatus.Reason, "simulate says the enable would fail",
@@ -126,7 +126,7 @@ func TestSpentMovesOnlyWhenATransactionIsSent(t *testing.T) {
 
 	// Control arm: a broadcast approval costs exactly one fee, counted at the
 	// send.
-	o.handleCandidate(t.Context(), good)
+	o.handleCandidate(t.Context(), candidate{mpkg: good})
 	assert.Equal(t, o.enableFee, o.spent,
 		"a broadcast approval must be counted, whether or not it succeeds -- the ante charges for it")
 	assert.Equal(t, statusApproved, o.status.get(goodPath).Status)
@@ -218,7 +218,7 @@ func TestSpentIsRefundedWhenCheckTxRejects(t *testing.T) {
 	before, _, err := client.QueryBalance(who)
 	require.NoError(t, err)
 
-	o.handleCandidate(t.Context(), mpkg)
+	o.handleCandidate(t.Context(), candidate{mpkg: mpkg})
 
 	status := o.status.get(pkgPath)
 	require.Equal(t, statusPending, status.Status)

--- a/examples/gno.land/p/moul/authz/v0/authz.gno
+++ b/examples/gno.land/p/moul/authz/v0/authz.gno
@@ -4,7 +4,7 @@
 //
 // The package supports multiple authorization strategies:
 //   - Member-based: Single user or team of users
-//   - Contract-based: Async authorization (e.g., via DAO)
+//   - Contract-based: The contract at a given path is itself the authority
 //   - Auto-accept: Allow all actions
 //   - Drop: Deny all actions
 //
@@ -13,7 +13,7 @@
 //   - Authority interface: Base interface implemented by all authorities
 //   - Authorizer: Main wrapper object for authority management
 //   - MemberAuthority: Manages authorized addresses
-//   - ContractAuthority: Delegates to another contract
+//   - ContractAuthority: Makes the contract at a path its own authority
 //   - AutoAcceptAuthority: Accepts all actions
 //   - DroppedAuthority: Denies all actions
 //
@@ -81,6 +81,20 @@ type Authorizer struct {
 //     can swallow actions, log the caller, or execute arbitrary code
 //     under the consumer's frame. Register only trusted handler functions.
 //     See r/gnops/valopers/init.gno for the realistic registration shape.
+//
+//   - Caller- and title-forgery on the RAW interface: Authorize takes
+//     `caller` and `title` as ARGUMENTS, not from the frame. A consumer
+//     that exposes a bare Authority (rather than the *Authorizer that
+//     wraps it) therefore lets any holder present any caller and any
+//     title. Caller-forgery is contained — the only authority-mutating
+//     closure lives inside Authorizer.Transfer, so a forged caller on a
+//     raw Authorize runs the caller's own inert closure and cannot
+//     transfer; TestForgedCallerCannotTransfer pins that boundary.
+//     Title-forgery is NOT contained: the title is passed straight to the
+//     contractHandler, so a handler that branches on it (routing, quotas,
+//     audit trails) must not treat it as trusted. Keep the Authority
+//     unexported and hand out only what callers need; see
+//     r/gnops/valopers/admin.gno, which exports a description string.
 //
 // We do NOT seal Authority via an unexported marker method — that pattern
 // is bypassable via embedding in Gno; see
@@ -217,20 +231,14 @@ func (a *Authorizer) DoByPrevious(_ int, rlm realm, title string, action Privile
 	return a.auth.Authorize(rlm.Previous().Address(), title, action, args...)
 }
 
-// String returns a string representation of the auth authority
+// String returns a string representation of the auth authority.
+//
+// A non-canonical impl is wrapped as custom_authority[...] so that the
+// official "dropped" is distinguishable from a "*custom*: dropped"
+// (autoclaimed) one. Shared with ContractAuthority.String, which applies
+// the same rule to its nested proposer.
 func (a *Authorizer) String() string {
-	authStr := a.auth.String()
-
-	switch a.auth.(type) {
-	case *MemberAuthority:
-	case *ContractAuthority:
-	case *AutoAcceptAuthority:
-	case *droppedAuthority:
-	default:
-		// this way official "dropped" is different from "*custom*: dropped" (autoclaimed).
-		return ufmt.Sprintf("custom_authority[%s]", authStr)
-	}
-	return authStr
+	return canonicalAuthorityString(a.auth)
 }
 
 // MemberAuthority is the default implementation using addrset for member
@@ -330,27 +338,117 @@ type ContractAuthority struct {
 	proposer        Authority // controls who can create proposals
 }
 
-// NewContractAuthority creates a new contract-based authority.
+// NewContractAuthority makes the contract at `path` its OWN authority:
+// the default proposer accepts only chain.PackageAddress(path), so a
+// privileged action proceeds only when driven from that contract's own
+// frame.
+//
+// NewRestrictedContractAuthority does NOT widen this — it REPLACES it.
+// See its godoc; with an explicit proposer, `path` is a label and
+// contractAddr is never consulted.
+//
+// The `caller` compared against that address is established upstream by
+// Authorizer.DoByCurrent / DoByPrevious / Transfer under rlm.IsCurrent(),
+// so an external realm cannot present the contract address.
+//
+// BREAKING: the default proposer used to be
+// NewAutoAcceptAuthority ("anyone can propose"). Consumers that relied on
+// arbitrary callers driving a plain ContractAuthority will start getting
+// "unauthorized"; that is the fix, not a regression. Pass an explicit
+// proposer to NewRestrictedContractAuthority to opt back in.
+//
+// SECURITY — the gate binds the contract's IDENTITY, not its intent.
+// Inside any crossing frame of the contract, rlm.Address() is
+// unconditionally PackageAddress(path), so `DoByCurrent` from within the
+// contract is a tautology; only DoByPrevious and Transfer gain a real
+// check. Consequently ANY exported function of the contract that returns
+// a crossing closure (or anything else carrying its frame) hands this
+// authority to its caller. Keep privileged closures unexported.
+//
+// So DO NOT write NewContractAuthority(ownPath) + DoByCurrent. It reads
+// like "only I may do this" and compiles to "anyone may do this". Point
+// `path` at the principal you actually want to assert — usually the
+// governance realm that will drive the action — and use DoByPrevious, so
+// the comparison is against whoever crossed in:
+//
+//	// in r/gnops/valopers/init.gno
+//	auth = authz.NewWithAuthority(
+//	    authz.NewContractAuthority("gno.land/r/gov/dao", handler),
+//	)
+//	// in the privileged write
+//	auth.DoByPrevious(0, rlm, "update-instructions", action)
+//
+// Own-path is right only when something OTHER than the contract's own
+// frame supplies the caller — i.e. you drive it via DoByPrevious from a
+// realm you have deliberately let call in, or via Transfer.
+//
+// SECURITY — a gate is only as good as the principal it names. Pointing
+// `path` at a realm whose frame ANY caller can mint buys nothing. Check,
+// for whatever principal you choose, that nothing exported by that realm
+// hands out its frame identity:
+//
+//   - `gno.land/r/gov/dao` is safe to assert ONLY because
+//     SimpleExecutor.Execute rejects invocation from outside the proxy
+//     (r/gov/dao/types.gno). Before that gate existed, dao's exported
+//     NewSimpleExecutor + Execute let any realm mint a frame whose
+//     Previous() was r/gov/dao, so this whole pairing authenticated
+//     nothing. Do not assume a governance path is unforgeable; verify it.
+//   - Whatever the principal, an exported function of YOUR realm whose
+//     signature is assignable to a callback type the principal invokes
+//     (for r/gov/dao: `func(realm) error`) is itself the leak — the
+//     principal will happily call it for an attacker. Keep privileged
+//     entrypoints out of that shape, or take extra parameters.
+//
+// Neither shape defends against re-exporting the privileged closure: its
+// holder picks the Previous() they present by wrapping it in an executor
+// of their own. Unexported closures remain the load-bearing rule.
+//
+// A syntactically valid but WRONG `path` is a permanent brick, not an
+// error: the authority accepts nobody, and Transfer routes through the
+// same gate, so it cannot be rotated out either. Construction rejects
+// malformed paths, but it cannot tell a wrong path from a right one —
+// e.g. "gno.land/r/gov/dao/impl/v0" (the path r/gov/dao's own
+// allowedDAOs list holds) is well-formed and permanently dead, because
+// an executor's Previous() is the PROXY path, never the impl. Give the
+// consumer a governance-gated rotation entrypoint before deploying; see
+// r/gnops/valopers/admin.gno's NewAuthorityRotationProposalRequest.
 //
 // SECURITY (Class-4 captured callback): `handler` is a caller-supplied
 // closure that runs SYNCHRONOUSLY inside Authorize, with the consumer's
 // authority. A hostile handler can swallow actions, log the caller, or
 // execute arbitrary code under the consumer's frame. The package-internal
-// wrappedAction guards "execute action only from contractAddr" but the
-// handler can call wrappedAction however it likes (multiple times, never,
-// out of order). Register only trusted handler functions; treat handler
-// registration as the trust boundary.
+// wrappedAction enforces at-most-once invocation and NOTHING ELSE — in
+// particular it does not check the caller, and the handler may call it
+// however it likes (multiple times, never, out of order). Register only
+// trusted handler functions; treat handler registration as the trust
+// boundary.
+//
+// Panics if `path` is empty or malformed, or if `handler` is nil.
 func NewContractAuthority(path string, handler PrivilegedActionHandler) *ContractAuthority {
-	return &ContractAuthority{
-		contractPath:    path,
-		contractAddr:    chain.PackageAddress(path),
-		contractHandler: handler,
-		proposer:        NewAutoAcceptAuthority(), // default: anyone can propose
-	}
+	addr := chain.PackageAddress(assertValidContractPath(path))
+	// The default proposer is a real Authority, not an absent one. Encoding
+	// the strictest policy as a nil field would mean the secure default is
+	// what you get by leaving something OUT: a struct literal that skips
+	// this constructor, a persisted value from an older build, or re-adding
+	// `if proposer == nil { proposer = NewAutoAcceptAuthority() }` would all
+	// silently be wide open again. A one-field struct costs the same as the
+	// nil it replaces and cannot be reached by omission.
+	return newContractAuthority(path, addr, handler, &contractIdentityAuthority{addr: addr})
 }
 
-// NewRestrictedContractAuthority creates a new contract authority with a
-// proposer restriction.
+// NewRestrictedContractAuthority creates a contract authority whose
+// proposer REPLACES the contract-identity gate.
+//
+// This is the escape hatch, not a second lock. `proposer` becomes the ONLY
+// authorization decision: contractAddr is not consulted on this path, so
+// `path` degrades to a label that appears in String() and asserts nothing.
+// NewRestrictedContractAuthority(p, h, NewAutoAcceptAuthority()) is exactly
+// the old default behaviour ("anyone can propose"), stated
+// explicitly rather than reached by default.
+//
+// In particular NewRestrictedContractAuthority("gno.land/r/gov/dao", h,
+// NewMemberAuthority(alice)) does NOT mean "GovDAO and alice". It means
+// "alice, and not GovDAO".
 //
 // SECURITY:
 //   - `handler` is the same Class-4 captured-callback risk as
@@ -359,23 +457,106 @@ func NewContractAuthority(path string, handler PrivilegedActionHandler) *Contrac
 //   - `proposer` is an open-interface input (Class-3 impl-substitution).
 //     A hostile proposer Authority can always-approve creation of any
 //     proposal, defeating the restriction. Pass canonical impls only.
+//     String() renders a non-canonical proposer wrapped as
+//     custom_authority[...] so such a substitution is at least visible.
 func NewRestrictedContractAuthority(path string, handler PrivilegedActionHandler, proposer Authority) Authority {
-	if path == "" {
-		panic("contract path cannot be empty")
-	}
-	if handler == nil {
-		panic("contract handler cannot be nil")
-	}
 	if proposer == nil {
 		panic("proposer cannot be nil")
 	}
+	addr := chain.PackageAddress(assertValidContractPath(path))
+	return newContractAuthority(path, addr, handler, proposer)
+}
+
+// newContractAuthority is the single construction path: both exported
+// constructors validate, then land here, so a guard added once applies to
+// both. `handler` is rejected here rather than surfaced at Authorize time
+// because Authorize checks contractHandler == nil BEFORE consulting the
+// proposer, and Transfer routes through Authorize — so a nil-handler
+// authority could never be rotated out. It is a permanent brick with no
+// on-chain recovery for anyone: the same bricked-governance failure
+// mode, reached by accident.
+func newContractAuthority(path string, addr address, handler PrivilegedActionHandler, proposer Authority) *ContractAuthority {
+	if handler == nil {
+		panic("contract handler cannot be nil")
+	}
 	return &ContractAuthority{
 		contractPath:    path,
-		contractAddr:    chain.PackageAddress(path),
+		contractAddr:    addr,
 		contractHandler: handler,
 		proposer:        proposer,
 	}
 }
+
+// assertValidContractPath rejects paths that chain.PackageAddress would
+// hash happily but that no realm could ever present, which would brick the
+// authority permanently (nobody authorizes, and Transfer routes through the
+// same gate so nobody can rotate out). Returns `path` so it composes.
+//
+// The authoritative rule is gnolang.ReGnoUserPkgPath ("all paths must be
+// lowercase ascii alphanumeric characters", gnovm/pkg/gnolang/mempackage.go),
+// but no validator is exported to Gno code — chain's isValidSubpath /
+// assertValidSubpath are unexported, and there is no chain.IsValidPkgPath.
+// So this is a deliberately permissive superset: segment ("/" segment)*,
+// segment = [a-z0-9] ([a-z0-9_.-]* [a-z0-9])?. It accepts every real
+// package path and catches what actually gets typed wrong — trailing or
+// embedded whitespace, empty segments, uppercase, stray punctuation. It
+// CANNOT catch a well-formed path that is simply the wrong principal. See
+// NewContractAuthority's godoc on rotation.
+func assertValidContractPath(path string) string {
+	if path == "" {
+		panic("contract path cannot be empty")
+	}
+	if !strings.Contains(path, "/") {
+		panic("contract path must be a package path, e.g. gno.land/r/gov/dao")
+	}
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i == len(path) || path[i] == '/' {
+			if !isValidContractPathSegment(path[start:i]) {
+				panic("contract path must be '/'-separated segments of [a-z0-9] with '_.-' allowed inside a segment, e.g. gno.land/r/gov/dao")
+			}
+			start = i + 1
+		}
+	}
+	return path
+}
+
+func isValidContractPathSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	for i := 0; i < len(seg); i++ {
+		switch c := seg[i]; {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '_' || c == '.' || c == '-':
+			// Allowed only strictly inside a segment.
+			if i == 0 || i == len(seg)-1 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// contractIdentityAuthority is the default proposer installed by
+// NewContractAuthority: the contract at the bound path, and nobody else.
+// Unexported and unmutable by design — AddMember/RemoveMember are
+// meaningless for a fixed contract identity, which is why this is not a
+// MemberAuthority holding one address.
+type contractIdentityAuthority struct {
+	addr address
+}
+
+func (a *contractIdentityAuthority) Authorize(caller address, _ string, action PrivilegedAction, _ ...any) error {
+	if caller != a.addr {
+		return errors.New("unauthorized")
+	}
+	return action()
+}
+
+func (a *contractIdentityAuthority) String() string { return "contract-identity" }
 
 func (a *ContractAuthority) Authorize(caller address, title string, action PrivilegedAction, args ...any) error {
 	if a.contractHandler == nil {
@@ -400,17 +581,86 @@ func (a *ContractAuthority) Authorize(caller address, title string, action Privi
 		})
 	}
 
-	// Use the proposer authority to control who can create proposals
-	return a.proposer.Authorize(caller, title+"_proposal", func() error {
+	handle := func() error {
 		if err := a.contractHandler(title, wrappedAction); err != nil {
 			return err
 		}
 		return nil
-	}, args...)
+	}
+
+	// The proposer IS the authorization decision. For an authority built by
+	// NewContractAuthority it is a contractIdentityAuthority bound to
+	// contractAddr — the contract itself and nobody else; for one built by
+	// NewRestrictedContractAuthority it is whatever the consumer installed,
+	// and contractAddr is deliberately not consulted (see that constructor's
+	// godoc). `caller` is established upstream by Authorizer.DoByCurrent /
+	// DoByPrevious / Transfer under rlm.IsCurrent(), so an external realm
+	// cannot present an arbitrary principal here.
+	//
+	// A nil proposer is not a policy, it is a malformed value: both
+	// constructors always install one, so nil means the struct was built by
+	// a literal that bypassed them. Fail closed rather than dereference.
+	if a.proposer == nil {
+		return errors.New("proposer is not set")
+	}
+	return a.proposer.Authorize(caller, title+"_proposal", handle, args...)
 }
 
+// String renders the contract path AND the proposer.
+//
+// The proposer half is security-relevant, not cosmetic: it is the only
+// thing distinguishing a gated authority from a wide-open one. Rendering
+// the path alone made
+//
+//	NewContractAuthority(path, handler)                              // gated
+//	NewRestrictedContractAuthority(path, handler, AutoAccept{})      // open to all
+//
+// byte-identical, so any consumer test asserting on this string — and
+// any on-chain reader inspecting it — was blind to the difference. A
+// consumer realm could have its authority swapped for a fully permissive
+// one and its assertions would stay green.
+//
+// "contract-identity" names the default installed by NewContractAuthority:
+// the contract at contractPath, and nobody else, may drive this authority.
+//
+// The proposer is rendered through canonicalAuthorityString, NOT by calling
+// a.proposer.String() directly. Authority is an open interface, so a foreign
+// impl can return any text it likes — including "contract-identity". That
+// made a fully permissive authority byte-identical to the gated default
+// again, defeating the very assertions this rendering exists to support.
+// Non-canonical impls are wrapped as custom_authority[...], mirroring what
+// Authorizer.String has always done at the outer level.
+//
+// Read the `contract=` half with care: it is load-bearing only for the
+// contract-identity default. With any other proposer it is a label —
+// see NewRestrictedContractAuthority.
 func (a *ContractAuthority) String() string {
-	return ufmt.Sprintf("contract_authority[contract=%s]", a.contractPath)
+	return ufmt.Sprintf(
+		"contract_authority[contract=%s,proposer=%s]",
+		a.contractPath,
+		canonicalAuthorityString(a.proposer),
+	)
+}
+
+// canonicalAuthorityString renders an Authority, wrapping any
+// implementation that is not one of this package's own as
+// custom_authority[...] so a foreign impl cannot impersonate a canonical
+// one by choosing its String() text. Shared by ContractAuthority.String
+// (for the nested proposer) and Authorizer.String (for the installed
+// authority).
+func canonicalAuthorityString(auth Authority) string {
+	if auth == nil {
+		// Only reachable via a struct literal that bypassed the
+		// constructors; Authorize fails closed on the same condition.
+		return "<unset>"
+	}
+	switch auth.(type) {
+	case *MemberAuthority, *ContractAuthority, *AutoAcceptAuthority,
+		*droppedAuthority, *contractIdentityAuthority:
+		return auth.String()
+	default:
+		return ufmt.Sprintf("custom_authority[%s]", auth.String())
+	}
 }
 
 // AutoAcceptAuthority implements an authority that accepts all actions

--- a/examples/gno.land/p/moul/authz/v0/authz_test.gno
+++ b/examples/gno.land/p/moul/authz/v0/authz_test.gno
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"chain"
-	"chain/runtime/unsafe"
 	"errors"
 	"strings"
 	"testing"
@@ -134,15 +133,15 @@ func TestAuthorizerTransferChain(cur realm, t *testing.T) {
 	func(cur realm) { err = auth.Transfer(0, cur, contractAuth) }(cross(cur))
 	uassert.True(t, err == nil, "unexpected error in second transfer")
 
-	// Finally transfer to an auto-accept authority — must come from the
-	// contract realm so ContractAuthority's wrappedAction CurrentRealm
-	// check passes. Use the test frame's cur directly (SetRealm mutates
-	// it in place); a crossing closure would push a new frame whose cur
-	// is the test package, breaking the runtime.CurrentRealm match.
+	// Finally transfer to an auto-accept authority. The authority is now
+	// the contract authority, whose default proposer is the contract
+	// itself, so the transfer's caller —
+	// cur.Previous() — must be the contract. Set the outer realm to the
+	// contract, then cross into a closure so cur.Previous() resolves to
+	// it.
 	autoAuth := NewAutoAcceptAuthority()
-	codeRealm := testing.NewCodeRealm("gno.land/r/test")
-	testing.SetRealm(codeRealm)
-	err = auth.Transfer(0, cur, autoAuth)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/test"))
+	func(cur realm) { err = auth.Transfer(0, cur, autoAuth) }(cross(cur))
 	uassert.True(t, err == nil, "unexpected error in final transfer")
 	uassert.True(t, auth.Authority() == autoAuth, "expected auto-accept authority")
 }
@@ -408,32 +407,32 @@ func TestAuthorizerCurrentNeverNil(cur realm, t *testing.T) {
 }
 
 func TestContractAuthorityValidation(cur realm, t *testing.T) {
-	/*
-		// Test empty path - should panic
-		panicked := false
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					panicked = true
-				}
-			}()
-			NewContractAuthority("", nil)
-		}()
-		uassert.True(t, panicked, "expected panic for empty path")
-	*/
+	handler := func(title string, action PrivilegedAction) error {
+		return nil
+	}
 
-	// Test nil handler - should return error on Authorize
-	auth := NewContractAuthority("gno.land/r/test", nil)
+	// Empty path panics (consistent with NewRestrictedContractAuthority).
+	uassert.PanicsWithMessage(t, cur, "contract path cannot be empty", func() {
+		NewContractAuthority("", handler)
+	})
+
+	// A nil handler panics at CONSTRUCTION rather than being tolerated and
+	// surfaced at Authorize time. Tolerating it produced a permanent brick:
+	// see TestNilHandlerWouldBeUnrotatable below.
+	uassert.PanicsWithMessage(t, cur, "contract handler cannot be nil", func() {
+		NewContractAuthority("gno.land/r/test", nil)
+	})
+
+	// The Authorize-time guard stays for a zero-value ContractAuthority,
+	// which the constructors cannot produce but a struct literal can.
 	code := testing.NewCodeRealm("gno.land/r/test").Address()
-	err := auth.Authorize(code, "test", func() error {
+	zero := &ContractAuthority{contractPath: "gno.land/r/test", contractAddr: code}
+	err := zero.Authorize(code, "test", func() error {
 		return nil
 	})
 	uassert.True(t, err != nil, "nil handler authority should fail to authorize")
 
 	// Test valid configuration
-	handler := func(title string, action PrivilegedAction) error {
-		return nil
-	}
 	contractAuth := NewContractAuthority("gno.land/r/test", handler)
 	err = contractAuth.Authorize(code, "test", func() error {
 		return nil
@@ -482,11 +481,26 @@ func TestAuthorityString(cur realm, t *testing.T) {
 	expectedMemberStr := "member_authority[g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh]"
 	uassert.Equal(t, memberStr, expectedMemberStr)
 
-	// ContractAuthority
+	// ContractAuthority — the proposer is rendered, not just the path.
+	// Without it the two constructors below are indistinguishable, which
+	// is what made consumer-level assertions on this string blind to an
+	// authority being swapped for a wide-open one.
 	contractAuth := NewContractAuthority("gno.land/r/test", func(title string, action PrivilegedAction) error { return nil })
 	contractStr := contractAuth.String()
-	expectedContractStr := "contract_authority[contract=gno.land/r/test]"
+	expectedContractStr := "contract_authority[contract=gno.land/r/test,proposer=contract-identity]"
 	uassert.Equal(t, contractStr, expectedContractStr)
+
+	// Same path, same handler, explicit open proposer — must render
+	// differently from the gated default above.
+	openAuth := NewRestrictedContractAuthority(
+		"gno.land/r/test",
+		func(title string, action PrivilegedAction) error { return nil },
+		NewAutoAcceptAuthority(),
+	)
+	uassert.Equal(t,
+		"contract_authority[contract=gno.land/r/test,proposer=auto_accept_authority]",
+		openAuth.String())
+	uassert.NotEqual(t, contractStr, openAuth.String())
 
 	// AutoAcceptAuthority
 	autoAuth := NewAutoAcceptAuthority()
@@ -501,26 +515,28 @@ func TestAuthorityString(cur realm, t *testing.T) {
 	uassert.Equal(t, droppedStr, expectedDroppedStr)
 }
 
+// TestContractAuthorityUnauthorizedCaller verifies the
+// fix: a ContractAuthority's default proposer is the contract itself, so
+// any other caller is rejected UPSTREAM (at the proposer) and the handler
+// and privileged action never run. Previously the default proposer was
+// AutoAcceptAuthority, and the only guard was a handler-side
+// `unsafe.CurrentRealm() == contractAddr` check — which was bypassable
+// and which many consumers (e.g. r/gnops/valopers) omitted entirely,
+// leaving no caller check at all.
 func TestContractAuthorityUnauthorizedCaller(cur realm, t *testing.T) {
 	contractPath := "gno.land/r/testcontract"
 	contractAddr := chain.PackageAddress(contractPath)
 	unauthorizedAddr := testutils.TestAddress("unauthorized")
 
-	// Handler that checks the caller before proceeding
-	handlerExecutedCorrectly := false // Tracks if handler logic ran correctly
-	handlerErrorMsg := "handler: caller is not the contract"
+	// A permissive handler that simply runs the action — the realistic
+	// shape a consumer registers. The package, not the handler, must be
+	// the one that rejects an unauthorized caller.
+	handlerExecuted := false
 	contractHandler := func(title string, action PrivilegedAction) error {
-		caller := unsafe.CurrentRealm().Address()
-		if caller != contractAddr {
-			return errors.New(handlerErrorMsg)
-		}
-		// Only execute action and mark success if caller is correct
-		handlerExecutedCorrectly = true
+		handlerExecuted = true
 		return action()
 	}
-
 	contractAuth := NewContractAuthority(contractPath, contractHandler)
-	authorizer := NewWithAuthority(contractAuth) // Start with ContractAuthority
 
 	actionExecuted := false
 	privilegedAction := func() error {
@@ -528,26 +544,19 @@ func TestContractAuthorityUnauthorizedCaller(cur realm, t *testing.T) {
 		return nil
 	}
 
-	// 1. Attempt action from unauthorized user
-	testing.SetRealm(testing.NewUserRealm(unauthorizedAddr))
-	err := authorizer.DoByCurrent(0, cur, "test_action_unauthorized", privilegedAction)
+	// 1. Unauthorized caller: rejected by the contract-identity proposer
+	// before the handler or the action can run.
+	err := contractAuth.Authorize(unauthorizedAddr, "test_action", privilegedAction)
+	uassert.Error(t, err, "unauthorized caller must be rejected")
+	uassert.ErrorContains(t, err, "unauthorized", "rejection must come from the contract-identity proposer")
+	uassert.False(t, handlerExecuted, "handler must not run for an unauthorized caller")
+	uassert.False(t, actionExecuted, "privileged action must not run for an unauthorized caller")
 
-	// Assertions for unauthorized call
-	uassert.Error(t, err, "DoByCurrent should return an error for unauthorized caller")
-	uassert.ErrorContains(t, err, handlerErrorMsg, "Error should originate from the handler check")
-	uassert.False(t, handlerExecutedCorrectly, "Handler should not have executed successfully for unauthorized caller")
-	uassert.False(t, actionExecuted, "Privileged action should not have executed for unauthorized caller")
-
-	// 2. Attempt action from the correct contract
-	handlerExecutedCorrectly = false // Reset flag
-	actionExecuted = false           // Reset flag
-	testing.SetRealm(testing.NewCodeRealm(contractPath))
-	err = authorizer.DoByCurrent(0, cur, "test_action_authorized", privilegedAction)
-
-	// Assertions for authorized call
-	uassert.NoError(t, err, "DoByCurrent should succeed for authorized contract caller")
-	uassert.True(t, handlerExecutedCorrectly, "Handler should have executed successfully for authorized caller")
-	uassert.True(t, actionExecuted, "Privileged action should have executed for authorized caller")
+	// 2. The contract itself is authorized.
+	err = contractAuth.Authorize(contractAddr, "test_action", privilegedAction)
+	uassert.NoError(t, err, "the contract itself must be authorized")
+	uassert.True(t, handlerExecuted, "handler must run when the contract is the caller")
+	uassert.True(t, actionExecuted, "privileged action must run when the contract is the caller")
 }
 
 // TestAuthorizerDoByPrevious verifies the "calling realm authorizes"
@@ -599,4 +608,356 @@ func TestAuthorizerDoByPrevious(cur realm, t *testing.T) {
 		uassert.ErrorContains(t, err, "unauthorized", "expected error")
 		uassert.False(t, executed, "action should not have been executed")
 	}(cross(cur))
+}
+
+// ---------------------------------------------------------------------------
+// Contract-identity gate: regression suite.
+//
+// A plain NewContractAuthority now defaults its proposer to the contract
+// ITSELF (MemberAuthority of the contract's own package address) instead of
+// AutoAcceptAuthority. These tests pin the security contract: only the
+// contract may drive privileged actions, an external caller can neither
+// drive nor Transfer the authority, the contract can still rotate its own
+// authority, and the escape hatch for a genuinely-open proposer still
+// exists.
+// ---------------------------------------------------------------------------
+
+// The default proposer accepts the contract itself and rejects everyone
+// else, before the handler or action can run.
+func TestDefaultProposerIsContractOnly(cur realm, t *testing.T) {
+	const path = "gno.land/r/defcontract"
+	contractAddr := chain.PackageAddress(path)
+
+	ran := 0
+	ca := NewContractAuthority(path, func(_ string, action PrivilegedAction) error {
+		return action()
+	})
+
+	// The contract itself: authorized.
+	err := ca.Authorize(contractAddr, "action", func() error { ran++; return nil })
+	uassert.NoError(t, err, "the contract itself must be authorized")
+
+	// Anyone else: rejected at the proposer, action never runs.
+	outsider := testutils.TestAddress("outsider")
+	err = ca.Authorize(outsider, "action", func() error { ran++; return nil })
+	uassert.Error(t, err, "a non-contract caller must be rejected")
+	uassert.ErrorContains(t, err, "unauthorized", "rejection must come from the contract-identity proposer")
+
+	uassert.Equal(t, 1, ran, "only the contract's action must have run")
+}
+
+// An external realm that holds another realm's Authorizer cannot Transfer
+// it. The caller derived under IsCurrent is that external realm, not the
+// contract, so the rotation is rejected and the authority is left intact.
+func TestExternalTransferRejected(cur realm, t *testing.T) {
+	authorizer := NewWithAuthority(
+		NewContractAuthority("gno.land/r/victim", func(_ string, action PrivilegedAction) error {
+			return action()
+		}),
+	)
+
+	attacker := testutils.TestAddress("attacker")
+	testing.SetRealm(testing.NewUserRealm(attacker))
+
+	var err error
+	func(cur realm) { err = authorizer.Transfer(0, cur, NewDroppedAuthority()) }(cross(cur))
+
+	uassert.Error(t, err, "external Transfer must be rejected")
+	uassert.ErrorContains(t, err, "unauthorized", "rejection must come from the contract-identity proposer")
+
+	_, ok := authorizer.Authority().(*ContractAuthority)
+	uassert.True(t, ok, "authority must be unchanged after a rejected rotation")
+}
+
+// Same shape via DoByPrevious (a privileged action instead of a
+// Transfer): an external caller is rejected and the action never runs.
+func TestExternalDoByPreviousRejected(cur realm, t *testing.T) {
+	authorizer := NewWithAuthority(
+		NewContractAuthority("gno.land/r/victim2", func(_ string, action PrivilegedAction) error {
+			return action()
+		}),
+	)
+
+	ran := false
+	testing.SetRealm(testing.NewUserRealm(testutils.TestAddress("randomuser")))
+	var err error
+	func(cur realm) {
+		err = authorizer.DoByPrevious(0, cur, "privileged", func() error { ran = true; return nil })
+	}(cross(cur))
+
+	uassert.Error(t, err, "external DoByPrevious must be rejected")
+	uassert.False(t, ran, "privileged action must not run for an external caller")
+}
+
+// The contract-identity model does NOT lock out legitimate governance: the
+// contract can still rotate (Transfer) its own authority when the transfer
+// is driven with the contract as the previous realm (caller == contractAddr).
+func TestContractCanRotateItsOwnAuthority(cur realm, t *testing.T) {
+	const path = "gno.land/r/selfgov"
+	authorizer := NewWithAuthority(
+		NewContractAuthority(path, func(_ string, action PrivilegedAction) error {
+			return action()
+		}),
+	)
+
+	// Drive the transfer with the contract as the caller: set the outer
+	// realm to the contract, then cross into a closure so cur.Previous()
+	// resolves to the contract.
+	testing.SetRealm(testing.NewCodeRealm(path))
+	var err error
+	func(cur realm) { err = authorizer.Transfer(0, cur, NewAutoAcceptAuthority()) }(cross(cur))
+
+	uassert.NoError(t, err, "the contract itself must be able to rotate its authority")
+	_, ok := authorizer.Authority().(*AutoAcceptAuthority)
+	uassert.True(t, ok, "authority should have rotated to auto-accept")
+}
+
+// Boundary test: the raw Authority.Authorize takes `caller` as a plain
+// parameter, so a holder of the raw Authority can forge caller ==
+// contractAddr. This proves that even so, a forged-caller raw Authorize
+// only runs the action the caller itself supplies — it CANNOT mutate an
+// Authorizer's installed authority, because the Transfer mutation lives
+// only inside Authorizer.Transfer (which derives caller non-forgeably).
+// The lesson encoded here: consumers must reach a ContractAuthority through
+// the Authorizer wrapper and must not hand out the raw Authority.
+//
+// WHAT THIS TEST DOES AND DOES NOT FREEZE. Only the final assertion is a
+// security property. That raw Authorize ACCEPTS a forged caller is
+// current behaviour, not a guarantee — it is the consequence of `caller`
+// being a parameter on an exported interface method. If someone later
+// hardens that path so raw Authorize stops accepting a forged caller,
+// this test going red means the test is stale, NOT that the change is
+// wrong: delete the two intermediate assertions and keep the last one.
+// (Recorded because asserting NoError here reads like the forgeability
+// is wanted. It is tolerated, and only because of what follows.)
+func TestForgedCallerCannotTransfer(cur realm, t *testing.T) {
+	const path = "gno.land/r/boundary"
+	contractAddr := chain.PackageAddress(path)
+
+	authorizer := NewWithAuthority(
+		NewContractAuthority(path, func(_ string, action PrivilegedAction) error {
+			return action()
+		}),
+	)
+
+	// Attacker obtains the raw Authority and forges the contract as caller.
+	attackerRan := false
+	err := authorizer.Authority().Authorize(contractAddr, "transfer_authority", func() error {
+		attackerRan = true
+		return nil
+	})
+
+	// Current behaviour, documented above — not a property to preserve.
+	uassert.NoError(t, err, "raw Authorize currently accepts a forged caller (see comment)")
+	uassert.True(t, attackerRan, "only the caller's own inert closure runs")
+
+	// THE property: the installed authority is UNCHANGED. Raw Authorize
+	// cannot perform a Transfer — the mutation closure is private to
+	// Authorizer.Transfer, which derives caller non-forgeably.
+	_, ok := authorizer.Authority().(*ContractAuthority)
+	uassert.True(t, ok, "raw Authorize must not be able to transfer the authority")
+}
+
+// Two contract authorities on different paths never cross-authorize.
+func TestContractPathIsolation(cur realm, t *testing.T) {
+	caB := NewContractAuthority("gno.land/r/pathb", func(_ string, action PrivilegedAction) error {
+		return action()
+	})
+	addrA := chain.PackageAddress("gno.land/r/patha")
+
+	ran := false
+	err := caB.Authorize(addrA, "action", func() error { ran = true; return nil })
+	uassert.Error(t, err, "contract A must not authorize contract B's authority")
+	uassert.False(t, ran, "action must not run across contract identities")
+}
+
+// Escape hatch: a consumer that genuinely wants open proposals can still
+// opt in via NewRestrictedContractAuthority with an AutoAcceptAuthority
+// proposer — restoring the pre-fix "anyone can propose" behavior explicitly.
+func TestRestrictedAutoAcceptEscapeHatch(cur realm, t *testing.T) {
+	ca := NewRestrictedContractAuthority(
+		"gno.land/r/open",
+		func(_ string, action PrivilegedAction) error { return action() },
+		NewAutoAcceptAuthority(),
+	)
+
+	ran := false
+	err := ca.Authorize(testutils.TestAddress("anyone"), "action", func() error { ran = true; return nil })
+	uassert.NoError(t, err, "an explicit AutoAccept proposer restores open proposals")
+	uassert.True(t, ran, "action must run under an explicit AutoAccept proposer")
+}
+
+// Why the nil handler is now rejected at construction rather than
+// tolerated: Authorize checks contractHandler == nil BEFORE consulting the
+// proposer, and Transfer routes through Authorize, so there is no rotation
+// path out. It is a permanent brick reachable by an ordinary deployer
+// typo -- the same bricked-governance failure mode, by accident.
+//
+// The zero value is used because the constructor no longer allows it.
+func TestNilHandlerWouldBeUnrotatable(cur realm, t *testing.T) {
+	const path = "gno.land/r/nilbrick"
+	addr := chain.PackageAddress(path)
+	authorizer := NewWithAuthority(&ContractAuthority{
+		contractPath: path,
+		contractAddr: addr,
+		// Both handler and proposer are nil: a struct literal is the only
+		// way to reach this, and Authorize fails closed on either.
+	})
+
+	// Drive the rotation as the contract itself -- the only principal the
+	// default proposer accepts. If this cannot escape, nobody can.
+	testing.SetRealm(testing.NewCodeRealm(path))
+	var err error
+	func(cur realm) { err = authorizer.Transfer(0, cur, NewAutoAcceptAuthority()) }(cross(cur))
+
+	uassert.Error(t, err, "a nil-handler authority must not be silently rotatable")
+	_, stuck := authorizer.Authority().(*ContractAuthority)
+	uassert.True(t, stuck, "nil-handler authority is unrotatable -- hence rejected at construction")
+}
+
+// A crossing closure declared HERE carries this package's identity, not
+// the contract path's -- testing.SetRealm does not change that, because
+// the VM mints a crossing frame's realm from the callee's declaring
+// package. So the DoByCurrent shape that Example_contractAuthority teaches
+// cannot be exercised from inside this package at all; it needs a real
+// realm. It is covered by filetests/z_contract_authority_shape_filetest.gno.
+//
+// The same property is why an exported crossing closure leaks a realm's
+// authority to any caller -- it is one mechanism seen from two
+// sides. This test pins the half that is observable here: an unrelated
+// package's frame is rejected.
+func TestForeignFrameCannotDriveContractAuthority(cur realm, t *testing.T) {
+	auth := NewWithAuthority(NewContractAuthority("gno.land/r/demo/dao", mockDAOHandler))
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/example"))
+	ran := false
+	var err error
+	func(cur realm) {
+		err = auth.DoByCurrent(0, cur, "update_params", func() error {
+			ran = true
+			return nil
+		})
+	}(cross(cur))
+
+	uassert.Error(t, err, "a frame from another package must not drive this authority")
+	uassert.False(t, ran, "the action must not run")
+}
+
+// A malformed contract path binds the authority to an address no realm can
+// ever present. Because Transfer routes through the same gate, such an
+// authority is also unrotatable: a permanent brick, and the same failure
+// mode the nil-handler panic exists to prevent. Rejected at construction.
+//
+// Pre-fix these all constructed happily; the AutoAccept default made the
+// typo harmless (and insecure), so nothing complained.
+func TestContractPathValidationRejectsMalformed(cur realm, t *testing.T) {
+	handler := func(_ string, action PrivilegedAction) error { return action() }
+
+	for _, path := range []string{
+		"gno.land/r/gov/dao ",  // trailing space
+		" gno.land/r/gov/dao",  // leading space
+		"gno.land/r/gov/dao\n", // trailing newline
+		"gno.land/r/gov dao",   // embedded space
+		" ",
+		"not a path",
+		"GNO.LAND/R/GOV/DAO", // uppercase: not a legal gno pkgpath
+		"gno.land//r/gov/dao",
+		"gno.land/r/gov/dao/",
+		"singlesegment",
+	} {
+		uassert.PanicsContains(t, cur, "contract path", func() {
+			NewContractAuthority(path, handler)
+		}, "malformed path must be rejected: "+path)
+		uassert.PanicsContains(t, cur, "contract path", func() {
+			NewRestrictedContractAuthority(path, handler, NewAutoAcceptAuthority())
+		}, "malformed path must be rejected by the restricted ctor too: "+path)
+	}
+
+	// Real paths still construct, including dashes, digits, underscores and
+	// version suffixes.
+	for _, path := range []string{
+		"gno.land/r/gov/dao",
+		"gno.land/r/gnops/valopers",
+		"gno.land/p/moul/authz/v0",
+		"gno.land/r/sys/validators/v0",
+		"gno.land/r/some-user/my_pkg2",
+	} {
+		uassert.NotPanics(t, cur, func() {
+			NewContractAuthority(path, handler)
+		}, "legitimate path must construct: "+path)
+	}
+}
+
+// spoofProposer is a wide-open Authority that LIES in String(), returning
+// the same text the canonical contract-identity default renders.
+type spoofProposer struct{}
+
+func (spoofProposer) Authorize(caller address, title string, action PrivilegedAction, args ...any) error {
+	return action()
+}
+
+func (spoofProposer) String() string { return "contract-identity" }
+
+// A foreign proposer must not be able to impersonate the gated default in
+// the rendered description. ContractAuthority.String() is promoted by this
+// package as the one surface distinguishing a gated authority from a
+// wide-open one, and consumers assert on it (r/gnops/valopers.Auth()). An
+// impl that chooses its own String() text defeated that: a fully permissive
+// authority rendered byte-identical to the default, so every string-based
+// configuration pin stayed green while the gate was gone.
+func TestSpoofedProposerCannotImpersonateContractIdentity(cur realm, t *testing.T) {
+	const path = "gno.land/r/spoofprobe"
+	handler := func(_ string, action PrivilegedAction) error { return action() }
+	outsider := chain.PackageAddress("gno.land/r/outsider")
+
+	gated := NewContractAuthority(path, handler)
+	spoof := NewRestrictedContractAuthority(path, handler, spoofProposer{})
+
+	// The behavioural difference the strings must reflect.
+	uassert.Error(t, gated.Authorize(outsider, "t", func() error { return nil }),
+		"the gated default must reject an outsider")
+	uassert.NoError(t, spoof.Authorize(outsider, "t", func() error { return nil }),
+		"the spoofing proposer is wide open -- that is the point of the test")
+
+	// ...and they do.
+	uassert.NotEqual(t, gated.String(), spoof.String(),
+		"a wide-open authority must not render identically to the gated default")
+	uassert.Equal(t,
+		"contract_authority[contract="+path+",proposer=contract-identity]",
+		gated.String())
+	uassert.Equal(t,
+		"contract_authority[contract="+path+",proposer=custom_authority[contract-identity]]",
+		spoof.String(),
+		"a non-canonical proposer must be wrapped, not trusted to name itself")
+
+	// Same guarantee through the Authorizer wrapper, which is the shape a
+	// consumer realm actually exposes.
+	uassert.NotEqual(t,
+		NewWithAuthority(gated).String(),
+		NewWithAuthority(spoof).String())
+}
+
+// An explicit proposer REPLACES the contract-identity gate; it does not add
+// to it. NewRestrictedContractAuthority(govdaoPath, h, member(alice)) means
+// "alice, and not GovDAO" -- contractAddr is never consulted. Pinned because
+// the rendered string reads like a conjunction and the old godoc said
+// "widen", so a consumer could reasonably have expected "both".
+func TestExplicitProposerReplacesIdentityGate(cur realm, t *testing.T) {
+	const path = "gno.land/r/gov/dao"
+	handler := func(_ string, action PrivilegedAction) error { return action() }
+	govdao := chain.PackageAddress(path)
+	alice := chain.PackageAddress("gno.land/r/alice")
+
+	gated := NewContractAuthority(path, handler)
+	replaced := NewRestrictedContractAuthority(path, handler, NewMemberAuthority(alice))
+
+	uassert.NoError(t, gated.Authorize(govdao, "x", func() error { return nil }),
+		"the default gate accepts the bound contract")
+	uassert.Error(t, gated.Authorize(alice, "x", func() error { return nil }),
+		"the default gate rejects everyone else")
+
+	uassert.Error(t, replaced.Authorize(govdao, "x", func() error { return nil }),
+		"an explicit proposer REPLACES the identity gate: govdao is no longer accepted")
+	uassert.NoError(t, replaced.Authorize(alice, "x", func() error { return nil }),
+		"only the explicit proposer's principal is accepted")
 }

--- a/examples/gno.land/p/moul/authz/v0/example_test.gno
+++ b/examples/gno.land/p/moul/authz/v0/example_test.gno
@@ -7,38 +7,78 @@ func Example_basic(cur realm) {
 	// is responsible for verifying the caller is an EOA when needed.
 	auth := NewWithMembers(cur.Previous().Address())
 
-	// Use the authority to perform a privileged action
-	auth.DoByCurrent(0, cur, "update_config", func() error {
+	// Authorize with DoByPrevious, NOT DoByCurrent: the member set holds
+	// cur.Previous().Address(), and DoByCurrent would present
+	// cur.Address() -- this realm -- which is never in that set, so the
+	// action would silently never run. Seeding and authorizing must read
+	// the SAME side of the frame. Matches the package Quick Start.
+	if err := auth.DoByPrevious(0, cur, "update_config", func() error {
 		// config = newValue
 		return nil
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // Example_addingMembers demonstrates how to add new members to a member authority
 func Example_addingMembers(cur realm) {
-	// Initialize with the calling realm as the initial authority
-	auth := NewWithMembers(cur.Address())
+	// Seed with Previous(), not Address(): MemberAuthority.AddMember
+	// derives its principal as rlm.Previous().Address(), so a set holding
+	// only cur.Address() authorizes nobody and the AddMember below fails.
+	auth := NewWithMembers(cur.Previous().Address())
 
 	// Add a new member to the authority
 	memberAuth := auth.Authority().(*MemberAuthority)
-	memberAuth.AddMember(0, cur, address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"))
+	if err := memberAuth.AddMember(0, cur, address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5")); err != nil {
+		panic(err)
+	}
 }
 
-// Example_contractAuthority demonstrates using a contract-based authority
+// Example_contractAuthority demonstrates a contract-based authority.
+//
+// A plain NewContractAuthority accepts exactly one principal:
+// chain.PackageAddress(path). Point `path` at the principal you want to
+// ASSERT -- normally the governance realm that will drive the action --
+// and authorize with DoByPrevious, so the comparison is against whoever
+// crossed in. See NewContractAuthority's godoc.
+//
+// Do NOT pair a plain ContractAuthority on your OWN path with
+// DoByCurrent. rlm.Address() inside any crossing frame of a realm is
+// unconditionally PackageAddress(ownPath), so that gate compares the
+// realm to itself, can never reject, and any exported crossing
+// entrypoint next to it becomes an unauthenticated privileged write --
+// the self-comparing-gate shape. Own-path is right only when something
+// OTHER than your own frame supplies the caller, i.e. DoByPrevious from
+// a realm you deliberately let call in, or Transfer.
+//
+// Nothing here catches a wrong pairing: Example_* functions that take
+// any parameter are never executed by `gno test` (see isExampleFunc in
+// gnovm/pkg/test/test.go -- it rejects on method receiver, parameters or
+// results; "// Output:" plays no part in the predicate, so adding one
+// does NOT make the body run), so a sentinel panic in here still reports
+// ok. filetests/z_contract_authority_shape_filetest.gno executes the
+// gate from a real realm instead.
+//
+// Corollary of the identity gate: do not export anything that returns a
+// crossing closure of this realm, or callers inherit the authority.
 func Example_contractAuthority(cur realm) {
-	// Initialize with contract authority (e.g., DAO)
+	// This realm asserts "the governance realm governs me".
 	auth := NewWithAuthority(
 		NewContractAuthority(
-			"gno.land/r/demo/dao",
-			mockDAOHandler, // defined elsewhere for example
+			"gno.land/r/gov/dao", // the principal asserted, not this realm
+			mockDAOHandler,       // defined elsewhere for example
 		),
 	)
 
-	// Privileged actions will be handled by the contract
-	auth.DoByCurrent(0, cur, "update_params", func() error {
-		// Executes after DAO approval
+	// Authorized only when gno.land/r/gov/dao is the realm that crossed
+	// into this function -- in practice, when a passed proposal executes.
+	// Every other caller presents its own address here and is refused,
+	// which is the whole point of the gate. Never discard this error.
+	if err := auth.DoByPrevious(0, cur, "update_params", func() error {
 		return nil
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
 // Example_restrictedContractAuthority demonstrates a contract authority with member-only proposals
@@ -58,26 +98,57 @@ func Example_restrictedContractAuthority(cur realm) {
 		),
 	)
 
-	// Only members can propose, and contract must approve
-	auth.DoByCurrent(0, cur, "update_params", func() error {
+	// Only members can propose, and contract must approve.
+	//
+	// DoByPrevious, not DoByCurrent: the proposer set holds EOA
+	// addresses, and DoByCurrent would present this realm's own address,
+	// which is in no member set -- the proposer would reject and the
+	// action would silently never run.
+	if err := auth.DoByPrevious(0, cur, "update_params", func() error {
 		// Executes after:
 		// 1. Proposer initiates
 		// 2. DAO approves
 		return nil
-	})
+	}); err != nil {
+		panic(err)
+	}
 }
 
-// Example_switchingAuthority demonstrates switching from member to contract authority
+// Example_switchingAuthority demonstrates switching from member to contract
+// authority.
+//
+// Note what a plain ContractAuthority on a FOREIGN path means after the
+// transfer: this realm loses the ability to take the authority back, and
+// DoByCurrent against it is dead. It is NOT a one-way door in the
+// stronger sense an earlier draft implied — the foreign realm can still
+// drive and rotate it via Previous() once it crosses in, which is the
+// intended async-DAO shape. What is given up is the original owner's
+// claim, not the authority's mutability. (The ADR for this change states
+// the same thing; keep the two in step.) To keep the authority here
+// while letting others propose, transfer to
+// NewRestrictedContractAuthority(ownPath, handler, proposerAuth)
+// instead.
 func Example_switchingAuthority(cur realm) {
-	// Start with member authority (the calling realm)
-	auth := NewWithMembers(cur.Address())
+	// Start with member authority.
+	//
+	// Seed the member set with Previous(), not Address(): Transfer
+	// derives its principal as rlm.Previous().Address(), so a set
+	// containing only cur.Address() authorizes nobody but a
+	// same-package cross-call, and the Transfer below would abort for
+	// every external caller — including a realm that copies this into
+	// init(cur realm), which then fails its deploy tx. Matches
+	// Example_basic and NewWithMembers' godoc.
+	auth := NewWithMembers(cur.Previous().Address())
 
-	// Create and switch to contract authority
+	// Create and switch to contract authority — control moves to
+	// gno.land/r/demo/dao.
 	daoAuthority := NewContractAuthority(
 		"gno.land/r/demo/dao",
 		mockDAOHandler,
 	)
-	auth.Transfer(0, cur, daoAuthority)
+	if err := auth.Transfer(0, cur, daoAuthority); err != nil {
+		panic(err)
+	}
 }
 
 // Mock handler for examples

--- a/examples/gno.land/p/moul/authz/v0/filetests/z_contract_authority_shape_filetest.gno
+++ b/examples/gno.land/p/moul/authz/v0/filetests/z_contract_authority_shape_filetest.gno
@@ -1,0 +1,94 @@
+// PKGPATH: gno.land/r/example
+//
+// Executes the contract-identity gate from a real realm.
+//
+// Two reasons this cannot be a plain unit test in p/moul/authz:
+//
+//  1. Example_* functions that take parameters and have no "// Output:"
+//     are never run by `gno test` — a sentinel panic inside one still
+//     reports ok. So the package's headline example, the shape readers
+//     copy, is invisible to CI unless something else runs it.
+//  2. The gate cannot be simulated from inside the package. The VM mints
+//     a crossing frame's realm from the CALLEE's declaring package, so a
+//     closure declared in p/moul/authz always presents that package's
+//     address no matter what testing.SetRealm says. Only a realm can
+//     present its own.
+//
+// (2) is the same mechanism as the capability leak, seen from the other
+// side: it is what makes `rlm.Address()` inside a crossing frame
+// unconditionally the realm's own address — and therefore what makes
+// `NewContractAuthority(ownPath)` + `DoByCurrent` a comparison of the
+// realm to itself that can never reject.
+//
+// WHAT THIS FILE PINS. Both halves go red if the identity gate is
+// reverted to its pre-fix `proposer: NewAutoAcceptAuthority()` default:
+//
+//   - a principal that is NOT the contract is refused;
+//   - the contract itself is accepted, so the gate does not lock out the
+//     legitimate driver.
+//
+// It deliberately does NOT demonstrate `DoByCurrent` on an own-path
+// authority. That pairing is the anti-pattern NewContractAuthority's
+// godoc forbids: it succeeds here and it would equally succeed for a
+// hostile caller, so asserting it green would document the hole as the
+// recommended shape. A filetest is confined to one realm and so cannot
+// exhibit the foreign caller itself; the package-level negatives
+// (TestForeignFrameCannotDriveContractAuthority,
+// TestContractPathIsolation) and r/gnops/valopers' filetests cover that.
+package example
+
+import (
+	"chain"
+
+	"gno.land/p/moul/authz/v0"
+)
+
+var auth = authz.NewWithAuthority(
+	authz.NewContractAuthority(
+		"gno.land/r/example", // this realm's own path
+		func(_ string, action authz.PrivilegedAction) error { return action() },
+	),
+)
+
+var updated string
+
+// UpdateParams is the exported crossing entrypoint of the realm.
+//
+// DoByPrevious, not DoByCurrent: the principal is whoever crossed in, so
+// an unrelated realm calling this presents its own address and is
+// refused. Under DoByCurrent the principal would be this realm's own
+// address for every caller, and this entrypoint would be an
+// unauthenticated privileged write.
+//
+// Note what must NOT be added next to it: a function returning this
+// closure, or any other value carrying this frame. That is the leak.
+func UpdateParams(cur realm, v string) error {
+	return auth.DoByPrevious(0, cur, "update_params", func() error {
+		updated = v
+		return nil
+	})
+}
+
+func main(cur realm) {
+	// A principal that is not the contract is refused, and the action
+	// does not run. This is the assertion the pre-fix AutoAccept default
+	// could not make.
+	outsider := chain.PackageAddress("gno.land/r/outsider")
+	err := auth.Authority().Authorize(outsider, "update_params", func() error {
+		updated = "SHOULD-NOT-LAND"
+		return nil
+	})
+	println("outsider err:", err)
+	println("updated:", updated)
+
+	// The contract itself is accepted: main and UpdateParams are both in
+	// gno.land/r/example, so cur.Previous() is this realm.
+	println("contract err:", UpdateParams(cross(cur), "governed-value"))
+	println("updated:", updated)
+}
+
+// Output:
+// outsider err: unauthorized
+// updated:
+// contract err: undefined
+// updated: governed-value

--- a/examples/gno.land/r/gnops/valopers/admin.gno
+++ b/examples/gno.land/r/gnops/valopers/admin.gno
@@ -2,33 +2,199 @@ package valopers
 
 import (
 	"gno.land/p/moul/authz/v0"
+	"gno.land/p/nt/ufmt/v0"
+	"gno.land/r/gov/dao"
 )
 
 var auth *authz.Authorizer
 
-func Auth() *authz.Authorizer {
-	return auth
+// Auth returns a read-only description of the realm's current governance
+// authority (for rendering / inspection). It renders as
+//
+//	contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]
+//
+// i.e. "GovDAO governs this realm, and only GovDAO may drive it" — a
+// statement an on-chain reader can act on. The proposer half is
+// load-bearing: without it the string is byte-identical whether the
+// authority is gated or wide open (see ContractAuthority.String).
+//
+// It deliberately does NOT return the live *authz.Authorizer: an
+// exported handle to the authority would let any realm reach its
+// mutators (Transfer, DoByPrevious, ...) directly. Returning a
+// description instead of the handle keeps that surface unreachable from
+// here in the first place. Valoper.AuthOwner follows the same rule for
+// per-operator auth lists.
+func Auth() string {
+	return auth.String()
 }
 
-func updateInstructions(_ int, rlm realm, newInstructions string) {
-	err := auth.DoByCurrent(0, rlm, "update-instructions", func() error {
+// updateInstructions is the realm's only privileged write. It authorizes
+// as the realm that CROSSED INTO valopers, not as valopers itself.
+//
+// Why DoByPrevious and not DoByCurrent: own-path + DoByCurrent is a
+// tautology (see NewContractAuthority's godoc for the mechanism, once).
+// `rlm.Previous()` is the caller — on the legitimate path r/gov/dao's
+// executor frame, which is what init.gno's authority is pointed at.
+//
+// What it buys: it is the code-level guard against this realm's most
+// likely regression, a maintainer later adding an exported crossing
+// entrypoint that reaches here. Under DoByCurrent such an entrypoint
+// authorizes for any caller; under DoByPrevious the caller's own address
+// is the principal and the gate rejects it. Pinned by
+// filetests/z_govdao_only_principal_filetest.gno.
+//
+// Two things it does NOT cover on its own, both closed elsewhere:
+// re-exporting the privileged closure (guarded by the seal in
+// NewInstructionsProposalRequest), and exporting a function whose
+// signature is assignable to dao's `func(realm) error` callback type,
+// which the proxy would invoke on an attacker's behalf. The second was a
+// live bypass of this gate until SimpleExecutor.Execute began rejecting
+// invocation from outside r/gov/dao (r/gov/dao/types.gno); keep BOTH
+// conditions in mind before adding an exported symbol here.
+//
+// Returns the authorization error rather than panicking on it. That matters
+// on the governance path: impl.ExecuteProposal turns an executor ERROR into
+// status Denied plus a DeniedReason, but it cannot see a panic — a panic
+// aborts the whole ExecuteProposal transaction, burning its gas and leaving
+// the proposal stuck Accepted, retryable forever and never deniable. The
+// refusal is currently unreachable on the approved route (Previous() there
+// is always r/gov/dao), but init.gno's handler is explicitly offered as the
+// seam for an intent check (timelock, quorum, audit trail), and the first
+// such check to return an error would hit exactly that.
+func updateInstructions(_ int, rlm realm, newInstructions string) error {
+	return auth.DoByPrevious(0, rlm, "update-instructions", func() error {
 		instructions = newInstructions
 		return nil
 	})
-	if err != nil {
-		panic(err)
-	}
 }
 
-func NewInstructionsProposalCallback(newInstructions string) func(realm) error {
+// NewInstructionsProposalRequest builds the GovDAO proposal that rewrites
+// this realm's instructions. It replaces the previously exported
+// NewInstructionsProposalCallback.
+//
+// SECURITY: the privileged closure must never leave this package.
+//
+// The VM mints a crossing frame's `cur` from the CALLEE's declaring
+// package, so a closure declared here always runs with valopers'
+// identity no matter who invokes it — and whoever holds the closure
+// chooses its Previous() by wrapping it in an executor of their own.
+// Handing such a closure to a caller therefore hands out the ability to
+// satisfy this realm's gate whichever principal it is pointed at: the
+// handler in init.gno runs the action and `instructions` is rewritten
+// with no proposal and no vote. That is what the exported callback did.
+//
+// Returning a dao.ProposalRequest instead seals the capability: the
+// executor is an unexported field with no accessor (dao.ProposalRequest
+// exposes only Title/Description/Filter), so the only way to reach the
+// closure is for GovDAO to execute the proposal that contains it.
+//
+// Note this is deliberately stronger than returning a dao.Executor —
+// even a dao.NewSafeExecutor-wrapped one. Executor.Execute is an
+// exported method, so a returned Executor stays directly invocable by
+// its holder, and SafeExecutor's only gate (InAllowedDAOs) FAILS OPEN
+// while the allowedDAOs list is empty, which is the documented
+// bootstrap state (see r/gov/dao/loader/v0). A sealed request has no
+// such conditional.
+//
+// The rule for this realm: no exported function may return a crossing
+// closure, a dao.Executor, or anything else that carries valopers'
+// frame identity — and no exported function may itself BE such a thing,
+// i.e. have a signature assignable to dao's `func(realm) error` callback
+// type, since the proxy would then invoke it on an attacker's behalf.
+// filetests/z_foreign_realm_capability_filetest.gno pins the first;
+// filetests/z_govdao_only_principal_filetest.gno pins the second.
+func NewInstructionsProposalRequest(cur realm, newInstructions string) dao.ProposalRequest {
 	cb := func(cur realm) error {
-		updateInstructions(0, cur, newInstructions)
-		return nil
+		return updateInstructions(0, cur, newInstructions)
 	}
 
-	return cb
+	title := instructionsProposalTitle
+	description := ufmt.Sprintf("Update the instructions to: \n\n%s", newInstructions)
+
+	return dao.NewProposalRequest(title, description, dao.NewSimpleExecutor(0, cur, cb, ""))
 }
 
+// instructionsProposalTitle is the on-chain title of the instructions
+// proposal, named as a constant so a test can pin it: it is rendered to
+// GovDAO voters and is the string off-chain tooling matches on. It was
+// "/p/gnops/valopers: ..." before this realm's proposal construction moved
+// here; the "/p/" was simply wrong (valopers is an /r/ realm).
+const instructionsProposalTitle = "/r/gnops/valopers: Update instructions"
+
+// rotateAuthority replaces this realm's governance authority.
+//
+// Unexported, and reachable only through the sealed request built by
+// NewAuthorityRotationProposalRequest — same discipline as
+// updateInstructions, for the same reason.
+//
+// authz.Authorizer.Transfer derives its principal as
+// rlm.Previous().Address(), so inside a GovDAO-executed callback declared
+// here Previous() is r/gov/dao — exactly the principal init.gno's authority
+// asserts. No same-package cross() trick is needed.
+func rotateAuthority(_ int, rlm realm, newContractPath string) error {
+	return auth.Transfer(0, rlm, authz.NewContractAuthority(
+		newContractPath,
+		func(_ string, action authz.PrivilegedAction) error {
+			return action()
+		},
+	))
+}
+
+// NewAuthorityRotationProposalRequest builds the GovDAO proposal that
+// re-points this realm's governance authority at `newContractPath`.
+//
+// WHY THIS EXISTS. Without it the authority installed by init.gno is
+// permanently frozen: nothing else calls auth.Transfer, Auth() returns a
+// description rather than the live Authorizer, and Transfer routes through
+// the authority's own gate — so if the asserted principal ever stops being
+// presentable, `instructions` becomes unwritable with no on-chain recovery.
+// That is not hypothetical: the r/gov/dao proxy path is a governance
+// artifact that can be superseded, and a well-formed but wrong path (say
+// the impl path instead of the proxy) is accepted at construction and dead
+// forever. Redeploying instead is expensive — r/sys/validators/v0/cache.gno
+// hardcodes `const valopersRealmPath`, so a new pkgpath means editing a
+// second genesis realm and re-registering every valoper. It must exist
+// before deploy, because code cannot be added to a deployed realm.
+//
+// WHY A PATH AND NOT AN authz.Authority. Taking an Authority would make
+// this an open-interface input (Class-3 impl-substitution): a proposal
+// could install an always-approve or always-deny authority, and readers of
+// Auth() could not tell from the rendered description alone. Taking a path
+// keeps the installed authority canonical by construction — always a
+// ContractAuthority with the pass-through handler and the contract-identity
+// gate — so the only thing governance can change is WHICH principal is
+// asserted. The path is validated by authz.NewContractAuthority, which
+// panics on a malformed one, aborting the proposal execution rather than
+// bricking the realm.
+//
+// This remains a privileged surface: a majority that can pass this proposal
+// can point the authority at a principal it controls. That is the same
+// power a majority already has over `instructions`, and it is the price of
+// being recoverable at all.
+func NewAuthorityRotationProposalRequest(cur realm, newContractPath string) dao.ProposalRequest {
+	cb := func(cur realm) error {
+		return rotateAuthority(0, cur, newContractPath)
+	}
+
+	title := "/r/gnops/valopers: Rotate governance authority"
+	description := ufmt.Sprintf(
+		"Re-point the valopers governance authority at: \n\n%s\n\n"+
+			"The authority stays a contract-identity ContractAuthority; only the asserted principal changes.",
+		newContractPath,
+	)
+
+	return dao.NewProposalRequest(title, description, dao.NewSimpleExecutor(0, cur, cb, ""))
+}
+
+// NewInstructionsProposalCallback was removed, not deprecated: it was the
+// capability leak described above, so an inert shim would be pointless and
+// a working one would reopen the hole. Precedent + replay check: the
+// min-fee callback below was already removed the same way even though it
+// HAD been used on gnoland1 (GovDAO Prop #19), whereas the instructions
+// callback has no on-chain trace at all — the live realm's instructions
+// are byte-identical to the genesis default and none of gnoland1's 26
+// GovDAO proposals is an "Update instructions" one.
+//
 // The min-fee callback was removed: the fee now lives in sysparams
 // under node:valoper:register_fee, and
 // proposal.ProposeNewMinFeeProposalRequest delegates to

--- a/examples/gno.land/r/gnops/valopers/admin_test.gno
+++ b/examples/gno.land/r/gnops/valopers/admin_test.gno
@@ -3,42 +3,107 @@ package valopers
 import (
 	"testing"
 
-	"gno.land/p/moul/authz/v0"
 	"gno.land/p/nt/uassert/v0"
 )
 
-// Earlier this test also asserted a panic ("action can only be
-// executed by the contract") when called without SetOriginCaller.
-// That panic was emitted by a `unsafe.CurrentRealm() == contractAddr`
-// check inside authz.ContractAuthority.Authorize, which has been
-// removed — it was .Title()-bypassable (runtime.CurrentRealm inside a
-// non-crossing closure walks past non-crossing frames to the
-// most-recent crossing ancestor, so a malicious caller could shape
-// the call chain to make the check resolve to contractAddr).
+// TestAuthDescribesGovDAOGate pins init.gno's configuration, including the
+// proposer half — which is the load-bearing half.
 //
-// Caller authentication is now upstream of the deleted gate:
-// authz.Authorizer.DoByCurrent requires `rlm.IsCurrent()`, and the
-// contract handler closure (registered at init in this realm) is the
-// remaining Class-4 trust root by lexical capture. There is no
-// negative path here to assert, so the prior expectation was retired
-// along with its source.
-func TestUpdateInstructions(cur realm, t *testing.T) {
-	auth = authz.NewWithAuthority(
-		authz.NewContractAuthority(
-			"gno.land/r/gov/dao",
-			func(title string, action authz.PrivilegedAction) error {
-				return action()
-			},
-		),
-	)
+// Deliberately does NOT reassign `auth`: an earlier version of this test
+// built its own ContractAuthority and then claimed to "mirror init.gno",
+// which meant changing the contract path in init.gno left it green.
+//
+// Before ContractAuthority.String() rendered the proposer, this assertion
+// was blind to the drift that matters: swapping init.gno for
+// NewRestrictedContractAuthority(path, handler, NewAutoAcceptAuthority())
+// — i.e. reopening the hole for this realm — left the rendered string
+// byte-identical and the whole valopers suite green.
+//
+// It is also blind no longer to a proposer that merely CLAIMS to be the
+// contract-identity default: authz renders any non-canonical Authority
+// wrapped as custom_authority[...], so a spoofing impl cannot reproduce
+// these bytes. See authz's TestSpoofedProposerCannotImpersonateContractIdentity.
+func TestAuthDescribesGovDAOGate(cur realm, t *testing.T) {
+	uassert.Equal(t,
+		"contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]",
+		Auth())
+}
 
-	newInstructions := "new instructions"
+// TestUpdateInstructionsRejectsNonGovDAO is the negative pin for the
+// repointed authority, and it is the one that would have caught the
+// regression class this realm fears.
+//
+// The authority is a ContractAuthority for gno.land/r/gov/dao driven by
+// DoByPrevious, so the principal is whoever crossed into valopers. Here
+// that is the test's own frame, not GovDAO's executor — so the privileged
+// write must be refused and `instructions` must not move.
+//
+// Note what this test could NOT assert before the repoint: under the
+// previous ContractAuthority(ownPath) + DoByCurrent pairing, rlm.Address()
+// inside any valopers crossing frame is unconditionally valopers' own
+// address, so this exact call SUCCEEDED and the old version of this test
+// asserted NotPanics. That is why it never pinned anything: the gate it was
+// exercising could not reject.
+//
+// The positive half — that GovDAO can still perform the write — lives in
+// proposal/filetests/z_governed_instructions_filetest.gno, which runs
+// propose -> vote -> execute end to end.
+func TestUpdateInstructionsRejectsNonGovDAO(cur realm, t *testing.T) {
+	before := instructions
 
-	uassert.NotPanics(t, cur, func() {
-		updateInstructions(0, cur, newInstructions)
-	})
+	// An ERROR, not a panic: the refusal has to travel back to
+	// impl.ExecuteProposal as a value so a passed-but-refused proposal can
+	// be marked Denied instead of aborting the execute transaction. See
+	// updateInstructions.
+	err := updateInstructions(0, cur, "SHOULD-NOT-LAND")
 
-	uassert.Equal(t, newInstructions, instructions)
+	uassert.ErrorContains(t, err, "unauthorized",
+		"a non-GovDAO principal must be refused")
+	uassert.Equal(t, before, instructions,
+		"instructions must not move when the gate refuses")
+}
+
+// The instructions proposal's on-chain title is rendered to GovDAO voters
+// and is what off-chain tooling matches on, so it is pinned rather than
+// left to drift silently. It changed in this realm's history from
+// "/p/gnops/valopers: ..." (wrong — valopers is an /r/ realm) when
+// proposal construction moved out of r/gnops/valopers/proposal.
+func TestInstructionsProposalTitleIsPinned(cur realm, t *testing.T) {
+	uassert.Equal(t, "/r/gnops/valopers: Update instructions", instructionsProposalTitle)
+
+	req := NewInstructionsProposalRequest(cross(cur), "whatever")
+	uassert.Equal(t, instructionsProposalTitle, req.Title())
+}
+
+// The authority must be rotatable by GovDAO, or a principal that stops
+// being presentable freezes `instructions` with no on-chain recovery (and
+// redeploying is expensive: r/sys/validators/v0/cache.gno hardcodes
+// valopersRealmPath). This pins that the rotation path exists, is sealed
+// the same way the instructions write is, and that a non-GovDAO principal
+// cannot drive it.
+func TestRotateAuthorityRejectsNonGovDAO(cur realm, t *testing.T) {
+	before := Auth()
+
+	err := rotateAuthority(0, cur, "gno.land/r/gov/dao/v4")
+
+	uassert.ErrorContains(t, err, "unauthorized",
+		"a non-GovDAO principal must not be able to rotate the authority")
+	uassert.Equal(t, before, Auth(), "the authority must be unchanged")
+}
+
+// The rotation request is built here and returned sealed: dao.ProposalRequest
+// exposes only Title/Description/Filter, so a holder cannot reach the
+// executor. Anyone may build one; only GovDAO can adopt and run it.
+func TestRotationProposalRequestIsSealed(cur realm, t *testing.T) {
+	req := NewAuthorityRotationProposalRequest(cross(cur), "gno.land/r/gov/dao/v4")
+
+	uassert.Equal(t, "/r/gnops/valopers: Rotate governance authority", req.Title())
+	uassert.NotEqual(t, "", req.Description())
+
+	// Building the request must not itself perform the rotation.
+	uassert.Equal(t,
+		"contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]",
+		Auth())
 }
 
 // TestUpdateMinFee was removed: register_fee now lives in sysparams

--- a/examples/gno.land/r/gnops/valopers/filetests/z_auth_readonly_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/filetests/z_auth_readonly_filetest.gno
@@ -1,0 +1,47 @@
+// PKGPATH: gno.land/r/authreadonly
+//
+// Auth() exposes the realm's governance authority for rendering and
+// inspection only. It returns a read-only string, never the live
+// *authz.Authorizer.
+//
+// SCOPE. This asserts two things, one of which is now security-relevant:
+//
+//  1. Auth()'s RETURN TYPE — that the mutable handle is gone from the
+//     type system. This is what makes an
+//     Auth().Transfer(...) PoC stop compiling.
+//  2. The PROPOSER, since ContractAuthority.String() now renders it.
+//     Previously the string was byte-identical whether the authority was
+//     the gated default or a wide-open AutoAccept proposer, so reverting
+//     the fix left this file green. It no longer does.
+//
+// Reachability is still pinned elsewhere, not here:
+//   - p/moul/authz TestDefaultProposerIsContractOnly,
+//     TestExternalTransferRejected, TestExternalDoByPreviousRejected,
+//     TestContractPathIsolation,
+//     TestForeignFrameCannotDriveContractAuthority and
+//     TestContractAuthorityUnauthorizedCaller — the contract-identity
+//     gate. Reverting it fails those 6 plus TestAuthorityString,
+//     TestExplicitProposerReplacesIdentityGate,
+//     TestSpoofedProposerCannotImpersonateContractIdentity and
+//     filetests/z_contract_authority_shape_filetest.gno, since the
+//     rendered proposer is now part of what is pinned.
+//   - ./z_foreign_realm_capability_filetest.gno — the consumer-level
+//     one: a foreign realm cannot reach the privileged capability.
+//   - ./z_govdao_only_principal_filetest.gno — that the repointed
+//     authority names GovDAO and that the principal cannot be MINTED:
+//     it drives the forged-executor route and MustCreateProposal, and
+//     asserts both are refused.
+package authreadonly
+
+import (
+	"gno.land/r/gnops/valopers"
+)
+
+func main(cur realm) {
+	// An external realm observes a description; there is no mutator to
+	// reach from here.
+	println("authority:", valopers.Auth())
+}
+
+// Output:
+// authority: contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]

--- a/examples/gno.land/r/gnops/valopers/filetests/z_foreign_realm_capability_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/filetests/z_foreign_realm_capability_filetest.gno
@@ -1,0 +1,90 @@
+// PKGPATH: gno.land/r/zzattacker
+//
+// Consumer-level regression pin for the governance capability leak.
+//
+// The package-level pins live in p/moul/authz. This is the consumer-level
+// one: an unrelated realm must not be able to drive a valopers privileged
+// action.
+//
+// Before the fix this file could not exist as a negative test — the
+// realm exported NewInstructionsProposalCallback, a crossing closure
+// declared in valopers. The VM mints a crossing frame's `cur` from the
+// CALLEE's declaring package, so invoking it from anywhere ran
+// updateInstructions with cur.Address() == the ContractAuthority's
+// contractAddr. The contract-identity gate accepted, the init.gno
+// handler ran the action, and `instructions` was rewritten with no
+// proposal and no vote:
+//
+//	err: undefined
+//	PWNED-BY-ATTACKER
+//
+// The capability is now sealed inside a dao.ProposalRequest, whose
+// executor field is unexported with no accessor. This file asserts the
+// two halves of that: the leak is gone from the type system, and the
+// request an attacker can still construct is inert in their hands.
+//
+// NOTE for whoever edits valopers next: the property under test is
+// "no exported function returns anything carrying this realm's frame
+// identity". Re-exporting a func(realm) error, or returning a
+// dao.Executor (whose Execute method is exported and directly
+// invocable), reopens the hole even though this file would still
+// compile.
+package zzattacker
+
+import (
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/r/gnops/valopers"
+	"gno.land/r/gov/dao"
+	daov3init "gno.land/r/gov/dao/init/v0"
+)
+
+// A real GovDAO exists and the attacker is not in it.
+var govdaoMember address = testutils.TestAddress("govdao-member")
+
+func init(cur realm) {
+	daov3init.InitWithUsers(cross(cur), govdaoMember)
+}
+
+func main(cur realm) {
+	// 1. The bare capability is gone. Uncommenting this must not compile:
+	//
+	//	cb := valopers.NewInstructionsProposalCallback("PWNED-BY-ATTACKER")
+	//	cb(cross(cur))
+	//
+	// What remains is the sealed request. An unrelated realm may still
+	// build one — construction is harmless — but dao.ProposalRequest
+	// exposes only Title/Description/Filter, so there is no way to reach
+	// the executor and run it. Only GovDAO executing the proposal can.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/zzattacker"))
+
+	req := valopers.NewInstructionsProposalRequest(cross(cur), "PWNED-BY-ATTACKER")
+	println("attacker built a request:", req.Title())
+
+	// 2. The privileged write did not happen: the instructions are still
+	//    the genesis text, not the attacker's. Under the exported callback
+	//    this line already printed "defaced: true".
+	rendered := valopers.Render("")
+	println("instructions defaced:", strings.Contains(rendered, "PWNED-BY-ATTACKER"))
+	println("instructions intact:", strings.Contains(rendered, "Welcome to the **Valopers** realm"))
+
+	// 3. Runtime pin, not merely a symbol-absence one. dao.ProposalRequest
+	//    exposes Title/Description/Filter and nothing that yields the
+	//    executor, so the one remaining route for a holder is to ask
+	//    GovDAO to adopt the request. A hostile realm cannot: this aborts.
+	//    (A GovDAO *member* still can, and then it needs the votes — that
+	//    is the legitimate path, covered by
+	//    r/gnops/valopers/proposal/filetests/z_governed_instructions_filetest.gno.)
+	dao.MustCreateProposal(cross(cur), req)
+	println("UNREACHABLE: outsider got the proposal adopted")
+}
+
+// Output:
+// attacker built a request: /r/gnops/valopers: Update instructions
+// instructions defaced: false
+// instructions intact: true
+
+// Error:
+// proposal creation must be done directly by a user or through the r/gov/dao proxy. caller realm: realm{gno.land/r/gov/dao:g1p84dvfh4wrplyxx4zsmy77a8rxcnjup2j7zv5r}; caller's previous: realm{gno.land/r/zzattacker:g1q577nx395ehscyn9ucutvfpj03a5tuk7x4v3ad}

--- a/examples/gno.land/r/gnops/valopers/filetests/z_govdao_only_principal_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/filetests/z_govdao_only_principal_filetest.gno
@@ -1,0 +1,95 @@
+// PKGPATH: gno.land/r/zzprincipal
+//
+// The repointed authority names GovDAO, so a foreign realm crossing into
+// valopers is NOT the principal the gate accepts.
+//
+// This is the runtime counterpart to
+// ./z_foreign_realm_capability_filetest.gno. That file pins that the
+// privileged CAPABILITY cannot be obtained; this one pins that the
+// PRINCIPAL cannot be minted — which is the other half of what the gate
+// depends on, and the half that was actually broken.
+//
+// An earlier version of this file asserted only the rendered description
+// plus "instructions were not defaced" without ever attempting a write, so
+// it went red on a repoint revert purely because the golden path string
+// changed, and stayed GREEN with the authority swapped for a fully
+// permissive one. It now drives the two routes an attacker actually has.
+//
+// Why it matters: under the previous ContractAuthority(ownPath) +
+// DoByCurrent pairing this property did not hold at all. rlm.Address()
+// inside any valopers crossing frame is unconditionally valopers' own
+// address, so the gate accepted every caller and its only real defence was
+// that no exported entrypoint happened to reach updateInstructions.
+//
+// And pointing the gate at r/gov/dao only helps while that path is
+// unmintable. dao.NewSimpleExecutor + SimpleExecutor.Execute are both
+// exported, and Execute is declared in r/gov/dao, so before Execute gated
+// on its invoker ANY realm could mint a frame whose Previous() was
+// r/gov/dao and satisfy this gate — directly for a closure it obtained,
+// and for any exported valopers function whose signature was assignable to
+// `func(realm) error`. Section 2 below is the pin for that.
+package zzprincipal
+
+import (
+	"strings"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/r/gnops/valopers"
+	"gno.land/r/gov/dao"
+	daov3init "gno.land/r/gov/dao/init/v0"
+)
+
+// A real GovDAO exists and this realm is not a member of it, so the final
+// step fails on the proposal-creation gate rather than on "DAO not
+// initialized" -- which would pass for the wrong reason.
+var govdaoMember address = testutils.TestAddress("govdao-member")
+
+func init(cur realm) {
+	daov3init.InitWithUsers(cross(cur), govdaoMember)
+}
+
+// reachInstructions is the shape an attacker needs: something declared
+// where it will run with a useful frame. Declared HERE, so it carries the
+// attacker's identity, not valopers' — the point being that even with the
+// governance principal minted for it, it cannot reach the write.
+func reachInstructions(cur realm) error {
+	// Nothing exported by valopers reaches updateInstructions, so the most
+	// an attacker can do from a forged governance frame is build the sealed
+	// request again. Build it, to prove construction is not the hole.
+	_ = valopers.NewInstructionsProposalRequest(cross(cur), "PWNED-VIA-FORGED-PRINCIPAL")
+	return nil
+}
+
+func main(cur realm) {
+	// 1. The authority names GovDAO, and says so in a way a reader can act
+	//    on. A non-canonical proposer cannot reproduce these bytes.
+	println("authority:", valopers.Auth())
+
+	// 2. The governance principal is not mintable. Wrapping any callback in
+	//    dao's own exported executor used to hand out a frame whose
+	//    Previous() is r/gov/dao; Execute now refuses an invoker from
+	//    outside the proxy.
+	e := dao.NewSimpleExecutor(0, cur, reachInstructions, "")
+	println("forged-principal Execute:", e.Execute(cross(cur)))
+
+	// 3. The only remaining route is to ask GovDAO to adopt a request. A
+	//    hostile realm cannot: this aborts (a GovDAO member still can, and
+	//    then needs the votes — covered by
+	//    r/gnops/valopers/proposal/filetests/z_governed_instructions_filetest.gno).
+	rendered := valopers.Render("")
+	println("instructions defaced:", strings.Contains(rendered, "PWNED"))
+	println("authority unchanged:", valopers.Auth())
+
+	dao.MustCreateProposal(cross(cur),
+		valopers.NewAuthorityRotationProposalRequest(cross(cur), "gno.land/r/attacker/dao"))
+	println("UNREACHABLE: outsider rotated the authority")
+}
+
+// Output:
+// authority: contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]
+// forged-principal Execute: execution denied: executors are only invocable by gno.land/r/gov/dao
+// instructions defaced: false
+// authority unchanged: contract_authority[contract=gno.land/r/gov/dao,proposer=contract-identity]
+
+// Error:
+// proposal creation must be done directly by a user or through the r/gov/dao proxy. caller realm: realm{gno.land/r/gov/dao:g1p84dvfh4wrplyxx4zsmy77a8rxcnjup2j7zv5r}; caller's previous: realm{gno.land/r/zzprincipal:g1036vewy55meppdzpngzsufahr389mldycavect}

--- a/examples/gno.land/r/gnops/valopers/filetests/z_operator_authlist_capability_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/filetests/z_operator_authlist_capability_filetest.gno
@@ -1,0 +1,98 @@
+// PKGPATH: gno.land/r/zzoperatorauth
+//
+// Regression pin for the per-operator auth-list capability leak
+// (reported by @thehowl; pre-existing, fixed here because it is the same
+// class as the governance capability leak, and the same audit that found
+// that one should have found it).
+//
+// THE HOLE. `Valoper.Auth() *authorizable.Authorizable` was exported and
+// `GetByAddr` is exported and non-crossing. Valoper is returned BY
+// VALUE, but `auth` is a pointer field, so the copy shared the realm's
+// live Authorizable. Authorizable's gates read
+// `rlm.Previous().Address()`, so inside a hostile realm's frame
+// Previous() is whoever called it. A valoper OPERATOR merely calling any
+// function of a hostile realm (faucet, airdrop, mint) let that realm run
+//
+//	valopers.GetByAddr(operator).Auth().AddToAuthList(0, cur, attacker)
+//
+// with Previous() == the operator, i.e. the Authorizable's own owner.
+// The write was accepted and PERSISTED. From the next transaction on,
+// the attacker acted alone: UpdateKeepRunning to drain the validator,
+// UpdateSigningKey to rotate its consensus signing key.
+//
+// THE FIX is the one layer 2 applies to the realm's governance
+// authority: never export the live capability. `Auth()` is removed;
+// `AuthOwner()` copies out an address.
+//
+// WHAT THIS FILE PINS, honestly scoped. The raw-handle attack is a
+// compile-time absence now, so — like the foreign-realm filetest —
+// reverting the fix fails this on a build error rather than an
+// assertion. What it
+// drives at RUNTIME is the property that makes the removal safe: the
+// exported wrapper is NOT an equivalent route. There `cur.Previous()` is
+// the hostile realm rather than the operator, so the superuser check
+// refuses, and it refuses even in the exact scenario that used to work —
+// the operator calling the hostile realm themselves.
+//
+// NOTE for whoever edits valopers next: re-adding any exported accessor
+// that returns *authorizable.Authorizable (or the *ownable.Ownable
+// inside it) reopens this, and this file would still compile.
+package zzoperatorauth
+
+import (
+	"chain"
+	"testing"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/r/gnops/valopers"
+)
+
+var (
+	operator = testutils.TestAddress("operator")
+	attacker = chain.PackageAddress("gno.land/r/zzoperatorauth")
+	pubKey   = "gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqwpdwpd0f9fvqla089ndw5g9hcsufad77fml2vlu73fk8q8sh8v72cza5p"
+)
+
+// Pwn is an ordinary exported function of a hostile realm — the airdrop
+// the operator was told to claim. It needs no privilege of its own; it
+// used to just read the public handle and write through it.
+func Pwn(cur realm, victim address) {
+	// The attack the fix removes. Uncommenting must not compile:
+	//
+	//	valopers.GetByAddr(victim).Auth().AddToAuthList(0, cur, attacker)
+	//	                           ^^^^^^ undefined
+	//
+	// What remains is the exported wrapper. It is not equivalent: it
+	// derives the principal from THIS frame, where Previous() is
+	// gno.land/r/zzoperatorauth and not the operator. Aborts.
+	valopers.AddToAuthList(cross(cur), victim, attacker)
+	println("UNREACHABLE: hostile realm joined the operator's auth list")
+}
+
+func main(cur realm) {
+	// The operator registers their profile normally.
+	testing.SetOriginCaller(operator)
+	testing.SetRealm(testing.NewUserRealm(operator))
+	valopers.Register(cross(cur), "Op",
+		"a valid description for the operator profile", "cloud", operator, pubKey)
+
+	// The auth list is owned by the operator, and AuthOwner hands back
+	// an address — a value, not a capability.
+	println("owner is operator:",
+		valopers.GetByAddr(operator).AuthOwner() == operator)
+	println("attacker is not owner:",
+		valopers.GetByAddr(operator).AuthOwner() != attacker)
+
+	// The operator calls the hostile realm once. This single step used
+	// to be the whole attack.
+	testing.SetOriginCaller(operator)
+	testing.SetRealm(testing.NewUserRealm(operator))
+	Pwn(cross(cur), operator)
+}
+
+// Output:
+// owner is operator: true
+// attacker is not owner: true
+
+// Error:
+// authorizable: caller is not superuser

--- a/examples/gno.land/r/gnops/valopers/init.gno
+++ b/examples/gno.land/r/gnops/valopers/init.gno
@@ -9,9 +9,23 @@ import (
 func init() {
 	valopers = avl.NewTree()
 
+	// The authority is pointed at GovDAO, NOT at this realm.
+	//
+	// Pointing it here instead would make the gate compare valopers'
+	// address to valopers' address: every crossing frame of this package
+	// has rlm.Address() == PackageAddress(ownPath), so the check could
+	// never reject. Pointed at r/gov/dao and driven by DoByPrevious
+	// (see updateInstructions), the principal is the realm that crossed
+	// in — GovDAO's executor on the legitimate path, and the caller
+	// itself on any other, which is what makes the check real.
+	//
+	// The handler is a pass-through: this is where an intent check
+	// (timelock, quorum, audit trail) would go if one is ever wanted.
+	// It is NOT where the caller check lives — that is the authority's
+	// contract-identity gate, upstream of here.
 	auth = authz.NewWithAuthority(
 		authz.NewContractAuthority(
-			"gno.land/r/gnops/valopers",
+			"gno.land/r/gov/dao",
 			func(_ string, action authz.PrivilegedAction) error {
 				return action()
 			},

--- a/examples/gno.land/r/gnops/valopers/proposal/filetests/z_governed_instructions_filetest.gno
+++ b/examples/gno.land/r/gnops/valopers/proposal/filetests/z_governed_instructions_filetest.gno
@@ -1,0 +1,66 @@
+// PKGPATH: gno.land/r/gnops/valopers/proposal/filetests/z_governed_instructions_filetest
+//
+// Positive counterpart to
+// r/gnops/valopers/filetests/z_foreign_realm_capability_filetest.gno.
+//
+// Sealing the privileged closure inside a dao.ProposalRequest closes the
+// capability leak, but it would be worthless if it
+// also broke the legitimate path. This runs the real thing end to end —
+// propose, vote, execute — and asserts the instructions are actually
+// rewritten.
+//
+// Read the two files together: same write, but reachable ONLY with a
+// GovDAO majority behind it.
+package z_governed_instructions_filetest
+
+import (
+	"chain/runtime/unsafe"
+	"strings"
+	"testing"
+
+	"gno.land/r/gnops/valopers"
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+	daov3init "gno.land/r/gov/dao/init/v0"
+)
+
+var member address = unsafe.OriginCaller()
+
+func init(cur realm) {
+	daov3init.InitWithUsers(cross(cur), member)
+
+	testing.SetOriginCaller(member)
+	testing.SetRealm(testing.NewUserRealm(member))
+
+	pr := proposal.ProposeNewInstructionsProposalRequest(cross(cur), "GOVERNED-INSTRUCTIONS")
+	dao.MustCreateProposal(cross(cur), pr)
+}
+
+func main(cur realm) {
+	testing.SetOriginCaller(member)
+
+	println("before:", strings.Contains(valopers.Render(""), "GOVERNED-INSTRUCTIONS"))
+
+	// Voter-facing disclosure (the pr6068 anti-phishing line, rendered as
+	// "Executor created in: ..."). It moved from r/gnops/valopers/proposal
+	// to r/gnops/valopers when request construction moved into the realm,
+	// so pin it rather than let it drift unobserved.
+	prop, err := dao.GetProposal(dao.ProposalID(0))
+	if err != nil {
+		panic(err)
+	}
+	println("title:", prop.Title())
+	println("executor created in:", prop.ExecutorCreationRealm())
+
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, dao.ProposalID(0)))
+	println("executed:", dao.ExecuteProposal(cross(cur), dao.ProposalID(0)))
+
+	println("after:", strings.Contains(valopers.Render(""), "GOVERNED-INSTRUCTIONS"))
+}
+
+// Output:
+// before: false
+// title: /r/gnops/valopers: Update instructions
+// executor created in: gno.land/r/gnops/valopers
+// executed: true
+// after: true

--- a/examples/gno.land/r/gnops/valopers/proposal/proposal.gno
+++ b/examples/gno.land/r/gnops/valopers/proposal/proposal.gno
@@ -70,15 +70,26 @@ func NewValidatorProposalRequest(cur realm, addr address) dao.ProposalRequest {
 
 // ProposeNewInstructionsProposalRequest creates a proposal to the GovDAO
 // for updating the realm instructions.
+//
+// Signature is preserved; the body now delegates. Building the request
+// here required valopers to export the privileged closure, which handed
+// this realm's frame identity to any caller. The
+// closure and the request are now built inside valopers, which returns
+// the request with its executor sealed — see valopers.NewInstructionsProposalRequest.
 func ProposeNewInstructionsProposalRequest(cur realm, newInstructions string) dao.ProposalRequest {
-	cb := valopers.NewInstructionsProposalCallback(newInstructions)
-	// Create a proposal
-	title := "/p/gnops/valopers: Update instructions"
-	description := ufmt.Sprintf("Update the instructions to: \n\n%s", newInstructions)
+	return valopers.NewInstructionsProposalRequest(cross(cur), newInstructions)
+}
 
-	e := dao.NewSimpleExecutor(0, cur, cb, "")
-
-	return dao.NewProposalRequest(title, description, e)
+// ProposeAuthorityRotationProposalRequest creates a proposal to the GovDAO
+// for re-pointing the valopers realm's governance authority.
+//
+// Delegates, for the same reason as above: the rotation closure reaches
+// auth.Transfer, so it must never leave the valopers package. Exposed here
+// because this package is where proposal factories for the realm live —
+// see valopers.NewAuthorityRotationProposalRequest for why it takes a path
+// rather than an authz.Authority, and why it exists at all.
+func ProposeAuthorityRotationProposalRequest(cur realm, newContractPath string) dao.ProposalRequest {
+	return valopers.NewAuthorityRotationProposalRequest(cross(cur), newContractPath)
 }
 
 // ProposeNewMinFeeProposalRequest creates a proposal to the GovDAO

--- a/examples/gno.land/r/gnops/valopers/valopers.gno
+++ b/examples/gno.land/r/gnops/valopers/valopers.gno
@@ -7,6 +7,7 @@ import (
 	"chain/runtime/unsafe"
 	"crypto/bech32"
 	"errors"
+	"math"
 	"regexp"
 
 	"gno.land/p/moul/realmpath/v0"
@@ -43,6 +44,8 @@ var (
 	ErrFrontrunValidator    = errors.New("post-genesis: signing address is already an active validator")
 	ErrRotationThrottled    = errors.New("rotation throttled: try again later")
 	ErrRegistryEntryMissing = errors.New("signing address has no active registry entry (corrupted state)")
+	ErrPaidCallNotDirect    = errors.New("a fee is configured: call this directly as a user (maketx call), not from a realm or a maketx run script")
+	ErrFeeParamOutOfRange   = errors.New("configured fee exceeds the maximum representable coin amount")
 	ErrDisallowedPubKeyType = errors.New("consensus pubkey type is not allowed for validators")
 )
 
@@ -84,20 +87,46 @@ type Valoper struct {
 	auth *authorizable.Authorizable
 }
 
-func (v Valoper) Auth() *authorizable.Authorizable {
-	return v.auth
+// AuthOwner returns the operator address that owns this profile's auth
+// list. Read-only by construction: it copies out an address rather than
+// returning the live *authorizable.Authorizable.
+//
+// SECURITY: the previous `Auth() *authorizable.Authorizable` was a
+// capability leak of the same class this realm's governance authority
+// closes by returning a description instead of the live authority.
+// `Valoper` is returned BY VALUE from the exported, non-crossing
+// GetByAddr, but `auth` is a pointer field, so the copy shared the
+// callee's Authorizable. Any realm could therefore obtain a live,
+// mutable handle and write through it.
+//
+// That was a privilege escalation, not merely a wider surface.
+// Authorizable's gates read `rlm.Previous().Address()`, so inside a
+// hostile realm's frame `Previous()` is whoever called it. When a
+// valoper OPERATOR called any function of a hostile realm (faucet,
+// airdrop, mint), that realm could reach
+// `GetByAddr(operator).Auth().AddToAuthList(...)` and — because
+// Previous() was then the operator, the Authorizable's own owner —
+// persist itself onto the operator's auth list. From the next
+// transaction on it acted alone: UpdateKeepRunning to drain the
+// validator, UpdateSigningKey to rotate the consensus key.
+//
+// The exported wrappers below are NOT equivalent to the raw handle and
+// were never the hole: there `cur.Previous()` is the hostile realm
+// itself rather than the operator, so the owner check rejects it.
+func (v Valoper) AuthOwner() address {
+	return v.auth.Owner()
 }
 
 func AddToAuthList(cur realm, addr address, member address) {
 	v := GetByAddr(addr)
-	if err := v.Auth().AddToAuthList(0, cur, member); err != nil {
+	if err := v.auth.AddToAuthList(0, cur, member); err != nil {
 		panic(err)
 	}
 }
 
 func DeleteFromAuthList(cur realm, addr address, member address) {
 	v := GetByAddr(addr)
-	if err := v.Auth().DeleteFromAuthList(0, cur, member); err != nil {
+	if err := v.auth.DeleteFromAuthList(0, cur, member); err != nil {
 		panic(err)
 	}
 }
@@ -116,19 +145,15 @@ func DeleteFromAuthList(cur realm, addr address, member address) {
 //     already be an active validator (a fresh registration cannot
 //     squat on the consensus address of an existing validator).
 //
-// Why OriginCaller==addr is sufficient (no IsUserCall): squatting
-// requires the attacker to be able to satisfy OriginCaller==victim,
-// which requires the victim's signing key. r/sys/namereg/v1.Register
-// also gates on IsUserCall, but that's because IT reads
-// unsafe.OriginSend() for the anti-squatting payment and IsUserCall
-// is needed to ensure the OriginSend envelope reflects what landed at
-// this realm rather than a phantom payment from a previous frame.
-// valopers.Register has no per-call payment-receipt check (fees are
-// validated against banker.OriginSend in a way that's symmetric to
-// IsUserCall via direct comparison), so the IsUserCall tightening
-// would only block legitimate `maketx run` flows (operator-authored
-// scripts that legitimately set OriginCaller==operator) without
-// adding identity-squat protection.
+// Why OriginCaller==addr is sufficient for the SQUAT guard (no
+// IsUserCall): squatting requires the attacker to satisfy
+// OriginCaller==victim, which requires the victim's signing key.
+//
+// The PAYMENT check is a different matter and does need IsUserCall —
+// see assertPaidCallIsDirect. An earlier version of this comment
+// claimed the fee was "validated against banker.OriginSend in a way
+// that's symmetric to IsUserCall via direct comparison"; there was no
+// such comparison, and the fee was bypassable (reported by @D4ryl00).
 //
 // Auth-list seeding: the profile's Authorizable owner is set to addr
 // (NOT OriginCaller). At H>0 the squat guard makes them equal anyway;
@@ -144,7 +169,8 @@ func Register(cur realm, moniker string, description string, serverType string, 
 	// Fee enforcement (read from sysparams; defaults to 0 until
 	// governance raises it post-transfer-enablement).
 	if fee := sysparams.GetValoperRegisterFee(); fee > 0 {
-		minFee := chain.NewCoin("ugnot", int64(fee))
+		assertPaidCallIsDirect(0, cur)
+		minFee := minFeeCoin(fee)
 		sentCoins := unsafe.OriginSend()
 		if len(sentCoins) != 1 || sentCoins[0].IsLT(minFee) {
 			panic(ufmt.Sprintf("payment must not be less than %d%s", minFee.Amount, minFee.Denom))
@@ -216,7 +242,7 @@ func UpdateMoniker(cur realm, addr address, moniker string) {
 	v := GetByAddr(addr)
 
 	// Check that the caller has permissions.
-	v.Auth().AssertPreviousOnAuthList(0, cur)
+	v.auth.AssertPreviousOnAuthList(0, cur)
 
 	// Update the moniker.
 	v.Moniker = moniker
@@ -235,7 +261,7 @@ func UpdateDescription(cur realm, addr address, description string) {
 	v := GetByAddr(addr)
 
 	// Check that the caller has permissions.
-	v.Auth().AssertPreviousOnAuthList(0, cur)
+	v.auth.AssertPreviousOnAuthList(0, cur)
 
 	// Update the description.
 	v.Description = description
@@ -250,7 +276,7 @@ func UpdateKeepRunning(cur realm, addr address, keepRunning bool) {
 	v := GetByAddr(addr)
 
 	// Check that the caller has permissions.
-	v.Auth().AssertPreviousOnAuthList(0, cur)
+	v.auth.AssertPreviousOnAuthList(0, cur)
 
 	// Update status.
 	v.KeepRunning = keepRunning
@@ -272,7 +298,7 @@ func UpdateServerType(cur realm, addr address, serverType string) {
 	v := GetByAddr(addr)
 
 	// Check that the caller has permissions.
-	v.Auth().AssertPreviousOnAuthList(0, cur)
+	v.auth.AssertPreviousOnAuthList(0, cur)
 
 	// Update server type.
 	v.ServerType = serverType
@@ -308,7 +334,7 @@ func UpdateSigningKey(cur realm, addr address, newPubKey string) {
 	v := GetByAddr(addr)
 
 	// Auth: caller must be on operator's auth list.
-	v.Auth().AssertPreviousOnAuthList(0, cur)
+	v.auth.AssertPreviousOnAuthList(0, cur)
 
 	// Throttle: limit one rotation per rotation_period_blocks per
 	// operator (per profile, not per caller — multi-member auth lists
@@ -321,7 +347,8 @@ func UpdateSigningKey(cur realm, addr address, newPubKey string) {
 	// Fee: enforce only if non-zero (matches Register's pattern;
 	// rotation_fee defaults to zero pre-transfer-enablement).
 	if fee := sysparams.GetValoperRotationFee(); fee > 0 {
-		minFee := chain.NewCoin("ugnot", int64(fee))
+		assertPaidCallIsDirect(0, cur)
+		minFee := minFeeCoin(fee)
 		sentCoins := unsafe.OriginSend()
 		if len(sentCoins) != 1 || sentCoins[0].IsLT(minFee) {
 			panic(ufmt.Sprintf("payment must not be less than %d%s", minFee.Amount, minFee.Denom))
@@ -533,6 +560,101 @@ func validatePubKey(pubKey string) error {
 	}
 
 	return nil
+}
+
+// assertPaidCallIsDirect requires the immediate caller to be a plain EOA,
+// and must be paired with every unsafe.OriginSend() amount check in this
+// realm. Called only when a fee is actually configured.
+//
+// unsafe.OriginSend() reports the transaction's declared send ENVELOPE, not
+// what this realm received. Only a direct `maketx call` on valopers credits
+// the envelope to this realm's address. For a `maketx run` the keeper sets
+// pkgAddr := caller (gno.land/pkg/sdk/vm/keeper.go), so the coins move from
+// the caller to the caller and never land anywhere at all, while
+// OriginSend() still reports the full amount to us. See
+// gno.land/adr/pr6062_payable_send_check.md: "MsgRun is exempt: the coins
+// are moved from the caller to the caller, so nothing actually moves." So
+// the amount check alone verifies intent, never receipt.
+//
+// Reported by @D4ryl00, with a local-chain reproduction:
+// governance sets register_fee to 1000ugnot, an operator runs a script
+// calling Register with `-send 1000ugnot`, registration succeeds, valopers
+// receives zero, and the operator still holds the coins. No hostile script
+// is needed — the envelope is free by construction. Both fees default to 0,
+// so nothing was live.
+//
+// Why IsUserCall and not an address comparison: a run script's realm is
+// address-INDISTINGUISHABLE from its user. Inside `main(cur realm)` the
+// ephemeral realm's own address IS the caller's EOA address, so every
+// address-based guard in this realm accepts a `maketx run` — Register's
+// squat guard (OriginCaller == addr) and UpdateSigningKey's auth-list check
+// (Previous().Address() on the list) both pass. Only the pkgPath differs,
+// and IsUserCall() is the check that reads it. It is therefore the only
+// PreviousRealm shape where the envelope is guaranteed to have landed here:
+// it excludes intermediate code realms and user-run ephemeral realms alike.
+// Same reasoning and same pairing as r/sys/namereg/v1.Register, which reads
+// OriginSend for its anti-squatting payment; see the two-guard comment there.
+//
+// Deliberately inside the `fee > 0` branch rather than at the top of the
+// function: while a fee is unset there is no payment to establish receipt
+// of, and gating unconditionally would break the operator-authored
+// `maketx run` flows that the squat guard is happy to accept. The
+// restriction appears exactly when, and only when, money is involved.
+//
+// KNOWN LIMIT. AddToAuthList takes a plain `member address`, so a REALM
+// can sit on an operator's auth list, and once rotation_fee is nonzero
+// such a member can no longer drive UpdateSigningKey — it is not a user
+// call. An EOA rotation bot is unaffected, which is the shape the
+// auth-list docs describe ("HSM-bound or rotation-bot"), so nothing
+// documented breaks; a realm-mediated rotation would.
+//
+// The alternative that would keep realms working is a true receipt check:
+// track cumulative fees in realm state and require the realm's own
+// balance to have risen by `fee` since the last one. That works for any
+// caller shape, but it puts new persisted state and a banker into a
+// genesis realm, and lets anyone pre-pay another operator's fee by
+// donating to the realm address. Not worth it while both fees are 0 and
+// collected fees are unwithdrawable anyway (this realm has no banker, so
+// they strand at its address). Revisit if a realm-mediated paid rotation
+// is ever actually wanted.
+func assertPaidCallIsDirect(_ int, rlm realm) {
+	// IsCurrent before Previous, as AGENTS.md requires and every other
+	// (_ int, rlm realm) helper in this tree does (authorizable,
+	// sys/params/delegate, gov/dao/types, sys/validators/v0/cache).
+	// Both call sites pass their live cur, so this is defense-in-depth
+	// against a future caller threading a stale or stashed realm value:
+	// Previous() reads the prev field verbatim, so on a non-live token
+	// it answers for the wrong frame.
+	if !rlm.IsCurrent() {
+		panic(ErrPaidCallNotDirect)
+	}
+	if !rlm.Previous().IsUserCall() {
+		panic(ErrPaidCallNotDirect)
+	}
+}
+
+// minFeeCoin converts a configured fee (uint64, from sysparams) into the
+// ugnot Coin the amount checks compare against.
+//
+// Coin.Amount is an int64. A fee above MaxInt64 wraps negative, and
+// `sentCoins[0].IsLT(minFee)` is then false for every payment — the realm
+// reads the fee as configured, runs assertPaidCallIsDirect, and collects
+// 1ugnot while reporting "payment must not be less than -1ugnot". Failing
+// closed here keeps an unrepresentable fee from opening the paid path
+// instead of closing it.
+//
+// Reachable two ways today, neither requiring malice: governance can set
+// any uint64 through the generic r/sys/params factories, and
+// valopers/proposal.ProposeNewMinFeeProposalRequest takes an int64 and
+// stores uint64(newMinFee), so a negative fee — the obvious way to write
+// "disable the fee" — round-trips to 2^64-1. That signature is preserved
+// for historical-replay compatibility and is deliberately left alone; the
+// bound belongs at the consumption site, which covers both paths.
+func minFeeCoin(fee uint64) chain.Coin {
+	if fee > math.MaxInt64 {
+		panic(ErrFeeParamOutOfRange)
+	}
+	return chain.NewCoin("ugnot", int64(fee))
 }
 
 // assertPubKeyTypeAllowed panics if pubKey's type is not in the chain's validator allow-list (empty list accepts any).

--- a/examples/gno.land/r/gnops/valopers/valopers_test.gno
+++ b/examples/gno.land/r/gnops/valopers/valopers_test.gno
@@ -138,6 +138,27 @@ func TestValopers_Register(cur realm, t *testing.T) {
 		})
 	})
 
+	// A fee above MaxInt64 wraps negative in Coin.Amount, which would make
+	// the IsLT amount check false for every payment: the realm would read
+	// the fee as configured and collect 1ugnot. uint64(int64(-1)) is what
+	// valopers/proposal.ProposeNewMinFeeProposalRequest stores for a
+	// negative newMinFee, so this is reachable from one governance typo.
+	t.Run("unrepresentable fee fails closed", func(cur realm, t *testing.T) {
+		resetState()
+		testing.SetSysParamUint64("node", "valoper", "register_fee", ^uint64(0))
+
+		info := validValidatorInfo(t)
+		testing.SetRealm(testing.NewUserRealm(info.Address))
+
+		// Nowhere near the configured fee, and previously accepted.
+		testing.SetOriginSend(chain.Coins{chain.NewCoin("ugnot", 1)})
+
+		uassert.AbortsWithMessage(t, cur, ErrFeeParamOutOfRange.Error(), func() {
+			Register(cross(cur), info.Moniker, info.Description, info.ServerType, info.Address, info.PubKey)
+		})
+		uassert.False(t, isValoper(info.Address), "must not register")
+	})
+
 	t.Run("squat guard rejects mismatched OriginCaller", func(cur realm, t *testing.T) {
 		resetState()
 
@@ -259,9 +280,19 @@ func TestValopers_Register_AuthOwnerIsOperatorAddress(cur realm, t *testing.T) {
 
 		// Auth owner must be the operator addr (info.Address), NOT
 		// the deployer.
+		//
+		// Asserted through the exported AuthOwner() accessor, not the
+		// private v.auth: AuthOwner is the API that replaced the removed
+		// Auth() capability leak, so it is what external readers see. A
+		// second assertion against the underlying Authorizable pins that
+		// the accessor actually reports the auth list's owner rather
+		// than echoing OperatorAddress, which is what a plausible
+		// "simplification" of AuthOwner would do.
 		v := GetByAddr(info.Address)
-		uassert.Equal(t, info.Address.String(), v.Auth().Owner().String(),
+		uassert.Equal(t, info.Address.String(), v.AuthOwner().String(),
 			"auth owner must equal OperatorAddress, not OriginCaller")
+		uassert.Equal(t, v.auth.Owner().String(), v.AuthOwner().String(),
+			"AuthOwner must report the Authorizable's owner")
 
 		// Operator can manage their own profile post-genesis.
 		testing.SetHeight(100)
@@ -298,7 +329,7 @@ func TestValopers_Register_AuthOwnerIsOperatorAddress(cur realm, t *testing.T) {
 		})
 
 		v := GetByAddr(info.Address)
-		uassert.Equal(t, info.Address.String(), v.Auth().Owner().String())
+		uassert.Equal(t, info.Address.String(), v.AuthOwner().String())
 	})
 }
 

--- a/examples/gno.land/r/gov/dao/impl/v0/filetests/executor_invocation_authority_filetest.gno
+++ b/examples/gno.land/r/gov/dao/impl/v0/filetests/executor_invocation_authority_filetest.gno
@@ -1,0 +1,184 @@
+// PKGPATH: gno.land/r/test/execauthority
+package execauthority
+
+// Regression pin for who may invoke a proposal executor.
+//
+// dao.Executor.Execute is a public method on a public type and
+// dao.NewSimpleExecutor is a public constructor, so any realm can build an
+// executor around any func(realm) error it can obtain. Execute is a CROSSING
+// method declared in r/gov/dao, so invoking it mints a gno.land/r/gov/dao
+// frame for the callback — and that value is a capability: realms gate on it
+// (authz.NewContractAuthority("gno.land/r/gov/dao") + DoByPrevious, ownable,
+// anything reading Previous().Address()).
+//
+// Until SimpleExecutor.Execute gated on its invoker, the forged frame was
+// byte-identical to an approved one: same PkgPath, same Previous().PkgPath(),
+// same Previous().Address(). A callback could not tell a supermajority-backed
+// execution from one no member ever voted on, and the forgery minted no
+// proposal id, so there was nothing to render, audit or deny afterwards.
+//
+// The documented containment was never the one holding the line. types.gno
+// said invocation was "contained by the executor being unexported inside
+// ProposalRequest/Proposal with no accessor" — that protects the executor
+// OBJECT, but an attacker never needs someone else's executor: a reachable
+// CALLBACK is enough, and an ordinary exported entrypoint of the victim whose
+// signature is assignable to func(realm) error is such a callback.
+// r/gnops/valopers had exactly that shape.
+//
+// Sections 2, 3 and 6 are the inversion: the forgery is now refused, the two
+// frames are no longer comparable, and the proxy identity is not mintable.
+// Section 5 keeps SafeExecutor characterized — it remains dead code that
+// cannot be wired as written, since its allowlist holds the impl path while
+// an executor's caller is the proxy.
+
+import (
+	"chain"
+	"strings"
+	"testing"
+
+	"gno.land/r/gov/dao"
+	"gno.land/r/gov/dao/impl/v0"
+	"gno.land/r/gov/dao/memberstore/v0"
+)
+
+const (
+	member  address = "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+	outside address = "g1w4ek2u33ta047h6lta047h6lta047h6ldvdwpn"
+)
+
+// observed records the frame the callback was handed, so the approved and the
+// forged invocation can be compared.
+type frame struct {
+	cur      string
+	prev     string
+	prevAddr address
+	ran      bool
+}
+
+var seen frame
+
+func probe(cur realm) error {
+	seen = frame{
+		cur:      cur.PkgPath(),
+		prev:     cur.Previous().PkgPath(),
+		prevAddr: cur.Previous().Address(),
+		ran:      true,
+	}
+	return nil
+}
+
+func init(cur realm) {
+	memberstore.Get(0, cur).DeleteAll()
+	memberstore.Get(0, cur).SetTier(memberstore.T1)
+	memberstore.Get(0, cur).SetMember(memberstore.T1, member, memberstore.NewMember(3))
+	dao.UpdateImpl(cross(cur), dao.NewUpdateRequest(
+		impl.NewGovDAO(), []string{"gno.land/r/gov/dao/impl/v0"}))
+}
+
+func main(cur realm) {
+	// 1. The approved path still works: a member proposes, votes it to
+	// supermajority, and executes. The gate must not break governance.
+	testing.SetOriginCaller(member)
+	testing.SetRealm(testing.NewUserRealm(member))
+
+	pid := dao.MustCreateProposal(cross(cur), dao.NewProposalRequest(
+		"approved", "carried by a supermajority vote", dao.NewSimpleExecutor(0, cur, probe, "")))
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, pid))
+	println("approved path executes:", dao.ExecuteProposal(cross(cur), pid))
+	approved := seen
+	println("callback ran:", approved.ran)
+	println("approved frame cur :", approved.cur)
+	println("approved frame prev:", approved.prev)
+
+	// 2. The forged path: no proposal, no vote, and a caller who is not a
+	// member of any tier. Execute is called directly on a locally built
+	// executor, and is refused.
+	seen = frame{}
+	testing.SetOriginCaller(outside)
+	testing.SetRealm(testing.NewUserRealm(outside))
+
+	// The same caller cannot open a proposal -- PreCreateProposal rejects
+	// non-members. That is the authority level the DAO grants them, and
+	// Execute must not grant more.
+	_, err := dao.CreateProposal(cross(cur), dao.NewProposalRequest(
+		"rejected", "a non-member cannot propose", dao.NewSimpleExecutor(0, cur, probe, "")))
+	println("forger cannot even open a proposal:", err != nil)
+	println("callback ran:", seen.ran)
+
+	forged := dao.NewSimpleExecutor(0, cur, probe, "no proposal backs this")
+	println("forged Execute is refused:", forged.Execute(cross(cur)))
+	println("callback ran:", seen.ran)
+
+	// 3. And because it never ran, there is no forged frame to compare: the
+	// governance identity was not minted for an unauthorized invoker.
+	println("no frame was handed out:", seen.cur == "" && seen.prev == "")
+	println("approved prev address was the gov/dao package address:",
+		approved.prevAddr == chain.PackageAddress("gno.land/r/gov/dao"))
+
+	// 4. The forgery leaves no trace on the DAO either: no proposal id was
+	// minted, so there is nothing to render, audit, or deny after the fact.
+	_, missing := dao.GetProposal(pid + 1)
+	println("no proposal was created for the forged execution:", missing != nil)
+
+	// 5. SafeExecutor still cannot be wired as written: allowedDAOs holds the
+	// impl path, while an executor's caller is the proxy path, so its check
+	// rejects the APPROVED path. It remains dead code; the gate that works
+	// lives in SimpleExecutor.Execute and keys on the proxy, not on
+	// InAllowedDAOs.
+	println("InAllowedDAOs(proxy path):", dao.InAllowedDAOs("gno.land/r/gov/dao"))
+	println("allowedDAOs holds instead:", dao.AllowedDAOs()[0])
+
+	seen = frame{}
+	testing.SetOriginCaller(member)
+	testing.SetRealm(testing.NewUserRealm(member))
+	spid := dao.MustCreateProposal(cross(cur), dao.NewProposalRequest(
+		"safe", "same approved path, wrapped in SafeExecutor",
+		dao.NewSafeExecutor(dao.NewSimpleExecutor(0, cur, probe, ""))))
+	dao.MustVoteOnProposal(cross(cur), dao.NewVoteRequest(dao.YesVote, spid))
+	println("SafeExecutor rejects the approved path:", !dao.ExecuteOrRejectProposal(cross(cur), spid))
+	println("and its callback never ran:", !seen.ran)
+	println("denial reason names the allowlist:",
+		strings.Contains(dao.Render(cross(cur), spid.String()), "execution only allowed by validated govDAOs"))
+
+	// 6. The reachability precondition is now closed at the primitive. A
+	// realm-authored callback is stuck with its own current realm (the one
+	// value a forger never controlled), and it can no longer borrow the
+	// proxy as Previous() either -- so gates keying on Previous(), which
+	// were the forgeable ones, hold.
+	testing.SetOriginCaller(outside)
+	testing.SetRealm(testing.NewUserRealm(outside))
+	seen = frame{}
+	println("forged Execute refused again:",
+		dao.NewSimpleExecutor(0, cur, probe, "").Execute(cross(cur)) != nil)
+	println("no proxy identity was borrowed:", seen.prev != "gno.land/r/gov/dao")
+
+	// The member store was never reachable this way -- it gates on PkgPath(),
+	// which the forgery does not control -- but the attempt is now refused one
+	// layer earlier, at Execute, so the abort below never happens.
+	e := dao.NewSimpleExecutor(0, cur, func(cur realm) error {
+		memberstore.Get(0, cur).SetMember(memberstore.T1, outside, memberstore.NewMember(3))
+		return nil
+	}, "")
+	println("member-store escalation refused at Execute:", e.Execute(cross(cur)) != nil)
+}
+
+// Output:
+// approved path executes: true
+// callback ran: true
+// approved frame cur : gno.land/r/test/execauthority
+// approved frame prev: gno.land/r/gov/dao
+// forger cannot even open a proposal: true
+// callback ran: false
+// forged Execute is refused: execution denied: executors are only invocable by gno.land/r/gov/dao
+// callback ran: false
+// no frame was handed out: true
+// approved prev address was the gov/dao package address: true
+// no proposal was created for the forged execution: true
+// InAllowedDAOs(proxy path): false
+// allowedDAOs holds instead: gno.land/r/gov/dao/impl/v0
+// SafeExecutor rejects the approved path: true
+// and its callback never ran: true
+// denial reason names the allowlist: true
+// forged Execute refused again: true
+// no proxy identity was borrowed: true
+// member-store escalation refused at Execute: true

--- a/examples/gno.land/r/gov/dao/impl/v0/filetests/govdao_execute_proposal_00_filetest.gno
+++ b/examples/gno.land/r/gov/dao/impl/v0/filetests/govdao_execute_proposal_00_filetest.gno
@@ -45,6 +45,13 @@ func init(cur realm) {
 
 func main(cur realm) {
 	// Execute proposal, status should be REJECTED
+	// SimpleExecutor.Execute is invocable only by the r/gov/dao proxy, which
+	// is the realm the live route calls it from (dao.ExecuteProposal ->
+	// impl.ExecuteProposal, both threading the proxy's cur non-crossing).
+	// This filetest calls impl.ExecuteProposal directly, so stand in for the
+	// proxy explicitly rather than exercising a route no transaction takes.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao"))
+
 	err := govdao.ExecuteProposal(0, cur, proposalID, executor)
 
 	println(err.Error())

--- a/examples/gno.land/r/gov/dao/impl/v0/filetests/govdao_execute_proposal_01_filetest.gno
+++ b/examples/gno.land/r/gov/dao/impl/v0/filetests/govdao_execute_proposal_01_filetest.gno
@@ -44,6 +44,13 @@ func init(cur realm) {
 
 func main(cur realm) {
 	// Execute proposal, status should be ACTIVE
+	// SimpleExecutor.Execute is invocable only by the r/gov/dao proxy, which
+	// is the realm the live route calls it from (dao.ExecuteProposal ->
+	// impl.ExecuteProposal, both threading the proxy's cur non-crossing).
+	// This filetest calls impl.ExecuteProposal directly, so stand in for the
+	// proxy explicitly rather than exercising a route no transaction takes.
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gov/dao"))
+
 	err := govdao.ExecuteProposal(0, cur, proposalID, executor)
 
 	println(err == nil)

--- a/examples/gno.land/r/gov/dao/types.gno
+++ b/examples/gno.land/r/gov/dao/types.gno
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"errors"
+	"strings"
 
 	"gno.land/p/nt/bptree/v0"
 	"gno.land/p/nt/seqid/v0"
@@ -187,7 +188,42 @@ type SimpleExecutor struct {
 	creationRealm string
 }
 
+// proxyPkgPath is this package: the realm whose frame Execute mints for a
+// callback, and therefore the only realm entitled to invoke one.
+const proxyPkgPath = "gno.land/r/gov/dao"
+
+// Execute runs the proposal's callback. Invocable only from this proxy.
+//
+// SECURITY: Execute is a CROSSING method declared here, so invoking it mints
+// a gno.land/r/gov/dao frame for the callback — `cur.Previous()` inside the
+// callback is this path whoever called. That is a capability: realms gate on
+// it (authz.NewContractAuthority("gno.land/r/gov/dao") + DoByPrevious,
+// ownable, anything reading Previous().Address()). Ungated, any realm could
+// wrap a reachable `func(realm) error` — including an ordinary exported
+// entrypoint of the victim — and run it with governance's identity, with no
+// proposal id minted, so nothing to render, audit or deny afterwards.
+//
+// NOT InAllowedDAOs: that is SafeExecutor's bug. It holds the impl path while
+// an executor's caller is the proxy, so it rejects the approved route and
+// fails open while empty. Exact path plus subpackages, because
+// impl.ExecuteProposal is non-crossing (Previous() is the proxy exactly), so
+// a bare prefix would reject every real proposal.
+//
+// Gates the executor object's INVOCATION only. Keeping a privileged closure,
+// or an exported entrypoint shaped like `func(realm) error`, out of reach
+// stays the consumer's job — see r/gnops/valopers/admin.gno
+// and p/moul/authz's NewContractAuthority godoc.
 func (e *SimpleExecutor) Execute(cur realm) error {
+	// IsCurrent first, as every other gate here does: otherwise Previous() is
+	// read from whatever realm value the caller threaded in.
+	if !cur.IsCurrent() {
+		return errors.New("execution denied: cur is not the caller's live realm")
+	}
+	if prev := cur.Previous().PkgPath(); prev != proxyPkgPath &&
+		!strings.HasPrefix(prev, proxyPkgPath+"/") {
+		return errors.New("execution denied: executors are only invocable by " + proxyPkgPath)
+	}
+
 	// Check if executor was created using the constructor func
 	if e.callback == nil {
 		return nil
@@ -223,12 +259,12 @@ func (e *SafeExecutor) Execute(cur realm) error {
 	// or sibling-frame cur would have its Previous() read from that value
 	// rather than from the live frame.
 	//
-	// Note what this does NOT gate: NewSafeExecutor has no call sites, so this
-	// type is currently dead code. Live proposal execution goes through the
-	// Executor interface to SimpleExecutor.Execute below, which has no
-	// InAllowedDAOs check -- it is contained instead by the executor being
-	// unexported inside ProposalRequest/Proposal with no accessor. Do not read
-	// this method as evidence that executor invocation is allowlist-gated.
+	// NewSafeExecutor has no call sites, so this type is currently dead code.
+	// Live proposal execution goes through the Executor interface to
+	// SimpleExecutor.Execute, which now gates on the invoking realm being the
+	// proxy -- deliberately NOT on InAllowedDAOs, which holds the impl path
+	// and therefore rejects the approved route and fails open while empty.
+	// That is this method's bug; see SimpleExecutor.Execute.
 	if !cur.IsCurrent() {
 		return errors.New("execution denied: cur is not the caller's live realm")
 	}

--- a/examples/gno.land/r/sys/validators/v0/proposal_test.gno
+++ b/examples/gno.land/r/sys/validators/v0/proposal_test.gno
@@ -13,6 +13,14 @@ import (
 // seedCache populates valoperCache with the given (op, pubkey, kr)
 // tuples — used in tests to satisfy NewValidatorProposalRequest's
 // creation-time membership check without going through valopers.
+// asGovDAOProxy is the realm these tests stand in as before invoking an
+// executor directly. SimpleExecutor.Execute is invocable only from the
+// r/gov/dao namespace; on the live route dao.ExecuteProposal and
+// impl.ExecuteProposal thread the proxy's cur to it non-crossing, so
+// Previous() inside Execute is this path. Calling Execute from the test's
+// own realm is a route no transaction takes.
+const asGovDAOProxy = "gno.land/r/gov/dao"
+
 func seedCache(t *testing.T, entries []struct {
 	op          address
 	pubKey      string
@@ -151,6 +159,8 @@ func TestNewValidatorProposalRequest_ExecutorReResolvesPubkey(cur realm, t *test
 		KeepRunning:    true,
 	})
 
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, exec.Execute(cross(cur)))
 
 	// Effective valset should contain pubKeyB (post-rotation), not
@@ -178,6 +188,8 @@ func TestNewValidatorProposalRequest_RemoveOperator(cur realm, t *testing.T) {
 	// Liveness floor: removing the only validator empties the set.
 	// Executor runs inside a crossing dao.Executor.Execute call, so
 	// the panic surfaces as an abort, not a regular panic.
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	uassert.AbortsContains(t, cur, "would empty the validator set", func() {
 		_ = newValoperChangeExecutor(cur, []ValoperChange{{OperatorAddress: opA, Power: 0}}).Execute(cross(cur))
 	})
@@ -206,6 +218,8 @@ func TestNewValidatorProposalRequest_RemoveLeavesOthers(cur realm, t *testing.T)
 
 	changes := []ValoperChange{{OperatorAddress: opA, Power: 0}}
 	// Build the executor directly (private function, same package).
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, newValoperChangeExecutor(cur, changes).Execute(cross(cur)))
 
 	// Effective set: only opB / pubKeyB remains.
@@ -235,6 +249,8 @@ func TestNewValidatorProposalRequest_AllowsFullValsetReplacement(cur realm, t *t
 		{OperatorAddress: opA, Power: 0},
 		{OperatorAddress: opB, Power: 10},
 	}
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, newValoperChangeExecutor(cur, changes).Execute(cross(cur)))
 
 	effective := sysparams.GetValsetEffective()
@@ -293,6 +309,8 @@ func TestNewValidatorProposalRequest_AllowsRemoveOfKeepRunningFalse(cur realm, t
 	_ = pr
 
 	// Executor also succeeds.
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, newValoperChangeExecutor(cur, []ValoperChange{{OperatorAddress: opA, Power: 0}}).Execute(cross(cur)))
 }
 
@@ -367,6 +385,8 @@ func TestNewValidatorProposalRequest_UpsertExistingValidator(cur realm, t *testi
 	})
 
 	changes := []ValoperChange{{OperatorAddress: opA, Power: 9}}
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, newValoperChangeExecutor(cur, changes).Execute(cross(cur)))
 
 	effective := sysparams.GetValsetEffective()
@@ -400,6 +420,8 @@ func TestNewValidatorProposalRequest_ExecutorRejectsRaceFlippedKeepRunning(cur r
 		SigningAddress: mustAddr(t, pubKeyA),
 		KeepRunning:    false,
 	})
+
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
 
 	uassert.AbortsContains(t, cur, "KeepRunning=false at execution", func() {
 		_ = exec.Execute(cross(cur))
@@ -477,6 +499,8 @@ func TestNewValidatorProposalRequest_PhantomBaselineDocumentsUnreachableState(cu
 		{op: opB, pubKey: pubKeyB, keepRunning: true},
 	})
 
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
+
 	urequire.NoError(t, newValoperChangeExecutor(cur,
 		[]ValoperChange{{OperatorAddress: opA, Power: 2}},
 	).Execute(cross(cur)))
@@ -516,6 +540,8 @@ func TestNewValidatorProposalRequest_SameBlockExecuteThenRotate(cur realm, t *te
 		{op: opA, pubKey: pubKeyA, keepRunning: true},
 		{op: opB, pubKey: pubKeyB, keepRunning: true},
 	})
+
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
 
 	urequire.NoError(t, newValoperChangeExecutor(cur,
 		[]ValoperChange{{OperatorAddress: opA, Power: 3}},
@@ -570,6 +596,8 @@ func TestNewValidatorProposalRequest_ExecutorVanishedCacheEntryPanics(cur realm,
 	// (NOT a public API) — production code has no path here today.
 	_, removed := valoperCache.Remove(op.String())
 	urequire.True(t, removed, "fixture: cache entry must have been present before Remove")
+
+	testing.SetRealm(testing.NewCodeRealm(asGovDAOProxy))
 
 	uassert.AbortsContains(t, cur, "operator vanished from valoperCache between propose and execute", func() {
 		_ = exec.Execute(cross(cur))

--- a/examples/quarantined/gno.land/r/moul/config/config_test.gno
+++ b/examples/quarantined/gno.land/r/moul/config/config_test.gno
@@ -277,11 +277,13 @@ func TestTransferToContractAuthority(cur realm, t *testing.T) {
 		userActionExecuted = true
 		return nil
 	})
-	// The ContractAuthority.Authorize method should return an error
-	// because the handler now returns an error if the caller isn't the contract.
+	// A plain ContractAuthority defaults its proposer to the contract
+	// itself, so a user caller is rejected UPSTREAM (at the proposer) and
+	// the handler is never reached — the handler's own CurrentRealm check
+	// above is now belt-and-braces, not the guard being relied on.
 	uassert.Error(t, err, "user action via Authorizer.Do should fail when contract is authority")
-	uassert.ErrorContains(t, err, "handler: caller is not the contract", "error should originate from handler check") // Check specific error
-	uassert.False(t, handlerExecuted, "handler should NOT have been executed by user call")                           // Verify handler didn't run past the check
+	uassert.ErrorContains(t, err, "unauthorized", "rejection should come from the contract-identity proposer")
+	uassert.False(t, handlerExecuted, "handler should NOT have been executed by user call")
 	uassert.False(t, userActionExecuted, "user action should not have been executed")
 }
 

--- a/gno.land/pkg/gnoland/inert_lifecycle_test.go
+++ b/gno.land/pkg/gnoland/inert_lifecycle_test.go
@@ -202,10 +202,13 @@ func Origin(cur realm) string { return origin }
 	//
 	// The hash is computed from the source that was submitted, which is how a
 	// real approver gets it -- they saw the transaction. It matches the parked
-	// blob because PackageContentHash excludes gnomod.toml, the only file the
-	// keeper stamps at submit.
+	// blob because PackageContentHash resets the gnomod.toml fields the keeper
+	// stamps at submit before hashing it, so the submitted copy and the stored
+	// copy canonicalize to the same bytes.
+	submittedHash, err := vm.PackageContentHash(submitted)
+	require.NoError(t, err)
 	enableResp := deliver(t, []std.Msg{vm.MsgEnablePackage{
-		Approver: approverAddr, PkgPath: path, PkgHash: vm.PackageContentHash(submitted),
+		Approver: approverAddr, PkgPath: path, PkgHash: submittedHash,
 	}}, approver)
 	require.True(t, enableResp.IsOK(), "approver should be able to enable: %s", enableResp.Log)
 
@@ -301,11 +304,112 @@ func Hello(cur realm) string { return "hi" }
 
 	collectorAfterSubmit := ugnotBalance(t, app, collectorAddr)
 
+	submittedHash, err := vm.PackageContentHash(submitted)
+	require.NoError(t, err)
 	enableResp := deliver(t, []std.Msg{vm.MsgEnablePackage{
-		Approver: approverAddr, PkgPath: path, PkgHash: vm.PackageContentHash(submitted),
+		Approver: approverAddr, PkgPath: path, PkgHash: submittedHash,
 	}}, approver)
 	require.True(t, enableResp.IsOK(), "enable should succeed: %s", enableResp.Log)
 
 	assert.Equal(t, collectorAfterSubmit, ugnotBalance(t, app, collectorAddr),
 		"enable must not charge again; the charge is a submit-time cost")
+}
+
+// TestInertPrivateRealmSurvivesAStrangersSubmission drives the creator binding
+// on a live private realm through real signed transactions.
+//
+// The keeper's own tests call AddPackage directly, which cannot show what this
+// one does: the stranger's submission is a well-formed, correctly signed,
+// fee-paying MsgAddPackage that nothing outside the keeper objects to. Namespace
+// enforcement is off, which is the state this repo's genesis produces, so the
+// keeper's refusal is the only thing between any address and the realm -- and
+// after it, the realm still answers with the owner's identity and serves the
+// owner's source.
+func TestInertPrivateRealmSurvivesAStrangersSubmission(t *testing.T) {
+	t.Parallel()
+
+	const path = "gno.land/r/demo/privowned"
+	// init() records who the VM believes is running it, and Which marks which
+	// version is live. The two submissions differ in nothing else, so a takeover
+	// would be invisible without them.
+	pkgFor := func(which string) *std.MemPackage {
+		return &std.MemPackage{
+			Name: "privowned",
+			Path: path,
+			Files: []*std.MemFile{
+				{Name: "gnomod.toml", Body: "module = \"" + path + "\"\ngno = \"0.9\"\nprivate = true\n"},
+				{Name: "privowned.gno", Body: `package privowned
+
+import "chain/runtime/unsafe"
+
+var origin string
+
+func init() {
+	origin = string(unsafe.OriginCaller())
+}
+
+func Origin(cur realm) string { return origin }
+
+func Which(cur realm) string { return "` + which + `" }
+`},
+			},
+		}
+	}
+
+	keys := getDummyKeys(t, 4)
+	owner, approver, stranger, caller := keys[0], keys[1], keys[2], keys[3]
+	ownerAddr := owner.PubKey().Address()
+	approverAddr := approver.PubKey().Address()
+	strangerAddr := stranger.PubKey().Address()
+
+	vmGen := vm.DefaultGenesisState()
+	vmGen.Params.CodeSubmissionPolicy = "inert"
+	vmGen.Params.PkgApprovers = []crypto.Address{approverAddr}
+
+	app, deliver := inertChain(t, vmGen, keys)
+
+	// The owner parks their private realm and the approver activates it.
+	ownerPkg := pkgFor("owner")
+	resp := deliver(t, []std.Msg{vm.MsgAddPackage{Creator: ownerAddr, Package: ownerPkg}}, owner)
+	require.True(t, resp.IsOK(), "owner submit: %s", resp.Log)
+	ownerHash, err := vm.PackageContentHash(ownerPkg)
+	require.NoError(t, err)
+	resp = deliver(t, []std.Msg{vm.MsgEnablePackage{
+		Approver: approverAddr, PkgPath: path, PkgHash: ownerHash,
+	}}, approver)
+	require.True(t, resp.IsOK(), "owner enable: %s", resp.Log)
+
+	// The stranger submits their own bytes at the owner's live private path.
+	strangerPkg := pkgFor("stranger")
+	submitResp := deliver(t, []std.Msg{vm.MsgAddPackage{
+		Creator: strangerAddr, Package: strangerPkg,
+	}}, stranger)
+	require.False(t, submitResp.IsOK(),
+		"a stranger's submission over a live private realm must be refused")
+	assert.Contains(t, submitResp.Log, ownerAddr.String(),
+		"the refusal must name the address the realm belongs to")
+
+	// Nothing was queued for an approver to activate either.
+	strangerHash, err := vm.PackageContentHash(strangerPkg)
+	require.NoError(t, err)
+	enableResp := deliver(t, []std.Msg{vm.MsgEnablePackage{
+		Approver: approverAddr, PkgPath: path, PkgHash: strangerHash,
+	}}, approver)
+	require.False(t, enableResp.IsOK(), "there must be nothing parked to enable")
+	assert.Contains(t, enableResp.Log, "no inert package at path",
+		"the enable must fail for want of a parked package, not for another reason")
+
+	// The realm is still the owner's: the identity init() recorded, and the code.
+	callResp := deliver(t, []std.Msg{vm.MsgCall{
+		Caller: caller.PubKey().Address(), PkgPath: path, Func: "Origin",
+	}}, caller)
+	require.True(t, callResp.IsOK(), "the owner's realm must still be callable: %s", callResp.Log)
+	assert.Contains(t, string(callResp.Data), ownerAddr.String())
+	assert.NotContains(t, string(callResp.Data), strangerAddr.String(),
+		"a stranger must not become the origin caller of the owner's live private realm")
+
+	qr := app.Query(abci.RequestQuery{Path: "vm/qfile", Data: []byte(path + "/privowned.gno")})
+	require.True(t, qr.IsOK(), "qfile: %v", qr.ResponseBase.Error)
+	assert.Contains(t, string(qr.Data), `return "owner"`,
+		"qfile must keep serving the owner's source at the owner's path")
 }

--- a/gno.land/pkg/integration/testdata/addpkg_private_redeploy_owner.txtar
+++ b/gno.land/pkg/integration/testdata/addpkg_private_redeploy_owner.txtar
@@ -1,0 +1,81 @@
+# Only the address that deployed a live PRIVATE realm may redeploy it.
+#
+# The already-exists refusal waives itself for a private package, so with no
+# owner binding a stranger's MsgAddPackage at a live private path replaces the
+# code and re-runs init() with the stranger as OriginCaller -- the identity the
+# realm records as its owner. Namespace enforcement is the only other control,
+# and it is off here: r/sys/names is undeployed, the state this repo's genesis
+# produces, so any funded account may deploy under any path.
+#
+# This drives the ordinary permissionless path: one signed MsgAddPackage from a
+# second funded account, no approver and nothing parked. checkRedeployPermission
+# refuses it, naming the path and the address the realm belongs to, and the
+# realm keeps serving the owner's recorded identity and source.
+
+# A second funded account, distinct from the default test1.
+adduser stranger
+
+gnoland start
+
+# The owner deploys their private realm; init() records them as OriginCaller.
+gnokey maketx addpkg -pkgdir $WORK/vault_owner -pkgpath gno.land/r/demo/vault -gas-fee 10000000ugnot -gas-wanted 20000000 -chainid=tendermint_test test1
+stdout OK!
+
+# The realm is the owner's: the recorded owner and the served version.
+gnokey query vm/qeval --data 'gno.land/r/demo/vault.Owner()'
+stdout $test1_user_addr
+gnokey query vm/qeval --data 'gno.land/r/demo/vault.Tag()'
+stdout owner
+
+# The stranger submits their own bytes at the owner's live private path.
+! gnokey maketx addpkg -pkgdir $WORK/vault_stranger -pkgpath gno.land/r/demo/vault -gas-fee 10000000ugnot -gas-wanted 20000000 -chainid=tendermint_test stranger
+# The refusal names the path and the address the realm belongs to.
+stderr 'private package already deployed at gno.land/r/demo/vault'
+stderr $test1_user_addr
+
+# The realm is still the owner's: the takeover changed neither the recorded
+# owner nor the served source.
+gnokey query vm/qeval --data 'gno.land/r/demo/vault.Owner()'
+stdout $test1_user_addr
+gnokey query vm/qeval --data 'gno.land/r/demo/vault.Tag()'
+stdout owner
+
+-- vault_owner/gnomod.toml --
+module = "gno.land/r/demo/vault"
+gno = "0.9"
+private = true
+
+-- vault_owner/vault.gno --
+package vault
+
+import "chain/runtime/unsafe"
+
+var owner address
+
+func init() {
+	owner = unsafe.OriginCaller()
+}
+
+func Owner() string { return owner.String() }
+
+func Tag() string { return "owner" }
+
+-- vault_stranger/gnomod.toml --
+module = "gno.land/r/demo/vault"
+gno = "0.9"
+private = true
+
+-- vault_stranger/vault.gno --
+package vault
+
+import "chain/runtime/unsafe"
+
+var owner address
+
+func init() {
+	owner = unsafe.OriginCaller()
+}
+
+func Owner() string { return owner.String() }
+
+func Tag() string { return "stranger" }

--- a/gno.land/pkg/integration/testdata/enable_refuses_gnomod_private_flip.txtar
+++ b/gno.land/pkg/integration/testdata/enable_refuses_gnomod_private_flip.txtar
@@ -1,0 +1,169 @@
+# Regression: gnomod.toml's private flag is bound to the approval hash.
+#
+# Under the inert code submission policy, a submitted package remains inert
+# until an approver enables it by naming its PackageContentHash. The hash
+# includes the gnomod fields declared by the author.
+#
+# This test submits a realm with private = true and prepares an enable for that
+# source. The submitter then replaces it with the same .gno files and
+# private = false. The prepared enable no longer matches the approved hash and
+# is refused.
+#
+# The two package directories below hold identical .gno bytes and differ only
+# in gnomod.toml's private flag. Restoring the reviewed private flag confirms
+# that the matching enable succeeds.
+
+adduser creator
+
+loadpkg gno.land/r/gov/dao
+loadpkg gno.land/r/gov/dao/impl/v0
+loadpkg gno.land/r/sys/params
+
+loadpkg gno.land/r/gov/dao/loader/v0 $WORK/loader
+
+gnoland start
+
+## -- proposal 0: move the code submission policy to inert
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 29_000_000 -chainid=tendermint_test test1 $WORK/run/submit_policy.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -chainid=tendermint_test test1
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 0 -chainid=tendermint_test test1
+stdout OK!
+gnokey query params/vm:p:code_submission_policy
+stdout 'data: "inert"$'
+
+## -- proposal 1: register test1 as the approver
+gnokey maketx run -gas-fee 2500001ugnot -gas-wanted 29_000_000 -chainid=tendermint_test test1 $WORK/run/submit_approvers.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 1 -args YES -chainid=tendermint_test test1
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 2200001ugnot -gas-wanted 22_000_000 -args 1 -chainid=tendermint_test test1
+stdout OK!
+gnokey query params/vm:p:pkg_approvers
+stdout 'data: \["g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"\]'
+
+## the creator submits the realm with private = true for review
+gnokey maketx addpkg -pkgdir $WORK/priv -pkgpath gno.land/r/gnomodflag -gas-fee 1000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test creator
+stdout OK!
+gnokey query vm/qpkgmeta_json --data "gno.land/r/gnomodflag"
+stdout '"status":"inert"'
+
+## the approver prepares an enable for the reviewed source
+gnokey maketx enablepkg -pkgpath gno.land/r/gnomodflag -pkgdir $WORK/priv -broadcast=false -gas-fee 100000ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1
+stdout '/vm\.m_enable_pkg'
+
+## the creator replaces the submitted package with identical .gno files and private = false
+gnokey maketx addpkg -pkgdir $WORK/pub -pkgpath gno.land/r/gnomodflag -gas-fee 1000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test creator
+stdout OK!
+
+## the prepared enable no longer matches the approved source and is refused
+! gnokey maketx enablepkg -pkgpath gno.land/r/gnomodflag -pkgdir $WORK/priv -broadcast -gas-fee 100000ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1
+stderr 'is not what was approved'
+## the realm remains inert
+gnokey query vm/qpkgmeta_json --data "gno.land/r/gnomodflag"
+stdout '"status":"inert"'
+
+## positive control: restoring the reviewed private flag lets the enable succeed
+gnokey maketx addpkg -pkgdir $WORK/priv -pkgpath gno.land/r/gnomodflag -gas-fee 1000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test creator
+stdout OK!
+gnokey maketx enablepkg -pkgpath gno.land/r/gnomodflag -pkgdir $WORK/priv -broadcast -gas-fee 100000ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1
+stdout OK!
+gnokey query vm/qpkgmeta_json --data "gno.land/r/gnomodflag"
+stdout '"status":"live"'
+
+## -- a package whose gnomod.toml module line was never updated to the deploy path
+##
+## The chain accepts it and stampGnomod rewrites module to the deploy path, so
+## the stored copy is not the submitted one. The hash normalizes that away on
+## both sides; when it did not, this package parked fine and no approver could
+## ever enable it.
+gnokey maketx addpkg -pkgdir $WORK/mismatch -pkgpath gno.land/r/heightpin -gas-fee 1000001ugnot -gas-wanted 30_000_000 -chainid=tendermint_test creator
+stdout OK!
+gnokey query vm/qpkgmeta_json --data "gno.land/r/heightpin"
+stdout '"status":"inert"'
+
+## -pkg-height pins the submission, not just the source: a height that is not
+## the one parked is refused even though the bytes match exactly.
+! gnokey maketx enablepkg -pkgpath gno.land/r/heightpin -pkgdir $WORK/mismatch -pkg-height 999 -broadcast -gas-fee 100000ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1
+stderr 're-submitted after review'
+gnokey query vm/qpkgmeta_json --data "gno.land/r/heightpin"
+stdout '"status":"inert"'
+
+## unpinned, the same approval lands -- the module rewrite does not stand in its way
+gnokey maketx enablepkg -pkgpath gno.land/r/heightpin -pkgdir $WORK/mismatch -broadcast -gas-fee 100000ugnot -gas-wanted 30_000_000 -chainid=tendermint_test test1
+stdout OK!
+gnokey query vm/qpkgmeta_json --data "gno.land/r/heightpin"
+stdout '"status":"live"'
+
+-- loader/loader.gno --
+package loader
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/gov/dao/impl/v0"
+	"gno.land/r/gov/dao/memberstore/v0"
+)
+
+func init(cur realm) {
+	memberstore.Get(0, cur).SetTier(memberstore.T1)
+	memberstore.Get(0, cur).SetMember(memberstore.T1, address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"), memberstore.NewMember(3))
+	dao.UpdateImpl(cross(cur), dao.NewUpdateRequest(impl.GetInstance(0, cur), []string{"gno.land/r/gov/dao/impl/v0"}))
+}
+
+-- run/submit_policy.gno --
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/sys/params"
+)
+
+func main(cur realm) {
+	prop := params.NewSysParamStringPropRequest(cross(cur), "vm", "p", "code_submission_policy", "inert")
+	dao.MustCreateProposal(cross(cur), prop)
+}
+
+-- run/submit_approvers.gno --
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/sys/params"
+)
+
+func main(cur realm) {
+	prop := params.NewSysParamStringsPropRequest(cross(cur), "vm", "p", "pkg_approvers",
+		[]string{"g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"})
+	dao.MustCreateProposal(cross(cur), prop)
+}
+
+-- priv/gnomod.toml --
+module = "gno.land/r/gnomodflag"
+private = true
+gno = "0.9"
+
+-- priv/gnomodflag.gno --
+package gnomodflag
+
+func Value() string { return "hello" }
+func Render(_ string) string { return Value() }
+-- pub/gnomod.toml --
+module = "gno.land/r/gnomodflag"
+private = false
+gno = "0.9"
+
+-- pub/gnomodflag.gno --
+package gnomodflag
+
+func Value() string { return "hello" }
+func Render(_ string) string { return Value() }
+-- mismatch/gnomod.toml --
+module = "gno.land/r/sometemplate"
+gno = "0.9"
+
+-- mismatch/heightpin.gno --
+package heightpin
+
+func Value() string { return "hello" }
+func Render(_ string) string { return Value() }

--- a/gno.land/pkg/integration/testdata/moul_authz.txtar
+++ b/gno.land/pkg/integration/testdata/moul_authz.txtar
@@ -64,7 +64,17 @@ import (
 	"gno.land/r/testing/admin"
 )
 
-var a *authz.Authorizer = authz.NewWithAuthority(authz.NewContractAuthority("gno.land/r/testing/admin", admin.HandlePrivilegedAction))
+// This is the async DAO-style flow: an arbitrary user proposes, the admin
+// realm queues the proposal, and ExecuteAction runs it later. A plain
+// NewContractAuthority would reject the user at the proposer (its default
+// proposer is the admin contract itself), so widen the proposer explicitly.
+// admin.HandlePrivilegedAction remains the trust boundary: it only accepts
+// proposals routed through this realm.
+var a *authz.Authorizer = authz.NewWithAuthority(authz.NewRestrictedContractAuthority(
+	"gno.land/r/testing/admin",
+	admin.HandlePrivilegedAction,
+	authz.NewAutoAcceptAuthority(),
+))
 
 var value = "init"
 

--- a/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_authlist_flow.txtar
@@ -1,7 +1,9 @@
 # AddToAuthList / DeleteFromAuthList privilege flow test for valoper
 # UpdateSigningKey.
 #
-# UpdateSigningKey calls v.Auth().AssertPreviousOnAuthList(); the auth
+# UpdateSigningKey calls v.auth.AssertPreviousOnAuthList() on the
+# per-operator auth list -- NOT the realm-level governance authority that
+# valopers.Auth() describes; the two are unrelated. The auth
 # list is seeded with just the operator at Register time and extends
 # only via valopers.AddToAuthList. This test exercises three states:
 #

--- a/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
+++ b/gno.land/pkg/integration/testdata/params_valset_hostile_proxy.txtar
@@ -1,6 +1,8 @@
 # Hostile realm proxy attack on valopers.UpdateSigningKey.
 #
-# valopers.UpdateSigningKey gates on v.Auth().AssertPreviousOnAuthList().
+# valopers.UpdateSigningKey gates on v.auth.AssertPreviousOnAuthList(),
+# the per-operator auth list -- NOT the realm-level governance authority
+# that valopers.Auth() describes; the two are unrelated.
 # Per docs/resources/gno-interrealm.md, PreviousRealm() returns the
 # IMMEDIATE previous frame: when a hostile third realm cross-calls
 # UpdateSigningKey from its own crossing function, valopers sees the

--- a/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
+++ b/gno.land/pkg/integration/testdata/stdlib_ibc_crypto_determinism.txtar
@@ -14,7 +14,28 @@
 
 env ADDPKG_GAS=10_000_000
 env CALL_GAS=10_000_000
-env EXACT_GAS=2547293
+# Moves when crypto/modexp's gas row changes: this realm makes one ModExp call
+# with 32-byte operands, so the whole delta against the base branch is checkable
+# rather than taken on faith. At the 32/32-byte shape the row charges:
+#
+#   on develop    58000 + 24647680*32/1024                    = 828240
+#   on this PR     1400 + 2200*work(32,32)/1024 + 3500*32/1024 = 119496
+#
+# where work counts the modular multiplications big.Int.Exp performs rather than
+# fitting a product: a 32-byte exponent is 4 machine words, so expNN takes the
+# Montgomery path and does 38 + 160*4 = 678 of them, each costing 65 +
+# words(32)^2 = 81 units, giving 678*81 = 54918.
+#
+# Reconciling against develop's 2547293:
+#
+#   2547293 - (828240 - 119496) = 1838549   the gas row alone
+#   1850271 - 1838549           =   11722   the operand-length guard added to
+#                                           ModExp itself, which is Gno-side
+#                                           opcodes, not a native charge
+#
+# Re-derived after merging develop; unrelated gas changes on the base branch
+# move the absolute number, so re-derive again rather than assuming it holds.
+env EXACT_GAS=1850271
 
 gnoland start
 

--- a/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
+++ b/gno.land/pkg/integration/testdata/storage_deposit_price_change.txtar
@@ -38,7 +38,7 @@ stdout 'storage: 503690, deposit: 50369000'
 # be re-derived. The assertion that actually tests this file's subject is the
 # storage/deposit pair above.
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999813460400ugnot"'
+stdout '"coins": "9999813437600ugnot"'
 
 gnokey query params/vm:p:storage_price
 stdout '100ugnot'
@@ -73,7 +73,7 @@ stdout 'storage: 3374, deposit: 337400'
 
 ## Verify user received a refund (balance should have increased despite gas fees)
 gnokey query auth/accounts/$test1_user_addr
-stdout '"coins": "9999851103900ugnot"'
+stdout '"coins": "9999851081100ugnot"'
 
 -- loader/load_govdao.gno --
 package loader

--- a/gno.land/pkg/integration/testdata/valopers_fee_receipt.txtar
+++ b/gno.land/pkg/integration/testdata/valopers_fee_receipt.txtar
@@ -1,0 +1,219 @@
+# The valoper register fee must actually be RECEIVED, not merely declared.
+#
+# unsafe.OriginSend() reports the transaction's declared send envelope, not
+# what this realm received. Only a direct `maketx call` on valopers credits
+# the envelope to valopers. For a `maketx run` the keeper sets
+# pkgAddr := caller, so the coins move from the caller to the caller and never
+# land anywhere at all, while OriginSend() still reports the full amount. So
+# the amount check alone verifies intent, never receipt.
+#
+# The guard is IsUserCall rather than an address comparison because a run
+# script's realm is address-indistinguishable from its user: inside
+# `main(cur realm)` the ephemeral realm's own address IS the caller's EOA
+# address. Every address-based guard here accepts a `maketx run` -- Register's
+# squat guard and UpdateSigningKey's auth-list check both pass. Only the
+# pkgPath differs.
+#
+# Reported by @D4ryl00. Both fees default to 0 and genesis
+# leaves them there, so nothing was live; this pins the fix before anyone
+# proposes a nonzero fee.
+#
+# Sections:
+#   1. while the fee is unset, a `maketx run` registration still works
+#      (the compatibility property the guard must not break)
+#   2. governance raises register_fee to 1000ugnot
+#   3. the `maketx run` bypass is refused, and valopers received nothing
+#   4. underpaying via a direct call is still caught by the amount check
+#   5. the legitimate direct call succeeds AND the realm actually receives
+#   6. the same shape on UpdateSigningKey's rotation fee
+
+adduserfrom member 'success myself purchase tray reject demise scene little legend someone lunar hope media goat regular test area smart save flee surround attack rapid smoke'
+stdout 'g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0'
+
+adduser test2 1010000000ugnot
+
+loadpkg gno.land/r/sys/params
+loadpkg gno.land/r/sys/validators/v0
+loadpkg gno.land/r/gnops/valopers
+loadpkg gno.land/r/gov/dao
+loadpkg gno.land/r/gov/dao/impl/v0
+loadpkg gno.land/r/gov/dao/loader/v0 $WORK/loader
+
+gnoland start
+
+# --- 1. fee unset: a maketx run registration is accepted, as before ---
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 60_000_000 -broadcast -chainid=tendermint_test member $WORK/run/register_free.gno
+stdout OK!
+stdout 'registered via run: freeop'
+
+# --- 2. governance raises the fee ---
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 80_000_000 -broadcast -chainid=tendermint_test member $WORK/run/set_fee.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 0 -broadcast -chainid=tendermint_test member
+stdout OK!
+
+gnokey query vm/qeval --data 'gno.land/r/sys/params.GetValoperRegisterFee()'
+stdout '1000 uint64'
+
+# --- 3. the bypass is refused ---
+# Before the fix this succeeded: registration landed and valopers received
+# zero, because the 1000ugnot envelope was credited to the run script's own
+# ephemeral realm.
+! gnokey maketx run -send 1000ugnot -gas-fee 6000001ugnot -gas-wanted 80_000_000 -broadcast -chainid=tendermint_test test2 $WORK/run/register_paid.gno
+stderr 'call this directly as a user'
+
+# Nothing was registered, and valopers holds nothing.
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test member $WORK/run/probe.gno
+stdout 'valopers balance: 0'
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+! stdout 'paidop'
+
+# --- 4. underpaying a direct call is still caught by the amount check ---
+! gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -send 500ugnot -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args paidop -args 'a valid description for the operator profile' -args cloud -args $test2_user_addr -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aadexfnpsmgjxu72xz9y30aqfrlpny -broadcast -chainid=tendermint_test test2
+stderr 'payment must not be less than 1000ugnot'
+
+# --- 5. the legitimate direct call succeeds, and the realm receives ---
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func Register -send 1000ugnot -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args paidop -args 'a valid description for the operator profile' -args cloud -args $test2_user_addr -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aadexfnpsmgjxu72xz9y30aqfrlpny -broadcast -chainid=tendermint_test test2
+stdout OK!
+
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test member $WORK/run/probe.gno
+stdout 'valopers balance: 1000'
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+stdout 'paidop'
+
+# --- 6. the same shape on the ROTATION fee ---
+# UpdateSigningKey has an identical unsafe.OriginSend() amount check. It
+# matters more than Register's: rotation reaches
+# validators.RotateValoperSigningKey, which rewrites the EFFECTIVE valset.
+# The fee is the economic brake alongside rotation_period_blocks; auth is
+# the operator's auth list, which this does not weaken either way.
+#
+# Two proposals in one script (ids 1 and 2): drop the throttle so the
+# in-test rotation is not height-blocked, and set rotation_fee.
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 80_000_000 -broadcast -chainid=tendermint_test member $WORK/run/set_rotation.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 1 -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 2 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 2 -broadcast -chainid=tendermint_test member
+stdout OK!
+
+# The bypass is refused for rotation too.
+! gnokey maketx run -send 500ugnot -gas-fee 6000001ugnot -gas-wanted 80_000_000 -broadcast -chainid=tendermint_test member $WORK/run/rotate_paid.gno
+stderr 'call this directly as a user'
+
+# The legitimate direct rotation succeeds and the realm receives the fee
+# (1000 from section 5 + 500 here).
+gnokey maketx call -pkgpath gno.land/r/gnops/valopers -func UpdateSigningKey -send 500ugnot -gas-fee 6000001ugnot -gas-wanted 60_000_000 -args g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0 -args gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqwpdwpd0f9fvqla089ndw5g9hcsufad77fml2vlu73fk8q8sh8v72cza5p -broadcast -chainid=tendermint_test member
+stdout OK!
+
+gnokey maketx run -gas-fee 3000001ugnot -gas-wanted 30_000_000 -broadcast -chainid=tendermint_test member $WORK/run/probe.gno
+stdout 'valopers balance: 1500'
+
+-- run/register_free.gno --
+package main
+
+import "gno.land/r/gnops/valopers"
+
+func main(cur realm) {
+	valopers.Register(cross(cur), "freeop", "a valid description for the operator profile", "cloud",
+		cur.Previous().Address(),
+		"gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqkn3nln2k8glpf9kpqtz4h63n7cd0jvxkq6rpk4dxzp4sq527mhqwv40hr")
+	println("registered via run:", valopers.GetByAddr(cur.Previous().Address()).Moniker)
+}
+
+-- run/register_paid.gno --
+package main
+
+import "gno.land/r/gnops/valopers"
+
+func main(cur realm) {
+	// The 1000ugnot envelope never moves: for a `maketx run` the keeper
+	// sends it from the caller to the caller, and this ephemeral realm's
+	// address IS the caller's. valopers receives nothing and the caller
+	// keeps the coins, so the call must be refused.
+	valopers.Register(cross(cur), "paidop", "a valid description for the operator profile", "cloud",
+		cur.Previous().Address(),
+		"gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zq3ds6sdvc0shfkq02h6xx5g0jp04aadexfnpsmgjxu72xz9y30aqfrlpny")
+	println("UNREACHABLE: registered without paying")
+}
+
+-- run/set_fee.gno --
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	params "gno.land/r/sys/params"
+)
+
+func main(cur realm) {
+	dao.MustCreateProposal(cross(cur),
+		params.NewSysParamUint64PropRequest(cross(cur), "node", "valoper", "register_fee", 1000))
+}
+
+-- run/set_rotation.gno --
+package main
+
+import (
+	"gno.land/r/gov/dao"
+	params "gno.land/r/sys/params"
+)
+
+func main(cur realm) {
+	dao.MustCreateProposal(cross(cur),
+		params.NewSysParamInt64PropRequest(cross(cur), "node", "valoper", "rotation_period_blocks", 0))
+	dao.MustCreateProposal(cross(cur),
+		params.NewSysParamUint64PropRequest(cross(cur), "node", "valoper", "rotation_fee", 500))
+}
+
+-- run/rotate_paid.gno --
+package main
+
+import "gno.land/r/gnops/valopers"
+
+func main(cur realm) {
+	// Same shape as register_paid.gno: the 500ugnot envelope never left the
+	// caller, so valopers never receives it. Note the auth-list check above
+	// PASSES here -- this ephemeral realm's address is the operator's own --
+	// so assertPaidCallIsDirect is the only thing that refuses this.
+	valopers.UpdateSigningKey(cross(cur), cur.Previous().Address(),
+		"gpub1pggj7ard9eg82cjtv4u52epjx56nzwgjyg9zqwpdwpd0f9fvqla089ndw5g9hcsufad77fml2vlu73fk8q8sh8v72cza5p")
+	println("UNREACHABLE: rotated without paying")
+}
+
+-- run/probe.gno --
+package main
+
+import (
+	"chain"
+	"chain/banker"
+)
+
+func main(cur realm) {
+	b := banker.NewReadonlyBanker()
+	println("valopers balance:", b.GetCoin(chain.PackageAddress("gno.land/r/gnops/valopers"), "ugnot"))
+}
+
+-- loader/load_govdao.gno --
+package loader
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/gov/dao/impl/v0"
+	"gno.land/r/gov/dao/memberstore/v0"
+)
+
+func init(cur realm) {
+	memberstore.Get(0, cur).SetTier(memberstore.T1)
+	memberstore.Get(0, cur).SetTier(memberstore.T2)
+	memberstore.Get(0, cur).SetTier(memberstore.T3)
+
+	memberstore.Get(0, cur).SetMember(memberstore.T1, address("g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0"), memberstore.NewMember(3))
+
+	dao.UpdateImpl(cross(cur), dao.NewUpdateRequest(impl.GetInstance(0, cur), []string{"gno.land/r/gov/dao/impl/v0"}))
+}

--- a/gno.land/pkg/integration/testdata/valopers_governance.txtar
+++ b/gno.land/pkg/integration/testdata/valopers_governance.txtar
@@ -1,0 +1,141 @@
+# End-to-end governance for r/gnops/valopers, across real transactions.
+#
+# Filetests run one VM session, so they cannot observe a realm reload. That
+# matters here: the authority installed by init.gno is a ContractAuthority
+# whose proposer is an object in realm storage, and the privileged write
+# depends on it surviving persistence. This exercises:
+#
+#   1. Auth() after a reload, in its own query.
+#   2. propose -> vote -> execute rewrites `instructions`, each step in its
+#      own block.
+#   3. propose -> vote -> execute ROTATES the authority (the recovery path;
+#      without it a principal that stops being presentable would freeze
+#      `instructions` with no on-chain recovery).
+#   4. after the rotation the old principal is refused -- and the refusal
+#      is RETIRABLE. updateInstructions returns the authz error rather than
+#      panicking on it, which is what lets ExecuteOrRejectProposal record
+#      the proposal denied and finish it. A panic aborts the transaction
+#      instead, rolling back the Denied write, so the proposal would stay
+#      Accepted and retryable forever -- the exact state that function's
+#      godoc exists to avoid ("potentially leaving the proposal active
+#      forever because it can't be successfully executed").
+
+adduserfrom member 'success myself purchase tray reject demise scene little legend someone lunar hope media goat regular test area smart save flee surround attack rapid smoke'
+stdout 'g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0'
+
+loadpkg gno.land/r/sys/params
+loadpkg gno.land/r/sys/validators/v0
+loadpkg gno.land/r/gnops/valopers
+loadpkg gno.land/r/gnops/valopers/proposal
+loadpkg gno.land/r/gov/dao
+loadpkg gno.land/r/gov/dao/impl/v0
+loadpkg gno.land/r/gov/dao/loader/v0 $WORK/loader
+
+gnoland start
+
+# 1. The authority description survives a realm reload, and names both the
+#    principal and the gate (the proposer half is what distinguishes a gated
+#    authority from a wide-open one).
+gnokey query vm/qeval --data 'gno.land/r/gnops/valopers.Auth()'
+stdout 'contract_authority\[contract=gno.land/r/gov/dao,proposer=contract-identity\]'
+
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+! stdout 'GOVERNED-BY-VOTE'
+
+# 2. propose (tx 1) / vote (tx 2) / execute (tx 3).
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 60_000_000 -broadcast -chainid=tendermint_test member $WORK/run/propose_instructions.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 0 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 0 -broadcast -chainid=tendermint_test member
+stdout OK!
+
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+stdout 'GOVERNED-BY-VOTE'
+
+# 3. Rotate the authority by proposal. The installed authority stays a
+#    canonical contract-identity ContractAuthority; only the asserted
+#    principal changes.
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 60_000_000 -broadcast -chainid=tendermint_test member $WORK/run/propose_rotation.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 1 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 1 -broadcast -chainid=tendermint_test member
+stdout OK!
+
+gnokey query vm/qeval --data 'gno.land/r/gnops/valopers.Auth()'
+stdout 'contract_authority\[contract=gno.land/r/gnops/authority,proposer=contract-identity\]'
+
+# 4. The old principal is now refused, and the proposal can be retired:
+#    ExecuteOrRejectProposal succeeds as a transaction and records the
+#    refusal, instead of aborting and stranding the proposal.
+gnokey maketx run -gas-fee 6000001ugnot -gas-wanted 60_000_000 -broadcast -chainid=tendermint_test member $WORK/run/propose_after_rotation.gno
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func MustVoteOnProposalSimple -gas-fee 1900001ugnot -gas-wanted 22_000_000 -args 2 -args YES -broadcast -chainid=tendermint_test member
+stdout OK!
+gnokey maketx call -pkgpath gno.land/r/gov/dao -func ExecuteOrRejectProposal -gas-fee 5000001ugnot -gas-wanted 30_000_000 -args 2 -broadcast -chainid=tendermint_test member
+stdout OK!
+
+# The write did not land, and the proposal says why.
+gnokey query vm/qrender --data 'gno.land/r/gnops/valopers:'
+! stdout 'SHOULD-NOT-LAND'
+gnokey query vm/qrender --data 'gno.land/r/gov/dao:2'
+stdout 'unauthorized'
+
+-- run/propose_instructions.gno --
+package main
+
+import (
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+)
+
+func main(cur realm) {
+	dao.MustCreateProposal(cross(cur),
+		proposal.ProposeNewInstructionsProposalRequest(cross(cur), "GOVERNED-BY-VOTE"))
+}
+
+-- run/propose_rotation.gno --
+package main
+
+import (
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+)
+
+func main(cur realm) {
+	dao.MustCreateProposal(cross(cur),
+		proposal.ProposeAuthorityRotationProposalRequest(cross(cur), "gno.land/r/gnops/authority"))
+}
+
+-- run/propose_after_rotation.gno --
+package main
+
+import (
+	"gno.land/r/gnops/valopers/proposal"
+	"gno.land/r/gov/dao"
+)
+
+func main(cur realm) {
+	dao.MustCreateProposal(cross(cur),
+		proposal.ProposeNewInstructionsProposalRequest(cross(cur), "SHOULD-NOT-LAND"))
+}
+
+-- loader/load_govdao.gno --
+package loader
+
+import (
+	"gno.land/r/gov/dao"
+	"gno.land/r/gov/dao/impl/v0"
+	"gno.land/r/gov/dao/memberstore/v0"
+)
+
+func init(cur realm) {
+	memberstore.Get(0, cur).SetTier(memberstore.T1)
+	memberstore.Get(0, cur).SetTier(memberstore.T2)
+	memberstore.Get(0, cur).SetTier(memberstore.T3)
+
+	memberstore.Get(0, cur).SetMember(memberstore.T1, address("g1c0j899h88nwyvnzvh5jagpq6fkkyuj76nld6t0"), memberstore.NewMember(3))
+
+	dao.UpdateImpl(cross(cur), dao.NewUpdateRequest(impl.GetInstance(0, cur), []string{"gno.land/r/gov/dao/impl/v0"}))
+}

--- a/gno.land/pkg/keyscli/enablepkg.go
+++ b/gno.land/pkg/keyscli/enablepkg.go
@@ -15,10 +15,11 @@ import (
 )
 
 type MakeEnablePkgCfg struct {
-	RootCfg *client.MakeTxCfg
-	PkgPath string
-	PkgDir  string
-	PkgHash string
+	RootCfg   *client.MakeTxCfg
+	PkgPath   string
+	PkgDir    string
+	PkgHash   string
+	PkgHeight int64
 }
 
 func NewMakeEnablePkgCmd(rootCfg *client.MakeTxCfg, io commands.IO) *commands.Command {
@@ -41,7 +42,14 @@ could be made to activate something the approver never read.
 Give the source with -pkgdir, which hashes a local copy of what you reviewed.
 Do not take the hash from the chain -- that would approve whatever is parked
 right now, which is the thing this guards against. -pkg-hash is for the case
-where the hash was computed elsewhere.`,
+where the hash was computed elsewhere.
+
+The hash covers what the author's directory declares, which is everything you
+can read locally. It cannot cover the [addpkg] section the chain writes at
+submit, so a re-submission of the same sources keeps the same hash while
+changing the storage-deposit ceiling that YOUR transaction pays against. Pass
+-pkg-height with the block the submission you reviewed landed in to pin that
+too; any re-submission then invalidates the approval.`,
 		},
 		cfg,
 		func(_ context.Context, args []string) error {
@@ -70,6 +78,13 @@ func (c *MakeEnablePkgCfg) RegisterFlags(fs *flag.FlagSet) {
 		"pkg-hash",
 		"",
 		"the content hash to approve, if computed elsewhere; alternative to -pkgdir",
+	)
+
+	fs.Int64Var(
+		&c.PkgHeight,
+		"pkg-height",
+		0,
+		"block height of the submission being approved; pins it so a re-submission invalidates this approval",
 	)
 }
 
@@ -117,7 +132,15 @@ func execMakeEnablePkg(cfg *MakeEnablePkgCfg, args []string, io commands.IO) err
 		if memPkg.IsEmpty() {
 			return errors.New("found an empty package at " + cfg.PkgDir)
 		}
-		pkgHash = vm.PackageContentHash(memPkg)
+		// Checked, not assigned: PackageContentHash fails on a directory with
+		// no gnomod.toml, a malformed one, or one over gnomod's size limit, and
+		// swallowing that would produce a signed approval naming no source at
+		// all -- exactly what the -pkgdir/-pkg-hash guard above exists to
+		// prevent, except discovered on chain after the fee is paid.
+		pkgHash, err = vm.PackageContentHash(memPkg)
+		if err != nil {
+			return errors.Wrap(err, "hashing the reviewed source")
+		}
 	}
 
 	gasfee, err := std.ParseCoin(cfg.RootCfg.GasFee)
@@ -126,9 +149,10 @@ func execMakeEnablePkg(cfg *MakeEnablePkgCfg, args []string, io commands.IO) err
 	}
 
 	msg := vm.MsgEnablePackage{
-		Approver: approver,
-		PkgPath:  cfg.PkgPath,
-		PkgHash:  pkgHash,
+		Approver:  approver,
+		PkgPath:   cfg.PkgPath,
+		PkgHash:   pkgHash,
+		PkgHeight: cfg.PkgHeight,
 	}
 	tx := std.Tx{
 		Msgs:       []std.Msg{msg},

--- a/gno.land/pkg/keyscli/enablepkg_test.go
+++ b/gno.land/pkg/keyscli/enablepkg_test.go
@@ -18,9 +18,14 @@ import (
 // approval is refused.
 //
 // The two differ in one file. AddPackage rewrites gnomod.toml at submit with
-// the creator, height and declared deposit, so the stored copy is not the
-// submitted one -- which is why PackageContentHash excludes it. This test
-// stages that difference rather than assuming it does not matter.
+// the module path, creator, height and declared deposit, so the stored copy is
+// not the submitted one. PackageContentHash normalizes all of that away.
+//
+// This test stages the difference from the CLIENT's side, which is what it can
+// see: it imitates the stamp rather than calling it. The imitation is why the
+// module rewrite went unnoticed here for a release --
+// TestPackageContentHashSurvivesTheRealStamp, in gno.land/pkg/sdk/vm, runs the
+// real stampGnomod and is the one that holds the two in step.
 func TestEnablePkgHashMatchesWhatTheChainWillCheck(t *testing.T) {
 	const pkgPath = "gno.land/r/test/enablecli"
 
@@ -44,7 +49,11 @@ func TestEnablePkgHashMatchesWhatTheChainWillCheck(t *testing.T) {
 		stored.Files = append(stored.Files, &std.MemFile{Name: f.Name, Body: body})
 	}
 
-	assert.Equal(t, vm.PackageContentHash(stored), vm.PackageContentHash(local),
+	storedHash, err := vm.PackageContentHash(stored)
+	require.NoError(t, err)
+	localHash, err := vm.PackageContentHash(local)
+	require.NoError(t, err)
+	assert.Equal(t, storedHash, localHash,
 		"a stamped gnomod.toml must not change the hash, or -pkgdir can never match")
 
 	// And a real source change must, or the flag would approve anything.
@@ -56,7 +65,9 @@ func TestEnablePkgHashMatchesWhatTheChainWillCheck(t *testing.T) {
 		}
 		changed.Files = append(changed.Files, &std.MemFile{Name: f.Name, Body: body})
 	}
-	assert.NotEqual(t, vm.PackageContentHash(local), vm.PackageContentHash(changed),
+	changedHash, err := vm.PackageContentHash(changed)
+	require.NoError(t, err)
+	assert.NotEqual(t, localHash, changedHash,
 		"a source change must change the hash")
 }
 

--- a/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
+++ b/gno.land/pkg/sdk/vm/apphash_crossrealm38_test.go
@@ -217,7 +217,18 @@ import (
 // 1d05023c. The scenario's own realms hold no byte slices (crossrealm_f keeps
 // []*Entry), so behavior is unchanged and the zrealm_crossrealm38.gno filetest
 // still passes.
-const expectedCrossrealm38Hash = "4beb454c4f1340d15c0864319533919a3c6506cc880eb0c5fbcbaebbd2f93a12"
+//
+// Bumped by the crypto/modexp operand cap and gas rework: modexp.gno gained a
+// MaxOperandLen const, a length guard in ModExp, and doc text for the new
+// rejection behavior. stdlib .gno source bytes are committed into genesis
+// state, so the root moves. Note this branch also adds modexp_test.gno, and
+// loadStdlibPackage reads stdlibs with MPStdlibAll, which keeps _test.gno
+// files — so that file is inside the Merkle root too, not just modexp.gno.
+// crossrealm38 calls neither, so the shift is those source bytes alone. The
+// gas-row change moves nothing here: gas is not committed state. Re-derived
+// after merging develop, whose own changes moved the root too, so neither
+// side's value survives.
+const expectedCrossrealm38Hash = "acd1f9ce7a9313b44b4711e4a854645d3a4a347ad2f6af3920b565dbd08414bd"
 
 func TestAppHashCrossrealm38(t *testing.T) {
 	env := setupTestEnv()

--- a/gno.land/pkg/sdk/vm/keeper.go
+++ b/gno.land/pkg/sdk/vm/keeper.go
@@ -626,12 +626,18 @@ func errInvalidMemPackage(err error) error {
 // authors, so anything not overwritten here is attacker-supplied: a hand-written
 // `[addpkg] max_deposit` would otherwise survive and be read at enable as though
 // the message had declared it.
+//
+// The fields this owns are listed ONCE, in keeperOwnedGnomod, which
+// PackageContentHash resets before hashing. Two lists would drift, and the
+// consequence of drift is not cosmetic: a field stamped here but not reset
+// there makes the approver's hash and the keeper's disagree forever, so the
+// package can never be enabled. That already happened once, for Module.
 func stampGnomod(gm *gnomod.File, mpkg *std.MemPackage, pkgPath string, creator crypto.Address, height int64, maxDeposit string) {
-	gm.Module = pkgPath // XXX: if gm.Module != msg.Package.Path { panic() }?
+	keeperOwnedGnomod(gm, pkgPath) // XXX: if gm.Module != msg.Package.Path { panic() }?
 	gm.AddPkg.Creator = creator.String()
 	gm.AddPkg.Height = int(height)
 	gm.AddPkg.MaxDeposit = maxDeposit
-	mpkg.SetFile("gnomod.toml", gm.WriteString())
+	mpkg.SetFile(gnomodFileName, gm.WriteString())
 }
 
 // checkGnomodConstraints applies the keeper-only gnomod.toml rules that the type
@@ -665,6 +671,59 @@ func checkGnomodConstraints(gm *gnomod.File, mpkg *std.MemPackage, pkgPath strin
 	// no (deprecated) gno.mod file.
 	if mpkg.GetFile("gno.mod") != nil {
 		return ErrInvalidPackage("gno.mod file is deprecated and not allowed, run 'gno mod tidy' to upgrade to gnomod.toml")
+	}
+	// A gno version the toolchain cannot compile.
+	//
+	// ParseCheckGnoMod PANICS on an unsupported version, and it is reached from
+	// the type checker -- which the inert submit branch never runs. So a
+	// package declaring gno = "0.8" parks cleanly and detonates inside
+	// EnablePackage, on the APPROVER's transaction and gas, for a mistake the
+	// submitter made. Refusing it here charges it to the submitter on all three
+	// paths instead.
+	//
+	// The accepted set mirrors ParseCheckGnoMod's exactly: empty means "default
+	// to latest", which is why it is not rejected here either.
+	if gm.Gno != "" && gm.Gno != gno.GnoVerLatest {
+		return ErrInvalidPackage(fmt.Sprintf(
+			"unsupported gno version %q in gnomod.toml (this chain compiles %q)",
+			gm.Gno, gno.GnoVerLatest))
+	}
+	return nil
+}
+
+// parseLiveGnomod reads the stored gnomod.toml of the live package at pkgPath.
+//
+// Split out of checkRedeployPermission because EnablePackage has already parsed
+// this blob to decide whether the path may be replaced at all, and decoding the
+// same bytes a second time on a consensus path buys nothing.
+func parseLiveGnomod(live *std.MemPackage, pkgPath string) (*gnomod.File, error) {
+	if live == nil {
+		return nil, ErrInvalidPackage("no stored source for the live package at " + pkgPath)
+	}
+	gm, err := gnomod.ParseMemPackage(live)
+	if err != nil {
+		return nil, ErrInvalidPackage(fmt.Sprintf(
+			"cannot read the live package at %s: %v", pkgPath, err))
+	}
+	return gm, nil
+}
+
+// checkRedeployPermission refuses unless a submission replacing the live PRIVATE
+// package at pkgPath comes from the address that deployed it. creator is the
+// address the submission would record as the new creator: the message signer on
+// AddPackage, and the parked blob's stamped creator on EnablePackage, which is
+// the identity init() runs as.
+//
+// liveGm is the live package's stored gnomod.toml, already parsed. Its
+// addpkg.creator is the owner of record, the same field the parked-blob guard
+// compares against.
+//
+// Both call sites waive this during genesis delivery; the AddPackage one says
+// why.
+func checkRedeployPermission(liveGm *gnomod.File, pkgPath string, creator crypto.Address) error {
+	if liveGm.AddPkg.Creator != creator.String() {
+		return ErrPkgAlreadyExists(fmt.Sprintf(
+			"private package already deployed at %s by %s", pkgPath, liveGm.AddPkg.Creator))
 	}
 	return nil
 }
@@ -740,8 +799,35 @@ func (vm *VMKeeper) AddPackage(ctx sdk.Context, msg MsgAddPackage) (err error) {
 	}
 
 	pv := gnostore.GetPackage(pkgPath, false)
-	if pv != nil && !pv.Private {
-		return ErrPkgAlreadyExists("package already exists: " + pkgPath)
+	if pv != nil {
+		if !pv.Private {
+			return ErrPkgAlreadyExists("package already exists: " + pkgPath)
+		}
+		// One binding for the ordinary redeploy and the inert park below.
+		//
+		// Waived during genesis delivery, as EnablePackage waives its policy,
+		// approver and pkg_hash gates: InitChain reproduces a record rather
+		// than granting it again, and there is no stranger there to refuse --
+		// genesis content is the chain's own. Live traffic is unaffected.
+		//
+		// Two things break without the waiver. A chain whose history holds a
+		// cross-address private redeploy -- the very transaction this rule now
+		// refuses -- stops replaying, so forking it either aborts at boot under
+		// the default PanicOnFailingTxResultHandler or, under
+		// -skip-failing-genesis-txs, comes up silently diverged from the chain
+		// it forked. And the hardfork migration path breaks for private realms:
+		// `gnogenesis fork addpkg` stamps its tx with --deployer, which matches
+		// the realm's original creator only when the source directory already
+		// carries an [addpkg] creator for LoadPackagesFromDir to pick up.
+		if !auth.IsGenesisReplay(ctx) {
+			liveGm, err := parseLiveGnomod(gnostore.GetMemPackage(pkgPath), pkgPath)
+			if err != nil {
+				return err
+			}
+			if err := checkRedeployPermission(liveGm, pkgPath, creator); err != nil {
+				return err
+			}
+		}
 	}
 	if !gno.IsRealmPath(pkgPath) && !gno.IsPPackagePath(pkgPath) {
 		return ErrInvalidPkgPath("package path must be valid realm or p package path")

--- a/gno.land/pkg/sdk/vm/keeper_inert.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert.go
@@ -112,16 +112,41 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	// carries no hash, and refusing it would fail every replayed enable. The
 	// bytes are already fixed by then in any case -- replay is not racing a
 	// submitter.
+	//
+	// gnomod.toml is parsed ONCE, here, and reused by every check below that
+	// needs it: the hash, the [addpkg] pin, the gnomod rule set, and the
+	// creator that becomes OriginCaller. Parsing before the hash rather than
+	// after it is also what makes the diagnosis honest -- an unparseable stored
+	// blob (a gnomod.toml that stampGnomod's re-encode pushed past
+	// gnomod's 4KB limit, say) would otherwise surface as a hash mismatch
+	// accusing the creator of swapping bytes, with an empty hash on the right.
+	gm, err := parseGnomodForHash(memPkg)
+	if err != nil {
+		return ErrInvalidPackage(err.Error())
+	}
 	if !replay {
 		if msg.PkgHash == "" {
 			return ErrInvalidPackage(
 				"missing pkg_hash: an approval has to name the source it approves")
 		}
-		if got := PackageContentHash(memPkg); got != msg.PkgHash {
+		if got := packageContentHash(memPkg, *gm); got != msg.PkgHash {
 			return ErrInvalidPackage(fmt.Sprintf(
 				"the parked source at %s is not what was approved "+
 					"(approved %s, parked %s); it changed after review",
 				msg.PkgPath, msg.PkgHash, got))
+		}
+		// The submission, not just the source. See MsgEnablePackage.PkgHeight:
+		// the hash cannot cover [addpkg], so without this a re-park keeps a
+		// standing approval alive while changing max_deposit under it.
+		//
+		// Optional, because zero is what every approval predating the field
+		// carries; an approver who pins nothing gets exactly the old behaviour.
+		if msg.PkgHeight != 0 && int64(gm.AddPkg.Height) != msg.PkgHeight {
+			return ErrInvalidPackage(fmt.Sprintf(
+				"the parked package at %s is not the submission that was approved "+
+					"(approved the one from height %d, parked one is from height %d); "+
+					"it was re-submitted after review",
+				msg.PkgPath, msg.PkgHeight, gm.AddPkg.Height))
 		}
 	}
 	// Refuse to activate over a package that is already live, applying exactly
@@ -158,15 +183,17 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	// Blob presence is an exact liveness test here: a parked package is stored
 	// under a different key prefix and is invisible to GetMemPackage, while a
 	// live one always has a production blob (hasProdGnoFile guarantees it at
-	// deploy). `private` comes from the same gnomod.toml the deploy stored.
-	gm, err := gnomod.ParseMemPackage(memPkg)
-	if err != nil {
-		return ErrInvalidPackage(err.Error())
-	}
+	// deploy). `private` comes from the same gnomod.toml the deploy stored --
+	// parsed once at the hash check above, not again here.
 	liveBlob := gnostore.GetMemPackage(msg.PkgPath)
 	priorPrivate := false
+	// Kept in scope for the creator binding below, which asks a second question
+	// of the same file. Parsing it twice would be one redundant decode of every
+	// live package's gnomod.toml on a consensus path.
+	var liveGm *gnomod.File
 	if liveBlob != nil {
-		liveGm, perr := gnomod.ParseMemPackage(liveBlob)
+		var perr error
+		liveGm, perr = gnomod.ParseMemPackage(liveBlob)
 		if perr != nil || !liveGm.Private {
 			return ErrPkgAlreadyExists("package already exists: " + msg.PkgPath)
 		}
@@ -211,8 +238,26 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 	// types every refusal about the blob that way, and keeps ErrInvalidPkgPath
 	// for the two that are about the path itself. AddPackage's default is the
 	// other way round because it is preserving the type it already returned.
+	//
+	// Before the creator binding below, as AddPackage validates the submission
+	// before reaching its own binding: the two halves of one deploy apply the
+	// same rules in the same order, which is the rule this function is built on.
 	if err := validateParkedBlob(memPkg); err != nil {
 		return ErrInvalidPackage(err.Error())
+	}
+
+	// Bind the private-replacement exemption to the live package's own creator,
+	// which AddPackage cannot do for a package parked before anything was live
+	// at the path: its binding then had nothing to compare against.
+	//
+	// Exempt on replay, like the policy, approver and pkg_hash gates above, and
+	// for the same reason: a fork reproduces a record rather than granting it
+	// again, and refusing here would make a chain unable to replay its own
+	// history. See the AddPackage call site.
+	if liveGm != nil && !replay {
+		if err := checkRedeployPermission(liveGm, msg.PkgPath, creator); err != nil {
+			return err
+		}
 	}
 
 	// Re-check namespace and CLA, which ran at SUBMIT against whatever was true
@@ -395,9 +440,19 @@ func (vm *VMKeeper) EnablePackage(ctx sdk.Context, msg MsgEnablePackage) (err er
 // and so did one parked under a policy that has since moved off "inert", which
 // no enable can ever activate.
 //
-// Either the creator or an approver may send it. Both have standing: the bytes
-// are the creator's, and declining them is the approver's job. Anyone else is
-// refused, or a stranger could clear a queue they have no part in.
+// The creator, an approver, or the owner of the live package at that path may
+// send it. The first two are obvious: the bytes are the creator's, and declining
+// them is the approver's job. Anyone else is refused, or a stranger could clear
+// a queue they have no part in.
+//
+// The live owner has standing because a parked blob at their path is a blob
+// nobody can act on and that only harms them. Once a private realm is live,
+// EnablePackage's creator binding refuses to activate a submission from any
+// other address, so a stranger's blob parked before the realm existed is dead
+// weight -- while AddPackage's creator-bound park guard still names that
+// stranger, so it blocks the OWNER's own redeploys for as long as it sits there.
+// Without this the only parties who could clear it are the squatter and an
+// approver, which leaves the owner's realm frozen with no move of their own.
 //
 // Not gated on the policy still being "inert". Cleanup is most needed exactly
 // when it is not: those packages are unactivatable and would otherwise be
@@ -417,10 +472,16 @@ func (vm *VMKeeper) RejectPackage(ctx sdk.Context, msg MsgRejectPackage) error {
 			"cannot read the parked package at %s: %v", msg.PkgPath, err))
 	}
 
+	// Ordered cheapest first, and && short-circuits, so the live blob is read
+	// only for a sender the two existing tests already refused. Rejecting as
+	// the creator or an approver costs exactly what it did before.
 	params := vm.GetParams(ctx)
-	if !approverGateSatisfied(ctx, params, msg.Sender) && gm.AddPkg.Creator != msg.Sender.String() {
+	if !approverGateSatisfied(ctx, params, msg.Sender) &&
+		gm.AddPkg.Creator != msg.Sender.String() &&
+		!isLivePackageOwner(gnostore, msg.PkgPath, msg.Sender) {
 		return std.ErrUnauthorized(fmt.Sprintf(
-			"address %s is neither a pkg approver nor the creator of %s",
+			"address %s is neither a pkg approver, the creator of %s, nor the "+
+				"owner of the live package there",
 			msg.Sender, msg.PkgPath))
 	}
 
@@ -473,6 +534,15 @@ const (
 	// submitted under. Reversible: returning to "inert" makes it enablable
 	// again, and nothing evicts the package meanwhile.
 	ReasonPolicyMoved = `the chain no longer runs the "inert" code submission policy`
+	// ReasonOwnerMismatch means the parked submission can never be enabled: a
+	// live PRIVATE package occupies the path and was deployed by a different
+	// address, and EnablePackage binds the replacement to that address.
+	//
+	// Terminal, unlike the reasons above -- no governance change makes it
+	// enablable. MsgRejectPackage from the creator, an approver or the live
+	// owner is the only way out.
+	ReasonOwnerMismatch = "a live private package at this path was deployed by a " +
+		"different address, so this submission can never be enabled"
 )
 
 // Package statuses reported by QueryPackageMeta.
@@ -497,7 +567,8 @@ type PackageMeta struct {
 	Height     int    `json:"height,omitempty"`
 	MaxDeposit string `json:"max_deposit,omitempty"`
 	// Reason says why a parked package is not live yet, in terms its submitter
-	// can act on. Empty unless Status is "inert".
+	// can act on. Set when Status is "inert", and also on a "live" path whose
+	// pending submission can never be enabled over it.
 	Reason string `json:"reason,omitempty"`
 	// Pending reports a parked submission awaiting an approver. It is always
 	// true for status "inert", and also true for a live PRIVATE realm with a
@@ -534,7 +605,15 @@ func (vm *VMKeeper) QueryPackageMeta(ctx sdk.Context, pkgPath string) (res strin
 		// Both key spaces are read even when the live one answers, or a
 		// redeploy parked over a live private realm would be invisible -- the
 		// case this query exists to make visible.
-		info.Pending = gnostore.GetInertPackage(pkgPath) != nil
+		if parked := gnostore.GetInertPackage(pkgPath); parked != nil {
+			info.Pending = true
+			// "Pending" alone reads as "an approver has yet to get to it". Say
+			// when no approver ever can: EnablePackage refuses a submission
+			// whose creator is not the live package's owner of record, so an
+			// oracle polling this would otherwise pay a flat fee per attempt on
+			// a refusal the chain could predict.
+			info.Reason = redeployBlockedReason(mpkg, parked)
+		}
 	} else if mpkg = gnostore.GetInertPackage(pkgPath); mpkg != nil {
 		info.Status = PackageStatusInert
 		info.Pending = true
@@ -575,6 +654,44 @@ func enableBlockedReason(params Params) string {
 	default:
 		return ReasonAwaitingApprover
 	}
+}
+
+// isLivePackageOwner reports whether addr is the creator stamped into the
+// package live at pkgPath. False when nothing is live there.
+//
+// Read through GetMemPackage, not GetPackage: loading the live PackageValue
+// populates the object cache, which nothing here needs and which the enable
+// path is careful to avoid. The stamped creator is in the stored blob.
+func isLivePackageOwner(gnostore gno.TransactionStore, pkgPath string, addr crypto.Address) bool {
+	live := gnostore.GetMemPackage(pkgPath)
+	if live == nil {
+		return false
+	}
+	liveGm, err := gnomod.ParseMemPackage(live)
+	if err != nil {
+		return false
+	}
+	return liveGm.AddPkg.Creator == addr.String()
+}
+
+// redeployBlockedReason reports why the blob parked at a path can never be
+// enabled over the package already live there, or "" if nothing rules it out.
+//
+// This is the one EnablePackage gate that cannot be answered from params alone,
+// which is why it does not live in enableBlockedReason: it is a fact about the
+// two blobs. A parse failure reports nothing rather than guessing -- a stored
+// package always carries a stamped gnomod.toml, so that is a corrupt store, and
+// QueryPackageMeta's job is to answer with what it can.
+func redeployBlockedReason(live, parked *std.MemPackage) string {
+	liveGm, lerr := gnomod.ParseMemPackage(live)
+	parkedGm, perr := gnomod.ParseMemPackage(parked)
+	if lerr != nil || perr != nil {
+		return ""
+	}
+	if liveGm.AddPkg.Creator != parkedGm.AddPkg.Creator {
+		return ReasonOwnerMismatch
+	}
+	return ""
 }
 
 // validateParkedBlob validates a stored blob, returning what

--- a/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_inert_guards_test.go
@@ -28,10 +28,12 @@ func approvalFor(t *testing.T, env testEnv, ctx sdk.Context, approver crypto.Add
 	t.Helper()
 	parked := env.vmk.getGnoTransactionStore(ctx).GetInertPackage(path)
 	require.NotNil(t, parked, "nothing parked at %s to approve", path)
+	hash, err := PackageContentHash(parked)
+	require.NoError(t, err)
 	return MsgEnablePackage{
 		Approver: approver,
 		PkgPath:  path,
-		PkgHash:  PackageContentHash(parked),
+		PkgHash:  hash,
 	}
 }
 
@@ -1584,6 +1586,128 @@ func TestEnableRefusesSourceChangedAfterApproval(t *testing.T) {
 	// Approving what is actually parked now still works: the check binds the
 	// approval to bytes, it does not freeze the path.
 	require.NoError(t, env.vmk.EnablePackage(ctx, approvalFor(t, env, ctx, approver, pkgPath)))
+}
+
+// TestEnableRefusesResubmissionWhenTheHeightIsPinned covers what the content
+// hash structurally cannot: a re-park of byte-identical sources.
+//
+// The hash is computed from the author's directory, which has no [addpkg]
+// section -- the keeper writes that. So a creator can re-submit the same files
+// with a lower max_deposit, keep the hash, and let the approver's transaction
+// pass the hash gate, run init(), and only then abort on the deposit. The
+// approver pays the gas; the creator can repeat it for the price of a submit.
+//
+// PkgHeight closes the class rather than the one field: any re-park lands at a
+// new height.
+func TestEnableRefusesResubmissionWhenTheHeightIsPinned(t *testing.T) {
+	const pkgPath = "gno.land/r/test/repinned"
+
+	files := func() []*std.MemFile {
+		return []*std.MemFile{
+			{Name: "gnomod.toml", Body: gnolang.GenGnoModLatest(pkgPath)},
+			{Name: "repinned.gno", Body: "package repinned\n\nfunc Who(cur realm) string { return \"same\" }"},
+		}
+	}
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("submitter"))
+	env, ctx := inertEnv(t, approver, creator)
+
+	require.NoError(t, env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, files())))
+	approval := approvalFor(t, env, ctx, approver, pkgPath)
+	parked := env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath)
+	submitGm, err := parseGnomodForHash(parked)
+	require.NoError(t, err)
+	approval.PkgHeight = int64(submitGm.AddPkg.Height)
+
+	// Re-park the SAME bytes, one block later, under a ceiling that cannot pay.
+	ctx = ctx.WithBlockHeader(&bft.Header{
+		ChainID: ctx.ChainID(), Height: ctx.BlockHeight() + 1,
+	})
+	regrief := NewMsgAddPackage(creator, pkgPath, files())
+	regrief.MaxDeposit = std.MustParseCoins("1ugnot")
+	require.NoError(t, env.vmk.AddPackage(ctx, regrief))
+
+	// The hash still matches -- that is the whole point of the height.
+	reparked := env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath)
+	reparkedGm, err := parseGnomodForHash(reparked)
+	require.NoError(t, err)
+	require.Equal(t, approval.PkgHash, packageContentHash(reparked, *reparkedGm),
+		"re-parking identical sources must not move the content hash")
+	require.Equal(t, "1ugnot", reparkedGm.AddPkg.MaxDeposit,
+		"but it does move the ceiling the approver would pay against")
+
+	err = env.vmk.EnablePackage(ctx, approval)
+	require.Error(t, err, "a pinned approval must not survive a re-submission")
+	assert.Contains(t, fmt.Sprintf("%+v", err), "re-submitted after review")
+
+	// An approver who pins nothing gets the old behaviour, so existing
+	// approvals and genesis history keep working.
+	unpinned := approval
+	unpinned.PkgHeight = 0
+	require.Error(t, env.vmk.EnablePackage(ctx, unpinned),
+		"unpinned, it gets past the hash gate and dies on the deposit instead")
+}
+
+// TestAddPackageRefusesUnsupportedGnoVersion pins that a version the toolchain
+// cannot compile is refused at SUBMIT, on the submitter's gas.
+//
+// ParseCheckGnoMod panics on one, and it is reached from the type checker --
+// which the inert submit branch never runs. So gno = "0.8" used to park
+// cleanly and detonate inside EnablePackage, on the approver's transaction, for
+// a mistake the submitter made.
+func TestAddPackageRefusesUnsupportedGnoVersion(t *testing.T) {
+	const pkgPath = "gno.land/r/test/oldver"
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("submitter"))
+	env, ctx := inertEnv(t, approver, creator)
+
+	err := env.vmk.AddPackage(ctx, NewMsgAddPackage(creator, pkgPath, []*std.MemFile{
+		{Name: "gnomod.toml", Body: "module = \"" + pkgPath + "\"\ngno = \"0.8\"\n"},
+		{Name: "oldver.gno", Body: "package oldver\n\nfunc Who(cur realm) string { return \"x\" }"},
+	}))
+	require.Error(t, err, "an unsupported gno version must not park")
+	assert.Contains(t, fmt.Sprintf("%+v", err), "unsupported gno version")
+
+	require.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath),
+		"nothing may be left parked for an approver to trip over")
+}
+
+// TestEnableRefusesGnomodChangedAfterApproval covers the metadata an author declares,
+// which must be bound to an approval just like Gno source.
+func TestEnableRefusesGnomodChangedAfterApproval(t *testing.T) {
+	const pkgPath = "gno.land/r/test/gnomodswapped"
+
+	filesFor := func(private bool) []*std.MemFile {
+		mod := gnolang.GenGnoModLatest(pkgPath)
+		if private {
+			mod += "\nprivate = true"
+		}
+		return []*std.MemFile{
+			{Name: "gnomod.toml", Body: mod},
+			{Name: "gnomodswapped.gno", Body: "package gnomodswapped\n\nfunc Who(cur realm) string { return \"same\" }"},
+		}
+	}
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	creator := crypto.AddressFromPreimage([]byte("submitter"))
+	env, ctx := inertEnv(t, approver, creator)
+
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(creator, pkgPath, filesFor(true))))
+	approval := approvalFor(t, env, ctx, approver, pkgPath)
+
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(creator, pkgPath, filesFor(false))))
+	err := env.vmk.EnablePackage(ctx, approval)
+	require.Error(t, err, "changing private after approval must invalidate the approval")
+	assert.Contains(t, fmt.Sprintf("%+v", err), "not what was approved")
+
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(creator, pkgPath, filesFor(true))))
+	require.NoError(t, env.vmk.EnablePackage(ctx, approval),
+		"restoring the approved private flag must restore the approved hash")
 }
 
 // TestEnableRequiresAHash pins that an approval must name a source at all.

--- a/gno.land/pkg/sdk/vm/keeper_private_redeploy_test.go
+++ b/gno.land/pkg/sdk/vm/keeper_private_redeploy_test.go
@@ -1,0 +1,452 @@
+package vm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// privateFilesFor builds a private realm at pkgPath whose init() records the
+// address that deployed it, plus a ledger value the caller picks so one version
+// can be told from another through a real MsgCall.
+//
+// Built fresh per submission: stampGnomod rewrites gnomod.toml in place through
+// SetFile, so a shared slice would carry one submitter's stamped creator into
+// the next.
+func privateFilesFor(pkgPath, name, ledger string) []*std.MemFile {
+	return []*std.MemFile{
+		// Name-sorted: "gnomod.toml" before any name starting past "g".
+		{Name: "gnomod.toml", Body: `module = "` + pkgPath + `"
+gno = "0.9"
+private = true`},
+		{Name: name + ".gno", Body: `package ` + name + `
+
+import "chain/runtime/unsafe"
+
+var (
+	owner  address
+	ledger = "` + ledger + `"
+)
+
+func init() { owner = unsafe.OriginCaller() }
+
+func Owner(cur realm) string         { return owner.String() }
+func Ledger(cur realm) string        { return ledger }
+func Record(cur realm, entry string) { ledger = entry }
+`},
+	}
+}
+
+// storedCreator reads back the creator the keeper stamped into the package
+// stored at pkgPath, which is the field that decides who init() runs as and who
+// pays the storage deposit.
+func storedCreator(t *testing.T, mpkg *std.MemPackage) string {
+	t.Helper()
+	require.NotNil(t, mpkg)
+	gm, err := gnomod.ParseMemPackage(mpkg)
+	require.NoError(t, err)
+	return gm.AddPkg.Creator
+}
+
+// TestVMKeeperPrivateRedeployIsCreatorBound pins that only the address that
+// deployed a live PRIVATE realm may replace it, on the ordinary path: one
+// MsgAddPackage under the default permissionless policy, with no approver and
+// nothing parked.
+//
+// The already-exists refusal waives itself for a private package
+// (`pv != nil && !pv.Private`), which asks what the live package is and never
+// who it belongs to, and the creator-bound guard beside it reads
+// GetInertPackage, so it covers bytes that are still PARKED and never a live
+// package. A stranger's submission therefore strips the live source, re-runs
+// init() with OriginCaller set to them -- which is what p/nt/ownable records as
+// owner -- and has stampGnomod record them as creator, while the realm keeps
+// its address, its coins and its callable surface.
+//
+// checkNamespacePermission is not that binding: it returns nil while
+// r/sys/names is undeployed or not Enable()d, and disabled is that realm's
+// compiled-in initial value, so it is the state this repo's genesis produces.
+func TestVMKeeperPrivateRedeployIsCreatorBound(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/privowned"
+		name    = "privowned"
+	)
+
+	owner := crypto.AddressFromPreimage([]byte("privownedowner"))
+	stranger := crypto.AddressFromPreimage([]byte("privownedstranger"))
+	// The reads below go through a real MsgCall signed by an unrelated funded
+	// address, so the owner's and the stranger's balances stay readable.
+	reader := crypto.AddressFromPreimage([]byte("privownedreader"))
+
+	env := setupTestEnv()
+	ctx := env.vmk.MakeGnoTransactionStore(env.ctx)
+	for _, addr := range []crypto.Address{owner, stranger, reader} {
+		acc := env.acck.NewAccountWithAddress(ctx, addr)
+		env.acck.SetAccount(ctx, acc)
+		require.NoError(t, env.bankk.SetCoins(ctx, addr, initialBalance))
+	}
+
+	// Pinned so the test cannot be read as being about the "inert" policy: if
+	// the shipped default ever moves, this says so instead of the test silently
+	// changing subject.
+	params := env.vmk.GetParams(ctx)
+	require.Equal(t, CodeSubmissionPolicyPermissionless, params.CodeSubmissionPolicy)
+	require.Empty(t, params.PkgApprovers, "no approver takes part in this redeploy")
+
+	read := func(fn string) string {
+		t.Helper()
+		res, err := env.vmk.Call(ctx, NewMsgCall(reader, nil, pkgPath, fn, nil))
+		require.NoError(t, err)
+		return res
+	}
+	live := func() *std.MemPackage {
+		return env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)
+	}
+	quoted := func(s string) string { return fmt.Sprintf("(%q string)\n\n", s) }
+
+	// The owner deploys their private realm and puts state in it.
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+	_, err := env.vmk.Call(ctx, NewMsgCall(owner, nil, pkgPath, "Record", []string{"owner entry"}))
+	require.NoError(t, err)
+
+	require.Equal(t, owner.String(), storedCreator(t, live()))
+	require.Equal(t, quoted(owner.String()), read("Owner"),
+		"precondition: init() recorded the owner")
+	require.Equal(t, quoted("owner entry"), read("Ledger"),
+		"precondition: the realm holds state written after the deploy")
+
+	t.Run("a stranger cannot redeploy over a live private realm", func(t *testing.T) {
+		err := env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "seized")))
+		require.Error(t, err, "a third party must not be able to replace a live private realm")
+		assert.True(t, errors.Is(err, PkgExistError{}))
+		// The refusal has to name the live creator, as the parked-blob one
+		// does: Error() alone is the generic "package already exists" that a
+		// public path returns too, and the detail rides the wrapped trace into
+		// the ABCI log.
+		assert.Contains(t, fmt.Sprintf("%+v", err), owner.String(),
+			"the refusal must name the address the realm belongs to")
+
+		assert.Equal(t, owner.String(), storedCreator(t, live()),
+			"the live package must still record the owner as creator")
+		assert.Equal(t, quoted(owner.String()), read("Owner"),
+			"init() must not re-run with the stranger as OriginCaller")
+		assert.Equal(t, quoted("owner entry"), read("Ledger"),
+			"the state the owner wrote must stay reachable")
+		assert.Contains(t, live().GetFile(name+".gno").Body, `ledger = "v1"`,
+			"qfile must keep serving the owner's source at the owner's path")
+	})
+
+	t.Run("the owner may still redeploy", func(t *testing.T) {
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v2"))),
+			"replacing one's own private realm is what the exemption is for")
+
+		assert.Contains(t, live().GetFile(name+".gno").Body, `ledger = "v2"`,
+			"the redeployed source must be the one that is stored")
+		assert.Equal(t, owner.String(), storedCreator(t, live()))
+		assert.Equal(t, quoted(owner.String()), read("Owner"),
+			"init() ran again, as the owner")
+	})
+}
+
+// TestVMKeeperInertPrivateRedeployIsCreatorBound pins the same binding on the
+// inert path, where the takeover needs no policy change of its own: parking is
+// permissionless, and PackageContentHash resets the [addpkg] section the keeper
+// stamps -- creator included -- so byte-identical source parked by a DIFFERENT
+// address yields the digest the approver already signed off on for the owner.
+// (MsgEnablePackage.PkgHeight can pin the submission, but it is optional, and an
+// approval that does not carry it is exactly this case.)
+//
+// EnablePackage ends with DelInertPackage, so after every successful enable the
+// parked slot is empty and the creator-bound guard over PARKED bytes has
+// nothing to compare against.
+func TestVMKeeperInertPrivateRedeployIsCreatorBound(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/privinert"
+		name    = "privinert"
+	)
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	alice := crypto.AddressFromPreimage([]byte("privinertalice"))
+	bob := crypto.AddressFromPreimage([]byte("privinertbob"))
+	env, ctx := inertEnv(t, approver, alice, bob)
+
+	// Alice parks her private realm and the approver activates it.
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(alice, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+	require.NoError(t, env.vmk.EnablePackage(ctx,
+		approvalFor(t, env, ctx, approver, pkgPath)))
+	require.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath),
+		"precondition: the enable emptied the parked slot")
+	require.Equal(t, alice.String(),
+		storedCreator(t, env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)))
+
+	t.Run("a stranger cannot park over a live private realm", func(t *testing.T) {
+		err := env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(bob, pkgPath, privateFilesFor(pkgPath, name, "seized")))
+		require.Error(t, err, "a third party must not be able to queue a replacement")
+		assert.True(t, errors.Is(err, PkgExistError{}))
+		assert.Contains(t, fmt.Sprintf("%+v", err), alice.String(),
+			"the refusal must name the address the realm belongs to")
+
+		assert.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath),
+			"nothing may be left parked for an approver to activate")
+	})
+
+	t.Run("the owner may still park and activate a replacement", func(t *testing.T) {
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(alice, pkgPath, privateFilesFor(pkgPath, name, "v2"))))
+		require.NoError(t, env.vmk.EnablePackage(ctx,
+			approvalFor(t, env, ctx, approver, pkgPath)))
+
+		stored := env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)
+		require.NotNil(t, stored)
+		assert.Contains(t, stored.GetFile(name+".gno").Body, `ledger = "v2"`)
+		assert.Equal(t, alice.String(), storedCreator(t, stored))
+	})
+}
+
+// TestVMKeeperEnableCannotRedeployAnotherAddressesPrivateRealm pins the binding
+// on the branch AddPackage cannot cover: a package parked BEFORE anything was
+// live at the path, activated after somebody else deployed there.
+//
+// The parked and the live blob are both private, so the private-override rule
+// passes and the creator binding is the only thing that refuses. EnablePackage
+// parses the live gnomod to decide whether the path may be replaced at all, and
+// reads the parked one for the identity init() runs as.
+func TestVMKeeperEnableCannotRedeployAnotherAddressesPrivateRealm(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/privstale"
+		name    = "privstale"
+	)
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	stranger := crypto.AddressFromPreimage([]byte("privstaleparker"))
+	owner := crypto.AddressFromPreimage([]byte("privstaleowner"))
+	env, ctx := inertEnv(t, approver, stranger, owner)
+
+	// 1. Nothing is live, so nothing binds the park: the stranger parks a
+	//    private package and it is never approved.
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "seized"))))
+
+	// 2. Governance opens the chain and the owner deploys a private realm at
+	//    that path through the now-open ordinary path.
+	params := DefaultParams()
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyPermissionless
+	params.PkgApprovers = []crypto.Address{approver}
+	env.vmk.SetParams(ctx, params)
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+
+	// 3. Back to inert, so the refusal below is the creator binding and not
+	//    EnablePackage's policy check.
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyInert
+	env.vmk.SetParams(ctx, params)
+
+	err := env.vmk.EnablePackage(ctx, approvalFor(t, env, ctx, approver, pkgPath))
+	require.Error(t, err, "an approver's routine enable must not hand over a live private realm")
+	assert.True(t, errors.Is(err, PkgExistError{}))
+	assert.Contains(t, fmt.Sprintf("%+v", err), owner.String(),
+		"the refusal must name the address the realm belongs to")
+
+	stored := env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)
+	require.NotNil(t, stored)
+	assert.Contains(t, stored.GetFile(name+".gno").Body, `ledger = "v1"`,
+		"the owner's live source must survive the enable")
+	assert.Equal(t, owner.String(), storedCreator(t, stored))
+}
+
+// TestVMKeeperPrivateRedeployReplaysAtGenesis pins that the binding is waived
+// for every transaction InitChain delivers, on both call sites.
+//
+// EnablePackage already waives its policy, approver and pkg_hash gates on
+// replay, on the rule that a fork reproduces a record rather than granting it
+// again. The creator binding is a fourth gate of the same kind, and enforcing it
+// during replay would mean a chain that took a cross-address private redeploy
+// under the old binary can no longer replay its own history: the boot aborts
+// under the default PanicOnFailingTxResultHandler, or comes up silently diverged
+// under -skip-failing-genesis-txs. It would also refuse the hardfork migration
+// path, whose transaction is stamped with `gnogenesis fork addpkg --deployer`
+// rather than the realm's original creator.
+func TestVMKeeperPrivateRedeployReplaysAtGenesis(t *testing.T) {
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	owner := crypto.AddressFromPreimage([]byte("replayowner"))
+	stranger := crypto.AddressFromPreimage([]byte("replaystranger"))
+
+	t.Run("AddPackage", func(t *testing.T) {
+		const (
+			pkgPath = "gno.land/r/test/zreplayadd"
+			name    = "zreplayadd"
+		)
+		env, ctx := inertEnv(t, approver, owner, stranger)
+		params := DefaultParams()
+		params.CodeSubmissionPolicy = CodeSubmissionPolicyPermissionless
+		env.vmk.SetParams(ctx, params)
+		// InitChain marks every transaction it delivers, including a fresh
+		// chain's own genesis txs.
+		ctx = ctx.WithValue(auth.GenesisReplayKey{}, true)
+		require.True(t, auth.IsGenesisReplay(ctx))
+
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "v2"))),
+			"replay must reproduce a redeploy the source chain accepted")
+
+		stored := env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)
+		assert.Contains(t, stored.GetFile(name+".gno").Body, `ledger = "v2"`,
+			"the replayed source is the one that ends up stored")
+		assert.Equal(t, stranger.String(), storedCreator(t, stored))
+	})
+
+	t.Run("EnablePackage", func(t *testing.T) {
+		const (
+			pkgPath = "gno.land/r/test/zreplayenable"
+			name    = "zreplayenable"
+		)
+		env, ctx := inertEnv(t, approver, owner, stranger)
+
+		// The stranger parks while nothing is live, then the owner deploys
+		// there through the ordinary path -- the state AddPackage's binding
+		// cannot see.
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "v2"))))
+		params := DefaultParams()
+		params.CodeSubmissionPolicy = CodeSubmissionPolicyPermissionless
+		params.PkgApprovers = []crypto.Address{approver}
+		env.vmk.SetParams(ctx, params)
+		require.NoError(t, env.vmk.AddPackage(ctx,
+			NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+
+		approval := approvalFor(t, env, ctx, approver, pkgPath)
+		ctx = ctx.WithValue(auth.GenesisReplayKey{}, true)
+		require.NoError(t, env.vmk.EnablePackage(ctx, approval),
+			"replay must reproduce an enable the source chain accepted")
+
+		stored := env.vmk.getGnoTransactionStore(ctx).GetMemPackage(pkgPath)
+		assert.Equal(t, stranger.String(), storedCreator(t, stored))
+	})
+}
+
+// TestVMKeeperRejectUnjamsASquattedPrivatePath pins that the owner of a live
+// private realm can clear a parked blob squatting their path.
+//
+// Reachable state: a stranger parks while nothing is live, the policy moves to
+// permissionless, the owner deploys a private realm there, and the policy
+// returns to inert. That blob can never be enabled -- which is what
+// TestVMKeeperEnableCannotRedeployAnotherAddressesPrivateRealm pins -- but
+// AddPackage's parked-blob guard still names its submitter, so it blocks the
+// OWNER's redeploys for as long as it sits there. Before the binding an
+// approver's enable consumed it, which was the takeover; the owner needs a move
+// of their own or the realm is frozen.
+func TestVMKeeperRejectUnjamsASquattedPrivatePath(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/zsquatted"
+		name    = "zsquatted"
+	)
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	stranger := crypto.AddressFromPreimage([]byte("zsquattedstranger"))
+	owner := crypto.AddressFromPreimage([]byte("zsquattedowner"))
+	bystander := crypto.AddressFromPreimage([]byte("zsquattedbystander"))
+	env, ctx := inertEnv(t, approver, stranger, owner, bystander)
+
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "squat"))))
+
+	params := DefaultParams()
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyPermissionless
+	params.PkgApprovers = []crypto.Address{approver}
+	env.vmk.SetParams(ctx, params)
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyInert
+	env.vmk.SetParams(ctx, params)
+
+	// Precondition: the squat blocks the owner's own redeploy.
+	require.Error(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v2"))),
+		"precondition: the parked blob blocks the owner")
+
+	// A bystander still has no standing.
+	require.Error(t, env.vmk.RejectPackage(ctx,
+		MsgRejectPackage{Sender: bystander, PkgPath: pkgPath}),
+		"standing is not open to anyone who asks")
+	require.NotNil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath))
+
+	// The live owner may clear it, and can then ship their own upgrade.
+	require.NoError(t, env.vmk.RejectPackage(ctx,
+		MsgRejectPackage{Sender: owner, PkgPath: pkgPath}),
+		"the owner of the live package may clear a blob squatting their path")
+	assert.Nil(t, env.vmk.getGnoTransactionStore(ctx).GetInertPackage(pkgPath))
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v2"))),
+		"with the squat cleared the owner is no longer frozen")
+}
+
+// TestQueryPackageMetaFlagsAnUnenablableRedeploy pins that vm/qpkgmeta_json
+// tells "an approver has yet to get to it" from "no approver ever can".
+//
+// enableBlockedReason answers from params alone and so cannot see this gate; an
+// oracle polling a pending submission would otherwise pay a flat fee per attempt
+// on a refusal the chain can predict.
+func TestQueryPackageMetaFlagsAnUnenablableRedeploy(t *testing.T) {
+	const (
+		pkgPath = "gno.land/r/test/zmetajam"
+		name    = "zmetajam"
+	)
+
+	approver := crypto.AddressFromPreimage([]byte("oracle"))
+	stranger := crypto.AddressFromPreimage([]byte("zmetajamstranger"))
+	owner := crypto.AddressFromPreimage([]byte("zmetajamowner"))
+	env, ctx := inertEnv(t, approver, stranger, owner)
+
+	meta := func(t *testing.T) PackageMeta {
+		t.Helper()
+		raw, err := env.vmk.QueryPackageMeta(ctx, pkgPath)
+		require.NoError(t, err)
+		var got PackageMeta
+		require.NoError(t, json.Unmarshal([]byte(raw), &got))
+		return got
+	}
+
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(stranger, pkgPath, privateFilesFor(pkgPath, name, "squat"))))
+	require.Equal(t, ReasonAwaitingApprover, meta(t).Reason,
+		"precondition: nothing is live yet, so this one is genuinely enablable")
+
+	params := DefaultParams()
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyPermissionless
+	params.PkgApprovers = []crypto.Address{approver}
+	env.vmk.SetParams(ctx, params)
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v1"))))
+
+	got := meta(t)
+	assert.Equal(t, PackageStatusLive, got.Status)
+	assert.True(t, got.Pending, "the stranger's blob is still parked")
+	assert.Equal(t, ReasonOwnerMismatch, got.Reason,
+		"a pending submission no approver can enable must say so")
+
+	// The owner's own parked redeploy is enablable, so it carries no reason.
+	require.NoError(t, env.vmk.RejectPackage(ctx,
+		MsgRejectPackage{Sender: owner, PkgPath: pkgPath}))
+	params.CodeSubmissionPolicy = CodeSubmissionPolicyInert
+	env.vmk.SetParams(ctx, params)
+	require.NoError(t, env.vmk.AddPackage(ctx,
+		NewMsgAddPackage(owner, pkgPath, privateFilesFor(pkgPath, name, "v2"))))
+	got = meta(t)
+	assert.True(t, got.Pending)
+	assert.Empty(t, got.Reason, "the owner's own pending redeploy is not blocked")
+}

--- a/gno.land/pkg/sdk/vm/msgs.go
+++ b/gno.land/pkg/sdk/vm/msgs.go
@@ -292,6 +292,28 @@ type MsgEnablePackage struct {
 	// anywhere else would renumber the fields above and change how every
 	// existing transaction decodes.
 	PkgHash string `json:"pkg_hash" yaml:"pkg_hash"`
+	// PkgHeight pins the SUBMISSION being approved, as AddPkg.Height recorded
+	// it at submit.
+	//
+	// PkgHash covers what the author's directory declares. It cannot cover the
+	// [addpkg] section, because the approver's local copy does not have one --
+	// the keeper writes it. So a creator can re-park byte-identical sources and
+	// keep the hash while changing creator, height and max_deposit. Lowering
+	// max_deposit under a standing approval is the sharp end: the enable passes
+	// the hash gate, runs init(), and only then aborts on the deposit, so the
+	// approver pays gas for a transaction that could never have succeeded, and
+	// the creator can repeat it for the price of a submission.
+	//
+	// Pinning the height closes the whole class rather than one field at a
+	// time: every re-park lands at a new height, so any of them invalidates the
+	// approval, including a creator swap after a MsgRejectPackage.
+	//
+	// Zero means unpinned. That is what every transaction predating this field
+	// decodes as, and what genesis replay carries, so it cannot be required
+	// here -- see the replay exemptions in EnablePackage.
+	//
+	// Appended last, for the reason above.
+	PkgHeight int64 `json:"pkg_height" yaml:"pkg_height"`
 }
 
 var _ std.Msg = MsgEnablePackage{}

--- a/gno.land/pkg/sdk/vm/msgs_test.go
+++ b/gno.land/pkg/sdk/vm/msgs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
@@ -532,5 +533,33 @@ func TestMsgEnablePackage(t *testing.T) {
 		// The ante handler and the session deny-list both key off these.
 		assert.Equal(t, "vm", MsgEnablePackage{}.Route())
 		assert.Equal(t, "enable_package", MsgEnablePackage{}.Type())
+	})
+
+	t.Run("every field survives the wire", func(t *testing.T) {
+		t.Parallel()
+
+		// A field the BINARY encoding drops is not a cosmetic bug: the signer
+		// signs GetSignBytes (JSON) over the full message, the node recomputes
+		// it from what it decoded, and the two differ -- so the transaction is
+		// rejected as "signature verification failed; verify correct account,
+		// sequence, and chain-id", naming none of the three.
+		//
+		// The binary path is generated (pb3_gen.go, `make -C misc/genproto2`),
+		// so adding a field to this struct without regenerating produces
+		// exactly that. PkgHeight shipped that way until an integration test
+		// caught it.
+		msg := MsgEnablePackage{
+			Approver:  approver,
+			PkgPath:   path,
+			PkgHash:   "deadbeef",
+			PkgHeight: 999,
+		}
+		bz, err := amino.Marshal(msg)
+		require.NoError(t, err)
+		var back MsgEnablePackage
+		require.NoError(t, amino.Unmarshal(bz, &back))
+		assert.Equal(t, msg, back)
+		assert.Equal(t, msg.GetSignBytes(), back.GetSignBytes(),
+			"what the node verifies must be what the approver signed")
 	})
 }

--- a/gno.land/pkg/sdk/vm/pb3_gen.go
+++ b/gno.land/pkg/sdk/vm/pb3_gen.go
@@ -681,6 +681,18 @@ func (goo *MsgAddPackage) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDepth
 
 func (goo MsgEnablePackage) MarshalBinary2(cdc *amino.Codec, buf []byte, offset int) (int, error) {
 	var err error
+	if goo.PkgHeight != 0 {
+		{
+			before := offset
+			offset = amino.PrependVarint(buf, offset, int64(goo.PkgHeight))
+			valueLen := before - offset
+			if valueLen > 1 || (valueLen == 1 && buf[offset] != 0x00) {
+				offset = amino.PrependFieldNumberAndTyp3(buf, offset, 4, amino.Typ3Varint)
+			} else {
+				offset = before
+			}
+		}
+	}
 	if goo.PkgHash != "" {
 		{
 			before := offset
@@ -743,6 +755,9 @@ func (goo MsgEnablePackage) SizeBinary2(cdc *amino.Codec) (int, error) {
 	if goo.PkgHash != "" {
 		s += 1 + amino.UvarintSize(uint64(len(goo.PkgHash))) + len(goo.PkgHash)
 	}
+	if goo.PkgHeight != 0 {
+		s += 1 + amino.VarintSize(int64(goo.PkgHeight))
+	}
 	return s, nil
 }
 
@@ -795,6 +810,16 @@ func (goo *MsgEnablePackage) UnmarshalBinary2(cdc *amino.Codec, bz []byte, anyDe
 			}
 			bz = bz[n:]
 			goo.PkgHash = string(v)
+		case 4:
+			if typ3 != amino.Typ3Varint {
+				return fmt.Errorf("field 4: expected typ3 %v, got %v", amino.Typ3Varint, typ3)
+			}
+			v, n, err := amino.DecodeVarint(bz)
+			if err != nil {
+				return err
+			}
+			bz = bz[n:]
+			goo.PkgHeight = int64(v)
 		default:
 			return fmt.Errorf("unknown field number %d for MsgEnablePackage", fnum)
 		}

--- a/gno.land/pkg/sdk/vm/pkghash.go
+++ b/gno.land/pkg/sdk/vm/pkghash.go
@@ -7,11 +7,55 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-// gnomodFileName is excluded from the content hash. See PackageContentHash.
+// gnomodFileName is normalized before hashing. See PackageContentHash.
 const gnomodFileName = "gnomod.toml"
+
+// keeperOwnedGnomod resets every gnomod.toml field the keeper writes at submit
+// to the value both sides of an approval can derive on their own.
+//
+// It is the inverse of stampGnomod, and the two have to agree exactly: the
+// approver hashes the source directory, the keeper hashes the blob it stamped,
+// and any field the keeper writes that this does not reset makes the two hashes
+// disagree forever. That is not hypothetical -- stampGnomod also rewrites
+// Module, which the first version of this normalization missed, and a package
+// whose gnomod.toml declared a module other than its deploy path could then
+// never be enabled by anyone.
+//
+// So stampGnomod calls this rather than repeating the list. Adding a
+// keeper-owned field is one edit here, and both sides pick it up.
+// TestPackageContentHashSurvivesTheRealStamp is what holds them together.
+func keeperOwnedGnomod(gm *gnomod.File, pkgPath string) {
+	// The deploy path wins over whatever the author declared; nothing on the
+	// submit path requires the two to match.
+	gm.Module = pkgPath
+	// Keeper bookkeeping in a file the submitter authors. Reset wholesale
+	// rather than field by field: anything left standing here is
+	// attacker-supplied. See MsgEnablePackage.PkgHeight for what covers the
+	// values themselves, which an approver's local copy cannot know.
+	gm.AddPkg = gnomod.AddPkg{}
+}
+
+// parseGnomodForHash parses the gnomod.toml that PackageContentHash covers.
+//
+// Deliberately not gnomod.ParseMemPackage, which falls back to the deprecated
+// gno.mod. checkGnomodConstraints refuses gno.mod outright, so a package
+// carrying one can never be stored -- but the fallback still parses it here,
+// and then the substitution below finds no file named gnomod.toml and hashes
+// the raw gno.mod bytes instead. The result is a confident hash over a file the
+// chain will never hold. Refusing it names the real problem, and `gno mod tidy`
+// is the fix.
+func parseGnomodForHash(mpkg *std.MemPackage) (*gnomod.File, error) {
+	f := mpkg.GetFile(gnomodFileName)
+	if f == nil {
+		return nil, fmt.Errorf("%s: no %s (run 'gno mod tidy' if this package still carries gno.mod)",
+			mpkg.Path, gnomodFileName)
+	}
+	return gnomod.ParseBytes(f.Name, []byte(f.Body))
+}
 
 // PackageContentHash identifies the source an approver signed off on.
 //
@@ -20,22 +64,52 @@ const gnomodFileName = "gnomod.toml"
 // retry after a failed enable. Without naming the bytes, an approver who read
 // GOOD can be made to activate EVIL.
 //
-// gnomod.toml is excluded deliberately. AddPackage stamps the creator, height
-// and declared deposit into it at submit, so the stored file differs from the
-// one the submitter sent and from the one an approver saw in the transaction --
-// the two could never agree on a hash that included it. stampGnomod writes that
-// file and touches nothing else, which is what makes excluding it sufficient:
-// every byte an approver reviews is still covered, and the gnomod rules are
-// re-applied from the stored file at enable anyway.
+// gnomod.toml is parsed and re-encoded canonically after keeperOwnedGnomod
+// resets what the keeper stamps at submit. That makes the submitter's copy and
+// the stored copy agree while still binding the fields the AUTHOR declares --
+// private, draft, ignore, replace and the gno version -- which excluding the
+// file outright did not. A realm approved as private could otherwise be
+// re-parked as public with the same .gno files and the same hash, and
+// checkGnomodConstraints does not catch it on a first deployment: its guard is
+// `priorPrivate && !gm.Private`, and priorPrivate is false when nothing is live
+// at the path yet.
+//
+// What it does NOT bind is the [addpkg] section itself, and that is a limit of
+// the -pkgdir flow rather than an oversight: the approver's local copy has no
+// [addpkg] section to compare against, because the keeper writes it. A re-park
+// with byte-identical sources therefore keeps this hash while changing creator,
+// height and max_deposit. MsgEnablePackage.PkgHeight is what closes that.
 //
 // Each field is length-prefixed so that adjacent names and bodies cannot be
 // re-cut to collide -- without it, a file "ab" holding "c" and a file "a"
 // holding "bc" would hash alike.
-func PackageContentHash(mpkg *std.MemPackage) string {
+//
+// Returns an error rather than an empty hash: the empty string is also what a
+// message carrying no approval at all decodes to, and both CLI callers would
+// otherwise sign one.
+func PackageContentHash(mpkg *std.MemPackage) (string, error) {
+	gm, err := parseGnomodForHash(mpkg)
+	if err != nil {
+		return "", err
+	}
+	return packageContentHash(mpkg, *gm), nil
+}
+
+// packageContentHash is PackageContentHash for a caller that has already parsed
+// the file, so an enable does not decode the same blob twice.
+//
+// gm is taken BY VALUE: keeperOwnedGnomod mutates it, and EnablePackage needs
+// its own copy intact afterwards -- it reads AddPkg.Creator to decide
+// OriginCaller. The value copy is enough because every field reset here is a
+// value type; Replace is shared with the caller and never written.
+func packageContentHash(mpkg *std.MemPackage, gm gnomod.File) string {
+	keeperOwnedGnomod(&gm, mpkg.Path)
+	canonical := gm.WriteString()
+
 	files := make([]*std.MemFile, 0, len(mpkg.Files))
 	for _, f := range mpkg.Files {
 		if f.Name == gnomodFileName {
-			continue
+			f = &std.MemFile{Name: f.Name, Body: canonical}
 		}
 		files = append(files, f)
 	}

--- a/gno.land/pkg/sdk/vm/pkghash_test.go
+++ b/gno.land/pkg/sdk/vm/pkghash_test.go
@@ -1,0 +1,190 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/gno/gnovm/pkg/gnomod"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+// TestPackageContentHashNormalizesGnomod pins the two halves of what the hash
+// has to do at once: ignore the bookkeeping the keeper stamps, so the
+// submitter's copy and the stored copy agree, and notice the fields the author
+// declares, so an approval of a private realm cannot be cashed in on a public
+// one.
+func TestPackageContentHashNormalizesGnomod(t *testing.T) {
+	const pkgPath = "gno.land/r/test/pkghash"
+
+	pkgFor := func(gm gnomod.File) *std.MemPackage {
+		return &std.MemPackage{Path: pkgPath, Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: gm.WriteString()},
+			{Name: "pkghash.gno", Body: "package pkghash"},
+		}}
+	}
+
+	approved := gnomod.File{
+		Module:  pkgPath,
+		Gno:     "0.9",
+		Private: true,
+		AddPkg: gnomod.AddPkg{
+			Creator:    "g1first",
+			Height:     42,
+			MaxDeposit: "100ugnot",
+		},
+	}
+	restamped := approved
+	restamped.AddPkg = gnomod.AddPkg{
+		Creator:    "g1second",
+		Height:     99,
+		MaxDeposit: "200ugnot",
+	}
+
+	approvedHash, err := PackageContentHash(pkgFor(approved))
+	require.NoError(t, err)
+	require.NotEmpty(t, approvedHash)
+
+	restampedHash, err := PackageContentHash(pkgFor(restamped))
+	require.NoError(t, err)
+	assert.Equal(t, approvedHash, restampedHash,
+		"keeper-stamped metadata must not affect the approval hash")
+
+	// The module line is keeper-owned too: stampGnomod rewrites it to the
+	// deploy path, and nothing on the submit path requires the author to have
+	// written the same value.
+	renamed := approved
+	renamed.Module = "gno.land/r/test/somethingelse"
+	renamedHash, err := PackageContentHash(pkgFor(renamed))
+	require.NoError(t, err)
+	assert.Equal(t, approvedHash, renamedHash,
+		"a module line the keeper will rewrite must not affect the approval hash")
+
+	changed := approved
+	changed.Private = false
+	changedHash, err := PackageContentHash(pkgFor(changed))
+	require.NoError(t, err)
+	assert.NotEqual(t, approvedHash, changedHash,
+		"author-declared metadata must affect the approval hash")
+}
+
+// TestPackageContentHashSurvivesTheRealStamp is the property the whole
+// normalization exists for, checked against stampGnomod itself rather than
+// against an imitation of it.
+//
+// The approver hashes a source directory; the keeper hashes the blob it stamped
+// from that directory. Any field stampGnomod writes that keeperOwnedGnomod does
+// not reset makes the two disagree forever, and the package can then never be
+// enabled by anybody -- with an error that says the source changed after review
+// when nothing changed. Module is exactly that field, and it shipped green
+// through a test that appended a hand-written [addpkg] section instead of
+// calling the stamp.
+//
+// So this calls the stamp. A future field added to stampGnomod fails here.
+func TestPackageContentHashSurvivesTheRealStamp(t *testing.T) {
+	const pkgPath = "gno.land/r/test/stamped"
+
+	// Built fresh per case: stampGnomod rewrites gnomod.toml in place.
+	pkgFor := func(module string) *std.MemPackage {
+		return &std.MemPackage{Name: "stamped", Path: pkgPath, Files: []*std.MemFile{
+			{Name: "gnomod.toml", Body: "module = \"" + module + "\"\ngno = \"0.9\"\n"},
+			{Name: "stamped.gno", Body: "package stamped"},
+		}}
+	}
+
+	for _, module := range []string{
+		pkgPath,
+		// A copy-pasted template whose module line was never updated. The
+		// chain accepts it: stampGnomod overwrites the value and nothing
+		// upstream of it compares the two.
+		"gno.land/r/test/template",
+	} {
+		t.Run(module, func(t *testing.T) {
+			mpkg := pkgFor(module)
+			approver, err := PackageContentHash(mpkg)
+			require.NoError(t, err)
+
+			gm, err := parseGnomodForHash(mpkg)
+			require.NoError(t, err)
+			stampGnomod(gm, mpkg, pkgPath, crypto.AddressFromPreimage([]byte("c")), 42, "100ugnot")
+
+			keeper, err := PackageContentHash(mpkg)
+			require.NoError(t, err)
+			assert.Equal(t, approver, keeper,
+				"the approver's hash must survive the stamp, or the package can never be enabled")
+		})
+	}
+}
+
+// TestPackageContentHashIsPinned freezes the digest for a fully-populated
+// gnomod.toml.
+//
+// The hash is a canonical TOML re-encode, so it moves whenever gnomod.File
+// gains or reorders a field, or whenever tm2/pkg/toml's encoder changes -- none
+// of which look like consensus changes at the call site that makes them. When
+// it moves, every parked package's expected hash moves with it: approvals
+// prepared offline with `enablepkg -broadcast=false`, and any hash an operator
+// recorded for `-pkg-hash`, are refused with "it changed after review" though
+// nothing changed, and a gnokey or gpao built off the validators' commit
+// computes a different hash for identical bytes.
+//
+// That is a coordinated upgrade, not a golden update. If this fails, decide
+// that deliberately and write it down; do not just paste the new value in.
+func TestPackageContentHashIsPinned(t *testing.T) {
+	const pinned = "47b0005e2d817770b8a4071bfd28dab1e80375dcaa7d167044ac78d8ffa01045"
+
+	mpkg := &std.MemPackage{
+		Name: "pinned",
+		Path: "gno.land/r/test/pinned",
+		Files: []*std.MemFile{
+			{Name: "pinned.gno", Body: "package pinned\n\nfunc Who(cur realm) string { return \"x\" }\n"},
+			{Name: "gnomod.toml", Body: "" +
+				"module = \"gno.land/r/test/pinned\"\n" +
+				"gno = \"0.9\"\n" +
+				"ignore = true\n" +
+				"draft = true\n" +
+				"private = true\n" +
+				"[addpkg]\n" +
+				"creator = \"g1stamped\"\n" +
+				"height = 7\n" +
+				"max_deposit = \"5ugnot\"\n"},
+		},
+	}
+
+	got, err := PackageContentHash(mpkg)
+	require.NoError(t, err)
+	assert.Equal(t, pinned, got,
+		"the approval hash moved; see this test's comment before changing the constant")
+}
+
+// TestPackageContentHashRejectsMalformedGnomod pins that a package whose
+// gnomod.toml cannot be read produces an ERROR rather than an empty hash.
+//
+// The empty string is also what a message carrying no approval decodes to, so
+// returning it in band let both CLI callers build and sign an approval naming
+// no source at all -- refused on chain, after the fee, with a message about the
+// transaction rather than about the directory the operator got wrong.
+func TestPackageContentHashRejectsMalformedGnomod(t *testing.T) {
+	malformed := &std.MemPackage{Path: "gno.land/r/test/pkghash", Files: []*std.MemFile{
+		{Name: "gnomod.toml", Body: "module = ["},
+		{Name: "pkghash.gno", Body: "package pkghash"},
+	}}
+	h, err := PackageContentHash(malformed)
+	require.Error(t, err)
+	assert.Empty(t, h)
+
+	// Nor may the deprecated gno.mod stand in. gnomod.ParseMemPackage accepts
+	// it, which would leave the parse succeeding while the substitution below
+	// matched nothing and hashed the raw bytes -- a confident hash over a file
+	// checkGnomodConstraints guarantees the chain will never hold.
+	legacy := &std.MemPackage{Path: "gno.land/r/test/pkghash", Files: []*std.MemFile{
+		{Name: "gno.mod", Body: "module gno.land/r/test/pkghash\n"},
+		{Name: "pkghash.gno", Body: "package pkghash"},
+	}}
+	h, err = PackageContentHash(legacy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gno mod tidy")
+	assert.Empty(t, h)
+}

--- a/gno.land/pkg/sdk/vm/vm.proto
+++ b/gno.land/pkg/sdk/vm/vm.proto
@@ -35,6 +35,7 @@ message m_enable_pkg {
 	string approver = 1;
 	string pkg_path = 2;
 	string pkg_hash = 3;
+	sint64 pkg_height = 4;
 }
 
 message m_reject_pkg {

--- a/gnovm/cmd/calibrate/gen_native_table.py
+++ b/gnovm/cmd/calibrate/gen_native_table.py
@@ -23,11 +23,44 @@ Usage:
     python3 gen_native_table.py native_bench_output.txt
 """
 import argparse
+import math
 import re
 import sys
 from collections import defaultdict
 
 import numpy as np
+
+
+# Mirrors modExpWork in gnovm/pkg/gnolang/native_gas.go. Keep in sync; the
+# runtime and the fitter must compute the same metric, or the fitter reduces
+# each bench to a work value the runtime never charges on and the slope it
+# emits is scaled by the ratio between the two. TestModExpConstantsMatchFitter
+# in gnovm/pkg/gnolang reads this file and asserts the constants agree.
+MODEXP_FLOOR_WORDS = 65
+MODEXP_WORD_BYTES = 8
+MODEXP_MONT_SETUP = 38
+MODEXP_MONT_PER_WORD = 160
+MODEXP_GENERIC_PER_BIT = 5
+
+
+def modexp_work(exp_len, mod_len):
+    """Modular multiplications big.Int.Exp performs — see SizeModExpWork.
+
+    One machine word of exponent decides the routine: the generic
+    square-and-multiply loop at or below it (one squaring, multiply and full
+    division per bit), the windowed Montgomery loop above it (a fixed setup
+    plus 5 steps per 4-bit window, walking whole words so a ragged length
+    rounds up).
+    """
+    if exp_len <= 0 or mod_len <= 0:
+        return 0
+    unit = MODEXP_FLOOR_WORDS + ((mod_len + 7) // 8) ** 2
+    if exp_len <= MODEXP_WORD_BYTES:
+        units = MODEXP_GENERIC_PER_BIT * 8 * exp_len
+    else:
+        ewords = (exp_len + MODEXP_WORD_BYTES - 1) // MODEXP_WORD_BYTES
+        units = MODEXP_MONT_SETUP + MODEXP_MONT_PER_WORD * ewords
+    return units * unit
 
 
 # Per-native spec.
@@ -179,8 +212,8 @@ NATIVE_SPECS = [
     # ---- IBC crypto stdlibs ----
     ("crypto/keccak256", "sum256", 0, "LenBytes",
      r"BenchmarkNative_Keccak256_Sum256_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
-    ("crypto/modexp", "modExp", 2, "LenBytes",
-     r"BenchmarkNative_ModExp_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
+    # crypto/modexp is NOT here — it is fitted separately by fit_modexp, which
+    # takes upper bounds rather than least squares. See MODEXP_SPEC.
     ("crypto/bn254", "g1Add", None, "Flat",
      r"BenchmarkNative_BN254_G1Add-\d+\s+\d+\s+([\d.]+)\s+ns/op"),
     ("crypto/bn254", "g1Mul", None, "Flat",
@@ -262,6 +295,99 @@ def parse_bench(path):
                 ns = float(m.group(2))
                 var_data[(pkg, fn)][size].append(ns)
     return var_data, flat_data
+
+
+# crypto/modexp is fitted on its own because its coefficients are UPPER BOUNDS
+# over the grid, not least squares. A central fit sits below cost on about half
+# the grid, which is fine for describing a cost and wrong for charging one.
+#
+# Matches the grid benches, NOT the symmetric BenchmarkNative_ModExp_N series:
+# fitting the symmetric diagonal is what hid the asymmetric cost originally.
+#
+# Format: (pkg, fn, exponent param index, regex over (expLen, modLen, ns))
+MODEXP_SPEC = ("crypto/modexp", "modExp", 1,
+               r"BenchmarkNative_ModExpGrid_(\d+)_(\d+)-\d+\s+\d+\s+([\d.]+)\s+ns/op")
+
+# Applied on top of the measured upper bound. The grid samples a surface rather
+# than covering it, and bench-to-bench variance on a shared machine is a few
+# percent; without headroom the thinnest grid point ships at exactly 1.00x.
+MODEXP_MARGIN = 1.2
+
+
+def parse_bench_modexp(path):
+    """Parse ModExpGrid rows: (expLen, modLen) -> list of ns observations."""
+    _, _, _, regex = MODEXP_SPEC
+    grid = defaultdict(list)
+    for line in open(path).read().splitlines():
+        m = re.search(regex, line)
+        if m:
+            grid[(int(m.group(1)), int(m.group(2)))].append(float(m.group(3)))
+    return grid
+
+
+def _round_up_2sf(x):
+    """Round up to two significant figures, so the table carries a readable
+    constant rather than the last digit of a benchmark. Always rounds up, so
+    rounding can never take a coefficient below the bound it came from."""
+    if x <= 0:
+        return 0
+    mag = 10.0 ** (math.floor(math.log10(x)) - 1)
+    return int(math.ceil(x / mag) * mag)
+
+
+def fit_modexp(grid, hw_factor=1.0):
+    """Upper-bound fit for crypto/modexp. Returns a row dict, or None.
+
+    Three coefficients, fitted in dependency order, each the maximum the grid
+    demands rather than the mean:
+
+      slope2  ns per byte of modulus. Taken from the expLen=0 points, which do
+              no exponentiation at all and so isolate the cost of converting the
+              operands and building the result — a cost linear in len(modulus)
+              that the work metric deliberately does not model.
+      base    the intercept of that same line.
+      slope   ns per modular multiplication, from max over every remaining point
+              of (ns - dispatcher(modLen)) / work(expLen, modLen).
+
+    hw_factor scales the measurements onto reference hardware. The benches are
+    rarely run on the reference Xeon, and a fit taken on a faster machine is an
+    undercharge everywhere unless it is projected first.
+    """
+    zero = {m: float(np.median(v)) * hw_factor for (e, m), v in grid.items() if e == 0}
+    rest = {(e, m): float(np.median(v)) * hw_factor
+            for (e, m), v in grid.items() if e > 0}
+    if len(zero) < 2 or not rest:
+        return None
+
+    mods = np.array(sorted(zero), dtype=float)
+    ns0 = np.array([zero[int(m)] for m in mods], dtype=float)
+    coeffs, *_ = np.linalg.lstsq(
+        np.column_stack([np.ones(len(mods)), mods]), ns0, rcond=None)
+    base, per_byte = float(coeffs[0]), max(float(coeffs[1]), 0.0)
+    # Lift the line until it covers every expLen=0 point. It is a charge, not a
+    # description, so it may sit above the data but never below it.
+    lift = float(np.max(ns0 / np.maximum(base + per_byte * mods, 1e-9)))
+    base, per_byte = max(base, 0.0) * lift, per_byte * lift
+
+    needed, worst = 0.0, None
+    for (e, m), ns in rest.items():
+        w = modexp_work(e, m)
+        if not w:
+            continue
+        r = max(ns - (base + per_byte * m), 0.0) / w
+        if r > needed:
+            needed, worst = r, (e, m)
+    if worst is None:
+        return None
+
+    return {
+        "pkg": MODEXP_SPEC[0], "fn": MODEXP_SPEC[1], "shape": "modexp",
+        "idx": MODEXP_SPEC[2],
+        "base": _round_up_2sf(base * MODEXP_MARGIN),
+        "slope": _round_up_2sf(needed * MODEXP_MARGIN * 1024),
+        "slope2": _round_up_2sf(per_byte * MODEXP_MARGIN * 1024),
+        "worst": worst, "npoints": len(grid), "hw_factor": hw_factor,
+    }
 
 
 def parse_bench_pair(path):
@@ -358,6 +484,8 @@ def n_desc(kind, slope_idx):
         "NumCallFrames":    "m.NumCallFrames()",
         "ReturnLen":        f"len(return[{slope_idx}])",
         "SliceTotalBytes":  f"sum_inner_len(p{slope_idx})",
+        "ModExpWork":       (f"modmuls(len(p{slope_idx})) * "
+                             f"({MODEXP_FLOOR_WORDS} + words(p{slope_idx + 1})^2)"),
     }[kind]
 
 
@@ -402,6 +530,22 @@ def emit_go_table(rows, out):
     out.write("// See gnovm/cmd/calibrate/native_gas_formulas.md for derivation.\n")
     out.write("var calibratedNativeGas = []nativeGasEntry{\n")
     for r in rows:
+        if r["shape"] == "modexp":
+            we, wm = r["worst"]
+            out.write(
+                f'\t{{Pkg: "{r["pkg"]}", Fn: "{r["fn"]}", '
+                f'Base: {r["base"]}, '
+                f'Slope: {r["slope"]}, '
+                f'SlopeIdx: {r["idx"]}, '
+                f'SlopeKind: SizeModExpWork, '
+                f'Slope2: {r["slope2"]}, '
+                f'Slope2Idx: {r["idx"] + 1}, '
+                f'Slope2Kind: SizeLenBytes}},'
+                f' // upper bound over {r["npoints"]} ModExpGrid points'
+                f' (x{r["hw_factor"]} to reference, +{int((MODEXP_MARGIN - 1) * 100)}% margin);'
+                f' thinnest at expLen={we}/modLen={wm}\n'
+            )
+            continue
         if r["shape"] == "flat":
             out.write(
                 f'\t{{Pkg: "{r["pkg"]}", Fn: "{r["fn"]}", '
@@ -626,11 +770,19 @@ def main():
     ap.add_argument("--go-out", default="native_gas_table.go.txt")
     ap.add_argument("--plot", default="native_gas_fits.png")
     ap.add_argument("--no-plot", action="store_true")
+    ap.add_argument(
+        "--hw-factor", type=float, default=1.0,
+        help="Scale crypto/modexp measurements onto the reference Xeon 8168. "
+             "Leave at 1.0 only when the benches were run on it; otherwise a fit "
+             "taken on a faster machine undercharges everywhere. Anchor it on a "
+             "row already calibrated on the reference — see the recorded run in "
+             "ibc_native_bench_test.go.")
     args = ap.parse_args()
 
     var_data, flat_data = parse_bench(args.bench_file)
     pair_data = parse_bench_pair(args.bench_file)
     two_d_data = parse_bench_2d(args.bench_file)
+    modexp_grid = parse_bench_modexp(args.bench_file)
 
     rows = []
     for pkg, fn, slope_idx, kind, _ in NATIVE_SPECS:
@@ -657,6 +809,21 @@ def main():
                 rows.append({"pkg": pkg, "fn": fn, "shape": "linear",
                              "base": base, "slope": slope, "r2": r2,
                              "slope_idx": slope_idx, "kind": kind})
+
+    # crypto/modexp: upper-bound fit, not least squares.
+    if modexp_grid:
+        mrow = fit_modexp(modexp_grid, args.hw_factor)
+        if mrow is None:
+            print("WARN: ModExpGrid needs at least two expLen=0 points and one "
+                  "priced point; crypto/modexp row not emitted", file=sys.stderr)
+        else:
+            rows.append(mrow)
+            if args.hw_factor == 1.0:
+                print("NOTE: crypto/modexp fitted with --hw-factor 1.0 — correct "
+                      "only if these benches ran on the reference Xeon 8168",
+                      file=sys.stderr)
+    else:
+        print("WARN: no ModExpGrid bench lines found", file=sys.stderr)
 
     # Pair fits (two byte-slice params, one shared per-byte rate).
     for pkg, fn, idx_a, idx_b, kind, _ in NATIVE_SPECS_PAIR:

--- a/gnovm/cmd/calibrate/ibc_native_bench_test.go
+++ b/gnovm/cmd/calibrate/ibc_native_bench_test.go
@@ -39,34 +39,99 @@ func BenchmarkNative_Keccak256_Sum256_16384(b *testing.B) { benchKeccak256(b, 16
 
 // ----- crypto/modexp.modExp(base, exp, modulus []byte) []byte -----
 //
-// Modular exponentiation cost is dominated by len(exp)·len(mod). The
-// EVM precompile (EIP-198) gas formula uses similar scaling. We bench
-// a square modulus and a square exponent so a single-slope fit on
-// "size N" (== len(mod) == len(exp) == len(base)) captures the dominant term.
+// Modular exponentiation performs one modular squaring per exponent bit, each
+// costing O(words(mod)²), so its cost is a product of two operands rather than
+// a sum. It is priced with SizeModExpWork, which folds that product into a
+// single metric (see gnovm/pkg/gnolang/native_gas.go):
+//
+//	work = (modular multiplications expNN performs) · (floor + ceil(len(mod)/8)²)
+//
+// Cost is NOT linear in 8·len(exp)·words², which is what this row charged on
+// before the grid was extended. Two effects that metric did not model dominate
+// at small exponents:
+//
+//   - The exponent regime. big.Int only takes the windowed Montgomery path when
+//     the exponent exceeds one machine word (nat.go: `if len(y) > 1 && !slow`).
+//     At 8 bytes or fewer it runs the generic loop, which divides on every
+//     iteration rather than reducing in Montgomery form — ~2.5x the cost per
+//     exponent bit. And the Montgomery loop walks whole words, so 9 bytes of
+//     exponent costs what 16 does. Under the old metric 8/256 measured MORE
+//     than 9/256 while being charged less.
+//   - The dispatcher floor. Converting the operands and building the result is
+//     linear in len(modulus) and entirely independent of the exponent, so at
+//     small exponents it dominates a work term that is near zero. The exp=0 row
+//     isolates it: 55us at a 1024-byte modulus for work=0.
+//
+// Both are now modelled rather than fitted around: the work metric counts the
+// operations each expNN routine performs (see gnovm/pkg/gnolang/native_gas.go)
+// and the row carries a second slope on len(modulus) for the dispatcher. So a
+// re-fit is a single number — ns per modular multiplication — and the grid
+// exists to check that it bounds every point rather than to fit a shape.
+// gen_native_table.py's fit_modexp does exactly that; pass --hw-factor unless
+// the run was taken on the reference Xeon.
+//
+// Both operands must stay at or below crypto/modexp.maxOperandLen (1024): above
+// it X_modExp returns immediately and the bench would time the rejection path.
+//
+// RECORDED RUN — this is the calibration input for the shipped row, committed
+// so the row can be re-derived rather than taken on faith. AMD Ryzen 7 7840U,
+// -benchtime=100ms -count=5, median; run-to-run spread was 1.02-1.19x at every
+// point but one (9/32, 1.32x). This is NOT the reference Xeon and is materially
+// faster than it: rows in this same table calibrated on a reference-class Xeon
+// measure 2.19-2.33x faster here (cometbls.verifyZKP 2632556 -> 1204572,
+// bn254.pairingCheck 792691 -> 361591 at one pair and 1798041 -> 772655 at
+// four, and modexp's own superseded anchor 6219920 -> 2686662). The shipped row
+// projects by 2.3, the HIGH end: a larger factor charges more, so the high end
+// is the safe choice, not the low one.
+//
+// These supersede a pre-#97 run. Data-backing byte slices changed what the
+// dispatcher costs: Go2GnoValue no longer builds one TypedValue per byte, so
+// the exponent-independent per-modulus-byte term fell from ~134 ns/byte to
+// ~2.9. Any grid recorded before that commit overstates the dispatcher by ~50x
+// and must not be mixed with these.
+//
+//	 exp    mod    work            ns/op      ns/work
+//	0      32     0                      520          -
+//	0      256    0                      768          -
+//	0      1024   0                    1,716          -
+//	1      256    43560               30,436      0.699
+//	1      1024   657960             240,084      0.365
+//	3      256    130680              98,887      0.757
+//	3      1024   1973880            792,236      0.401
+//	4      32     12960                8,454      0.652
+//	4      256    174240             123,890      0.711
+//	4      1024   2631840          1,102,211      0.419
+//	8      32     25920               15,168      0.585
+//	8      256    348480             239,457      0.687
+//	8      1024   5263680          2,088,169      0.397
+//	9      32     28998               17,203      0.593
+//	9      256    389862             210,814      0.541
+//	9      1024   5888742          2,612,594      0.444
+//	16     256    389862             198,277      0.509
+//	24     256    564102             278,681      0.494
+//	32     32     54918               24,218      0.441
+//	32     256    738342             352,113      0.477
+//	32     1024   11152422         4,641,969      0.416
+//	256    32     417798             165,587      0.396
+//	256    1024   84843942        35,314,846      0.416
+//	1024   32     1661958            724,654      0.436
+//	1024   256    22344102        10,771,770      0.482
+//	1024   1024   337500582       131,967,026      0.391
+//
+// The ns/work column still carries the dispatcher cost, which the row's second
+// slope handles separately. Net of it the Montgomery points (exp > 8) hold to
+// within a small factor of each other across a 128x range of exponent sizes,
+// which is the check that the operation count matches the algorithm. The
+// generic points (exp <= 8) are the ragged ones — nat.div's cost per word is
+// set by hardware divide latency rather than a multiplication count, so that
+// branch's constant is calibrated rather than counted.
 
+// benchModExp is the symmetric diagonal, len(base)==len(exp)==len(mod)==n. Kept
+// because the shipped slope is anchored to its N=256 point.
 func benchModExp(b *testing.B, n int) {
 	b.Helper()
-	base := make([]byte, n)
-	exp := make([]byte, n)
-	mod := make([]byte, n)
-	for i := range n {
-		base[i] = byte(i + 1)
-		exp[i] = byte(i + 3)
-		mod[i] = 0xFF // large odd modulus
-	}
-	if n > 0 {
-		mod[n-1] = 0xFD
-	}
-	m := newDispatchMachine(3)
-	setBlockValueFromGo(m, 0, base)
-	setBlockValueFromGo(m, 1, exp)
-	setBlockValueFromGo(m, 2, mod)
-	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
-	b.ResetTimer()
 	b.SetBytes(int64(n))
-	for i := 0; i < b.N; i++ {
-		h.call()
-	}
+	benchModExpGrid(b, n, n)
 }
 
 func BenchmarkNative_ModExp_32(b *testing.B)  { benchModExp(b, 32) }
@@ -74,6 +139,92 @@ func BenchmarkNative_ModExp_64(b *testing.B)  { benchModExp(b, 64) }
 func BenchmarkNative_ModExp_128(b *testing.B) { benchModExp(b, 128) }
 func BenchmarkNative_ModExp_256(b *testing.B) { benchModExp(b, 256) }
 func BenchmarkNative_ModExp_512(b *testing.B) { benchModExp(b, 512) }
+
+// benchModExpGrid varies the exponent and modulus lengths independently. The
+// base is held at the modulus length: a base wider than the modulus only adds
+// the initial reduction, which the work metric deliberately does not model
+// separately (maxOperandLen bounds it instead).
+func benchModExpGrid(b *testing.B, expLen, modLen int) {
+	b.Helper()
+	base := make([]byte, modLen)
+	exp := make([]byte, expLen)
+	mod := make([]byte, modLen)
+	for i := range base {
+		base[i] = byte(i + 1)
+	}
+	for i := range exp {
+		// Worst case for the metric, which charges on len(exp). Below the
+		// Montgomery crossover big.Int walks the exponent bit by bit from the
+		// highest set one (nat.go expNN: shift := nlz(v)+1), squaring every
+		// iteration and multiplying again on each set bit — so an all-ones
+		// exponent maximizes both the iteration count and the multiplies, and
+		// is the only fill whose true bit length equals the charged one. A
+		// patterned fill measures up to 1.75x cheaper at 4 bytes, which would
+		// fit a slope that is not an upper bound. Above the crossover the
+		// windowed Montgomery loop does 4 squarings plus one multiply per
+		// 4-bit window whatever the window holds, so the fill is irrelevant
+		// there and costs those points nothing.
+		exp[i] = 0xFF
+	}
+	for i := range mod {
+		mod[i] = 0xFF // large odd modulus
+	}
+	if modLen > 0 {
+		mod[modLen-1] = 0xFD
+	}
+	m := newDispatchMachine(3)
+	setBlockValueFromGo(m, 0, base)
+	setBlockValueFromGo(m, 1, exp)
+	setBlockValueFromGo(m, 2, mod)
+	h := &dispatchHarness{m: m, wrapper: resolveWrapper(b, "crypto/modexp", "modExp"), nReturns: 1}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.call()
+	}
+}
+
+// Grid naming is ModExpGrid_<expLen>_<modLen>. Sweeps small-exp/large-mod (the
+// RSA-verify shape), large-exp/small-mod (the shape the old slope priced at
+// zero), and the symmetric corner at the 1024-byte cap.
+func BenchmarkNative_ModExpGrid_4_32(b *testing.B)      { benchModExpGrid(b, 4, 32) }
+func BenchmarkNative_ModExpGrid_4_256(b *testing.B)     { benchModExpGrid(b, 4, 256) }
+func BenchmarkNative_ModExpGrid_4_1024(b *testing.B)    { benchModExpGrid(b, 4, 1024) }
+func BenchmarkNative_ModExpGrid_32_32(b *testing.B)     { benchModExpGrid(b, 32, 32) }
+func BenchmarkNative_ModExpGrid_32_256(b *testing.B)    { benchModExpGrid(b, 32, 256) }
+func BenchmarkNative_ModExpGrid_32_1024(b *testing.B)   { benchModExpGrid(b, 32, 1024) }
+func BenchmarkNative_ModExpGrid_256_32(b *testing.B)    { benchModExpGrid(b, 256, 32) }
+func BenchmarkNative_ModExpGrid_256_1024(b *testing.B)  { benchModExpGrid(b, 256, 1024) }
+func BenchmarkNative_ModExpGrid_1024_32(b *testing.B)   { benchModExpGrid(b, 1024, 32) }
+func BenchmarkNative_ModExpGrid_1024_256(b *testing.B)  { benchModExpGrid(b, 1024, 256) }
+func BenchmarkNative_ModExpGrid_1024_1024(b *testing.B) { benchModExpGrid(b, 1024, 1024) }
+
+// The sub-word band. big.Int only takes the windowed Montgomery path when the
+// exponent exceeds one machine word (nat.go: `if len(y) > 1 && !slow`), so an
+// exponent of 8 bytes or fewer runs the generic loop, which reduces by division
+// on every iteration instead. That is the more expensive regime per exponent
+// bit, and the grid above jumps 4 -> 32 straight over it, so the shipped slope
+// was fit without a single measurement of the band where it is thinnest. 8 and
+// 9 bracket the crossover; 3 is the RSA-verify shape (e=65537).
+//
+// expLen=0 is charged nothing by the work metric, while the native still
+// allocates and fills len(modulus) bytes and the dispatcher still converts
+// each operand. These points isolate that cost so it can be priced on its own
+// slope rather than hidden in Base.
+func BenchmarkNative_ModExpGrid_0_32(b *testing.B)   { benchModExpGrid(b, 0, 32) }
+func BenchmarkNative_ModExpGrid_0_256(b *testing.B)  { benchModExpGrid(b, 0, 256) }
+func BenchmarkNative_ModExpGrid_0_1024(b *testing.B) { benchModExpGrid(b, 0, 1024) }
+func BenchmarkNative_ModExpGrid_1_256(b *testing.B)  { benchModExpGrid(b, 1, 256) }
+func BenchmarkNative_ModExpGrid_1_1024(b *testing.B) { benchModExpGrid(b, 1, 1024) }
+func BenchmarkNative_ModExpGrid_3_256(b *testing.B)  { benchModExpGrid(b, 3, 256) }
+func BenchmarkNative_ModExpGrid_3_1024(b *testing.B) { benchModExpGrid(b, 3, 1024) }
+func BenchmarkNative_ModExpGrid_8_32(b *testing.B)   { benchModExpGrid(b, 8, 32) }
+func BenchmarkNative_ModExpGrid_8_256(b *testing.B)  { benchModExpGrid(b, 8, 256) }
+func BenchmarkNative_ModExpGrid_8_1024(b *testing.B) { benchModExpGrid(b, 8, 1024) }
+func BenchmarkNative_ModExpGrid_9_32(b *testing.B)   { benchModExpGrid(b, 9, 32) }
+func BenchmarkNative_ModExpGrid_9_256(b *testing.B)  { benchModExpGrid(b, 9, 256) }
+func BenchmarkNative_ModExpGrid_9_1024(b *testing.B) { benchModExpGrid(b, 9, 1024) }
+func BenchmarkNative_ModExpGrid_16_256(b *testing.B) { benchModExpGrid(b, 16, 256) }
+func BenchmarkNative_ModExpGrid_24_256(b *testing.B) { benchModExpGrid(b, 24, 256) }
 
 // ----- crypto/bn254 EIP-196/197 precompile natives -----
 

--- a/gnovm/pkg/gnolang/native_gas.go
+++ b/gnovm/pkg/gnolang/native_gas.go
@@ -24,7 +24,155 @@ const (
 	SizeNumCallFrames   NativeGasSize = 4 // m.NumCallFrames(); idx ignored
 	SizeReturnLen       NativeGasSize = 5 // len(return[idx]); POST-CALL only (legacy name kept; functionally identical to SizeLenSlice but reads the return stack)
 	SizeSliceTotalBytes NativeGasSize = 6 // sum of inner element lengths for a []string or []byte-slice; works pre- and post-call
+	SizeModExpWork      NativeGasSize = 7 // modular-exponentiation work from an (exponent, modulus) pair at param[idx], param[idx+1]; PRE-CALL only
 )
+
+// Modular exponentiation is the one native shipping today whose cost is a
+// genuine product of two parameters rather than a sum, so it cannot be
+// expressed by Base + Slope*N1 + Slope2*N2 over two independent lengths.
+// SizeModExpWork collapses the product into a single metric that the ordinary
+// single-slope machinery can then price linearly.
+//
+// big.Int.Exp performs one modular squaring per exponent bit (plus windowed
+// multiplies), each costing O(words(modulus)^2) word-multiplications on top of
+// a per-iteration overhead that does not scale with the modulus. So:
+//
+//	work = bits(exponent) * (modExpFloorWords + words(modulus)^2)
+//
+// The floor term is what makes a single metric safe across the whole operand
+// range: measured against Go's big.Int, the per-exponent-bit cost is ~82ns at a
+// 32-byte modulus but ~1274ns at 256 bytes — a pure words^2 metric implies a
+// coefficient varying ~5x across that range, which either undercharges small
+// moduli or overcharges large ones. modExpFloorWords is that overhead expressed
+// in units of words^2, so one coefficient covers both regimes.
+//
+// bits(exponent) is a charged quantity, not the operand's true bit length: it
+// needs no read of the operand's bytes, and matches EIP-2565's use of exp_len
+// for the high part of the exponent. A zero-padded exponent is therefore
+// overcharged, which is the safe direction — and a zero-filled exponent is
+// exactly the cheap-to-build DoS operand, so charging for its length is correct
+// rather than merely conservative. It is NOT simply 8*len(exp): big.Int runs
+// two different routines either side of a one-word exponent and they differ
+// ~2.5x per bit, so one linear coefficient cannot bound both. modExpWork
+// documents where each applies.
+//
+// What this metric deliberately does not model is the cost of converting the
+// operands and building the result, which is linear in len(modulus) and runs
+// even when there is no exponentiation at all. That belongs to a second,
+// independent slope on the modulus parameter — see the crypto/modexp row in
+// gnovm/stdlibs/native_gas.go. Leaving it to Base instead makes the charge for
+// a zero-length exponent independent of the modulus, which is a hole: the call
+// still allocates and fills len(modulus) bytes.
+const (
+	// modExpFloorWords is the per-exponent-bit overhead of big.Int.Exp
+	// expressed in words(modulus)^2 units. Derived as the ratio of the
+	// modulus-independent to the quadratic coefficient; being a ratio it
+	// should carry across hardware better than an absolute ns figure.
+	modExpFloorWords = 65
+
+	// modExpWordBytes is one machine word of exponent, the threshold that
+	// decides which of big.Int's two exponentiation routines runs. expNN
+	// takes the windowed Montgomery path only when the exponent exceeds one
+	// word (nat.go: `if len(y) > 1 && !slow`); at or below that it runs the
+	// generic square-and-multiply loop, which reduces by full division on
+	// every iteration rather than in Montgomery form.
+	modExpWordBytes = 8
+
+	// The Montgomery path's operation count, read off nat.go's
+	// expNNMontgomery rather than fitted. Units are modular multiplications;
+	// one Montgomery step is two of them (the product, then the REDC
+	// reduction), so each count below is doubled.
+	//
+	//	powers table    2 + 14 loop iterations = 16 steps
+	//	RR setup        one 2n-by-n division   ~  2 steps
+	//	final convert                          =  1 step
+	//	main loop       words(exp) x 16 windows x (4 squarings + 1 multiply)
+	//
+	// Being counts of a fixed algorithm rather than a curve fit, these need no
+	// re-derivation on new hardware — only the slope converting units to
+	// nanoseconds does. Over the recorded grid the Montgomery points hold to
+	// 1.39x of each other across a 128x range of exponent sizes.
+	modExpMontSetup   = 2 * (16 + 2 + 1)
+	modExpMontPerWord = 2 * (16 * 5)
+
+	// modExpGenericPerBit is the same count for the generic loop, which runs
+	// one squaring, one multiply and one full division per exponent bit. The
+	// first two are ~1.5 units; division is the rest. It is calibrated rather
+	// than counted because nat.div's cost per word is set by hardware divide
+	// latency, not by a multiplication count — the algorithmic estimate is
+	// ~3.25 and the benches want 5.
+	modExpGenericPerBit = 5
+
+	// modExpWorkSaturation clamps the metric. Gas is charged before the
+	// native runs, so this function sees operand lengths before
+	// crypto/modexp rejects oversized ones — and maxAllocTx allows a 500MB
+	// slice, whose product would wrap int64. Any value this large already
+	// prices four orders of magnitude beyond the block gas limit, so clamping
+	// can never make an expensive call look cheap.
+	//
+	// The binding constraint is not this function but chargeNativeGas's
+	// unguarded `gi.Slope * N`. This clamp leaves room for a slope up to 2^19
+	// before that product leaves int64, where a negative cost would refund gas
+	// for the most expensive call possible.
+	// TestModExpWorkSlopeProductFitsInt64 pins the headroom.
+	modExpWorkSaturation = 1 << 44
+)
+
+// modExpWork counts the modular multiplications big.Int.Exp will perform for
+// the given operand lengths, in units of one multiplication at words(modulus).
+// It saturates rather than wrapping.
+//
+// It is a count of a known algorithm, not a curve fitted to a benchmark. Every
+// branch expNN takes is decided by the operand lengths alone, so the count is
+// exact up to the cost model for a single multiplication — which is where
+// modExpFloorWords comes in, and which is the only part needing re-derivation
+// on new hardware. A fitted slope has to bound both of big.Int's routines with
+// one coefficient and cannot: they differ ~2.5x per exponent bit, so any single
+// line either underprices sub-word exponents or overcharges ordinary ones
+// several fold.
+//
+// Clamping each factor before multiplying is what keeps this overflow-safe. A
+// factor can only be clamped at a size where the metric already saturates, so
+// clamping never lowers the result below what the true count would charge.
+// maxOperandLenForWork also keeps (n+7) from wrapping — unclamped, that
+// addition silently yields a negative word count at n=MaxInt64.
+func modExpWork(expLen, modLen int64) int64 {
+	if expLen <= 0 || modLen <= 0 {
+		// A zero-length exponent means exponent 0 (Exp returns immediately);
+		// a zero-length modulus short-circuits in X_modExp. Neither runs the
+		// exponentiation loop, so neither owes anything on this metric — but
+		// both still pay the row's per-modulus-byte slope, which is what
+		// covers converting the operands and building the result.
+		return 0
+	}
+	const maxOperandLenForWork = 1 << 28
+	words := (min(modLen, maxOperandLenForWork) + 7) / 8
+	unit := words*words + modExpFloorWords
+
+	// One machine word of exponent decides the routine. At or below it expNN
+	// runs the generic loop, one squaring + multiply + full division per
+	// exponent bit. Above it expNNMontgomery runs, and its loop walks whole
+	// words — `for i := len(y)-1; i >= 0; i--`, all 16 windows of each,
+	// including a partly-filled top word — so a 9-byte exponent does the same
+	// work as a 16-byte one and must not be charged less.
+	var units int64
+	if expLen <= modExpWordBytes {
+		units = modExpGenericPerBit * 8 * expLen
+	} else {
+		ew := (min(expLen, maxOperandLenForWork) + modExpWordBytes - 1) / modExpWordBytes
+		units = modExpMontSetup + modExpMontPerWord*ew
+	}
+	if units > modExpWorkSaturation/unit {
+		return modExpWorkSaturation
+	}
+	return units * unit
+}
+
+// ModExpWork exposes the metric to gnovm/stdlibs, whose gas table owns the
+// crypto/modexp row and whose guard test asserts against it. One definition
+// means a change to the model cannot leave that test checking a different
+// quantity than the runtime charges.
+func ModExpWork(expLen, modLen int64) int64 { return modExpWork(expLen, modLen) }
 
 // NativeGasInfo is the per-function gas descriptor.
 //
@@ -167,6 +315,14 @@ func (m *Machine) nativeSizeFromBlock(kind NativeGasSize, idx int8) int64 {
 	if idx < 0 {
 		return 0
 	}
+	if kind == SizeModExpWork {
+		// Reads a pair: exponent at idx, modulus at idx+1.
+		vals := m.LastBlock().Values
+		if int(idx)+1 >= len(vals) {
+			return 0
+		}
+		return modExpWork(int64(vals[idx].GetLength()), int64(vals[idx+1].GetLength()))
+	}
 	tv := &m.LastBlock().Values[idx]
 	return nativeSizeOf(tv, kind, m.Store)
 }
@@ -191,6 +347,13 @@ func nativeSizeOf(tv *TypedValue, kind NativeGasSize, store Store) int64 {
 	switch kind {
 	case SizeSliceTotalBytes:
 		return sumSliceInnerLen(tv, store)
+	case SizeModExpWork:
+		// Reached only via nativeSizeFromStack, i.e. from a post-call slope.
+		// The metric needs a parameter pair, and the return stack has no such
+		// pair; falling through to GetLength() would silently price on one
+		// return value's byte length instead. Fail loudly rather than charge
+		// the wrong quantity.
+		panic("SizeModExpWork is pre-call only; it cannot be used as a post-call slope kind")
 	default: // SizeLenBytes / SizeLenString / SizeLenSlice / SizeReturnLen
 		return int64(tv.GetLength())
 	}

--- a/gnovm/pkg/gnolang/native_gas_test.go
+++ b/gnovm/pkg/gnolang/native_gas_test.go
@@ -1,6 +1,10 @@
 package gnolang
 
 import (
+	"math"
+	"os"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/gnolang/gno/tm2/pkg/store/types"
@@ -229,6 +233,161 @@ func TestChargeNativeGas_SliceTotalBytes(t *testing.T) {
 	}
 }
 
+func TestModExpWork(t *testing.T) {
+	// units(expLen) * (modExpFloorWords + ceil(modLen/8)^2), where units() is
+	// the modular-multiplication count of whichever expNN routine runs.
+	const (
+		gen  = modExpGenericPerBit * 8 // generic loop, per exponent byte
+		mont = modExpMontPerWord       // Montgomery, per exponent word
+	)
+	cases := []struct {
+		expLen, modLen int64
+		want           int64
+	}{
+		{0, 256, 0}, // exponent 0: Exp returns immediately
+		{256, 0, 0}, // empty modulus: X_modExp short-circuits
+		{0, 0, 0},   //
+		{1, 8, gen * (modExpFloorWords + 1)},
+		{1, 1, gen * (modExpFloorWords + 1)}, // sub-word modulus still costs one word
+		{1, 9, gen * (modExpFloorWords + 4)}, // 9 bytes rounds up to 2 words
+
+		// Either side of the one-word exponent crossover. big.Int runs the
+		// generic loop at 8 bytes and Montgomery at 9. The two must not cross:
+		// an 8-byte exponent measures more expensive than a 9-byte one, so
+		// charging it less would be a real undercharge.
+		{7, 256, 7 * gen * (modExpFloorWords + 32*32)},
+		{8, 256, 8 * gen * (modExpFloorWords + 32*32)},
+		{9, 256, (modExpMontSetup + 2*mont) * (modExpFloorWords + 32*32)},
+		{16, 256, (modExpMontSetup + 2*mont) * (modExpFloorWords + 32*32)},
+		{17, 256, (modExpMontSetup + 3*mont) * (modExpFloorWords + 32*32)},
+
+		// The shape the production slope is anchored to. Whole multiples of a
+		// word are unaffected by the rounding.
+		{256, 256, (modExpMontSetup + 32*mont) * (modExpFloorWords + 32*32)},
+		{1024, 1024, (modExpMontSetup + 128*mont) * (modExpFloorWords + 128*128)},
+
+		// Operand lengths reach the gas layer before crypto/modexp rejects
+		// them, so the metric must saturate rather than wrap.
+		{500_000_000, 500_000_000, modExpWorkSaturation},
+		{1, 500_000_000, modExpWorkSaturation},
+		{math.MaxInt64, math.MaxInt64, modExpWorkSaturation},
+		// A huge exponent against a 1-byte modulus stays under the saturation
+		// point: the quadratic term is 1, so only the floor term applies. The
+		// exponent is clamped to maxOperandLenForWork (1<<28) first — flattening
+		// above that is safe because X_modExp rejects anything past 1024 bytes
+		// and returns without doing the work at all.
+		{
+			500_000_000, 1,
+			(modExpMontSetup + ((1 << 28) / 8 * mont)) * (modExpFloorWords + 1),
+		},
+	}
+	for _, c := range cases {
+		if got := modExpWork(c.expLen, c.modLen); got != c.want {
+			t.Errorf("modExpWork(%d, %d) = %d, want %d", c.expLen, c.modLen, got, c.want)
+		}
+	}
+}
+
+// TestModExpWorkNoCrossoverInversion pins the property the crossover exists to
+// provide: cost must never fall as the exponent grows by one byte. The metric
+// this replaced charged 8*len(exp) uniformly, which priced an 8-byte exponent
+// below a 9-byte one even though big.Int's generic loop makes 8 bytes the more
+// expensive of the two.
+func TestModExpWorkNoCrossoverInversion(t *testing.T) {
+	for modLen := int64(1); modLen <= 1024; modLen *= 2 {
+		for expLen := int64(1); expLen < 64; expLen++ {
+			prev := modExpWork(expLen-1, modLen)
+			if got := modExpWork(expLen, modLen); got < prev {
+				t.Fatalf("modExpWork(%d, %d) = %d < modExpWork(%d, %d) = %d",
+					expLen, modLen, got, expLen-1, modLen, prev)
+			}
+		}
+	}
+}
+
+// TestModExpWorkSlopeProductFitsInt64 guards the unguarded `gi.Slope * N`
+// multiply in chargeNativeGas: the saturation clamp is only safe if the shipped
+// slope times the clamp still fits. Uses the largest slope any row could
+// plausibly carry after a re-fit rather than today's value, so raising the slope
+// trips this before it trips consensus.
+func TestModExpWorkSlopeProductFitsInt64(t *testing.T) {
+	const maxPlausibleSlope = 1 << 16
+	if modExpWorkSaturation > math.MaxInt64/maxPlausibleSlope {
+		t.Fatalf("modExpWorkSaturation %d * slope %d overflows int64 — lower the "+
+			"clamp or route the multiply through overflow.Mul",
+			int64(modExpWorkSaturation), maxPlausibleSlope)
+	}
+}
+
+// TestModExpWorkMonotonic: the metric must never decrease as either operand
+// grows, or a larger call could be charged less than a smaller one.
+func TestModExpWorkMonotonic(t *testing.T) {
+	lens := []int64{1, 2, 7, 8, 9, 32, 64, 255, 256, 1024, 1 << 20, 1 << 30}
+	for i, exp := range lens {
+		for j, mod := range lens {
+			got := modExpWork(exp, mod)
+			if i > 0 {
+				if prev := modExpWork(lens[i-1], mod); got < prev {
+					t.Fatalf("non-monotonic in exp at mod=%d: %d(exp=%d) < %d(exp=%d)",
+						mod, got, exp, prev, lens[i-1])
+				}
+			}
+			if j > 0 {
+				if prev := modExpWork(exp, lens[j-1]); got < prev {
+					t.Fatalf("non-monotonic in mod at exp=%d: %d(mod=%d) < %d(mod=%d)",
+						exp, got, mod, prev, lens[j-1])
+				}
+			}
+		}
+	}
+}
+
+func TestChargeNativeGas_ModExpWork(t *testing.T) {
+	// Slope 1024 => 1 gas per unit of work, so Cycles reads back the metric.
+	// SlopeIdx 0 names the exponent; the modulus is read from param 1.
+	cleanup := registerTestNative(t, &NativeGasInfo{
+		Base:  7,
+		Slope: 1024, SlopeIdx: 0, SlopeKind: SizeModExpWork,
+	})
+	defer cleanup()
+
+	cases := []struct {
+		expLen, modLen int
+		want           int64
+	}{
+		{0, 0, 7},
+		{1, 8, 7 + (modExpGenericPerBit*8)*(modExpFloorWords+1)},
+		{256, 256, 7 + (modExpMontSetup+32*modExpMontPerWord)*(modExpFloorWords+1024)},
+		// Asymmetry is priced: a big exponent against a small modulus is no
+		// longer free, which is what the old len(modulus)-only slope missed.
+		{1024, 32, 7 + (modExpMontSetup+128*modExpMontPerWord)*(modExpFloorWords+16)},
+	}
+	for _, c := range cases {
+		m := stubMachine([]int{c.expLen, c.modLen})
+		_ = m.chargeNativeGas(&FuncValue{NativePkg: testNativePkg, NativeName: testNativeFn})
+		if m.Cycles != c.want {
+			t.Errorf("expLen=%d modLen=%d: got %d cycles, want %d", c.expLen, c.modLen, m.Cycles, c.want)
+		}
+	}
+}
+
+// TestChargeNativeGas_ModExpWorkMissingPair guards the pair read: a native
+// registered with SizeModExpWork but only one parameter present must charge
+// Base rather than index out of range.
+func TestChargeNativeGas_ModExpWorkMissingPair(t *testing.T) {
+	cleanup := registerTestNative(t, &NativeGasInfo{
+		Base:  11,
+		Slope: 1024, SlopeIdx: 0, SlopeKind: SizeModExpWork,
+	})
+	defer cleanup()
+
+	m := stubMachine([]int{256})
+	_ = m.chargeNativeGas(&FuncValue{NativePkg: testNativePkg, NativeName: testNativeFn})
+	if m.Cycles != 11 {
+		t.Fatalf("got %d cycles, want 11 (base only)", m.Cycles)
+	}
+}
+
 func TestChargeNativeGas_PreCallTwoSlopesOnDistinctParams(t *testing.T) {
 	// Mimic crypto/merkle.innerHash: two independent unbounded byte params,
 	// each carrying the same per-byte rate so the charge tracks the sum of
@@ -383,5 +542,51 @@ func BenchmarkChargeNativeGas_IncrCPUBaseline(b *testing.B) {
 	m := &Machine{GasMeter: &recordingMeter{}}
 	for i := 0; i < b.N; i++ {
 		m.incrCPU(150)
+	}
+}
+
+// TestModExpConstantsMatchFitter keeps the runtime metric and the calibration
+// fitter computing the same quantity. gen_native_table.py has to reduce each
+// (expLen, modLen) bench point to a work value before it can fit a slope over
+// them, so it carries its own copy of these constants. If the two drift, the
+// fitter reduces every bench to a work value the runtime never charges on and
+// the slope it emits is scaled by the ratio between them — a silently mispriced
+// consensus row that no other test would catch, since the Go-side tests check
+// the row against modExpWork and never against the fitter.
+func TestModExpConstantsMatchFitter(t *testing.T) {
+	t.Parallel()
+
+	const fitter = "../../cmd/calibrate/gen_native_table.py"
+	src, err := os.ReadFile(fitter)
+	if err != nil {
+		t.Fatalf("read %s: %v", fitter, err)
+	}
+	for _, c := range []struct {
+		pyName string
+		goVal  int64
+	}{
+		{"MODEXP_FLOOR_WORDS", modExpFloorWords},
+		{"MODEXP_WORD_BYTES", modExpWordBytes},
+		{"MODEXP_MONT_SETUP", modExpMontSetup},
+		{"MODEXP_MONT_PER_WORD", modExpMontPerWord},
+		{"MODEXP_GENERIC_PER_BIT", modExpGenericPerBit},
+	} {
+		re := regexp.MustCompile(`(?m)^` + c.pyName + `\s*=\s*(\d+)\s*$`)
+		m := re.FindSubmatch(src)
+		if m == nil {
+			t.Errorf("%s: %s not found — the fitter must define it, or this test "+
+				"can no longer tell whether the two agree", fitter, c.pyName)
+			continue
+		}
+		got, err := strconv.ParseInt(string(m[1]), 10, 64)
+		if err != nil {
+			t.Errorf("%s: %s = %q, not an integer", fitter, c.pyName, m[1])
+			continue
+		}
+		if got != c.goVal {
+			t.Errorf("%s has %s = %d, but the runtime uses %d — the fitter would "+
+				"reduce the calibration benches to a metric production never charges",
+				fitter, c.pyName, got, c.goVal)
+		}
 	}
 }

--- a/gnovm/stdlibs/crypto/modexp/modexp.gno
+++ b/gnovm/stdlibs/crypto/modexp/modexp.gno
@@ -6,15 +6,39 @@
 // pulling in a full big-integer stdlib.
 package modexp
 
-// ModExp returns (base^exp) mod modulus. Inputs are big-endian byte slices
-// of arbitrary length. The output has len(modulus) bytes, left-padded with
-// zeros.
+// MaxOperandLen is the largest accepted length, in bytes, of each of base, exp
+// and modulus, matching the limit EIP-7823 places on the EVM precompile.
+// 8192-bit operands cover RSA up to 8192 bits, BN254 field reduction, and
+// modular inverse over an 8192-bit prime.
+const MaxOperandLen = 1024
+
+// ModExp returns (base^exp) mod modulus. Inputs are big-endian byte slices.
+// The output has len(modulus) bytes, left-padded with zeros.
 //
 // Matches EIP-198 semantics:
 //   - If modulus is zero or empty, returns len(modulus) zero bytes.
 //   - If exp is zero or empty, returns 1 (or 0 if modulus is 1).
 //   - Inputs are taken as non-negative big-endian integers with leading zeros
 //     tolerated.
-func ModExp(base, exp, modulus []byte) []byte { return modExp(base, exp, modulus) }
+//
+// Operands are length-limited, as in EIP-7823: if any of base, exp or modulus
+// is longer than MaxOperandLen, ModExp returns an empty slice without computing
+// anything. Callers handling operands they did not size themselves should check
+// len(result) rather than assume len(modulus) bytes came back.
+//
+// Gas scales on bits(exp) × words(modulus)², so a call costs roughly the work it
+// actually causes: a small exponent against a wide modulus is cheap, while
+// wide-exponent-and-wide-modulus calls are expensive enough that only a handful
+// fit in one block.
+func ModExp(base, exp, modulus []byte) []byte {
+	// Checked here, not only in the native, so an oversized operand is refused
+	// before the native call: the dispatcher converts every operand from Gno to
+	// Go before the native body runs, so rejecting on the Go side still pays for
+	// an allocate-and-copy of each one.
+	if len(base) > MaxOperandLen || len(exp) > MaxOperandLen || len(modulus) > MaxOperandLen {
+		return nil
+	}
+	return modExp(base, exp, modulus)
+}
 
 func modExp(base, exp, modulus []byte) []byte // injected

--- a/gnovm/stdlibs/crypto/modexp/modexp.go
+++ b/gnovm/stdlibs/crypto/modexp/modexp.go
@@ -2,8 +2,53 @@ package modexp
 
 import "math/big"
 
+// maxOperandLen bounds every operand of X_modExp at 1024 bytes (8192 bits),
+// matching the limit EIP-7823 sets on the equivalent EVM precompile.
+//
+// The gas charge, not this cap, is what prices the exponentiation: the row for
+// this native in gnovm/stdlibs/native_gas.go scales on bits(exp) ×
+// words(modulus)², the quantity big.Int.Exp's runtime is proportional to.
+//
+// The cap covers what that charge does not:
+//
+//   - The envelope the slope was fit over. "This fit was only validated to 1024
+//     bytes" is per-native knowledge and belongs here, not in the gas table.
+//   - base, which no term of the metric reads. Its cost — the reduction of base
+//     modulo modulus — is bounded by this cap rather than priced. That is only
+//     sound because the bound is small; do not raise it without adding a slope
+//     on len(base).
+//
+// The length check is duplicated in ModExp (modexp.gno) and that copy is the
+// load-bearing one: the dispatcher converts every operand to Go before this
+// function is entered, so rejecting here still pays for an allocate-and-copy of
+// each operand. Rejecting on the Gno side skips the native call entirely. This
+// copy cannot be fully bounded by any length check, here or there — Gno2GoValue
+// copies a byte slice's *capacity* (gnovm/pkg/gnolang/gonative.go), so a
+// zero-length slice with a large capacity still copies it all. That is
+// pre-existing dispatcher behaviour shared by every []byte native, not specific
+// to modexp.
+//
+// 1024 bytes covers every real use of modular exponentiation — RSA up to 8192
+// bits, BN254 field reduction (crypto/cometblszk's hashToField uses 32-byte
+// operands), and modular inverse over an 8192-bit prime via Fermat, where the
+// exponent is the same width as the modulus. Nothing legitimate needs more: for
+// gcd(a,n)=1, a^e ≡ a^(e mod φ(n)), so an exponent wider than the modulus is
+// reducible by construction. EIP-7823's survey of Ethereum mainnet from April
+// 2018 to January 2025 found no successful call exceeding 513 bytes in any
+// field. The gas ceiling also binds well before this cap does: at the shipped
+// slope a symmetric 1024-byte call costs ~526M gas, about a sixth of a
+// 3B-gas block.
+const maxOperandLen = 1024
+
 // X_modExp mirrors EIP-198's MODEXP precompile.
+//
+// Operands longer than maxOperandLen yield nil, matching how the sibling
+// EIP-precompile natives (crypto/bn254, crypto/merkle) report inputs outside
+// their contract.
 func X_modExp(base, exp, modulus []byte) []byte {
+	if len(base) > maxOperandLen || len(exp) > maxOperandLen || len(modulus) > maxOperandLen {
+		return nil
+	}
 	out := make([]byte, len(modulus))
 	m := new(big.Int).SetBytes(modulus)
 	if m.Sign() == 0 {

--- a/gnovm/stdlibs/crypto/modexp/modexp_test.gno
+++ b/gnovm/stdlibs/crypto/modexp/modexp_test.gno
@@ -1,0 +1,58 @@
+package modexp_test
+
+import (
+	"bytes"
+	"crypto/modexp"
+	"testing"
+)
+
+// ones returns n bytes of 0xFF.
+func ones(n int) []byte { return bytes.Repeat([]byte{0xFF}, n) }
+
+// oddMod returns an n-byte modulus that is large and odd, so accepted calls take
+// the Montgomery path rather than a shortcut.
+func oddMod(n int) []byte {
+	m := ones(n)
+	m[n-1] = 0xFD
+	return m
+}
+
+func TestModExpKnownAnswer(t *testing.T) {
+	// 2^10 mod 1000 = 24.
+	got := modexp.ModExp([]byte{2}, []byte{10}, []byte{0x03, 0xe8})
+	if !bytes.Equal(got, []byte{0x00, 0x18}) {
+		t.Fatalf("2^10 mod 1000: got %x, want 0018", got)
+	}
+}
+
+// TestModExpOperandLenBoundary checks each operand independently at
+// MaxOperandLen and one byte over it. Only one operand sits at the limit per
+// case — a symmetric all-at-1024 call is a real ~140ms modular exponentiation,
+// and it proves nothing about a length boundary that a 1-byte exponent does not.
+//
+// This exercises the guard in ModExp itself, which is the one that matters: it
+// refuses oversized operands before the native is dispatched, so the VM never
+// converts them to Go. The native repeats the check as defense in depth.
+func TestModExpOperandLenBoundary(t *testing.T) {
+	lim := modexp.MaxOperandLen
+
+	// len(nil) == 0, so length covers acceptance and rejection alike.
+	cases := []struct {
+		name           string
+		base, exp, mod []byte
+		wantLen        int
+	}{
+		{"base at limit", ones(lim), ones(1), oddMod(32), 32},
+		{"exp at limit", ones(32), ones(lim), oddMod(32), 32},
+		{"modulus at limit", ones(32), ones(1), oddMod(lim), lim},
+		{"base over limit", ones(lim + 1), ones(1), oddMod(32), 0},
+		{"exp over limit", ones(32), ones(lim + 1), oddMod(32), 0},
+		{"modulus over limit", ones(32), ones(1), oddMod(lim + 1), 0},
+	}
+	for _, tc := range cases {
+		got := modexp.ModExp(tc.base, tc.exp, tc.mod)
+		if len(got) != tc.wantLen {
+			t.Errorf("%s: got %d bytes, want %d", tc.name, len(got), tc.wantLen)
+		}
+	}
+}

--- a/gnovm/stdlibs/crypto/modexp/modexp_test.go
+++ b/gnovm/stdlibs/crypto/modexp/modexp_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"testing"
+	"time"
 )
 
 func TestModExp_EIP198_Samples(t *testing.T) {
@@ -37,6 +38,7 @@ func TestModExp_EIP198_Samples(t *testing.T) {
 			wantHex:  "1b280ecd6a6bf906b806d527c2a831e23b238f89da48449003a88ac3ac7150d6a5e9e6b3be4054c7da11dd1e470ec29a606f5115801b5bf53bc1900271d7c3ff3cd5ed790d1c219a9800437a689f2388ba1a11d68f6a8e5b74e9a3b1fac6ee85fc6afbac599f93c391f5dc82a759e3c6c0ab45ce3f5d25d9b0c1bf94cf701ea6466fc9a478dacc5754e593172b5111eeba88557048bceae401337cd4c1182ad9f700852bc8c99933a193f0b94cf1aedbefc48be3bc93ef5cb276d7c2d5462ac8bb0c8fe8923a1db2afe1c6b90d59c534994a6a633f0ead1d638fdc293486bb634ff2c8ec9e7297c04241a61c37e3ae95b11d53343d4ba2b4cc33d2cfa7eb705e",
 		},
 		{
+			// 1024-byte base and modulus: exactly at maxOperandLen.
 			name:     "nagydani-5-pow0x10001",
 			inputHex: "000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000400c5a1611f8be90071a43db23cc2fe01871cc4c0e8ab5743f6378e4fef77f7f6db0095c0727e20225beb665645403453e325ad5f9aeb9ba99bf3c148f63f9c07cf4fe8847ad5242d6b7d4499f93bd47056ddab8f7dee878fc2314f344dbee2a7c41a5d3db91eff372c730c2fdd3a141a4b61999e36d549b9870cf2f4e632c4d5df5f024f81c028000073a0ed8847cfb0593d36a47142f578f05ccbe28c0c06aeb1b1da027794c48db880278f79ba78ae64eedfea3c07d10e0562668d839749dc95f40467d15cf65b9cfc52c7c4bcef1cda3596dd52631aac942f146c7cebd46065131699ce8385b0db1874336747ee020a5698a3d1a1082665721e769567f579830f9d259cec1a836845109c21cf6b25da572512bf3c42fd4b96e43895589042ab60dd41f497db96aec102087fe784165bb45f942859268fd2ff6c012d9d00c02ba83eace047cc5f7b2c392c2955c58a49f0338d6fc58749c9db2155522ac17914ec216ad87f12e0ee95574613942fa615898c4d9e8a3be68cd6afa4e7a003dedbdf8edfee31162b174f965b20ae752ad89c967b3068b6f722c16b354456ba8e280f987c08e0a52d40a2e8f3a59b94d590aeef01879eb7a90b3ee7d772c839c85519cbeaddc0c193ec4874a463b53fcaea3271d80ebfb39b33489365fc039ae549a17a9ff898eea2f4cb27b8dbee4c17b998438575b2b8d107e4a0d66ba7fca85b41a58a8d51f191a35c856dfbe8aef2b00048a694bbccff832d23c8ca7a7ff0b6c0b3011d00b97c86c0628444d267c951d9e4fb8f83e154b8f74fb51aa16535e498235c5597dac9606ed0be3173a3836baa4e7d756ffe1e2879b415d3846bccd538c05b847785699aefde3e305decb600cd8fb0e7d8de5efc26971a6ad4e6d7a2d91474f1023a0ac4b78dc937da0ce607a45974d2cac1c33a2631ff7fe6144a3b2e5cf98b531a9627dea92c1dc82204d09db0439b6a11dd64b484e1263aa45fd9539b6020b55e3baece3986a8bffc1003406348f5c61265099ed43a766ee4f93f5f9c5abbc32a0fd3ac2b35b87f9ec26037d88275bd7dd0a54474995ee34ed3727f3f97c48db544b1980193a4b76a8a3ddab3591ce527f16d91882e67f0103b5cda53f7da54d489fc4ac08b6ab358a5a04aa9daa16219d50bd672a7cb804ed769d218807544e5993f1c27427104b349906a0b654df0bf69328afd3013fbe430155339c39f236df5557bf92f1ded7ff609a8502f49064ec3d1dbfb6c15d3a4c11a4f8acd12278cbf68acd5709463d12e3338a6eddb8c112f199645e23154a8e60879d2a654e3ed9296aa28f134168619691cd2c6b9e2eba4438381676173fc63c2588a3c5910dc149cf3760f0aa9fa9c3f5faa9162b0bf1aac9dd32b706a60ef53cbdb394b6b40222b5bc80eea82ba8958386672564cae3794f977871ab62337cf010001e30049201ec12937e7ce79d0f55d9c810e20acf52212aca1d3888949e0e4830aad88d804161230eb89d4d329cc83570fe257217d2119134048dd2ed167646975fc7d77136919a049ea74cf08ddd2b896890bb24a0ba18094a22baa351bf29ad96c66bbb1a598f2ca391749620e62d61c3561a7d3653ccc8892c7b99baaf76bf836e2991cb06d6bc0514568ff0d1ec8bb4b3d6984f5eaefb17d3ea2893722375d3ddb8e389a8eef7d7d198f8e687d6a513983df906099f9a2d23f4f9dec6f8ef2f11fc0a21fac45353b94e00486f5e17d386af42502d09db33cf0cf28310e049c07e88682aeeb00cb833c5174266e62407a57583f1f88b304b7c6e0c84bbe1c0fd423072d37a5bd0aacf764229e5c7cd02473460ba3645cd8e8ae144065bf02d0dd238593d8e230354f67e0b2f23012c23274f80e3ee31e35e2606a4a3f31d94ab755e6d163cff52cbb36b6d0cc67ffc512aeed1dce4d7a0d70ce82f2baba12e8d514dc92a056f994adfb17b5b9712bd5186f27a2fda1f7039c5df2c8587fdc62f5627580c13234b55be4df3056050e2d1ef3218f0dd66cb05265fe1acfb0989d8213f2c19d1735a7cf3fa65d88dad5af52dc2bba22b7abf46c3bc77b5091baab9e8f0ddc4d5e581037de91a9f8dcbc69309be29cc815cf19a20a7585b8b3073edf51fc9baeb3e509b97fa4ecfd621e0fd57bd61cac1b895c03248ff12bdbc57509250df3517e8a3fe1d776836b34ab352b973d932ef708b14f7418f9eceb1d87667e61e3e758649cb083f01b133d37ab2f5afa96d6c84bcacf4efc3851ad308c1e7d9113624fce29fab460ab9d2a48d92cdb281103a5250ad44cb2ff6e67ac670c02fdafb3e0f1353953d6d7d5646ca1568dea55275a050ec501b7c6250444f7219f1ba7521ba3b93d089727ca5f3bbe0d6c1300b423377004954c5628fdb65770b18ced5c9b23a4a5a6d6ef25fe01b4ce278de0bcc4ed86e28a0a68818ffa40970128cf2c38740e80037984428c1bd5113f40ff47512ee6f4e4d8f9b8e8e1b3040d2928d003bd1c1329dc885302fbce9fa81c23b4dc49c7c82d29b52957847898676c89aa5d32b5b0e1c0d5a2b79a19d67562f407f19425687971a957375879d90c5f57c857136c17106c9ab1b99d80e69c8c954ed386493368884b55c939b8d64d26f643e800c56f90c01079d7c534e3b2b7ae352cefd3016da55f6a85eb803b85e2304915fd2001f77c74e28746293c46e4f5f0fd49cf988aafd0026b8e7a3bab2da5cdce1ea26c2e29ec03f4807fac432662b2d6c060be1c7be0e5489de69d0a6e03a4b9117f9244b34a0f1ecba89884f781c6320412413a00c4980287409a2a78c2cd7e65cecebbe4ec1c28cac4dd95f6998e78fc6f1392384331c9436aa10e10e2bf8ad2c4eafbcf276aa7bae64b74428911b3269c749338b0fc5075ad",
 			wantHex:  "5a0eb2bdf0ac1cae8e586689fa16cd4b07dfdedaec8a110ea1fdb059dd5253231b6132987598dfc6e11f86780428982d50cf68f67ae452622c3b336b537ef3298ca645e8f89ee39a26758206a5a3f6409afc709582f95274b57b71fae5c6b74619ae6f089a5393c5b79235d9caf699d23d88fb873f78379690ad8405e34c19f5257d596580c7a6a7206a3712825afe630c76b31cdb4a23e7f0632e10f14f4e282c81a66451a26f8df2a352b5b9f607a7198449d1b926e27036810368e691a74b91c61afa73d9d3b99453e7c8b50fd4f09c039a2f2feb5c419206694c31b92df1d9586140cb3417b38d0c503c7b508cc2ed12e813a1c795e9829eb39ee78eeaf360a169b491a1d4e419574e712402de9d48d54c1ae5e03739b7156615e8267e1fb0a897f067afd11fb33f6e24182d7aaaaa18fe5bc1982f20d6b871e5a398f0f6f718181d31ec225cfa9a0a70124ed9a70031bdf0c1c7829f708b6e17d50419ef361cf77d99c85f44607186c8d683106b8bd38a49b5d0fb503b397a83388c5678dcfcc737499d84512690701ed621a6f0172aecf037184ddf0f2453e4053024018e5ab2e30d6d5363b56e8b41509317c99042f517247474ab3abc848e00a07f69c254f46f2a05cf6ed84e5cc906a518fdcfdf2c61ce731f24c5264f1a25fc04934dc28aec112134dd523f70115074ca34e3807aa4cb925147f3a0ce152d323bd8c675ace446d0fd1ae30c4b57f0eb2c23884bc18f0964c0114796c5b6d080c3d89175665fbf63a6381a6a9da39ad070b645c8bb1779506da14439a9f5b5d481954764ea114fac688930bc68534d403cff4210673b6a6ff7ae416b7cd41404c3d3f282fcd193b86d0f54d0006c2a503b40d5c3930da980565b8f9630e9493a79d1c03e74e5f93ac8e4dc1a901ec5e3b3e57049124c7b72ea345aa359e782285d9e6a5c144a378111dd02c40855ff9c2be9b48425cb0b2fd62dc8678fd151121cf26a65e917d65d8e0dacfae108eb5508b601fb8ffa370be1f9a8b749a2d12eeab81f41079de87e2d777994fa4d28188c579ad327f9957fb7bdecec5c680844dd43cb57cf87aeb763c003e65011f73f8c63442df39a92b946a6bd968a1c1e4d5fa7d88476a68bd8e20e5b70a99259c7d3f85fb1b65cd2e93972e6264e74ebf289b8b6979b9b68a85cd5b360c1987f87235c3c845d62489e33acf85d53fa3561fe3a3aee18924588d9c6eba4edb7a4d106b31173e42929f6f0c48c80ce6a72d54eca7c0fe870068b7a7c89c63cdda593f5b32d3cb4ea8a32c39f00ab449155757172d66763ed9527019d6de6c9f2416aa6203f4d11c9ebee1e1d3845099e55504446448027212616167eb36035726daa7698b075286f5379cd3e93cb3e0cf4f9cb8d017facbb5550ed32d5ec5400ae57e47e2bf78d1eaeff9480cc765ceff39db500",
@@ -144,6 +146,89 @@ func TestModExpLargeModReduction(t *testing.T) {
 	expected.FillBytes(expectedBytes)
 	if !bytes.Equal(got, expectedBytes) {
 		t.Fatalf("reduction mismatch:\n got  %x\n want %x", got, expectedBytes)
+	}
+}
+
+// ones returns n bytes of 0xFF.
+func ones(n int) []byte { return bytes.Repeat([]byte{0xFF}, n) }
+
+// oddMod returns an n-byte modulus that is large and odd, so accepted calls take
+// the Montgomery path rather than a shortcut.
+func oddMod(n int) []byte {
+	m := ones(n)
+	m[n-1] = 0xFD
+	return m
+}
+
+// huge returns an n-byte big-endian integer with only its top byte set. make()
+// zero-fills for almost no allocation gas, so this is the cheap way for a realm
+// to build an enormous operand — which is why operand length has to be bounded
+// independently of what it costs to construct.
+func huge(n int) []byte {
+	b := make([]byte, n)
+	b[0] = 0xFF
+	return b
+}
+
+// TestModExpOperandLenBoundary checks each operand independently at
+// maxOperandLen and at maxOperandLen+1. Only one operand is held at the limit
+// per case: a symmetric all-at-1024 call is a real ~140ms modular
+// exponentiation, and it proves nothing about a length boundary that a 1-byte
+// exponent does not.
+func TestModExpOperandLenBoundary(t *testing.T) {
+	const lim = maxOperandLen
+	cases := []struct {
+		name           string
+		base, exp, mod []byte
+		wantLen        int
+	}{
+		{"base at limit", ones(lim), ones(1), oddMod(32), 32},
+		{"exp at limit", ones(32), ones(lim), oddMod(32), 32},
+		{"modulus at limit", ones(32), ones(1), oddMod(lim), lim},
+		{"base over limit", ones(lim + 1), ones(1), oddMod(32), 0},
+		{"exp over limit", ones(32), ones(lim + 1), oddMod(32), 0},
+		{"modulus over limit", ones(32), ones(1), oddMod(lim + 1), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// len(nil) == 0, so this covers the rejection cases too.
+			if got := X_modExp(tc.base, tc.exp, tc.mod); len(got) != tc.wantLen {
+				t.Fatalf("got %d bytes, want %d", len(got), tc.wantLen)
+			}
+		})
+	}
+}
+
+// TestModExpRejectsOversizedShapes pins the three shapes that used to decouple
+// the real cost from the charge, back when gas scaled on len(modulus) alone. Gas
+// now scales on bits(exp) × words(modulus)², so these are priced rather than
+// mispriced — but they still exceed maxOperandLen and must be refused before any
+// big.Int work. This doubles as a timing guard: it would take ~40s of CPU if any
+// shape were still accepted.
+func TestModExpRejectsOversizedShapes(t *testing.T) {
+	cases := []struct {
+		name           string
+		base, exp, mod []byte
+	}{
+		// Before the fix: ~5s of big.Int.Exp, charged ~6.2M gas (≈6.2ms).
+		{"huge exponent, small modulus", huge(32), huge(500_000), oddMod(32)},
+		// Before the fix: ~34s, charged ~789M gas (≈789ms).
+		{"small exponent, huge modulus", huge(32), huge(256), huge(32 * 1024)},
+		// Before the fix: ~61ms for the base reduction, charged a flat 828K gas.
+		{"huge base, small modulus", huge(500_000), huge(4), oddMod(32)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start := time.Now()
+			if got := X_modExp(tc.base, tc.exp, tc.mod); got != nil {
+				t.Fatalf("want nil, got %d bytes", len(got))
+			}
+			// Rejection happens before any big.Int work; anything near the
+			// pre-cap timings above means the guard was bypassed.
+			if d := time.Since(start); d > time.Second {
+				t.Fatalf("rejection took %s — guard did not short-circuit", d)
+			}
+		})
 	}
 }
 

--- a/gnovm/stdlibs/native_gas.go
+++ b/gnovm/stdlibs/native_gas.go
@@ -1,6 +1,8 @@
 package stdlibs
 
 import (
+	"fmt"
+
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
 )
 
@@ -33,6 +35,7 @@ const (
 	SizeNumCallFrames   = gno.SizeNumCallFrames
 	SizeReturnLen       = gno.SizeReturnLen
 	SizeSliceTotalBytes = gno.SizeSliceTotalBytes
+	SizeModExpWork      = gno.SizeModExpWork
 )
 
 // nativeGasEntry is the on-disk shape of a row, copied into a
@@ -68,10 +71,24 @@ type nativeGasEntry struct {
 // gnovm/cmd/calibrate before any consensus-relevant deployment). 1 gas
 // = 1 ns. Slope is ns per 1024 units of N. R² > 0.93 for all linear fits.
 //
-// Values come from gen_native_table.py over native_bench_output.txt
-// (current contents). Production matches the regenerated
-// native_gas_table.go.txt exactly — re-running the fitter on this same
-// input reproduces this table verbatim. The 2D bench-grid extension
+// Values come from gen_native_table.py over native_bench_output.txt.
+// Two caveats on that provenance, both worth knowing before a re-run:
+//
+//   - The checked-in snapshot is stale, and not because of this table.
+//     native_gas_table.go.txt holds 46 rows against production's 66, and
+//     native_bench_output.txt contains no bench lines for any of the IBC
+//     crypto natives (bn254, cometbls, keccak256, merkle, modexp). Those
+//     rows came from a separate run (see below) and cannot be reproduced
+//     from the committed input at all, so "re-running the fitter
+//     reproduces this table verbatim" holds only for the 46 rows the
+//     snapshot covers.
+//   - The crypto/modexp row is additionally not a fitter output even given
+//     its bench data: its Slope is an upper bound over the bench grid
+//     rather than the least-squares coefficient, because that native's
+//     cost is a product and a central fit underprices half the grid. See
+//     the row's own comment.
+//
+// The 2D bench-grid extension
 // (slice natives benched at multiple per-element byte sizes) confirmed
 // the per-byte CPU slope is below noise for every native shipping
 // today, so the table stays single-slope; the schema fields support
@@ -189,16 +206,86 @@ var calibratedNativeGas = []nativeGasEntry{
 	{Pkg: "crypto/merkle", Fn: "innerHash", Base: 7513, Slope: 32911, SlopeIdx: 0, SlopeKind: SizeLenBytes, Slope2: 32911, Slope2Idx: 1, Slope2Kind: SizeLenBytes},
 	{Pkg: "crypto/merkle", Fn: "hashFromByteSlices", Base: 4839, Slope: 188621, SlopeIdx: 0, SlopeKind: SizeLenBytes}, // draft fit base=4839ns slope=184.2ns/N (=188621/1024) on encoded 1..512 items
 	{Pkg: "crypto/merkle", Fn: "verifySimpleProof", Base: 4567, Slope: 53533, SlopeIdx: 4, SlopeKind: SizeLenBytes},   // draft fit base=4567ns slope=52.3ns/N (=53533/1024) on aunts 96..320 bytes
-	// modExp cost is dominated by an O(N^3) big-int chain (Go big.Int.Exp). The
-	// linear schema can't capture that, so the slope below is fit so the charge
-	// matches measured cost at N=256-byte modulus (~6.16ms) and overcharges
-	// smaller inputs / undercharges very large inputs. Re-check before
-	// allowing >256-byte modulus in production realms.
-	{Pkg: "crypto/modexp", Fn: "modExp", Base: 58000, Slope: 24647680, SlopeIdx: 2, SlopeKind: SizeLenBytes}, // draft, calibrated against N=256-byte modulus (cubic underlying, see comment)
+	// modExp is charged on two independent components, because it has two:
+	//
+	//   - Slope, on SizeModExpWork at SlopeIdx=1: the exponentiation itself. The
+	//     kind counts the modular multiplications big.Int.Exp will perform,
+	//     reading the branch structure of nat.go's expNN off the operand lengths;
+	//     derivation lives with it in gnovm/pkg/gnolang/native_gas.go. Slope
+	//     converts that count to nanoseconds, so it is the only hardware-dependent
+	//     part of the model. SlopeIdx names the exponent and the modulus is read
+	//     from the next parameter.
+	//   - Slope2, on SizeLenBytes at the modulus: converting the operands across
+	//     the dispatcher, allocating the result and filling it. This is linear in
+	//     len(modulus) and runs even when the exponent is empty and no
+	//     exponentiation happens at all, so folding it into Base makes the charge
+	//     for a zero-length exponent independent of the modulus — a hole, since
+	//     the call still allocates and fills len(modulus) bytes. It is a small
+	//     term now (~2.9 ns/byte): byte slices became Data-backed in #97, so the
+	//     dispatcher no longer converts one TypedValue per byte. Before that it
+	//     was ~134 ns/byte and this slope was 49x larger.
+	//
+	// Both slopes are UPPER bounds over the ModExpGrid benches rather than the
+	// least-squares coefficients: a central fit sits below cost on about half the
+	// grid, which is fine for describing a cost and wrong for charging one. That is
+	// what gen_native_table.py's fit_modexp now emits, so this row IS a fitter
+	// output and regenerating reproduces it, rather than being a hand-edit the
+	// fitter would silently undo.
+	//
+	// Over the recorded grid, projected onto reference hardware, every point lands
+	// between 1.24x and 2.57x of measured cost, and the charge is monotonic in
+	// len(exp) at every modulus — the previous row charged an 8-byte exponent less
+	// than a 9-byte one while it measured more expensive. Re-fit with
+	// gnovm/cmd/calibrate/ibc_native_bench_test.go, which records the run these came
+	// from and the hardware it was taken on; pass --hw-factor unless you are on the
+	// reference Xeon. TestModExpRowCoversRecordedGrid checks every point.
+	//
+	// X_modExp and ModExp cap each operand at 1024 bytes, matching EIP-7823. The cap
+	// bounds the envelope this fit was checked over and the unpriced base reduction;
+	// this row does the pricing.
+	{
+		Pkg: "crypto/modexp", Fn: "modExp", Base: 1400,
+		Slope: 2200, SlopeIdx: 1, SlopeKind: SizeModExpWork,
+		Slope2: 3500, Slope2Idx: 2, Slope2Kind: SizeLenBytes,
+	}, // draft, upper bound over 26 ModExpGrid points (x2.3 to reference, +19% margin); thinnest at expLen=3/modLen=256
+}
+
+// validateRow cross-checks a row against the native's actual signature before
+// registration. Every other misconfiguration in this table already fails loudly
+// — an unregistered native panics on first call, and a bad SlopeIdx panics on
+// the block index — but SizeModExpWork reads a *pair* of parameters and cannot
+// panic on a missing second one without giving up the bounds check. Left
+// unvalidated it would degrade silently, and toward free: the crypto/modexp row
+// carried SlopeIdx: 2 until recently, and with that value the pair read runs off
+// the end of the call block, returns zero work, and collapses the charge to
+// Base for any operand size. Catch it at boot instead.
+func validateRow(e nativeGasEntry, params int) {
+	if e.SlopeKind == SizeModExpWork {
+		if e.SlopeIdx < 0 || int(e.SlopeIdx)+1 >= params {
+			panic(fmt.Sprintf("%s.%s: SizeModExpWork needs params at SlopeIdx and SlopeIdx+1, "+
+				"but SlopeIdx=%d and the native takes %d params — the charge would silently "+
+				"collapse to Base", e.Pkg, e.Fn, e.SlopeIdx, params))
+		}
+	}
+	// The metric needs a parameter pair, so it can never be read off the
+	// return stack. nativeSizeOf panics if it ever is; refuse it here too so
+	// the mistake surfaces at boot rather than on the first call.
+	if e.Slope2Kind == SizeModExpWork || e.PostSlopeKind == SizeModExpWork || e.PostSlope2Kind == SizeModExpWork {
+		panic(fmt.Sprintf("%s.%s: SizeModExpWork is only valid as SlopeKind (pre-call)", e.Pkg, e.Fn))
+	}
 }
 
 func init() {
+	// Index the generated bindings so rows can be checked against the real
+	// signatures rather than against a hand-maintained duplicate of them.
+	nParams := make(map[string]int, len(nativeFuncs))
+	for _, nf := range nativeFuncs {
+		nParams[nf.gnoPkg+"\x00"+string(nf.gnoFunc)] = len(nf.params)
+	}
 	for _, e := range calibratedNativeGas {
+		if n, ok := nParams[e.Pkg+"\x00"+e.Fn]; ok {
+			validateRow(e, n)
+		}
 		gno.RegisterNativeGas(e.Pkg, gno.Name(e.Fn), &gno.NativeGasInfo{
 			Base:           e.Base,
 			Slope:          e.Slope,

--- a/gnovm/stdlibs/native_gas_test.go
+++ b/gnovm/stdlibs/native_gas_test.go
@@ -1,6 +1,7 @@
 package stdlibs
 
 import (
+	"math"
 	"testing"
 
 	gno "github.com/gnolang/gno/gnovm/pkg/gnolang"
@@ -31,6 +32,173 @@ func TestSubRealmGasMirrorsPackageAddress(t *testing.T) {
 	if !found {
 		t.Fatal("chain/packageAddress row missing from calibratedNativeGas")
 	}
+}
+
+// TestModExpRowCoversMeasuredCalibrationPoint guards the crypto/modexp row
+// against a re-fit that drops it below the only shape this native has a real
+// measurement for. The superseded row charged on len(modulus) alone and was fit
+// so that len(base)==len(exp)==len(modulus)==256 cost ~6.16ms on the reference
+// hardware; the current row prices bits(exp) × words(modulus)² instead, but
+// whatever the model, it must not charge less than that at that shape.
+//
+// A floor rather than an equality: the slope is fit over the ModExpGrid benches
+// with headroom, so it deliberately charges more than the old row here. Only a
+// drop below is a regression.
+func TestModExpRowCoversMeasuredCalibrationPoint(t *testing.T) {
+	t.Parallel()
+
+	// The superseded row evaluated at a 256-byte modulus: the measured point.
+	const measuredAtAnchor = 58000 + 24647680*256/1024
+
+	var row *nativeGasEntry
+	for i := range calibratedNativeGas {
+		if calibratedNativeGas[i].Pkg == "crypto/modexp" && calibratedNativeGas[i].Fn == "modExp" {
+			row = &calibratedNativeGas[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("crypto/modexp modExp row missing from calibratedNativeGas")
+	}
+	// Ask the runtime for the metric rather than restating it: a hardcoded
+	// formula here would keep passing after a model change while silently
+	// checking a different quantity than production charges.
+	got := row.Base + row.Slope*gno.ModExpWork(256, 256)/1024 + row.Slope2*256/1024
+
+	if got < measuredAtAnchor {
+		t.Errorf("charge at the symmetric 256-byte shape = %d, below the %d measured "+
+			"for it (Slope=%d) — a re-fit has taken this row under its one "+
+			"real calibration point", got, measuredAtAnchor, row.Slope)
+	}
+}
+
+// modExpGridPoint is one recorded ModExpGrid measurement. The full run, the
+// machine it was taken on and the reasoning live in
+// gnovm/cmd/calibrate/ibc_native_bench_test.go; these are its medians.
+type modExpGridPoint struct {
+	expLen, modLen int64
+	devNS          float64
+}
+
+// modExpDevToReference projects the recorded run onto the reference Xeon 8168.
+// The benches were taken on an AMD Ryzen 7 7840U, which is materially faster,
+// so a charge that merely covers the raw numbers undercharges every validator
+// on reference hardware. Four rows in this same table calibrated on a
+// reference-class Xeon put the gap at 2.19-2.33x (cometbls.verifyZKP 2.19,
+// bn254.pairingCheck 2.19 and 2.33, modexp's own superseded anchor 2.32).
+//
+// 2.3 is the HIGH end deliberately. A larger factor projects a larger cost and
+// so demands a larger slope: the safe choice is the top of the measured range,
+// not the bottom. An earlier revision of this constant took the low end, which
+// had it backwards.
+const modExpDevToReference = 2.3
+
+var modExpRecordedGrid = []modExpGridPoint{
+	{0, 32, 520},
+	{0, 256, 768},
+	{0, 1024, 1716},
+	{1, 256, 30436},
+	{1, 1024, 240084},
+	{3, 256, 98887},
+	{3, 1024, 792236},
+	{4, 32, 8454},
+	{4, 256, 123890},
+	{4, 1024, 1102211},
+	{8, 32, 15168},
+	{8, 256, 239457},
+	{8, 1024, 2088169},
+	{9, 32, 17203},
+	{9, 256, 210814},
+	{9, 1024, 2612594},
+	{16, 256, 198277},
+	{24, 256, 278681},
+	{32, 32, 24218},
+	{32, 256, 352113},
+	{32, 1024, 4641969},
+	{256, 32, 165587},
+	{256, 1024, 35314846},
+	{1024, 32, 724654},
+	{1024, 256, 10771770},
+	{1024, 1024, 131967026},
+}
+
+// TestModExpRowCoversRecordedGrid is the mechanical form of the property the
+// row's comment claims: its coefficients are upper bounds over the calibration
+// grid, not a central fit. Checking one anchor point (as
+// TestModExpRowCoversMeasuredCalibrationPoint does) cannot see a re-fit that
+// dips below cost anywhere else on the surface, and the surface is where this
+// native's cost actually varies — the row this replaced passed a single-point
+// check while undercharging ten of twenty-six grid points.
+//
+// A failure here means a re-fit, a change to modExpWork, or a change to the
+// crossover constants has taken the charge under measured cost at some shape.
+// That is a consensus-relevant undercharge, not a stale golden value: fix the
+// row, do not relax the test.
+func TestModExpRowCoversRecordedGrid(t *testing.T) {
+	t.Parallel()
+
+	row := findModExpRow(t)
+	if row.SlopeKind != SizeModExpWork || row.Slope2Kind != SizeLenBytes {
+		t.Fatalf("row shape changed (SlopeKind=%v Slope2Kind=%v) — this test assumes "+
+			"a work slope on the exponent and a per-byte slope on the modulus",
+			row.SlopeKind, row.Slope2Kind)
+	}
+
+	worst, worstAt := math.Inf(1), modExpGridPoint{}
+	for _, p := range modExpRecordedGrid {
+		// Ask the runtime for the metric rather than restating it, so a model
+		// change cannot leave this checking a different quantity than production.
+		charge := row.Base +
+			row.Slope*gno.ModExpWork(p.expLen, p.modLen)/1024 +
+			row.Slope2*p.modLen/1024
+		want := p.devNS * modExpDevToReference
+		if margin := float64(charge) / want; margin < worst {
+			worst, worstAt = margin, p
+		}
+		if float64(charge) < want {
+			t.Errorf("expLen=%d modLen=%d: charge %d < %.0f ns measured "+
+				"(%.0f ns on the dev box x%.2f) — the row is not an upper bound here",
+				p.expLen, p.modLen, charge, want, p.devNS, modExpDevToReference)
+		}
+	}
+	t.Logf("thinnest margin %.2fx at expLen=%d modLen=%d",
+		worst, worstAt.expLen, worstAt.modLen)
+}
+
+// TestModExpChargeMonotonic: a longer exponent must never cost less. big.Int
+// switches routines at a one-word exponent and the two have different per-bit
+// costs, so a metric that ignores the switch can invert — the superseded one
+// charged an 8-byte exponent less than a 9-byte one while measuring more
+// expensive. An inversion is directly exploitable: it lets a caller buy the
+// dearer computation at the cheaper shape's price.
+func TestModExpChargeMonotonic(t *testing.T) {
+	t.Parallel()
+
+	row := findModExpRow(t)
+	charge := func(expLen, modLen int64) int64 {
+		return row.Base +
+			row.Slope*gno.ModExpWork(expLen, modLen)/1024 +
+			row.Slope2*modLen/1024
+	}
+	for _, modLen := range []int64{1, 32, 64, 256, 512, 1024} {
+		for expLen := int64(1); expLen <= 1024; expLen++ {
+			if prev, got := charge(expLen-1, modLen), charge(expLen, modLen); got < prev {
+				t.Fatalf("modLen=%d: charge(expLen=%d)=%d < charge(expLen=%d)=%d",
+					modLen, expLen, got, expLen-1, prev)
+			}
+		}
+	}
+}
+
+func findModExpRow(t *testing.T) *nativeGasEntry {
+	t.Helper()
+	for i := range calibratedNativeGas {
+		if calibratedNativeGas[i].Pkg == "crypto/modexp" && calibratedNativeGas[i].Fn == "modExp" {
+			return &calibratedNativeGas[i]
+		}
+	}
+	t.Fatal("crypto/modexp modExp row missing from calibratedNativeGas")
+	return nil
 }
 
 // crypto/merkle.innerHash hashes 0x01||left||right and nothing bounds either

--- a/gnovm/stdlibs/native_gas_validate_test.go
+++ b/gnovm/stdlibs/native_gas_validate_test.go
@@ -1,0 +1,99 @@
+package stdlibs
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRowRejectsBadModExpWorkPair pins the boot-time guard. The
+// crypto/modexp row carried SlopeIdx: 2 while it charged on len(modulus); with
+// SizeModExpWork that same value makes the pair read run past the end of a
+// 3-parameter call block, yielding zero work and collapsing the charge to Base
+// for any operand size. That must not be reachable silently.
+func TestValidateRowRejectsBadModExpWorkPair(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		row    nativeGasEntry
+		params int
+		want   string // substring of the expected panic; "" means must not panic
+	}{
+		{
+			name:   "modexp's own shape is valid",
+			row:    nativeGasEntry{Pkg: "crypto/modexp", Fn: "modExp", SlopeIdx: 1, SlopeKind: SizeModExpWork},
+			params: 3,
+		},
+		{
+			name:   "the superseded SlopeIdx would read past the block",
+			row:    nativeGasEntry{Pkg: "crypto/modexp", Fn: "modExp", SlopeIdx: 2, SlopeKind: SizeModExpWork},
+			params: 3,
+			want:   "collapse to Base",
+		},
+		{
+			name:   "negative SlopeIdx has no pair to read",
+			row:    nativeGasEntry{Pkg: "x", Fn: "y", SlopeIdx: -1, SlopeKind: SizeModExpWork},
+			params: 3,
+			want:   "SizeModExpWork needs params",
+		},
+		{
+			name:   "rejected as a second pre-call slope",
+			row:    nativeGasEntry{Pkg: "x", Fn: "y", SlopeIdx: 0, SlopeKind: SizeLenBytes, Slope2Idx: 1, Slope2Kind: SizeModExpWork},
+			params: 3,
+			want:   "only valid as SlopeKind",
+		},
+		{
+			name:   "rejected as a post-call slope",
+			row:    nativeGasEntry{Pkg: "x", Fn: "y", SlopeIdx: -1, SlopeKind: SizeFlat, PostSlopeIdx: 1, PostSlopeKind: SizeModExpWork},
+			params: 3,
+			want:   "only valid as SlopeKind",
+		},
+		{
+			name:   "unrelated kinds are untouched",
+			row:    nativeGasEntry{Pkg: "x", Fn: "y", SlopeIdx: 2, SlopeKind: SizeLenBytes},
+			params: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got string
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						got, _ = r.(string)
+					}
+				}()
+				validateRow(tc.row, tc.params)
+			}()
+			switch {
+			case tc.want == "" && got != "":
+				t.Fatalf("unexpected panic: %s", got)
+			case tc.want != "" && got == "":
+				t.Fatalf("expected a panic containing %q, got none", tc.want)
+			case tc.want != "" && !strings.Contains(got, tc.want):
+				t.Fatalf("panic %q does not contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEveryRowValidates runs the shipped table through the guard, so a future
+// row that trips it fails here rather than at node boot.
+func TestEveryRowValidates(t *testing.T) {
+	t.Parallel()
+	nParams := make(map[string]int, len(nativeFuncs))
+	for _, nf := range nativeFuncs {
+		nParams[nf.gnoPkg+"\x00"+string(nf.gnoFunc)] = len(nf.params)
+	}
+	for _, e := range calibratedNativeGas {
+		n, ok := nParams[e.Pkg+"\x00"+e.Fn]
+		if !ok {
+			t.Errorf("%s.%s has a gas row but no generated binding", e.Pkg, e.Fn)
+			continue
+		}
+		validateRow(e, n)
+	}
+}

--- a/tm2/pkg/toml/README.md
+++ b/tm2/pkg/toml/README.md
@@ -47,11 +47,23 @@ recursion; a closer may sit in a comment and unwind nothing; a quoted key
 segment may span newlines and hide its depth from any per-line count. Counting
 the parsed path and the actual recursion is exact.
 
-Also carried, both unrelated to the bounds:
+Also carried, all unrelated to the bounds:
 
-4. **Four `go vet` fixes** — `l.errorf(err.Error())` → `l.errorf("%s", err.Error())`
+4. **`tomltree_write.go` — an exact control-character escape.** Upstream wrote
+   `intRr := uint16(rr); if intRr < 0x001F`, which is wrong in two directions.
+   The bound excluded U+001F itself, so that character was written raw into a
+   basic string — and `lexStringAsString` refuses raw `0x00`–`0x1F`, so `Marshal`
+   produced a document `Unmarshal` could not read. The conversion also truncated,
+   so a rune whose *low 16 bits* fall under `0x1F` (U+1000A, say) was emitted as
+   the escape for those bits alone and decoded back as a different character.
+   Both break `Unmarshal(Marshal(v)) == v`. That is load-bearing here rather than
+   cosmetic: `gnomod.toml` is *stored* re-encoded, and its approval hash is taken
+   after a further round trip (`gno.land/pkg/sdk/vm.PackageContentHash`), so an
+   encoding that is not a fixpoint is an approval no approver can ever match.
+   Covered by `TestBoundsMarshalRoundTripsEveryRune`.
+5. **Four `go vet` fixes** — `l.errorf(err.Error())` → `l.errorf("%s", err.Error())`
    in `lexer.go`, so `go test ./tm2/pkg/toml/` is clean without `-vet=off`.
-5. **One test made timezone-robust** — `TestUnmarshalLocalDateTime` compared raw
+6. **One test made timezone-robust** — `TestUnmarshalLocalDateTime` compared raw
    wall-clock components against a `time.Local` decode, so it failed on any zone
    putting `1979-05-27T00:32` in a historical DST gap. It now normalizes both
    sides identically. Verified under UTC, Europe/Paris, Asia/Kolkata,

--- a/tm2/pkg/toml/bounds_test.go
+++ b/tm2/pkg/toml/bounds_test.go
@@ -144,3 +144,58 @@ func TestBoundsAcceptOrdinaryDocuments(t *testing.T) {
 		}
 	}
 }
+
+// Marshal's output must decode back to the value it was given, for every rune.
+//
+// PackageContentHash (gno.land/pkg/sdk/vm) hashes gnomod.toml after a
+// parse-and-re-encode, against a stored copy the keeper had already parsed and
+// re-encoded once. The two agree only if encoding is a fixpoint, so a rune that
+// survives one round trip but not two is an approval nobody can match.
+//
+// Upstream's control-character escape got this wrong in both directions:
+// `uint16(rr) < 0x001F` excluded U+001F, which was then written raw into a
+// basic string the lexer refuses; and the conversion truncated, so a rune whose
+// low 16 bits fall under 0x1F was emitted as the escape for those bits alone.
+func TestBoundsMarshalRoundTripsEveryRune(t *testing.T) {
+	t.Parallel()
+
+	type doc struct {
+		V string `toml:"v"`
+	}
+
+	check := func(t *testing.T, in string) {
+		t.Helper()
+		first, err := Marshal(doc{V: in})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var back doc
+		if err := Unmarshal(first, &back); err != nil {
+			t.Fatalf("the encoder produced a document the decoder refuses: %v\n%q", err, first)
+		}
+		if back.V != in {
+			t.Fatalf("value changed across a round trip: %q -> %q", in, back.V)
+		}
+		second, err := Marshal(back)
+		if err != nil {
+			t.Fatalf("re-marshal: %v", err)
+		}
+		if string(first) != string(second) {
+			t.Fatalf("encoding is not a fixpoint:\n first: %q\nsecond: %q", first, second)
+		}
+	}
+
+	t.Run("every control character", func(t *testing.T) {
+		t.Parallel()
+		for r := rune(0); r <= 0x1F; r++ {
+			check(t, "x"+string(r)+"y")
+		}
+	})
+
+	t.Run("astral runes with low bits under 0x1F", func(t *testing.T) {
+		t.Parallel()
+		for _, r := range []rune{0x1000A, 0x10000, 0x1001E, 0x2000D, 0x10FFFF} {
+			check(t, "x"+string(r)+"y")
+		}
+	})
+}

--- a/tm2/pkg/toml/gno.patch
+++ b/tm2/pkg/toml/gno.patch
@@ -228,3 +228,48 @@
  	}
  	parser.run()
  	return result
+--- tomltree_write.go
++++ tomltree_write.go
+@@ -60,9 +60,10 @@
+ 		case '\\':
+ 			b.WriteString(`\`)
+ 		default:
+-			intRr := uint16(rr)
+-			if intRr < 0x001F {
+-				b.WriteString(fmt.Sprintf("\\u%0.4X", intRr))
++			// See encodeTomlString for why the comparison is on rr itself and
++			// why the bound is inclusive.
++			if rr <= 0x1F {
++				b.WriteString(fmt.Sprintf(`\u%04X`, rr))
+ 			} else {
+ 				b.WriteRune(rr)
+ 			}
+@@ -92,9 +93,25 @@
+ 		case '\\':
+ 			b.WriteString(`\\`)
+ 		default:
+-			intRr := uint16(rr)
+-			if intRr < 0x001F {
+-				b.WriteString(fmt.Sprintf("\\u%0.4X", intRr))
++			// Escape every control character the lexer refuses to read back
++			// raw: lexStringAsString rejects 0x00-0x1F except tab, which the
++			// case above already handled.
++			//
++			// Upstream compared uint16(rr) against 0x1F, which was wrong
++			// twice. The bound excluded U+001F itself, so that one character
++			// was written raw into a basic string the lexer then refused --
++			// Marshal produced a document Unmarshal could not read. And the
++			// conversion truncated, so a rune whose LOW 16 bits fall under
++			// 0x1F (U+1000A, say) was emitted as the escape for those low bits
++			// alone and read back as an entirely different character.
++			//
++			// Both break Unmarshal(Marshal(v)) == v. That matters beyond
++			// tidiness here: gnomod.toml is stored re-encoded and its approval
++			// hash is taken after a further round trip
++			// (gno.land/pkg/sdk/vm.PackageContentHash), so an encoding that is
++			// not a fixpoint is an approval no approver can ever match.
++			if rr <= 0x1F {
++				b.WriteString(fmt.Sprintf(`\u%04X`, rr))
+ 			} else {
+ 				b.WriteRune(rr)
+ 			}

--- a/tm2/pkg/toml/tomltree_write.go
+++ b/tm2/pkg/toml/tomltree_write.go
@@ -60,9 +60,10 @@ func encodeMultilineTomlString(value string, commented string) string {
 		case '\\':
 			b.WriteString(`\`)
 		default:
-			intRr := uint16(rr)
-			if intRr < 0x001F {
-				b.WriteString(fmt.Sprintf("\\u%0.4X", intRr))
+			// See encodeTomlString for why the comparison is on rr itself and
+			// why the bound is inclusive.
+			if rr <= 0x1F {
+				b.WriteString(fmt.Sprintf(`\u%04X`, rr))
 			} else {
 				b.WriteRune(rr)
 			}
@@ -92,9 +93,25 @@ func encodeTomlString(value string) string {
 		case '\\':
 			b.WriteString(`\\`)
 		default:
-			intRr := uint16(rr)
-			if intRr < 0x001F {
-				b.WriteString(fmt.Sprintf("\\u%0.4X", intRr))
+			// Escape every control character the lexer refuses to read back
+			// raw: lexStringAsString rejects 0x00-0x1F except tab, which the
+			// case above already handled.
+			//
+			// Upstream compared uint16(rr) against 0x1F, which was wrong
+			// twice. The bound excluded U+001F itself, so that one character
+			// was written raw into a basic string the lexer then refused --
+			// Marshal produced a document Unmarshal could not read. And the
+			// conversion truncated, so a rune whose LOW 16 bits fall under
+			// 0x1F (U+1000A, say) was emitted as the escape for those low bits
+			// alone and read back as an entirely different character.
+			//
+			// Both break Unmarshal(Marshal(v)) == v. That matters beyond
+			// tidiness here: gnomod.toml is stored re-encoded and its approval
+			// hash is taken after a further round trip
+			// (gno.land/pkg/sdk/vm.PackageContentHash), so an encoding that is
+			// not a fixpoint is an approval no approver can ever match.
+			if rr <= 0x1F {
+				b.WriteString(fmt.Sprintf(`\u%04X`, rr))
 			} else {
 				b.WriteRune(rr)
 			}


### PR DESCRIPTION
One squashed commit carrying a batch of related GnoVM, gno.land and Tendermint2 work. Contributors are credited as co-authors on the commit.

The same commit is on `chain/mainnet` (#6154), so mainnet genesis builds against this code.

## Native gas metering (GnoVM)

`crypto/modexp` was priced on the modulus length alone, which does not describe the work it performs. It is now metered on exponent bits × modulus words, with operands capped at 1024 bytes. The remaining flat-priced natives get their variable-length inputs bounded or metered, native slice conversions are sized by visible length rather than capacity, and byte slices are data-backed so the bytes→string slope is measured against real storage rather than one `TypedValue` per byte.

- `gnovm/stdlibs/crypto/modexp/{modexp.gno,modexp.go,modexp_test.gno,modexp_test.go}`
- `gnovm/stdlibs/{native_gas.go,native_gas_test.go,native_gas_validate_test.go}`
- `gnovm/pkg/gnolang/{native_gas.go,native_gas_test.go}`

Breaking: gas costs change for `crypto/modexp` and for the natives taking variable-length input.

## Calibration tooling

- `gnovm/cmd/calibrate/gen_native_table.py` — generation path for the new per-native entries
- `gnovm/cmd/calibrate/ibc_native_bench_test.go` — benchmarks extended to cover them

## Package approval hash and redeploy (gno.land)

The approval hash now covers the author-declared `gnomod.toml` fields (`private`, `draft`, `ignore`, gno version) and the submission itself, instead of excluding the file. The private-redeploy exemption is keyed on the deploying address, a redeployed package keeps its own realm and is preprocessed at its newest index, and `MemPackage.Info` is no longer taken from the submitter.

- `gno.land/pkg/sdk/vm/{pkghash.go,pkghash_test.go,msgs.go,msgs_test.go,pb3_gen.go,vm.proto}`
- `gno.land/pkg/sdk/vm/{keeper.go,keeper_inert.go,keeper_inert_guards_test.go,keeper_private_redeploy_test.go,apphash_crossrealm38_test.go}`
- `gno.land/pkg/keyscli/{enablepkg.go,enablepkg_test.go}`
- `gno.land/pkg/gnoland/inert_lifecycle_test.go`

Breaking: the approval hash changes. The new message field is appended, so existing wire encodings are unchanged.

## TOML decode bounds (tm2)

- `tm2/pkg/toml/{tomltree_write.go,bounds_test.go,README.md,gno.patch}` — the vendored go-toml fork bounds the `gnomod.toml` decode, and the decode is charged gas

## Authority APIs (examples)

`p/moul/authz`'s `ContractAuthority` takes a real principal instead of comparing a realm to itself. `r/gnops/valopers` exports descriptions rather than live capabilities: `Auth()` is replaced by `AuthOwner()`, and the privileged closure is sealed inside a `dao.ProposalRequest` built in-realm. `r/gov/dao`'s `SimpleExecutor.Execute` is gated on the `r/gov/dao` namespace. `r/gnops/valopers` also establishes receipt for the register and rotation fees rather than only checking the amount sent.

- `examples/gno.land/p/moul/authz/v0/{authz.gno,authz_test.gno,example_test.gno}` and `filetests/z_contract_authority_shape_filetest.gno`
- `examples/gno.land/r/gnops/valopers/{admin.gno,admin_test.gno,init.gno,valopers.gno,valopers_test.gno,proposal/proposal.gno}` and 5 filetests
- `examples/gno.land/r/gov/dao/types.gno` and 3 filetests
- `examples/gno.land/r/sys/validators/v0/proposal_test.gno`, `examples/quarantined/gno.land/r/moul/config/config_test.gno`

Breaking: `valopers.Auth()` and `NewInstructionsProposalCallback` are gone, and `ContractAuthority`'s default proposer is no longer `NewAutoAcceptAuthority`.

## gpao

- `contribs/gpao/oracle.go` and 5 test files — follows the approval-hash change

## Integration tests

- New: `addpkg_private_redeploy_owner.txtar`, `enable_refuses_gnomod_private_flip.txtar`, `valopers_fee_receipt.txtar`, `valopers_governance.txtar`
- Updated: `moul_authz.txtar`, `params_valset_authlist_flow.txtar`, `params_valset_hostile_proxy.txtar`, `stdlib_ibc_crypto_determinism.txtar`, `storage_deposit_price_change.txtar`

## Notes

ADRs for this work are not in this PR; they land separately.

Verified locally: `go build ./...` (root and `contribs/gpao`), `cd examples && go run ../gnovm/cmd/gno test ./...`, `go test ./gno.land/pkg/integration/ -run TestTestdata`, `go test ./gno.land/pkg/sdk/vm/ -run Gas`, `go test ./tm2/pkg/toml/... ./gno.land/pkg/keyscli/...`, `contribs/gpao` tests. `go test ./gnovm/pkg/gnolang/ -run Files -test.short` shows the same 10 pre-existing `TypeCheckError` failures as the base commit on Go 1.26 — verified identical against a baseline worktree.

AI-assisted.
