### PR TITLE
docs: clarify the current state of chain upgrades and migration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Learn about core concepts found in Gno.land & Gno.
 - [Packages](resources/gno-packages.md) - Learn about realms, pure packages, smart contracts, dApps and how they're organized in the Gno.land ecosystem.
 - [Data Structures](resources/gno-data-structures.md) - Learn about arrays, slices, maps, structs, pointers, and when to use AVL trees for efficient storage.
 - [Networks](resources/gnoland-networks.md) - Discover different Gno.land networks (testnets, devnets) and their purposes, including network configurations.
+- [Chain Upgrades](resources/chain-upgrades.md) - How a gno.land chain halts, restarts, and migrates its state across a coordinated upgrade.
 - [Users and Teams](resources/users-and-teams.md) - Understand user registration, namespace ownership, and team collaboration in the Gno.land ecosystem.
 - [Gas Fees](resources/gas-fees.md) - Learn about gas pricing, estimation, and optimization strategies in Gno.land.
 - [Storage Deposit](resources/storage-deposit.md) - Learn how storage deposits work, including costs, refunds, and cleanup incentives in Gno.land.

--- a/docs/resources/chain-upgrades.md
+++ b/docs/resources/chain-upgrades.md
@@ -1,0 +1,358 @@
+# Chain upgrades
+
+This page describes how a gno.land chain moves from one binary — and one state
+— to the next: what the chain does on its own, what operators have to do by
+hand, and which parts of the design exist today versus which are still only
+written down.
+
+## Three kinds of upgrade
+
+| Kind | State-breaking | Coordination needed | How it happens |
+|---|---|---|---|
+| **Rolling** | No | None | Operators switch binaries whenever convenient. The chain never stops. |
+| **Coordinated** | Yes | Halt height | Every node stops at the same block, then restarts on the new binary — replaying history into a fresh genesis if the state format changed. |
+| **Hotfix** | Yes | Fully manual | No governance vote. Last resort. |
+
+Only the coordinated path has chain-level machinery behind it. The rest of this
+page is about that path.
+
+## Halting the chain
+
+A coordinated upgrade starts by stopping every node at the *same* height, so
+each one ends up with byte-identical state for the new binary to start from.
+
+### Setting the halt height
+
+The normal path is governance. The config field is the fallback for the cases
+governance cannot reach. Use one **or** the other — never both on the same node;
+see [Do not mix the two](#do-not-mix-the-two) below.
+
+#### Chain-wide, via governance
+
+A GovDAO proposal writes the height into chain state, so every node picks it up
+on its own and no operator has to touch a config file:
+
+```gno
+package main
+
+import (
+    "gno.land/r/gov/dao"
+    "gno.land/r/sys/params"
+)
+
+func main(cur realm) {
+    // Halt at block 704052; require binary >= chain/gnoland1.1 to resume.
+    preq := params.NewSetHaltRequest(cross(cur), 704052, "chain/gnoland1.1")
+    dao.MustCreateProposal(cross(cur), preq)
+}
+```
+
+This sets two params, readable by anyone:
+
+| Param | Type | Meaning |
+|---|---|---|
+| `node:p:halt_height` | `int64` | Height to halt at. `0` cancels a scheduled halt. |
+| `node:p:halt_min_version` | `string` | Minimum binary version required to restart afterwards. `""` means no version gate. |
+
+```bash
+gnokey query params/node:p:halt_height
+gnokey query params/node:p:halt_min_version
+```
+
+The height must be strictly greater than the height at which the proposal
+executes, but nothing enforces a *minimum* notice period — a proposal executing
+at height H can legally set H+1.
+
+Nothing has to be cleaned up afterwards. The params stay in state and the node
+still resumes, because the arming check fires only on the exact halt height and
+that height is behind it by then. (`halt_min_version` does stay in force as a
+permanent version floor — see [Restart gates](#restart-gates).)
+
+#### Per node, via config — when governance is not an option
+
+Some halts cannot go through a vote: a local fork or devnet with no GovDAO, a
+chain already halted or otherwise unable to execute a proposal, replay tooling,
+or an emergency stop on a single node. For those, `halt_height` in `config.toml`
+does the same job without chain state:
+
+```bash
+gnoland config set halt_height 704052
+```
+
+Each operator sets it themselves, which is also its weakness: coordination is
+out-of-band, so one operator who misses the message keeps producing blocks.
+That is why it is the fallback rather than the default for a network-wide halt.
+
+`gnoland config set` only edits the file. The node reads `halt_height` once at
+startup, so a running node has to be restarted before a new value takes effect.
+
+**Clearing it afterwards is required, not just hygiene.** Unlike the governance
+params, this value is re-applied at every startup — so once the node has halted
+at `halt_height` it cannot resume: the next block is already past the limit, and
+`BeginBlock` panics again on the first block it tries to process. Reset it
+before restarting:
+
+```bash
+gnoland config set halt_height 0
+```
+
+### Do not mix the two
+
+The governance param and the config field write the *same* field on the node —
+there is one halt height in memory, and whoever writes it last wins. The config
+value is applied at every startup; the governance value is applied by the block
+that reaches it. A node carrying both halts at the wrong block, in one of two
+directions:
+
+- **Config below the governance height.** The node halts at its own value and
+  never reaches the agreed one. It stops out of step with the network — exactly
+  the divergence the governance halt exists to prevent.
+- **Config above the governance height.** Governance wins at the time, but the
+  restart re-applies the config value, so the node halts a second time at a
+  height nobody voted for.
+
+Both of those failures need a config value that is still in the *future*. A
+value the chain has already passed simply blocks the restart, as described
+above — loud, and found immediately. What survives unnoticed in a `config.toml`
+is a future-dated height, which sits there silently until the halt it causes.
+
+In practice: before a governance halt, every operator should confirm their own
+config is clear.
+
+```bash
+gnoland config get halt_height   # expect 0
+```
+
+### What a halt actually looks like
+
+The block **at** `halt_height` is fully committed. The halt is armed, and the
+panic fires when the *next* block begins, so the last committed block is
+`halt_height` itself.
+
+The stop itself is identical whether the halt was scheduled by governance or set
+in `config.toml`: each writes the same in-memory halt height, so each reaches the
+same check in `BeginBlock`, where the panic is caught by the consensus routine:
+
+```
+CONSENSUS FAILURE!!!  err="halt height 704052 reached, node shutting down"  stack=...
+```
+
+What differs is the warning you get beforehand.
+
+**A governance halt announces itself at the halt block.** The EndBlocker reads
+`node:p:halt_height` on every block and logs when it matches, one block before
+the stop:
+
+```
+GovDAO halt height reached, will halt after this block  height=704052  halt_height=704052
+```
+
+**A config halt announces itself only at startup.** The value is read once when
+the node boots, which is where its single log line appears — possibly days
+before the halt:
+
+```
+Halt height configured  height=704052
+```
+
+After that there is nothing until the crash. Nothing runs at the halt block,
+because the config path never consults chain state, so no "will halt after this
+block" line is ever emitted. If you are watching for a config-driven halt, watch
+the height, not the log.
+
+**The process does not exit.** `gnoland start` waits on its signal context, not
+on consensus health, so the node stops producing blocks while the RPC server
+stays up and the process idles. Stop it yourself. Process supervisors configured
+to restart on exit will not fire.
+
+That is a deliberate trade, not an oversight. The governance halt originally
+called `osm.Kill()`, which sends the node `SIGTERM` and does end the process.
+Review replaced it with `BaseApp.SetHaltHeight()` so that both ways of setting a
+halt height share one deterministic path with no async signals: every node stops
+at the same block because the same check runs during block execution, not because
+a signal arrived at some moment. A process that outlives its own halt is the cost
+of that guarantee.
+
+### Restart gates
+
+If `halt_min_version` is set, the node checks the running binary against it at
+startup — before any blocks are processed — and refuses to start in two
+directions:
+
+- **After the halt** (`lastBlockHeight >= halt_height`): a binary *below* the
+  minimum version is refused. This is what keeps a retired binary from resuming
+  the chain and diverging from everyone else.
+- **Before the halt** (`lastBlockHeight < halt_height`): a binary that *already
+  meets* the minimum version is refused. The upgrade binary is for after the
+  cut; running it early is the same divergence from the other side.
+
+Both checks are skipped entirely when `halt_height` is `0` or
+`halt_min_version` is empty. A halt proposal that leaves the version empty is a
+coordinated *pause*, not an upgrade gate.
+
+An operator who has already migrated out-of-band can bypass both:
+
+```bash
+gnoland config set skip_upgrade_height 704052   # must equal halt_height
+```
+
+#### Where the binary's version comes from
+
+The value being compared is the `tm2/pkg/version.Version` variable compiled into
+the binary. It is a build-time constant, not something the node reads from
+config or chain state, so it is fixed the moment the binary is produced:
+
+| How it was built | Reported version |
+|---|---|
+| `go build ./gno.land/cmd/gnoland` | `develop` — the hardcoded default, since nothing overrides it |
+| `make build.gnoland` on a release tag | the tag, e.g. `chain/gnoland1.1` |
+| `make build.gnoland` off a tag | `<branch>.<commits>+<hash>`, e.g. `master.3335+bc43a5fb7` |
+| `go build -ldflags "-X github.com/gnolang/gno/tm2/pkg/version.Version=..."` | whatever you pass |
+
+The Makefile injects it with `-ldflags -X`, deriving the value from
+`git describe --tags --exact-match` and falling back to the branch/count/hash
+form when the commit is not tagged. `chain/gnoland1.0` and `chain/gnoland1.1`
+are real tags in this repository — that is where the
+`chain/gnoland<major>.<minor>` format comes from, and why a binary built on a
+release tag reports exactly the shape the comparison understands.
+
+Versions are compared by parsing that shape: different majors compare as majors,
+otherwise the minor must be greater or equal. **Anything that does not parse
+falls back to exact string equality**, so `develop` and `master.3335+bc43a5fb7`
+satisfy no `chain/gnolandX.Y` floor at all. A release build passes the gate; an
+ad-hoc build of the same code does not.
+
+To read a version back:
+
+```bash
+gnoland version                              # gnoland version: chain/gnoland1.1
+curl -s localhost:26657/status | grep -i build_version
+```
+
+The RPC `/status` endpoint reports it as `BuildVersion`, so you can survey what
+the rest of the network is running — worth doing before choosing a
+`halt_min_version` that some validators cannot satisfy.
+
+**The halt params are never cleared.** Nothing in the node resets them after a
+successful resume, so `halt_min_version` stays in force as a permanent
+minimum-version floor for every later restart. That is usually what you want.
+To lift it, pass a new proposal with `NewSetHaltRequest(cross(cur), 0, "")`.
+
+## Changing state: genesis replay
+
+Halting and restarting is enough when the new binary can read the old state.
+When it cannot, the state has to be rebuilt — and gno.land does that by
+**replaying history into a new genesis**, not by transforming the old database
+in place.
+
+### How it works
+
+`gnogenesis fork generate` reads the halted chain (an RPC endpoint, a halted
+data directory, or a pre-exported archive) and writes a genesis file containing
+the full transaction history plus the metadata needed to replay it:
+
+```bash
+gnogenesis fork generate \
+    --source-txs-data-dir /path/to/halted/gnoland/data \
+    --source-genesis-file /path/to/source/genesis.json \
+    --chain-id gnoland-1 \
+    --output genesis.json
+```
+
+On the new chain, `InitChain` replays every historical transaction through the
+full ante handler. Three genesis-level fields make that possible:
+
+| Field | Purpose |
+|---|---|
+| `PastChainIDs` | Chain IDs whose signatures stay valid during replay. Historical txs were signed against the source chain and cannot be re-signed. |
+| `InitialHeight` | The new chain's first block. Set to `halt_height + 1`, so block numbering continues instead of restarting at 1. |
+| `GasReplayMode` | `strict` (default) meters historical txs with the new VM's gas rules; `source` bypasses metering so txs that changed cost still reproduce their original outcome. |
+
+At the end of replay the node emits a report counting each transaction as `ok`,
+`ok_gas_differs`, `failed`, or `skipped_failed`, with a warn line per failure.
+
+A new chain ID is **not** required. `PastChainIDs` may contain the current chain
+ID, which is the right shape for a fork that changes state without changing the
+chain's external identity.
+
+### Expressing the migration
+
+Since replay re-executes the original history, anything the upgrade *adds* is
+expressed as extra input to genesis rather than as code in the node:
+
+| Flag | What it does |
+|---|---|
+| `--migration-tx FILE` | Appends transactions to the end of `appState.Txs`, after all historical replay. Repeatable. This is where new deploys, param changes, and data seeding go. |
+| `--patch-realm PKGPATH=SRCDIR` | Rewrites a genesis-mode `addpkg` transaction in place with files from `SRCDIR`. The only way to land a realm code change as part of a fork, since you cannot re-`addpkg` a path that already exists. |
+| `--patch-txs FILE` | Patches specific historical transactions, matched by block height and signer. |
+
+Two helpers build `--migration-tx` inputs: `gnogenesis fork valoper-seed` (from
+a CSV of validators) and `gnogenesis fork addpkg` (from local package
+directories). `gnogenesis fork test` boots the result in-process as a smoke
+test before you ship it, and `gnogenesis fork inspect` prints a provenance
+report over a finished genesis — how many transactions came from history, from
+migration files, and from patches, and why.
+
+### Known limits
+
+- Fork genesis files are large — roughly 192 MB for a chain halted at height
+  ~704k, since they carry the whole transaction history.
+- The RPC source has no retry or resume; a single transient error aborts the
+  fetch. Prefer `--source-txs-data-dir` against a halted data directory.
+- All transactions are held in memory during generation, so very large chains
+  can exhaust RAM.
+
+### Worked examples
+
+The deployment scripts are the real reference, and they are considerably more
+detailed than this page:
+
+- [`misc/deployments/test13.gno.land/gen-genesis.sh`](../../misc/deployments/test13.gno.land/gen-genesis.sh)
+  — the fullest example, including `--migration-tx` for valoper seeding
+- [`misc/deployments/pearl.gno.land/gen-genesis.sh`](../../misc/deployments/pearl.gno.land/gen-genesis.sh)
+
+## What does not exist
+
+Worth stating plainly, because the design documents describe more than the code
+implements:
+
+- **There is no migrate function or upgrade-handler framework.** A binary
+  cannot register a migration keyed to `halt_min_version` and have the node run
+  it on resume. `halt_min_version` gates startup and does nothing else. The
+  idea was raised in review on
+  [#5368](https://github.com/gnolang/gno/pull/5368) and deferred; the follow-ups
+  that would have built it were closed unmerged, and
+  [#5377](https://github.com/gnolang/gno/pull/5377) (`gnoland start --migrate`,
+  which rebuilds app state by re-executing the block store in place) is still
+  open. Migration happens on the new chain during replay, not in the binary
+  that halted.
+- **`skip_upgrade_height` is narrower than its name suggests.** It was added to
+  skip a migrate function for operators who had already migrated out-of-band.
+  With no migrate function, it only bypasses the two version checks.
+
+## A coordinated upgrade, end to end
+
+1. Agree the halt height, leaving room for the proposal to be voted and
+   executed.
+2. Pass a GovDAO `NewSetHaltRequest(cross(cur), H, minVersion)` proposal.
+   Operators should confirm `halt_height` is unset in their own `config.toml`;
+   a future-dated value there halts the node at the wrong block — early if it is
+   below H, or a second time after the upgrade if above.
+3. The chain commits block H and stops. Operators stop the idle processes.
+4. **If the state format did not change**: restart on the new binary. It must
+   satisfy `minVersion`. The chain continues at H+1.
+5. **If it did change**: run `gnogenesis fork generate` against a halted data
+   directory, add `--migration-tx` / `--patch-realm` for anything the upgrade
+   introduces, verify with `gnogenesis fork test`, distribute the new
+   `genesis.json`, and start the new binary against it. Replay rebuilds state
+   and the chain produces its first fresh block at `InitialHeight`.
+
+## Reference
+
+| Topic | Where |
+|---|---|
+| Halt params, arming, startup checks | [`gno.land/adr/pr5368_govdao_halt_height.md`](../../gno.land/adr/pr5368_govdao_halt_height.md) |
+| Genesis replay, tx metadata, fork tooling | [`gno.land/adr/pr5511_chain_upgrade_genesis_replay.md`](../../gno.land/adr/pr5511_chain_upgrade_genesis_replay.md) |
+| `InitialHeight` in consensus and the block store | [`tm2/adr/pr5511_initial_height.md`](../../tm2/adr/pr5511_initial_height.md) |
+| Manual test plan for the halt mechanism | [Testing the halt height feature](test-halt-height.md) |
+| Node configuration and operation | [`gno.land/cmd/gnoland/README.md`](../../gno.land/cmd/gnoland/README.md) |

--- a/docs/resources/test-halt-height.md
+++ b/docs/resources/test-halt-height.md
@@ -2,6 +2,10 @@
 
 Single-validator manual test plan for the governance-based chain halt mechanism.
 
+For where this fits in a chain upgrade, see [Chain upgrades](chain-upgrades.md).
+For how the mechanism works internally (params, arming, the two startup checks),
+see [`gno.land/adr/pr5368_govdao_halt_height.md`](../../gno.land/adr/pr5368_govdao_halt_height.md).
+
 ## Cleanup / Starting Fresh
 
 To reset and start the test from scratch:
@@ -19,8 +23,11 @@ will regenerate everything from scratch.
 ### Build two gnoland binaries with distinct versions
 
 The startup checks compare `tm2/pkg/version.Version` against the governance
-`halt_min_version` param. The `gnoland` Makefile target does **not** inject
-the version via ldflags by default, so you must pass it explicitly.
+`halt_min_version` param. Comparison only understands the
+`chain/gnoland<major>.<minor>` format; anything else falls back to exact string
+equality. The `gno.land/Makefile` build targets *do* inject a version, but it is
+derived from `git describe` (e.g. `master.12345+abc1234`), which never parses as
+a chain version — so you must pass the version explicitly.
 
 ```bash
 # "Old" binary — simulates the currently running chain software.
@@ -64,9 +71,10 @@ Verify the address matches the funded genesis account:
     --skip-genesis-sig-verification
 ```
 
-The default GovDAO loader creates tiers but adds **no members** and leaves
-`AllowedDAOs` empty. When `AllowedDAOs` is empty, any caller can interact with
-the DAO. We exploit this to bootstrap `test1` as a T1 member via MsgRun.
+The default GovDAO loader creates tiers and sets the DAO impl, but adds **no
+members** and leaves `AllowedDAOs` empty. When `AllowedDAOs` is empty, any
+caller can interact with the DAO. We exploit this to bootstrap `test1` as a T1
+member via MsgRun.
 
 Write a bootstrap script (`/tmp/bootstrap_govdao.gno`):
 
@@ -77,14 +85,17 @@ import (
     "gno.land/r/gov/dao/v3/memberstore"
 )
 
-func main() {
+func main(cur realm) {
     // Add test1 as a T1 member (supermajority power).
     // The loader already set the DAO impl; AllowedDAOs is empty so any
     // caller is permitted. We just need to register the member.
-    memberstore.Get().SetMember(memberstore.T1,
+    err := memberstore.Get(0, cur).SetMember(memberstore.T1,
         address("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"),
-        &memberstore.Member{InvitationPoints: 3},
+        memberstore.NewMember(3),
     )
+    if err != nil {
+        panic(err)
+    }
 }
 ```
 
@@ -100,7 +111,10 @@ Submit it (in a second terminal while the node is running):
 **Expected**: `OK!` — test1 is now a T1 GovDAO member.
 
 Note the current block height from the node logs and choose a **halt height**
-comfortably in the future (e.g. current height + 40).
+comfortably in the future (e.g. current height + 40). `WillSetParam` rejects a
+halt height that is not strictly greater than the height at which the proposal
+executes, so leave room for the vote and execution txs. The examples below use
+`50`; substitute your own value consistently.
 
 ## Propose and execute a halt via GovDAO
 
@@ -118,9 +132,9 @@ import (
     "gno.land/r/sys/params"
 )
 
-func main() {
-    preq := params.NewSetHaltRequest(50, "chain/gnoland1.1")
-    dao.MustCreateProposal(cross, preq)
+func main(cur realm) {
+    preq := params.NewSetHaltRequest(cross(cur), 50, "chain/gnoland1.1")
+    dao.MustCreateProposal(cross(cur), preq)
 }
 ```
 
@@ -178,18 +192,74 @@ description mentioning block 50 and version `chain/gnoland1.1`.
 # Expected: data: "chain/gnoland1.1"
 ```
 
+### The new binary is refused before the halt
+
+**Goal**: Verify the pre-halt startup check (`checkNodeStartupParams`, check 2):
+a binary that already meets `halt_min_version` must not run before the chain
+has reached `halt_height`.
+
+Stop the node (Ctrl-C) while the chain is still below block 50 and try the new
+binary:
+
+```bash
+./build/gnoland-v1.1 start --data-dir ./testnode --genesis ./testnode/genesis.json
+```
+
+**Expected**: startup fails with
+
+```
+binary version "chain/gnoland1.1" is an upgrade intended for halt height 50,
+but the chain is at height <N>; please use the previous binary until the halt,
+or set skip_upgrade_height = 50 in config.toml if you have already migrated
+```
+
+Restart the old binary and let it run to the halt:
+
+```bash
+./build/gnoland-v1.0 start --data-dir ./testnode --genesis ./testnode/genesis.json
+```
+
 ### Observe the halt
 
-The node should panic at BeginBlock of block 50 (the halt height). The block
-at halt_height is **never committed** — the last committed block is 49.
+Block 50 — the halt height — **is committed**. The EndBlocker of block 50 arms
+the halt, and `BaseApp.BeginBlock` panics when the *next* block (51) begins.
+The last committed block is therefore 50, not 49.
 
-Watch the logs for:
+Watch the logs for the EndBlocker arming the halt at block 50:
 
 ```
-halt height 50 reached, node shutting down
+GovDAO halt height reached, will halt after this block  height=50  halt_height=50
 ```
 
-**Result**: The node process exits. Block 49 is the last committed block.
+then, as block 51 begins, the panic surfacing through the consensus routine's
+recover:
+
+```
+CONSENSUS FAILURE!!!  err="halt height 50 reached, node shutting down"  stack=...
+```
+
+**Result**: the consensus routine stops and the node produces no further
+blocks. Note the **process does not exit** — `gnoland start` blocks on its
+signal context, not on consensus health, so the RPC server stays up and the
+process idles. Stop it with Ctrl-C.
+
+### The old binary is refused after the halt
+
+**Goal**: Verify the post-halt startup check (`checkNodeStartupParams`, check 1):
+once the chain has reached `halt_height`, a binary below `halt_min_version`
+must not resume it.
+
+```bash
+./build/gnoland-v1.0 start --data-dir ./testnode --genesis ./testnode/genesis.json
+```
+
+**Expected**: startup fails with
+
+```
+binary version "chain/gnoland1.0" does not meet the minimum version
+"chain/gnoland1.1" required by governance; please upgrade to a compatible
+binary before restarting
+```
 
 ### New binary resumes after halt
 
@@ -200,19 +270,22 @@ the startup check and resumes the chain.
 ./build/gnoland-v1.1 start --data-dir ./testnode --genesis ./testnode/genesis.json
 ```
 
-**Expected**: The node starts, replays block 50 (the halt height), and the
-EndBlocker detects the binary meets the min version. It clears the halt params
-from state. The chain continues normally from block 51 onward.
+**Expected**: The node starts and the chain continues from block 51 onward.
+The EndBlocker arms the halt only on `req.Height == halt_height`, so at height
+51 and above it never re-fires and the node does not halt again.
 
-Watch the logs for:
-
-```
-binary meets halt min version, clearing halt params  height=50  halt_height=50  ...
-```
-
-Verify the halt params have been cleared:
+The halt params are **not** cleared on resume — nothing in the node clears
+them, by design:
 
 ```bash
 ./build/gnokey query params/node:p:halt_height
-# Expected: data: "0"
+# Expected: still data: "50"
+
+./build/gnokey query params/node:p:halt_min_version
+# Expected: still data: "chain/gnoland1.1"
 ```
+
+`halt_min_version` therefore stays in force as a permanent minimum-version
+floor: every subsequent restart re-runs check 1 and keeps binaries below
+`chain/gnoland1.1` off the chain. To lift the requirement, pass a new GovDAO
+proposal with `NewSetHaltRequest(cross(cur), 0, "")`.

--- a/gno.land/adr/pr5368_govdao_halt_height.md
+++ b/gno.land/adr/pr5368_govdao_halt_height.md
@@ -1,0 +1,247 @@
+# ADR: GovDAO-Scheduled Chain Halt via `r/sys/params`
+
+## Context
+
+A coordinated chain upgrade needs every validator to stop at the *same* height.
+If some nodes keep producing blocks past the agreed cut, the new binary starts
+from a state the rest of the network never saw, and the upgrade becomes a fork.
+
+### What existed before
+
+#5334 added a per-node `halt_height` field to `config.toml`
+(`tm2/pkg/bft/config/config.go:310`), wired in `gno.land/cmd/gnoland/start.go:287`
+and enforced in `tm2/pkg/sdk/baseapp.go`. It works, but it has two gaps:
+
+1. **Coordination is out-of-band.** Every operator has to edit their own config
+   with the same number. One operator who misses the message keeps producing
+   blocks past the cut; one who fat-fingers the number halts early. There is no
+   on-chain record of the agreed height, so there is nothing to check against.
+
+2. **Nothing keeps the wrong binary out.** After the halt, an operator can
+   restart the *old* binary and rejoin. That is precisely the divergence the
+   halt was meant to prevent — the halt buys a synchronized stopping point and
+   then immediately gives it away.
+
+### Why not just tell operators the number
+
+Because the number is a consensus-relevant decision and the network already has
+a mechanism for those. Any solution that lives only in each operator's config
+file is advisory; the chain cannot enforce it, and post-mortem it cannot even
+tell you what was agreed.
+
+## Decision
+
+Make the halt height **governance-owned chain state**, and add a binary-version
+floor that gates restart. Keep the config field as a per-node override.
+
+### Params keys
+
+Two scalars under the existing `node` module in the params store:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `node:p:halt_height` | `int64` | Height to halt at. `0` = no halt / cancel. |
+| `node:p:halt_min_version` | `string` | Minimum `tm2/pkg/version.Version` required to restart once the halt is reached. `""` = no version gate. |
+
+They are written by `r/sys/params.NewSetHaltRequest(cur, height, minVersion)`
+(`examples/gno.land/r/sys/params/halt.gno`), which builds a GovDAO
+`ProposalRequest` whose executor sets both keys and emits a `set_halt` event.
+`height == 0` is the cancel sentinel.
+
+`nodeParamsKeeper.WillSetParam` (`gno.land/pkg/gnoland/node_params.go:53`)
+validates at write time: `halt_height` must be an `int64`, non-negative, and —
+unless it is the `0` sentinel — strictly greater than the current block height.
+`halt_min_version` must be a `string`. Unknown `p:` keys panic, so governance
+cannot write arbitrary keys into the `node` namespace.
+
+### Arming and halting
+
+The halt is a two-step handoff from chain state to the ABCI app:
+
+1. **EndBlocker arms it** (`gno.land/pkg/gnoland/app.go:1102`). At the end of
+   every block it reads `node:p:halt_height` and, if
+   `req.Height == haltHeight`, calls `baseApp.SetHaltHeight(haltHeight)`.
+   `SetHaltHeight` is the only method the `endBlockerApp` interface needs for
+   this (`app.go:1022`).
+
+2. **BeginBlock fires it** (`tm2/pkg/sdk/baseapp.go:590`). It panics when
+   `header.Height > haltHeight`.
+
+So the block **at** `halt_height` is fully committed, and the panic lands at the
+start of `halt_height + 1`. The last committed block is `halt_height`.
+
+The comparison in step 1 is `==`, not `>=`, and that matters: with `>=`, a node
+restarted after the halt would re-arm on its very first block and panic again,
+forever. With `==`, the condition is false for every `req.Height > haltHeight`,
+so the halt fires exactly once and a compliant binary can resume.
+
+The panic is caught by the consensus routine's recover
+(`tm2/pkg/bft/consensus/state.go:639`), which logs `CONSENSUS FAILURE!!!`,
+stops the WAL, and exits `receiveRoutine`. The process itself keeps running —
+`gnoland start` blocks on its signal context (`start.go:316`), not on consensus
+health — so the node stops making blocks but the operator still has to stop it.
+
+### The two startup checks
+
+`checkNodeStartupParams` (`node_params.go:134`) runs once in
+`NewAppWithOptions`, after `LoadLatestVersion`, against committed state
+(`app.go:284`). It returns early — no checks at all — when `halt_height == 0`
+or `halt_min_version == ""`. Otherwise it compares `tm2/pkg/version.Version`
+against `halt_min_version` in one of two directions:
+
+- **Check 1 — `lastBlockHeight >= haltHeight`** (the halt has happened). Refuse
+  to start unless the binary meets the minimum version. This is what keeps a
+  retired binary from resuming the chain.
+- **Check 2 — `lastBlockHeight < haltHeight`** (the halt has not happened yet).
+  Refuse to start *any* binary that already meets the minimum version. The
+  upgrade binary is for after the cut; running it early is the same divergence
+  from the other side.
+
+`skip_upgrade_height` in `config.toml` (`config.go:314`, threaded through
+`AppOptions.SkipUpgradeHeight`) bypasses both when it equals `haltHeight` — the
+escape hatch for an operator who has already migrated out-of-band.
+
+### Version comparison
+
+`meetsMinVersion` (`node_params.go:193`) parses `chain/gnoland<major>.<minor>`:
+if the majors differ it compares majors, otherwise it requires
+`minor >= minMinor`. If *either* side fails to parse, it falls back to exact
+string equality.
+
+The fallback is deliberately strict rather than permissive, but it has a sharp
+edge worth knowing: `gno.land/Makefile` builds inject a `git describe`-derived
+version (`master.12345+abc1234`), which never parses as a chain version. Such a
+binary satisfies only a byte-identical `halt_min_version`, so in practice it
+fails any `chain/gnolandX.Y` requirement. Testing this feature requires
+building with an explicit `-ldflags` version; see
+[`docs/resources/test-halt-height.md`](../../docs/resources/test-halt-height.md).
+
+## Alternatives Considered
+
+- **Keep the config-only halt from #5334.** Rejected for the two gaps above.
+  It is *kept*, but as an alternative rather than a complement: both write the
+  same `BaseApp.haltHeight` field, so a node with both set halts at whichever
+  was written last, and a stale config value re-applied at startup can strand
+  the node entirely. It is the lever for cases governance cannot reach — local
+  forks, replay tooling, stopping a single node in an emergency — and should be
+  cleared afterwards.
+
+- **Halt inside `Commit` instead of the next `BeginBlock`.** Cutting after
+  writing block N inside `Commit` is the same logical cut point, but panicking
+  mid-`Commit` risks stopping between `deliverState.ms.MultiWrite()` and
+  `cms.Commit()` — an ordering the code explicitly depends on. Checking at the
+  next `BeginBlock` puts the panic outside every write path. (The doc comment
+  on `BaseApp.Commit` still describes the older deferred-in-`Commit` design and
+  is stale.)
+
+- **Halt *at* `halt_height` rather than after it** — i.e. never commit the
+  block at the halt height. Raised in review. Rejected because it re-introduces
+  the restart loop from the other direction: if the block never commits, a
+  restarted node sees the same last height, arms again, and panics again, with
+  no way forward. Committing `halt_height` and panicking at `halt_height + 1`
+  leaves the chain cleanly stopped on a committed block, which is also the state
+  the replay tooling expects.
+
+- **`osm.Kill()` — send the node's own process `SIGTERM`.** The governance
+  halt's first implementation. It ends the process, which is friendlier to
+  operators and to process supervisors, but it stops the node through an async
+  signal delivered outside block execution. Review replaced it with
+  `BaseApp.SetHaltHeight()` so the governance halt shares the deterministic
+  `BeginBlock` path from #5334: nodes stop at the same block because the same
+  check runs during block execution, not because a signal landed at some point.
+  The process surviving its own halt is the cost of that (see Consequences).
+
+- **`>=` in the EndBlocker check.** Simpler to read, and wrong: it makes the
+  halt unrecoverable, as described above.
+
+- **Clear the halt params automatically once a compliant binary resumes.**
+  Considered and not implemented. Auto-clearing would make `halt_min_version` a
+  one-shot gate; leaving it set makes it a persistent floor, which is the more
+  useful property (see Consequences). Clearing also means a chain-internal
+  write to a governance-owned key, which the `node` module otherwise only
+  permits for the `valset:` mirrors.
+
+- **A migrate function linked to `halt_min_version`.** Raised in review on
+  #5368: if the new binary carries a state migration, have the node look for a
+  migration keyed to `halt_min_version` and run it on resume. Deferred at the
+  time as needing "a more complete upgrade handler framework", which #5374
+  (`meta: chain hardfork`) then specced — every hardfork defined by
+  source + binary + overlay, where the overlay could be numbered shell scripts
+  *or* "named Go migration functions registered in the binary".
+
+  It never landed, and neither did the tooling #5374 listed alongside it:
+  #5411, #5376 and #5369 were all closed unmerged, and #5374 itself is closed.
+
+  #5377 (`--migrate`, in-place block-replay migration) is still open, but it is
+  a different mechanism rather than this hook. It has the operator rebuild app
+  state by re-executing the existing block store with the new binary — state
+  rebuild by re-execution, not state transformation — and its extension point,
+  `MigrationConfig.GenesisOverlay`, patches the *genesis doc* before replay
+  instead of running off `halt_min_version`. Its own ADR proposes
+  auto-triggering the rebuild when `node:p:halt_height` matches the block store
+  height and defers that too, on the grounds that the params-based halt height
+  was not yet merged. So #5368 deferred the trigger forward to an upgrade
+  framework and #5377 deferred it back to these params; neither built it.
+
+  #5377 then lost its rationale. It had rejected "export-then-genesis" because
+  block heights would reset and indexers would lose continuity — but #5540's
+  `GenesisDoc.InitialHeight` made a replayed chain resume at the source chain's
+  halt height + 1, and #5511 shipped that route.
+
+  The upgrade path that shipped instead is genesis replay
+  (#5511, #5540 — see
+  [pr5511_chain_upgrade_genesis_replay.md](./pr5511_chain_upgrade_genesis_replay.md)),
+  which expresses migrations as *transactions appended to the new chain's
+  genesis* (`gnogenesis fork generate --migration-tx`, plus `--patch-realm`)
+  rather than as Go functions in the halting binary. Migration therefore
+  happens on the new chain during replay, not in the binary that halted, so
+  there is nothing left for `halt_min_version` to hook into. Anyone reviving
+  the idea should start from the genesis-replay design rather than from this
+  params pair.
+
+- **A dedicated upgrade module (Cosmos SDK `x/upgrade` style).** Rejected as
+  overkill for a coordinated stop: two scalars in the params store already
+  cover it, without a new module, keeper, and store prefix. The migration
+  half of what such a module would provide went to the genesis-replay tooling
+  instead, as described in the previous bullet.
+
+## Consequences
+
+- **The halt params are never cleared.** Nothing in the node clears them; only
+  a new proposal can. Three effects follow:
+  - `halt_min_version` becomes a permanent minimum-version floor. Every later
+    restart re-runs check 1, so binaries below it stay off the chain
+    indefinitely. Useful; surprising if you expected a one-shot gate.
+  - Check 2 stops applying once `lastBlockHeight >= haltHeight`, so newer
+    binaries can be started freely after the halt.
+  - Scheduling the next halt needs a fresh proposal, and `WillSetParam`
+    guarantees the new height is in the future. Lifting the version floor needs
+    `NewSetHaltRequest(cross(cur), 0, "")`.
+
+- **A halt is a supermajority action with an immediate chain-wide effect.**
+  `WillSetParam` bounds the height to the future but not to the *near* future:
+  a proposal executing at height H can legally set `H+1`, halting the chain on
+  the next block. There is no minimum notice period.
+
+- **An empty `halt_min_version` disables both startup checks.** The halt still
+  happens, but nothing stops the old binary from resuming. Setting a min
+  version is what buys the anti-divergence protection; a halt proposal that
+  leaves it empty is a coordinated pause, not an upgrade gate.
+
+- **The stop is a crash, not a graceful shutdown.** Operators see
+  `CONSENSUS FAILURE!!!` in the logs, the process idles with its RPC server
+  still up, and they must stop it themselves. Process supervisors that restart
+  on exit will not trigger, because the process does not exit. This follows
+  directly from choosing the `BeginBlock` panic over `osm.Kill()` (see
+  Alternatives) — determinism was preferred to a clean process exit.
+
+- **`skip_upgrade_height` is narrower than its origin suggests.** It was added
+  in #5368 to answer "skip the migrate function, for a validator that has
+  already migrated its state out-of-band". Since that migrate function was
+  never built (see Alternatives), the flag only bypasses the two version
+  checks. Its `config.go:314` comment describes what it does; the broader
+  intent is unimplemented.
+
+- **Adding a node param now requires touching `node_params.go`**, since
+  `WillSetParam` panics on unknown `p:` keys. That is the intended trade: an
+  allowlist of node-level knobs, at the cost of a Go-side change per new key.

--- a/misc/docs/sidebar.json
+++ b/misc/docs/sidebar.json
@@ -37,6 +37,7 @@
           "resources/gno-packages",
           "resources/gno-data-structures",
           "resources/gnoland-networks",
+          "resources/chain-upgrades",
           "resources/users-and-teams",
           "resources/gas-fees",
           "resources/storage-deposit",


### PR DESCRIPTION
The knowledge about how a gno.land chain is upgraded was spread across four ADRs, a manual test plan, and the deployment scripts, with no single place saying which parts are implemented. Some of it had also drifted from the code.

Add docs/resources/chain-upgrades.md, an overview covering:

- the three kinds of upgrade (rolling, coordinated, hotfix)
- setting the halt height, governance first with the config field as the fallback, and why the two must not be combined
- what a halt looks like in the logs, which differs between the two paths
- the restart version gates, and where the binary's version comes from
- genesis replay as the shipped migration path (gnogenesis fork, migration txs, realm patches), and what does not exist: there is no migrate function or upgrade handler keyed to halt_min_version

Add gno.land/adr/pr5368_govdao_halt_height.md, a retrospective ADR for the already-merged #5368, recording the params, the EndBlocker-arms / BeginBlock-fires handoff, the two startup checks, and the alternatives weighed in review: osm.Kill, halting at halt_height rather than after it, and the deferred migrate hook that genesis replay later superseded.

Fix docs/resources/test-halt-height.md, which no longer matched the code:

- the block at halt_height is committed; the panic lands at halt_height+1
- the node process does not exit after halting
- halt params are not cleared on resume
- the test scripts used a stale Gno API (main(cur realm), cross(cur), memberstore.Get(0, cur))
- the Makefile does inject a version, just not one that parses as a chain version
- add the two startup-check paths the plan never exercised